### PR TITLE
[SPARK-46840][SQL][TESTS]  Add `CollationBenchmark`

### DIFF
--- a/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
@@ -2,25 +2,35 @@ OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 filter df column with collation:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-filter df column with collation - UNICODE_CI                    48             68          25          0.0     2377015.5       1.0X
-filter df column with collation - UNICODE                       20             28           6          0.0      985946.5       2.4X
-filter df column with collation - UTF8_BINARY_LCASE             15             19           4          0.0      766053.2       3.1X
-filter df column with collation - UTF8_BINARY                   14             15           3          0.0      678785.9       3.5X
+filter df column with collation - UTF8_BINARY_LCASE             30             36           4          0.3        3038.1       1.0X
+filter df column with collation - UNICODE                       21             24           4          0.5        2098.3       1.4X
+filter df column with collation - UTF8_BINARY                   20             22           3          0.5        2023.6       1.5X
+filter df column with collation - UNICODE_CI                    25             28           4          0.4        2467.8       1.2X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------
+UTF8_BINARY_LCASE                                   29904          29937          47          0.0      299036.1       1.0X
+UNICODE                                              3886           3893          10          0.0       38863.0       7.7X
+UTF8_BINARY                                          3945           3945           0          0.0       39449.6       7.6X
+UNICODE_CI                                          45321          45330          12          0.0      453210.3       0.7X
+
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
+AMD EPYC 7763 64-Core Processor
+collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------
+UTF8_BINARY_LCASE                                    29807          29818          17          0.0      298065.0       1.0X
+UNICODE                                              45704          45723          27          0.0      457036.2       0.7X
+UTF8_BINARY                                           6460           6464           7          0.0       64597.9       4.6X
+UNICODE_CI                                           45498          45508          14          0.0      454977.6       0.7X
+
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
+AMD EPYC 7763 64-Core Processor
+collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-equalsFunction - UTF8_BINARY                          0              0           0          2.3         439.8       1.0X
-collator.compare - UTF8_BINARY                        1              1           0          1.2         863.5       0.5X
-hashFunction - UTF8_BINARY                            3              4           0          0.3        3271.4       0.1X
-equalsFunction - UTF8_BINARY_LCASE                   84             85           1          0.0       83734.0       0.0X
-collator.compare - UTF8_BINARY_LCASE                 81             82           1          0.0       81132.4       0.0X
-hashFunction - UTF8_BINARY_LCASE                     47             47           1          0.0       46509.5       0.0X
-equalsFunction - UNICODE                              0              0           0          2.3         437.4       1.0X
-collator.compare - UNICODE                           50             51           1          0.0       49775.5       0.0X
-hashFunction - UNICODE                              217            221           3          0.0      217053.0       0.0X
-equalsFunction - UNICODE_CI                          49             50           1          0.0       48482.7       0.0X
-collator.compare - UNICODE_CI                        49             50           1          0.0       48517.4       0.0X
-hashFunction - UNICODE_CI                           211            213           3          0.0      210795.4       0.0X
+UTF8_BINARY_LCASE                                 23553          23595          59          0.0      235531.8       1.0X
+UNICODE                                          197303         197309           8          0.0     1973034.1       0.1X
+UTF8_BINARY                                       14389          14391           2          0.0      143891.2       1.6X
+UNICODE_CI                                       166880         166885           7          0.0     1668799.5       0.1X
 

--- a/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
@@ -2,25 +2,25 @@ OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 filter df column with collation:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-filter df column with collation - UNICODE_CI                    41             64          25          0.0     2054778.3       1.0X
-filter df column with collation - UNICODE                       20             26           6          0.0      992422.6       2.1X
-filter df column with collation - UTF8_BINARY_LCASE             16             18           4          0.0      780918.7       2.6X
-filter df column with collation - UTF8_BINARY                   14             16           5          0.0      702731.4       2.9X
+filter df column with collation - UNICODE_CI                    48             68          25          0.0     2377015.5       1.0X
+filter df column with collation - UNICODE                       20             28           6          0.0      985946.5       2.4X
+filter df column with collation - UTF8_BINARY_LCASE             15             19           4          0.0      766053.2       3.1X
+filter df column with collation - UTF8_BINARY                   14             15           3          0.0      678785.9       3.5X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-equalsFunction - UTF8_BINARY                          1              1           0          1.9         517.4       1.0X
-collator.compare - UTF8_BINARY                        1              1           0          1.1         926.2       0.6X
-hashFunction - UTF8_BINARY                            3              3           0          0.3        3142.9       0.2X
-equalsFunction - UTF8_BINARY_LCASE                   80             81           1          0.0       80355.8       0.0X
-collator.compare - UTF8_BINARY_LCASE                 79             80           1          0.0       79282.1       0.0X
-hashFunction - UTF8_BINARY_LCASE                     46             47           1          0.0       45974.7       0.0X
-equalsFunction - UNICODE                              1              1           0          1.0         953.8       0.5X
-collator.compare - UNICODE                           49             50           0          0.0       49269.9       0.0X
-hashFunction - UNICODE                              221            223           5          0.0      220473.2       0.0X
-equalsFunction - UNICODE_CI                          49             50           1          0.0       48945.0       0.0X
-collator.compare - UNICODE_CI                        48             49           1          0.0       48266.0       0.0X
-hashFunction - UNICODE_CI                           210            211           1          0.0      210119.3       0.0X
+equalsFunction - UTF8_BINARY                          0              0           0          2.3         439.8       1.0X
+collator.compare - UTF8_BINARY                        1              1           0          1.2         863.5       0.5X
+hashFunction - UTF8_BINARY                            3              4           0          0.3        3271.4       0.1X
+equalsFunction - UTF8_BINARY_LCASE                   84             85           1          0.0       83734.0       0.0X
+collator.compare - UTF8_BINARY_LCASE                 81             82           1          0.0       81132.4       0.0X
+hashFunction - UTF8_BINARY_LCASE                     47             47           1          0.0       46509.5       0.0X
+equalsFunction - UNICODE                              0              0           0          2.3         437.4       1.0X
+collator.compare - UNICODE                           50             51           1          0.0       49775.5       0.0X
+hashFunction - UNICODE                              217            221           3          0.0      217053.0       0.0X
+equalsFunction - UNICODE_CI                          49             50           1          0.0       48482.7       0.0X
+collator.compare - UNICODE_CI                        49             50           1          0.0       48517.4       0.0X
+hashFunction - UNICODE_CI                           211            213           3          0.0      210795.4       0.0X
 

