### PR TITLE
[MINOR][INFRA] Update the link text and ref in `notify_test_workflow.yml`

### DIFF
--- a/.github/workflows/notify_test_workflow.yml
+++ b/.github/workflows/notify_test_workflow.yml
@@ -92,7 +92,7 @@ jobs:
                   summary: `
             Unable to detect the workflow run for testing the changes in your PR.
 
-            1. If you did not enable GitHub Actions in your forked repository, please enable it by clicking the button as shown in the image below. See also [Disabling or limiting GitHub Actions for a repository](https://docs.github.com/en/github/administering-a-repository/disabling-or-limiting-github-actions-for-a-repository) for more details.
+            1. If you did not enable GitHub Actions in your forked repository, please enable it by clicking the button as shown in the image below. See also [Managing Github Actions Settings for a repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository) for more details.
             2. It is possible your branch is based on the old \`master\` branch in Apache Spark, please sync your branch to the latest master branch. For example as below:
                 \`\`\`bash
                 git fetch upstream


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to update the link `text` and `ref` in `notify_test_workflow.yml`.

### Why are the changes needed?
1.The keyword `Disabling or limiting GitHub Actions for a repository` does not exist on the page.
  <img width="1027" alt="image" src="https://github.com/apache/spark/assets/15246973/392320de-53b9-4b08-9956-afd2bb3708f9">
  If a new user encounters the above issue, `she/he` will generally click on this page to search for `Disabling or limiting GitHub Actions for a repository`  But unfortunately, the content of this page has changed and the keyword `Disabling or limiting GitHub Actions for a repository` no longer exists.  I propose `updating` it to reduce user confusion.

2.The url [`https://docs.github.com/en/github/administering-a-repository/disabling-or-limiting-github-actions-for-a-repository`](https://docs.github.com/en/github/administering-a-repository/disabling-or-limiting-github-actions-for-a-repository) has been redirected to [`https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository`](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository).


### Does this PR introduce _any_ user-facing change?
Yes, only for dev.


### How was this patch tested?
Manually test.


### Was this patch authored or co-authored using generative AI tooling?
No.
