### PR TITLE
[SPARK-47365][PYTHON] Add toArrow() DataFrame method to PySpark

### DIFF
--- a/examples/src/main/python/sql/arrow.py
+++ b/examples/src/main/python/sql/arrow.py
@@ -34,7 +34,7 @@ require_minimum_pyarrow_version()
 
 
 def dataframe_to_arrow_table_example(spark: SparkSession) -> None:
-    import pyarrow as pa # noqa: F401
+    import pyarrow as pa  # noqa: F401
     from pyspark.sql.functions import rand
 
     # Create a Spark DataFrame

--- a/examples/src/main/python/sql/arrow.py
+++ b/examples/src/main/python/sql/arrow.py
@@ -35,6 +35,7 @@ require_minimum_pyarrow_version()
 
 def dataframe_to_arrow_table_example(spark: SparkSession) -> None:
     import pyarrow as pa
+    from pyspark.sql.functions import rand
 
     # Create a Spark DataFrame
     df = spark.range(100).drop("id").withColumns({"0": rand(), "1": rand(), "2": rand()})

--- a/examples/src/main/python/sql/arrow.py
+++ b/examples/src/main/python/sql/arrow.py
@@ -34,7 +34,7 @@ require_minimum_pyarrow_version()
 
 
 def dataframe_to_arrow_table_example(spark: SparkSession) -> None:
-    import pyarrow as pa
+    import pyarrow as pa # noqa: F401
     from pyspark.sql.functions import rand
 
     # Create a Spark DataFrame

--- a/examples/src/main/python/sql/arrow.py
+++ b/examples/src/main/python/sql/arrow.py
@@ -41,7 +41,7 @@ def dataframe_to_arrow_table_example(spark: SparkSession) -> None:
     df = spark.range(100).drop("id").withColumns({"0": rand(), "1": rand(), "2": rand()})
 
     # Convert the Spark DataFrame to a PyArrow Table
-    table = df.select("*").toArrowTable()  # type: ignore
+    table = df.select("*").toArrow()  # type: ignore
 
     print(table.schema)
     # 0: double not null

--- a/examples/src/main/python/sql/arrow.py
+++ b/examples/src/main/python/sql/arrow.py
@@ -41,7 +41,7 @@ def dataframe_to_arrow_table_example(spark: SparkSession) -> None:
     df = spark.range(100).drop("id").withColumns({"0": rand(), "1": rand(), "2": rand()})
 
     # Convert the Spark DataFrame to a PyArrow Table
-    table = df.select("*").toArrowTable()
+    table = df.select("*").toArrowTable()  # type: ignore
 
     print(table.schema)
     # 0: double not null

--- a/examples/src/main/python/sql/arrow.py
+++ b/examples/src/main/python/sql/arrow.py
@@ -41,7 +41,7 @@ def dataframe_to_arrow_table_example(spark: SparkSession) -> None:
     df = spark.range(100).drop("id").withColumns({"0": rand(), "1": rand(), "2": rand()})
 
     # Convert the Spark DataFrame to a PyArrow Table
-    table = df.select("*").toArrow()  # type: ignore
+    table = df.select("*").toArrow()
 
     print(table.schema)
     # 0: double not null

--- a/examples/src/main/python/sql/arrow.py
+++ b/examples/src/main/python/sql/arrow.py
@@ -33,6 +33,21 @@ require_minimum_pandas_version()
 require_minimum_pyarrow_version()
 
 
+def dataframe_to_arrow_table_example(spark: SparkSession) -> None:
+    import pyarrow as pa
+
+    # Create a Spark DataFrame
+    df = spark.range(100).drop("id").withColumns({"0": rand(), "1": rand(), "2": rand()})
+
+    # Convert the Spark DataFrame to a PyArrow Table
+    table = df.select("*").toArrowTable()
+
+    print(table.schema)
+    # 0: double not null
+    # 1: double not null
+    # 2: double not null
+
+
 def dataframe_with_arrow_example(spark: SparkSession) -> None:
     import numpy as np
     import pandas as pd
@@ -302,6 +317,8 @@ if __name__ == "__main__":
         .appName("Python Arrow-in-Spark example") \
         .getOrCreate()
 
+    print("Running Arrow conversion example: DataFrame to Table")
+    dataframe_to_arrow_table_example(spark)
     print("Running Pandas to/from conversion example")
     dataframe_with_arrow_example(spark)
     print("Running pandas_udf example: Series to Frame")

