### PR TITLE
[SPARK-47247][SQL] Use smaller target size when coalescing partitions with exploding joins

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -75,8 +75,8 @@ case class CoalesceShufflePartitions(session: SparkSession) extends AQEShuffleRe
     val minNumPartitionsByGroup = if (coalesceGroups.length == 1) {
       Seq(math.max(minNumPartitions, 1))
     } else {
-      val sizes =
-        coalesceGroups.map(_.flatMap(_.shuffleStage.mapStats.map(_.bytesByPartitionId.sum)).sum)
+      val sizes = coalesceGroups.map(
+        _.shuffleStages.flatMap(_.shuffleStage.mapStats.map(_.bytesByPartitionId.sum)).sum)
       val totalSize = sizes.sum
       sizes.map { size =>
         val num = if (totalSize > 0) {
@@ -90,8 +90,8 @@ case class CoalesceShufflePartitions(session: SparkSession) extends AQEShuffleRe
 
     val specsMap = mutable.HashMap.empty[Int, Seq[ShufflePartitionSpec]]
     // Coalesce partitions for each coalesce group independently.
-    coalesceGroups.zip(minNumPartitionsByGroup).foreach { case (shuffleStages, minNumPartitions) =>
-      val advisoryTargetSize = advisoryPartitionSize(shuffleStages)
+    coalesceGroups.zip(minNumPartitionsByGroup).foreach { case (coalesceGroup, minNumPartitions) =>
+      val advisoryTargetSize = advisoryPartitionSize(coalesceGroup)
       val minPartitionSize = if (Utils.isTesting) {
         // In the tests, we usually set the target size to a very small value that is even smaller
         // than the default value of the min partition size. Here we also adjust the min partition
@@ -103,14 +103,14 @@ case class CoalesceShufflePartitions(session: SparkSession) extends AQEShuffleRe
       }
 
       val newPartitionSpecs = ShufflePartitionsUtil.coalescePartitions(
-        shuffleStages.map(_.shuffleStage.mapStats),
-        shuffleStages.map(_.partitionSpecs),
+        coalesceGroup.shuffleStages.map(_.shuffleStage.mapStats),
+        coalesceGroup.shuffleStages.map(_.partitionSpecs),
         advisoryTargetSize = advisoryTargetSize,
         minNumPartitions = minNumPartitions,
         minPartitionSize = minPartitionSize)
 
       if (newPartitionSpecs.nonEmpty) {
-        shuffleStages.zip(newPartitionSpecs).map { case (stageInfo, partSpecs) =>
+        coalesceGroup.shuffleStages.zip(newPartitionSpecs).map { case (stageInfo, partSpecs) =>
           specsMap.put(stageInfo.shuffleStage.id, partSpecs)
         }
       }
@@ -126,9 +126,12 @@ case class CoalesceShufflePartitions(session: SparkSession) extends AQEShuffleRe
   // data sources may request a particular advisory partition size for the final write stage
   // if it happens, the advisory partition size will be set in ShuffleQueryStageExec
   // only one shuffle stage is expected in such cases
-  private def advisoryPartitionSize(shuffleStages: Seq[ShuffleStageInfo]): Long = {
+  private def advisoryPartitionSize(coalesceGroup: CoalesceGroup): Long = {
+    if (coalesceGroup.hasExplodingJoin) {
+      return conf.getConf(SQLConf.COALESCE_PARTITIONS_MIN_PARTITION_SIZE)
+    }
     val defaultAdvisorySize = conf.getConf(SQLConf.ADVISORY_PARTITION_SIZE_IN_BYTES)
-    shuffleStages match {
+    coalesceGroup.shuffleStages match {
       case Seq(stage) =>
         stage.shuffleStage.advisoryPartitionSize.getOrElse(defaultAdvisorySize)
       case _ =>
@@ -143,18 +146,18 @@ case class CoalesceShufflePartitions(session: SparkSession) extends AQEShuffleRe
    * 1) all leaf nodes of this child are exchange stages; and
    * 2) all these shuffle stages support coalescing.
    */
-  private def collectCoalesceGroups(plan: SparkPlan): Seq[Seq[ShuffleStageInfo]] = plan match {
+  private def collectCoalesceGroups(
+      plan: SparkPlan,
+      hasExplodingJoin: Boolean = false): Seq[CoalesceGroup] = plan match {
     case r @ AQEShuffleReadExec(q: ShuffleQueryStageExec, _) if isSupported(q.shuffle) =>
-      Seq(collectShuffleStageInfos(r))
-    case unary: UnaryExecNode => collectCoalesceGroups(unary.child)
-    case union: UnionExec => union.children.flatMap(collectCoalesceGroups)
-    case join: CartesianProductExec => join.children.flatMap(collectCoalesceGroups)
-    // Note that, `BroadcastQueryStageExec` is a valid case:
-    // If a join has been optimized from shuffled join to broadcast join, then the one side is
-    // `BroadcastQueryStageExec` and other side is `ShuffleQueryStageExec`. It can coalesce the
-    // shuffle side as we do not expect broadcast exchange has same partition number.
-    case join: BroadcastHashJoinExec => join.children.flatMap(collectCoalesceGroups)
-    case join: BroadcastNestedLoopJoinExec => join.children.flatMap(collectCoalesceGroups)
+      Seq(CoalesceGroup(collectShuffleStageInfos(r), hasExplodingJoin))
+    case unary: UnaryExecNode => collectCoalesceGroups(unary.child, hasExplodingJoin)
+    // If a plan node does not need compatible data partitioning for its children, then each of its
+    // child can be an individual coalesce group and Spark will apply shuffle partitions coalescing
+    // for them independently,
+    case p if !childrenNeedCompatiblePartitioning(p) =>
+      val hasExplodingJoinSoFar = hasExplodingJoin || isExplodingJoin(p)
+      p.children.flatMap(collectCoalesceGroups(_, hasExplodingJoinSoFar))
     // If not all leaf nodes are exchange query stages, it's not safe to reduce the number of
     // shuffle partitions, because we may break the assumption that all children of a spark plan
     // have same number of output partitions.
@@ -163,11 +166,28 @@ case class CoalesceShufflePartitions(session: SparkSession) extends AQEShuffleRe
       // ShuffleExchanges introduced by repartition do not support partition number change.
       // We change the number of partitions only if all the ShuffleExchanges support it.
       if (shuffleStages.forall(s => isSupported(s.shuffleStage.shuffle))) {
-        Seq(shuffleStages)
+        // The recursion stops here, we need to call `p.exists(isExplodingJoin)` and find out if
+        // there is any exploding join in this sub-plan-tree.
+        Seq(CoalesceGroup(shuffleStages, hasExplodingJoin || p.exists(isExplodingJoin)))
       } else {
         Seq.empty
       }
     case _ => Seq.empty
+  }
+
+  private def childrenNeedCompatiblePartitioning(p: SparkPlan): Boolean = p match {
+    // TODO: match more plan nodes here.
+    case _: UnionExec => false
+    case _: CartesianProductExec => false
+    case _: BroadcastHashJoinExec => false
+    case _: BroadcastNestedLoopJoinExec => false
+    case _ => true
+  }
+
+  private def isExplodingJoin(p: SparkPlan): Boolean = p match {
+    case _: BroadcastNestedLoopJoinExec => true
+    case _: CartesianProductExec => true
+    case _ => false
   }
 
   private def collectShuffleStageInfos(plan: SparkPlan): Seq[ShuffleStageInfo] = plan match {
@@ -202,3 +222,7 @@ private object ShuffleStageInfo {
     case _ => None
   }
 }
+
+private case class CoalesceGroup(
+  shuffleStages: Seq[ShuffleStageInfo],
+  hasExplodingJoin: Boolean)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR changes the target partition size of AQE partition coalescing from `spark.sql.adaptive.advisoryPartitionSizeInBytes` (default 64MB) to `spark.sql.adaptive.coalescePartitions.minPartitionSize` (default 1MB) for non-equi joins, namely, broadcast nested loop join and cartesian product join, in order to minimize OOM risks as these join operators tend to be exploding joins and usually work better with smaller partitions compared to other operators.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
reduce the OOM risk, as after data exploding, 64mb input can become super large

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no