### PR TITLE
[SPARK-47318][CORE] Adds HKDF round to AuthEngine key derivation to follow standard KEX practices

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/crypto/AuthEngine.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/crypto/AuthEngine.java
@@ -65,7 +65,8 @@ class AuthEngine implements Closeable {
     this.preSharedSecret = preSharedSecret.getBytes(UTF_8);
     this.conf = conf;
     this.cryptoConf = conf.cryptoConf();
-    // This is for backward compatibility with older versions of this protocol which did not perform a final HKDF
+    // This is for backward compatibility with version 1.0 of this protocol,
+    // which did not perform a final HKDF round.
     this.unsafeSkipFinalHkdf = conf.authEngineVersion() == UNSAFE_SKIP_HKDF_VERSION;
   }
 

--- a/common/network-common/src/main/java/org/apache/spark/network/crypto/AuthEngine.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/crypto/AuthEngine.java
@@ -236,7 +236,7 @@ class AuthEngine implements Closeable {
 
   private byte[] getTranscript(AuthMessage... encryptedPublicKeys) {
     ByteBuf transcript = Unpooled.buffer(
-        Arrays.stream(encryptedPublicKeys).mapToInt(AuthMessage::encodedLength).sum());
+        Arrays.stream(encryptedPublicKeys).mapToInt(k -> k.encodedLength()).sum());
     Arrays.stream(encryptedPublicKeys).forEachOrdered(k -> k.encode(transcript));
     return transcript.array();
   }

--- a/common/network-common/src/main/java/org/apache/spark/network/crypto/README.md
+++ b/common/network-common/src/main/java/org/apache/spark/network/crypto/README.md
@@ -1,14 +1,6 @@
 Forward Secure Auth Protocol v2.0
 ==============================================
 
