### PR TITLE
[SPARK-47235][CORE][TESTS] Disable `deleteRecursivelyUsingUnixNative` in Apple Silicon test env

### DIFF
--- a/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -104,7 +104,9 @@ public class JavaUtils {
 
     // On Unix systems, use operating system command to run faster
     // If that does not work out, fallback to the Java IO way
-    if (SystemUtils.IS_OS_UNIX && filter == null) {
+    // We exclude Apple Silicon test environment due to the limited resource issues.
+    if (SystemUtils.IS_OS_UNIX && filter == null && !(SystemUtils.IS_OS_MAC_OSX &&
+        (System.getenv("SPARK_TESTING") != null || System.getProperty("spark.testing") != null))) {
       try {
         deleteRecursivelyUsingUnixNative(file);
         return;


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to disable `deleteRecursivelyUsingUnixNative` shortcut and to use the default Java implementation, `deleteRecursivelyUsingJavaIO`, without invoking a new process if it's a test on Apple Silicon environment.

### Why are the changes needed?

According to the log, `OOM` happens at `deleteRecursivelyUsingUnixNative` because it creates a new process.
- https://github.com/apache/spark/actions/runs/8101893556/artifacts/1287488302

```
Caused by: java.lang.OutOfMemoryError: unable to create native thread: possibly out of memory or process/resource limits reached
	at java.base/java.lang.Thread.start0(Native Method)
	at java.base/java.lang.Thread.start(Thread.java:1553)
	at java.base/java.lang.System$2.start(System.java:2577)
	at java.base/jdk.internal.vm.SharedThreadContainer.start(SharedThreadContainer.java:152)
	at java.base/java.util.concurrent.ThreadPoolExecutor.addWorker(ThreadPoolExecutor.java:953)
	at java.base/java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1375)
	at java.base/java.lang.ProcessHandleImpl.completion(ProcessHandleImpl.java:156)
	at java.base/java.lang.ProcessImpl.initStreams(ProcessImpl.java:344)
	at java.base/java.lang.ProcessImpl.lambda$new$0(ProcessImpl.java:307)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:571)
	at java.base/java.lang.ProcessImpl.<init>(ProcessImpl.java:306)
	at java.base/java.lang.ProcessImpl.start(ProcessImpl.java:225)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1126)
	at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1089)
	at org.apache.spark.network.util.JavaUtils.deleteRecursivelyUsingUnixNative(JavaUtils.java:161)
```

### Does this PR introduce _any_ user-facing change?

No, this disables only test environment.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.