### PR TITLE
[SPARK-47313][SQL] Added scala.MatchError handling inside QueryExecution.toInternalError

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -540,7 +540,7 @@ object QueryExecution {
   }
 
   /**
-   * Converts asserts, null pointer exceptions to internal errors.
+   * Converts asserts, null pointer exceptions and scala match errors to internal errors.
    */
   private[sql] def toInternalError(msg: String, e: Throwable): Throwable = e match {
     case e @ (_: java.lang.NullPointerException | _: java.lang.AssertionError) =>
@@ -548,12 +548,18 @@ object QueryExecution {
         msg + " You hit a bug in Spark or the Spark plugins you use. Please, report this bug " +
           "to the corresponding communities or vendors, and provide the full stack trace.",
         e)
+    case e @ (_: scala.MatchError) =>
+      SparkException.internalError(
+        msg + " You have tried to match an object which doesn't belong to any pattern or " +
+          "pattern matching expression.",
+        e)
     case e: Throwable =>
       e
   }
 
   /**
-   * Catches asserts, null pointer exceptions, and converts them to internal errors.
+   * Catches asserts, null pointer exceptions, scala match errors,
+   * and converts them to internal errors.
    */
   private[sql] def withInternalError[T](msg: String)(block: => T): T = {
     try {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -540,22 +540,31 @@ object QueryExecution {
   }
 
   /**
-   * Converts asserts, null pointer exceptions and scala match errors to internal errors.
+   * Marks null pointer exceptions, asserts and scala match errors as internal errors
    */
-  private[sql] def toInternalError(msg: String, e: Throwable): Throwable = e match {
-    case e @ (_: java.lang.NullPointerException | _: java.lang.AssertionError |
-              _: scala.MatchError) =>
+  private[sql] def isInternalError(e: Throwable): Boolean = e match {
+    case _: java.lang.NullPointerException => true
+    case _: java.lang.AssertionError => true
+    case _: scala.MatchError => true
+    case _ => false
+  }
+
+  /**
+   * Converts marked exceptions from [[isInternalError]] to internal errors.
+   */
+  private[sql] def toInternalError(msg: String, e: Throwable): Throwable = {
+    if (isInternalError(e)) {
       SparkException.internalError(
         msg + " You hit a bug in Spark or the Spark plugins you use. Please, report this bug " +
           "to the corresponding communities or vendors, and provide the full stack trace.",
         e)
-    case e: Throwable =>
+    } else {
       e
+    }
   }
 
   /**
-   * Catches asserts, null pointer exceptions, scala match errors,
-   * and converts them to internal errors.
+   * Catches marked exceptions from [[isInternalError]], and converts them to internal errors.
    */
   private[sql] def withInternalError[T](msg: String)(block: => T): T = {
     try {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -543,15 +543,11 @@ object QueryExecution {
    * Converts asserts, null pointer exceptions and scala match errors to internal errors.
    */
   private[sql] def toInternalError(msg: String, e: Throwable): Throwable = e match {
-    case e @ (_: java.lang.NullPointerException | _: java.lang.AssertionError) =>
+    case e @ (_: java.lang.NullPointerException | _: java.lang.AssertionError |
+              _: scala.MatchError) =>
       SparkException.internalError(
         msg + " You hit a bug in Spark or the Spark plugins you use. Please, report this bug " +
           "to the corresponding communities or vendors, and provide the full stack trace.",
-        e)
-    case e @ (_: scala.MatchError) =>
-      SparkException.internalError(
-        msg + " You have tried to match an object which doesn't belong to any pattern or " +
-          "pattern matching expression.",
         e)
     case e: Throwable =>
       e


### PR DESCRIPTION
### What changes were proposed in this pull request?
Created `isInternalError` function that marks `java.lang.NullPointerException`, `java.lang.AssertionError` and newly added `scala.MatchError` as internal errors.


### Why are the changes needed?
Additional error coverage and code refactoring.


### Does this PR introduce _any_ user-facing change?
No


### Was this patch authored or co-authored using generative AI tooling?
No
