### PR TITLE
[SPARK-47276][PYTHON][CONNECT] Introduce `spark.profile.clear` for SparkSession-based profiling

### DIFF
--- a/python/pyspark/sql/profiler.py
+++ b/python/pyspark/sql/profiler.py
@@ -239,7 +239,7 @@ class ProfilerCollector(ABC):
         with self._lock:
             if id is not None:
                 if id in self._profile_results:
-                    perf, mem, *_ = self._profile_results[id]  # type: ignore
+                    perf, mem, *_ = self._profile_results[id]
                     self._profile_results[id] = (None, mem, *_)
                     if mem is None:
                         self._profile_results.pop(id, None)
@@ -264,7 +264,7 @@ class ProfilerCollector(ABC):
         with self._lock:
             if id is not None:
                 if id in self._profile_results:
-                    perf, mem, *_ = self._profile_results[id]  # type: ignore
+                    perf, mem, *_ = self._profile_results[id]
                     self._profile_results[id] = (perf, None, *_)
                     if perf is None:
                         self._profile_results.pop(id, None)

--- a/python/pyspark/sql/profiler.py
+++ b/python/pyspark/sql/profiler.py
@@ -236,11 +236,18 @@ class ProfilerCollector(ABC):
             The UDF ID whose profiling results should be cleared.
             If not specified, all the results will be cleared.
         """
+        ids_to_remove = [
+            result_id
+            for result_id, (perf, _, *_) in self._profile_results.items()
+            if perf is not None
+        ]
         with self._lock:
             if id is not None:
-                self._perf_profile_results.pop(id, None)
+                if id in ids_to_remove:
+                    self._profile_results.pop(id, None)
             else:
-                self._perf_profile_results.clear()
+                for id_to_remove in ids_to_remove:
+                    self._profile_results.pop(id_to_remove, None)
 
     def clear_memory_profiles(self, id: Optional[int] = None) -> None:
         """
@@ -255,10 +262,15 @@ class ProfilerCollector(ABC):
             If not specified, all the results will be cleared.
         """
         with self._lock:
+            ids_to_remove = [
+                id for id, (_, mem, *_) in self._profile_results.items() if mem is not None
+            ]
             if id is not None:
-                self._memory_profile_results.pop(id, None)
+                if id in ids_to_remove:
+                    self._profile_results.pop(id, None)
             else:
-                self._memory_profile_results.clear()
+                for id_to_remove in ids_to_remove:
+                    self._profile_results.pop(id_to_remove, None)
 
 
 class AccumulatorProfilerCollector(ProfilerCollector):

--- a/python/pyspark/sql/profiler.py
+++ b/python/pyspark/sql/profiler.py
@@ -239,19 +239,15 @@ class ProfilerCollector(ABC):
         with self._lock:
             if id is not None:
                 if id in self._profile_results:
-                    perf, mem, *rest = self._profile_results[id]
-                    self._profile_results[id] = (None, mem, *rest)
+                    perf, mem, *_ = self._profile_results[id]  # type: ignore
+                    self._profile_results[id] = (None, mem, *_)
                     if mem is None:
                         self._profile_results.pop(id, None)
             else:
-                ids_to_remove = []
-                for id, (perf, mem, *rest) in list(self._profile_results.items()):
-                    self._profile_results[id] = (None, mem, *rest)
+                for id, (perf, mem, *_) in list(self._profile_results.items()):
+                    self._profile_results[id] = (None, mem, *_)
                     if mem is None:
-                        ids_to_remove.append(id)
-
-                for id in ids_to_remove:
-                    self._profile_results.pop(id, None)
+                        self._profile_results.pop(id, None)
 
     def clear_memory_profiles(self, id: Optional[int] = None) -> None:
         """
@@ -268,19 +264,15 @@ class ProfilerCollector(ABC):
         with self._lock:
             if id is not None:
                 if id in self._profile_results:
