### PR TITLE
[SPARK-47186][DOCKER][FOLLOWUP] Reduce test time for docker ITs

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
@@ -37,8 +37,8 @@ import org.scalatest.concurrent.{Eventually, PatienceConfiguration}
 import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.util.DockerUtils
-import org.apache.spark.util.Utils.{bytesToString, timeStringAsSeconds}
+import org.apache.spark.util.{DockerUtils, Utils}
+import org.apache.spark.util.Utils.timeStringAsSeconds
 
 abstract class DatabaseOnDocker {
   /**
@@ -154,33 +154,22 @@ abstract class DockerJDBCIntegrationSuite
           val callback = new PullImageResultCallback {
             override def onNext(item: PullResponseItem): Unit = {
               super.onNext(item)
-              if (item.getStatus != null) {
-                item.getStatus match {
-                  case s if item.getProgressDetail != null &&
-                      item.getProgressDetail.getCurrent != null &&
-                      item.getProgressDetail.getCurrent == item.getProgressDetail.getTotal =>
-                    // logging for final progress procedural status
-                    logInfo(s"$s ${item.getId} ${bytesToString(item.getProgressDetail.getTotal)}")
-                  case s if s != "Downloading" && s != "Extracting" =>
-                    logInfo(s"${item.getStatus} ${item.getId}")
-                  case _ =>
-                }
+              val status = item.getStatus
+              if (status != null && status != "Downloading" && status != "Extracting") {
+                logInfo(s"$status ${item.getId}")
               }
-            }
-
-            override def onComplete(): Unit = {
-              pulled = true
-            }
-
-            override def onError(throwable: Throwable): Unit = {
-              logError(s"Failed to pull Docker image ${db.imageName}", throwable)
             }
           }
 
-          docker.pullImageCmd(db.imageName)
-            .exec(callback)
-            .awaitCompletion(imagePullTimeout, TimeUnit.SECONDS)
-          if (!pulled) {
+          val (success, time) = Utils.timeTakenMs(
+            docker.pullImageCmd(db.imageName)
+              .exec(callback)
+              .awaitCompletion(imagePullTimeout, TimeUnit.SECONDS))
+
+          if (success) {
+            pulled = success
+            logInfo(s"Successfully pulled image ${db.imageName} in $time ms")
+          } else {
             throw new TimeoutException(
               s"Timeout('$imagePullTimeout secs') waiting for image ${db.imageName} to be pulled")
           }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This is a follow-up of SPARK-47186, which accidentally increased the test time by about 80 minutes. 

After some investigation, I have found that `PullResponseItem.getProgressDetail` is the root cause.

In this PR, we remove the codes that touch it.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Save CI time from ~120 minutes to ~40 minutes


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
![image](https://github.com/apache/spark/assets/8326978/98f6768b-f8d4-43bf-975b-7ca7f99813da)

![image](https://github.com/apache/spark/assets/8326978/ca221031-5010-4fd9-ae92-a4fd9cfe8a4a)



### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->no
