### PR TITLE
[MINOR][INFRA] Make "y/n" consistent within merge script

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -283,7 +283,7 @@ def get_jira_issue(prompt, default_jira_id=""):
         if status == "Resolved" or status == "Closed":
             print("JIRA issue %s already has status '%s'" % (jira_id, status))
             return None
-        if bold_input("Check if the JIRA information is as expected (Y/n): ").lower() != "n":
+        if bold_input("Check if the JIRA information is as expected (y/N): ").lower() == "y":
             return issue
         else:
             return get_jira_issue("Enter the revised JIRA ID again or leave blank to skip")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes the y/n message and condition consistent within merging script.

### Why are the changes needed?

For consistency.

```
Would you like to use the modified body? (y/N): y
...
Proceed with merging pull request #45426? (y/N): y
...
Merge complete (local ref PR_TOOL_MERGE_PR_45426_MASTER). Push to apache? (y/N): y
...
Would you like to pick 9cac2bb6 into another branch? (y/N): n
...
Would you like to update an associated JIRA? (y/N): y
...
Check if the JIRA information is as expected (Y/n): y  # <-- Inconsistent.
```

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.