### PR TITLE
[SPARK-47390][SQL] PostgresDialect distinguishes TIMESTAMP from TIMESTAMP_TZ

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -284,7 +284,7 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationSuite {
     assert(schema(1).dataType == ShortType)
   }
 
-  test("SPARK-20557: Convert TIMESTAMP/TIME WITH TIME ZONE regardless of preferTimestampNTZ") {
+  test("SPARK-47390: Convert TIMESTAMP/TIME WITH TIME ZONE regardless of preferTimestampNTZ") {
     Seq(true, false).foreach { prefer =>
       val rows = sqlContext.read
         .option("preferTimestampNTZ", prefer)

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -284,15 +284,14 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationSuite {
     assert(schema(1).dataType == ShortType)
   }
 
-  test("SPARK-20557: column type TIMESTAMP with TIME ZONE and TIME with TIME ZONE " +
-    "should be recognized") {
-    // When using JDBC to read the columns of TIMESTAMP with TIME ZONE and TIME with TIME ZONE
-    // the actual types are java.sql.Types.TIMESTAMP and java.sql.Types.TIME
-    val dfRead = sqlContext.read.jdbc(jdbcUrl, "ts_with_timezone", new Properties)
-    val rows = dfRead.collect()
-    val types = rows(0).toSeq.map(x => x.getClass.toString)
-    assert(types(1).equals("class java.sql.Timestamp"))
-    assert(types(2).equals("class java.sql.Timestamp"))
+  test("SPARK-20557: Convert TIMESTAMP/TIME WITH TIME ZONE regardless of preferTimestampNTZ") {
+    Seq(true, false).foreach { prefer =>
+      val rows = sqlContext.read
+        .option("preferTimestampNTZ", prefer)
+        .jdbc(jdbcUrl, "ts_with_timezone", new Properties)
+        .collect()
+      rows.head.toSeq.tail.foreach(c => assert(c.isInstanceOf[java.sql.Timestamp]))
+    }
   }
 
   test("SPARK-22291: Conversion error when transforming array types of " +

--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -40,6 +40,7 @@ license: |
 - Since Spark 4.0, `SELECT (*)` is equivalent to `SELECT struct(*)` instead of `SELECT *`. To restore the previous behavior, set `spark.sql.legacy.ignoreParenthesesAroundStar` to `true`.
 - Since Spark 4.0, the SQL config `spark.sql.legacy.allowZeroIndexInFormatString` is deprecated. Consider to change `strfmt` of the `format_string` function to use 1-based indexes. The first argument must be referenced by "1$", the second by "2$", etc.
 - Since Spark 4.0, the function `to_csv` no longer supports input with the data type `STRUCT`, `ARRAY`, `MAP`, `VARIANT` and `BINARY` (because the `CSV specification` does not have standards for these data types and cannot be read back using `from_csv`), Spark will throw `DATATYPE_MISMATCH.UNSUPPORTED_INPUT_TYPE` exception.
+- Since Spark 4.0, JDBC read option `preferTimestampNTZ=true` will not convert Postgres TIMESTAMP WITH TIME ZONE and TIME WITH TIME ZONE data types to TimestampNTZType, which is available in Spark 3.5. 
 
 ## Upgrading from Spark SQL 3.4 to 3.5
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -49,26 +49,28 @@ private object PostgresDialect extends JdbcDialect with SQLConfHelper {
 
   override def getCatalystType(
       sqlType: Int, typeName: String, size: Int, md: MetadataBuilder): Option[DataType] = {
-    if (sqlType == Types.REAL) {
-      Some(FloatType)
-    } else if (sqlType == Types.SMALLINT) {
-      Some(ShortType)
-    } else if (sqlType == Types.BIT && typeName == "bit" && size != 1) {
-      Some(BinaryType)
-    } else if (sqlType == Types.DOUBLE && typeName == "money") {
-      // money type seems to be broken but one workaround is to handle it as string.
-      // See SPARK-34333 and https://github.com/pgjdbc/pgjdbc/issues/100
-      Some(StringType)
-    } else if (sqlType == Types.OTHER) {
-      Some(StringType)
-    } else if ("text".equalsIgnoreCase(typeName)) {
-      Some(StringType) // sqlType is  Types.VARCHAR
-    } else if (sqlType == Types.ARRAY) {
-      val scale = md.build().getLong("scale").toInt
-      val isTimestampNTZ = md.build().getBoolean("isTimestampNTZ")
-      // postgres array type names start with underscore
-      toCatalystType(typeName.drop(1), size, scale, isTimestampNTZ).map(ArrayType(_))
-    } else None
+    sqlType match {
+      case Types.REAL => Some(FloatType)
+      case Types.SMALLINT => Some(ShortType)
+      case Types.BIT if typeName == "bit" && size != 1 => Some(BinaryType)
+      case Types.DOUBLE if typeName == "money" =>
+        // money type seems to be broken but one workaround is to handle it as string.
+        // See SPARK-34333 and https://github.com/pgjdbc/pgjdbc/issues/100
+        Some(StringType)
+      case Types.TIMESTAMP
+        if "timestamptz".equalsIgnoreCase(typeName) || "timetz".equalsIgnoreCase(typeName) =>
+        // timestamptz represents timestamp with time zone, currently it maps to Types.TIMESTAMP.
+        // We need to change to Types.TIMESTAMP_WITH_TIMEZONE if the upstream changes.
+        Some(TimestampType)
+      case Types.OTHER => Some(StringType)
+      case _ if "text".equalsIgnoreCase(typeName) => Some(StringType) // sqlType is Types.VARCHAR
+      case Types.ARRAY =>
+        val scale = md.build().getLong("scale").toInt
+        val isTimestampNTZ = md.build().getBoolean("isTimestampNTZ")
+        // postgres array type names start with underscore
+        toCatalystType(typeName.drop(1), size, scale, isTimestampNTZ).map(ArrayType(_))
+      case _ => None
+    }
   }
 
   private def toCatalystType(
@@ -91,7 +93,8 @@ private object PostgresDialect extends JdbcDialect with SQLConfHelper {
          "interval" | "pg_snapshot" =>
       Some(StringType)
     case "bytea" => Some(BinaryType)
-    case "timestamp" | "timestamptz" | "time" | "timetz" =>
+    case "timestamptz" | "timetz" => Some(TimestampType)
+    case "timestamp" | "time" =>
       Some(if (isTimestampNTZ) TimestampNTZType else TimestampType)
     case "date" => Some(DateType)
     case "numeric" | "decimal" if precision > 0 => Some(DecimalType.bounded(precision, scale))


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Regarding SPARK-47375, this PR fixes the issue of converting PG TIMESTAMP_TZ & TIME_TZ to our NTZ.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

bugfix


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, as 3.5 is out, this PR add a migration guide for this.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
mo