--- a/python/docs/source/reference/pyspark.sql/dataframe.rst
+++ b/python/docs/source/reference/pyspark.sql/dataframe.rst
@@ -109,6 +109,7 @@ DataFrame
     DataFrame.tail
     DataFrame.take
     DataFrame.to
+    DataFrame.toArrowTable
     DataFrame.toDF
     DataFrame.toJSON
     DataFrame.toLocalIterator

--- a/python/docs/source/reference/pyspark.sql/dataframe.rst
+++ b/python/docs/source/reference/pyspark.sql/dataframe.rst
@@ -109,7 +109,7 @@ DataFrame
     DataFrame.tail
     DataFrame.take
     DataFrame.to
-    DataFrame.toArrowTable
+    DataFrame.toArrow
     DataFrame.toDF
     DataFrame.toJSON
     DataFrame.toLocalIterator

--- a/python/docs/source/user_guide/sql/arrow_pandas.rst
+++ b/python/docs/source/user_guide/sql/arrow_pandas.rst
@@ -42,16 +42,16 @@ You can install it using pip or conda from the conda-forge channel. See PyArrow
 Conversion to Arrow Table
 -------------------------
 
-You can call :meth:`DataFrame.toArrowTable` to convert a Spark DataFrame to a PyArrow Table.
+You can call :meth:`DataFrame.toArrow` to convert a Spark DataFrame to a PyArrow Table.
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
     :lines: 37-49
     :dedent: 4
 
-Note that :meth:`DataFrame.toArrowTable` results in the collection of all records in the DataFrame
-to the driver program and should be done on a small subset of the data. Not all Spark data types
-are currently supported and an error can be raised if a column has an unsupported type.
+Note that :meth:`DataFrame.toArrow` results in the collection of all records in the DataFrame to
+the driver program and should be done on a small subset of the data. Not all Spark data types are
+currently supported and an error can be raised if a column has an unsupported type.
 
 Enabling for Conversion to/from Pandas
 --------------------------------------
@@ -438,7 +438,7 @@ Setting Arrow ``self_destruct`` for memory savings
 Since Spark 3.2, the Spark configuration ``spark.sql.execution.arrow.pyspark.selfDestruct.enabled``
 can be used to enable PyArrow's ``self_destruct`` feature, which can save memory when creating a
 Pandas DataFrame via ``toPandas`` by freeing Arrow-allocated memory while building the Pandas
-DataFrame. This option can also save memory when creating a PyArrow Table via ``toArrowTable``.
+DataFrame. This option can also save memory when creating a PyArrow Table via ``toArrow``.
 This option is experimental. When used with ``toPandas``, some operations may fail on the resulting
 Pandas DataFrame due to immutable backing arrays. Typically, you would see the error
 ``ValueError: buffer source array is read-only``. Newer versions of Pandas may fix these errors by

--- a/python/docs/source/user_guide/sql/arrow_pandas.rst
+++ b/python/docs/source/user_guide/sql/arrow_pandas.rst
@@ -435,9 +435,12 @@ be verified by the user.
 Setting Arrow ``self_destruct`` for memory savings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Since Spark 3.2, the Spark configuration ``spark.sql.execution.arrow.pyspark.selfDestruct.enabled`` can be used to enable PyArrow's ``self_destruct`` feature, which can save memory when creating a Pandas DataFrame via ``toPandas`` by freeing Arrow-allocated memory while building the Pandas DataFrame.
-This option is experimental, and some operations may fail on the resulting Pandas DataFrame due to immutable backing arrays.
-Typically, you would see the error ``ValueError: buffer source array is read-only``.
-Newer versions of Pandas may fix these errors by improving support for such cases.
-You can work around this error by copying the column(s) beforehand.
-Additionally, this conversion may be slower because it is single-threaded.
+Since Spark 3.2, the Spark configuration ``spark.sql.execution.arrow.pyspark.selfDestruct.enabled``
+can be used to enable PyArrow's ``self_destruct`` feature, which can save memory when creating a
+Pandas DataFrame via ``toPandas`` by freeing Arrow-allocated memory while building the Pandas
+DataFrame. This option can also save memory when creating a PyArrow Table via ``toArrowTable``.
+This option is experimental. When used with ``toPandas``, some operations may fail on the resulting
+Pandas DataFrame due to immutable backing arrays. Typically, you would see the error
+``ValueError: buffer source array is read-only``. Newer versions of Pandas may fix these errors by
+improving support for such cases. You can work around this error by copying the column(s)
+beforehand. Additionally, this conversion may be slower because it is single-threaded.

