### PR TITLE
[SPARK-47238][SQL] Reduce executor memory usage by making generated code in WSCG a broadcast variable

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1792,6 +1792,18 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val WHOLESTAGE_BROADCAST_CLEANED_SOURCE_THRESHOLD =
+    buildConf("spark.sql.codegen.broadcastCleanedSourceThreshold")
+      .internal()
+      .doc("A threshold (in string length) to determine if we should make the generated code a" +
+        "broadcast variable in whole stage codegen. To disable this, set the threshold to < 0; " +
+        "otherwise if the size if above the threshold, it'll use broadcast variable. Note that " +
+        "maximum string length allowed in Java is Integer.MAX_VALUE, so anything above it would " +
+        "be meaningless. The default value is set to -1 (disabled by default).")
+      .version("4.0.0")
+      .intConf
+      .createWithDefault(-1)
+
   val FILES_MAX_PARTITION_BYTES = buildConf("spark.sql.files.maxPartitionBytes")
     .doc("The maximum number of bytes to pack into a single partition when reading files. " +
       "This configuration is effective only when using file-based sources such as Parquet, JSON " +
@@ -5049,6 +5061,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def wholeStageSplitConsumeFuncByOperator: Boolean =
     getConf(WHOLESTAGE_SPLIT_CONSUME_FUNC_BY_OPERATOR)
+
+  def broadcastCleanedSourceThreshold: Int =
+    getConf(SQLConf.WHOLESTAGE_BROADCAST_CLEANED_SOURCE_THRESHOLD)
 
   def tableRelationCacheSize: Int =
     getConf(StaticSQLConf.FILESOURCE_TABLE_RELATION_CACHE_SIZE)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1797,7 +1797,7 @@ object SQLConf {
       .internal()
       .doc("A threshold (in string length) to determine if we should make the generated code a" +
         "broadcast variable in whole stage codegen. To disable this, set the threshold to < 0; " +
-        "otherwise if the size if above the threshold, it'll use broadcast variable. Note that " +
+        "otherwise if the size is above the threshold, it'll use broadcast variable. Note that " +
         "maximum string length allowed in Java is Integer.MAX_VALUE, so anything above it would " +
         "be meaningless. The default value is set to -1 (disabled by default).")
       .version("4.0.0")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
 import scala.collection.mutable
 import scala.util.control.NonFatal
 
-import org.apache.spark.{broadcast, SparkContext, SparkException, SparkUnsupportedOperationException}
+import org.apache.spark.{broadcast, SparkException, SparkUnsupportedOperationException}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -843,8 +843,7 @@ case class WholeStageCodegenExec(child: SparkPlan)(val codegenStageId: Int)
     }
     val enabled = conf.broadcastCleanedSourceThreshold >= 0
     if (enabled && exceedThreshold()) {
-      SparkContext.getActive.map(sc => scala.util.Left(sc.broadcast(code)))
-        .getOrElse(scala.util.Right(code))
+      scala.util.Left(sparkContext.broadcast(code))
     } else {
       scala.util.Right(code)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/WholeStageCodegenExec.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
 import scala.collection.mutable
 import scala.util.control.NonFatal
 
-import org.apache.spark.{broadcast, SparkException, SparkUnsupportedOperationException}
+import org.apache.spark.{broadcast, SparkContext, SparkException, SparkUnsupportedOperationException}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -752,8 +752,9 @@ case class WholeStageCodegenExec(child: SparkPlan)(val codegenStageId: Int)
     // but the output must be rows.
     val rdds = child.asInstanceOf[CodegenSupport].inputRDDs()
     assert(rdds.size <= 2, "Up to two input RDDs can be supported")
+    val cleanedSourceOpt = tryBroadcastCleanedSource(cleanedSource)
     val evaluatorFactory = new WholeStageCodegenEvaluatorFactory(
-      cleanedSource, durationMs, references)
+      cleanedSourceOpt, durationMs, references)
     if (rdds.length == 1) {
       if (conf.usePartitionEvaluator) {
         rdds.head.mapPartitionsWithEvaluator(evaluatorFactory)
@@ -830,6 +831,24 @@ case class WholeStageCodegenExec(child: SparkPlan)(val codegenStageId: Int)
 
   override protected def withNewChildInternal(newChild: SparkPlan): WholeStageCodegenExec =
     copy(child = newChild)(codegenStageId)
+
+  // Use broadcast if the conf is enabled and the code + comment size exceeds the threshold,
+  // otherwise, fallback to use cleanedSource directly. The method returns either a
+  // broadcast variable or the original form of cleanedSource.
+  private[spark] def tryBroadcastCleanedSource(code: CodeAndComment):
+      Either[broadcast.Broadcast[CodeAndComment], CodeAndComment] = {
+    def exceedThreshold(): Boolean = {
+      code.body.length + code.comment.iterator.map(
+        e => e._1.length + e._2.length).sum > conf.broadcastCleanedSourceThreshold
+    }
+    val enabled = conf.broadcastCleanedSourceThreshold >= 0
+    if (enabled && exceedThreshold()) {
+      SparkContext.getActive.map(sc => scala.util.Left(sc.broadcast(code)))
+        .getOrElse(scala.util.Right(code))
+    } else {
+      scala.util.Right(code)
+    }
+  }
 }
 
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR proposes an improvement to reduce executor memory usage by broadcasting the generated code during whole stage codegen.

In certain internal workloads, we have observed instances where the generated code can be large (up to tens or even hundreds of MBs), serving as the last straw leading to executor OOM. To enhance stability and handle such pathological cases, we make the `cleanedSource` (the generated code) a broadcast variable. Theoretically, this change would reduce memory usage for the code size from (`cleanedSource` * number of tasks) to (`cleanedSource` * 1) per executor, with the trade-off of network latency.

The feature is gated by a Spark conf `spark.sql.codegen.broadcastCleanedSourceThreshold`. This config sets a threshold to determine if we should use a broadcast variable for the generated code during WSCG. If it is set to a value less than 0, the feature is disabled, which is the default.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Stability improvement.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

#### Unit Test
Added a new unit test in `WholeStageCodegenSuite` for three cases:
1. threshold is -1, shouldn't broadcast since smaller than 0 means disabled.
2. threshold is a larger number, shouldn't broadcast, not yet exceeded.
3. threshold is 0, should broadcast since it's always smaller than generated code size.

```bash
~/spark$ build/sbt -java-home /usr/lib/jvm/java-17-openjdk-amd64 "sql/testOnly *WholeStageCodegenSuite -- -z SPARK-47238"
```

#### Manual Test
For the ease of demonstration, we created a query that generates a lot of "comments" which leads to large code size, and additionally configure the cluster with the following:
- set `spark.sql.codegen.comments=true` to enable verbose comments.
- set `spark.sql.adaptive.enabled=false` to ensure whole stage codegen.
- set `spark.driver.memory=10G` to give driver enough memory.
- set a larger core numbers (16) and a smaller overall memory (1G) for executor.

##### Build Locally
```bash
~/spark$ build/sbt -mem 10000 -java-home /usr/lib/jvm/java-17-openjdk-amd64 package
```

##### Without Broadcast
1. create a local cluster, with the configs mentioned above.
```bash
~/spark$ ./bin/spark-shell --master local-cluster[2,16,1024] --conf spark.sql.codegen.comments=true --conf spark.sql.adaptive.enabled=false --conf spark.driver.memory=10G
```
2. run the artificial workload, executor OOM-ed.
```bash
scala> spark.sql(s"select ${(1 to 99).map(i => s"id as ${"name" * 300000}$i").mkString(", ")} from range(100)").collect()
```

##### With Broadcast
1. create a local cluster, with the configs mentioned above, and further set `spark.sql.codegen.broadcastCleanedSourceThreshold=0` to ensure it's broadcasting
```bash
~/spark$ ./bin/spark-shell --master local-cluster[2,16,1024] --conf spark.sql.codegen.comments=true --conf spark.sql.adaptive.enabled=false --conf spark.driver.memory=10G --conf spark.sql.codegen.broadcastCleanedSourceThreshold=0
```
2. run the same artificial workload, the query finished successfully.
```bash
scala> spark.sql(s"select ${(1 to 99).map(i => s"id as ${"name" * 300000}$i").mkString(", ")} from range(100)").collect()
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.