### PR TITLE
[SPARK-47387][SQL] Remove some unused error classes

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -3522,12 +3522,6 @@
     ],
     "sqlState" : "42802"
   },
-  "STATE_STORE_MULTIPLE_VALUES_PER_KEY" : {
-    "message" : [
-      "Store does not support multiple values per key"
-    ],
-    "sqlState" : "42802"
-  },
   "STATE_STORE_UNSUPPORTED_OPERATION" : {
     "message" : [
       "<operationType> operation not supported with <entity>"
@@ -3699,12 +3693,6 @@
       "CREATE TEMPORARY VIEW or the corresponding Dataset APIs only accept single-part view names, but got: <actualName>."
     ],
     "sqlState" : "428EK"
-  },
-  "TWS_VALUE_SHOULD_NOT_BE_NULL" : {
-    "message" : [
-      "New value should be non-null for <typeOfState>"
-    ],
-    "sqlState" : "22004"
   },
   "UDTF_ALIAS_NUMBER_MISMATCH" : {
     "message" : [
@@ -7751,16 +7739,6 @@
       "Datatype not supported <dt>"
     ]
   },
-  "_LEGACY_ERROR_TEMP_3193" : {
-    "message" : [
-      "Creating multiple column families with HDFSBackedStateStoreProvider is not supported"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3197" : {
-    "message" : [
-      "Failed to create column family with reserved name=<colFamilyName>"
-    ]
-  },
   "_LEGACY_ERROR_TEMP_3198" : {
     "message" : [
       "Cannot grow BufferHolder by size <neededSize> because the size is negative"
@@ -7939,11 +7917,6 @@
   "_LEGACY_ERROR_TEMP_3233" : {
     "message" : [
       "cannot generate code for unsupported type: <dataType>"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3234" : {
-    "message" : [
-      "Unsupported input type <other>"
     ]
   },
   "_LEGACY_ERROR_TEMP_3235" : {

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -2179,12 +2179,6 @@ Failed to perform column family operation=`<operationName>` with invalid name=`<
 The handle has not been initialized for this StatefulProcessor.
 Please only use the StatefulProcessor within the transformWithState operator.
 
-### STATE_STORE_MULTIPLE_VALUES_PER_KEY
-
-[SQLSTATE: 42802](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
-
-Store does not support multiple values per key
-
 ### STATE_STORE_UNSUPPORTED_OPERATION
 
 [SQLSTATE: XXKST](sql-error-conditions-sqlstates.html#class-XX-internal-error)
@@ -2341,12 +2335,6 @@ Choose a different name, drop or replace the existing view,  or add the IF NOT E
 [SQLSTATE: 428EK](sql-error-conditions-sqlstates.html#class-42-syntax-error-or-access-rule-violation)
 
 CREATE TEMPORARY VIEW or the corresponding Dataset APIs only accept single-part view names, but got: `<actualName>`.
-
-### TWS_VALUE_SHOULD_NOT_BE_NULL
-
-[SQLSTATE: 22004](sql-error-conditions-sqlstates.html#class-22-data-exception)
-
-New value should be non-null for `<typeOfState>`
 
 ### UDTF_ALIAS_NUMBER_MISMATCH
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to remove some unused error classes, include:
- _LEGACY_ERROR_TEMP_3193: The code in PR(https://github.com/apache/spark/pull/44961) no longer uses this error class, but the related item in the file `error-classes.json` has not been deleted synchronously.
- _LEGACY_ERROR_TEMP_3197: The code in PR(https://github.com/apache/spark/pull/44961) no longer uses this error class, but the related item in the file `error-classes.json` has not been deleted synchronously.
- _LEGACY_ERROR_TEMP_3234: This should be the follow-up work of https://github.com/apache/spark/pull/44665
- STATE_STORE_MULTIPLE_VALUES_PER_KEY: Introduced by [SPARK-46864](https://github.com/apache/spark/pull/44883), but not actually used in codebase.
- TWS_VALUE_SHOULD_NOT_BE_NULL: Introduced by [SPARK-46864](https://github.com/apache/spark/pull/44883), but not actually used in codebase.


### Why are the changes needed?
Make the code cleaner.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- Pass GA.
- Manually check.

### Was this patch authored or co-authored using generative AI tooling?
No.
