### PR TITLE
[SPARK-47311][SQL][PYTHON] Suppress Python exceptions where PySpark is not in the Python path

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
@@ -103,6 +103,11 @@ object DataSourceManager extends Logging {
         val maybeResult = try {
           Some(UserDefinedPythonDataSource.lookupAllDataSourcesInPython())
         } catch {
+          case e: Throwable if e.toString.contains(
+              "ModuleNotFoundError: No module named 'pyspark'") =>
+            // If PySpark is not in the Python path at all, suppress the warning
+            // To make it less noisy, see also SPARK-47311.
+            None
           case e: Throwable =>
             // Even if it fails for whatever reason, we shouldn't make the whole
             // application fail.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to suppress Python exceptions where PySpark is not in the Python path

### Why are the changes needed?

`pyspark` library itself might be missing when users run Scala/Java and R Spark applications. In that case, this warning messages might too nosiy.

### Does this PR introduce _any_ user-facing change?

Yes, it will hide the warning message when a user meet all conditions below:
- Use Scala or R only Spark application
- Have a Python, but the Python does not have have PySpark in their Python path
  - Either because `SPARK_HOME` is undefined for some reasons,
  - Or, by other environment problems.

### How was this patch tested?

Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.
