### PR TITLE
[SPARK-47146][CORE] Possible thread leak when doing sort merge join

### DIFF
--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java
@@ -85,13 +85,15 @@ public final class UnsafeSorterSpillReader extends UnsafeSorterIterator implemen
       Closeables.close(bs, /* swallowIOException = */ true);
       throw e;
     }
-    taskContext.addTaskCompletionListener(context -> {
-      try {
-        close();
-      } catch (IOException e) {
-        logger.info("error while closing UnsafeSorterSpillReader", e);
-      }
-    });
+    if (taskContext != null) {
+      taskContext.addTaskCompletionListener(context -> {
+        try {
+          close();
+        } catch (IOException e) {
+          logger.info("error while closing UnsafeSorterSpillReader", e);
+        }
+      });
+    }
   }
 
   @Override

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java
@@ -89,8 +89,7 @@ public final class UnsafeSorterSpillReader extends UnsafeSorterIterator implemen
       try {
         close();
       } catch (IOException e) {
-        logger.error("error while closing UnsafeSorterSpillReader", e);
-        throw new RuntimeException(e);
+        logger.info("error while closing UnsafeSorterSpillReader", e);
       }
     });
   }

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java
@@ -28,6 +28,8 @@ import org.apache.spark.io.ReadAheadInputStream;
 import org.apache.spark.serializer.SerializerManager;
 import org.apache.spark.storage.BlockId;
 import org.apache.spark.unsafe.Platform;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 
@@ -36,6 +38,7 @@ import java.io.*;
  * of the file format).
  */
 public final class UnsafeSorterSpillReader extends UnsafeSorterIterator implements Closeable {
+  private static final Logger logger = LoggerFactory.getLogger(ReadAheadInputStream.class);
   public static final int MAX_BUFFER_SIZE_BYTES = 16777216; // 16 mb
 
   private InputStream in;
@@ -82,6 +85,14 @@ public final class UnsafeSorterSpillReader extends UnsafeSorterIterator implemen
       Closeables.close(bs, /* swallowIOException = */ true);
       throw e;
     }
+    taskContext.addTaskCompletionListener(context -> {
+      try {
+        close();
+      } catch (IOException e) {
+        logger.error("error while closing UnsafeSorterSpillReader", e);
+        throw new RuntimeException(e);
+      }
+    });
   }
 
   @Override

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -1758,7 +1758,6 @@ class ThreadLeakInSortMergeJoinSuite
 
       assertSpilled(sparkContext, "inner join") {
         sql("SELECT * FROM testData JOIN testData2 ON key = a").collect()
-        System.gc()
       }
 
       val readAheadThread = Thread.getAllStackTraces.keySet().asScala

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -23,6 +23,7 @@ import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.TestUtils.{assertNotSpilled, assertSpilled}
+import org.apache.spark.internal.config.SHUFFLE_SPILL_NUM_ELEMENTS_FORCE_SPILL_THRESHOLD
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.expressions.{Ascending, GenericRow, SortOrder}
@@ -34,7 +35,7 @@ import org.apache.spark.sql.execution.exchange.{ShuffleExchangeExec, ShuffleExch
 import org.apache.spark.sql.execution.joins._
 import org.apache.spark.sql.execution.python.BatchEvalPythonExec
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.sql.test.{SharedSparkSession, TestSparkSession}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.tags.SlowSQLTest
 
@@ -1734,6 +1735,37 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
       }.isEmpty, df.queryExecution)
     } finally {
       cached.unpersist()
+    }
+  }
+}
+
+class ThreadLeakInSortMergeJoinSuite
+  extends QueryTest
+    with SharedSparkSession
+    with AdaptiveSparkPlanHelper {
+
+  setupTestData()
+  override protected def createSparkSession: TestSparkSession = {
+    SparkSession.cleanupAnyExistingSession()
+    new TestSparkSession(
+      sparkConf.set(SHUFFLE_SPILL_NUM_ELEMENTS_FORCE_SPILL_THRESHOLD, 20))
+  }
+
+  test("SPARK-47146: thread leak when doing SortMergeJoin (with spill)") {
+
+    withSQLConf(
+      SQLConf.AUTO_BROADCASTJOIN_THRESHOLD.key -> "1") {
+
+      assertSpilled(sparkContext, "inner join") {
+        sql("SELECT * FROM testData JOIN testData2 ON key = a").collect()
+        System.gc()
+      }
+
+      val readAheadThread = Thread.getAllStackTraces.keySet().asScala
+        .find {
+          _.getName.startsWith("read-ahead")
+        }
+      assert(readAheadThread.isEmpty)
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add TaskCompletionListener to close inputStream to avoid thread leakage caused by unclosed ReadAheadInputStream.


### Why are the changes needed?
SPARK-40849 modified the implementation of `newDaemonSingleThreadExecutor` to use `newFixedThreadPool` instead of `newSingleThreadExecutor` .The difference is that `newSingleThreadExecutor` uses the `FinalizableDelegatedExecutorService`, which provides a `finalize` method that automatically closes the thread pool. In some cases, sort merge join execution uses `ReadAheadSteam` and does not close it, so this change caused a thread leak. Since Finalization is deprecated and subject to removal in a future release, we should close the associated streams instead of relying on the finalize method.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Unit test


### Was this patch authored or co-authored using generative AI tooling?
No
