### PR TITLE
[SPARK-47222][SQL] fileCompressionFactor also applied to the size of the table

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/LogicalRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/LogicalRelation.scala
@@ -42,7 +42,8 @@ case class LogicalRelation(
 
   override def computeStats(): Statistics = {
     catalogTable
-      .flatMap(_.stats.map(_.toPlanStats(output, conf.cboEnabled || conf.planStatsEnabled)))
+      .flatMap(_.stats.map(_.toPlanStats(output, conf.cboEnabled || conf.planStatsEnabled,
+        conf.fileCompressionFactor)))
       .getOrElse(Statistics(sizeInBytes = relation.sizeInBytes))
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes `spark.sql.sources.fileCompressionFactor` also applied to the size of the table.

### Why are the changes needed?

To keep the behavior consistent. For example:
```shell
bin/spark-shell --conf spark.sql.catalogImplementation=in-memory
```
```
scala> spark.range(5).write.parquet("/tmp/spark/parquet")
                                                                                
scala> spark.sql("set spark.sql.sources.fileCompressionFactor=2.0")
res1: org.apache.spark.sql.DataFrame = [key: string, value: string]

scala> spark.sql("create table t(id long) using parquet location '/tmp/spark/parquet'")
res2: org.apache.spark.sql.DataFrame = []

scala> spark.sql("select * from t").explain("cost")
== Optimized Logical Plan ==
Relation spark_catalog.default.t[id#13L] parquet, Statistics(sizeInBytes=5.2 KiB) // The sizeInBytes is location.sizeInBytes * spark.sql.sources.fileCompressionFactor

scala> sql("ANALYZE TABLE t COMPUTE STATISTICS noscan")
res4: org.apache.spark.sql.DataFrame = []

scala> spark.sql("select * from t").explain("cost")
== Optimized Logical Plan ==
Relation spark_catalog.default.t[id#17L] parquet, Statistics(sizeInBytes=2.6 KiB) // The sizeInBytes is table statistics
```

After this PR:
```
scala> spark.sql("select * from t").explain("cost")
== Optimized Logical Plan ==
Relation spark_catalog.default.t[id#17L] parquet, Statistics(sizeInBytes=5.2 KiB) // The sizeInBytes is table statistics * compressionFactor
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.


### Was this patch authored or co-authored using generative AI tooling?

No.
