### PR TITLE
[SPARK-47218][SQL] XML: Ignore commented row tags in XML tokenizer

### DIFF
--- a/sql/core/src/test/resources/test-data/xml-resources/commented-row.xml
+++ b/sql/core/src/test/resources/test-data/xml-resources/commented-row.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!-- Should read 1 to 8 without any 0s -->
+<ROWSET>
+    <ROW><a>1</a></ROW>
+    <!-- <ROW><a>0</a></ROW>-->
+    <ROW><a>2</a></ROW>
+    <!-- <ROW><a>0</a></ROW>-->
+    <ROW>
+        <!-- Just another comment -->
+        <a> <!-- before a value --> 3 <!-- after a value --></a>
+        <!-- <ROW>
+             <a>3</a>
+            </ROW> -->
+    </ROW>
+    <!-- --><ROW><!----><!----><a><!---->4<!----></a><!----></ROW><!-- -->
+    <!-- --> <!----><ROW><a>5</a></ROW><!--<ROW><a>0</a></ROW>--><ROW><a>6</a></ROW>
+    <ROW><a>7</a></ROW>
+    <!-- <ROW><a>0</a></ROW>-->
+    <ROW> <!-- 0 </ROW> --> <!-- --> <a> 8 </a> </ROW>
+    <ROW><a>9</a></ROW>
+    <NOTROW><!----></NOTROW>
+    <!----><!----><NOTROW><!----><!----></NOTROW><!----><!---->
+    <ROW><a>10</a></ROW>
+</ROWSET>

--- a/sql/core/src/test/resources/test-data/xml-resources/commented-row.xml
+++ b/sql/core/src/test/resources/test-data/xml-resources/commented-row.xml
@@ -21,4 +21,5 @@
     <NOTROW><!----></NOTROW>
     <!----><!----><NOTROW><!----><!----></NOTROW><!----><!---->
     <ROW><a>10</a></ROW>
+    <!-- <ROW><a>0</a></ROW>
 </ROWSET>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
@@ -2540,6 +2540,16 @@ class XmlSuite
     checkAnswer(df, Seq(Row(Row(Array(1, 2, 3), Array(1, 2)))))
   }
 
+  test("ignore commented row tags") {
+    val results = spark.read.format("xml")
+      .option("rowTag", "ROW")
+      .option("multiLine", "true")
+      .load(getTestResourcePath(resDir + "commented-row.xml"))
+
+    val expectedResults = Seq.range(1, 11).map(Row(_))
+    checkAnswer(results, expectedResults)
+  }
+
   test("capture values interspersed between elements - nested struct") {
     val xmlString =
       s"""


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
<!--
Please fill in changes proposed in this fix.
-->
Added some logic to handle comments in XMLTokenizer. Comments are ignored anytime they appear. Anything enclosed in a leftmost `<!--` and leftmost `-->` will be ignored. 

Does not handle nested comments:
`<!-- <!-- --> -->` will leave the last `-->` dangling. 

Does not handle comments *within* row tags
- `<ROW<!-- -->> ...` will fail
- `<ROW id="1" <!-- comment -->> ...` will fail

These two cases are not considered valid XML according to the official spec (no nested comments, no comments within tags)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is a bug which results in incorrect data being parsed. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit test covering different cases of where comments may be placed relative to row tags. 


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No