--- a/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
@@ -2,25 +2,25 @@ OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 filter df column with collation:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-filter df column with collation - UNICODE_CI                    40             65          25          0.0     2001199.6       1.0X
-filter df column with collation - UNICODE                       19             28           7          0.0      958487.5       2.1X
-filter df column with collation - UTF8_BINARY_LCASE             15             18           4          0.0      773536.9       2.6X
-filter df column with collation - UTF8_BINARY                   14             16           4          0.0      683145.3       2.9X
+filter df column with collation - UNICODE_CI                    41             64          25          0.0     2054778.3       1.0X
+filter df column with collation - UNICODE                       20             26           6          0.0      992422.6       2.1X
+filter df column with collation - UTF8_BINARY_LCASE             16             18           4          0.0      780918.7       2.6X
+filter df column with collation - UTF8_BINARY                   14             16           5          0.0      702731.4       2.9X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-equalsFunction - UTF8_BINARY                          1              1           0          1.9         520.0       1.0X
-collator.compare - UTF8_BINARY                        1              1           0          1.1         922.8       0.6X
-hashFunction - UTF8_BINARY                            3              3           0          0.3        3149.9       0.2X
-equalsFunction - UTF8_BINARY_LCASE                   77             79           5          0.0       77352.5       0.0X
-collator.compare - UTF8_BINARY_LCASE                 78             79           1          0.0       78172.8       0.0X
-hashFunction - UTF8_BINARY_LCASE                     45             46           2          0.0       44696.4       0.0X
-equalsFunction - UNICODE                              1              1           0          1.9         532.5       1.0X
-collator.compare - UNICODE                           49             50           1          0.0       49057.9       0.0X
-hashFunction - UNICODE                              218            219           1          0.0      217967.1       0.0X
-equalsFunction - UNICODE_CI                          49             50           1          0.0       49134.8       0.0X
-collator.compare - UNICODE_CI                        50             52           4          0.0       50278.5       0.0X
-hashFunction - UNICODE_CI                           206            207           1          0.0      205526.8       0.0X
+equalsFunction - UTF8_BINARY                          1              1           0          1.9         517.4       1.0X
+collator.compare - UTF8_BINARY                        1              1           0          1.1         926.2       0.6X
+hashFunction - UTF8_BINARY                            3              3           0          0.3        3142.9       0.2X
+equalsFunction - UTF8_BINARY_LCASE                   80             81           1          0.0       80355.8       0.0X
+collator.compare - UTF8_BINARY_LCASE                 79             80           1          0.0       79282.1       0.0X
+hashFunction - UTF8_BINARY_LCASE                     46             47           1          0.0       45974.7       0.0X
+equalsFunction - UNICODE                              1              1           0          1.0         953.8       0.5X
+collator.compare - UNICODE                           49             50           0          0.0       49269.9       0.0X
+hashFunction - UNICODE                              221            223           5          0.0      220473.2       0.0X
+equalsFunction - UNICODE_CI                          49             50           1          0.0       48945.0       0.0X
+collator.compare - UNICODE_CI                        48             49           1          0.0       48266.0       0.0X
+hashFunction - UNICODE_CI                           210            211           1          0.0      210119.3       0.0X
 

--- a/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
@@ -1,14 +1,5 @@
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
-filter df column with collation:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------
-filter df column with collation - UTF8_BINARY_LCASE             30             36           4          0.3        3038.1       1.0X
-filter df column with collation - UNICODE                       21             24           4          0.5        2098.3       1.4X
-filter df column with collation - UTF8_BINARY                   20             22           3          0.5        2023.6       1.5X
-filter df column with collation - UNICODE_CI                    25             28           4          0.4        2467.8       1.2X
-
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
-AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
 UTF8_BINARY_LCASE                                   29904          29937          47          0.0      299036.1       1.0X