--- a/python/docs/source/user_guide/sql/arrow_pandas.rst
+++ b/python/docs/source/user_guide/sql/arrow_pandas.rst
@@ -39,6 +39,20 @@ is installed and available on all cluster nodes.
 You can install it using pip or conda from the conda-forge channel. See PyArrow
 `installation <https://arrow.apache.org/docs/python/install.html>`_ for details.
 
+Conversion to Arrow Table
+-------------------------
+
+You can call :meth:`DataFrame.toArrowTable` to convert a Spark DataFrame to a PyArrow Table.
+
+.. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
+    :language: python
+    :lines: 37-48
+    :dedent: 4
+
+Note that :meth:`DataFrame.toArrowTable` results in the collection of all records in the DataFrame
+to the driver program and should be done on a small subset of the data. Not all Spark data types
+are currently supported and an error can be raised if a column has an unsupported type.
+
 Enabling for Conversion to/from Pandas
 --------------------------------------
 
@@ -53,7 +67,7 @@ This can be controlled by ``spark.sql.execution.arrow.pyspark.fallback.enabled``
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 37-52
+    :lines: 52-67
     :dedent: 4
 
 Using the above optimizations with Arrow will produce the same results as when Arrow is not
@@ -90,7 +104,7 @@ specify the type hints of ``pandas.Series`` and ``pandas.DataFrame`` as below:
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 56-80
+    :lines: 71-95
     :dedent: 4
 
 In the following sections, it describes the combinations of the supported type hints. For simplicity,
@@ -113,7 +127,7 @@ The following example shows how to create this Pandas UDF that computes the prod
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 84-114
+    :lines: 99-129
     :dedent: 4
 
 For detailed usage, please see :func:`pandas_udf`.
@@ -152,7 +166,7 @@ The following example shows how to create this Pandas UDF:
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 118-140
+    :lines: 133-155
     :dedent: 4
 
 For detailed usage, please see :func:`pandas_udf`.
@@ -174,7 +188,7 @@ The following example shows how to create this Pandas UDF:
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 144-167
+    :lines: 159-182
     :dedent: 4
 
 For detailed usage, please see :func:`pandas_udf`.
@@ -205,7 +219,7 @@ and window operations:
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 171-212
+    :lines: 186-227
     :dedent: 4
 
 .. currentmodule:: pyspark.sql.functions
@@ -270,7 +284,7 @@ in the group.
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 216-234
+    :lines: 231-249
     :dedent: 4
 
 For detailed usage, please see  please see :meth:`GroupedData.applyInPandas`
@@ -288,7 +302,7 @@ The following example shows how to use :meth:`DataFrame.mapInPandas`:
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 238-249
+    :lines: 253-264
     :dedent: 4
 
 For detailed usage, please see :meth:`DataFrame.mapInPandas`.
@@ -327,7 +341,7 @@ The following example shows how to use ``DataFrame.groupby().cogroup().applyInPa
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 253-275
+    :lines: 268-290
     :dedent: 4
 
 
@@ -349,7 +363,7 @@ Here's an example that demonstrates the usage of both a default, pickled Python 
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 279-297
+    :lines: 294-312
     :dedent: 4
 
 Compared to the default, pickled Python UDFs, Arrow Python UDFs provide a more coherent type coercion mechanism. UDF

--- a/python/docs/source/user_guide/sql/arrow_pandas.rst
+++ b/python/docs/source/user_guide/sql/arrow_pandas.rst
@@ -46,7 +46,7 @@ You can call :meth:`DataFrame.toArrowTable` to convert a Spark DataFrame to a Py
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 37-48
+    :lines: 37-49
     :dedent: 4
 
 Note that :meth:`DataFrame.toArrowTable` results in the collection of all records in the DataFrame
@@ -67,7 +67,7 @@ This can be controlled by ``spark.sql.execution.arrow.pyspark.fallback.enabled``
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 52-67
+    :lines: 53-68
     :dedent: 4
 
 Using the above optimizations with Arrow will produce the same results as when Arrow is not
