### PR TITLE
[SPARK-47374][CONNECT][DOCS] Fix connect-repl `usage prompt` & `docs link`

### DIFF
--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClientParser.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClientParser.scala
@@ -29,17 +29,21 @@ private[sql] object SparkConnectClientParser {
    *   usage string.
    */
   def usage(): String =
+    // scalastyle:off line.size.limit
     s"""
        |Options:
        |   --remote REMOTE          URI of the Spark Connect Server to connect to.
        |   --host HOST              Host where the Spark Connect Server is running.
        |   --port PORT              Port where the Spark Connect Server is running.
-       |   --enable-ssl             Connect to the server using SSL.
+       |   --use_ssl                Connect to the server using SSL.
        |   --token TOKEN            Token to use for authentication.
        |   --user_id USER_ID        Id of the user connecting.
        |   --user_name USER_NAME    Name of the user connecting.
+       |   --user_agent USER_AGENT  The User-Agent Client information (only intended for logging purposes by the server).
+       |   --session_id SESSION_ID  Session Id of the user connecting.
        |   --option KEY=VALUE       Key-value pair that is used to further configure the session.
      """.stripMargin
+     // scalastyle:on line.size.limit
 
   /**
    * Parse the command line and configure the builder.

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClientParser.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClientParser.scala
@@ -24,12 +24,12 @@ import scala.annotation.tailrec
  */
 private[sql] object SparkConnectClientParser {
 
+  // scalastyle:off line.size.limit
   /**
    * @return
    *   usage string.
    */
   def usage(): String =
-    // scalastyle:off line.size.limit
     s"""
        |Options:
        |   --remote REMOTE          URI of the Spark Connect Server to connect to.
@@ -43,7 +43,7 @@ private[sql] object SparkConnectClientParser {
        |   --session_id SESSION_ID  Session Id of the user connecting.
        |   --option KEY=VALUE       Key-value pair that is used to further configure the session.
      """.stripMargin
-     // scalastyle:on line.size.limit
+  // scalastyle:on line.size.limit
 
   /**
    * Parse the command line and configure the builder.

--- a/docs/spark-connect-overview.md
+++ b/docs/spark-connect-overview.md
@@ -279,7 +279,7 @@ The customizations may also be passed in through CLI arguments as shown below:
 spark-connect-repl --host myhost.com --port 443 --token ABCDEFG
 {% endhighlight %}
 
-The supported list of CLI arguments may be found [here](https://github.com/apache/spark/blob/master/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClientParser.scala#L48).
+The supported list of CLI arguments may be found [here](https://github.com/apache/spark/blob/master/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClientParser.scala#L48).
 
 #### Configure programmatically with a connection string
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to:
- fix connect-repl `usage prompt`.
- fix docs link.


### Why are the changes needed?
Only fix bug.

- Usage prompt
1.update `enable_ssl` to `use_ssl`.
2.add `user_agent` and `session_id`
  Before:
  <img width="1025" alt="image" src="https://github.com/apache/spark/assets/15246973/db401e7f-9569-469c-90eb-17c277472b4d">

  After:
  <img width="1025" alt="image" src="https://github.com/apache/spark/assets/15246973/de7b1f8c-1d0d-4696-8f93-f72636b0d1a0">

- Docs link
  The url `https://github.com/apache/spark/blob/master/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClientParser.scala#L48` does not exist.
  Before:
  <img width="1324" alt="image" src="https://github.com/apache/spark/assets/15246973/a1dd0578-cba1-4cfe-8330-fcd48c84ca69">

  After:
  <img width="1222" alt="image" src="https://github.com/apache/spark/assets/15246973/a66467e3-652f-4288-888d-d676b3365569">

### Does this PR introduce _any_ user-facing change?
Yes, the `connect-repl` `usage prompt` and `docs link` have been corrected.


### How was this patch tested?
- Manually test.
- Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
