### PR TITLE
[SPARK-47251][PYTHON] Block invalid types from the `args` argument for `sql` command

### DIFF
--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -1179,8 +1179,11 @@ class SQL(LogicalPlan):
             if isinstance(args, Dict):
                 for k, v in args.items():
                     assert isinstance(k, str)
-            else:
-                assert isinstance(args, List)
+            elif not isinstance(args, List):
+                raise PySparkTypeError(
+                    error_class="INVALID_TYPE",
+                    message_parameters={"arg_name": "args", "arg_type": str(type(args))},
+                )
 
         self._query = query
         self._args = args

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1679,10 +1679,15 @@ class SparkSession(SparkConversionMixin):
         try:
             if isinstance(args, Dict):
                 litArgs = {k: _to_java_column(lit(v)) for k, v in (args or {}).items()}
-            else:
+            elif args is None or isinstance(args, List):
                 assert self._jvm is not None
                 litArgs = self._jvm.PythonUtils.toArray(
                     [_to_java_column(lit(v)) for v in (args or [])]
+                )
+            else:
+                raise PySparkTypeError(
+                    error_class="INVALID_TYPE",
+                    message_parameters={"arg_name": "args", "arg_type": str(type(args))},
                 )
             return DataFrame(self._jsparkSession.sql(sqlQuery, litArgs), self)
         finally:

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -1400,6 +1400,18 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         df2 = self.spark.sql(sqlText, args=[SF.array(SF.lit(1)), 7])
         self.assert_eq(df.toPandas(), df2.toPandas())
 
+    def test_sql_with_invalid_args(self):
+        sqlText = "SELECT ?, ?, ?"
+        for session in [self.connect, self.spark]:
+            with self.assertRaises(PySparkTypeError) as pe:
+                session.sql(sqlText, args={1, 2, 3})
+
+            self.check_error(
+                exception=pe.exception,
+                error_class="INVALID_TYPE",
+                message_parameters={"arg_name": "args", "arg_type": "<class 'set'>"},
+            )
+
     def test_head(self):
         # SPARK-41002: test `head` API in Python Client
         df = self.connect.read.table(self.tbl_name)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Blocks invalid types from the `args` argument for `sql` command.

Additionally, uses a `PySparkValueError` instead of assertions in Spark Connect.

### Why are the changes needed?

Currently the vanilla PySpark accepts any value, even `set`, which could cause unexpected results because `set` won't guarantee the item order.

```py
>>> spark.sql("select ?, ?, ?", args={2,1,3}).show()
+---+---+---+
|  1|  2|  3|
+---+---+---+
|  1|  2|  3|
+---+---+---+
```

whereas with list:

```py
>>> spark.sql("select ?, ?, ?", args=[2,1,3]).show()
+---+---+---+
|  2|  1|  3|
+---+---+---+
|  2|  1|  3|
+---+---+---+
```

### Does this PR introduce _any_ user-facing change?

Yes, the `args` argument for `sql` command will only accept `None`, `dict`, or `list`.

### How was this patch tested?

Added the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.