### PR TITLE
[SPARK-47388][SQL] Pass `messageParameters` by name to `require()`

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/SparkException.scala
+++ b/common/utils/src/main/scala/org/apache/spark/SparkException.scala
@@ -116,7 +116,7 @@ object SparkException {
   def require(
       requirement: Boolean,
       errorClass: String,
-      messageParameters: Map[String, String]): Unit = {
+      messageParameters: => Map[String, String]): Unit = {
     if (!requirement) {
       throw new SparkIllegalArgumentException(errorClass, messageParameters)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to pass `messageParameters` by name to avoid eager instantiation.

### Why are the changes needed?
Passing `messageParameters` by value independently from `requirement` might introduce perf regression.

### Does this PR introduce _any_ user-facing change?
No, this is not a part of public API.

### How was this patch tested?
By running the affected test suite:
```
$ build/sbt "test:testOnly *QueryCompilationErrorsSuite"
```

### Was this patch authored or co-authored using generative AI tooling?
No.