### PR TITLE
[SPARK-47216][DOCS] Refine layout of SQL performance tuning page

### DIFF
--- a/docs/_data/menu-sql.yaml
+++ b/docs/_data/menu-sql.yaml
@@ -53,14 +53,12 @@
 - text: Performance Tuning
   url: sql-performance-tuning.html
   subitems:
-    - text: Caching Data In Memory
-      url: sql-performance-tuning.html#caching-data-in-memory
-    - text: Other Configuration Options
-      url: sql-performance-tuning.html#other-configuration-options
-    - text: Join Strategy Hints for SQL Queries
-      url: sql-performance-tuning.html#join-strategy-hints-for-sql-queries
-    - text: Coalesce Hints for SQL Queries
-      url: sql-performance-tuning.html#coalesce-hints-for-sql-queries
+    - text: Caching Data
+      url: sql-performance-tuning.html#caching-data
+    - text: Tuning Partitions
+      url: sql-performance-tuning.html#tuning-partitions
+    - text: Optimizing the Join Strategy
+      url: sql-performance-tuning.html#optimizing-the-join-strategy
     - text: Adaptive Query Execution
       url: sql-performance-tuning.html#adaptive-query-execution
 - text: Distributed SQL Engine

--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -19,13 +19,12 @@ license: |
   limitations under the License.
 ---
 
+Spark offers many techniques for tuning the performance of DataFrame or SQL workloads. Those techniques, broadly speaking, include caching data, altering how datasets are partitioned, selecting the optimal join strategy, and providing the optimizer with additional information it can use to build more efficient execution plans.
+
 * Table of contents
 {:toc}
 
-For some workloads, it is possible to improve performance by either caching data in memory, or by
-turning on some experimental options.
-
-## Caching Data In Memory
+## Caching Data
 
 Spark SQL can cache tables using an in-memory columnar format by calling `spark.catalog.cacheTable("tableName")` or `dataFrame.cache()`.
 Then Spark SQL will scan only required columns and will automatically tune compression to minimize
@@ -54,13 +53,9 @@ Configuration of in-memory caching can be done via `spark.conf.set` or by runnin
   </td>
   <td>1.1.1</td>
 </tr>
-
 </table>
 
-## Other Configuration Options
-
-The following options can also be used to tune the performance of query execution. It is possible
-that these options will be deprecated in future release as more optimizations are performed automatically.
+## Tuning Partitions
 
 <table class="spark-config">
   <thead><tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr></thead>
@@ -107,27 +102,6 @@ that these options will be deprecated in future release as more optimizations ar
     <td>3.5.0</td>
   </tr>
   <tr>
-    <td><code>spark.sql.broadcastTimeout</code></td>
-    <td>300</td>
-    <td>
-      <p>
-        Timeout in seconds for the broadcast wait time in broadcast joins
-      </p>
-    </td>
-    <td>1.3.0</td>
-  </tr>
-  <tr>
-    <td><code>spark.sql.autoBroadcastJoinThreshold</code></td>
-    <td>10485760 (10 MB)</td>
-    <td>
-      Configures the maximum size in bytes for a table that will be broadcast to all worker nodes when
-      performing a join. By setting this value to -1, broadcasting can be disabled. Note that currently
-      statistics are only supported for Hive Metastore tables where the command
-      <code>ANALYZE TABLE &lt;tableName&gt; COMPUTE STATISTICS noscan</code> has been run.
-    </td>
-    <td>1.1.0</td>
-  </tr>
-  <tr>
     <td><code>spark.sql.shuffle.partitions</code></td>
     <td>200</td>
     <td>
@@ -158,7 +132,61 @@ that these options will be deprecated in future release as more optimizations ar
   </tr>
 </table>
 
