### PR TITLE
[SPARK-47346][PYTHON] Make daemon mode configurable when creating Python planner workers

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -141,20 +141,22 @@ class SparkEnv (
       pythonExec: String,
       workerModule: String,
       daemonModule: String,
-      envVars: Map[String, String]): (PythonWorker, Option[Long]) = {
+      envVars: Map[String, String],
+      useDaemon: Boolean = conf.get(Python.PYTHON_USE_DAEMON)): (PythonWorker, Option[Long]) = {
     synchronized {
       val key = PythonWorkersKey(pythonExec, workerModule, daemonModule, envVars)
-      pythonWorkers.getOrElseUpdate(key,
-        new PythonWorkerFactory(pythonExec, workerModule, daemonModule, envVars)).create()
+      pythonWorkers.getOrElseUpdate(key, new PythonWorkerFactory(
+          pythonExec, workerModule, daemonModule, envVars, useDaemon)).create()
     }
   }
 
   private[spark] def createPythonWorker(
       pythonExec: String,
       workerModule: String,
-      envVars: Map[String, String]): (PythonWorker, Option[Long]) = {
+      envVars: Map[String, String],
+      useDaemon: Boolean): (PythonWorker, Option[Long]) = {
     createPythonWorker(
-      pythonExec, workerModule, PythonWorkerFactory.defaultDaemonModule, envVars)
+      pythonExec, workerModule, PythonWorkerFactory.defaultDaemonModule, envVars, useDaemon)
   }
 
   private[spark] def destroyPythonWorker(

--- a/core/src/main/scala/org/apache/spark/SparkEnv.scala
+++ b/core/src/main/scala/org/apache/spark/SparkEnv.scala
@@ -142,7 +142,7 @@ class SparkEnv (
       workerModule: String,
       daemonModule: String,
       envVars: Map[String, String],
-      useDaemon: Boolean = conf.get(Python.PYTHON_USE_DAEMON)): (PythonWorker, Option[Long]) = {
+      useDaemon: Boolean): (PythonWorker, Option[Long]) = {
     synchronized {
       val key = PythonWorkersKey(pythonExec, workerModule, daemonModule, envVars)
       pythonWorkers.getOrElseUpdate(key, new PythonWorkerFactory(
@@ -157,6 +157,19 @@ class SparkEnv (
       useDaemon: Boolean): (PythonWorker, Option[Long]) = {
     createPythonWorker(
       pythonExec, workerModule, PythonWorkerFactory.defaultDaemonModule, envVars, useDaemon)
+  }
+
+  private[spark] def createPythonWorker(
+      pythonExec: String,
+      workerModule: String,
+      daemonModule: String,
+      envVars: Map[String, String]): (PythonWorker, Option[Long]) = {
+    synchronized {
+      val key = PythonWorkersKey(pythonExec, workerModule, daemonModule, envVars)
+      val useDaemon = conf.get(Python.PYTHON_USE_DAEMON)
+      pythonWorkers.getOrElseUpdate(key, new PythonWorkerFactory(
+        pythonExec, workerModule, daemonModule, envVars, useDaemon)).create()
+    }
   }
 
   private[spark] def destroyPythonWorker(

--- a/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
@@ -47,7 +47,7 @@ private[spark] class PythonWorkerFactory(
     workerModule: String,
     daemonModule: String,
     envVars: Map[String, String],
-    useDaemonEnabled: Boolean)
+    val useDaemonEnabled: Boolean)
   extends Logging { self =>
 
   def this(

--- a/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
@@ -31,7 +31,6 @@ import scala.jdk.CollectionConverters._
 import org.apache.spark._
 import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.internal.Logging
-import org.apache.spark.internal.config.Python._
 import org.apache.spark.security.SocketAuthHelper
 import org.apache.spark.util.{RedirectThread, Utils}
 
@@ -48,14 +47,16 @@ private[spark] class PythonWorkerFactory(
     workerModule: String,
     daemonModule: String,
     envVars: Map[String, String],
-    useDaemonEnabled: Boolean = SparkEnv.get.conf.get(PYTHON_USE_DAEMON))
+    useDaemonEnabled: Boolean)
   extends Logging { self =>
 
   def this(
       pythonExec: String,
       workerModule: String,
-      envVars: Map[String, String]) =
-    this(pythonExec, workerModule, PythonWorkerFactory.defaultDaemonModule, envVars)
+      envVars: Map[String, String],
+      useDaemonEnabled: Boolean) =
+    this(pythonExec, workerModule, PythonWorkerFactory.defaultDaemonModule,
+      envVars, useDaemonEnabled)
 
   import PythonWorkerFactory._
 

--- a/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonWorkerFactory.scala
@@ -47,7 +47,8 @@ private[spark] class PythonWorkerFactory(
     pythonExec: String,
     workerModule: String,
     daemonModule: String,
-    envVars: Map[String, String])
+    envVars: Map[String, String],
+    useDaemonEnabled: Boolean = SparkEnv.get.conf.get(PYTHON_USE_DAEMON))
   extends Logging { self =>
 
   def this(
@@ -63,8 +64,6 @@ private[spark] class PythonWorkerFactory(
   // currently only works on UNIX-based systems now because it uses signals for child management,
   // so we can also fall back to launching workers, pyspark/worker.py (by default) directly.
   private val useDaemon = {
-    val useDaemonEnabled = SparkEnv.get.conf.get(PYTHON_USE_DAEMON)
-
     // This flag is ignored on Windows as it's unable to fork.
     !System.getProperty("os.name").startsWith("Windows") && useDaemonEnabled
   }

--- a/core/src/main/scala/org/apache/spark/api/python/StreamingPythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/StreamingPythonRunner.scala
@@ -24,7 +24,7 @@ import scala.jdk.CollectionConverters._
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.BUFFER_SIZE
-import org.apache.spark.internal.config.Python.{PYTHON_AUTH_SOCKET_TIMEOUT, PYTHON_USE_DAEMON}
+import org.apache.spark.internal.config.Python.PYTHON_AUTH_SOCKET_TIMEOUT
 
 
 private[spark] object StreamingPythonRunner {
@@ -68,17 +68,11 @@ private[spark] class StreamingPythonRunner(
     envVars.put("SPARK_BUFFER_SIZE", bufferSize.toString)
     envVars.put("SPARK_CONNECT_LOCAL_URL", connectUrl)
 
-    val prevConf = conf.get(PYTHON_USE_DAEMON)
-    conf.set(PYTHON_USE_DAEMON, false)
-    try {
-      val workerFactory =
-        new PythonWorkerFactory(pythonExec, workerModule, envVars.asScala.toMap)
-      val (worker: PythonWorker, _) = workerFactory.createSimpleWorker(blockingMode = true)
-      pythonWorker = Some(worker)
-      pythonWorkerFactory = Some(workerFactory)
-    } finally {
-      conf.set(PYTHON_USE_DAEMON, prevConf)
-    }
+    val workerFactory =
+      new PythonWorkerFactory(pythonExec, workerModule, envVars.asScala.toMap, false)
+    val (worker: PythonWorker, _) = workerFactory.createSimpleWorker(blockingMode = true)
+    pythonWorker = Some(worker)
+    pythonWorkerFactory = Some(workerFactory)
 
     val stream = new BufferedOutputStream(
       pythonWorker.get.channel.socket().getOutputStream, bufferSize)

--- a/core/src/test/scala/org/apache/spark/api/python/PythonWorkerFactorySuite.scala
+++ b/core/src/test/scala/org/apache/spark/api/python/PythonWorkerFactorySuite.scala
@@ -38,7 +38,7 @@ class PythonWorkerFactorySuite extends SparkFunSuite with SharedSparkContext {
     // E.g. the worker might fail at the beginning before it tries to connect back.
 
     val workerFactory = new PythonWorkerFactory(
-      "python3", "pyspark.testing.non_existing_worker_module", Map.empty
+      "python3", "pyspark.testing.non_existing_worker_module", Map.empty, false
     )
 
     // Create the worker in a separate thread so that if there is a bug where it does not

--- a/core/src/test/scala/org/apache/spark/api/python/PythonWorkerFactorySuite.scala
+++ b/core/src/test/scala/org/apache/spark/api/python/PythonWorkerFactorySuite.scala
@@ -26,7 +26,6 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 import org.apache.spark.SharedSparkContext
-import org.apache.spark.SparkEnv
 import org.apache.spark.SparkException
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.util.ThreadUtils
@@ -56,14 +55,5 @@ class PythonWorkerFactorySuite extends SparkFunSuite with SharedSparkContext {
 
     // Timeout ensures that the test fails in 5 minutes if createSimplerWorker() doesn't return.
     ThreadUtils.awaitReady(createFuture, 5.minutes)
-  }
-
-  test("SPARK-47346: cannot create Python worker with different useDaemon flag") {
-    val env = SparkEnv.get
-    env.createPythonWorker(
-      "python3", "pyspark.testing.worker_module", Map.empty, useDaemon = true)
-    assert(intercept[SparkException](env.createPythonWorker(
-      "python3", "pyspark.testing.worker_module", Map.empty, useDaemon = false))
-      .getMessage.contains("PythonWorkerFactory is already created with useDaemon = true"))
   }
 }

--- a/core/src/test/scala/org/apache/spark/api/python/PythonWorkerFactorySuite.scala
+++ b/core/src/test/scala/org/apache/spark/api/python/PythonWorkerFactorySuite.scala
@@ -26,6 +26,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 import org.apache.spark.SharedSparkContext
+import org.apache.spark.SparkEnv
 import org.apache.spark.SparkException
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.util.ThreadUtils
@@ -55,5 +56,14 @@ class PythonWorkerFactorySuite extends SparkFunSuite with SharedSparkContext {
 
     // Timeout ensures that the test fails in 5 minutes if createSimplerWorker() doesn't return.
     ThreadUtils.awaitReady(createFuture, 5.minutes)
+  }
+
+  test("SPARK-47346: cannot create Python worker with different useDaemon flag") {
+    val env = SparkEnv.get
+    env.createPythonWorker(
+      "python3", "pyspark.testing.worker_module", Map.empty, useDaemon = true)
+    assert(intercept[SparkException](env.createPythonWorker(
+      "python3", "pyspark.testing.worker_module", Map.empty, useDaemon = false))
+      .getMessage.contains("PythonWorkerFactory is already created with useDaemon = true"))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonPlannerRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonPlannerRunner.scala
@@ -44,7 +44,7 @@ abstract class PythonPlannerRunner[T](func: PythonFunction) {
 
   protected def receiveFromPython(dataIn: DataInputStream): T
 
-  def runInPython(): T = {
+  def runInPython(useDaemon: Boolean = SparkEnv.get.conf.get(PYTHON_USE_DAEMON)): T = {
     val env = SparkEnv.get
     val bufferSize: Int = env.conf.get(BUFFER_SIZE)
     val authSocketTimeout = env.conf.get(PYTHON_AUTH_SOCKET_TIMEOUT)
@@ -82,7 +82,7 @@ abstract class PythonPlannerRunner[T](func: PythonFunction) {
       /* valueCompare = */ false)
 
     val (worker: PythonWorker, _) =
-      env.createPythonWorker(pythonExec, workerModule, envVars.asScala.toMap)
+      env.createPythonWorker(pythonExec, workerModule, envVars.asScala.toMap, useDaemon)
     var releasedOrClosed = false
     val bufferStream = new DirectByteBufferOutputStream()
     try {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonStreamingSourceRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/PythonStreamingSourceRunner.scala
@@ -81,7 +81,7 @@ class PythonStreamingSourceRunner(
     envVars.put("SPARK_BUFFER_SIZE", bufferSize.toString)
 
     val workerFactory =
-      new PythonWorkerFactory(pythonExec, workerModule, envVars.asScala.toMap)
+      new PythonWorkerFactory(pythonExec, workerModule, envVars.asScala.toMap, false)
     val (worker: PythonWorker, _) = workerFactory.createSimpleWorker(blockingMode = true)
     pythonWorker = Some(worker)
     pythonWorkerFactory = Some(workerFactory)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.python
 
 import java.io.{File, FileWriter}
 
-import org.apache.spark.{SparkEnv, SparkException}
+import org.apache.spark.SparkException
 import org.apache.spark.api.python.PythonUtils
 import org.apache.spark.sql.{AnalysisException, IntegratedUDFTestUtils, QueryTest, Row}
 import org.apache.spark.sql.execution.datasources.DataSourceManager
@@ -863,15 +863,5 @@ class PythonDataSourceSuite extends PythonDataSourceSuiteBase {
       .format(dataSourceName).load()
     checkAnswer(df, Row("1", "2", "true"))
     df.write.option("foo", 1).option("bar", 2).format(dataSourceName).mode("append").save()
-  }
-
-  test("SPARK-47346: cannot create Python worker with different useDaemon flag") {
-    assume(shouldTestPythonUDFs)
-    val env = SparkEnv.get
-    env.createPythonWorker(
-      "python3", "pyspark.sql.worker.create_data_source", Map.empty, useDaemon = true)
-    assert(intercept[SparkException](env.createPythonWorker(
-      "python3", "pyspark.sql.worker.create_data_source", Map.empty, useDaemon = false))
-      .getMessage.contains("PythonWorkerFactory is already created with useDaemon = true"))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds an extra config to env.createPythonWorker to make daemon mode configurable to give more flexibility when creating Python planner workers.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To make python workers more flexible.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No