### PR TITLE
[SPARK-47253][CORE] Allow LiveEventBus to stop without the completely draining of event queue

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1014,7 +1014,7 @@ package object config {
       .timeConf(TimeUnit.NANOSECONDS)
       .createWithDefaultString("1s")
 
-  private[spark] val LISTENER_BUS_EVENT_QUEUE_EVENT_DISPATCH_EXIT_WAITING_TIME_ON_STOP =
+  private[spark] val LISTENER_BUS_EXIT_TIMEOUT =
     ConfigBuilder("spark.scheduler.listenerbus.exitTimeout")
       .doc("The time that event queue waits until the dispatch thread exits " +
         "when stop is invoked. " +

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1014,14 +1014,15 @@ package object config {
       .timeConf(TimeUnit.NANOSECONDS)
       .createWithDefaultString("1s")
 
-  private[spark] val LISTENER_BUS_EVENT_QUEUE_WAIT_FOR_EVENT_DISPATCH_EXIT_ON_STOP =
-    ConfigBuilder("spark.scheduler.listenerbus.eventqueue.waitForEventDispatchExitOnStop")
-      .doc("Whether wait until the dispatch thread exit when stop invoked. " +
-        "This is set to true by default for graceful shutdown of the event queue, " +
-        "but allow user to configure the behavior if they don't need.")
+  private[spark] val LISTENER_BUS_EVENT_QUEUE_EVENT_DISPATCH_EXIT_WAITING_TIME_ON_STOP =
+    ConfigBuilder("spark.scheduler.listenerbus.eventqueue.eventDispatchExitWaitingTimeOnStop")
+      .doc("The time that event queue waits until the dispatch thread exits " +
+        "when stop is invoked. " +
+        "This is set to 0 by default for graceful shutdown of the event queue, " +
+        "but allow the user to configure the waiting time.")
       .version("4.0.0")
-      .booleanConf
-      .createWithDefault(true)
+      .timeConf(TimeUnit.MILLISECONDS)
+      .createWithDefault(0)
 
   // This property sets the root namespace for metrics reporting
   private[spark] val METRICS_NAMESPACE = ConfigBuilder("spark.metrics.namespace")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1022,6 +1022,7 @@ package object config {
         "but allow the user to configure the waiting time.")
       .version("4.0.0")
       .timeConf(TimeUnit.MILLISECONDS)
+      .checkValue(_ >= 0, "Listener bus exit timeout must be non-negative duration")
       .createWithDefault(0)
 
   // This property sets the root namespace for metrics reporting

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1015,7 +1015,7 @@ package object config {
       .createWithDefaultString("1s")
 
   private[spark] val LISTENER_BUS_EVENT_QUEUE_EVENT_DISPATCH_EXIT_WAITING_TIME_ON_STOP =
-    ConfigBuilder("spark.scheduler.listenerbus.eventqueue.eventDispatchExitWaitingTimeOnStop")
+    ConfigBuilder("spark.scheduler.listenerbus.exitTimeout")
       .doc("The time that event queue waits until the dispatch thread exits " +
         "when stop is invoked. " +
         "This is set to 0 by default for graceful shutdown of the event queue, " +

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1019,7 +1019,7 @@ package object config {
       .doc("Whether wait until the dispatch thread exit when stop invoked. " +
         "This is set to true by default for graceful shutdown of the event queue, " +
         "but allow user to configure the behavior if they don't need.")
-      .version("3.5.0")
+      .version("4.0.0")
       .booleanConf
       .createWithDefault(true)
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1014,6 +1014,15 @@ package object config {
       .timeConf(TimeUnit.NANOSECONDS)
       .createWithDefaultString("1s")
 
+  private[spark] val LISTENER_BUS_EVENT_QUEUE_WAIT_FOR_EVENT_DISPATCH_EXIT_ON_STOP =
+    ConfigBuilder("spark.scheduler.listenerbus.eventqueue.waitForEventDispatchExitOnStop")
+      .doc("Whether wait until the dispatch thread exit when stop invoked. " +
+        "This is set to true by default for graceful shutdown of the event queue, " +
+        "but allow user to configure the behavior if they don't need.")
+      .version("3.5.0")
+      .booleanConf
+      .createWithDefault(true)
+
   // This property sets the root namespace for metrics reporting
   private[spark] val METRICS_NAMESPACE = ConfigBuilder("spark.metrics.namespace")
     .version("2.1.0")

--- a/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
@@ -142,17 +142,15 @@ private class AsyncEventQueue(
       eventCount.incrementAndGet()
       eventQueue.put(POISON_PILL)
     }
-    // 1. This thread might be trying to stop itself as part of error handling -- we can't join
-    //    in that case.
-    // 2. If users don't want to wait for the dispatch to end until all events are drained,
-    //    they can control the waiting time by themselves
-    //    or omit the thread join by set the waiting time to a negative value.
-    val waitingTimeMs =
-      conf.get(LISTENER_BUS_EVENT_QUEUE_EVENT_DISPATCH_EXIT_WAITING_TIME_ON_STOP)
+    // This thread might be trying to stop itself as part of error handling -- we can't join
+    // in that case.
     if (Thread.currentThread() != dispatchThread) {
+      // If users don't want to wait for the dispatch to end until all events are drained,
+      // they can control the waiting time by themselves.
       // By default, the `waitingTimeMs` is set to 0,
       // which means it will wait until all events are drained.
-      dispatchThread.join(waitingTimeMs)
+      val exitTimeoutMs = conf.get(LISTENER_BUS_EXIT_TIMEOUT)
+      dispatchThread.join(exitTimeoutMs)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
@@ -149,7 +149,7 @@ private class AsyncEventQueue(
     //    or omit the thread join by set the waiting time to a negative value.
     val waitingTimeMs =
       conf.get(LISTENER_BUS_EVENT_QUEUE_EVENT_DISPATCH_EXIT_WAITING_TIME_ON_STOP)
-    if (waitingTimeMs >= 0 && Thread.currentThread() != dispatchThread) {
+    if (Thread.currentThread() != dispatchThread) {
       // By default, the `waitingTimeMs` is set to 0,
       // which means it will wait until all events are drained.
       dispatchThread.join(waitingTimeMs)

--- a/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
@@ -142,13 +142,17 @@ private class AsyncEventQueue(
       eventCount.incrementAndGet()
       eventQueue.put(POISON_PILL)
     }
-    // 1.If the user does not want to wait for the dispatch to end,
-    // they can omit the thread join.
-    // 2.this thread might be trying to stop itself as part of error handling -- we can't join
-    // in that case.
-    if (conf.get(LISTENER_BUS_EVENT_QUEUE_WAIT_FOR_EVENT_DISPATCH_EXIT_ON_STOP) &&
-      Thread.currentThread() != dispatchThread) {
-      dispatchThread.join()
+    // 1. This thread might be trying to stop itself as part of error handling -- we can't join
+    //    in that case.
+    // 2. If users don't want to wait for the dispatch to end until all events are drained,
+    //    they can control the waiting time by themselves
+    //    or omit the thread join by set the waiting time to a negative value.
+    val waitingTimeMs =
+      conf.get(LISTENER_BUS_EVENT_QUEUE_EVENT_DISPATCH_EXIT_WAITING_TIME_ON_STOP)
+    if (waitingTimeMs >= 0 && Thread.currentThread() != dispatchThread) {
+      // By default, the `waitingTimeMs` is set to 0,
+      // which means it will wait until all events are drained.
+      dispatchThread.join(waitingTimeMs)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
@@ -146,7 +146,8 @@ private class AsyncEventQueue(
     // they can omit the thread join.
     // 2.this thread might be trying to stop itself as part of error handling -- we can't join
     // in that case.
-    if (waitForEventDispatchExit() && Thread.currentThread() != dispatchThread) {
+    if (conf.get(LISTENER_BUS_EVENT_QUEUE_WAIT_FOR_EVENT_DISPATCH_EXIT_ON_STOP) &&
+      Thread.currentThread() != dispatchThread) {
       dispatchThread.join()
     }
   }
@@ -208,15 +209,6 @@ private class AsyncEventQueue(
     // the listener failed in an unrecoverably way, we want to remove it from the entire
     // LiveListenerBus (potentially stopping a queue if it is empty)
     bus.removeListener(listener)
-  }
-
-  /**
-   * Wait for the dispatch exit on queue stop or not.
-   *
-   * @return true if wait for event dispatch exit.
-   */
-  private def waitForEventDispatchExit(): Boolean = {
-    conf.get(LISTENER_BUS_EVENT_QUEUE_WAIT_FOR_EVENT_DISPATCH_EXIT_ON_STOP)
   }
 
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/AsyncEventQueue.scala
@@ -210,6 +210,11 @@ private class AsyncEventQueue(
     bus.removeListener(listener)
   }
 
+  /**
+   * Wait for the dispatch exit on queue stop or not.
+   *
+   * @return true if wait for event dispatch exit.
+   */
   private def waitForEventDispatchExit(): Boolean = {
     conf.get(LISTENER_BUS_EVENT_QUEUE_WAIT_FOR_EVENT_DISPATCH_EXIT_ON_STOP)
   }

--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -197,7 +197,7 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
       }
     }
     val sparkConf = new SparkConf()
-      .set(LISTENER_BUS_EVENT_QUEUE_WAIT_FOR_EVENT_DISPATCH_EXIT_ON_STOP, false)
+      .set(LISTENER_BUS_EVENT_QUEUE_EVENT_DISPATCH_EXIT_WAITING_TIME_ON_STOP, -1L)
     val bus = new LiveListenerBus(sparkConf)
     val blockingListener = new BlockingListener
 

--- a/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SparkListenerSuite.scala
@@ -220,10 +220,6 @@ class SparkListenerSuite extends SparkFunSuite with LocalSparkContext with Match
 
     // unblock the dispatch thread
     listenerWait.release()
-
-    // let the event drained now
-    drainWait.acquire()
-    assert(drained)
   }
 
   test("metrics for dropped listener events") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add config spark.scheduler.listenerbus.exitTimeout(default 0, wait until dispatch thread exist).
Before this PR: The event queue will wait for the event to drain completely on stop.
After this PR: Allow user to control this behavior(wait for completely drain or not) by spark config.


### Why are the changes needed?
####Problem statement:
The SparkContext.stop() hung a long time on LiveEventBus.stop() when listeners slow

####User scenarios:
We have a centralized service with multiple instances to regularly execute user's scheduled tasks.
For each user task within one service instance, the process is as follows:

1.Create a Spark session directly within the service process with an account defined in the task.
2.Instantiate listeners by class names and register them with the SparkContext. The JARs containing the listener classes are uploaded to the service by the user.
3.Prepare resources.
4.Run user logic (Spark SQL).
5.Stop the Spark session by invoking SparkSession.stop().

In step 5, it will wait for the LiveEventBus to stop, which requires the remaining events to be completely drained by each listener.

Since the listener is implemented by users and we cannot prevent some heavy stuffs within the listener on each event, there are cases where a single heavy job has over 30,000 tasks,
and it could take 30 minutes for the listener to process all the remaining events, because within the listener, it requires a coarse-grained global lock and update the internal status to the remote database.

This kind of delay affects other user tasks in the queue. Therefore, from the server side perspective, we need the guarantee that the stop operation finishes quickly.



### Does this PR introduce _any_ user-facing change?
Add cofig spark.scheduler.listenerbus.exitTimeout.
Default is `0`, it will wait for the event to drain completely. If set to a non negative integer, the LivenEventBus will wait for atleast that duration (in ms) before it stops irrespective of whether the events are drained or not.


### How was this patch tested?
By UT and verified the feature in out production environment


### Was this patch authored or co-authored using generative AI tooling?
No