### PR TITLE
[Work in Progress] Experimenting to move TransportCipher to GCM based on Google Tink

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/crypto/AuthClientBootstrap.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/crypto/AuthClientBootstrap.java
@@ -104,7 +104,7 @@ public class AuthClientBootstrap implements TransportClientBootstrap {
     throws GeneralSecurityException, IOException {
 
     String secretKey = secretKeyHolder.getSecretKey(appId);
-    try (AuthEngine engine = new AuthEngine(appId, secretKey, conf)) {
+    try (AuthEngine engine = new AuthEngine(appId, secretKey)) {
       AuthMessage challenge = engine.challenge();
       ByteBuf challengeData = Unpooled.buffer(challenge.encodedLength());
       challenge.encode(challengeData);

--- a/common/network-common/src/main/java/org/apache/spark/network/crypto/AuthRpcHandler.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/crypto/AuthRpcHandler.java
@@ -112,7 +112,7 @@ class AuthRpcHandler extends AbstractAuthRpcHandler {
       Preconditions.checkState(secret != null,
         "Trying to authenticate non-registered app %s.", challenge.appId());
       LOG.debug("Authenticating challenge for app {}.", challenge.appId());
-      engine = new AuthEngine(challenge.appId(), secret, conf);
+      engine = new AuthEngine(challenge.appId(), secret);
       AuthMessage response = engine.response(challenge);
       ByteBuf responseData = Unpooled.buffer(response.encodedLength());
       response.encode(responseData);

--- a/common/network-common/src/main/java/org/apache/spark/network/crypto/InternalStreamingAeadDecryptingChannel.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/crypto/InternalStreamingAeadDecryptingChannel.java
@@ -1,0 +1,280 @@
+package org.apache.spark.network.crypto;
+
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import com.google.crypto.tink.subtle.AesGcmHkdfStreaming;
+import com.google.crypto.tink.subtle.StreamSegmentDecrypter;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.security.GeneralSecurityException;
+
+
+/**
+ * This is adapted from Google Tink's StreamingAeadDecryptingChannel in order to allow callers to pass in pre-defined
+ * plaintext and ciphertext buffers.
+ */
+
+/** An instance of {@link ReadableByteChannel} that returns the plaintext for some ciphertext. */
+class InternalStreamingAeadDecryptingChannel implements ReadableByteChannel {
+    /* The stream containing the ciphertext */
+    private ReadableByteChannel ciphertextChannel;
+
+    /**
+     * A buffer containing ciphertext that has not yet been decrypted.
+     * The limit of ciphertextSegment is set such that it can contain segment plus the first
+     * character of the next segment. It is necessary to read a segment plus one more byte
+     * to decrypt a segment, since the last segment of a ciphertext is encrypted differently.
+     */
+    private final ByteBuffer ciphertextSegment;
+
+    /**
+     * A buffer containing a plaintext segment.
+     * The bytes in the range plaintexSegment.position() .. plaintextSegment.limit() - 1
+     * are plaintext that have been decrypted but not yet read out of AesGcmInputStream.
+     */
+    private final ByteBuffer plaintextSegment;
+
+    /* A buffer containg the header information from the ciphertext. */
+    private final ByteBuffer header;
+
+    /* Determines whether the header has been completely read. */
+    private boolean headerRead;
+
+    /* Indicates whether the end of this InputStream has been reached. */
+    boolean endOfCiphertext;
+
+    /* Indicates whether the end of the plaintext has been reached. */
+    private boolean endOfPlaintext;
+
+    /**
+     * Indicates whether this stream is in a defined state.
+     * Currently the state of this instance becomes undefined when
+     * an authentication error has occurred.
+     */
+    private boolean definedState;
+
+    /** The associated data that is authenticated with the ciphertext. */
+    private final byte[] UNUSED_AAD = new byte[0];
+
+    /**
+     * The number of the current segment of ciphertext buffered in ciphertextSegment.
+     */
+    private int segmentNr;
+
+    private final StreamSegmentDecrypter decrypter;
+    private final int ciphertextSegmentSize;
+    private final int firstCiphertextSegmentSize;
+
+    public InternalStreamingAeadDecryptingChannel(
+            AesGcmHkdfStreaming streamAead,
+            ByteBuffer plaintextBuffer,
+            ByteBuffer ciphertextBuffer)
+            throws GeneralSecurityException {
+        decrypter = streamAead.newStreamSegmentDecrypter();
+        header = ByteBuffer.allocate(streamAead.getHeaderLength());
+
+        // ciphertextSegment is one byte longer than a ciphertext segment,
+        // so that the code can decide if the current segment is the last segment in the
+        // stream.
+        ciphertextSegmentSize = streamAead.getCiphertextSegmentSize();
+        ciphertextSegment = ciphertextBuffer;
+        ciphertextSegment.limit(0);
+        firstCiphertextSegmentSize = ciphertextSegmentSize - streamAead.getCiphertextOffset();
+        plaintextSegment = plaintextBuffer;
+        plaintextSegment.limit(0);
+        headerRead = false;
+        endOfCiphertext = false;
+        endOfPlaintext = false;
+        segmentNr = 0;
+        definedState = true;
+    }
+
+    // This must be set by the caller prior to reading any data.
+    void setCiphertextChannel(ReadableByteChannel ciphertextChannel) {
+        this.ciphertextChannel = ciphertextChannel;
+    }
+
+    /**
+     * Reads some ciphertext.
+     * @param buffer the destination for the ciphertext.
+     * @throws IOException when an exception reading the ciphertext stream occurs.
+     */
+    private void readSomeCiphertext(ByteBuffer buffer) throws IOException {
+        int read;
+        do {
+            read = ciphertextChannel.read(buffer);
+        } while (read > 0 && buffer.remaining() > 0);
+        if (read == -1) {
+            endOfCiphertext = true;
+        }
+    }
+
+    /**
+     * Tries to read the header of the ciphertext.
+     * @return true if the header has been fully read and false if not enough bytes were available
+     *          from the ciphertext stream.
+     * @throws IOException when an exception occurs while reading the ciphertextStream or when
+     *         the header is too short.
+     */
+    private boolean tryReadHeader() throws IOException {
+        if (endOfCiphertext) {
+            throw new IOException("Ciphertext is too short");
+        }
+        readSomeCiphertext(header);
+        if (header.remaining() > 0) {
+            return false;
+        } else {
+            header.flip();
+            try {
+                decrypter.init(header, UNUSED_AAD);
+                headerRead = true;
+            } catch (GeneralSecurityException ex) {
+                // TODO(b/74249330): Try to define the state of this.
+                setUndefinedState();
+                throw new IOException(ex);
+            }
+            return true;
+        }
+    }
+
+    private void setUndefinedState() {
+        definedState = false;
+        plaintextSegment.limit(0);
+    }
+
+    /**
+     * Tries to load the next plaintext segment.
+     */
+    private boolean tryLoadSegment() throws IOException {
+        // Try filling the ciphertextSegment
+        if (!endOfCiphertext) {
+            readSomeCiphertext(ciphertextSegment);
+        }
+        if (ciphertextSegment.remaining() > 0 && !endOfCiphertext) {
+            // we have not enough ciphertext for the next segment
+            return false;
+        }
+        byte lastByte = 0;
+        if (!endOfCiphertext) {
+            lastByte = ciphertextSegment.get(ciphertextSegment.position() - 1);
+            ciphertextSegment.position(ciphertextSegment.position() - 1);
+        }
+        ciphertextSegment.flip();
+        plaintextSegment.clear();
+        try {
+            decrypter.decryptSegment(
+                    ciphertextSegment, segmentNr, endOfCiphertext, plaintextSegment);
+        } catch (GeneralSecurityException ex) {
+            // The current segment did not validate.
+            // Currently this means that decryption cannot resume.
+            setUndefinedState();
+            throw new IOException(ex.getMessage() + "\n" + toString()
+                    + "\nsegmentNr:" + segmentNr
+                    + " endOfCiphertext:" + endOfCiphertext,
+                    ex);
+        }
+        segmentNr += 1;
+        plaintextSegment.flip();
+        ciphertextSegment.clear();
+        if (!endOfCiphertext) {
+            ciphertextSegment.clear();
+            ciphertextSegment.limit(ciphertextSegmentSize + 1);
+            ciphertextSegment.put(lastByte);
+        }
+        return true;
+    }
+
+    @Override
+    public synchronized int read(ByteBuffer dst) throws IOException {
+        if (!definedState) {
+            throw new IOException("This StreamingAeadDecryptingChannel is in an undefined state");
+        }
+        if (!headerRead) {
+            if (!tryReadHeader()) {
+                return 0;
+            }
+            ciphertextSegment.clear();
+            ciphertextSegment.limit(firstCiphertextSegmentSize + 1);
+        }
+        if (endOfPlaintext) {
+            return -1;
+        }
+        int startPosition = dst.position();
+        while (dst.remaining() > 0) {
+            if (plaintextSegment.remaining() == 0) {
+                if (endOfCiphertext) {
+                    endOfPlaintext = true;
+                    break;
+                }
+                if (!tryLoadSegment()) {
+                    break;
+                }
+            }
+            if (plaintextSegment.remaining() <= dst.remaining()) {
+                dst.put(plaintextSegment);
+            } else {
+                int sliceSize = dst.remaining();
+                ByteBuffer slice = plaintextSegment.duplicate();
+                slice.limit(slice.position() + sliceSize);
+                dst.put(slice);
+                plaintextSegment.position(plaintextSegment.position() + sliceSize);
+            }
+        }
+        int bytesRead = dst.position() - startPosition;
+        if (bytesRead == 0 && endOfPlaintext) {
+            return -1;
+        } else {
+            return bytesRead;
+        }
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+        if (ciphertextChannel != null) {
+            ciphertextChannel.close();
+            ciphertextChannel = null;
+        }
+    }
+
+    @Override
+    public synchronized boolean isOpen() {
+        return ciphertextChannel.isOpen();
+    }
+
+
+    /* Returns the state of the channel. */
+    @Override
+    public synchronized String toString() {
+        StringBuilder res = new StringBuilder();
+        res.append("StreamingAeadDecryptingChannel")
+                .append("\n\tsegmentNr:").append(segmentNr)
+                .append("\tciphertextSegmentSize:").append(ciphertextSegmentSize)
+                .append("\n\theaderRead:").append(headerRead)
+                .append("\tendOfCiphertext:").append(endOfCiphertext)
+                .append("\tendOfPlaintext:").append(endOfPlaintext)
+                .append("\tdefinedState:").append(definedState)
+                .append("\n\tHeader position:").append(header.position())
+                .append("\tlimit:").append(header.position())
+                .append("\n\tciphertextSegment position:").append(ciphertextSegment.position())
+                .append("\tlimit:").append(ciphertextSegment.limit())
+                .append("\n\tplaintextSegment position:").append(plaintextSegment.position())
+                .append("\tlimit:").append(plaintextSegment.limit());
+        return res.toString();
+    }
+}

--- a/common/network-common/src/main/java/org/apache/spark/network/crypto/InternalStreamingAeadEncryptingChannel.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/crypto/InternalStreamingAeadEncryptingChannel.java
@@ -1,0 +1,164 @@
+package org.apache.spark.network.crypto;
+
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+import com.google.crypto.tink.subtle.AesGcmHkdfStreaming;
+import com.google.crypto.tink.subtle.StreamSegmentEncrypter;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.WritableByteChannel;
+import java.security.GeneralSecurityException;
+
+/**
+ * This code is based on from Google Tink's StreamingAeadEncryptingChannel. We adapt it here because Tink does
+ * not allow you to pass in a buffer and would allocate a new buffer on each run.
+ */
+class InternalStreamingAeadEncryptingChannel implements WritableByteChannel {
+    private static final byte[] UNUSED_AAD = new byte[0];
+    private final StreamSegmentEncrypter encrypter;
+    private final ByteBuffer plaintextBuffer;
+    private final ByteBuffer ciphertextBuffer;
+    private WritableByteChannel ciphertextChannel;
+    private boolean open = true;
+    private long inputTransferred;
+    long written;
+
+    InternalStreamingAeadEncryptingChannel(AesGcmHkdfStreaming gcmStreamer,
+                                           ByteBuffer plaintextBuffer,
+                                           ByteBuffer ciphertextBuffer) throws GeneralSecurityException {
+        this.encrypter = gcmStreamer.newStreamSegmentEncrypter(UNUSED_AAD);
+
+        // Clear and limit the plaintext buffer
+        this.plaintextBuffer = plaintextBuffer;
+        this.plaintextBuffer.clear();
+        int plaintextSegmentSize = gcmStreamer.getPlaintextSegmentSize();
+        int ciphertextOffset = gcmStreamer.getCiphertextOffset();
+        this.plaintextBuffer.limit( plaintextSegmentSize - ciphertextOffset);
+
+        // Clear the ciphertext buffer
+        this.ciphertextBuffer = ciphertextBuffer;
+        this.ciphertextBuffer.clear();
+
+        this.inputTransferred = 0;
+    }
+
+    @Override
+    public int write(ByteBuffer plaintext) throws IOException {
+        if (!open) {
+            throw new ClosedChannelException();
+        }
+        int bytesWritten = 0;
+        if (ciphertextBuffer.remaining() > 0) {
+            bytesWritten += ciphertextChannel.write(ciphertextBuffer);
+        }
+        int startPosition = plaintext.position();
+        while (plaintext.remaining() > plaintextBuffer.remaining()) {
+            if (ciphertextBuffer.remaining() > 0) {
+                return plaintext.position() - startPosition;
+            }
+            int sliceSize = plaintextBuffer.remaining();
+            ByteBuffer slice = plaintext.slice();
+            slice.limit(sliceSize);
+            plaintext.position(plaintext.position() + sliceSize);
+            try {
+                plaintextBuffer.flip();
+                ciphertextBuffer.clear();
+                if (slice.remaining() != 0) {
+                    encrypter.encryptSegment(plaintextBuffer, slice, false, ciphertextBuffer);
+                } else {
+                    encrypter.encryptSegment(plaintextBuffer, false, ciphertextBuffer);
+                }
+            } catch (GeneralSecurityException ex) {
+                throw new IOException(ex);
+            }
+            ciphertextBuffer.flip();
+            bytesWritten += ciphertextChannel.write(ciphertextBuffer);
+            plaintextBuffer.clear();
+            plaintextBuffer.limit(plaintextBuffer.capacity());
+        }
+        plaintextBuffer.put(plaintext);
+        int t = (plaintext.position() - startPosition);
+        inputTransferred += t;
+        written += bytesWritten;
+        return t;
+    }
+
+    /**
+     * @return The total number of plaintext bytes read from a source to far
+     */
+    long getInputTransferred() { return inputTransferred;}
+
+    /**
+     * The total number of ciphertext bytes written so far. We expect this to be greater than the number transferred
+     * since it will include a header and authentication tag.
+     *
+     * @return The total number of ciphertext bytes written so far.
+     */
+    long getWritten() { return written; }
+
+    @Override
+    public boolean isOpen() { return open;}
+
+    @Override
+    public void close() throws IOException {
+        written += flushCiphertextBuffer(false);
+        try {
+            ciphertextBuffer.clear();
+            plaintextBuffer.flip();
+            encrypter.encryptSegment(plaintextBuffer, true, ciphertextBuffer);
+        } catch (GeneralSecurityException ex) {
+            throw new IOException(ex);
+        }
+        ciphertextBuffer.flip();
+        written += flushCiphertextBuffer(true);
+        ciphertextChannel.close();
+        this.open = false;
+    }
+
+    private int flushCiphertextBuffer(boolean isLastSegment) throws IOException {
+        int totalWritten = 0;
+        while (ciphertextBuffer.remaining() > 0) {
+            int bytesToWrite = ciphertextBuffer.remaining();
+            int written = ciphertextChannel.write(ciphertextBuffer);
+            totalWritten += written;
+            if (written <= 0) {
+                throw new IOException("Unable to write remaining " + bytesToWrite + " bytes of ciphertext " +
+                        ((isLastSegment) ? "for final segment." : ".") + " Ensure output channel has capacity.");
+            }
+        }
+        return totalWritten;
+    }
+
+    void setCiphertextChannel(WritableByteChannel target) throws IOException {
+        if (ciphertextChannel == null) {
+            ciphertextChannel = target;
+            ciphertextBuffer.clear();
+            // At this point, ciphertextChannel might not yet be ready to receive bytes.
+            // Buffering the header in ciphertextBuffer ensures that the header will be written when writing to
+            // ciphertextChannel is possible.
+            ciphertextBuffer.put(encrypter.getHeader());
+            ciphertextBuffer.flip();
+            written += ciphertextChannel.write(ciphertextBuffer);
+        }
+    }
+}
+
+
+

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -214,13 +214,6 @@ public class TransportConf {
   }
 
   /**
-   * The cipher transformation to use for encrypting session data.
-   */
-  public String cipherTransformation() {
-    return conf.get("spark.network.crypto.cipher", "AES/CTR/NoPadding");
-  }
-
-  /**
    * Whether to fall back to SASL if the new auth protocol fails. Enabled by default for
    * backwards compatibility.
    */

--- a/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthEngineSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthEngineSuite.java
@@ -17,20 +17,20 @@
 
 package org.apache.spark.network.crypto;
 
+import java.io.*;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
-import java.util.Random;
+import java.util.Arrays;
 
 import com.google.crypto.tink.subtle.Hex;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.FileRegion;
 import org.apache.spark.network.util.ByteArrayWritableChannel;
-import org.apache.spark.network.util.MapConfigProvider;
-import org.apache.spark.network.util.TransportConf;
 import static org.junit.jupiter.api.Assertions.*;
-import org.junit.jupiter.api.BeforeAll;
+
 import org.junit.jupiter.api.Test;
 import static org.mockito.Mockito.*;
 import org.mockito.invocation.InvocationOnMock;
@@ -48,22 +48,14 @@ public class AuthEngineSuite {
       "fb00000005617070496400000010708451c9dd2792c97c1ca66e6df449ef0000003c64fe899ecdaf458d4" +
       "e25e9d5c5a380b8e6d1a184692fac065ed84f8592c18e9629f9c636809dca2ffc041f20346eb53db78738" +
       "08ecad08b46b5ee3ff";
-  private static final String sharedKey =
-      "31963f15a320d5c90333f7ecf5cf3a31c7eaf151de07fef8494663a9f47cfd31";
-  private static final String inputIv = "fc6a5dc8b90a9dad8f54f08b51a59ed2";
-  private static final String outputIv = "a72709baf00785cad6329ce09f631f71";
-  private static TransportConf conf;
-
-  @BeforeAll
-  public static void setUp() {
-    conf = new TransportConf("rpc", MapConfigProvider.EMPTY);
-  }
+  private static final String expectedTransportCipherId =
+      "TransportCipher(id=bzYVxiQSeBV4oGiLKV0BnFkrAOp0ijld4h47pVh6Sh8)";
 
   @Test
   public void testAuthEngine() throws Exception {
 
-    try (AuthEngine client = new AuthEngine("appId", "secret", conf);
-         AuthEngine server = new AuthEngine("appId", "secret", conf)) {
+    try (AuthEngine client = new AuthEngine("appId", "secret");
+         AuthEngine server = new AuthEngine("appId", "secret")) {
       AuthMessage clientChallenge = client.challenge();
       AuthMessage serverResponse = server.response(clientChallenge);
       client.deriveSessionCipher(clientChallenge, serverResponse);
@@ -71,17 +63,27 @@ public class AuthEngineSuite {
       TransportCipher serverCipher = server.sessionCipher();
       TransportCipher clientCipher = client.sessionCipher();
 
-      assertArrayEquals(serverCipher.getInputIv(), clientCipher.getOutputIv());
-      assertArrayEquals(serverCipher.getOutputIv(), clientCipher.getInputIv());
-      assertEquals(serverCipher.getKey(), clientCipher.getKey());
+      // Encrypt a message from the server
+      String plaintext = "Hello world";
+      ByteArrayOutputStream ciphertext = new ByteArrayOutputStream(100);
+      OutputStream encryptStream = serverCipher.getGcmStreamer().newEncryptingStream(ciphertext, new byte[0]);
+      encryptStream.write(plaintext.getBytes(StandardCharsets.UTF_8));
+      encryptStream.close();
+
+      // Decrypt it on the client
+      ByteArrayInputStream ciphertextInputStream = new ByteArrayInputStream(ciphertext.toByteArray());
+      InputStream decryptStream = clientCipher.getGcmStreamer().newDecryptingStream(ciphertextInputStream, new byte[0]);
+      byte[] decrypted = decryptStream.readAllBytes();
+      String decryptedString = new String(decrypted, StandardCharsets.UTF_8);
+      assertEquals(plaintext, decryptedString);
     }
   }
 
   @Test
   public void testCorruptChallengeAppId() throws Exception {
 
-    try (AuthEngine client = new AuthEngine("appId", "secret", conf);
-         AuthEngine server = new AuthEngine("appId", "secret", conf)) {
+    try (AuthEngine client = new AuthEngine("appId", "secret");
+         AuthEngine server = new AuthEngine("appId", "secret")) {
       AuthMessage clientChallenge = client.challenge();
       AuthMessage corruptChallenge =
               new AuthMessage("junk", clientChallenge.salt(), clientChallenge.ciphertext());
@@ -92,8 +94,8 @@ public class AuthEngineSuite {
   @Test
   public void testCorruptChallengeSalt() throws Exception {
 
-    try (AuthEngine client = new AuthEngine("appId", "secret", conf);
-         AuthEngine server = new AuthEngine("appId", "secret", conf)) {
+    try (AuthEngine client = new AuthEngine("appId", "secret");
+         AuthEngine server = new AuthEngine("appId", "secret")) {
       AuthMessage clientChallenge = client.challenge();
       clientChallenge.salt()[0] ^= 1;
       assertThrows(GeneralSecurityException.class, () -> server.response(clientChallenge));
@@ -103,8 +105,8 @@ public class AuthEngineSuite {
   @Test
   public void testCorruptChallengeCiphertext() throws Exception {
 
-    try (AuthEngine client = new AuthEngine("appId", "secret", conf);
-         AuthEngine server = new AuthEngine("appId", "secret", conf)) {
+    try (AuthEngine client = new AuthEngine("appId", "secret");
+         AuthEngine server = new AuthEngine("appId", "secret")) {
       AuthMessage clientChallenge = client.challenge();
       clientChallenge.ciphertext()[0] ^= 1;
       assertThrows(GeneralSecurityException.class, () -> server.response(clientChallenge));
@@ -114,8 +116,8 @@ public class AuthEngineSuite {
   @Test
   public void testCorruptResponseAppId() throws Exception {
 
-    try (AuthEngine client = new AuthEngine("appId", "secret", conf);
-         AuthEngine server = new AuthEngine("appId", "secret", conf)) {
+    try (AuthEngine client = new AuthEngine("appId", "secret");
+         AuthEngine server = new AuthEngine("appId", "secret")) {
       AuthMessage clientChallenge = client.challenge();
       AuthMessage serverResponse = server.response(clientChallenge);
       AuthMessage corruptResponse =
@@ -128,8 +130,8 @@ public class AuthEngineSuite {
   @Test
   public void testCorruptResponseSalt() throws Exception {
 
-    try (AuthEngine client = new AuthEngine("appId", "secret", conf);
-         AuthEngine server = new AuthEngine("appId", "secret", conf)) {
+    try (AuthEngine client = new AuthEngine("appId", "secret");
+         AuthEngine server = new AuthEngine("appId", "secret")) {
       AuthMessage clientChallenge = client.challenge();
       AuthMessage serverResponse = server.response(clientChallenge);
       serverResponse.salt()[0] ^= 1;
@@ -141,8 +143,8 @@ public class AuthEngineSuite {
   @Test
   public void testCorruptServerCiphertext() throws Exception {
 
-    try (AuthEngine client = new AuthEngine("appId", "secret", conf);
-         AuthEngine server = new AuthEngine("appId", "secret", conf)) {
+    try (AuthEngine client = new AuthEngine("appId", "secret");
+         AuthEngine server = new AuthEngine("appId", "secret")) {
       AuthMessage clientChallenge = client.challenge();
       AuthMessage serverResponse = server.response(clientChallenge);
       serverResponse.ciphertext()[0] ^= 1;
@@ -153,7 +155,7 @@ public class AuthEngineSuite {
 
   @Test
   public void testFixedChallenge() throws Exception {
-    try (AuthEngine server = new AuthEngine("appId", "secret", conf)) {
+    try (AuthEngine server = new AuthEngine("appId", "secret")) {
       AuthMessage clientChallenge =
               AuthMessage.decodeMessage(ByteBuffer.wrap(Hex.decode(clientChallengeHex)));
       // This tests that the server will accept an old challenge as expected. However,
@@ -164,7 +166,7 @@ public class AuthEngineSuite {
 
   @Test
   public void testFixedChallengeResponse() throws Exception {
-    try (AuthEngine client = new AuthEngine("appId", "secret", conf)) {
+    try (AuthEngine client = new AuthEngine("appId", "secret")) {
       byte[] clientPrivateKey = Hex.decode(clientPrivate);
       client.setClientPrivateKey(clientPrivateKey);
       AuthMessage clientChallenge =
@@ -174,16 +176,15 @@ public class AuthEngineSuite {
       // Verify that the client will accept an old transcript.
       client.deriveSessionCipher(clientChallenge, serverResponse);
       TransportCipher clientCipher = client.sessionCipher();
-      assertEquals(Hex.encode(clientCipher.getKey().getEncoded()), sharedKey);
-      assertEquals(Hex.encode(clientCipher.getInputIv()), inputIv);
-      assertEquals(Hex.encode(clientCipher.getOutputIv()), outputIv);
+      String id = clientCipher.toString();
+      assertEquals(expectedTransportCipherId, id);
     }
   }
 
   @Test
   public void testMismatchedSecret() throws Exception {
-    try (AuthEngine client = new AuthEngine("appId", "secret", conf);
-         AuthEngine server = new AuthEngine("appId", "different_secret", conf)) {
+    try (AuthEngine client = new AuthEngine("appId", "secret");
+         AuthEngine server = new AuthEngine("appId", "different_secret")) {
       AuthMessage clientChallenge = client.challenge();
       assertThrows(GeneralSecurityException.class, () -> server.response(clientChallenge));
     }
@@ -191,38 +192,74 @@ public class AuthEngineSuite {
 
   @Test
   public void testEncryptedMessage() throws Exception {
-    try (AuthEngine client = new AuthEngine("appId", "secret", conf);
-         AuthEngine server = new AuthEngine("appId", "secret", conf)) {
+    try (AuthEngine client = new AuthEngine("appId", "secret");
+         AuthEngine server = new AuthEngine("appId", "secret")) {
       AuthMessage clientChallenge = client.challenge();
       AuthMessage serverResponse = server.response(clientChallenge);
       client.deriveSessionCipher(clientChallenge, serverResponse);
 
-      TransportCipher cipher = server.sessionCipher();
-      TransportCipher.EncryptionHandler handler = new TransportCipher.EncryptionHandler(cipher);
+      TransportCipher transportCipher = server.sessionCipher();
+      TransportCipher.EncryptionHandler handler = new TransportCipher.EncryptionHandler(transportCipher);
+      int[] TEST_PLAINTEXT_LENGTHS = {
+              10,
+              100,
+              TransportCipher.PLAINTEXT_SEGMENT_SIZE_32K_BYTES,
+              TransportCipher.PLAINTEXT_SEGMENT_SIZE_32K_BYTES + 1,
+              TransportCipher.PLAINTEXT_SEGMENT_SIZE_32K_BYTES * 2,
+              TransportCipher.PLAINTEXT_SEGMENT_SIZE_32K_BYTES * 3 + 100
+      };
 
-      byte[] data = new byte[TransportCipher.STREAM_BUFFER_SIZE + 1];
-      new Random().nextBytes(data);
-      ByteBuf buf = Unpooled.wrappedBuffer(data);
-
-      ByteArrayWritableChannel channel = new ByteArrayWritableChannel(data.length);
-      TransportCipher.EncryptedMessage emsg = handler.createEncryptedMessage(buf);
-      while (emsg.transferred() < emsg.count()) {
-        emsg.transferTo(channel, emsg.transferred());
+      for (int dataLength : TEST_PLAINTEXT_LENGTHS) {
+        byte[] data = new byte[dataLength];
+        Arrays.fill(data, (byte) 'x');
+        ByteBuf buf = Unpooled.wrappedBuffer(data);
+        ByteArrayWritableChannel channel = new ByteArrayWritableChannel((int) transportCipher.expectedCiphertextSize(dataLength));
+        TransportCipher.EncryptedMessage<ByteBuf> emsg = handler.createEncryptedMessage(buf);
+        while (emsg.transferred() < emsg.count()) {
+          emsg.transferTo(channel, emsg.transferred());
+        }
+        assertEquals(dataLength, emsg.transferred());
       }
-      assertEquals(data.length, channel.length());
+    }
+  }
+
+  @Test
+  public void testDestinationTooSmall() throws Exception {
+    try (AuthEngine client = new AuthEngine("appId", "secret");
+         AuthEngine server = new AuthEngine("appId", "secret")) {
+      AuthMessage clientChallenge = client.challenge();
+      AuthMessage serverResponse = server.response(clientChallenge);
+      client.deriveSessionCipher(clientChallenge, serverResponse);
+
+      TransportCipher transportCipher = server.sessionCipher();
+      TransportCipher.EncryptionHandler handler = new TransportCipher.EncryptionHandler(transportCipher);
+      int fixedDataLength = TransportCipher.PLAINTEXT_SEGMENT_SIZE_32K_BYTES * 3 + 100;
+      byte[] data = new byte[fixedDataLength];
+      Arrays.fill(data, (byte) 'x');
+      ByteBuf buf = Unpooled.wrappedBuffer(data);
+      // This output channel will be too short since it will not have space for headers and authentication tags
+      ByteArrayWritableChannel channel = new ByteArrayWritableChannel(fixedDataLength);
+      TransportCipher.EncryptedMessage<ByteBuf> emsg = handler.createEncryptedMessage(buf);
+
+      assertThrows(IOException.class, () -> {
+        while (emsg.transferred() < emsg.count()) {
+          emsg.transferTo(channel, emsg.transferred());
+        }
+      });
+      assertEquals(fixedDataLength, emsg.transferred());
     }
   }
 
   @Test
   public void testEncryptedMessageWhenTransferringZeroBytes() throws Exception {
-    try (AuthEngine client = new AuthEngine("appId", "secret", conf);
-         AuthEngine server = new AuthEngine("appId", "secret", conf)) {
+    try (AuthEngine client = new AuthEngine("appId", "secret");
+         AuthEngine server = new AuthEngine("appId", "secret")) {
       AuthMessage clientChallenge = client.challenge();
       AuthMessage serverResponse = server.response(clientChallenge);
       client.deriveSessionCipher(clientChallenge, serverResponse);
 
-      TransportCipher cipher = server.sessionCipher();
-      TransportCipher.EncryptionHandler handler = new TransportCipher.EncryptionHandler(cipher);
+      TransportCipher transportCipher = server.sessionCipher();
+      TransportCipher.EncryptionHandler handler = new TransportCipher.EncryptionHandler(transportCipher);
 
       int testDataLength = 4;
       FileRegion region = mock(FileRegion.class);
@@ -239,19 +276,22 @@ public class AuthEngineSuite {
             return 0L;
           } else {
             WritableByteChannel channel = invocationOnMock.getArgument(0);
-            channel.write(ByteBuffer.wrap(new byte[testDataLength]));
+            byte[] testData = new byte[testDataLength];
+            Arrays.fill(testData, (byte) 'x');
+            channel.write(ByteBuffer.wrap(testData));
             return (long) testDataLength;
           }
         }
       });
 
-      TransportCipher.EncryptedMessage emsg = handler.createEncryptedMessage(region);
-      ByteArrayWritableChannel channel = new ByteArrayWritableChannel(testDataLength);
+      TransportCipher.EncryptedMessage<FileRegion> emsg = handler.createEncryptedMessage(region);
+      int expectedCiphertextLength = (int) emsg.expectedCiphertextSize(testDataLength);
+      ByteArrayWritableChannel channel = new ByteArrayWritableChannel(expectedCiphertextLength);
       // "transferTo" should act correctly when the underlying FileRegion transfers 0 bytes.
       assertEquals(0L, emsg.transferTo(channel, emsg.transferred()));
-      assertEquals(testDataLength, emsg.transferTo(channel, emsg.transferred()));
+      assertEquals(expectedCiphertextLength, emsg.transferTo(channel, emsg.transferred()));
       assertEquals(emsg.transferred(), emsg.count());
-      assertEquals(4, channel.length());
+      assertEquals(expectedCiphertextLength, channel.length());
     }
   }
 }

--- a/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthIntegrationSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthIntegrationSuite.java
@@ -119,7 +119,7 @@ public class AuthIntegrationSuite {
   @Test
   public void testLargeMessageEncryption() throws Exception {
     // Use a big length to create a message that cannot be put into the encryption buffer completely
-    final int testErrorMessageLength = TransportCipher.STREAM_BUFFER_SIZE;
+    final int testErrorMessageLength = TransportCipher.PLAINTEXT_SEGMENT_SIZE_32K_BYTES;
     ctx = new AuthTestCtx(new RpcHandler() {
       @Override
       public void receive(

--- a/common/network-common/src/test/java/org/apache/spark/network/crypto/TransportCipherSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/crypto/TransportCipherSuite.java
@@ -16,50 +16,26 @@
  */
 package org.apache.spark.network.crypto;
 
-import javax.crypto.spec.SecretKeySpec;
 import java.io.IOException;
-import java.nio.channels.ReadableByteChannel;
-import java.nio.channels.WritableByteChannel;
+import java.security.GeneralSecurityException;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
-import org.apache.commons.crypto.stream.CryptoInputStream;
-import org.apache.commons.crypto.stream.CryptoOutputStream;
-import org.apache.spark.network.util.MapConfigProvider;
-import org.apache.spark.network.util.TransportConf;
 import org.junit.jupiter.api.Test;
+
+import javax.crypto.spec.SecretKeySpec;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class TransportCipherSuite {
 
   @Test
-  public void testBufferNotLeaksOnInternalError() throws IOException {
-    String algorithm = "TestAlgorithm";
-    TransportConf conf = new TransportConf("Test", MapConfigProvider.EMPTY);
-    TransportCipher cipher = new TransportCipher(conf.cryptoConf(), conf.cipherTransformation(),
-      new SecretKeySpec(new byte[256], algorithm), new byte[0], new byte[0]) {
-
-      @Override
-      CryptoOutputStream createOutputStream(WritableByteChannel ch) {
-        return null;
-      }
-
-      @Override
-      CryptoInputStream createInputStream(ReadableByteChannel ch) throws IOException {
-        CryptoInputStream mockInputStream = mock(CryptoInputStream.class);
-        when(mockInputStream.read(any(byte[].class), anyInt(), anyInt()))
-          .thenThrow(new InternalError());
-        return mockInputStream;
-      }
-    };
+  public void testBufferNotLeaksOnInternalError() throws GeneralSecurityException {
+    SecretKeySpec fakeAesKey = new SecretKeySpec(new byte[16], "AES");
+    TransportCipher cipher = new TransportCipher("ID", fakeAesKey);
 
     EmbeddedChannel channel = new EmbeddedChannel();
     cipher.addToChannel(channel);

--- a/common/network-common/src/test/resources/log4j2.properties
+++ b/common/network-common/src/test/resources/log4j2.properties
@@ -28,4 +28,4 @@ appender.file.layout.pattern = %d{yy/MM/dd HH:mm:ss.SSS} %t %p %c{1}: %m%n%ex
 
 # Silence verbose logs from 3rd-party libraries.
 logger.netty.name = io.netty
-logger.netty.level = info
+logger.netty.level = trace


### PR DESCRIPTION
### What changes were proposed in this pull request?
The high level issue is that Apache Spark's RPC encryption is using unauthenticated CTR. We want to switch to GCM.

The complication is Spark currently uses Apache Commons' CryptoInputStream and CryptoOutputStream, which do not support GCM. GCM also increases the ciphertext size by prepending an IV and adding an authentication tag.

So far, this is requiring a larger rewrite to work with Spark's ByteBufs and FileRegions. This diff is currently a Work in Progress


### Why are the changes needed?

AES CTR mode with no authentication is vulnerable to someone modifying ciphertexts. That would allow them to change RPC call contents.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Existing unit tests

### Was this patch authored or co-authored using generative AI tooling?

No.