### PR TITLE
[SPARK-47214][Python] Create UDTF API for 'analyze' method to differentiate constant NULL arguments and other types of arguments

### DIFF
--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -1247,6 +1247,7 @@ class BaseUDTFTestsMixin:
                 assert isinstance(a.dataType, DataType)
                 assert a.value is not None
                 assert a.isTable is False
+                assert a.isConstantExpression is True
                 return AnalyzeResult(StructType().add("a", a.dataType))
 
             def eval(self, a):
@@ -1400,6 +1401,7 @@ class BaseUDTFTestsMixin:
                 assert isinstance(a.dataType, StructType)
                 assert a.value is None
                 assert a.isTable is True
+                assert a.isConstantExpression is False
                 return AnalyzeResult(StructType().add("a", a.dataType[0].dataType))
 
             def eval(self, a: Row):
@@ -1419,6 +1421,7 @@ class BaseUDTFTestsMixin:
             def analyze(a: AnalyzeArgument) -> AnalyzeResult:
                 assert isinstance(a.dataType, StructType)
                 assert a.isTable is True
+                assert a.isConstantExpression is False
                 return AnalyzeResult(a.dataType.add("is_even", BooleanType()))
 
             def eval(self, a: Row):
@@ -1957,7 +1960,8 @@ class BaseUDTFTestsMixin:
             def analyze(**kwargs: AnalyzeArgument) -> AnalyzeResult:
                 assert isinstance(kwargs["a"].dataType, IntegerType)
                 assert kwargs["a"].value == 10
-                assert not kwargs["a"].isTable
+                assert kwargs["a"].isTable is False
+                assert kwargs["a"].isConstantExpression is True
                 assert isinstance(kwargs["b"].dataType, StringType)
                 assert kwargs["b"].value == "x"
                 assert not kwargs["b"].isTable
@@ -2019,6 +2023,7 @@ class BaseUDTFTestsMixin:
                 assert isinstance(a.dataType, IntegerType)
                 assert a.value == 10
                 assert not a.isTable
+                assert a.isConstantExpression is True
                 if b is not None:
                     assert isinstance(b.dataType, StringType)
                     assert b.value == "z"

--- a/python/pyspark/sql/udtf.py
+++ b/python/pyspark/sql/udtf.py
@@ -62,11 +62,18 @@ class AnalyzeArgument:
         The calculated value if the argument is foldable; otherwise None
     isTable : bool
         If True, the argument is a table argument.
