### PR TITLE
[WIP][SPARK-47321][INFRA] Upgrade `dawidd6/action-download-artifact` to v4 and `scacap/action-surefire-report` to latest

### DIFF
--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -30,14 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download test results to report
-      uses: dawidd6/action-download-artifact@v3
+      uses: dawidd6/action-download-artifact@71072fbb1229e1317f1a8de6b04206afb461bd67 # pin@v3.1.2
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         workflow: ${{ github.event.workflow_run.workflow_id }}
         commit: ${{ github.event.workflow_run.head_commit.id }}
         workflow_conclusion: completed
     - name: Publish test report
-      uses: scacap/action-surefire-report@v1
+      uses: scacap/action-surefire-report@a2911bd1a4412ec18dde2d93b1758b3e56d2a880 # pin@v1.8.0
       with:
         check_name: Report test results
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -30,14 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download test results to report
-      uses: dawidd6/action-download-artifact@09385b76de790122f4da9c82b17bccf858b9557c # pin@v2
+      uses: dawidd6/action-download-artifact@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         workflow: ${{ github.event.workflow_run.workflow_id }}
         commit: ${{ github.event.workflow_run.head_commit.id }}
         workflow_conclusion: completed
     - name: Publish test report
-      uses: scacap/action-surefire-report@482f012643ed0560e23ef605a79e8e87ca081648 # pin@v1
+      uses: scacap/action-surefire-report@v1
       with:
         check_name: Report test results
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade
- `dawidd6/action-download-artifact` from `09385b76de790122f4da9c82b17bccf858b9557c` to `v3.1.2`
- `scacap/action-surefire-report` from `482f012643ed0560e23ef605a79e8e87ca081648` to `v1.8.0`.

### Why are the changes needed?
- Eliminate warning messages about the workflow `test_report` running, especially the deprecated issue regarding `node16`.
  https://github.com/apache/spark/actions/runs/8184857052
  <img width="1017" alt="image" src="https://github.com/apache/spark/assets/15246973/a49249ee-3ae4-406f-beb1-b3c374248903">

- dawidd6/action-download-artifact
  https://github.com/dawidd6/action-download-artifact/releases/tag/v3.0.0
  <img width="797" alt="image" src="https://github.com/apache/spark/assets/15246973/7fe3a137-13af-409c-a196-966c1edf5d7d">

- scacap/action-surefire-report
  https://github.com/ScaCap/action-surefire-report/releases/tag/v1.8.0
  <img width="773" alt="image" src="https://github.com/apache/spark/assets/15246973/182c935e-6328-4411-8645-8ac8c7473156">

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Observe the running status of the workflow `test_report` in github.


### Was this patch authored or co-authored using generative AI tooling?
No.
