### PR TITLE
[SPARK-41392][BUILD][TESTS] Add `bouncy-castle` test dependencies to `sql/core` module for Hadoop 3.4.0

### DIFF
--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -223,6 +223,18 @@
       <artifactId>htmlunit3-driver</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Explicit declaration of bouncy-castle dependencies are
+         needed for maven test builds on later hadoop releases.-->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>


### PR DESCRIPTION



### What changes were proposed in this pull request?

Adds bouncy-castle jdk18 artifacts to test builds in spark-sql.

Based on #38974
* only applies the test import changes
* dependencies are those of #44359

### Why are the changes needed?

Forthcoming Hadoop 3.4.0 release doesn't export the bouncy-castle
JARs; maven builds fail.

### Does this PR introduce _any_ user-facing change?

No: test time dependency declarations only.

### How was this patch tested?

This was done through the release build/test project
https://github.com/apache/hadoop-release-support

1. Latest RC2 artifacts pulled from apache maven staging
2. Spark maven build triggered with the hadoop-version passed down.
3. The 3.3.6 release template worked with spark master (as it should!)
4. With this change the 3.4.0 RC build worked with this change

Note: have not *yet* done a maven test run through this yet

### Was this patch authored or co-authored using generative AI tooling?

No
