### PR TITLE
[SPARK-47249][CONNECT] Fix bug where all connect executions are considered abandoned regardless of their actual status  

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManager.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectExecutionManager.scala
@@ -120,8 +120,10 @@ private[connect] class SparkConnectExecutionManager() extends Logging {
     // close the execution outside the lock
     executeHolder.foreach { e =>
       e.close()
-      // Update in abandonedTombstones: above it wasn't yet updated with closedTime etc.
-      abandonedTombstones.put(key, e.getExecuteInfo)
+      if (abandoned) {
+        // Update in abandonedTombstones: above it wasn't yet updated with closedTime etc.
+        abandonedTombstones.put(key, e.getExecuteInfo)
+      }
     }
   }
 

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/execution/ReattachableExecuteSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/execution/ReattachableExecuteSuite.scala
@@ -416,9 +416,8 @@ class ReattachableExecuteSuite extends SparkConnectServerTest {
 
   test("SPARK-47249: non-abandoned executions are not added to tombstone cache upon close") {
     val dummyOpId = UUID.randomUUID().toString
-    val dummyRequest = buildExecutePlanRequest(
-      buildPlan("select * from range(1)"),
-      operationId = dummyOpId)
+    val dummyRequest =
+      buildExecutePlanRequest(buildPlan("select * from range(1)"), operationId = dummyOpId)
     val manager = SparkConnectService.executionManager
     val holder = manager.createExecuteHolder(dummyRequest)
     holder.eventsManager.postStarted()

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/execution/ReattachableExecuteSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/execution/ReattachableExecuteSuite.scala
@@ -413,4 +413,17 @@ class ReattachableExecuteSuite extends SparkConnectServerTest {
       assert(newAccessTime > lastAccessTime, "reattach should update session holder access time")
     }
   }
+
+  test("SPARK-47249: non-abandoned executions are not added to tombstone cache upon close") {
+    val dummyOpId = UUID.randomUUID().toString
+    val dummyRequest = buildExecutePlanRequest(
+      buildPlan("select * from range(1)"),
+      operationId = dummyOpId)
+    val manager = SparkConnectService.executionManager
+    val holder = manager.createExecuteHolder(dummyRequest)
+    holder.eventsManager.postStarted()
+    manager.removeExecuteHolder(holder.key, abandoned = false)
+    val abandonedExecutions = manager.listAbandonedExecutions
+    assert(abandonedExecutions.forall(_.operationId != dummyOpId))
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Adds a guard to check if the execution was abandoned before putting it into the `abandonedTombstones` cache

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fixes a bug where all connect executions end up in the `abandonedTombstones` cache due to a missing `if` guard.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, it fixes previously incorrect behaviour. A user would hit an `OPERATION_ABANDONED` error if they attempted to reattach to an operation that has already been completed (for some particular reason) when it should not error out (or at least, with the mentioned error). 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit test.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.