### PR TITLE
[SPARK-49321][SQL] Bind JDBC dialect to JDBCRDD at construction

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -183,8 +183,9 @@ class JDBCRDD(
   private lazy val dialect = prescribedDialect.getOrElse(JdbcDialects.get(url))
 
   /**
-   * Prescribe a particular dialect to use for this RDD. If not set, the dialect will be automatically
-   * resolved from the JDBC URL. This previous behavior is preserved for binary compatibility.
+   * Prescribe a particular dialect to use for this RDD. If not set, the dialect will be
+   * automatically resolved from the JDBC URL. This previous behavior is preserved for binary
+   * compatibility.
    */
   def withDialect(dialect: JdbcDialect): JDBCRDD = {
     prescribedDialect = Some(dialect)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -130,12 +130,12 @@ object JDBCRDD extends Logging {
     }
     new JDBCRDD(
       sc,
+      dialect,
       dialect.createConnectionFactory(options),
       outputSchema.getOrElse(pruneSchema(schema, requiredColumns)),
       quotedColumns,
       predicates,
       parts,
-      url,
       options,
       groupByColumns,
       sample,
@@ -153,12 +153,12 @@ object JDBCRDD extends Logging {
  */
 class JDBCRDD(
     sc: SparkContext,
+    dialect: JdbcDialect,
     getConnection: Int => Connection,
     schema: StructType,
     columns: Array[String],
     predicates: Array[Predicate],
     partitions: Array[Partition],
-    url: String,
     options: JDBCOptions,
     groupByColumns: Option[Array[String]],
     sample: Option[TableSampleInfo],
@@ -173,8 +173,6 @@ class JDBCRDD(
   val queryExecutionTimeMetric: SQLMetric = SQLMetrics.createNanoTimingMetric(
     sparkContext,
     name = "JDBC query execution time")
-
-  private lazy val dialect = JdbcDialects.get(url)
 
   def generateJdbcQuery(partition: Option[JDBCPartition]): String = {
     // H2's JDBC driver does not support the setSchema() method.  We pass a


### PR DESCRIPTION
Registered dialects may differ between driver and executors. Bind dialect to the RDD on creation to use the same dialect regardless of JVM state.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Bind the resolved JDBC dialect to the `JDBCRDD` instance during construction.

### Why are the changes needed?

While working on a Spark application, I created a custom JDBC dialect and registered before creating a `SparkSession`. Spark did not use the dialect's `JdbcSQLQueryBuilder`, however, so I investigated further. I discovered that `JDBCRDD` [repeats the dialect resolution](https://github.com/apache/spark/blame/fe2174d8caaf6f9474319a8d729a2f537038b4c1/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala#L177), and this runs on the executor. 

From what I can understand, additional dialects registered by the driver will not be available in the executor when running in cluster mode. Consequently, I propose binding the resolved dialect to the `JDBCRDD` instance to produce deterministic behavior.


### Does this PR introduce _any_ user-facing change?

No aside from resolving a bug that some users may have encountered.

### How was this patch tested?

I have not written tests, but I have manually tested the fix on a local 3.5.1 cluster. Applying this change produced the desired behavior (i.e. the custom dialect's `JdbcSQLQueryBuilder` was used to generate queries from executors).

### Was this patch authored or co-authored using generative AI tooling?

No
