### PR TITLE
[SPARK-47314][DOC] Remove the  wrong comment line of `ExternalSorter#writePartitionedMapOutput` method

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
@@ -689,8 +689,6 @@ private[spark] class ExternalSorter[K, V, C](
   /**
    * Write all the data added into this ExternalSorter into a map output writer that pushes bytes
    * to some arbitrary backing store. This is called by the SortShuffleWriter.
-   *
-   * Update the partition's length, when call partition pair writer to close.
    */
   def writePartitionedMapOutput(
       shuffleId: Int,

--- a/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/ExternalSorter.scala
@@ -690,7 +690,7 @@ private[spark] class ExternalSorter[K, V, C](
    * Write all the data added into this ExternalSorter into a map output writer that pushes bytes
    * to some arbitrary backing store. This is called by the SortShuffleWriter.
    *
-   * @return array of lengths, in bytes, of each partition of the file (used by map output tracker)
+   * Update the partition's length, when call partition pair writer to close.
    */
   def writePartitionedMapOutput(
       shuffleId: Int,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Correct the comment of `ExternalSorter#writePartitionedMapOutput`.

`ExternalSorter#writePartitionedMapOutput` return nothing, and will update the partition's length when call partition pair writer to close.

### Why are the changes needed?

Correct comment.


### Does this PR introduce _any_ user-facing change?
No, developers will meet this change in source code.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
No need.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
