### PR TITLE
[SPARK-47237][BUILD] Upgrade xmlschema-core to 2.3.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -268,7 +268,7 @@ txw2/3.0.2//txw2-3.0.2.jar
 univocity-parsers/2.9.1//univocity-parsers-2.9.1.jar
 wildfly-openssl/1.1.3.Final//wildfly-openssl-1.1.3.Final.jar
 xbean-asm9-shaded/4.24//xbean-asm9-shaded-4.24.jar
-xmlschema-core/2.3.0//xmlschema-core-2.3.0.jar
+xmlschema-core/2.3.1//xmlschema-core-2.3.1.jar
 xz/1.9//xz-1.9.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.9.1//zookeeper-jute-3.9.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
     <codehaus.jackson.version>1.9.13</codehaus.jackson.version>
     <fasterxml.jackson.version>2.16.1</fasterxml.jackson.version>
     <fasterxml.jackson.databind.version>2.16.1</fasterxml.jackson.databind.version>
-    <ws.xmlschema.version>2.3.0</ws.xmlschema.version>
+    <ws.xmlschema.version>2.3.1</ws.xmlschema.version>
     <org.glassfish.jaxb.txw2.version>3.0.2</org.glassfish.jaxb.txw2.version>
     <snappy.version>1.1.10.5</snappy.version>
     <netlib.ludovic.dev.version>3.0.3</netlib.ludovic.dev.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `xmlschema-core` from `2.3.0` to `2.3.1`.
The previous version was released 2 years ago:
<img width="817" alt="image" src="https://github.com/apache/spark/assets/15246973/8d04f2d7-5a80-47e9-b92e-c1fc2ef3a94c">

### Why are the changes needed?
The new version brings some bug fixes, eg:
https://issues.apache.org/jira/browse/XMLSCHEMA-64
https://github.com/apache/ws-xmlschema/pull/3


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
No.
