### PR TITLE
[MINOR][DOCS] Remove extraneous whitespace from SQL tuning page

### DIFF
--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -176,48 +176,33 @@ Note that there is no guarantee that Spark will choose the join strategy specifi
 a specific strategy may not support all join types.
 
 <div class="codetabs">
-
-<div data-lang="python"  markdown="1">
-
-{% highlight python %}
+<div data-lang="python" markdown="1">
+```python
 spark.table("src").join(spark.table("records").hint("broadcast"), "key").show()
-{% endhighlight %}
-
+```
 </div>
-
-<div data-lang="scala"  markdown="1">
-
-{% highlight scala %}
+<div data-lang="scala" markdown="1">
+```scala
 spark.table("src").join(spark.table("records").hint("broadcast"), "key").show()
-{% endhighlight %}
-
+```
 </div>
-
-<div data-lang="java"  markdown="1">
-
-{% highlight java %}
+<div data-lang="java" markdown="1">
+```java
 spark.table("src").join(spark.table("records").hint("broadcast"), "key").show();
-{% endhighlight %}
-
+```
 </div>
-
-<div data-lang="r"  markdown="1">
-
-{% highlight r %}
+<div data-lang="r" markdown="1">
+```r
 src <- sql("SELECT * FROM src")
 records <- sql("SELECT * FROM records")
 head(join(src, hint(records, "broadcast"), src$key == records$key))
-{% endhighlight %}
-
+```
 </div>
-
-<div data-lang="SQL"  markdown="1">
-
-{% highlight sql %}
+<div data-lang="SQL" markdown="1">
+```sql
 -- We accept BROADCAST, BROADCASTJOIN and MAPJOIN for broadcast hint
 SELECT /*+ BROADCAST(r) */ * FROM records r JOIN src s ON r.key = s.key
-{% endhighlight %}
-
+```
 </div>
 </div>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Remove extraneous whitespace.
- Change Liquid formatting block into "normal" Markdown code block.

### Why are the changes needed?

Minor documentation cleanup.

### Does this PR introduce _any_ user-facing change?

No. Here is the rendered output, which is unchanged.

<img width="500" alt="Screenshot 2024-02-28 at 2 12 25 PM" src="https://github.com/apache/spark/assets/1039369/ae6fcc1c-b0fe-496b-87d0-a6c44c597c0e">


### How was this patch tested?

I built and reviewed the docs locally.

### Was this patch authored or co-authored using generative AI tooling?

No.