--- a/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
@@ -1,0 +1,26 @@
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
+AMD EPYC 7763 64-Core Processor
+filter df column with collation:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------------
+filter df column with collation - UNICODE_CI                    40             65          25          0.0     2001199.6       1.0X
+filter df column with collation - UNICODE                       19             28           7          0.0      958487.5       2.1X
+filter df column with collation - UTF8_BINARY_LCASE             15             18           4          0.0      773536.9       2.6X
+filter df column with collation - UTF8_BINARY                   14             16           4          0.0      683145.3       2.9X
+
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
+AMD EPYC 7763 64-Core Processor
+collation unit benchmarks:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+equalsFunction - UTF8_BINARY                          1              1           0          1.9         520.0       1.0X
+collator.compare - UTF8_BINARY                        1              1           0          1.1         922.8       0.6X
+hashFunction - UTF8_BINARY                            3              3           0          0.3        3149.9       0.2X
+equalsFunction - UTF8_BINARY_LCASE                   77             79           5          0.0       77352.5       0.0X
+collator.compare - UTF8_BINARY_LCASE                 78             79           1          0.0       78172.8       0.0X
+hashFunction - UTF8_BINARY_LCASE                     45             46           2          0.0       44696.4       0.0X
+equalsFunction - UNICODE                              1              1           0          1.9         532.5       1.0X
+collator.compare - UNICODE                           49             50           1          0.0       49057.9       0.0X
+hashFunction - UNICODE                              218            219           1          0.0      217967.1       0.0X
+equalsFunction - UNICODE_CI                          49             50           1          0.0       49134.8       0.0X
+collator.compare - UNICODE_CI                        50             52           4          0.0       50278.5       0.0X
+hashFunction - UNICODE_CI                           206            207           1          0.0      205526.8       0.0X
+

--- a/sql/core/benchmarks/CollationBenchmark-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-results.txt
@@ -2,25 +2,35 @@ OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 filter df column with collation:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-filter df column with collation - UNICODE_CI                   403            463          39          0.0    20147470.0       1.0X
-filter df column with collation - UNICODE                      187            223          37          0.0     9339586.0       2.2X
-filter df column with collation - UTF8_BINARY_LCASE            426            434           7          0.0    21300903.4       0.9X
-filter df column with collation - UTF8_BINARY                  188            199           5          0.0     9403169.1       2.1X
+filter df column with collation - UTF8_BINARY_LCASE             33             39           4          0.3        3323.1       1.0X
+filter df column with collation - UNICODE                       23             27           4          0.4        2320.3       1.4X
+filter df column with collation - UTF8_BINARY                   22             25           3          0.5        2199.7       1.5X
+filter df column with collation - UNICODE_CI                    27             29           3          0.4        2678.7       1.2X
 
 OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------
+UTF8_BINARY_LCASE                                   34122          34152          42          0.0      341224.2       1.0X
+UNICODE                                              4520           4522           2          0.0       45201.8       7.5X
+UTF8_BINARY                                          4524           4526           2          0.0       45243.0       7.5X
+UNICODE_CI                                          52706          52711           7          0.0      527056.1       0.6X
+
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+AMD EPYC 7763 64-Core Processor
+collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------
+UTF8_BINARY_LCASE                                    33467          33474          10          0.0      334671.7       1.0X
+UNICODE                                              51168          51168           1          0.0      511677.4       0.7X
+UTF8_BINARY                                           5561           5593          45          0.0       55610.9       6.0X
+UNICODE_CI                                           51929          51955          36          0.0      519291.8       0.6X
+
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+AMD EPYC 7763 64-Core Processor
+collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-equalsFunction - UTF8_BINARY                          0              0           0         10.4          96.6       1.0X
-collator.compare - UTF8_BINARY                        4              4           0          0.3        3717.9       0.0X
-hashFunction - UTF8_BINARY                            0              0           0         42.0          23.8       4.1X
-equalsFunction - UTF8_BINARY_LCASE                    5              5           0          0.2        5014.7       0.0X
-collator.compare - UTF8_BINARY_LCASE                 71             72           1          0.0       70796.2       0.0X
-hashFunction - UTF8_BINARY_LCASE                      0              0           0          4.2         239.5       0.4X
-equalsFunction - UNICODE                              0              0           0          9.6         104.7       0.9X
-collator.compare - UNICODE                           25             26           0          0.0       25414.8       0.0X
-hashFunction - UNICODE                                1              1           0          1.0        1030.0       0.1X
-equalsFunction - UNICODE_CI                           3              4           0          0.3        3455.1       0.0X
-collator.compare - UNICODE_CI                        25             26           1          0.0       25266.4       0.0X
-hashFunction - UNICODE_CI                             1              1           0          1.0         990.7       0.1X
+UTF8_BINARY_LCASE                                 22079          22083           5          0.0      220786.7       1.0X
+UNICODE                                          177636         177709         103          0.0     1776363.9       0.1X
+UTF8_BINARY                                       11954          11956           3          0.0      119536.7       1.8X
+UNICODE_CI                                       158014         158038          35          0.0     1580135.7       0.1X
 

