### PR TITLE
[SPARK-47242][BUILD] Bump ap-loader 3.0(v8) to support for async-profiler 3.0

### DIFF
--- a/connector/profiler/pom.xml
+++ b/connector/profiler/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>me.bechberger</groupId>
       <artifactId>ap-loader-all</artifactId>
-      <version>2.9-7</version>
+      <version>3.0-8</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bump ap-loader from 3.0(v8) to support for async-profiler 3.0.

### Why are the changes needed?

ap-loader 3.0(v8) has already been released, which supports for async-profier 3.0. The release guide refers to [Loader for 3.0 (v8): Binary launcher and AsyncGetCallTrace replacement](https://github.com/jvm-profiling-tools/ap-loader/releases/tag/3.0-8). Breaking changes with async-profiler 3.0:
async-profiler 3.0 changed the meaning of the `--lib` option from `--lib path        full path to libasyncProfiler.so in the container` to `-l, --lib         prepend library names`, so the `AsyncProfilerLoader` will throw an `UnsupportedOperation` exception when using the --lib option with a path argument and async-profiler 3.0 or higher.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass GA. Tested in production environment of Spark cluster.

### Was this patch authored or co-authored using generative AI tooling?

No.