### PR TITLE
[SPARK-46988][CONNECT][TESTS] Add tests for `map` type in `ProtoUtils.abbreviate`

### DIFF
--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/common/ProtoUtils.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/common/ProtoUtils.scala
@@ -79,7 +79,6 @@ private[connect] object ProtoUtils {
               .concat(createTruncatedByteString(size)))
         }
 
-      // TODO(SPARK-46988): should support map<xxx, msg>
       case (field: FieldDescriptor, msg: Message)
           if field.getJavaType == FieldDescriptor.JavaType.MESSAGE && !field.isRepeated
             && msg != null =>

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/messages/AbbreviateSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/messages/AbbreviateSuite.scala
@@ -210,4 +210,12 @@ class AbbreviateSuite extends SparkFunSuite {
       }
     }
   }
+
+  test("skip map fields") {
+    val message = proto.Read.NamedTable.newBuilder()
+      .putAllOptions(Map("k1" -> "v1" * 4096, "k2" -> "v2" * 4096).asJava)
+      .build()
+
+    val truncated = ProtoUtils.abbreviate(message)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add tests for map types in `ProtoUtils.abbreviate`


### Why are the changes needed?
when I started working on `SPARK-46988` to make `ProtoUtils.abbreviate` support `map` type, I just found that it had already been supported when we supported `repeated Message`.

A `map` field internally is also a `repeated` field, and each element is a `Message`.

see https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MapEntry

> In reflection API, map fields will be treated as repeated message fields and each map entry is accessed as a message. This MapEntry class is used to represent these map entry messages in reflection API.


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
added tests


### Was this patch authored or co-authored using generative AI tooling?
no