--- a/sql/core/benchmarks/CollationBenchmark-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-results.txt
@@ -2,25 +2,25 @@ OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 filter df column with collation:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-filter df column with collation - UNICODE_CI                   417            473          42          0.0    20865569.2       1.0X
-filter df column with collation - UNICODE                      196            243          38          0.0     9815404.0       2.1X
-filter df column with collation - UTF8_BINARY_LCASE            461            485          14          0.0    23064486.2       0.9X
-filter df column with collation - UTF8_BINARY                  168            187          10          0.0     8396762.8       2.5X
+filter df column with collation - UNICODE_CI                   420            460          63          0.0    21000062.3       1.0X
+filter df column with collation - UNICODE                      184            217          30          0.0     9176301.7       2.3X
+filter df column with collation - UTF8_BINARY_LCASE            480            495          12          0.0    24000624.4       0.9X
+filter df column with collation - UTF8_BINARY                  173            184           6          0.0     8670535.8       2.4X
 
 OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-equalsFunction - UTF8_BINARY                          0              0           0         10.5          95.4       1.0X
-collator.compare - UTF8_BINARY                        4              4           0          0.3        3794.1       0.0X
-hashFunction - UTF8_BINARY                            0              0           0         42.2          23.7       4.0X
-equalsFunction - UTF8_BINARY_LCASE                    5              5           0          0.2        5099.6       0.0X
-collator.compare - UTF8_BINARY_LCASE                 70             71           1          0.0       69938.7       0.0X
-hashFunction - UTF8_BINARY_LCASE                      0              0           0          4.2         236.6       0.4X
-equalsFunction - UNICODE                              0              0           0         10.2          98.4       1.0X
-collator.compare - UNICODE                           29             30           1          0.0       29434.4       0.0X
-hashFunction - UNICODE                                1              1           0          1.0        1036.7       0.1X
-equalsFunction - UNICODE_CI                           4              4           0          0.3        3676.5       0.0X
-collator.compare - UNICODE_CI                        30             31           2          0.0       29792.5       0.0X
-hashFunction - UNICODE_CI                             1              1           0          1.0         974.8       0.1X
+equalsFunction - UTF8_BINARY                          0              0           0         11.3          88.8       1.0X
+collator.compare - UTF8_BINARY                        4              4           0          0.3        3914.0       0.0X
+hashFunction - UTF8_BINARY                            0              0           0         45.7          21.9       4.1X
+equalsFunction - UTF8_BINARY_LCASE                    5              5           0          0.2        4949.6       0.0X
+collator.compare - UTF8_BINARY_LCASE                 72             73           1          0.0       72000.6       0.0X
+hashFunction - UTF8_BINARY_LCASE                      0              0           0          4.1         241.5       0.4X
+equalsFunction - UNICODE                              0              0           0         10.5          95.5       0.9X
+collator.compare - UNICODE                           24             25           1          0.0       23936.1       0.0X
+hashFunction - UNICODE                                1              1           0          1.0         966.9       0.1X
+equalsFunction - UNICODE_CI                           3              3           0          0.3        3179.9       0.0X
+collator.compare - UNICODE_CI                        23             24           1          0.0       23360.3       0.0X
+hashFunction - UNICODE_CI                             1              1           0          1.1         905.0       0.1X
 

--- a/sql/core/benchmarks/CollationBenchmark-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-results.txt
@@ -2,25 +2,25 @@ OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 filter df column with collation:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------
-filter df column with collation - UNICODE_CI                   420            460          63          0.0    21000062.3       1.0X
-filter df column with collation - UNICODE                      184            217          30          0.0     9176301.7       2.3X
-filter df column with collation - UTF8_BINARY_LCASE            480            495          12          0.0    24000624.4       0.9X
-filter df column with collation - UTF8_BINARY                  173            184           6          0.0     8670535.8       2.4X
+filter df column with collation - UNICODE_CI                   403            463          39          0.0    20147470.0       1.0X
+filter df column with collation - UNICODE                      187            223          37          0.0     9339586.0       2.2X
+filter df column with collation - UTF8_BINARY_LCASE            426            434           7          0.0    21300903.4       0.9X
+filter df column with collation - UTF8_BINARY                  188            199           5          0.0     9403169.1       2.1X
 
 OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-equalsFunction - UTF8_BINARY                          0              0           0         11.3          88.8       1.0X
-collator.compare - UTF8_BINARY                        4              4           0          0.3        3914.0       0.0X
-hashFunction - UTF8_BINARY                            0              0           0         45.7          21.9       4.1X
-equalsFunction - UTF8_BINARY_LCASE                    5              5           0          0.2        4949.6       0.0X
-collator.compare - UTF8_BINARY_LCASE                 72             73           1          0.0       72000.6       0.0X
-hashFunction - UTF8_BINARY_LCASE                      0              0           0          4.1         241.5       0.4X
-equalsFunction - UNICODE                              0              0           0         10.5          95.5       0.9X
-collator.compare - UNICODE                           24             25           1          0.0       23936.1       0.0X
-hashFunction - UNICODE                                1              1           0          1.0         966.9       0.1X
-equalsFunction - UNICODE_CI                           3              3           0          0.3        3179.9       0.0X
-collator.compare - UNICODE_CI                        23             24           1          0.0       23360.3       0.0X
-hashFunction - UNICODE_CI                             1              1           0          1.1         905.0       0.1X
+equalsFunction - UTF8_BINARY                          0              0           0         10.4          96.6       1.0X
+collator.compare - UTF8_BINARY                        4              4           0          0.3        3717.9       0.0X
+hashFunction - UTF8_BINARY                            0              0           0         42.0          23.8       4.1X
+equalsFunction - UTF8_BINARY_LCASE                    5              5           0          0.2        5014.7       0.0X
+collator.compare - UTF8_BINARY_LCASE                 71             72           1          0.0       70796.2       0.0X
+hashFunction - UTF8_BINARY_LCASE                      0              0           0          4.2         239.5       0.4X
+equalsFunction - UNICODE                              0              0           0          9.6         104.7       0.9X
+collator.compare - UNICODE                           25             26           0          0.0       25414.8       0.0X
+hashFunction - UNICODE                                1              1           0          1.0        1030.0       0.1X
+equalsFunction - UNICODE_CI                           3              4           0          0.3        3455.1       0.0X
+collator.compare - UNICODE_CI                        25             26           1          0.0       25266.4       0.0X
+hashFunction - UNICODE_CI                             1              1           0          1.0         990.7       0.1X
 

