### PR TITLE
[MINOR][DOCS] Fix the doc for Integral types

### DIFF
--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -443,21 +443,21 @@ class FloatType(FractionalType, metaclass=DataTypeSingleton):
 
 
 class ByteType(IntegralType):
-    """Byte data type, i.e. a signed integer in a single byte."""
+    """Byte data type, representing signed 8-bit integers."""
 
     def simpleString(self) -> str:
         return "tinyint"
 
 
 class IntegerType(IntegralType):
-    """Int data type, i.e. a signed 32-bit integer."""
+    """Int data type, representing signed 32-bit integers."""
 
     def simpleString(self) -> str:
         return "int"
 
 
 class LongType(IntegralType):
-    """Long data type, i.e. a signed 64-bit integer.
+    """Long data type, representing signed 64-bit integers.
 
     If the values are beyond the range of [-9223372036854775808, 9223372036854775807],
     please use :class:`DecimalType`.
@@ -468,7 +468,7 @@ class LongType(IntegralType):
 
 
 class ShortType(IntegralType):
-    """Short data type, i.e. a signed 16-bit integer."""
+    """Short data type, representing signed 16-bit integers."""
 
     def simpleString(self) -> str:
         return "smallint"


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the doc for Integral types


### Why are the changes needed?
it seems the description of integral type are not correctly rendered

before:
https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/data_types.html

![image](https://github.com/apache/spark/assets/7322292/edf1061e-fea4-427d-ae72-010b180a2cd3)



after:
![image](https://github.com/apache/spark/assets/7322292/cf53494e-f4b1-4c86-83b2-ecf8cad806c7)


### Does this PR introduce _any_ user-facing change?
yes, doc


### How was this patch tested?
manually check


### Was this patch authored or co-authored using generative AI tooling?
no
