### PR TITLE
[SPARK-47202][PYTHON][TESTS][FOLLOW-UP] Run the test only with Python 3.9+

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_arrow.py
+++ b/python/pyspark/sql/tests/connect/test_parity_arrow.py
@@ -16,6 +16,7 @@
 #
 
 import unittest
+import sys
 
 from pyspark.sql.tests.test_arrow import ArrowTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
@@ -129,6 +130,7 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase, PandasOnSparkTest
     def test_toPandas_nested_timestamp(self):
         self.check_toPandas_nested_timestamp(True)
 
+    @unittest.skipIf(sys.version_info < (3, 9), "zoneinfo is available from Python 3.9+")
     def test_toPandas_timestmap_tzinfo(self):
         self.check_toPandas_timestmap_tzinfo(True)
 

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -23,7 +23,7 @@ import time
 import unittest
 from typing import cast
 from collections import namedtuple
-from zoneinfo import ZoneInfo
+import sys
 
 from pyspark import SparkContext, SparkConf
 from pyspark.sql import Row, SparkSession
@@ -998,6 +998,7 @@ class ArrowTestsMixin:
 
         self.assertEqual(df.first(), expected)
 
+    @unittest.skipIf(sys.version_info < (3, 9), "zoneinfo is available from Python 3.9+")
     def test_toPandas_timestmap_tzinfo(self):
         for arrow_enabled in [True, False]:
             with self.subTest(arrow_enabled=arrow_enabled):
@@ -1005,6 +1006,8 @@ class ArrowTestsMixin:
 
     def check_toPandas_timestmap_tzinfo(self, arrow_enabled):
         # SPARK-47202: Test timestamp with tzinfo in toPandas and createDataFrame
+        from zoneinfo import ZoneInfo
+
         ts_tzinfo = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=ZoneInfo("America/Los_Angeles"))
         data = pd.DataFrame({"a": [ts_tzinfo]})
         df = self.spark.createDataFrame(data)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to run the tzinfo test only with Python 3.9+. This is a followup of https://github.com/apache/spark/pull/45308.

### Why are the changes needed?

To make the Python build passing with Python 3.8. It fails as below:

```python
Starting test(pypy3): pyspark.sql.tests.test_arrow (temp output: /__w/spark/spark/python/target/605c2e61-b7c8-4898-ac7b-1d86f495bd4f/pypy3__pyspark.sql.tests.test_arrow__qrwyvw4l.log)
Traceback (most recent call last):
  File "/usr/local/pypy/pypy3.8/lib/pypy3.8/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/pypy/pypy3.8/lib/pypy3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/__w/spark/spark/python/pyspark/sql/tests/test_arrow.py", line 26, in <module>
    from zoneinfo import ZoneInfo
ModuleNotFoundError: No module named 'zoneinfo'
```

https://github.com/apache/spark/actions/runs/8082492167/job/22083534905

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

CI in this PR should test it out.

### Was this patch authored or co-authored using generative AI tooling?

No,
