### PR TITLE
[SPARK-47223][SQL][CORE] Update usage of deprecated Thread.getId() to Thread.threadId()

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala
@@ -167,7 +167,7 @@ private[spark] class SparkHadoopUtil extends Logging {
    */
   private[spark] def getFSBytesReadOnThreadCallback(): () => Long = {
     val f = () => FileSystem.getAllStatistics.asScala.map(_.getThreadStatistics.getBytesRead).sum
-    val baseline = (Thread.currentThread().getId, f())
+    val baseline = (Thread.currentThread().threadId, f())
 
     /**
      * This function may be called in both spawned child threads and parent task thread (in
@@ -180,7 +180,7 @@ private[spark] class SparkHadoopUtil extends Logging {
 
       override def apply(): Long = {
         bytesReadMap.synchronized {
-          bytesReadMap.put(Thread.currentThread().getId, f())
+          bytesReadMap.put(Thread.currentThread().threadId, f())
           bytesReadMap.map { case (k, v) =>
             v - (if (k == baseline._1) baseline._2 else 0)
           }.sum

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -554,7 +554,7 @@ private[spark] class Executor(
       }
 
       setMDCForTask(taskName, mdcProperties)
-      threadId = Thread.currentThread.getId
+      threadId = Thread.currentThread.threadId
       Thread.currentThread.setName(threadName)
       val threadMXBean = ManagementFactory.getThreadMXBean
       val taskMemoryManager = new TaskMemoryManager(env.memoryManager, taskId)

--- a/core/src/main/scala/org/apache/spark/util/collection/Spillable.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/Spillable.scala
@@ -142,7 +142,7 @@ private[spark] abstract class Spillable[C](taskMemoryManager: TaskMemoryManager)
    * @param size number of bytes spilled
    */
   @inline private def logSpillage(size: Long): Unit = {
-    val threadId = Thread.currentThread().getId
+    val threadId = Thread.currentThread().threadId
     logInfo("Thread %d spilling in-memory map of %s to disk (%d time%s so far)"
       .format(threadId, org.apache.spark.util.Utils.bytesToString(size),
         _spillCount, if (_spillCount > 1) "s" else ""))

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -1223,7 +1223,7 @@ class RDDSuite extends SparkFunSuite with SharedSparkContext with Eventually {
       })
       t.setDaemon(false)
       t.start()
-      tid.add(t.getId)
+      tid.add(t.threadId)
       Iterator(0)
     }.collect()
     val tmx = ManagementFactory.getThreadMXBean

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -214,7 +214,7 @@ object SQLConf {
       val isSchedulerEventLoopThread = SparkContext.getActive
         .flatMap { sc => Option(sc.dagScheduler) }
         .map(_.eventProcessLoop.eventThread)
-        .exists(_.getId == Thread.currentThread().getId)
+        .exists(_.threadId == Thread.currentThread().threadId)
       if (isSchedulerEventLoopThread) {
         // DAGScheduler event loop thread does not have an active SparkSession, the `confGetter`
         // will return `fallbackConf` which is unexpected. Here we require the caller to get the

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -717,7 +717,7 @@ class RocksDB(
     def timeWaitedMs = System.currentTimeMillis - waitStartTime
     def isAcquiredByDifferentThread = acquiredThreadInfo != null &&
       acquiredThreadInfo.threadRef.get.isDefined &&
-      newAcquiredThreadInfo.threadRef.get.get.getId != acquiredThreadInfo.threadRef.get.get.getId
+      newAcquiredThreadInfo.threadRef.get.get.threadId != acquiredThreadInfo.threadRef.get.get.threadId
 
     while (isAcquiredByDifferentThread && timeWaitedMs < conf.lockAcquireTimeoutMs) {
       acquireLock.wait(10)
@@ -1113,7 +1113,7 @@ case class AcquiredThreadInfo() {
       s", task: $taskDetails"
     } else ""
 
-    s"[ThreadId: ${threadRef.get.map(_.getId)}$taskStr]"
+    s"[ThreadId: ${threadRef.get.map(_.threadId)}$taskStr]"
   }
 }
 

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/server/ThreadFactoryWithGarbageCleanup.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/server/ThreadFactoryWithGarbageCleanup.java
@@ -53,7 +53,7 @@ public class ThreadFactoryWithGarbageCleanup implements ThreadFactory {
   @Override
   public Thread newThread(Runnable runnable) {
     Thread newThread = new ThreadWithGarbageCleanup(runnable);
-    newThread.setName(namePrefix + ": Thread-" + newThread.getId());
+    newThread.setName(namePrefix + ": Thread-" + newThread.threadId());
     return newThread;
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Switch any usage of [`Thread.getId()`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Thread.html#getId()) to the final method [`Thread.threadId()`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Thread.html#threadId()). 

This is an official Java recommendation after Java 19, as they state for `getId()`:

> This method is not final and may be overridden to return a value that is not the thread ID. Use [threadId()](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Thread.html#threadId()) instead.

More info [here](https://bugs.openjdk.org/browse/JDK-8017617?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel). 

No behavioral changes to Spark expected here as both the old and new methods return the same long value.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Multiple usages of Thread.getId() emitted some warning statements in the build. I decided to just cleanup those warning statements.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
No new tests were added due to only switching done of internal Java method, Java Docs suggest `threadId()` as a replacement for `getId()`, so I believe we can trust it.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
