### PR TITLE
[SPARK-47378][PROTOBUF][TESTS] Make the related Protobuf UT run well in IDE

### DIFF
--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufTestBase.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufTestBase.scala
@@ -28,6 +28,9 @@ import org.apache.spark.sql.types.{DataType, StructType}
 
 trait ProtobufTestBase extends SQLTestUtils {
 
+  private val descriptorDir = getWorkspaceFilePath(
+    "connector", "protobuf", "target", "generated-test-sources")
+
   /**
    * Returns path for a Protobuf descriptor file used in the tests. These files are generated
    * during the build. Maven and SBT create the descriptor files differently. Maven creates one
@@ -35,7 +38,7 @@ trait ProtobufTestBase extends SQLTestUtils {
    * all the Protobuf files. As a result actual file path returned in each case is different.
    */
   protected def protobufDescriptorFile(fileName: String): String = {
-    val dir = "target/generated-test-sources"
+    val dir = descriptorDir.toFile.getCanonicalPath
     if (new File(s"$dir/$fileName").exists) {
       s"$dir/$fileName"
     } else { // sbt test


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to make the related Protobuf `UT` run well in IDE (IntelliJ IDEA).

### Why are the changes needed?
Facilitate developers to debug the related Protobuf `UT`.

Before:
<img width="1279" alt="image" src="https://github.com/apache/spark/assets/15246973/c00781b2-3477-4b2c-b871-ead997fda697">

After:
<img width="884" alt="image" src="https://github.com/apache/spark/assets/15246973/665fc67d-c69e-45c7-b37d-bb4ef8e72930">

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- Manually test.
- Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
No.
