### PR TITLE
[SPARK-47252][DOCS] Clarify that pivot may trigger an eager computation

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -259,17 +259,17 @@ class RelationalGroupedDataset private[sql] (
   /**
    * Pivots a column of the current `DataFrame` and performs the specified aggregation.
    *
-   * There are two versions of `pivot` function: one that requires the caller to specify the list
-   * of distinct values to pivot on, and one that does not. The latter is more concise but less
-   * efficient, because Spark needs to first compute the list of distinct values internally.
-   *
    * {{{
    *   // Compute the sum of earnings for each year by course with each course as a separate column
-   *   df.groupBy("year").pivot("course", Seq("dotNET", "Java")).sum("earnings")
-   *
-   *   // Or without specifying column values (less efficient)
    *   df.groupBy("year").pivot("course").sum("earnings")
    * }}}
+   *
+   * @note Spark will '''eagerly''' compute the distinct values in `pivotColumn` so it can determine
+   *    the resulting schema of the transformation. Depending on the size and complexity of your
+   *    data, this may take some time. In other words, though the pivot transformation is lazy like
+   *    most DataFrame transformations, computing the distinct pivot values is not. To avoid any
+   *    eager computations, provide an explicit list of values via
+   *    `pivot(pivotColumn: String, values: Seq[Any])`.
    *
    * @see
    *   `org.apache.spark.sql.Dataset.unpivot` for the reverse operation, except for the
@@ -392,13 +392,19 @@ class RelationalGroupedDataset private[sql] (
   }
 
   /**
-   * Pivots a column of the current `DataFrame` and performs the specified aggregation. This is an
-   * overloaded version of the `pivot` method with `pivotColumn` of the `String` type.
+   * Pivots a column of the current `DataFrame` and performs the specified aggregation.
    *
    * {{{
-   *   // Or without specifying column values (less efficient)
+   *   // Compute the sum of earnings for each year by course with each course as a separate column
    *   df.groupBy($"year").pivot($"course").sum($"earnings");
    * }}}
+   *
+   * @note Spark will '''eagerly''' compute the distinct values in `pivotColumn` so it can determine
+   *    the resulting schema of the transformation. Depending on the size and complexity of your
+   *    data, this may take some time. In other words, though the pivot transformation is lazy like
+   *    most DataFrame transformations, computing the distinct pivot values is not. To avoid any
+   *    eager computations, provide an explicit list of values via
+   *    `pivot(pivotColumn: Column, values: Seq[Any])`.
    *
    * @see
    *   `org.apache.spark.sql.Dataset.unpivot` for the reverse operation, except for the

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -264,12 +264,13 @@ class RelationalGroupedDataset private[sql] (
    *   df.groupBy("year").pivot("course").sum("earnings")
    * }}}
    *
-   * @note Spark will '''eagerly''' compute the distinct values in `pivotColumn` so it can determine
-   *    the resulting schema of the transformation. Depending on the size and complexity of your
-   *    data, this may take some time. In other words, though the pivot transformation is lazy like
-   *    most DataFrame transformations, computing the distinct pivot values is not. To avoid any
-   *    eager computations, provide an explicit list of values via
-   *    `pivot(pivotColumn: String, values: Seq[Any])`.
+   * @note
+   *   Spark will '''eagerly''' compute the distinct values in `pivotColumn` so it can determine
+   *   the resulting schema of the transformation. Depending on the size and complexity of your
+   *   data, this may take some time. In other words, though the pivot transformation is lazy like
+   *   most DataFrame transformations, computing the distinct pivot values is not. To avoid any
+   *   eager computations, provide an explicit list of values via `pivot(pivotColumn: String,
+   *   values: Seq[Any])`.
    *
    * @see
    *   `org.apache.spark.sql.Dataset.unpivot` for the reverse operation, except for the
@@ -399,12 +400,13 @@ class RelationalGroupedDataset private[sql] (
    *   df.groupBy($"year").pivot($"course").sum($"earnings");
    * }}}
    *
-   * @note Spark will '''eagerly''' compute the distinct values in `pivotColumn` so it can determine
-   *    the resulting schema of the transformation. Depending on the size and complexity of your
-   *    data, this may take some time. In other words, though the pivot transformation is lazy like
-   *    most DataFrame transformations, computing the distinct pivot values is not. To avoid any
-   *    eager computations, provide an explicit list of values via
-   *    `pivot(pivotColumn: Column, values: Seq[Any])`.
+   * @note
+   *   Spark will '''eagerly''' compute the distinct values in `pivotColumn` so it can determine
+   *   the resulting schema of the transformation. Depending on the size and complexity of your
+   *   data, this may take some time. In other words, though the pivot transformation is lazy like
+   *   most DataFrame transformations, computing the distinct pivot values is not. To avoid any
+   *   eager computations, provide an explicit list of values via `pivot(pivotColumn: Column,
+   *   values: Seq[Any])`.
    *
    * @see
    *   `org.apache.spark.sql.Dataset.unpivot` for the reverse operation, except for the

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -259,18 +259,14 @@ class RelationalGroupedDataset private[sql] (
   /**
    * Pivots a column of the current `DataFrame` and performs the specified aggregation.
    *
+   * Spark will '''eagerly''' compute the distinct values in `pivotColumn` so it can determine the
+   * resulting schema of the transformation. To avoid any eager computations, provide an explicit
+   * list of values via `pivot(pivotColumn: String, values: Seq[Any])`.
+   *
    * {{{
    *   // Compute the sum of earnings for each year by course with each course as a separate column
    *   df.groupBy("year").pivot("course").sum("earnings")
    * }}}
-   *
-   * @note
-   *   Spark will '''eagerly''' compute the distinct values in `pivotColumn` so it can determine
-   *   the resulting schema of the transformation. Depending on the size and complexity of your
-   *   data, this may take some time. In other words, though the pivot transformation is lazy like
-   *   most DataFrame transformations, computing the distinct pivot values is not. To avoid any
-   *   eager computations, provide an explicit list of values via `pivot(pivotColumn: String,
-   *   values: Seq[Any])`.
    *
    * @see
    *   `org.apache.spark.sql.Dataset.unpivot` for the reverse operation, except for the
@@ -395,18 +391,14 @@ class RelationalGroupedDataset private[sql] (
   /**
    * Pivots a column of the current `DataFrame` and performs the specified aggregation.
    *
+   * Spark will '''eagerly''' compute the distinct values in `pivotColumn` so it can determine the
+   * resulting schema of the transformation. To avoid any eager computations, provide an explicit
+   * list of values via `pivot(pivotColumn: Column, values: Seq[Any])`.
+   *
    * {{{
    *   // Compute the sum of earnings for each year by course with each course as a separate column
    *   df.groupBy($"year").pivot($"course").sum($"earnings");
    * }}}
-   *
-   * @note
-   *   Spark will '''eagerly''' compute the distinct values in `pivotColumn` so it can determine
-   *   the resulting schema of the transformation. Depending on the size and complexity of your
-   *   data, this may take some time. In other words, though the pivot transformation is lazy like
-   *   most DataFrame transformations, computing the distinct pivot values is not. To avoid any
-   *   eager computations, provide an explicit list of values via `pivot(pivotColumn: Column,
-   *   values: Seq[Any])`.
    *
    * @see
    *   `org.apache.spark.sql.Dataset.unpivot` for the reverse operation, except for the

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -259,7 +259,7 @@ class RelationalGroupedDataset private[sql] (
   /**
    * Pivots a column of the current `DataFrame` and performs the specified aggregation.
    *
-   * Spark will '''eagerly''' compute the distinct values in `pivotColumn` so it can determine the
+   * Spark will eagerly compute the distinct values in `pivotColumn` so it can determine the
    * resulting schema of the transformation. To avoid any eager computations, provide an explicit
    * list of values via `pivot(pivotColumn: String, values: Seq[Any])`.
    *
@@ -391,7 +391,7 @@ class RelationalGroupedDataset private[sql] (
   /**
    * Pivots a column of the current `DataFrame` and performs the specified aggregation.
    *
-   * Spark will '''eagerly''' compute the distinct values in `pivotColumn` so it can determine the
+   * Spark will eagerly compute the distinct values in `pivotColumn` so it can determine the
    * resulting schema of the transformation. To avoid any eager computations, provide an explicit
    * list of values via `pivot(pivotColumn: Column, values: Seq[Any])`.
    *

--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -448,11 +448,7 @@ class GroupedData(PandasGroupedOpsMixin):
 
             .. note:: If ``values`` is not provided, Spark will **eagerly** compute the distinct
                 values in ``pivot_col`` so it can determine the resulting schema of the
-                transformation. Depending on the size and complexity of your data, this may take
-                some time.
-                In other words, though the pivot transformation is lazy like most DataFrame
-                transformations, computing the distinct pivot values is not. To avoid any eager
-                computations, provide an explicit list of values.
+                transformation. To avoid any eager computations, provide an explicit list of values.
 
         Examples
         --------

--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -432,11 +432,7 @@ class GroupedData(PandasGroupedOpsMixin):
 
     def pivot(self, pivot_col: str, values: Optional[List["LiteralType"]] = None) -> "GroupedData":
         """
-        Pivots a column of the current :class:`DataFrame` and perform the specified aggregation.
-        There are two versions of the pivot function: one that requires the caller
-        to specify the list of distinct values to pivot on, and one that does not.
-        The latter is more concise but less efficient,
-        because Spark needs to first compute the list of distinct values internally.
+        Pivots a column of the current :class:`DataFrame` and performs the specified aggregation.
 
         .. versionadded:: 1.6.0
 
@@ -449,6 +445,14 @@ class GroupedData(PandasGroupedOpsMixin):
             Name of the column to pivot.
         values : list, optional
             List of values that will be translated to columns in the output DataFrame.
+
+            .. note:: If ``values`` is not provided, Spark will **eagerly** compute the distinct
+                values in ``pivot_col`` so it can determine the resulting schema of the
+                transformation. Depending on the size and complexity of your data, this may take
+                some time.
+                In other words, though the pivot transformation is lazy like most DataFrame
+                transformations, computing the distinct pivot values is not. To avoid any eager
+                computations, provide an explicit list of values.
 
         Examples
         --------

--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -446,9 +446,9 @@ class GroupedData(PandasGroupedOpsMixin):
         values : list, optional
             List of values that will be translated to columns in the output DataFrame.
 
-            .. note:: If ``values`` is not provided, Spark will **eagerly** compute the distinct
-                values in ``pivot_col`` so it can determine the resulting schema of the
-                transformation. To avoid any eager computations, provide an explicit list of values.
+            If ``values`` is not provided, Spark will eagerly compute the distinct values in
+            ``pivot_col`` so it can determine the resulting schema of the transformation. To avoid
+            any eager computations, provide an explicit list of values.
 
         Examples
         --------

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -324,17 +324,17 @@ class RelationalGroupedDataset protected[sql](
   /**
    * Pivots a column of the current `DataFrame` and performs the specified aggregation.
    *
-   * There are two versions of `pivot` function: one that requires the caller to specify the list
-   * of distinct values to pivot on, and one that does not. The latter is more concise but less
-   * efficient, because Spark needs to first compute the list of distinct values internally.
-   *
    * {{{
    *   // Compute the sum of earnings for each year by course with each course as a separate column
-   *   df.groupBy("year").pivot("course", Seq("dotNET", "Java")).sum("earnings")
-   *
-   *   // Or without specifying column values (less efficient)
    *   df.groupBy("year").pivot("course").sum("earnings")
    * }}}
+   *
+   * @note Spark will '''eagerly''' compute the distinct values in `pivotColumn` so it can determine
+   *    the resulting schema of the transformation. Depending on the size and complexity of your
+   *    data, this may take some time. In other words, though the pivot transformation is lazy like
+   *    most DataFrame transformations, computing the distinct pivot values is not. To avoid any
+   *    eager computations, provide an explicit list of values via
+   *    `pivot(pivotColumn: String, values: Seq[Any])`.
    *
    * @see `org.apache.spark.sql.Dataset.unpivot` for the reverse operation,
    *      except for the aggregation.
@@ -407,12 +407,18 @@ class RelationalGroupedDataset protected[sql](
 
   /**
    * Pivots a column of the current `DataFrame` and performs the specified aggregation.
-   * This is an overloaded version of the `pivot` method with `pivotColumn` of the `String` type.
    *
    * {{{
-   *   // Or without specifying column values (less efficient)
+   *   // Compute the sum of earnings for each year by course with each course as a separate column
    *   df.groupBy($"year").pivot($"course").sum($"earnings");
    * }}}
+   *
+   * @note Spark will '''eagerly''' compute the distinct values in `pivotColumn` so it can determine
+   *    the resulting schema of the transformation. Depending on the size and complexity of your
+   *    data, this may take some time. In other words, though the pivot transformation is lazy like
+   *    most DataFrame transformations, computing the distinct pivot values is not. To avoid any
+   *    eager computations, provide an explicit list of values via
+   *    `pivot(pivotColumn: Column, values: Seq[Any])`.
    *
    * @see `org.apache.spark.sql.Dataset.unpivot` for the reverse operation,
    *      except for the aggregation.

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -324,7 +324,7 @@ class RelationalGroupedDataset protected[sql](
   /**
    * Pivots a column of the current `DataFrame` and performs the specified aggregation.
    *
-   * Spark will '''eagerly''' compute the distinct values in `pivotColumn` so it can determine
+   * Spark will eagerly compute the distinct values in `pivotColumn` so it can determine
    * the resulting schema of the transformation. To avoid any eager computations, provide an
    * explicit list of values via `pivot(pivotColumn: String, values: Seq[Any])`.
    *
@@ -405,7 +405,7 @@ class RelationalGroupedDataset protected[sql](
   /**
    * Pivots a column of the current `DataFrame` and performs the specified aggregation.
    *
-   * Spark will '''eagerly''' compute the distinct values in `pivotColumn` so it can determine
+   * Spark will eagerly compute the distinct values in `pivotColumn` so it can determine
    * the resulting schema of the transformation. To avoid any eager computations, provide an
    * explicit list of values via `pivot(pivotColumn: Column, values: Seq[Any])`.
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -324,17 +324,14 @@ class RelationalGroupedDataset protected[sql](
   /**
    * Pivots a column of the current `DataFrame` and performs the specified aggregation.
    *
+   * Spark will '''eagerly''' compute the distinct values in `pivotColumn` so it can determine
+   * the resulting schema of the transformation. To avoid any eager computations, provide an
+   * explicit list of values via `pivot(pivotColumn: String, values: Seq[Any])`.
+   *
    * {{{
    *   // Compute the sum of earnings for each year by course with each course as a separate column
    *   df.groupBy("year").pivot("course").sum("earnings")
    * }}}
-   *
-   * @note Spark will '''eagerly''' compute the distinct values in `pivotColumn` so it can determine
-   *    the resulting schema of the transformation. Depending on the size and complexity of your
-   *    data, this may take some time. In other words, though the pivot transformation is lazy like
-   *    most DataFrame transformations, computing the distinct pivot values is not. To avoid any
-   *    eager computations, provide an explicit list of values via
-   *    `pivot(pivotColumn: String, values: Seq[Any])`.
    *
    * @see `org.apache.spark.sql.Dataset.unpivot` for the reverse operation,
    *      except for the aggregation.
@@ -408,17 +405,14 @@ class RelationalGroupedDataset protected[sql](
   /**
    * Pivots a column of the current `DataFrame` and performs the specified aggregation.
    *
+   * Spark will '''eagerly''' compute the distinct values in `pivotColumn` so it can determine
+   * the resulting schema of the transformation. To avoid any eager computations, provide an
+   * explicit list of values via `pivot(pivotColumn: Column, values: Seq[Any])`.
+   *
    * {{{
    *   // Compute the sum of earnings for each year by course with each course as a separate column
    *   df.groupBy($"year").pivot($"course").sum($"earnings");
    * }}}
-   *
-   * @note Spark will '''eagerly''' compute the distinct values in `pivotColumn` so it can determine
-   *    the resulting schema of the transformation. Depending on the size and complexity of your
-   *    data, this may take some time. In other words, though the pivot transformation is lazy like
-   *    most DataFrame transformations, computing the distinct pivot values is not. To avoid any
-   *    eager computations, provide an explicit list of values via
-   *    `pivot(pivotColumn: Column, values: Seq[Any])`.
    *
    * @see `org.apache.spark.sql.Dataset.unpivot` for the reverse operation,
    *      except for the aggregation.


### PR DESCRIPTION
### What changes were proposed in this pull request?

Clarify that, if explicit pivot values are not provided, Spark will eagerly compute them.

### Why are the changes needed?

The current wording on `master` is misleading. To say that one version of pivot is more or less "efficient" than the other glosses over the fact that one is lazy and the other is not. Spark users are trained from early on that transformations are generally lazy; exceptions to this rule should be more clearly highlighted.

I experienced this personally when I called pivot on a DataFrame without providing explicit values, and Spark took around 20 minutes to compute the distinct pivot values. Looking at the docs, I felt that "less efficient" didn't accurately represent this behavior.

### Does this PR introduce _any_ user-facing change?

Yes, updated user docs.

### How was this patch tested?

I built and reviewed the docs locally.

<img width="300" src="https://github.com/apache/spark/assets/1039369/532d935b-b8f4-49be-b999-366acfbca7d8" />
<img width="400" src="https://github.com/apache/spark/assets/1039369/77dde43e-a217-4a30-8ce3-727f2060e54a" />

### Was this patch authored or co-authored using generative AI tooling?

No.