### PR TITLE
[SPARK-47301][SQL][TESTS] Fix flaky ParquetIOSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -1224,8 +1224,10 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
             .coalesce(1)
           df.write.partitionBy("a").options(extraOptions).parquet(dir.getCanonicalPath)
         }
-        assert(m2.getErrorClass == "TASK_WRITE_FAILED")
-        assert(m2.getCause.getMessage.contains("Intentional exception for testing purposes"))
+        if (m2.getErrorClass != null) {
+          assert(m2.getErrorClass == "TASK_WRITE_FAILED")
+          assert(m2.getCause.getMessage.contains("Intentional exception for testing purposes"))
+        }
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetIOSuite.scala
@@ -1227,6 +1227,8 @@ class ParquetIOSuite extends QueryTest with ParquetTest with SharedSparkSession 
         if (m2.getErrorClass != null) {
           assert(m2.getErrorClass == "TASK_WRITE_FAILED")
           assert(m2.getCause.getMessage.contains("Intentional exception for testing purposes"))
+        } else {
+          assert(m2.getMessage.contains("TASK_WRITE_FAILED"))
         }
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix flaky `ParquetIOSuite`, as follows:
https://github.com/panbingkun/spark/actions/runs/8167992505/job/22329299706
<img width="998" alt="image" src="https://github.com/apache/spark/assets/15246973/7b447c98-877f-4804-a131-071d002fbac2">


### Why are the changes needed?
Only fix flaky UT `ParquetIOSuite`.

Through log analysis, the logic has reached the following point (possibly due to the timing of event processing):
https://github.com/apache/spark/blob/58761623dcdd6438a76a13d9b52afeeba92147a0/core/src/main/scala/org/apache/spark/scheduler/OutputCommitCoordinator.scala#L161-L164

https://github.com/apache/spark/blob/58761623dcdd6438a76a13d9b52afeeba92147a0/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala#L2841

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Manually test.
- Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
