### PR TITLE
[MINOR][DOCS] Remove the extra text on page sql-error-conditions-sqlstates

### DIFF
--- a/docs/sql-error-conditions-sqlstates.md
+++ b/docs/sql-error-conditions-sqlstates.md
@@ -739,6 +739,3 @@ Spark SQL uses the following `SQLSTATE` classes:
 </tr>
 
 </table>
-
-
-.. include:: /shared/replacements.md


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to remove the extra text `.. include:: /shared/replacements.md` on page `sql-error-conditions-sqlstates.md`.

### Why are the changes needed?
- Eliminate misunderstandings
  https://spark.apache.org/docs/latest/sql-error-conditions-sqlstates.html
  <img width="1252" alt="image" src="https://github.com/apache/spark/assets/15246973/287a3699-c0e8-4416-a6b1-4651388f05d0">

- The file `shared/replacements.md` does not exist in the `spark codebase`.

### Does this PR introduce _any_ user-facing change?
Yes, only for web page.


### How was this patch tested?
Manually test.


### Was this patch authored or co-authored using generative AI tooling?
No.