-                    perf, mem, *rest = self._profile_results[id]
-                    self._profile_results[id] = (perf, None, *rest)
+                    perf, mem, *_ = self._profile_results[id]  # type: ignore
+                    self._profile_results[id] = (perf, None, *_)
                     if perf is None:
                         self._profile_results.pop(id, None)
             else:
-                ids_to_remove = []
-                for id, (perf, mem, *rest) in list(self._profile_results.items()):
-                    self._profile_results[id] = (perf, None, *rest)
+                for id, (perf, mem, *_) in list(self._profile_results.items()):
+                    self._profile_results[id] = (perf, None, *_)
                     if perf is None:
-                        ids_to_remove.append(id)
-
-                for id in ids_to_remove:
-                    self._profile_results.pop(id, None)
+                        self._profile_results.pop(id, None)
 
 
 class AccumulatorProfilerCollector(ProfilerCollector):

--- a/python/pyspark/sql/profiler.py
+++ b/python/pyspark/sql/profiler.py
@@ -224,6 +224,42 @@ class ProfilerCollector(ABC):
             for id in sorted(code_map.keys()):
                 dump(id)
 
+    def clear_perf_profiles(self, id: Optional[int] = None) -> None:
+        """
+        Clear the perf profile results.
+
+        .. versionadded:: 4.0.0
+
+        Parameters
+        ----------
+        id : int, optional
+            The UDF ID whose profiling results should be cleared.
+            If not specified, all the results will be cleared.
+        """
+        with self._lock:
+            if id is not None:
+                self._perf_profile_results.pop(id, None)
+            else:
+                self._perf_profile_results.clear()
+
+    def clear_memory_profiles(self, id: Optional[int] = None) -> None:
+        """
+        Clear the memory profile results.
+
+        .. versionadded:: 4.0.0
+
+        Parameters
+        ----------
+        id : int, optional
+            The UDF ID whose profiling results should be cleared.
+            If not specified, all the results will be cleared.
+        """
+        with self._lock:
+            if id is not None:
+                self._memory_profile_results.pop(id, None)
+            else:
+                self._memory_profile_results.clear()
+
 
 class AccumulatorProfilerCollector(ProfilerCollector):
     def __init__(self) -> None:
@@ -301,6 +337,35 @@ class Profile:
             self.profiler_collector.dump_perf_profiles(path, id)
             if type is None:  # Dump both perf and memory profiles
                 self.profiler_collector.dump_memory_profiles(path, id)
+        else:
+            raise PySparkValueError(
+                error_class="VALUE_NOT_ALLOWED",
+                message_parameters={
+                    "arg_name": "type",
+                    "allowed_values": str(["perf", "memory"]),
+                },
+            )
+
+    def clear(self, id: Optional[int] = None, *, type: Optional[str] = None) -> None:
+        """
+        Clear the profile results.
+
+        .. versionadded:: 4.0.0
+
+        Parameters
+        ----------
+        id : int, optional
+            The UDF ID whose profiling results should be cleared.
+            If not specified, all the results will be cleared.
+        type : str, optional
+            The profiler type to clear results for, which can be either "perf" or "memory".
+        """
+        if type == "memory":
+            self.profiler_collector.clear_memory_profiles(id)
+        elif type == "perf" or type is None:
+            self.profiler_collector.clear_perf_profiles(id)
+            if type is None:  # Clear both perf and memory profiles
+                self.profiler_collector.clear_memory_profiles(id)
         else:
             raise PySparkValueError(
                 error_class="VALUE_NOT_ALLOWED",

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -531,6 +531,33 @@ class SparkSessionProfileTests(unittest.TestCase, PySparkErrorTestUtils):
             },
         )
 
