### PR TITLE
[SPARK-47339][BUILD] Upgrade checkStyle to `10.14.0`

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/SparkAppHandle.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkAppHandle.java
@@ -114,7 +114,7 @@ public interface SparkAppHandle {
    *
    * @since 1.6.0
    */
-  public interface Listener {
+  interface Listener {
 
     /**
      * Callback for changes in the handle's state.

--- a/pom.xml
+++ b/pom.xml
@@ -3502,7 +3502,7 @@
             -->
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>9.3</version>
+            <version>10.14.0</version>
           </dependency>
         </dependencies>
         <executions>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,7 +20,7 @@ addSbtPlugin("software.purpledragon" % "sbt-checkstyle-plugin" % "4.0.1")
 // sbt-checkstyle-plugin uses an old version of checkstyle. Match it to Maven's.
 // If you are changing the dependency setting for checkstyle plugin,
 // please check pom.xml in the root of the source tree too.
-libraryDependencies += "com.puppycrawl.tools" % "checkstyle" % "9.3"
+libraryDependencies += "com.puppycrawl.tools" % "checkstyle" % "10.14.0"
 
 // checkstyle uses guava 31.0.1-jre.
 libraryDependencies += "com.google.guava" % "guava" % "31.0.1-jre"


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade checkStyle from `9.3` to `10.14.0`.

### Why are the changes needed?
- In Spark 4.0, our JDK version has been upgraded to `JDK17` (no longer supporting `JDK1.8`), so this obstacle has been eliminated, and we can upgrade the version of `checkStyle` to the `10.x`.
  <img width="1136" alt="image" src="https://github.com/apache/spark/assets/15246973/1311edb3-ced9-4f19-948a-c6d1bf5d96eb">
  https://checkstyle.sourceforge.io/index.html

- The full release notes:
  v10.14.0: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.14.0
  v10.13.0: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.13.0
  v10.12.7: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.12.7
  v10.12.6: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.12.6
  v10.12.5: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.12.5
  v10.12.4: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.12.4
  v10.12.3: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.12.3
  v10.12.2: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.12.2
  v10.12.1: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.12.1
  v10.12.0: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.12.0
  v10.11.0: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.11.0
  v10.10.0: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.10.0
  v10.9.3: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.9.3
  v10.9.2: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.9.2
  v10.9.1: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.9.1
  v10.9.0: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.9.0
  v10.8.1: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.8.1
  v10.8.0: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.8.0
  v10.7.0: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.7.0
  v10.6.0: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.6.0
  v10.5.0: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.5.0
  v10.4: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.4
  v10.3.4: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.3.4
  v10.3.3: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.3.3
  v10.3.2: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.3.2
  v10.3.1: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.3.1
  v10.3: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.3
  v10.2: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.2
  v10.1: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.1
  v10.0: https://checkstyle.sourceforge.io/releasenotes.html#Release_10.0

- The last upgrade happened 1.5 years ago: https://github.com/apache/spark/pull/37506

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Manually test:
```
./dev/lint-java
./dev/sbt-checkstyle

```

- Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
