### PR TITLE
[SPARK-47364][CORE] Make `PluginEndpoint` warn when plugins reply for one-way message

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/plugin/PluginEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/internal/plugin/PluginEndpoint.scala
@@ -35,7 +35,7 @@ private class PluginEndpoint(
           try {
             val reply = plugin.receive(message)
             if (reply != null) {
-              logInfo(
+              logWarning(
                 s"Plugin $pluginName returned reply for one-way message of type " +
                 s"${message.getClass().getName()}.")
             }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `PluginEndpoint` warn when plugins reply for one-way message.

### Why are the changes needed?

Previously, it logs `INFO` level messages. Sometimes, it look 66% driver INFO logs. We had better increase the log level to make the users fix the issues.

### Does this PR introduce _any_ user-facing change?

No. Only a log level.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.