+    def test_clear_memory_type(self):
+        self.profile.clear(type="memory")
+        self.profiler_collector_mock.clear_memory_profiles.assert_called_once()
+        self.profiler_collector_mock.clear_perf_profiles.assert_not_called()
+
+    def test_clear_perf_type(self):
+        self.profile.clear(type="perf")
+        self.profiler_collector_mock.clear_perf_profiles.assert_called_once()
+        self.profiler_collector_mock.clear_memory_profiles.assert_not_called()
+
+    def test_clear_no_type(self):
+        self.profile.clear()
+        self.profiler_collector_mock.clear_perf_profiles.assert_called_once()
+        self.profiler_collector_mock.clear_memory_profiles.assert_called_once()
+
+    def test_clear_invalid_type(self):
+        with self.assertRaises(PySparkValueError) as e:
+            self.profile.clear(type="invalid")
+        self.check_error(
+            exception=e.exception,
+            error_class="VALUE_NOT_ALLOWED",
+            message_parameters={
+                "arg_name": "type",
+                "allowed_values": str(["perf", "memory"]),
+            },
+        )
+
 
 class SparkExtensionsTest(unittest.TestCase):
     # These tests are separate because it uses 'spark.sql.extensions' which is

--- a/python/pyspark/sql/tests/test_udf_profiler.py
+++ b/python/pyspark/sql/tests/test_udf_profiler.py
@@ -521,6 +521,32 @@ class UDFProfiler2TestsMixin:
                 io.getvalue(), f"2.*{os.path.basename(inspect.getfile(_do_computation))}"
             )
 
+    def test_perf_profiler_clear(self):
+        with self.sql_conf({"spark.sql.pyspark.udf.profiler": "perf"}):
+            _do_computation(self.spark)
+        self.assertEqual(3, len(self.profile_results), str(list(self.profile_results)))
+
+        for id in self.profile_results:
+            self.spark.profile.clear(id)
+            self.assertNotIn(id, self.profile_results)
+        self.assertEqual(0, len(self.profile_results), str(list(self.profile_results)))
+
+        with self.sql_conf({"spark.sql.pyspark.udf.profiler": "perf"}):
+            _do_computation(self.spark)
+        self.assertEqual(3, len(self.profile_results), str(list(self.profile_results)))
+
+        self.spark.profile.clear(type="memory")
+        self.assertEqual(3, len(self.profile_results), str(list(self.profile_results)))
+        self.spark.profile.clear(type="perf")
+        self.assertEqual(0, len(self.profile_results), str(list(self.profile_results)))
+
+        with self.sql_conf({"spark.sql.pyspark.udf.profiler": "perf"}):
+            _do_computation(self.spark)
+        self.assertEqual(3, len(self.profile_results), str(list(self.profile_results)))
+
+        self.spark.profile.clear()
+        self.assertEqual(0, len(self.profile_results), str(list(self.profile_results)))
+
 
 class UDFProfiler2Tests(UDFProfiler2TestsMixin, ReusedSQLTestCase):
     def setUp(self) -> None:

--- a/python/pyspark/tests/test_memory_profiler.py
+++ b/python/pyspark/tests/test_memory_profiler.py
@@ -608,7 +608,7 @@ class MemoryProfiler2TestsMixin:
             _do_computation(self.spark)
 
         self.assertEqual(3, len(self.profile_results), str(list(self.profile_results)))
-        some_id = next(iter(self.profile_results[0]))
+        some_id = next(iter(self.profile_results))
 
         # clear a specific memory profile
         self.spark.profile.clear(some_id, type="memory")

--- a/python/pyspark/tests/test_memory_profiler.py
+++ b/python/pyspark/tests/test_memory_profiler.py
@@ -571,6 +571,32 @@ class MemoryProfiler2TestsMixin:
                 io.getvalue(), f"Filename.*{os.path.basename(inspect.getfile(_do_computation))}"
             )
 
