### PR TITLE
[SPARK-47294][SQL] OptimizeSkewInRebalanceRepartitions should support ProjectExec(_,ShuffleQueryStageExec)

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewInRebalancePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/OptimizeSkewInRebalancePartitions.scala
@@ -93,6 +93,8 @@ object OptimizeSkewInRebalancePartitions extends AQEShuffleReadRule {
     }
 
     plan transformUp {
+      case p @ ProjectExec(_, stage: ShuffleQueryStageExec) if isSupported(stage.shuffle) =>
+        p.copy(child = tryOptimizeSkewedPartitions(stage))
       case stage: ShuffleQueryStageExec if isSupported(stage.shuffle) =>
         tryOptimizeSkewedPartitions(stage)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Current OptimizeSkewInRebalanceRepartitions only support match case ShuffleQueryStageExec
```
    plan transformUp {
      case stage: ShuffleQueryStageExec if isSupported(stage.shuffle) =>
        tryOptimizeSkewedPartitions(stage)
    }
```

This only can work when we write a query with rebalance hint
```
SELECT /*+ REBALANCE(col) */ * FROM table
```

This won't work when we are writing to a table 
```
INSERT INTO t1
SELECT  /*+ REBALANCE(key1) */
*
FROM skewData1
```
This pr support this.

### Why are the changes needed?
Support more case since this can avoid skew when we are writing to a table with `REBALANCE` hint




### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
MT



### Was this patch authored or co-authored using generative AI tooling?
Before 
![image](https://github.com/apache/spark/assets/46485123/cde10d04-8cc0-427a-bc83-c4c51929e0bc)

After
![image](https://github.com/apache/spark/assets/46485123/8d1c8a18-77f2-48a2-b388-b9939dd644e0)

