### PR TITLE
[MINOR][PYTHON][DOCS] Clarify verifySchema at createDataFrame not working with pandas DataFrame with Arrow optimization

### DIFF
--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1325,6 +1325,9 @@ class SparkSession(SparkConversionMixin):
             if ``samplingRatio`` is ``None``.
         verifySchema : bool, optional
             verify data types of every row against schema. Enabled by default.
+            When the input is :class:`pandas.DataFrame` and
+            `spark.sql.execution.arrow.pyspark.enabled` is enabled, this option is not
+            effective. It follows Arrow type coercion.
 
             .. versionadded:: 2.1.0
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to clarify that  `verifySchema` at createDataFrame does not wotj with pandas DataFrame with Arrow optimization enabled.

### Why are the changes needed?

For correct information about `verifySchema` <> Arrow optimization in `createDataFrame`.

### Does this PR introduce _any_ user-facing change?

Yes, it fixes the user-facing documentation.

### How was this patch tested?

I manually ran linters

### Was this patch authored or co-authored using generative AI tooling?

No.