--- a/sql/core/benchmarks/CollationBenchmark-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-results.txt
@@ -1,0 +1,26 @@
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+AMD EPYC 7763 64-Core Processor
+filter df column with collation:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+-----------------------------------------------------------------------------------------------------------------------------------
+filter df column with collation - UNICODE_CI                   417            473          42          0.0    20865569.2       1.0X
+filter df column with collation - UNICODE                      196            243          38          0.0     9815404.0       2.1X
+filter df column with collation - UTF8_BINARY_LCASE            461            485          14          0.0    23064486.2       0.9X
+filter df column with collation - UTF8_BINARY                  168            187          10          0.0     8396762.8       2.5X
+
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+AMD EPYC 7763 64-Core Processor
+collation unit benchmarks:                Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+equalsFunction - UTF8_BINARY                          0              0           0         10.5          95.4       1.0X
+collator.compare - UTF8_BINARY                        4              4           0          0.3        3794.1       0.0X
+hashFunction - UTF8_BINARY                            0              0           0         42.2          23.7       4.0X
+equalsFunction - UTF8_BINARY_LCASE                    5              5           0          0.2        5099.6       0.0X
+collator.compare - UTF8_BINARY_LCASE                 70             71           1          0.0       69938.7       0.0X
+hashFunction - UTF8_BINARY_LCASE                      0              0           0          4.2         236.6       0.4X
+equalsFunction - UNICODE                              0              0           0         10.2          98.4       1.0X
+collator.compare - UNICODE                           29             30           1          0.0       29434.4       0.0X
+hashFunction - UNICODE                                1              1           0          1.0        1036.7       0.1X
+equalsFunction - UNICODE_CI                           4              4           0          0.3        3676.5       0.0X
+collator.compare - UNICODE_CI                        30             31           2          0.0       29792.5       0.0X
+hashFunction - UNICODE_CI                             1              1           0          1.0         974.8       0.1X
+

--- a/sql/core/benchmarks/CollationBenchmark-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-results.txt
@@ -1,14 +1,5 @@
 OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
