### PR TITLE
[SPARK-45245][CONNECT][TESTS][FOLLOW-UP] Remove unneeded Matchers trait in the test

### DIFF
--- a/core/src/test/scala/org/apache/spark/api/python/PythonWorkerFactorySuite.scala
+++ b/core/src/test/scala/org/apache/spark/api/python/PythonWorkerFactorySuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.SparkFunSuite
 import org.apache.spark.util.ThreadUtils
 
 // Tests for PythonWorkerFactory.
-class PythonWorkerFactorySuite extends SparkFunSuite with Matchers with SharedSparkContext {
+class PythonWorkerFactorySuite extends SparkFunSuite with SharedSparkContext {
 
   test("createSimpleWorker() fails with a timeout error if worker does not connect back") {
     // It verifies that server side times out in accept(), if the worker does not connect back.

--- a/core/src/test/scala/org/apache/spark/api/python/PythonWorkerFactorySuite.scala
+++ b/core/src/test/scala/org/apache/spark/api/python/PythonWorkerFactorySuite.scala
@@ -25,8 +25,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-import org.scalatest.matchers.must.Matchers
-
 import org.apache.spark.SharedSparkContext
 import org.apache.spark.SparkException
 import org.apache.spark.SparkFunSuite


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/43023 that addresses a post-review comment.

### Why are the changes needed?

It is unnecessary. It also matters with Scala compatibility so should better remove if unused.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.