+    isConstantExpression : bool
+        If True, the argument is a constant-foldable scalar expression. Then the 'value' field
+        contains None if the argument is a NULL literal, or a non-None value if the argument is a
+        non-NULL literal. In this way, we can distinguish between a literal NULL argument and other
+        types of arguments such as complex expression trees or table arguments where the 'value'
+        field is always None.
     """
 
     dataType: DataType
     value: Optional[Any]
     isTable: bool
+    isConstantExpression: bool
 
 
 @dataclass(frozen=True)

--- a/python/pyspark/sql/worker/analyze_udtf.py
+++ b/python/pyspark/sql/worker/analyze_udtf.py
@@ -87,7 +87,8 @@ def read_arguments(infile: IO) -> Tuple[List[AnalyzeArgument], Dict[str, Analyze
             value = None
         is_table = read_bool(infile)
         argument = AnalyzeArgument(
-            dataType=dt, value=value, isTable=is_table, isConstantExpression=is_constant_expression)
+            dataType=dt, value=value, isTable=is_table, isConstantExpression=is_constant_expression
+        )
 
         is_named_arg = read_bool(infile)
         if is_named_arg:

--- a/python/pyspark/sql/worker/analyze_udtf.py
+++ b/python/pyspark/sql/worker/analyze_udtf.py
@@ -78,14 +78,14 @@ def read_arguments(infile: IO) -> Tuple[List[AnalyzeArgument], Dict[str, Analyze
     kwargs: Dict[str, AnalyzeArgument] = {}
     for _ in range(num_args):
         dt = _parse_datatype_json_string(utf8_deserializer.loads(infile))
-        if read_bool(infile):  # is foldable
+        is_constant_expression = read_bool(infile)
+        if is_constant_expression:
             value = pickleSer._read_with_length(infile)
             if dt.needConversion():
                 value = dt.fromInternal(value)
         else:
             value = None
         is_table = read_bool(infile)
-        is_constant_expression = read_bool(infile)
         argument = AnalyzeArgument(
             dataType=dt, value=value, isTable=is_table, isConstantExpression=is_constant_expression)
 

--- a/python/pyspark/sql/worker/analyze_udtf.py
+++ b/python/pyspark/sql/worker/analyze_udtf.py
@@ -84,8 +84,10 @@ def read_arguments(infile: IO) -> Tuple[List[AnalyzeArgument], Dict[str, Analyze
                 value = dt.fromInternal(value)
         else:
             value = None
-        is_table = read_bool(infile)  # is table argument
-        argument = AnalyzeArgument(dataType=dt, value=value, isTable=is_table)
+        is_table = read_bool(infile)
+        is_constant_expression = read_bool(infile)
+        argument = AnalyzeArgument(
+            dataType=dt, value=value, isTable=is_table, isConstantExpression=is_constant_expression)
 
         is_named_arg = read_bool(infile)
         if is_named_arg:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/FunctionTableSubqueryArgumentExpression.scala
@@ -166,9 +166,7 @@ case class FunctionTableSubqueryArgumentExpression(
     val extraPartitionByExpressionsToIndexes: Map[Expression, Int] =
       extraProjectedPartitioningExpressions.map(_.child).zipWithIndex.toMap
     partitionByExpressions.map { e =>
-      subqueryOutputs.get(e).getOrElse {
-        extraPartitionByExpressionsToIndexes.get(e).get + plan.output.length
-      }
+      subqueryOutputs.getOrElse(e, extraPartitionByExpressionsToIndexes(e) + plan.output.length)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
@@ -207,7 +207,7 @@ class UserDefinedPythonTableFunctionAnalyzeRunner(
         case NamedArgumentExpression(k, v) => (Some(k), v)
         case _ => (None, expr)
       }
-      // Write the 'value' field to provide the argument's value if it is a foldable scalar\
+      // Write the 'value' field to provide the argument's value if it is a foldable scalar
       // expression.
       if (value.foldable) {
         dataOut.writeBoolean(true)
@@ -218,11 +218,6 @@ class UserDefinedPythonTableFunctionAnalyzeRunner(
       }
       // Write the 'isTable' field to indicate whether the argument is a table.
       dataOut.writeBoolean(isTable)
-      // Write the 'isConstantExpression' field to indicate whether the argument is a foldable
-      // scalar expression. In this way, the UDTF can distinguish between a literal NULL argument
-      // and other types of arguments such as complex expression trees or table arguments where the
-      // 'value' field is always None.
-      dataOut.writeBoolean(value.foldable)
       // If the expr is NamedArgumentExpression, send its name.
       key match {
         case Some(key) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
@@ -207,6 +207,8 @@ class UserDefinedPythonTableFunctionAnalyzeRunner(
         case NamedArgumentExpression(k, v) => (Some(k), v)
         case _ => (None, expr)
       }
+      // Write the 'value' field to provide the argument's value if it is a foldable scalar\
+      // expression.
       if (value.foldable) {
         dataOut.writeBoolean(true)
         val obj = pickler.dumps(EvaluatePython.toJava(value.eval(), value.dataType))
@@ -214,7 +216,13 @@ class UserDefinedPythonTableFunctionAnalyzeRunner(
       } else {
         dataOut.writeBoolean(false)
       }
+      // Write the 'isTable' field to indicate whether the argument is a table.
       dataOut.writeBoolean(isTable)
+      // Write the 'isConstantExpression' field to indicate whether the argument is a foldable
+      // scalar expression. In this way, the UDTF can distinguish between a literal NULL argument
+      // and other types of arguments such as complex expression trees or table arguments where the
+      // 'value' field is always None.
+      dataOut.writeBoolean(value.foldable)
       // If the expr is NamedArgumentExpression, send its name.
       key match {
         case Some(key) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
@@ -207,8 +207,6 @@ class UserDefinedPythonTableFunctionAnalyzeRunner(
         case NamedArgumentExpression(k, v) => (Some(k), v)
         case _ => (None, expr)
       }
-      // Write the 'value' field to provide the argument's value if it is a foldable scalar
-      // expression.
       if (value.foldable) {
         dataOut.writeBoolean(true)
         val obj = pickler.dumps(EvaluatePython.toJava(value.eval(), value.dataType))
@@ -216,7 +214,6 @@ class UserDefinedPythonTableFunctionAnalyzeRunner(
       } else {
         dataOut.writeBoolean(false)
       }
-      // Write the 'isTable' field to indicate whether the argument is a table.
       dataOut.writeBoolean(isTable)
       // If the expr is NamedArgumentExpression, send its name.
       key match {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR creates a Python UDTF API for 'analyze' method to differentiate constant NULL arguments and other types of arguments.

### Why are the changes needed?

Before this PR, each `AnalyzeArgument` had a `value` field which was non-None if the argument was a constant-foldable scalar expression:

```
@dataclass(frozen=True)
class AnalyzeArgument:
    """
    The argument for Python UDTF's analyze static method.

    Parameters
    ----------
    dataType : :class:`DataType`
        The argument's data type
    value : any, optional
        The calculated value if the argument is foldable; otherwise None
    isTable : bool
        If True, the argument is a table argument.
    """

    dataType: DataType
    value: Optional[Any]
    isTable: bool
```

However, it was also `None` if the argument is literal NULL! This is a challenge for UDTF authors who want to tell exactly which scalar arguments were literal NULL.

Now we add a new field to tell the difference:

```
isConstantExpression : bool
    If True, the argument is a constant-foldable scalar expression. Then the 'value' field
    contains None if the argument is a NULL literal, or a non-None value if the argument is a
    non-NULL literal. In this way, we can distinguish between a literal NULL argument and other
    types of arguments such as complex expression trees or table arguments where the 'value'
    field is always None.
```

### Does this PR introduce _any_ user-facing change?

Yes, see above.

### How was this patch tested?

This PR applies test coverage.

### Was this patch authored or co-authored using generative AI tooling?

No.