### PR TITLE
[SPARK-42929][CONNECT][PYTHON][TEST] test barrier mode for mapInPandas/mapInArrow

### DIFF
--- a/python/pyspark/sql/tests/pandas/test_pandas_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_map.py
@@ -401,6 +401,31 @@ class MapInPandasTestsMixin:
         finally:
             shutil.rmtree(path)
 
+    def test_map_in_pandas_with_barrier_mode(self):
+        df = self.spark.range(10)
+
+        def func1(iterator):
+            from pyspark import TaskContext, BarrierTaskContext
+
+            tc = TaskContext.get()
+            assert tc is not None
+            assert not isinstance(tc, BarrierTaskContext)
+            for batch in iterator:
+                yield batch
+
+        df.mapInPandas(func1, "id long", False).collect()
+
+        def func2(iterator):
+            from pyspark import TaskContext, BarrierTaskContext
+
+            tc = TaskContext.get()
+            assert tc is not None
+            assert isinstance(tc, BarrierTaskContext)
+            for batch in iterator:
+                yield batch
+
+        df.mapInPandas(func2, "id long", True).collect()
+
 
 class MapInPandasTests(ReusedSQLTestCase, MapInPandasTestsMixin):
     @classmethod


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add barrier mode tests for mapInPandas and mapInArrow.

### Why are the changes needed?

This is the follow-up of https://github.com/apache/spark/pull/40559

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

The newly added tests can pass the CIs


### Was this patch authored or co-authored using generative AI tooling?
No