@@ -104,7 +104,7 @@ specify the type hints of ``pandas.Series`` and ``pandas.DataFrame`` as below:
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 71-95
+    :lines: 72-96
     :dedent: 4
 
 In the following sections, it describes the combinations of the supported type hints. For simplicity,
@@ -127,7 +127,7 @@ The following example shows how to create this Pandas UDF that computes the prod
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 99-129
+    :lines: 100-130
     :dedent: 4
 
 For detailed usage, please see :func:`pandas_udf`.
@@ -166,7 +166,7 @@ The following example shows how to create this Pandas UDF:
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 133-155
+    :lines: 134-156
     :dedent: 4
 
 For detailed usage, please see :func:`pandas_udf`.
@@ -188,7 +188,7 @@ The following example shows how to create this Pandas UDF:
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 159-182
+    :lines: 160-183
     :dedent: 4
 
 For detailed usage, please see :func:`pandas_udf`.
@@ -219,7 +219,7 @@ and window operations:
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 186-227
+    :lines: 187-228
     :dedent: 4
 
 .. currentmodule:: pyspark.sql.functions
@@ -284,7 +284,7 @@ in the group.
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 231-249
+    :lines: 232-250
     :dedent: 4
 
 For detailed usage, please see  please see :meth:`GroupedData.applyInPandas`
@@ -302,7 +302,7 @@ The following example shows how to use :meth:`DataFrame.mapInPandas`:
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 253-264
+    :lines: 254-265
     :dedent: 4
 
 For detailed usage, please see :meth:`DataFrame.mapInPandas`.
@@ -341,7 +341,7 @@ The following example shows how to use ``DataFrame.groupby().cogroup().applyInPa
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 268-290
+    :lines: 269-291
     :dedent: 4
 
 
@@ -363,7 +363,7 @@ Here's an example that demonstrates the usage of both a default, pickled Python 
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 294-312
+    :lines: 295-313
     :dedent: 4
 
 Compared to the default, pickled Python UDFs, Arrow Python UDFs provide a more coherent type coercion mechanism. UDF

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1825,6 +1825,9 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     ) -> ParentDataFrame:
         return PandasMapOpsMixin.mapInArrow(self, func, schema, barrier, profile)
 
+    def toArrowTable(self) -> "pa.Table":
+        return PandasConversionMixin.toArrowTable(self)
+
     def toPandas(self) -> "PandasDataFrameLike":
         return PandasConversionMixin.toPandas(self)
 

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1825,8 +1825,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     ) -> ParentDataFrame:
         return PandasMapOpsMixin.mapInArrow(self, func, schema, barrier, profile)
 
-    def toArrowTable(self) -> "pa.Table":
-        return PandasConversionMixin.toArrowTable(self)
+    def toArrow(self) -> "pa.Table":
+        return PandasConversionMixin.toArrow(self)
 
     def toPandas(self) -> "PandasDataFrameLike":
         return PandasConversionMixin.toPandas(self)

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -74,6 +74,7 @@ from pyspark.sql.pandas.map_ops import PandasMapOpsMixin
 
 if TYPE_CHECKING:
     from py4j.java_gateway import JavaObject
+    import pyarrow as pa
     from pyspark.core.rdd import RDD
     from pyspark.core.context import SparkContext
     from pyspark._typing import PrimitiveType

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1768,7 +1768,7 @@ class DataFrame(ParentDataFrame):
         assert table is not None
         return (table, schema)
 
-    def toArrowTable(self) -> "pa.Table":
+    def toArrow(self) -> "pa.Table":
         table, _ = self._to_table()
         return table
 

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1772,8 +1772,6 @@ class DataFrame(ParentDataFrame):
         table = self._to_table()[0]
         return table
 
-    _toArrow.__doc__ = PySparkDataFrame._toArrow.__doc__
-
     def toPandas(self) -> "PandasDataFrameLike":
         query = self._plan.to_proto(self._session.client)
         return self._session.client.to_pandas(query, self._plan.observations)

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1769,8 +1769,8 @@ class DataFrame(ParentDataFrame):
         return (table, schema)
 
     def _toArrow(self) -> "pa.Table":
-        query = self._plan.to_proto(self._session.client)
-        return self._session.client.to_table(query, self._plan.observations)
+        table = self._to_table()[0]
+        return table
 
     _toArrow.__doc__ = PySparkDataFrame._toArrow.__doc__
 

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1769,7 +1769,7 @@ class DataFrame(ParentDataFrame):
         return (table, schema)
 
     def _toArrow(self) -> "pa.Table":
