### PR TITLE
[SPARK-47244][CONNECT] `SparkConnectPlanner` make internal functions private

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -108,7 +108,7 @@ class SparkConnectPlanner(
 
   private[connect] def sessionId: String = sessionHolder.sessionId
 
-  lazy val executeHolder = executeHolderOpt.getOrElse {
+  private lazy val executeHolder = executeHolderOpt.getOrElse {
     throw new IllegalArgumentException("executeHolder is not set")
   }
 

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -2518,7 +2518,7 @@ class SparkConnectPlanner(
     }
   }
 
-  def handleSqlCommand(
+  private def handleSqlCommand(
       getSqlCommand: SqlCommand,
       responseObserver: StreamObserver[ExecutePlanResponse]): Unit = {
     // Eagerly execute commands of the provided SQL string.
@@ -2828,7 +2828,7 @@ class SparkConnectPlanner(
    *
    * @param writeOperation
    */
-  def handleWriteOperationV2(writeOperation: proto.WriteOperationV2): Unit = {
+  private def handleWriteOperationV2(writeOperation: proto.WriteOperationV2): Unit = {
     // Transform the input plan into the logical plan.
     val plan = transformRelation(writeOperation.getInput)
     // And create a Dataset from the plan.
@@ -2887,7 +2887,7 @@ class SparkConnectPlanner(
     executeHolder.eventsManager.postFinished()
   }
 
-  def handleWriteStreamOperationStart(
+  private def handleWriteStreamOperationStart(
       writeOp: WriteStreamOperationStart,
       responseObserver: StreamObserver[ExecutePlanResponse]): Unit = {
     val plan = transformRelation(writeOp.getInput)
@@ -3013,7 +3013,7 @@ class SparkConnectPlanner(
         .build())
   }
 
-  def handleStreamingQueryCommand(
+  private def handleStreamingQueryCommand(
       command: StreamingQueryCommand,
       responseObserver: StreamObserver[ExecutePlanResponse]): Unit = {
 
@@ -3191,7 +3191,7 @@ class SparkConnectPlanner(
     builder.build()
   }
 
-  def handleStreamingQueryManagerCommand(
+  private def handleStreamingQueryManagerCommand(
       command: StreamingQueryManagerCommand,
       responseObserver: StreamObserver[ExecutePlanResponse]): Unit = {
     val respBuilder = StreamingQueryManagerCommandResult.newBuilder()
@@ -3272,7 +3272,7 @@ class SparkConnectPlanner(
         .build())
   }
 
-  def handleGetResourcesCommand(
+  private def handleGetResourcesCommand(
       responseObserver: StreamObserver[proto.ExecutePlanResponse]): Unit = {
     executeHolder.eventsManager.postFinished()
     responseObserver.onNext(


### PR DESCRIPTION
### What changes were proposed in this pull request?
`SparkConnectPlanner` make internal functions private



### Why are the changes needed?
they are internal functions, should not be exposed to users


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no