### PR TITLE
[SPARK-47384][BUILD] Upgrade RoaringBitmap to 1.0.5

### DIFF
--- a/core/benchmarks/MapStatusesConvertBenchmark-jdk21-results.txt
+++ b/core/benchmarks/MapStatusesConvertBenchmark-jdk21-results.txt
@@ -2,12 +2,12 @@
 MapStatuses Convert Benchmark
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.1+12-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 MapStatuses Convert:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Num Maps: 50000 Fetch partitions:500                689            694           5          0.0   688848614.0       1.0X
-Num Maps: 50000 Fetch partitions:1000              1511           1517           7          0.0  1511337028.0       0.5X
-Num Maps: 50000 Fetch partitions:1500              2279           2298          20          0.0  2278703144.0       0.3X
+Num Maps: 50000 Fetch partitions:500                696            699           3          0.0   695980122.0       1.0X
+Num Maps: 50000 Fetch partitions:1000              1593           1615          19          0.0  1592993119.0       0.4X
+Num Maps: 50000 Fetch partitions:1500              2455           2476          22          0.0  2454771901.0       0.3X
 
 

--- a/core/benchmarks/MapStatusesConvertBenchmark-results.txt
+++ b/core/benchmarks/MapStatusesConvertBenchmark-results.txt
@@ -2,12 +2,12 @@
 MapStatuses Convert Benchmark
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.9+9-LTS on Linux 5.15.0-1053-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 MapStatuses Convert:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Num Maps: 50000 Fetch partitions:500                646            655          13          0.0   645845205.0       1.0X
-Num Maps: 50000 Fetch partitions:1000              1175           1195          18          0.0  1174727440.0       0.5X
-Num Maps: 50000 Fetch partitions:1500              1767           1830          55          0.0  1767363076.0       0.4X
+Num Maps: 50000 Fetch partitions:500                714            716           2          0.0   713899011.0       1.0X
+Num Maps: 50000 Fetch partitions:1000              1602           1647          59          0.0  1602358288.0       0.4X
+Num Maps: 50000 Fetch partitions:1500              2517           2538          22          0.0  2517027078.0       0.3X
 
 

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -1,7 +1,7 @@
 HikariCP/2.5.1//HikariCP-2.5.1.jar
 JLargeArrays/1.5//JLargeArrays-1.5.jar
 JTransforms/3.1//JTransforms-3.1.jar
-RoaringBitmap/1.0.1//RoaringBitmap-1.0.1.jar
+RoaringBitmap/1.0.5//RoaringBitmap-1.0.5.jar
 ST4/4.0.4//ST4-4.0.4.jar
 activation/1.1.1//activation-1.1.1.jar
 aircompressor/0.26//aircompressor-0.26.jar

--- a/pom.xml
+++ b/pom.xml
@@ -812,7 +812,7 @@
       <dependency>
         <groupId>org.roaringbitmap</groupId>
         <artifactId>RoaringBitmap</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.5</version>
       </dependency>
 
       <!-- Netty Begin -->


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `RoaringBitmap` from `1.0.1` to `1.0.5`.


### Why are the changes needed?
Release notes: https://github.com/RoaringBitmap/RoaringBitmap/releases/tag/1.0.5
This version includes some bugs fixed, eg:
- fix roaringbitmap - batchiterator's advanceIfNeeded to handle run lengths of zero by
- fix RangeBitmap#between bug in full section after empty section


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
