### PR TITLE
 [SPARK-47146][CORE][FOLLOWUP]Rename incorrect logger name

### DIFF
--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java
@@ -38,7 +38,7 @@ import java.io.*;
  * of the file format).
  */
 public final class UnsafeSorterSpillReader extends UnsafeSorterIterator implements Closeable {
-  private static final Logger logger = LoggerFactory.getLogger(ReadAheadInputStream.class);
+  private static final Logger logger = LoggerFactory.getLogger(UnsafeSorterSpillReader.class);
   public static final int MAX_BUFFER_SIZE_BYTES = 16777216; // 16 mb
 
   private InputStream in;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Rename incorrect logger name in `UnsafeSorterSpillReader`.

### Why are the changes needed?
The logger name in UnsafeSorterSpillReader is incorrect.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
No

### Was this patch authored or co-authored using generative AI tooling?
No
