### PR TITLE
Allow spark-class script to be ran in an environment where /dev/fd is unavailable (AWS Lambda)

### DIFF
--- a/bin/spark-class
+++ b/bin/spark-class
@@ -77,6 +77,10 @@ set +o posix
 CMD=()
 DELIM=$'\n'
 CMD_START_FLAG="false"
+
+temp_file=$(mktemp)
+build_command "$@" > "$temp_file"
+
 while IFS= read -d "$DELIM" -r _ARG; do
   ARG=${_ARG//$'\r'}
   if [ "$CMD_START_FLAG" == "true" ]; then
@@ -90,7 +94,9 @@ while IFS= read -d "$DELIM" -r _ARG; do
       echo "$ARG"
     fi
   fi
-done < <(build_command "$@")
+done < "$temp_file"
+
+rm -f "$temp_file"
 
 COUNT=${#CMD[@]}
 LAST=$((COUNT - 1))


### PR DESCRIPTION
### Why are the changes needed?
* Running pyspark in an environment like AWS Lambda where /dev/fd is unavailable throws an error because /dev/fd does not exist
```
/var/lang/lib/python3.11/site-packages/pyspark/bin/spark-class: line 93: /dev/fd/62: No such file or directory
/var/lang/lib/python3.11/site-packages/pyspark/bin/spark-class: line 97: CMD: bad array subscript
```

### What changes were proposed in this pull request?
Using a temporary file to run the command instead of process substitution allows the code to be ran in environments where /dev/fd does not exist.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
* Tested in AWS Lambda Python 3.11 Container based image using pyspark
* Tested in Mac Python 3.11 environment using pyspark

### Was this patch authored or co-authored using generative AI tooling?
No