-        table = self._to_table()[0]
+        table, _ = self._to_table()
         return table
 
     def toPandas(self) -> "PandasDataFrameLike":

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1768,7 +1768,7 @@ class DataFrame(ParentDataFrame):
         assert table is not None
         return (table, schema)
 
-    def _toArrow(self) -> "pa.Table":
+    def toArrowTable(self) -> "pa.Table":
         table, _ = self._to_table()
         return table
 

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1768,6 +1768,12 @@ class DataFrame(ParentDataFrame):
         assert table is not None
         return (table, schema)
 
+    def _toArrow(self) -> "pa.Table":
+        query = self._plan.to_proto(self._session.client)
+        return self._session.client.to_table(query, self._plan.observations)
+
+    _toArrow.__doc__ = PySparkDataFrame._toArrow.__doc__
+
     def toPandas(self) -> "PandasDataFrameLike":
         query = self._plan.to_proto(self._session.client)
         return self._session.client.to_pandas(query, self._plan.observations)

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1200,7 +1200,7 @@ class DataFrame:
         DataFrame.take : Returns the first `n` rows.
         DataFrame.head : Returns the first `n` rows.
         DataFrame.toPandas : Returns the data as a pandas DataFrame.
-        DataFrame.toArrowTable : Returns the data as a PyArrow Table.
+        DataFrame.toArrow : Returns the data as a PyArrow Table.
 
         Notes
         -----
@@ -6215,7 +6215,7 @@ class DataFrame:
         ...
 
     @dispatch_df_method
-    def toArrowTable(self) -> "pa.Table":
+    def toArrow(self) -> "pa.Table":
         """
         Returns the contents of this :class:`DataFrame` as PyArrow ``pyarrow.Table``.
 
@@ -6232,7 +6232,7 @@ class DataFrame:
 
         Examples
         --------
-        >>> df.toArrowTable()  # doctest: +SKIP
+        >>> df.toArrow()  # doctest: +SKIP
         pyarrow.Table
         age: int64
         name: string

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -6227,6 +6227,8 @@ class DataFrame:
         This method should only be used if the resulting PyArrow ``pyarrow.Table`` is
         expected to be small, as all the data is loaded into the driver's memory.
 
+        This API is a developer API.
+
         Examples
         --------
         >>> df.toArrowTable()  # doctest: +SKIP

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -44,6 +44,7 @@ from pyspark.sql.utils import dispatch_df_method
 
 if TYPE_CHECKING:
     from py4j.java_gateway import JavaObject
+    import pyarrow as pa
     from pyspark.core.context import SparkContext
     from pyspark.core.rdd import RDD
     from pyspark._typing import PrimitiveType

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -1200,6 +1200,7 @@ class DataFrame:
         DataFrame.take : Returns the first `n` rows.
         DataFrame.head : Returns the first `n` rows.
         DataFrame.toPandas : Returns the data as a pandas DataFrame.
+        DataFrame.toArrowTable : Returns the data as a PyArrow Table.
 
         Notes
         -----
@@ -6210,6 +6211,31 @@ class DataFrame:
         --------
         pyspark.sql.functions.pandas_udf
         pyspark.sql.DataFrame.mapInPandas
+        """
+        ...
+
+    def toArrowTable(self) -> "pa.Table":
+        """
+        Returns the contents of this :class:`DataFrame` as PyArrow ``pyarrow.Table``.
+
+        This is only available if PyArrow is installed and available.
+
+        .. versionadded:: 4.0.0
+
+        Notes
+        -----
+        This method should only be used if the resulting PyArrow ``pyarrow.Table`` is
+        expected to be small, as all the data is loaded into the driver's memory.
+
+        Examples
+        --------
+        >>> df.toArrowTable()  # doctest: +SKIP
+        pyarrow.Table
+        age: int64
+        name: string
+        ----
+        age: [[2,5]]
+        name: [["Alice","Bob"]]
         """
         ...
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -6214,6 +6214,7 @@ class DataFrame:
         """
         ...
 
+    @dispatch_df_method
     def toArrowTable(self) -> "pa.Table":
         """
         Returns the contents of this :class:`DataFrame` as PyArrow ``pyarrow.Table``.

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -295,11 +295,6 @@ class PandasConversionMixin:
 
         assert isinstance(self, DataFrame)
 
