### PR TITLE
[SPARK-45827][SQL][FOLLOWUP] Fix for collation

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -192,7 +192,7 @@ trait CreatableRelationProvider {
       case udt: UserDefinedType[_] => supportsDataType(udt.sqlType)
       case BinaryType | BooleanType | ByteType | CharType(_) | DateType | _ : DecimalType |
            DoubleType | FloatType | IntegerType | LongType | NullType | ObjectType(_) | ShortType |
-           StringType | TimestampNTZType | TimestampType | VarcharType(_) => true
+           _: StringType | TimestampNTZType | TimestampType | VarcharType(_) => true
       case _ => false
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommandSuite.scala
@@ -81,7 +81,8 @@ class SaveIntoDataSourceCommandSuite extends QueryTest with SharedSparkSession {
       options = Map())
 
     val df = spark.range(1).selectExpr(
-        "cast('a' as binary) a", "true b", "cast(1 as byte) c", "1.23 d")
+        "cast('a' as binary) a", "true b", "cast(1 as byte) c", "1.23 d", "'abc'",
+        "'abc' COLLATE UTF8_BINARY_LCASE")
     dataSource.planForWriting(SaveMode.ErrorIfExists, df.logicalPlan)
 
     // Variant and Interval types are disallowed by default.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

https://github.com/apache/spark/pull/45409 created a default allow-list of types for data sources. The intent was to only prevent creation of the two types that had already been prevented elsewhere in code, but the match expression matched `StringType`, which is an object representing the default collation, instead of the `StringType` class, which represents any collation. This PR fixes the issue.

### Why are the changes needed?

Without it, the previous PR would be a breaking change for data sources that write StringType with a non-default collation.

### Does this PR introduce _any_ user-facing change?

It reverts the previous unintentional user-facing change.

### How was this patch tested?

Unit test.

### Was this patch authored or co-authored using generative AI tooling?

No.