### PR TITLE
[SPARK-45827][SQL] Move data type checks to CreatableRelationProvider

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -182,23 +182,16 @@ trait CreatableRelationProvider {
    * @param dt Data type to check
    * @return True if the data type is supported
    */
-  def supportsDataType(
-      dt: DataType
-  ): Boolean = {
+  def supportsDataType(dt: DataType): Boolean = {
     dt match {
       case ArrayType(e, _) => supportsDataType(e)
-      case MapType(k, v, _) =>
-        supportsDataType(k) && supportsDataType(v)
+      case MapType(k, v, _) => supportsDataType(k) && supportsDataType(v)
       case StructType(fields) => fields.forall(f => supportsDataType(f.dataType))
       case udt: UserDefinedType[_] => supportsDataType(udt.sqlType)
-      case _: AnsiIntervalType | CalendarIntervalType | VariantType => false
-      case BinaryType | BooleanType | ByteType | CalendarIntervalType | CharType(_) | DateType |
-           DayTimeIntervalType(_, _) | _ : DecimalType |  DoubleType | FloatType |
-           IntegerType | LongType | NullType | ObjectType(_) | ShortType |
-           StringType | TimestampNTZType | TimestampType | VarcharType(_) |
-           YearMonthIntervalType(_, _) => true
+      case BinaryType | BooleanType | ByteType | CharType(_) | DateType | _ : DecimalType |
+           DoubleType | FloatType | IntegerType | LongType | NullType | ObjectType(_) | ShortType |
+           StringType | TimestampNTZType | TimestampType | VarcharType(_) => true
       case _ => false
-
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -181,6 +181,8 @@ trait CreatableRelationProvider {
    *
    * @param dt Data type to check
    * @return True if the data type is supported
+   *
+   * @since 4.0.0
    */
   def supportsDataType(dt: DataType): Boolean = {
     dt match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.streaming.{Sink, Source}
 import org.apache.spark.sql.streaming.OutputMode
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types._
 
 /**
  * Data sources should implement this trait so that they can register an alias to their data source.
@@ -175,6 +175,32 @@ trait CreatableRelationProvider {
       mode: SaveMode,
       parameters: Map[String, String],
       data: DataFrame): BaseRelation
+
+  /**
+   * Check if the relation supports the given data type.
+   *
+   * @param dt Data type to check
+   * @return True if the data type is supported
+   */
+  def supportsDataType(
+      dt: DataType
+  ): Boolean = {
+    dt match {
+      case ArrayType(e, _) => supportsDataType(e)
+      case MapType(k, v, _) =>
+        supportsDataType(k) && supportsDataType(v)
+      case StructType(fields) => fields.forall(f => supportsDataType(f.dataType))
+      case udt: UserDefinedType[_] => supportsDataType(udt.sqlType)
+      case _: AnsiIntervalType | CalendarIntervalType | VariantType => false
+      case BinaryType | BooleanType | ByteType | CalendarIntervalType | CharType(_) | DateType |
+           DayTimeIntervalType(_, _) | _ : DecimalType |  DoubleType | FloatType |
+           IntegerType | LongType | NullType | ObjectType(_) | ShortType |
+           StringType | TimestampNTZType | TimestampType | VarcharType(_) |
+           YearMonthIntervalType(_, _) => true
+      case _ => false
+
+    }
+  }
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommandSuite.scala
@@ -84,24 +84,22 @@ class SaveIntoDataSourceCommandSuite extends QueryTest with SharedSparkSession {
         "cast('a' as binary) a", "true b", "cast(1 as byte) c", "1.23 d")
     dataSource.planForWriting(SaveMode.ErrorIfExists, df.logicalPlan)
 
-    withSQLConf("spark.databricks.variant.enabled" -> "true") {
-      // Variant and Interval types are disallowed by default.
-      val unsupportedTypes = Seq(
-          "parse_json('1') v",
-          "array(parse_json('1'))",
-          "struct(1, parse_json('1')) s",
-          "map(1, parse_json('1')) s",
-          "INTERVAL '1' MONTH i",
-          "make_ym_interval(1, 2) ym",
-          "make_dt_interval(1, 2, 3, 4) dt")
+    // Variant and Interval types are disallowed by default.
+    val unsupportedTypes = Seq(
+        "parse_json('1') v",
+        "array(parse_json('1'))",
+        "struct(1, parse_json('1')) s",
+        "map(1, parse_json('1')) s",
+        "INTERVAL '1' MONTH i",
+        "make_ym_interval(1, 2) ym",
+        "make_dt_interval(1, 2, 3, 4) dt")
 
-      unsupportedTypes.foreach { expr =>
-        val df = spark.range(1).selectExpr(expr)
-        val e = intercept[AnalysisException] {
-          dataSource.planForWriting(SaveMode.ErrorIfExists, df.logicalPlan)
-        }
-        assert(e.getMessage.contains("UNSUPPORTED_DATA_TYPE_FOR_DATASOURCE"))
+    unsupportedTypes.foreach { expr =>
+      val df = spark.range(1).selectExpr(expr)
+      val e = intercept[AnalysisException] {
+        dataSource.planForWriting(SaveMode.ErrorIfExists, df.logicalPlan)
       }
+      assert(e.getMessage.contains("UNSUPPORTED_DATA_TYPE_FOR_DATASOURCE"))
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

In DataSource.scala, there are checks to prevent writing Variant and Interval types to a `CreatableRelationalProvider`. This PR unifies the checks in a method on `CreatableRelationalProvider` so that data sources can override in order to specify a different set of supported data types.

### Why are the changes needed?

Allows data sources to specify what types they support, while providing a sensible default for most data sources.

### Does this PR introduce _any_ user-facing change?

The error message for Variant and Interval are now shared, and are a bit more generic. The intent is to otherwise not have any user-facing change.

### How was this patch tested?

Unit tests added.

### Was this patch authored or co-authored using generative AI tooling?

No.