### PR TITLE
[SPARK-47373][SQL] Match FileSourceScanLike to get metadata instead of FileSourceScanExec

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanInfo.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanInfo.scala
@@ -66,7 +66,7 @@ private[execution] object SparkPlanInfo {
 
     // dump the file scan metadata (e.g file path) to event log
     val metadata = plan match {
-      case fileScan: FileSourceScanExec => fileScan.metadata
+      case fileScan: FileSourceScanLike => fileScan.metadata
       case _ => Map[String, String]()
     }
     new SparkPlanInfo(


### PR DESCRIPTION
### What changes were proposed in this pull request?

When get Spark Plan info, we should match basic trait `FileSourceScanLike` to get metadata instead of matching 
subclass `FileSourceScanExec`.

So that user-define file scan operators(which extend `FileSourceScanLike`) can be matched.

### Why are the changes needed?

Match user-define file scan operators.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Exists Unit Test

### Was this patch authored or co-authored using generative AI tooling?
No