-Deprecation Notice
-------------------
-This is a bespoke key exchange protocol that was implemented before Spark supported TLS (aka SSL) for RPC
-calls. It is recommended that Spark users upgrade to using TLS for RPC calls between Spark processes.
-
-See the [Spark security documentation](https://github.com/apache/spark/blob/master/docs/security.md#ssl-encryption)
-for more information on how to configure TLS.
-
 Summary
 -------
 

--- a/common/network-common/src/main/java/org/apache/spark/network/crypto/README.md
+++ b/common/network-common/src/main/java/org/apache/spark/network/crypto/README.md
@@ -1,16 +1,13 @@
-Forward Secure Auth Protocol v1.1
+Forward Secure Auth Protocol v2.0
 ==============================================
 
 Deprecation Notice
 ------------------
 This is a bespoke key exchange protocol that was implemented before Spark supported TLS (aka SSL) for RPC
-calls. It is recommended that Spark users upgrade to using TLS for RPC calls between Spark processes. This protocol
-will be deprecated and removed in the long-term.
+calls. It is recommended that Spark users upgrade to using TLS for RPC calls between Spark processes.
 
-See
-the [Spark security documentation](https://github.com/apache/spark/blob/master/docs/security.md#ssl-encryption) for
-more information on how to configure TLS.
-
+See the [Spark security documentation](https://github.com/apache/spark/blob/master/docs/security.md#ssl-encryption)
+for more information on how to configure TLS.
 
 Summary
 -------
@@ -119,8 +116,8 @@ Security Changes & Compatibility
 
 The original version of this protocol, retroactively called v1.0, did not apply an HKDF to `sharedSecret` and was
 directly using the encoded X coordinate as key material. This is atypical and standard practice is to pass that shared
-coordinate through an HKDF. The current version, v1.1, adds this additional HKDF to
+coordinate through an HKDF. The current version, v2.0, adds this additional HKDF to
 derive `derivedKey`.
 
 Consequently, older Spark versions using v1.0 of this protocol will not negotiate the same key as
-Spark versions using v1.1 and will be **unable to send encrypted RPCs** across incompatible versions.
+Spark versions using v2.0 and will be **unable to send encrypted RPCs** across incompatible versions.

--- a/common/network-common/src/main/java/org/apache/spark/network/crypto/README.md
+++ b/common/network-common/src/main/java/org/apache/spark/network/crypto/README.md
@@ -108,8 +108,9 @@ Security Changes & Compatibility
 
 The original version of this protocol, retroactively called v1.0, did not apply an HKDF to `sharedSecret` to derive
 a key (i.e. `derivedKey`) and was directly using the encoded X coordinate as key material. This is atypical and
-standard practice is to pass that shared coordinate through an HKDF. The current version, v2.0, adds this additional
+standard practice is to pass that shared coordinate through an HKDF. The latest version adds this additional
 HKDF to derive `derivedKey`.
 
-Consequently, older Spark versions using v1.0 of this protocol will not negotiate the same key as
-Spark versions using v2.0 and will be **unable to send encrypted RPCs** across incompatible versions.
+Consequently, Apache Spark instances using v1.0 of this protocol will not negotiate the same key as
+instances using v2.0 and will be **unable to send encrypted RPCs** across incompatible versions. For this reason, v1.0
+remains the default to preserve backward-compatibility.

--- a/common/network-common/src/main/java/org/apache/spark/network/crypto/README.md
+++ b/common/network-common/src/main/java/org/apache/spark/network/crypto/README.md
@@ -106,10 +106,10 @@ observer. Only active adversaries spoofing a session would be able to recover pl
 Security Changes & Compatibility
 -------------
 
-The original version of this protocol, retroactively called v1.0, did not apply an HKDF to `sharedSecret` and was
-directly using the encoded X coordinate as key material. This is atypical and standard practice is to pass that shared
-coordinate through an HKDF. The current version, v2.0, adds this additional HKDF to
-derive `derivedKey`.
+The original version of this protocol, retroactively called v1.0, did not apply an HKDF to `sharedSecret` to derive
+a key (i.e. `derivedKey`) and was directly using the encoded X coordinate as key material. This is atypical and
+standard practice is to pass that shared coordinate through an HKDF. The current version, v2.0, adds this additional
+HKDF to derive `derivedKey`.
 
 Consequently, older Spark versions using v1.0 of this protocol will not negotiate the same key as
 Spark versions using v2.0 and will be **unable to send encrypted RPCs** across incompatible versions.

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -214,6 +214,11 @@ public class TransportConf {
   }
 
   /**
+   * Version number to be used by the AuthEngine key agreement protocol. Value values are 1 or 2.
+   */
+  public int authEngineVersion() { return conf.getInt("spark.network.crypto.authEngineVersion", 2); }
+
+  /**
    * The cipher transformation to use for encrypting session data.
    */
   public String cipherTransformation() {

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -215,9 +215,12 @@ public class TransportConf {
 
   /**
    * Version number to be used by the AuthEngine key agreement protocol. Valid values are 1 or 2.
-   * The default version is 1 for backward compatibility. Version 2 is recommended for stronger security properties.
+   * The default version is 1 for backward compatibility. Version 2 is recommended for stronger
+   * security properties.
    */
-  public int authEngineVersion() { return conf.getInt("spark.network.crypto.authEngineVersion", 1); }
+  public int authEngineVersion() {
+    return conf.getInt("spark.network.crypto.authEngineVersion", 1);
+  }
 
   /**
    * The cipher transformation to use for encrypting session data.

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -214,7 +214,8 @@ public class TransportConf {
   }
 
   /**
-   * Version number to be used by the AuthEngine key agreement protocol. Value values are 1 or 2.
+   * Version number to be used by the AuthEngine key agreement protocol. Valid values are 1 or 2.
+   * The default version is 1 for backward compatibility. Version 2 is recommended for stronger security properties.
    */
   public int authEngineVersion() { return conf.getInt("spark.network.crypto.authEngineVersion", 1); }
 

--- a/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/TransportConf.java
@@ -216,7 +216,7 @@ public class TransportConf {
   /**
    * Version number to be used by the AuthEngine key agreement protocol. Value values are 1 or 2.
    */
-  public int authEngineVersion() { return conf.getInt("spark.network.crypto.authEngineVersion", 2); }
+  public int authEngineVersion() { return conf.getInt("spark.network.crypto.authEngineVersion", 1); }
 
   /**
    * The cipher transformation to use for encrypting session data.

--- a/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthEngineSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthEngineSuite.java
@@ -28,6 +28,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.FileRegion;
 import org.apache.spark.network.util.ByteArrayWritableChannel;
+import org.apache.spark.network.util.ConfigProvider;
 import org.apache.spark.network.util.MapConfigProvider;
 import org.apache.spark.network.util.TransportConf;
 import static org.junit.jupiter.api.Assertions.*;
@@ -59,7 +60,9 @@ public class AuthEngineSuite {
 
   @BeforeAll
   public static void setUp() {
-    conf = new TransportConf("rpc", MapConfigProvider.EMPTY);
+    ConfigProvider v2Provider = new MapConfigProvider(Collections.singletonMap(
+            "spark.network.crypto.authEngineVersion", "2"));
+    conf = new TransportConf("rpc", v2Provider);
   }
 
   @Test
@@ -185,10 +188,9 @@ public class AuthEngineSuite {
 
   @Test
   public void testFixedChallengeResponseUnsafeVersion() throws Exception {
-    MapConfigProvider configProvider = new MapConfigProvider(Collections.singletonMap(
-      "spark.network.crypto.authEngineVersion", "1"));
-    TransportConf v1Conf = new TransportConf("rpc", configProvider);
-
+    ConfigProvider v1Provider = new MapConfigProvider(Collections.singletonMap(
+            "spark.network.crypto.authEngineVersion", "1"));
+    TransportConf v1Conf = new TransportConf("rpc", v1Provider);
     try (AuthEngine client = new AuthEngine("appId", "secret", v1Conf)) {
       byte[] clientPrivateKey = Hex.decode(clientPrivate);
       client.setClientPrivateKey(clientPrivateKey);

--- a/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthEngineSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthEngineSuite.java
@@ -51,8 +51,9 @@ public class AuthEngineSuite {
       "e25e9d5c5a380b8e6d1a184692fac065ed84f8592c18e9629f9c636809dca2ffc041f20346eb53db78738" +
       "08ecad08b46b5ee3ff";
   private static final String derivedKey = "2d6e7a9048c8265c33a8f3747bfcc84c";
-  // This key would have been derived from an older version of the protocol that did not run a final HKDF pass
-  private static final String unsafeDerivedKey = "31963f15a320d5c90333f7ecf5cf3a31c7eaf151de07fef8494663a9f47cfd31";
+  // This key would have been derived for version 1.0 protocol that did not run a final HKDF round.
+  private static final String unsafeDerivedKey =
+      "31963f15a320d5c90333f7ecf5cf3a31c7eaf151de07fef8494663a9f47cfd31";
 
   private static final String inputIv = "fc6a5dc8b90a9dad8f54f08b51a59ed2";
   private static final String outputIv = "a72709baf00785cad6329ce09f631f71";

--- a/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthEngineSuite.java
+++ b/common/network-common/src/test/java/org/apache/spark/network/crypto/AuthEngineSuite.java
@@ -48,8 +48,7 @@ public class AuthEngineSuite {
       "fb00000005617070496400000010708451c9dd2792c97c1ca66e6df449ef0000003c64fe899ecdaf458d4" +
       "e25e9d5c5a380b8e6d1a184692fac065ed84f8592c18e9629f9c636809dca2ffc041f20346eb53db78738" +
       "08ecad08b46b5ee3ff";
-  private static final String sharedKey =
-      "31963f15a320d5c90333f7ecf5cf3a31c7eaf151de07fef8494663a9f47cfd31";
+  private static final String derivedKey = "2d6e7a9048c8265c33a8f3747bfcc84c";
   private static final String inputIv = "fc6a5dc8b90a9dad8f54f08b51a59ed2";
   private static final String outputIv = "a72709baf00785cad6329ce09f631f71";
   private static TransportConf conf;
@@ -174,7 +173,7 @@ public class AuthEngineSuite {
       // Verify that the client will accept an old transcript.
       client.deriveSessionCipher(clientChallenge, serverResponse);
       TransportCipher clientCipher = client.sessionCipher();
-      assertEquals(Hex.encode(clientCipher.getKey().getEncoded()), sharedKey);
+      assertEquals(Hex.encode(clientCipher.getKey().getEncoded()), derivedKey);
       assertEquals(Hex.encode(clientCipher.getInputIv()), inputIv);
       assertEquals(Hex.encode(clientCipher.getOutputIv()), outputIv);
     }

--- a/docs/security.md
+++ b/docs/security.md
@@ -181,6 +181,12 @@ authentication must also be enabled and properly configured. AES encryption uses
 [Apache Commons Crypto](https://commons.apache.org/proper/commons-crypto/) library, and Spark's
 configuration system allows access to that library's configuration for advanced users.
 
+This legacy protocol has two mutually incompatible versions. Version 1 omits applying key derivation function
+(KDF) to the key exchange protocol's output, while version 2 applies a KDF to ensure that the derived session
+key is uniformly distributed. Version 1 is default for backward compatibility. It is **recommended to use version 2**
+for better security properties. The version can be configured by setting `spark.network.crypto.authEngineVersion` to
+1 or 2 respectively.
+
 There is also support for SASL-based encryption, although it should be considered deprecated. It
 is still required when talking to shuffle services from Spark versions older than 2.2.0.
 
@@ -195,6 +201,11 @@ The following table describes the different options available for configuring th
     Enable AES-based RPC encryption, including the new authentication protocol added in 2.2.0.
   </td>
   <td>2.2.0</td>
+</tr>
+<tr>
+  <td><code>spark.network.crypto.authEngineVersion</code></td>
+  <td>1</td>
+  <td>Version of AES-based RPC encryption to use. Valid versions are 1 or 2. Version 2 is recommended. Added in 4.0.0</td>
 </tr>
 <tr>
   <td><code>spark.network.crypto.config.*</code></td>

--- a/docs/security.md
+++ b/docs/security.md
@@ -149,24 +149,32 @@ secret file agrees with the executors' secret file.
 
 # Network Encryption
 
-Spark supports two mutually exclusive forms of encryption for RPC connections.
+Spark supports two mutually exclusive forms of encryption for RPC connections:
 
-The first is an AES-based encryption which relies on a shared secret, and thus requires
-RPC authentication to also be enabled.
+The **preferred method** uses TLS (aka SSL) encryption via Netty's support for SSL. Enabling SSL
+requires keys and certificates to be properly configured. SSL is standardized and considered more
+secure.
 
-The second is an SSL based encryption mechanism utilizing Netty's support for SSL. This requires
-keys and certificates to be properly configured. It can be used with or without the authentication
-mechanism discussed earlier.
-
-One may prefer to use the SSL based encryption in scenarios where compliance mandates the usage
-of specific protocols; or to leverage the security of a more standard encryption library. However,
-the AES based encryption is simpler to configure and may be preferred if the only requirement
-is that data be encrypted in transit.
+The legacy method is an AES-based encryption mechanism relying on a shared secret. This requires
+RPC authentication to also be enabled. This method uses a bespoke protocol and should be considered
+deprecated in favor of SSL.
 
 If both options are enabled in the configuration, the SSL based RPC encryption takes precedence
 and the AES based encryption will not be used (and a warning message will be emitted).
 
-## AES based Encryption
+## SSL Encryption (Preferred)
+
+Spark supports SSL based encryption for RPC connections. Please refer to the SSL Configuration
+section below to understand how to configure it. The SSL settings are mostly similar across the UI
+and RPC, however there are a few additional settings which are specific to the RPC implementation.
+The RPC implementation uses Netty under the hood (while the UI uses Jetty), which supports a
+different set of options.
+
+Unlike the other SSL settings for the UI, the RPC SSL is *not* automatically enabled if
+`spark.ssl.enabled` is set. It must be explicitly enabled, to ensure a safe migration path for users
+upgrading Spark versions.
+
+## AES-based Encryption (Legacy)
 
 Spark supports AES-based encryption for RPC connections. For encryption to be enabled, RPC
 authentication must also be enabled and properly configured. AES encryption uses the
@@ -227,18 +235,6 @@ The following table describes the different options available for configuring th
   <td>1.4.0</td>
 </tr>
 </table>
-
-## SSL Encryption
-
-Spark supports SSL based encryption for RPC connections. Please refer to the SSL Configuration
-section below to understand how to configure it. The SSL settings are mostly similar across the UI 
-and RPC, however there are a few additional settings which are specific to the RPC implementation.
-The RPC implementation uses Netty under the hood (while the UI uses Jetty), which supports a
-different set of options.
-
-Unlike the other SSL settings for the UI, the RPC SSL is *not* automatically enabled if 
-`spark.ssl.enabled` is set. It must be explicitly enabled, to ensure a safe migration path for users
-upgrading Spark versions.
 
 # Local Storage Encryption
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -159,6 +159,11 @@ The legacy method is an AES-based encryption mechanism relying on a shared secre
 RPC authentication to also be enabled. This method uses a bespoke protocol and it is recommended
 to use SSL instead.
 
+One may prefer to use the SSL based encryption in scenarios where compliance mandates the usage
+of specific protocols; or to leverage the security of a more standard encryption library. However,
+the AES based encryption is simpler to configure and may be preferred if the only requirement
+is that data be encrypted in transit.
+
 If both options are enabled in the configuration, the SSL based RPC encryption takes precedence
 and the AES based encryption will not be used (and a warning message will be emitted).
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -205,7 +205,8 @@ The following table describes the different options available for configuring th
 <tr>
   <td><code>spark.network.crypto.authEngineVersion</code></td>
   <td>1</td>
-  <td>Version of AES-based RPC encryption to use. Valid versions are 1 or 2. Version 2 is recommended. Added in 4.0.0</td>
+  <td>Version of AES-based RPC encryption to use. Valid versions are 1 or 2. Version 2 is recommended.</td>
+  <td>4.0.0</td>
 </tr>
 <tr>
   <td><code>spark.network.crypto.config.*</code></td>

--- a/docs/security.md
+++ b/docs/security.md
@@ -156,8 +156,8 @@ requires keys and certificates to be properly configured. SSL is standardized an
 secure.
 
 The legacy method is an AES-based encryption mechanism relying on a shared secret. This requires
-RPC authentication to also be enabled. This method uses a bespoke protocol and should be considered
-deprecated in favor of SSL.
+RPC authentication to also be enabled. This method uses a bespoke protocol and it is recommended
+to use SSL instead.
 
 If both options are enabled in the configuration, the SSL based RPC encryption takes precedence
 and the AES based encryption will not be used (and a warning message will be emitted).


### PR DESCRIPTION
### What changes were proposed in this pull request?

This change adds an additional pass through a key derivation function (KDF) to the key exchange protocol in `AuthEngine`. Currently, it uses the shared secret from a bespoke key negotiation protocol directly. This is an encoded X coordinate on the X25519 curve. It is atypical and not recommended to use that coordinate directly as a key, but rather to pass it to an KDF.

Note, Spark now supports TLS for RPC calls. It is preferable to use that rather than the bespoke AES RPC encryption implemented by `AuthEngine` and `TransportCipher`.

### Why are the changes needed?

This follows best practices of key negotiation protocols. The encoded X coordinate is not guaranteed to be uniformly distributed over the 32-byte key space. Rather, we pass it through a HKDF function to map it uniformly to a 16-byte key space.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Exiting tests under:
`build/sbt "network-common/test:testOnly"`

Specifically:
`build/sbt "network-common/test:testOnly org.apache.spark.network.crypto.AuthEngineSuite"`
`build/sbt "network-common/test:testOnly org.apache.spark.network.crypto.AuthIntegrationSuite"`

### Was this patch authored or co-authored using generative AI tooling?

No.