### PR TITLE
[SPARK-47343][SQL] Fix NPE when `sqlString` variable value is null string in execute immediate

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -3004,6 +3004,12 @@
     ],
     "sqlState" : "2200E"
   },
+  "NULL_QUERY_STRING_EXECUTE_IMMEDIATE" : {
+    "message" : [
+      "SQLQuery string should not be null."
+    ],
+    "sqlState" : "42K09"
+  },
   "NUMERIC_OUT_OF_SUPPORTED_RANGE" : {
     "message" : [
       "The value <value> cannot be interpreted as a numeric since it has more than 38 digits."

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -3006,7 +3006,7 @@
   },
   "NULL_QUERY_STRING_EXECUTE_IMMEDIATE" : {
     "message" : [
-      "Execute immediate requires non-null value for sqlString variable, but provided <varName> is null."
+      "Execute immediate requires a non-null variable as the query string, but the provided variable <varName> is null."
     ],
     "sqlState" : "42K09"
   },

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -3008,7 +3008,7 @@
     "message" : [
       "Execute immediate requires a non-null variable as the query string, but the provided variable <varName> is null."
     ],
-    "sqlState" : "42K09"
+    "sqlState" : "22004"
   },
   "NUMERIC_OUT_OF_SUPPORTED_RANGE" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -3006,7 +3006,7 @@
   },
   "NULL_QUERY_STRING_EXECUTE_IMMEDIATE" : {
     "message" : [
-      "SQLQuery string should not be null."
+      "Execute immediate requires non-null value for sqlString variable, but provided <varName> is null."
     ],
     "sqlState" : "42K09"
   },

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -1765,7 +1765,7 @@ Cannot use null as map key.
 
 ### NULL_QUERY_STRING_EXECUTE_IMMEDIATE
 
-[SQLSTATE: 42K09](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+[SQLSTATE: 22004](sql-error-conditions-sqlstates.html#class-22-data-exception)
 
 Execute immediate requires a non-null variable as the query string, but the provided variable `<varName>` is null.
 

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -1763,6 +1763,12 @@ Row ID attributes cannot be nullable: `<nullableRowIdAttrs>`.
 
 Cannot use null as map key.
 
+### NULL_QUERY_STRING_EXECUTE_IMMEDIATE
+
+[SQLSTATE: 42K09](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
+
+SQLQuery string should not be null.
+
 ### NUMERIC_OUT_OF_SUPPORTED_RANGE
 
 [SQLSTATE: 22003](sql-error-conditions-sqlstates.html#class-22-data-exception)

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -1767,7 +1767,7 @@ Cannot use null as map key.
 
 [SQLSTATE: 42K09](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
 
-SQLQuery string should not be null.
+Execute immediate requires non-null value for sqlString variable, but provided `<varName>` is null.
 
 ### NUMERIC_OUT_OF_SUPPORTED_RANGE
 

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -1767,7 +1767,7 @@ Cannot use null as map key.
 
 [SQLSTATE: 42K09](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
 
-Execute immediate requires non-null value for sqlString variable, but provided `<varName>` is null.
+Execute immediate requires a non-null variable as the query string, but the provided variable `<varName>` is null.
 
 ### NUMERIC_OUT_OF_SUPPORTED_RANGE
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/executeImmediate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/executeImmediate.scala
@@ -88,6 +88,10 @@ class SubstituteExecuteImmediate(val catalogManager: CatalogManager)
           throw QueryCompilationErrors.invalidExecuteImmediateVariableType(varReference.dataType)
         }
 
+        if (varReference.eval(null) == null) {
+          throw QueryCompilationErrors.nullSQLStringExecuteImmediate()
+        }
+
         // Call eval with null value passed instead of a row.
         // This is ok as this is variable and invoking eval should
         // be independent of row value.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/executeImmediate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/executeImmediate.scala
@@ -88,14 +88,16 @@ class SubstituteExecuteImmediate(val catalogManager: CatalogManager)
           throw QueryCompilationErrors.invalidExecuteImmediateVariableType(varReference.dataType)
         }
 
-        if (varReference.eval(null) == null) {
-          throw QueryCompilationErrors.nullSQLStringExecuteImmediate()
+        val varReferenceValue = varReference.eval(null)
+
+        if (varReferenceValue == null) {
+          throw QueryCompilationErrors.nullSQLStringExecuteImmediate(u.name)
         }
 
         // Call eval with null value passed instead of a row.
         // This is ok as this is variable and invoking eval should
         // be independent of row value.
-        varReference.eval(null).toString
+        varReferenceValue.toString
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/executeImmediate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/executeImmediate.scala
@@ -88,15 +88,15 @@ class SubstituteExecuteImmediate(val catalogManager: CatalogManager)
           throw QueryCompilationErrors.invalidExecuteImmediateVariableType(varReference.dataType)
         }
 
+        // Call eval with null value passed instead of a row.
+        // This is ok as this is variable and invoking eval should
+        // be independent of row value.
         val varReferenceValue = varReference.eval(null)
 
         if (varReferenceValue == null) {
           throw QueryCompilationErrors.nullSQLStringExecuteImmediate(u.name)
         }
 
-        // Call eval with null value passed instead of a row.
-        // This is ok as this is variable and invoking eval should
-        // be independent of row value.
         varReferenceValue.toString
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3954,10 +3954,10 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("varType" -> toSQLType(dataType)))
   }
 
-  def nullSQLStringExecuteImmediate(): Throwable = {
+  def nullSQLStringExecuteImmediate(varName: String): Throwable = {
     throw new AnalysisException(
       errorClass = "NULL_QUERY_STRING_EXECUTE_IMMEDIATE",
-      messageParameters = Map.empty)
+      messageParameters = Map("varName" -> varName))
   }
 
   def invalidStatementForExecuteInto(queryString: String): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3954,6 +3954,12 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("varType" -> toSQLType(dataType)))
   }
 