-        from pyspark.sql.pandas.types import to_arrow_schema
-        from pyspark.sql.pandas.utils import require_minimum_pyarrow_version
-
-        require_minimum_pyarrow_version()
-
         with SCCallSiteSync(self._sc):
             (
                 port,
@@ -346,6 +341,7 @@ class PandasConversionMixin:
             # Re-order the batch list using the correct order
             return [batches[i] for i in batch_order]
         else:
+            from pyspark.sql.pandas.types import to_arrow_schema
             schema = to_arrow_schema(self.schema)
             empty_arrays = [pa.array([], type=field.type) for field in schema]
             return [pa.RecordBatch.from_arrays(empty_arrays, schema=schema)]

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -254,22 +254,21 @@ class PandasConversionMixin:
 
         jconf = self.sparkSession._jconf
 
-        try:
-            from pyspark.sql.pandas.types import to_arrow_schema
-            from pyspark.sql.pandas.utils import require_minimum_pyarrow_version
+        from pyspark.sql.pandas.types import to_arrow_schema
+        from pyspark.sql.pandas.utils import require_minimum_pyarrow_version
 
-            require_minimum_pyarrow_version()
-            schema = to_arrow_schema(self.schema)
+        require_minimum_pyarrow_version()
+        schema = to_arrow_schema(self.schema)
 
-            import pyarrow as pa
+        import pyarrow as pa
 
-            self_destruct = jconf.arrowPySparkSelfDestructEnabled()
-            batches = self._collect_as_arrow(split_batches=self_destruct)
-            table = pa.Table.from_batches(batches, schema=schema)
-            # Ensure only the table has a reference to the batches, so that
-            # self_destruct (if enabled) is effective
-            del batches
-            return table
+        self_destruct = jconf.arrowPySparkSelfDestructEnabled()
+        batches = self._collect_as_arrow(split_batches=self_destruct)
+        table = pa.Table.from_batches(batches, schema=schema)
+        # Ensure only the table has a reference to the batches, so that
+        # self_destruct (if enabled) is effective
+        del batches
+        return table
 
     def _collect_as_arrow(self, split_batches: bool = False) -> List["pa.RecordBatch"]:
         """

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -258,32 +258,45 @@ class PandasConversionMixin:
         from pyspark.sql.pandas.utils import require_minimum_pyarrow_version
 
         require_minimum_pyarrow_version()
-        schema = to_arrow_schema(self.schema)
+        to_arrow_schema(self.schema)
 
         import pyarrow as pa
 
         self_destruct = jconf.arrowPySparkSelfDestructEnabled()
-        batches = self._collect_as_arrow(split_batches=self_destruct)
-        table = pa.Table.from_batches(batches, schema=schema)
+        batches = self._collect_as_arrow(
+            split_batches=self_destruct,
+            empty_list_if_zero_records=False
+        )
+        table = pa.Table.from_batches(batches)
         # Ensure only the table has a reference to the batches, so that
         # self_destruct (if enabled) is effective
         del batches
         return table
 
-    def _collect_as_arrow(self, split_batches: bool = False) -> List["pa.RecordBatch"]:
+    def _collect_as_arrow(
+        self,
+        split_batches: bool = False,
+        empty_list_if_zero_records: bool = True,
+    ) -> List["pa.RecordBatch"]:
         """
-        Returns all records as a list of ArrowRecordBatches, pyarrow must be installed
+        Returns all records as a list of Arrow RecordBatches. PyArrow must be installed
         and available on driver and worker Python environments.
         This is an experimental feature.
 
         :param split_batches: split batches such that each column is in its own allocation, so
             that the selfDestruct optimization is effective; default False.
 
+        :param empty_list_if_zero_records: If True (the default), returns an empty list if the
+            result has 0 records. Otherwise, returns a list of length 1 containing an empty
+            Arrow RecordBatch which includes the schema.
+
         .. note:: Experimental.
         """
         from pyspark.sql.dataframe import DataFrame
 
         assert isinstance(self, DataFrame)
+
+        require_minimum_pyarrow_version()
 
         with SCCallSiteSync(self._sc):
             (
@@ -327,8 +340,13 @@ class PandasConversionMixin:
         batches = results[:-1]
         batch_order = results[-1]
 
-        # Re-order the batch list using the correct order
-        return [batches[i] for i in batch_order]
+        if len(batches) or empty_list_if_zero_records: 
+            # Re-order the batch list using the correct order
+            return [batches[i] for i in batch_order]
+        else:
+            schema = to_arrow_schema(self.schema)
+            empty_arrays = [pa.array([], type=field.type) for field in schema]
+            return [pa.RecordBatch.from_arrays(empty_arrays, schema=schema)]
 
 
 class SparkConversionMixin:

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -264,8 +264,7 @@ class PandasConversionMixin:
 
         self_destruct = jconf.arrowPySparkSelfDestructEnabled()
         batches = self._collect_as_arrow(
-            split_batches=self_destruct,
-            empty_list_if_zero_records=False
+            split_batches=self_destruct, empty_list_if_zero_records=False
         )
         table = pa.Table.from_batches(batches)
         # Ensure only the table has a reference to the batches, so that
@@ -343,7 +342,7 @@ class PandasConversionMixin:
         batches = results[:-1]
         batch_order = results[-1]
 
-        if len(batches) or empty_list_if_zero_records: 
+        if len(batches) or empty_list_if_zero_records:
             # Re-order the batch list using the correct order
             return [batches[i] for i in batch_order]
         else:

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -225,7 +225,7 @@ class PandasConversionMixin:
         else:
             return pdf
 
-    def toArrowTable(self) -> "pa.Table":
+    def toArrow(self) -> "pa.Table":
         from pyspark.sql.dataframe import DataFrame
 
         assert isinstance(self, DataFrame)

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -342,6 +342,7 @@ class PandasConversionMixin:
             return [batches[i] for i in batch_order]
         else:
             from pyspark.sql.pandas.types import to_arrow_schema
+
             schema = to_arrow_schema(self.schema)
             empty_arrays = [pa.array([], type=field.type) for field in schema]
             return [pa.RecordBatch.from_arrays(empty_arrays, schema=schema)]

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -226,26 +226,6 @@ class PandasConversionMixin:
             return pdf
 
     def toArrowTable(self) -> "pa.Table":
-        """
-        Returns the contents of this :class:`DataFrame` as PyArrow ``pyarrow.Table``.
-
-        This is only available if PyArrow is installed and available.
-
-        Notes
-        -----
-        This method should only be used if the resulting PyArrow ``pyarrow.Table`` is
-        expected to be small, as all the data is loaded into the driver's memory.
-
-        Examples
-        --------
-        >>> df.toArrowTable()  # doctest: +SKIP
-        pyarrow.Table
-        age: int64
-        name: string
-        ----
-        age: [[2,5]]
-        name: [["Alice","Bob"]]
-        """
         from pyspark.sql.dataframe import DataFrame
 
         assert isinstance(self, DataFrame)

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -296,6 +296,9 @@ class PandasConversionMixin:
 
         assert isinstance(self, DataFrame)
 
+        from pyspark.sql.pandas.types import to_arrow_schema
+        from pyspark.sql.pandas.utils import require_minimum_pyarrow_version
+
         require_minimum_pyarrow_version()
 
         with SCCallSiteSync(self._sc):

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -225,7 +225,7 @@ class PandasConversionMixin:
         else:
             return pdf
 
-    def _toArrow(self) -> "pa.Table":
+    def toArrowTable(self) -> "pa.Table":
         """
         Returns the contents of this :class:`DataFrame` as PyArrow ``pyarrow.Table``.
 
@@ -238,15 +238,13 @@ class PandasConversionMixin:
 
         Examples
         --------
-        >>> df.toArrow()  # doctest: +SKIP
+        >>> df.toArrowTable()  # doctest: +SKIP
         pyarrow.Table
         age: int64
         name: string
         ----
         age: [[2,5]]
         name: [["Alice","Bob"]]
-
-        .. note:: Experimental.
         """
         from pyspark.sql.dataframe import DataFrame
 

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -179,6 +179,26 @@ class ArrowTestsMixin:
         data_dict["4_float_t"] = np.float32(data_dict["4_float_t"])
         return pd.DataFrame(data=data_dict)
 
+    def create_arrow_table(self):
+        import pyarrow as pa
+
+        data_dict = {}
+        for j, name in enumerate(self.schema.names):
+            data_dict[name] = [self.data[i][j] for i in range(len(self.data))]
+        t = pa.Table.from_pydict(data_dict)
+        # convert these to Arrow types
+        new_schema = t.schema.set(
+            t.schema.get_field_index("2_int_t"), pa.field("2_int_t", pa.int32())
+        )
+        new_schema = new_schema.set(
+            new_schema.get_field_index("4_float_t"), pa.field("4_float_t", pa.float32())
+        )
+        new_schema = new_schema.set(
+            new_schema.get_field_index("6_decimal_t"),
+            pa.field("6_decimal_t", pa.decimal128(38, 18)),
+        )
+        return t.cast(new_schema)
+
     @property
     def create_np_arrs(self):
         import numpy as np
@@ -338,6 +358,12 @@ class ArrowTestsMixin:
         df = self.spark.createDataFrame(self.data, schema=self.schema)
         pdf_arrow = df.toPandas()
         assert_frame_equal(pdf_arrow, pdf)
+
+    def test_arrow_round_trip(self):
+        t_in = self.create_arrow_table()
+        df = self.spark.createDataFrame(self.data, schema=self.schema)
+        t_out = df._toArrow()
+        self.assertTrue(t_out.equals(t_in))
 
     def test_pandas_self_destruct(self):
         import pyarrow as pa

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -371,7 +371,7 @@ class ArrowTestsMixin:
     def test_arrow_round_trip(self):
         t_in = self.create_arrow_table()
         df = self.spark.createDataFrame(self.data, schema=self.schema)
-        t_out = df.toArrowTable()
+        t_out = df.toArrow()
         self.assertTrue(t_out.equals(t_in))
 
     def test_pandas_self_destruct(self):

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -371,7 +371,7 @@ class ArrowTestsMixin:
     def test_arrow_round_trip(self):
         t_in = self.create_arrow_table()
         df = self.spark.createDataFrame(self.data, schema=self.schema)
-        t_out = df._toArrow()
+        t_out = df.toArrowTable()
         self.assertTrue(t_out.equals(t_in))
 
     def test_pandas_self_destruct(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Add a PySpark DataFrame method `toArrow()` which returns the contents of the DataFrame as a [PyArrow Table](https://arrow.apache.org/docs/python/generated/pyarrow.Table.html), for both local Spark and Spark Connect.
- Add a new entry to the **Apache Arrow in PySpark** user guide page describing usage of the `toArrow()` method.
- Add  a new option to the method `_collect_as_arrow()` to provide more useful output when there are zero records returned. (This keeps the implementation of `toArrow()` simpler.)

### Why are the changes needed?
In the Apache Arrow community, we hear from a lot of users who want to return the contents of a PySpark DataFrame as a PyArrow Table. Currently the only documented way to do this is to return the contents as a pandas DataFrame, then use PyArrow (`pa`) to convert that to a PyArrow Table.
```py
pa.Table.from_pandas(df.toPandas())
```
But going through pandas adds significant overhead which is easily avoided since internally `toPandas()` already converts the contents of Spark DataFrame to Arrow format as an intermediate step when `spark.sql.execution.arrow.pyspark.enabled` is `true`.

Currently it is also possible to use the experimental `_collect_as_arrow()` method to return the contents of a PySpark DataFrame as a list of PyArrow RecordBatches. This PR adds a new non-experimental method `toArrow()` which returns the more user-friendly PyArrow Table object.

This PR also adds a new argument `empty_list_if_zero_records` to the experimental method `_collect_as_arrow()` to control what the method returns in the case when the result data has zero rows. If set to `True` (the default), the existing behavior is preserved, and the method returns an empty Python list. If set to `False`, the method returns returns a length-one list containing an empty Arrow RecordBatch which includes the schema. This is used by `toArrow()` which requires the schema even if the data has zero rows.

For Spark Connect, there is already a `SparkSession.client.to_table()` method that returns a PyArrow table. This PR uses that to expose `toArrow()` for Spark Connect.

### Does this PR introduce _any_ user-facing change?

- It adds a DataFrame method `toArrow()` to the PySpark SQL DataFrame API.
- It adds a new argument `empty_list_if_zero_records` to the experimental DataFrame method `_collect_as_arrow()` with a default value which preserves the method's existing behavior.
- It exposes `toArrow()` for Spark Connect, via the existing `SparkSession.client.to_table()` method.
- It does not introduce any other user-facing changes.

### How was this patch tested?
This adds a new test and a new helper function for the test in `pyspark/sql/tests/test_arrow.py`.

### Was this patch authored or co-authored using generative AI tooling?
No