### PR TITLE
[SPARK-47271][DOCS] Explain importance of statistics on SQL performance tuning page

### DIFF
--- a/docs/_data/menu-sql.yaml
+++ b/docs/_data/menu-sql.yaml
@@ -57,6 +57,8 @@
       url: sql-performance-tuning.html#caching-data
     - text: Tuning Partitions
       url: sql-performance-tuning.html#tuning-partitions
+    - text: Leveraging Statistics
+      url: sql-performance-tuning.html#leveraging-statistics
     - text: Optimizing the Join Strategy
       url: sql-performance-tuning.html#optimizing-the-join-strategy
     - text: Adaptive Query Execution

--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -180,9 +180,7 @@ Missing or inaccurate statistics will hinder Spark's ability to select an optima
     <td>10485760 (10 MB)</td>
     <td>
       Configures the maximum size in bytes for a table that will be broadcast to all worker nodes when
-      performing a join. By setting this value to -1, broadcasting can be disabled. Note that currently
-      statistics are only supported for Hive Metastore tables where the command
-      <code>ANALYZE TABLE &lt;tableName&gt; COMPUTE STATISTICS noscan</code> has been run.
+      performing a join. By setting this value to -1, broadcasting can be disabled.
     </td>
     <td>1.1.0</td>
   </tr>

--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -157,6 +157,18 @@ SELECT /*+ REBALANCE(3, c) */ * FROM t;
 
 For more details please refer to the documentation of [Partitioning Hints](sql-ref-syntax-qry-select-hints.html#partitioning-hints).
 
+## Leveraging Statistics
+Apache Spark's ability to choose the best execution plan among many possible options is determined in part by its estimates of how many rows will be output by every node in the execution plan (read, filter, join, etc.). Those estimates in turn are based on statistics that are made available to Spark in one of several ways:
+
+- **Data source**: Statistics that Spark reads directly from the underlying data source, like the counts and min/max values in the metadata of Parquet files. These statistics are maintained by the underlying data source.
+- **Catalog**: Statistics that Spark reads from the catalog, like the Hive Metastore. These statistics are collected or updated whenever you run [`ANALYZE TABLE`](sql-ref-syntax-aux-analyze-table.html).
+- **Runtime**: Statistics that Spark computes itself at runtime as a job is running.
+
+Missing or inaccurate statistics will hinder Spark's ability to select an optimal plan, and may lead to poor query performance. It's helpful then to inspect the statistics available to Spark and the estimates it makes during query planning.
+
+- **Data object statistics**: You can inspect the statistics on a table or column with [`DESCRIBE EXTENDED`](sql-ref-syntax-aux-describe-table.html).
+- **Query plan estimates**: You can inspect Spark's cost estimates in the optimized query plan via [`EXPLAIN COST`](sql-ref-syntax-qry-explain.html) or `DataFrame.explain(mode="cost")`.
+
 ## Optimizing the Join Strategy
 
 ### Automatically Broadcasting Joins

--- a/docs/sql-performance-tuning.md
+++ b/docs/sql-performance-tuning.md
@@ -162,12 +162,13 @@ Apache Spark's ability to choose the best execution plan among many possible opt
 
 - **Data source**: Statistics that Spark reads directly from the underlying data source, like the counts and min/max values in the metadata of Parquet files. These statistics are maintained by the underlying data source.
 - **Catalog**: Statistics that Spark reads from the catalog, like the Hive Metastore. These statistics are collected or updated whenever you run [`ANALYZE TABLE`](sql-ref-syntax-aux-analyze-table.html).
-- **Runtime**: Statistics that Spark computes itself at runtime as a job is running.
+- **Runtime**: Statistics that Spark computes itself as a query is running. This is part of the [adaptive query execution framework](#adaptive-query-execution).
 
-Missing or inaccurate statistics will hinder Spark's ability to select an optimal plan, and may lead to poor query performance. It's helpful then to inspect the statistics available to Spark and the estimates it makes during query planning.
+Missing or inaccurate statistics will hinder Spark's ability to select an optimal plan, and may lead to poor query performance. It's helpful then to inspect the statistics available to Spark and the estimates it makes during query planning and execution.
 
 - **Data object statistics**: You can inspect the statistics on a table or column with [`DESCRIBE EXTENDED`](sql-ref-syntax-aux-describe-table.html).
 - **Query plan estimates**: You can inspect Spark's cost estimates in the optimized query plan via [`EXPLAIN COST`](sql-ref-syntax-qry-explain.html) or `DataFrame.explain(mode="cost")`.
+- **Runtime statistics**: You can inspect these statistics in the [SQL UI](web-ui.html#sql-tab) under the "Details" section as a query is running. Look for `Statistics(..., isRuntime=true)` in the plan.
 
 ## Optimizing the Join Strategy
 

--- a/docs/sql-ref-syntax-aux-analyze-table.md
+++ b/docs/sql-ref-syntax-aux-analyze-table.md
@@ -22,7 +22,9 @@ license: |
 ### Description
 
 The `ANALYZE TABLE` statement collects statistics about one specific table or all the tables in one specified database,
-that are to be used by the query optimizer to find a better query execution plan.
+that are to be [used by the query optimizer][stats] to find a better query execution plan. These statistics are stored in the catalog.
+
+[stats]: sql-performance-tuning.html#leveraging-statistics
 
 ### Syntax
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -582,11 +582,7 @@ object SQLConf {
 
   val AUTO_BROADCASTJOIN_THRESHOLD = buildConf("spark.sql.autoBroadcastJoinThreshold")
     .doc("Configures the maximum size in bytes for a table that will be broadcast to all worker " +
-      "nodes when performing a join.  By setting this value to -1 broadcasting can be disabled. " +
-      "Note that currently statistics are only supported for Hive Metastore tables where the " +
-      "command `ANALYZE TABLE <tableName> COMPUTE STATISTICS noscan` has been " +
-      "run, and file-based data source tables where the statistics are computed directly on " +
-      "the files of data.")
+      "nodes when performing a join.  By setting this value to -1 broadcasting can be disabled.")
     .version("1.1.0")
     .bytesConf(ByteUnit.BYTE)
     .createWithDefaultString("10MB")


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a new section to the SQL performance tuning page on statistics.

Tweak some related documentation relevant to this new section.

### Why are the changes needed?

Statistics are a basic and critical part of how Spark optimizes queries and achieves high performance. Yet, they receive no discussion in our performance tuning guide.

### Does this PR introduce _any_ user-facing change?

Yes, new user-facing documentation.

<img width="500" src="https://github.com/apache/spark/assets/1039369/a5fef3dd-1015-41c6-9dd7-b9f2952b32ef" />

### How was this patch tested?

Built and reviewed the docs locally.

### Was this patch authored or co-authored using generative AI tooling?

No.