### PR TITLE
[SPARK-47335][BUILD] Upgrade `mvn-scalafmt` to `1.1.1684076452.9f83818` & `scalafmt` to `3.8.0`

### DIFF
--- a/dev/.scalafmt.conf
+++ b/dev/.scalafmt.conf
@@ -32,4 +32,4 @@ fileOverride {
     runner.dialect = scala213
   }
 }
-version = 3.7.17
+version = 3.8.0

--- a/pom.xml
+++ b/pom.xml
@@ -3564,7 +3564,7 @@
       <plugin>
         <groupId>org.antipathy</groupId>
         <artifactId>mvn-scalafmt_${scala.binary.version}</artifactId>
-        <version>1.1.1640084764.9f463a9</version>
+        <version>1.1.1684076452.9f83818</version>
         <configuration>
           <validateOnly>${scalafmt.validateOnly}</validateOnly> <!-- (Optional) skip formatting -->
           <skipSources>${scalafmt.skip}</skipSources>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `mvn-scalafmt` from `1.1.1640084764.9f463a9` to `1.1.1684076452.9f83818`.

### Why are the changes needed?
- mvn-scalafmt
  The last `mvn-scalafmt` upgrade occurred 1 year ago, https://github.com/apache/spark/pull/37727
  The latest version of `mvn-scalafmt`  release notes: https://github.com/SimonJPegg/mvn_scalafmt/releases/tag/2.13-1.1.1684076452.9f83818

- scalafmt
  The latest version of `scalafmt`  release notes: https://github.com/scalameta/scalafmt/releases/tag/v3.8.0

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Manually test.
```
./build/mvn scalafmt:format -Dscalafmt.skip=false

...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.216 s
[INFO] Finished at: 2024-03-10T20:30:11+08:00
[INFO] ------------------------------------------------------------------------

```

```
./dev/scalafmt

...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:56 min
[INFO] Finished at: 2024-03-10T20:19:46+08:00
[INFO] ------------------------------------------------------------------------

```
- Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
No.