-## Join Strategy Hints for SQL Queries
+### Coalesce Hints
+
+Coalesce hints allow Spark SQL users to control the number of output files just like
+`coalesce`, `repartition` and `repartitionByRange` in the Dataset API, they can be used for performance
+tuning and reducing the number of output files. The "COALESCE" hint only has a partition number as a
+parameter. The "REPARTITION" hint has a partition number, columns, or both/neither of them as parameters.
+The "REPARTITION_BY_RANGE" hint must have column names and a partition number is optional. The "REBALANCE"
+hint has an initial partition number, columns, or both/neither of them as parameters.
+
+```sql
+SELECT /*+ COALESCE(3) */ * FROM t;
+SELECT /*+ REPARTITION(3) */ * FROM t;
+SELECT /*+ REPARTITION(c) */ * FROM t;
+SELECT /*+ REPARTITION(3, c) */ * FROM t;
+SELECT /*+ REPARTITION */ * FROM t;
+SELECT /*+ REPARTITION_BY_RANGE(c) */ * FROM t;
+SELECT /*+ REPARTITION_BY_RANGE(3, c) */ * FROM t;
+SELECT /*+ REBALANCE */ * FROM t;
+SELECT /*+ REBALANCE(3) */ * FROM t;
+SELECT /*+ REBALANCE(c) */ * FROM t;
+SELECT /*+ REBALANCE(3, c) */ * FROM t;
+```
+
+For more details please refer to the documentation of [Partitioning Hints](sql-ref-syntax-qry-select-hints.html#partitioning-hints).
+
+## Optimizing the Join Strategy
+
+### Automatically Broadcasting Joins
+
+<table class="spark-config">
+  <thead><tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr></thead>
+  <tr>
+    <td><code>spark.sql.autoBroadcastJoinThreshold</code></td>
+    <td>10485760 (10 MB)</td>
+    <td>
+      Configures the maximum size in bytes for a table that will be broadcast to all worker nodes when
+      performing a join. By setting this value to -1, broadcasting can be disabled. Note that currently
+      statistics are only supported for Hive Metastore tables where the command
+      <code>ANALYZE TABLE &lt;tableName&gt; COMPUTE STATISTICS noscan</code> has been run.
+    </td>
+    <td>1.1.0</td>
+  </tr>
+  <tr>
+    <td><code>spark.sql.broadcastTimeout</code></td>
+    <td>300</td>
+    <td>
+      <p>
+        Timeout in seconds for the broadcast wait time in broadcast joins
+      </p>
+    </td>
+    <td>1.3.0</td>
+  </tr>
+</table>
+
+### Join Strategy Hints
 
 The join strategy hints, namely `BROADCAST`, `MERGE`, `SHUFFLE_HASH` and `SHUFFLE_REPLICATE_NL`,
 instruct Spark to use the hinted strategy on each specified relation when joining them with another
@@ -223,33 +251,20 @@ SELECT /*+ BROADCAST(r) */ * FROM records r JOIN src s ON r.key = s.key
 
 For more details please refer to the documentation of [Join Hints](sql-ref-syntax-qry-select-hints.html#join-hints).
 
-## Coalesce Hints for SQL Queries
-
-Coalesce hints allow Spark SQL users to control the number of output files just like
-`coalesce`, `repartition` and `repartitionByRange` in the Dataset API, they can be used for performance
-tuning and reducing the number of output files. The "COALESCE" hint only has a partition number as a
-parameter. The "REPARTITION" hint has a partition number, columns, or both/neither of them as parameters.
-The "REPARTITION_BY_RANGE" hint must have column names and a partition number is optional. The "REBALANCE"
-hint has an initial partition number, columns, or both/neither of them as parameters.
-
-```sql
-SELECT /*+ COALESCE(3) */ * FROM t;
-SELECT /*+ REPARTITION(3) */ * FROM t;
-SELECT /*+ REPARTITION(c) */ * FROM t;
-SELECT /*+ REPARTITION(3, c) */ * FROM t;
-SELECT /*+ REPARTITION */ * FROM t;
-SELECT /*+ REPARTITION_BY_RANGE(c) */ * FROM t;
-SELECT /*+ REPARTITION_BY_RANGE(3, c) */ * FROM t;
-SELECT /*+ REBALANCE */ * FROM t;
-SELECT /*+ REBALANCE(3) */ * FROM t;
-SELECT /*+ REBALANCE(c) */ * FROM t;
-SELECT /*+ REBALANCE(3, c) */ * FROM t;
-```
-
-For more details please refer to the documentation of [Partitioning Hints](sql-ref-syntax-qry-select-hints.html#partitioning-hints).
-
 ## Adaptive Query Execution
-Adaptive Query Execution (AQE) is an optimization technique in Spark SQL that makes use of the runtime statistics to choose the most efficient query execution plan, which is enabled by default since Apache Spark 3.2.0. Spark SQL can turn on and off AQE by `spark.sql.adaptive.enabled` as an umbrella configuration. As of Spark 3.0, there are three major features in AQE: including coalescing post-shuffle partitions, converting sort-merge join to broadcast join, and skew join optimization.
+Adaptive Query Execution (AQE) is an optimization technique in Spark SQL that makes use of the runtime statistics to choose the most efficient query execution plan, which is enabled by default since Apache Spark 3.2.0. Spark SQL can turn on and off AQE by `spark.sql.adaptive.enabled` as an umbrella configuration.
+
+ <table class="spark-config">
+   <thead><tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr></thead>
+   <tr>
+     <td><code>spark.sql.adaptive.enabled</code></td>
+     <td>true</td>
+     <td>
+     When true, enable adaptive query execution, which re-optimizes the query plan in the middle of query execution, based on accurate runtime statistics.
+     </td>
+     <td>1.6.0</td>
+   </tr>
+</table>
 
 ### Coalescing Post Shuffle Partitions
 This feature coalesces the post shuffle partitions based on the map output statistics when both `spark.sql.adaptive.enabled` and `spark.sql.adaptive.coalescePartitions.enabled` configurations are true. This feature simplifies the tuning of shuffle partition number when running queries. You do not need to set a proper shuffle partition number to fit your dataset. Spark can pick the proper shuffle partition number at runtime once you set a large enough initial number of shuffle partitions via `spark.sql.adaptive.coalescePartitions.initialPartitionNum` configuration.
@@ -319,7 +334,8 @@ This feature coalesces the post shuffle partitions based on the map output stati
  </table>
 
 ### Converting sort-merge join to broadcast join
-AQE converts sort-merge join to broadcast hash join when the runtime statistics of any join side is smaller than the adaptive broadcast hash join threshold. This is not as efficient as planning a broadcast hash join in the first place, but it's better than keep doing the sort-merge join, as we can save the sorting of both the join sides, and read shuffle files locally to save network traffic(if `spark.sql.adaptive.localShuffleReader.enabled` is true)
+AQE converts sort-merge join to broadcast hash join when the runtime statistics of any join side are smaller than the adaptive broadcast hash join threshold. This is not as efficient as planning a broadcast hash join in the first place, but it's better than continuing the sort-merge join, as we can avoid sorting both join sides and read shuffle files locally to save network traffic (provided `spark.sql.adaptive.localShuffleReader.enabled` is true).
+
   <table class="spark-config">
      <thead><tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr></thead>
      <tr>
@@ -341,7 +357,8 @@ AQE converts sort-merge join to broadcast hash join when the runtime statistics 
   </table>
 
 ### Converting sort-merge join to shuffled hash join
-AQE converts sort-merge join to shuffled hash join when all post shuffle partitions are smaller than a threshold, the max threshold can see the config `spark.sql.adaptive.maxShuffledHashJoinLocalMapThreshold`.
+AQE converts sort-merge join to shuffled hash join when all post shuffle partitions are smaller than the threshold configured in `spark.sql.adaptive.maxShuffledHashJoinLocalMapThreshold`.
+
   <table class="spark-config">
      <thead><tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr></thead>
      <tr>
@@ -392,7 +409,10 @@ Data skew can severely downgrade the performance of join queries. This feature d
      </tr>
    </table>
 
-### Misc
+### Advanced Customization
+
+You can control the details of how AQE works by providing your own cost evaluator class or by excluding AQE optimizer rules.
+
   <table class="spark-config">
     <thead><tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr></thead>
     <tr>


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Add a new introduction.
- Rename some section headings.
- Group the paragraphs on query hints with related tuning techniques.
- Minor grammar fixes in some places.

### Why are the changes needed?

These changes organize the various tuning techniques a bit better than before so they are easier to map out mentally. This will also make it easier to make future improvements to this page (which I intend to do in follow-up PRs).

### Does this PR introduce _any_ user-facing change?

Yes.

Master is on the left; this branch is on the right. Here is how the first page changed:

<img width="1470" alt="Screenshot 2024-02-28 at 6 16 36 PM" src="https://github.com/apache/spark/assets/1039369/6450525b-69e7-4dce-936f-78c61baaabc1">

The table of contents gives a quick view of the changes.

If you'd like to see more, here are full screenshots of the whole page:
- [sql-tuning-performance-master](https://github.com/apache/spark/assets/1039369/822476d7-c2f7-4546-98bd-28a50fc54de6)
- [sql-tuning-performance-branch](https://github.com/apache/spark/assets/1039369/412b1697-f64f-4360-9381-cf21390cb958)

### How was this patch tested?

Built the docs and reviewed them locally.

### Was this patch authored or co-authored using generative AI tooling?

No.