### PR TITLE
[SPARK-47290][SQL] Extend CustomTaskMetric to allow metric values from multiple sources

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/metric/CustomFileTaskMetric.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/metric/CustomFileTaskMetric.java
@@ -17,15 +17,13 @@
 
 package org.apache.spark.sql.connector.metric;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 import org.apache.spark.annotation.Evolving;
 
 /**
  * A custom file task metric. This allows file based data source V2 implementations
  * to use a single PartitionReader with multiple file readers. Each file reader can
  * provide its own metrics values and they can be added into the parent PartitionReader
+ *
  * @since 4.0.0
  */
 @Evolving
@@ -36,28 +34,4 @@ public interface CustomFileTaskMetric extends CustomTaskMetric {
    */
   default void update(long addValue) {}
 
-
-  /*
-  Merge(add) the values of the corresponding CustomTaskMetric from src array into target array
-  adding a new element if it doesn't already exist. Returns a new array without modifying the
-  target array
-  */
-  static List<CustomFileTaskMetric> mergeMetricValues(List<CustomTaskMetric> src,
-      List<CustomFileTaskMetric> target) {
-    List<CustomFileTaskMetric> out = new ArrayList<>(target);
-    src.forEach(srcMetric -> {
-          Optional<CustomFileTaskMetric> m = out.stream()
-              .filter(targetMetric -> targetMetric.name().equals(srcMetric.name()))
-              .findFirst();
-          if (m.isPresent()) {
-            m.get().update(srcMetric.value());
-          } else {
-            if (srcMetric instanceof CustomFileTaskMetric) {
-              out.add((CustomFileTaskMetric) srcMetric);
-            }
-          }
-        }
-    );
-    return out;
-  }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/metric/CustomFileTaskMetric.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/metric/CustomFileTaskMetric.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.metric;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.apache.spark.annotation.Evolving;
+
+/**
+ * A custom file task metric. This allows file based data source V2 implementations
+ * to use a single PartitionReader with multiple file readers. Each file reader can
+ * provide its own metrics values and they can be added into the parent PartitionReader
+ * @since 4.0.0
+ */
+@Evolving
+public interface CustomFileTaskMetric extends CustomTaskMetric {
+
+  /**
+   * Updates the underlying value of the metric by adding addValue to the existing value
+   */
+  default void update(long addValue) {}
+
+
+  /*
+  Merge(add) the values of the corresponding CustomTaskMetric from src array into target array
+  adding a new element if it doesn't already exist. Returns a new array without modifying the
+  target array
+  */
+  static List<CustomFileTaskMetric> mergeMetricValues(List<CustomTaskMetric> src,
+      List<CustomFileTaskMetric> target) {
+    List<CustomFileTaskMetric> out = new ArrayList<>(target);
+    src.forEach(srcMetric -> {
+          Optional<CustomFileTaskMetric> m = out.stream()
+              .filter(targetMetric -> targetMetric.name().equals(srcMetric.name()))
+              .findFirst();
+          if (m.isPresent()) {
+            m.get().update(srcMetric.value());
+          } else {
+            if (srcMetric instanceof CustomFileTaskMetric) {
+              out.add((CustomFileTaskMetric) srcMetric);
+            }
+          }
+        }
+    );
+    return out;
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/CustomMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/CustomMetrics.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.metric
 
 import org.apache.spark.TaskContext
-import org.apache.spark.sql.connector.metric.{CustomMetric, CustomTaskMetric}
+import org.apache.spark.sql.connector.metric.{CustomFileTaskMetric, CustomMetric, CustomTaskMetric}
 
 object CustomMetrics {
   private[spark] val V2_CUSTOM = "v2Custom"
@@ -69,5 +69,24 @@ object CustomMetrics {
         }
       }
     }
+  }
+
+  /**
+   * Merge(add) the values of the corresponding CustomTaskMetric from src array into target array
+   * adding a new element if it doesn't already exist.
+   */
+  def mergeMetricValues(src: Array[CustomFileTaskMetric],
+      target: Array[CustomFileTaskMetric]): Array[CustomFileTaskMetric] = {
+    var out = target
+    src.foreach(srcMetric => {
+      out.find(_.name == srcMetric.name) match {
+        case Some(m) =>
+          m.update(srcMetric.value)
+        case None =>
+          out +:= srcMetric
+          ()
+      }
+    })
+    out
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Provides a new interface `CustomFileTaskMetric` that extends the `CustomTaskMetric` and allows updating of values.

### Why are the changes needed?
The current interface to provide custom metrics does not work for adding file based metrics for the parquet reader where a single `FilePartitionReader` may need to collect metrics from multiple parquet file readers 

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
This is just adding the interface. The implementation and tests will be done in a follow up PR that addresses https://issues.apache.org/jira/browse/SPARK-47291

### Was this patch authored or co-authored using generative AI tooling?
No