-filter df column with collation:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------
-filter df column with collation - UTF8_BINARY_LCASE             33             39           4          0.3        3323.1       1.0X
-filter df column with collation - UNICODE                       23             27           4          0.4        2320.3       1.4X
-filter df column with collation - UTF8_BINARY                   22             25           3          0.5        2199.7       1.5X
-filter df column with collation - UNICODE_CI                    27             29           3          0.4        2678.7       1.2X
-
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
-AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
 UTF8_BINARY_LCASE                                   34122          34152          42          0.0      341224.2       1.0X

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
@@ -36,13 +36,29 @@ import org.apache.spark.unsafe.types.UTF8String
  */
 
 object CollationBenchmark extends SqlBasedBenchmark {
-  private val collationTypes = Seq("UTF8_BINARY", "UTF8_BINARY_LCASE", "UNICODE", "UNICODE_CI")
+  private val collationTypes = Seq("UTF8_BINARY_LCASE", "UNICODE", "UTF8_BINARY", "UNICODE_CI")
 
-  def generateUTF8Strings(n: Int): Seq[UTF8String] = {
-    // Generate n UTF8Strings
-    Seq("ABC", "aBC", "abc", "DEF", "def", "GHI", "ghi", "JKL", "jkl",
-      "MNO", "mno", "PQR", "pqr", "STU", "stu", "VWX", "vwx", "YZ").map(UTF8String.fromString) ++
-    (18 to n).map(i => UTF8String.fromString(i.toOctalString))
+  def generateSeqInput(n: Long): Seq[UTF8String] = {
+    val input = Seq("ABC", "ABC", "aBC", "aBC", "abc", "abc", "DEF", "DEF", "def",
+      "def", "GHI", "ghi",
+      "JKL", "jkl", "MNO", "mno", "PQR", "pqr", "STU", "stu", "VWX", "vwx", "YZ",
+      "ABC", "ABC", "aBC", "aBC", "abc", "abc", "DEF", "DEF", "def", "def", "GHI", "ghi",
+      "JKL", "jkl", "MNO", "mno", "PQR", "pqr", "STU", "stu", "VWX", "vwx", "YZ")
+      .map(UTF8String.fromString)
+    val inputLong: Seq[UTF8String] = (0L until n).map(i => input(i.toInt % input.size))
+    inputLong
+  }
+
+  private def getDataFrame(strings: Seq[String]): DataFrame = {
+    val asPairs = strings.sliding(2, 1).toSeq.map {
+      case Seq(s1, s2) => (s1, s2)
+    }
+    val d = spark.createDataFrame(asPairs).toDF("s1", "s2")
+    d
+  }
+
+  private def generateDataframeInput(l: Long): DataFrame = {
+    getDataFrame(generateSeqInput(l).map(_.toString))
   }
 
   def benchmarkUTFString(collationTypes: Seq[String], utf8Strings: Seq[UTF8String]): Unit = {
@@ -77,36 +93,26 @@ object CollationBenchmark extends SqlBasedBenchmark {
     benchmark.run()
   }
 
-  def df1: DataFrame = {
-    val d = spark.createDataFrame(Seq(
-      ("ABC", "ABC"), ("aBC", "abc"), ("abc", "ABC"), ("DEF", "DEF"), ("def", "DEF"),
-      ("GHI", "GHI"), ("ghi", "IG"), ("JKL", "NOP"), ("jkl", "LKJ"), ("mnO", "MNO"),
-      ("hello", "hola"))
-    ).toDF("s1", "s2")
-    d
-  }
-
-  def collationBenchmarkFilterEqual(collationTypes: Seq[String]): Unit = {
+  def benchmarkFilterEqual(collationTypes: Seq[String],
+                           dfUncollated: DataFrame): Unit = {
     val benchmark = collationTypes.foldLeft(
-      new Benchmark(s"filter df column with collation", 11, output = output)) {
+      new Benchmark(s"filter df column with collation", dfUncollated.count(), output = output)) {
       (b, collationType) =>
-        b.addCase(s"filter df column with collation - $collationType") { _ =>
-          val df = df1.selectExpr(
+          val dfCollated = dfUncollated.selectExpr(
             s"collate(s2, '$collationType') as k2_$collationType",
             s"collate(s1, '$collationType') as k1_$collationType")
-
-          df.where(col(s"k1_$collationType") === col(s"k2_$collationType"))
+        b.addCase(s"filter df column with collation - $collationType") { _ =>
+          dfCollated.where(col(s"k1_$collationType") === col(s"k2_$collationType"))
                 .queryExecution.executedPlan.executeCollect()
-
         }
         b
     }
     benchmark.run()
   }
 
-
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
-    collationBenchmarkFilterEqual(collationTypes.reverse)
-    benchmarkUTFString(collationTypes, generateUTF8Strings(200))
+    benchmarkFilterEqual(collationTypes, generateDataframeInput(10000L))
+    benchmarkUTFString(collationTypes, generateSeqInput(10000L))
   }
+
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
@@ -67,16 +67,17 @@ object CollationBenchmark extends SqlBasedBenchmark {
 
     val benchmark = new Benchmark(
       "collation unit benchmarks - equalsFunction",
-      utf8Strings.size,
+      utf8Strings.size * 10,
       warmupTime = 4.seconds,
-      // minNumIters = 10,
       output = output)
     collationTypes.foreach(collationType => {
       val collation = CollationFactory.fetchCollation(collationType)
-      benchmark.addCase(s"$collationType", numIters = 20) { _ =>
+      benchmark.addCase(s"$collationType") { _ =>
         sublistStrings.foreach(s1 =>
           utf8Strings.foreach(s =>
-            collation.equalsFunction(s, s1).booleanValue())
+            (0 to 10).foreach(_ =>
+              collation.equalsFunction(s, s1).booleanValue())
+          )
         )
       }
     }
@@ -88,9 +89,8 @@ object CollationBenchmark extends SqlBasedBenchmark {
 
     val benchmark = new Benchmark(
       "collation unit benchmarks - compareFunction",
-      utf8Strings.size,
+      utf8Strings.size * 10,
       warmupTime = 4.seconds,
-      // minNumIters = 10,
       output = output)
     collationTypes.foreach(collationType => {
       val collation = CollationFactory.fetchCollation(collationType)
@@ -115,17 +115,17 @@ object CollationBenchmark extends SqlBasedBenchmark {
 
     val benchmark = new Benchmark(
       "collation unit benchmarks - hashFunction",
-      utf8Strings.size,
+      utf8Strings.size * 10,
       warmupTime = 4.seconds,
-      // minNumIters = 10,
       output = output)
     collationTypes.foreach(collationType => {
       val collation = CollationFactory.fetchCollation(collationType)
       benchmark.addCase(s"$collationType") { _ =>
         sublistStrings.foreach(_ =>
           utf8Strings.foreach(s =>
-            collation.hashFunction.applyAsLong(s)
-
+            (0 to 10).foreach(_ =>
+              collation.hashFunction.applyAsLong(s)
+            )
           )
         )
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
@@ -17,7 +17,7 @@
 package org.apache.spark.sql.execution.benchmark
 
 import org.apache.spark.benchmark.Benchmark
-import org.apache.spark.sql.{DataFrame}
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.util.CollationFactory
 import org.apache.spark.sql.functions._
 import org.apache.spark.unsafe.types.UTF8String
@@ -66,7 +66,7 @@ object CollationBenchmark extends SqlBasedBenchmark {
           )
         }
         b.addCase(s"hashFunction - $collationType") { _ =>
-          sublistStrings.foreach(s1 =>
+          sublistStrings.foreach(_ =>
             utf8Strings.foreach(s =>
               collation.hashFunction.applyAsLong(s)
             )
@@ -87,8 +87,6 @@ object CollationBenchmark extends SqlBasedBenchmark {
   }
 
   def collationBenchmarkFilterEqual(collationTypes: Seq[String]): Unit = {
-    val N = 2 << 20
-
     val benchmark = collationTypes.foldLeft(
       new Benchmark(s"filter df column with collation", 11, output = output)) {
       (b, collationType) =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
@@ -70,6 +70,7 @@ object CollationBenchmark extends SqlBasedBenchmark {
     )
     benchmark.run()
   }
+
   def benchmarkUTFStringCompare(collationTypes: Seq[String], utf8Strings: Seq[UTF8String]): Unit = {
     val sublistStrings = utf8Strings
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
@@ -77,20 +77,20 @@ object CollationBenchmark extends SqlBasedBenchmark {
       benchmark.addCase(s"equalsFunction - $collationType", numIters = 20) { _ =>
         sublistStrings.foreach(s1 =>
           utf8Strings.foreach(s =>
-              collation.equalsFunction(s, s1).booleanValue())
+            collation.equalsFunction(s, s1).booleanValue())
         )
       }
       benchmark.addCase(s"collator.compare - $collationType") { _ =>
         sublistStrings.foreach(s1 =>
           utf8Strings.foreach(s =>
-              collation.comparator.compare(s, s1)
+            collation.comparator.compare(s, s1)
           )
         )
       }
       benchmark.addCase(s"hashFunction - $collationType") { _ =>
         sublistStrings.foreach(_ =>
           utf8Strings.foreach(s =>
-              collation.hashFunction.applyAsLong(s)
+            collation.hashFunction.applyAsLong(s)
 
           )
         )

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
@@ -93,8 +93,9 @@ object CollationBenchmark extends SqlBasedBenchmark {
     benchmark.run()
   }
 
-  def benchmarkFilterEqual(collationTypes: Seq[String],
-                           dfUncollated: DataFrame): Unit = {
+  def benchmarkFilterEqual(
+      collationTypes: Seq[String],
+      dfUncollated: DataFrame): Unit = {
     val benchmark =
       new Benchmark("filter df column with collation", dfUncollated.count(), output = output)
     collationTypes.foreach(collationType => {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.execution.benchmark
 
 import scala.concurrent.duration._
 
-import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
 import org.apache.spark.sql.catalyst.util.CollationFactory
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -35,7 +35,7 @@ import org.apache.spark.unsafe.types.UTF8String
  * }}}
  */
 
-object CollationBenchmark extends SqlBasedBenchmark {
+object CollationBenchmark extends BenchmarkBase {
   private val collationTypes = Seq("UTF8_BINARY_LCASE", "UNICODE", "UTF8_BINARY", "UNICODE_CI")
 
   def generateSeqInput(n: Long): Seq[UTF8String] = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
@@ -31,7 +31,7 @@ import org.apache.spark.unsafe.types.UTF8String
  *   2. build/sbt "sql/Test/runMain org.apache.spark.sql.execution.benchmark.CollationBenchmark"
  *   3. generate result:
  *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/Test/runMain <this class>"
- *      Results will be written to "benchmarks/JoinBenchmark-results.txt".
+ *      Results will be written to "benchmarks/CollationBenchmark-results.txt".
  * }}}
  */
 
@@ -70,7 +70,7 @@ object CollationBenchmark extends SqlBasedBenchmark {
         b.addCase(s"equalsFunction - $collationType") { _ =>
           sublistStrings.foreach(s1 =>
             utf8Strings.foreach(s =>
-            collation.equalsFunction(s, s1).booleanValue()
+              collation.equalsFunction(s, s1).booleanValue()
             )
           )
         }
@@ -98,12 +98,12 @@ object CollationBenchmark extends SqlBasedBenchmark {
     val benchmark = collationTypes.foldLeft(
       new Benchmark(s"filter df column with collation", dfUncollated.count(), output = output)) {
       (b, collationType) =>
-          val dfCollated = dfUncollated.selectExpr(
-            s"collate(s2, '$collationType') as k2_$collationType",
-            s"collate(s1, '$collationType') as k1_$collationType")
+        val dfCollated = dfUncollated.selectExpr(
+          s"collate(s2, '$collationType') as k2_$collationType",
+          s"collate(s1, '$collationType') as k1_$collationType")
         b.addCase(s"filter df column with collation - $collationType") { _ =>
           dfCollated.where(col(s"k1_$collationType") === col(s"k2_$collationType"))
-                .queryExecution.executedPlan.executeCollect()
+            .queryExecution.executedPlan.executeCollect()
         }
         b
     }
@@ -114,5 +114,4 @@ object CollationBenchmark extends SqlBasedBenchmark {
     benchmarkFilterEqual(collationTypes, generateDataframeInput(10000L))
     benchmarkUTFString(collationTypes, generateSeqInput(10000L))
   }
-
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
@@ -83,7 +83,9 @@ object CollationBenchmark extends SqlBasedBenchmark {
       benchmark.addCase(s"collator.compare - $collationType") { _ =>
         sublistStrings.foreach(s1 =>
           utf8Strings.foreach(s =>
-            collation.comparator.compare(s, s1)
+            (0 to 10).foreach(_ =>
+              collation.comparator.compare(s, s1)
+            )
           )
         )
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.benchmark
+
+import scala.util.Random
+
+import org.apache.spark.benchmark.Benchmark
+import org.apache.spark.sql.{DataFrame}
+import org.apache.spark.sql.catalyst.util.CollationFactory
+import org.apache.spark.sql.functions._
+import org.apache.spark.unsafe.types.UTF8String
+
+/**
+ * Benchmark to measure performance for joins. To run this benchmark:
+ * {{{
+ *   1. without sbt:
+ *      bin/spark-submit --class <this class>
+ *        --jars <spark core test jar>,<spark catalyst test jar> <spark sql test jar>
+ *   2. build/sbt "sql/Test/runMain org.apache.spark.sql.execution.benchmark.CollationBenchmark"
+ *   3. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/Test/runMain <this class>"
+ *      Results will be written to "benchmarks/JoinBenchmark-results.txt".
+ * }}}
+ */
+
+object CollationBenchmark extends SqlBasedBenchmark {
+  private val collationTypes = Seq("UTF8_BINARY", "UTF8_BINARY_LCASE", "UNICODE", "UNICODE_CI")
+
+  def generateUTF8Strings(n: Int): Seq[UTF8String] = {
+    // Generate n UTF8Strings
+    Seq("ABC", "aBC", "abc", "DEF", "def", "GHI", "ghi", "JKL", "jkl",
+      "MNO", "mno", "PQR", "pqr", "STU", "stu", "VWX", "vwx", "YZ").map(UTF8String.fromString) ++
+    (18 to n).map(i => UTF8String.fromString(Random.nextString(i % 25))).sortBy(_.hashCode())
+  }
+
+  def benchmarkUTFString(collationTypes: Seq[String], utf8Strings: Seq[UTF8String]): Unit = {
+    val sublistStrings = utf8Strings.slice(0, 200)
+    val benchmark = collationTypes.foldLeft(
+      new Benchmark(s"collation unit benchmarks", utf8Strings.size, output = output)) {
+      (b, collationType) =>
+        val collation = CollationFactory.fetchCollation(collationType)
+        b.addCase(s"equalsFunction - $collationType") { _ =>
+          sublistStrings.foreach(s1 =>
+            utf8Strings.foreach(s =>
+            collation.equalsFunction(s, s1).booleanValue()
+            )
+          )
+        }
+        b.addCase(s"collator.compare - $collationType") { _ =>
+          sublistStrings.foreach(s1 =>
+            utf8Strings.foreach(s =>
+              collation.comparator.compare(s, s1)
+            )
+          )
+        }
+        b.addCase(s"hashFunction - $collationType") { _ =>
+          sublistStrings.foreach(s1 =>
+            utf8Strings.foreach(s =>
+              collation.hashFunction.applyAsLong(s)
+            )
+          )
+        }
+        b
+    }
+    benchmark.run()
+  }
+
+  def df1: DataFrame = {
+    val d = spark.createDataFrame(Seq(
+      ("ABC", "ABC"), ("aBC", "abc"), ("abc", "ABC"), ("DEF", "DEF"), ("def", "DEF"),
+      ("GHI", "GHI"), ("ghi", "IG"), ("JKL", "NOP"), ("jkl", "LKJ"), ("mnO", "MNO"),
+      ("hello", "hola"))
+    ).toDF("s1", "s2")
+    d
+  }
+
+  def collationBenchmarkFilterEqual(
+      collationTypes: Seq[String],
+      utf8Strings: Seq[UTF8String]): Unit = {
+    val N = 2 << 20
+
+    val benchmark = collationTypes.foldLeft(
+      new Benchmark(s"filter df column with collation", utf8Strings.size, output = output)) {
+      (b, collationType) =>
+        b.addCase(s"filter df column with collation - $collationType") { _ =>
+          val df = df1.selectExpr(
+            s"collate(s2, '$collationType') as k2_$collationType",
+            s"collate(s1, '$collationType') as k1_$collationType")
+
+          (0 to 10).foreach(_ =>
+          df.where(col(s"k1_$collationType") === col(s"k2_$collationType"))
+                .queryExecution.executedPlan.executeCollect()
+          )
+        }
+        b
+    }
+    benchmark.run()
+  }
+
+  // How to benchmark "without the rest of the spark stack"?
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    val utf8Strings = generateUTF8Strings(1000) // Adjust the size as needed
+    collationBenchmarkFilterEqual(collationTypes.reverse, utf8Strings.slice(0, 20))
+    benchmarkUTFString(collationTypes, utf8Strings)
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?


https://issues.apache.org/jira/browse/SPARK-46840
  
[Collation Support in Spark.docx](https://github.com/apache/spark/files/14551958/Collation.Support.in.Spark.docx)

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


Work is underway to introduce collation concept into Spark. There is a need to build out a benchmarking suite to allow engineers to address performance impact.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
GHA 'Run Benchmarks' ran on this, for both JDK 17 and JDK 21

In addition, both the author and @dbatomic tested locally on personal computers:
`build/sbt "sql/Test/runMain  org.apache.spark.sql.execution.benchmark.CollationBenchmark"`


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
