### PR TITLE
[SPARK-47277][3.5] PySpark util function assertDataFrameEqual should not support streaming DF

### DIFF
--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -1611,6 +1611,18 @@ class UtilsTestsMixin:
             message_parameters={"error_msg": error_msg},
         )
 
+    def test_assert_data_frame_equal_not_support_streaming(self):
+        df1 = self.spark.readStream.format("rate").load()
+        df2 = self.spark.readStream.format("rate").load()
+        exception_thrown = False
+        try:
+            assertDataFrameEqual(df1, df2)
+        except PySparkAssertionError as e:
+            self.assertEqual(e.getErrorClass(), "UNSUPPORTED_OPERATION")
+            exception_thrown = True
+
+        self.assertTrue(exception_thrown)
+
 
 class UtilsTests(ReusedSQLTestCase, UtilsTestsMixin):
     def test_capture_analysis_exception(self):
@@ -1657,10 +1669,6 @@ class UtilsTests(ReusedSQLTestCase, UtilsTestsMixin):
         try:
             self.spark.sql("""SELECT a""")
         except AnalysisException as e:
-<<<<<<< HEAD
-            self.assertEquals(e.getErrorClass(), "UNRESOLVED_COLUMN.WITHOUT_SUGGESTION")
-            self.assertEquals(e.getSqlState(), "42703")
-=======
             exception = e
 
         self.assertIsNotNone(exception)
@@ -1690,23 +1698,6 @@ class UtilsTests(ReusedSQLTestCase, UtilsTestsMixin):
             self.assertIsNone(e.getSqlState())
             self.assertEqual(e.getMessageParameters(), {})
             self.assertEqual(e.getMessage(), "")
-
-    def test_assert_data_frame_equal_not_support_streaming(self):
-        df1 = self.spark.readStream.format("rate").load()
-        df2 = self.spark.readStream.format("rate").load()
-        exception_thrown = False
-        try:
-            assertDataFrameEqual(df1, df2)
-        except PySparkAssertionError as e:
-            self.assertEqual(e.getErrorClass(), "UNSUPPORTED_OPERATION")
-            exception_thrown = True
-
-        self.assertTrue(exception_thrown)
-
-
-class UtilsTests(ReusedSQLTestCase, UtilsTestsMixin):
-    pass
->>>>>>> 4743103478 ([SPARK-47277] PySpark util function assertDataFrameEqual should not support streaming DF)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -1669,35 +1669,8 @@ class UtilsTests(ReusedSQLTestCase, UtilsTestsMixin):
         try:
             self.spark.sql("""SELECT a""")
         except AnalysisException as e:
-            exception = e
-
-        self.assertIsNotNone(exception)
-        self.assertEqual(exception.getErrorClass(), "UNRESOLVED_COLUMN.WITHOUT_SUGGESTION")
-        self.assertEqual(exception.getSqlState(), "42703")
-        self.assertEqual(exception.getMessageParameters(), {"objectName": "`a`"})
-        self.assertIn(
-            (
-                "[UNRESOLVED_COLUMN.WITHOUT_SUGGESTION] A column, variable, or function "
-                "parameter with name `a` cannot be resolved.  SQLSTATE: 42703"
-            ),
-            exception.getMessage(),
-        )
-        self.assertEqual(len(exception.getQueryContext()), 1)
-        qc = exception.getQueryContext()[0]
-        self.assertEqual(qc.fragment(), "a")
-        self.assertEqual(qc.stopIndex(), 7)
-        self.assertEqual(qc.startIndex(), 7)
-        self.assertEqual(qc.contextType(), QueryContextType.SQL)
-        self.assertEqual(qc.objectName(), "")
-        self.assertEqual(qc.objectType(), "")
-
-        try:
-            self.spark.sql("""SELECT assert_true(FALSE)""")
-        except AnalysisException as e:
-            self.assertIsNone(e.getErrorClass())
-            self.assertIsNone(e.getSqlState())
-            self.assertEqual(e.getMessageParameters(), {})
-            self.assertEqual(e.getMessage(), "")
+            self.assertEquals(e.getErrorClass(), "UNRESOLVED_COLUMN.WITHOUT_SUGGESTION")
+            self.assertEquals(e.getSqlState(), "42703")
 
 
 if __name__ == "__main__":

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -587,11 +587,21 @@ def assertDataFrameEqual(
         assertSchemaEqual(actual.schema, expected.schema)
 
     if not isinstance(actual, list):
+        if actual.isStreaming:
+            raise PySparkAssertionError(
+                error_class="UNSUPPORTED_OPERATION",
+                message_parameters={"operation": "assertDataFrameEqual on streaming DataFrame"},
+            )
         actual_list = actual.collect()
     else:
         actual_list = actual
 
     if not isinstance(expected, list):
+        if expected.isStreaming:
+            raise PySparkAssertionError(
+                error_class="UNSUPPORTED_OPERATION",
+                message_parameters={"operation": "assertDataFrameEqual on streaming DataFrame"},
+            )
         expected_list = expected.collect()
     else:
         expected_list = expected

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/progress.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/progress.scala
@@ -243,7 +243,7 @@ class SourceProgress protected[spark](
   }
 }
 
-test_utils.py/**
+/**
  * Information about progress made for a sink in the execution of a [[StreamingQuery]]
  * during a trigger. See [[StreamingQueryProgress]] for more information.
  *

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/progress.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/progress.scala
@@ -243,7 +243,7 @@ class SourceProgress protected[spark](
   }
 }
 
-/**
+test_utils.py/**
  * Information about progress made for a sink in the execution of a [[StreamingQuery]]
  * during a trigger. See [[StreamingQueryProgress]] for more information.
  *


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Backport https://github.com/apache/spark/pull/45380 to branch-3.5

The handy util function should not support streaming dataframes, currently if you call it upon streaming queries, it throws a relatively hard-to-understand error:
```
>>> df1 = spark.readStream.format("rate").load()
>>> df2 = spark.readStream.format("rate").load()
>>> from pyspark.testing.utils import QuietTest, assertDataFrameEqual
>>> assertDataFrameEqual(df1, df2)
/Users/wei.liu/oss-spark/python/pyspark/pandas/__init__.py:43: UserWarning: 'PYARROW_IGNORE_TIMEZONE' environment variable was not set. It is required to set this environment variable to '1' in both driver and executor sides if you use pyarrow>=2.0.0. pandas-on-Spark will set it for you but it does not work if there is a Spark context already launched.
  warnings.warn(
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/wei.liu/oss-spark/python/pyspark/testing/utils.py", line 936, in assertDataFrameEqual
    actual_list = actual.collect()
  File "/Users/wei.liu/oss-spark/python/pyspark/sql/dataframe.py", line 1453, in collect
    sock_info = self._jdf.collectToPython()
  File "/Users/wei.liu/oss-spark/python/lib/py4j-0.10.9.7-src.zip/py4j/java_gateway.py", line 1322, in __call__
  File "/Users/wei.liu/oss-spark/python/pyspark/errors/exceptions/captured.py", line 221, in deco
    raise converted from None
pyspark.errors.exceptions.captured.AnalysisException: Queries with streaming sources must be executed with writeStream.start();
rate
```
Because the function calls `collect` which is not supported on streaming dataframes. It'd be good if we can catch this earlier.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Improve usability

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Github Copilot
It helped me to pick the error class UNSUPPORTED_OPERATION