+  def nullSQLStringExecuteImmediate(): Throwable = {
+    throw new AnalysisException(
+      errorClass = "NULL_QUERY_STRING_EXECUTE_IMMEDIATE",
+      messageParameters = Map.empty)
+  }
+
   def invalidStatementForExecuteInto(queryString: String): Throwable = {
     throw new AnalysisException(
       errorClass = "INVALID_STATEMENT_FOR_EXECUTE_INTO",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3957,7 +3957,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
   def nullSQLStringExecuteImmediate(varName: String): Throwable = {
     throw new AnalysisException(
       errorClass = "NULL_QUERY_STRING_EXECUTE_IMMEDIATE",
-      messageParameters = Map("varName" -> varName))
+      messageParameters = Map("varName" -> toSQLId(varName)))
   }
 
   def invalidStatementForExecuteInto(queryString: String): Throwable = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -872,7 +872,7 @@ class AnalysisErrorSuite extends AnalysisTest with DataTypeErrorsBase {
     assertAnalysisErrorClass(
       inputPlan = execImmediatePlan,
       expectedErrorClass = "NULL_QUERY_STRING_EXECUTE_IMMEDIATE",
-      expectedMessageParameters = Map("varName" -> "testVarNull"))
+      expectedMessageParameters = Map("varName" -> "`testVarNull`"))
   }
 
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -872,7 +872,7 @@ class AnalysisErrorSuite extends AnalysisTest with DataTypeErrorsBase {
     assertAnalysisErrorClass(
       inputPlan = execImmediatePlan,
       expectedErrorClass = "NULL_QUERY_STRING_EXECUTE_IMMEDIATE",
-      expectedMessageParameters = Map.empty)
+      expectedMessageParameters = Map("varName" -> "testVarNull"))
   }
 
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -863,6 +863,19 @@ class AnalysisErrorSuite extends AnalysisTest with DataTypeErrorsBase {
       ))
   }
 
