### PR TITLE
[SPARK-47300][SQL] `quoteIfNeeded` should quote identifier starts with digits

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/QuotingUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/QuotingUtils.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.sql.catalyst.util
 
+import java.util.regex.Pattern
+
 import org.apache.spark.sql.connector.catalog.Identifier
 
 object QuotingUtils {
@@ -41,11 +43,13 @@ object QuotingUtils {
     name.map(part => quoteIdentifier(part)).mkString(".")
   }
 
+  private val validIdentPattern = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*")
+
   def quoteIfNeeded(part: String): String = {
-    if (part.matches("[a-zA-Z0-9_]+") && !part.matches("\\d+")) {
+    if (validIdentPattern.matcher(part).matches()) {
       part
     } else {
-      s"`${part.replace("`", "``")}`"
+      quoteIdentifier(part)
     }
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/QuotingUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/QuotingUtilsSuite.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.util
+
+import org.apache.spark.SparkFunSuite
+
+class QuotingUtilsSuite extends SparkFunSuite {
+
+  test("do not quote for legal identifier strings") {
+    assert(quoteIfNeeded("a") == "a")
+    assert(quoteIfNeeded("a0") == "a0")
+    assert(quoteIfNeeded("a0a") == "a0a")
+    assert(quoteIfNeeded("_") == "_")
+    assert(quoteIfNeeded("_a") == "_a")
+    assert(quoteIfNeeded("_0") == "_0")
+    assert(quoteIfNeeded("_ab_") === "_ab_")
+  }
+
+  test("quote for illegal identifier strings") {
+    assert(quoteIfNeeded("&") == "`&`")
+    assert(quoteIfNeeded("a b") === "`a b`")
+    assert(quoteIfNeeded("a*b") === "`a*b`")
+    assert(quoteIfNeeded("0") == "`0`")
+    assert(quoteIfNeeded("01") == "`01`")
+    assert(quoteIfNeeded("0d") == "`0d`")
+    assert(quoteIfNeeded("") === "``")
+  }
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/StringUtilsSuite.scala
@@ -129,16 +129,6 @@ class StringUtilsSuite extends SparkFunSuite with SQLHelper {
     }
   }
 
-  test("SPARK-34872: quoteIfNeeded should quote a string which contains non-word characters") {
-    assert(quoteIfNeeded("a b") === "`a b`")
-    assert(quoteIfNeeded("a*b") === "`a*b`")
-    assert(quoteIfNeeded("123") === "`123`")
-    assert(quoteIfNeeded("1a") === "1a")
-    assert(quoteIfNeeded("_ab_") === "_ab_")
-    assert(quoteIfNeeded("_") === "_")
-    assert(quoteIfNeeded("") === "``")
-  }
-
   test("SPARK-43841: mix of multipart and single-part identifiers") {
     val baseString = "b"
     // mix of multipart and single-part


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
`quoteIfNeeded` is used to generate pretty strings of identifiers in error message, EXPLAIN result, etc. It's mostly for humans to read but sometimes people may copy-paste the identifier string and put it in a SQL. There is a small issue in `quoteIfNeeded`: it does not quote number literals like `0d`, and people will get parse exception if they directly put the identifier string in SQL.

This PR fixes the issue by always quoting the identifier if it does not start with alphabet or underscore. Note, there might be program trying to parse the identifier string, but this change is safe as these programs should already handle quoting and it's ok to quote more.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
make identifier string parsable is more user-friendly.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, the identifier string in the error message and EXPLAIN result will be properly quoted.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new test suite

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no