### PR TITLE
[SPARK-47269][BUILD] Upgrade jetty to 11.0.20

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -136,8 +136,8 @@ jersey-container-servlet/3.0.12//jersey-container-servlet-3.0.12.jar
 jersey-hk2/3.0.12//jersey-hk2-3.0.12.jar
 jersey-server/3.0.12//jersey-server-3.0.12.jar
 jettison/1.5.4//jettison-1.5.4.jar
-jetty-util-ajax/11.0.19//jetty-util-ajax-11.0.19.jar
-jetty-util/11.0.19//jetty-util-11.0.19.jar
+jetty-util-ajax/11.0.20//jetty-util-ajax-11.0.20.jar
+jetty-util/11.0.20//jetty-util-11.0.20.jar
 jline/2.14.6//jline-2.14.6.jar
 jline/3.22.0//jline-3.22.0.jar
 jna/5.13.0//jna-5.13.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
     <parquet.version>1.13.1</parquet.version>
     <orc.version>1.9.2</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>
-    <jetty.version>11.0.19</jetty.version>
+    <jetty.version>11.0.20</jetty.version>
     <jakartaservlet.version>5.0.0</jakartaservlet.version>
     <!-- SPARK-46938: Required by Hive / LibThrift libs -->
     <javaxservlet.version>4.0.1</javaxservlet.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade jetty from 11.0.19 to 11.0.20.

### Why are the changes needed?
The new version brings a security update:
- [CVE-2024-22201](https://github.com/advisories/GHSA-rggv-cv7r-mw98) - HTTP/2 connection not closed after idle timeout when TCP congested

The full release notes as follows:
- https://github.com/jetty/jetty.project/releases/tag/jetty-11.0.20


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub  Actions


### Was this patch authored or co-authored using generative AI tooling?
No