+  test("EXEC IMMEDIATE - Null string as sqlString parameter") {
+    val execImmediatePlan = ExecuteImmediateQuery(
+      Seq.empty,
+      scala.util.Right(UnresolvedAttribute("testVarNull")),
+      Seq(UnresolvedAttribute("testVarNull")))
+
+    assertAnalysisErrorClass(
+      inputPlan = execImmediatePlan,
+      expectedErrorClass = "NULL_QUERY_STRING_EXECUTE_IMMEDIATE",
+      expectedMessageParameters = Map.empty)
+  }
+
+
   test("EXEC IMMEDIATE - Unsupported expr for parameter") {
     val execImmediatePlan: LogicalPlan = ExecuteImmediateQuery(
       Seq(UnresolvedAttribute("testVarA"), NaNvl(Literal(1), Literal(1))),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisTest.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.catalyst.plans.PlanTest
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{StringType, StructType}
 
 trait AnalysisTest extends PlanTest {
 
@@ -88,6 +88,8 @@ trait AnalysisTest extends PlanTest {
     new Analyzer(catalog) {
       catalogManager.tempVariableManager.create(
         "testVarA", "1", Literal(1), overrideIfExists = true)
+      catalogManager.tempVariableManager.create(
+        "testVarNull", null, Literal(null, StringType), overrideIfExists = true)
       override val extendedResolutionRules = extendedAnalysisRules
     }
   }

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/execute-immediate.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/execute-immediate.sql.out
@@ -792,7 +792,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "NULL_QUERY_STRING_EXECUTE_IMMEDIATE",
   "sqlState" : "42K09",
   "messageParameters" : {
-    "varName" : "sql_string"
+    "varName" : "`sql_string`"
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/execute-immediate.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/execute-immediate.sql.out
@@ -790,7 +790,7 @@ EXECUTE IMMEDIATE sql_string
 org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "NULL_QUERY_STRING_EXECUTE_IMMEDIATE",
-  "sqlState" : "42K09",
+  "sqlState" : "22004",
   "messageParameters" : {
     "varName" : "`sql_string`"
   }

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/execute-immediate.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/execute-immediate.sql.out
@@ -776,6 +776,28 @@ org.apache.spark.sql.AnalysisException
 
 
 -- !query
+SET VAR sql_string = null
+-- !query analysis
+SetVariable [variablereference(system.session.sql_string='SELECT * from tbl_view where name = :first or id = :second')]
++- Project [cast(sql_string#x as string) AS sql_string#x]
+   +- Project [null AS sql_string#x]
+      +- OneRowRelation
+
+
+-- !query
+EXECUTE IMMEDIATE sql_string
+-- !query analysis
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "NULL_QUERY_STRING_EXECUTE_IMMEDIATE",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "varName" : "sql_string"
+  }
+}
+
+
+-- !query
 DROP TABLE x
 -- !query analysis
 DropTable false, false

--- a/sql/core/src/test/resources/sql-tests/inputs/execute-immediate.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/execute-immediate.sql
@@ -135,4 +135,8 @@ EXECUTE IMMEDIATE 'SELECT id, data.f1 FROM tbl_view WHERE id = 10' INTO res_id, 
 -- nested execute immediate
 EXECUTE IMMEDIATE 'EXECUTE IMMEDIATE \'SELECT id FROM tbl_view WHERE id = ? USING 10\'';
 
+-- sqlString is null
+SET VAR sql_string = null;
+EXECUTE IMMEDIATE sql_string;
+
 DROP TABLE x;

--- a/sql/core/src/test/resources/sql-tests/results/execute-immediate.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/execute-immediate.sql.out
@@ -748,7 +748,7 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "NULL_QUERY_STRING_EXECUTE_IMMEDIATE",
   "sqlState" : "42K09",
   "messageParameters" : {
-    "varName" : "sql_string"
+    "varName" : "`sql_string`"
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/execute-immediate.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/execute-immediate.sql.out
@@ -746,7 +746,7 @@ struct<>
 org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "NULL_QUERY_STRING_EXECUTE_IMMEDIATE",
-  "sqlState" : "42K09",
+  "sqlState" : "22004",
   "messageParameters" : {
     "varName" : "`sql_string`"
   }

--- a/sql/core/src/test/resources/sql-tests/results/execute-immediate.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/execute-immediate.sql.out
@@ -731,6 +731,29 @@ org.apache.spark.sql.AnalysisException
 
 
 -- !query
+SET VAR sql_string = null
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+EXECUTE IMMEDIATE sql_string
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "NULL_QUERY_STRING_EXECUTE_IMMEDIATE",
+  "sqlState" : "42K09",
+  "messageParameters" : {
+    "varName" : "sql_string"
+  }
+}
+
+
+-- !query
 DROP TABLE x
 -- !query schema
 struct<>


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR I propose a change to add new error class NULL_QUERY_STRING_EXECUTE_IMMEDIATE that is thrown when sqlString variable is a null string in execute immediate query. Null pointer exception was thrown before this change.


### Why are the changes needed?
To ensure that user facing error is as clear as possible and to avoid NPE for possible user input.


### Does this PR introduce _any_ user-facing change?
Yes. This PR introduces a new error class that has an user facing description.


### How was this patch tested?
By running an "EXEC IMMEDIATE - Null string as sqlString parameter" test from AnalysisErrorSuite. 


### Was this patch authored or co-authored using generative AI tooling?
No
