### PR TITLE
[SPARK-47197] Failed to connect HiveMetastore when using iceberg with HiveCatalog on spark-sql or spark-shell

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/security/HiveDelegationTokenProvider.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/security/HiveDelegationTokenProvider.scala
@@ -62,6 +62,12 @@ private[spark] class HiveDelegationTokenProvider
   override def delegationTokensRequired(
       sparkConf: SparkConf,
       hadoopConf: Configuration): Boolean = {
+    // provide a way to force to get HIVE_DELEGATION_TOKEN
+    // HIVE_DELEGATION_TOKEN is needed when using iceberg with HiveCatalog on spark-sql or
+    // spark-shell
+    if (sparkConf.getBoolean("spark.security.credentials.hive.enabled", defaultValue = false)) {
+      return true
+    }
     // Delegation tokens are needed only when:
     // - trying to connect to a secure metastore
     // - either deploying in cluster mode without a keytab, or impersonating another user


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Make `spark-sql`, `spark-shell` be able to access iceberg with HiveCatalog.
If a user want to access iceberg table with HiveCatalog through `spark-sql`, `spark-shell`, the user should specify additional configuration:

```
$ spark-sql --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
--conf spark.sql.catalog.hadoop_prod=org.apache.iceberg.spark.SparkCatalog \
--conf spark.sql.catalog.hadoop_prod.type=hive \
--conf spark.sql.catalog.hadoop_prod.uri=thrift://hms1.example.com:9083,thrift://hms2.example.com:9083 \
--conf spark.hadoop.iceberg.engine.hive.enabled=true \
--conf spark.jars=hdfs:///some/path/to/iceberg-spark-runtime-3.2_2.12-1.4.3.jar \
--conf spark.hadoop.hive.aux.jars.path=hdfs:///some/path/to/iceberg-hive-runtime-1.4.3.jar \
--conf spark.security.credentials.hive.enabled=true
```





### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

`spark-sql` and `spark-shell` cannot access iceberg table with HiveCatalog because there is no HIVE_DELEGATION_TOKEN.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

If there is a user who specify `--conf spark.security.credentials.hive.enabled=true`, spark will get HIVE_DELEGATION_TOKEN even though deploy mode is not "cluster".


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Manually tested on on-premise internal cluster with Hadoop 3.3.4, Iceberg 1.4.3, and Spark 3.2.3.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.