### PR TITLE
[SPARK-47239][SQL] Support distinct window function

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -358,7 +358,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
               messageParameters = Map("funcName" -> toSQLExpr(w)))
 
           // Distinct window function only support entire partition frame and
-          // growing frame.
+          // growing frame, and Distinct fields can't all be foldable.
           case w @ WindowExpression(AggregateExpression(f, _, true, _, _),
             WindowSpecDefinition(_, _, frame: SpecifiedWindowFrame))
              if f.children.forall(_.foldable) || frame.lower != UnboundedPreceding =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -221,12 +221,12 @@ class AnalysisErrorSuite extends AnalysisTest with DataTypeErrorsBase {
         WindowSpecDefinition(
           UnresolvedAttribute("a") :: Nil,
           SortOrder(UnresolvedAttribute("b"), Ascending) :: Nil,
-          UnspecifiedFrame)).as("window")),
+          SpecifiedWindowFrame(RangeFrame, CurrentRow, UnboundedFollowing))).as("window")),
     errorClass = "DISTINCT_WINDOW_FUNCTION_UNSUPPORTED",
     messageParameters = Map("windowExpr" ->
       s"""
          |"count(DISTINCT b) OVER (PARTITION BY a ORDER BY b ASC NULLS FIRST
-         | RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)"
+         | RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)"
          |""".stripMargin.replaceAll("\n", "")))
 
   errorTest(

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/window.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/window.sql.out
@@ -1410,3 +1410,67 @@ Project [cate#x, val#x, r#x]
                            +- Project [val#x, val_long#xL, val_double#x, val_date#x, val_timestamp#x, cate#x]
                               +- SubqueryAlias testData
                                  +- LocalRelation [val#x, val_long#xL, val_double#x, val_date#x, val_timestamp#x, cate#x]
+
+
+-- !query
+SELECT
+    cate,
+    val,
+    count(DISTINCT val_long) OVER(PARTITION BY cate ORDER BY val) as ct,
+    sum(DISTINCT val_long) OVER(PARTITION BY cate) as s
+FROM
+    testData
+-- !query analysis
+Project [cate#x, val#x, ct#xL, s#xL]
++- Project [cate#x, val#x, val_long#xL, ct#xL, s#xL, ct#xL, s#xL]
+   +- Window [sum(distinct val_long#xL) windowspecdefinition(cate#x, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS s#xL], [cate#x]
+      +- Window [count(distinct val_long#xL) windowspecdefinition(cate#x, val#x ASC NULLS FIRST, specifiedwindowframe(RangeFrame, unboundedpreceding$(), currentrow$())) AS ct#xL], [cate#x], [val#x ASC NULLS FIRST]
+         +- Project [cate#x, val#x, val_long#xL]
+            +- SubqueryAlias testdata
+               +- View (`testData`, [val#x, val_long#xL, val_double#x, val_date#x, val_timestamp#x, cate#x])
+                  +- Project [cast(val#x as int) AS val#x, cast(val_long#xL as bigint) AS val_long#xL, cast(val_double#x as double) AS val_double#x, cast(val_date#x as date) AS val_date#x, cast(val_timestamp#x as timestamp) AS val_timestamp#x, cast(cate#x as string) AS cate#x]
+                     +- Project [val#x, val_long#xL, val_double#x, val_date#x, val_timestamp#x, cate#x]
+                        +- SubqueryAlias testData
+                           +- LocalRelation [val#x, val_long#xL, val_double#x, val_date#x, val_timestamp#x, cate#x]
+
+
+-- !query
+SELECT
+    cate,
+    val,
+    count(DISTINCT val_long) OVER(PARTITION BY cate ORDER BY val) as ct,
+    sum(DISTINCT val_long) OVER(PARTITION BY cate ORDER BY val) as s
+FROM
+    testData
+-- !query analysis
+Project [cate#x, val#x, ct#xL, s#xL]
++- Project [cate#x, val#x, val_long#xL, ct#xL, s#xL, ct#xL, s#xL]
+   +- Window [count(distinct val_long#xL) windowspecdefinition(cate#x, val#x ASC NULLS FIRST, specifiedwindowframe(RangeFrame, unboundedpreceding$(), currentrow$())) AS ct#xL, sum(distinct val_long#xL) windowspecdefinition(cate#x, val#x ASC NULLS FIRST, specifiedwindowframe(RangeFrame, unboundedpreceding$(), currentrow$())) AS s#xL], [cate#x], [val#x ASC NULLS FIRST]
+      +- Project [cate#x, val#x, val_long#xL]
+         +- SubqueryAlias testdata
+            +- View (`testData`, [val#x, val_long#xL, val_double#x, val_date#x, val_timestamp#x, cate#x])
+               +- Project [cast(val#x as int) AS val#x, cast(val_long#xL as bigint) AS val_long#xL, cast(val_double#x as double) AS val_double#x, cast(val_date#x as date) AS val_date#x, cast(val_timestamp#x as timestamp) AS val_timestamp#x, cast(cate#x as string) AS cate#x]
+                  +- Project [val#x, val_long#xL, val_double#x, val_date#x, val_timestamp#x, cate#x]
+                     +- SubqueryAlias testData
+                        +- LocalRelation [val#x, val_long#xL, val_double#x, val_date#x, val_timestamp#x, cate#x]
+
+
+-- !query
+SELECT
+    cate,
+    val,
+    count(DISTINCT val_long) OVER(PARTITION BY cate ORDER BY val) as ct,
+    rank() OVER(PARTITION BY cate ORDER BY val) as r
+FROM
+    testData
+-- !query analysis
+Project [cate#x, val#x, ct#xL, r#x]
++- Project [cate#x, val#x, val_long#xL, ct#xL, r#x, ct#xL, r#x]
+   +- Window [count(distinct val_long#xL) windowspecdefinition(cate#x, val#x ASC NULLS FIRST, specifiedwindowframe(RangeFrame, unboundedpreceding$(), currentrow$())) AS ct#xL, rank(val#x) windowspecdefinition(cate#x, val#x ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS r#x], [cate#x], [val#x ASC NULLS FIRST]
+      +- Project [cate#x, val#x, val_long#xL]
+         +- SubqueryAlias testdata
+            +- View (`testData`, [val#x, val_long#xL, val_double#x, val_date#x, val_timestamp#x, cate#x])
+               +- Project [cast(val#x as int) AS val#x, cast(val_long#xL as bigint) AS val_long#xL, cast(val_double#x as double) AS val_double#x, cast(val_date#x as date) AS val_date#x, cast(val_timestamp#x as timestamp) AS val_timestamp#x, cast(cate#x as string) AS cate#x]
+                  +- Project [val#x, val_long#xL, val_double#x, val_date#x, val_timestamp#x, cate#x]
+                     +- SubqueryAlias testData
+                        +- LocalRelation [val#x, val_long#xL, val_double#x, val_date#x, val_timestamp#x, cate#x]

--- a/sql/core/src/test/resources/sql-tests/inputs/window.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/window.sql
@@ -478,3 +478,28 @@ SELECT * FROM (SELECT cate, val, dense_rank() OVER(PARTITION BY cate ORDER BY va
 SELECT * FROM (SELECT cate, val, dense_rank() OVER(PARTITION BY cate ORDER BY val) as r FROM testData) where r <= 2;
 SELECT * FROM (SELECT cate, val, row_number() OVER(PARTITION BY cate ORDER BY val) as r FROM testData) where r = 1;
 SELECT * FROM (SELECT cate, val, row_number() OVER(PARTITION BY cate ORDER BY val) as r FROM testData) where r <= 2;
+
+-- Test cases for distinct window function
+SELECT
+    cate,
+    val,
+    count(DISTINCT val_long) OVER(PARTITION BY cate ORDER BY val) as ct,
+    sum(DISTINCT val_long) OVER(PARTITION BY cate) as s
+FROM
+    testData;
+
+SELECT
+    cate,
+    val,
+    count(DISTINCT val_long) OVER(PARTITION BY cate ORDER BY val) as ct,
+    sum(DISTINCT val_long) OVER(PARTITION BY cate ORDER BY val) as s
+FROM
+    testData;
+
+SELECT
+    cate,
+    val,
+    count(DISTINCT val_long) OVER(PARTITION BY cate ORDER BY val) as ct,
+    rank() OVER(PARTITION BY cate ORDER BY val) as r
+FROM
+    testData;

--- a/sql/core/src/test/resources/sql-tests/results/window.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/window.sql.out
@@ -1432,3 +1432,69 @@ a	1	2
 a	NULL	1
 b	1	1
 b	2	2
+
+
+-- !query
+SELECT
+    cate,
+    val,
+    count(DISTINCT val_long) OVER(PARTITION BY cate ORDER BY val) as ct,
+    sum(DISTINCT val_long) OVER(PARTITION BY cate) as s
+FROM
+    testData
+-- !query schema
+struct<cate:string,val:int,ct:bigint,s:bigint>
+-- !query output
+NULL	3	1	1
+NULL	NULL	0	1
+a	1	2	2147483653
+a	1	2	2147483653
+a	2	3	2147483653
+a	NULL	1	2147483653
+b	1	0	2147483653
+b	2	1	2147483653
+b	3	2	2147483653
+
+
+-- !query
+SELECT
+    cate,
+    val,
+    count(DISTINCT val_long) OVER(PARTITION BY cate ORDER BY val) as ct,
+    sum(DISTINCT val_long) OVER(PARTITION BY cate ORDER BY val) as s
+FROM
+    testData
+-- !query schema
+struct<cate:string,val:int,ct:bigint,s:bigint>
+-- !query output
+NULL	3	1	1
+NULL	NULL	0	NULL
+a	1	2	3
+a	1	2	3
+a	2	3	2147483653
+a	NULL	1	1
+b	1	0	NULL
+b	2	1	3
+b	3	2	2147483653
+
+
+-- !query
+SELECT
+    cate,
+    val,
+    count(DISTINCT val_long) OVER(PARTITION BY cate ORDER BY val) as ct,
+    rank() OVER(PARTITION BY cate ORDER BY val) as r
+FROM
+    testData
+-- !query schema
+struct<cate:string,val:int,ct:bigint,r:int>
+-- !query output
+NULL	3	1	2
+NULL	NULL	0	1
+a	1	2	2
+a	1	2	2
+a	2	3	4
+a	NULL	1	1
+b	1	0	1
+b	2	1	2
+b	3	2	3


### PR DESCRIPTION

### What changes were proposed in this pull request?

Support distinct window function when window frame is entire partition frame or
 growing frame.
For example,
entire partition frame:
```
select 
    a, 
    b, 
    count(distinct c) over (partition by a) as cc
from t
```
growing frame:
```
select 
    a, 
    b, 
    count(distinct c) over (partition by a order by b) as cc
from t
```



### Why are the changes needed?

Distinct window function is a commonly used function and is supported by many SQL engines, such as hive, impala, clickhouse, and presto.

### Does this PR introduce _any_ user-facing change?
Yes, after this pr, can use dinctinct window function like hive.


### How was this patch tested?
UT.


### Was this patch authored or co-authored using generative AI tooling?
No.
