### PR TITLE
[SPARK-47251][PYTHON][FOLLOWUP] Use __name__ instead of string representation

### DIFF
--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -1182,7 +1182,7 @@ class SQL(LogicalPlan):
             elif not isinstance(args, List):
                 raise PySparkTypeError(
                     error_class="INVALID_TYPE",
-                    message_parameters={"arg_name": "args", "arg_type": str(type(args))},
+                    message_parameters={"arg_name": "args", "arg_type": type(args).__name__},
                 )
 
         self._query = query

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1687,7 +1687,7 @@ class SparkSession(SparkConversionMixin):
             else:
                 raise PySparkTypeError(
                     error_class="INVALID_TYPE",
-                    message_parameters={"arg_name": "args", "arg_type": str(type(args))},
+                    message_parameters={"arg_name": "args", "arg_type": type(args).__name__},
                 )
             return DataFrame(self._jsparkSession.sql(sqlQuery, litArgs), self)
         finally:

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -1409,7 +1409,7 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             self.check_error(
                 exception=pe.exception,
                 error_class="INVALID_TYPE",
-                message_parameters={"arg_name": "args", "arg_type": "<class 'set'>"},
+                message_parameters={"arg_name": "args", "arg_type": "set"},
             )
 
     def test_head(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of apache/spark#45361.

Use `__name__` instead of string representation for the error parameter.

### Why are the changes needed?

To be consistent with other places.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Updated the related tests.

### Was this patch authored or co-authored using generative AI tooling?

No.