### PR TITLE
[SPARK-47325][INFRA] Use the latest `buf-setup-action` in github workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -574,9 +574,8 @@ jobs:
         git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' merge --no-commit --progress --squash FETCH_HEAD
         git -c user.name='Apache Spark Test Account' -c user.email='sparktestacc@gmail.com' commit -m "Merged commit" --allow-empty
     - name: Install Buf
-      uses: bufbuild/buf-setup-action@v1.29.0
+      uses: bufbuild/buf-setup-action@v1
       with:
-        version: 1.29.0
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Protocol Buffers Linter
       uses: bufbuild/buf-lint-action@v1


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to `unpin` specific version `buf-setup-action` in github workflow building.

### Why are the changes needed?
- [The last](https://github.com/apache/spark/pull/45205) `pin` to a `specific version` was due to a bug in the version `v1.29.0-1`.  The latest version has been upgraded to `v1.30.0`, and testing has found that this version is ok.

- This latest version `v1.30.0` has a `change` regarding the upgrade from `node16` to `node20`.
  https://github.com/bufbuild/buf-setup-action/compare/v1.29.0...v1.30.0
  <img width="1257" alt="image" src="https://github.com/apache/spark/assets/15246973/8277ac62-dc36-4237-8dc0-1522f5f248b8">


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
