### PR TITLE
[SPARK-47298][BUILD] Upgrade `mysql-connector-j` to `8.3.0` and `mariadb-java-client` to `2.7.12`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1250,13 +1250,13 @@
       <dependency>
         <groupId>com.mysql</groupId>
         <artifactId>mysql-connector-j</artifactId>
-        <version>8.2.0</version>
+        <version>8.3.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mariadb.jdbc</groupId>
         <artifactId>mariadb-java-client</artifactId>
-        <version>2.7.11</version>
+        <version>2.7.12</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to:
- upgrade `mysql-connector-j` from `8.2.0` to `8.3.0`.
- upgrade `mariadb-java-client` from `2.7.11` to `2.7.12`.


### Why are the changes needed?
Routine upgrade.

- com.mysql:mysql-connector-j, release notes:
https://dev.mysql.com/doc/relnotes/connector-j/en/news-8-3-0.html
Bugs Fixed, eg:
1.Setting a very large value for query timeout caused an IllegalArgumentException when a query was executed. It was due to an integer overflow, which is now avoided by changing the timeout value's data type from Integer to Long. (Bug #112884, Bug #36043166)
2.Calling PreparedStatement.executeUpdate() on a query that was only a comment caused a SQLException to be thrown, with the complaint that executeUpdate() "cannot issue statements that produce result sets." It was because the check on whether the query would produce results sets was faulty, and it has now been fixed. (Bug #109546, Bug #34958912)

- org.mariadb.jdbc:mariadb-java-client, release notes:
https://mariadb.com/kb/en/mariadb-connector-j-2-7-12-release-notes/
Bugs Fixed, eg:
[CONJ-1145](https://jira.mariadb.org/browse/CONJ-1145) Wrong sequence number of sub header with compressing procotol active
[CONJ-1151](https://jira.mariadb.org/browse/CONJ-1151) Wrong debug trace when using compression protocol
[CONJ-1152](https://jira.mariadb.org/browse/CONJ-1152) Improve message when reaching socket timeout during connection initial commands

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