+    def test_memory_profiler_clear(self):
+        with self.sql_conf({"spark.sql.pyspark.udf.profiler": "memory"}):
+            _do_computation(self.spark)
+        self.assertEqual(3, len(self.profile_results), str(list(self.profile_results)))
+
+        for id in list(self.profile_results.keys()):
+            self.spark.profile.clear(id)
+            self.assertNotIn(id, self.profile_results)
+        self.assertEqual(0, len(self.profile_results), str(list(self.profile_results)))
+
+        with self.sql_conf({"spark.sql.pyspark.udf.profiler": "memory"}):
+            _do_computation(self.spark)
+        self.assertEqual(3, len(self.profile_results), str(list(self.profile_results)))
+
+        self.spark.profile.clear(type="perf")
+        self.assertEqual(3, len(self.profile_results), str(list(self.profile_results)))
+        self.spark.profile.clear(type="memory")
+        self.assertEqual(0, len(self.profile_results), str(list(self.profile_results)))
+
+        with self.sql_conf({"spark.sql.pyspark.udf.profiler": "memory"}):
+            _do_computation(self.spark)
+        self.assertEqual(3, len(self.profile_results), str(list(self.profile_results)))
+
+        self.spark.profile.clear()
+        self.assertEqual(0, len(self.profile_results), str(list(self.profile_results)))
+
 
 class MemoryProfiler2Tests(MemoryProfiler2TestsMixin, ReusedSQLTestCase):
     def setUp(self) -> None:

--- a/python/pyspark/tests/test_memory_profiler.py
+++ b/python/pyspark/tests/test_memory_profiler.py
@@ -608,16 +608,18 @@ class MemoryProfiler2TestsMixin:
             _do_computation(self.spark)
 
         self.assertEqual(3, len(self.profile_results), str(list(self.profile_results)))
-        some_id = next(iter(self.profile_results))
 
         # clear a specific memory profile
+        some_id = next(iter(self.profile_results))
         self.spark.profile.clear(some_id, type="memory")
         self.assertEqual(2, len(self.profile_results), str(list(self.profile_results)))
         self.assertEqual(3, len(self.perf_profile_results), str(list(self.perf_profile_results)))
 
         # clear a specific perf profile
+        some_id = next(iter(self.perf_profile_results))
         self.spark.profile.clear(some_id, type="perf")
         self.assertEqual(2, len(self.perf_profile_results), str(list(self.perf_profile_results)))
+        self.assertEqual(2, len(self.profile_results), str(list(self.profile_results)))
 
         # clear all memory profiles
         self.spark.profile.clear(type="memory")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduce `spark.profile.clear` for SparkSession-based profiling.

### Why are the changes needed?
A straightforward and unified interface for managing and resetting profiling results for SparkSession-based profilers.

### Does this PR introduce _any_ user-facing change?
Yes. `spark.profile.clear` is supported as shown below.

Preparation:
```py
>>> from pyspark.sql.functions import pandas_udf
>>> df = spark.range(3)
>>> @pandas_udf("long")
... def add1(x):
...   return x + 1
... 
>>> added = df.select(add1("id"))
>>> spark.conf.set("spark.sql.pyspark.udf.profiler", "perf")
>>> added.show()
+--------+                                                                      
|add1(id)|
+--------+
...
+--------+
>>> spark.profile.show()
============================================================
Profile of UDF<id=2>
============================================================
         1410 function calls (1374 primitive calls) in 0.004 seconds
...
```

Example usage:
```py
>>> spark.profile.profiler_collector._profile_results
{2: (<pstats.Stats object at 0x7ff6484d22e0>, None)}

>>> spark.profile.clear(1)  # id mismatch
>>> spark.profile.profiler_collector._profile_results
{2: (<pstats.Stats object at 0x7ff6484d22e0>, None)}

>>> spark.profile.clear(type="memory")  # type mismatch
>>> spark.profile.profiler_collector._profile_results
{2: (<pstats.Stats object at 0x7ff6484d22e0>, None)}

>>> spark.profile.clear()  # clear all
>>> spark.profile.profiler_collector._profile_results
{}
>>> spark.profile.show()
>>> 
```

### How was this patch tested?
Unit tests.

### Was this patch authored or co-authored using generative AI tooling?
No.
