### PR TITLE
[SPARK-47404][SQL] Add hooks to release the ANTLR DFA cache after parsing SQL

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/parsers.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/parsers.scala
@@ -110,7 +110,7 @@ abstract class AbstractParser extends DataTypeParserInterface with Logging {
           queryContext = e.getQueryContext)
     }
     finally {
-      if (conf.releaseAntlrCacheAfterParse) {
+      if (conf.releaseAntlrCacheAfterParsing) {
         AbstractSqlParser.refreshParserCaches()
       }
     }

--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConf.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConf.scala
@@ -43,6 +43,7 @@ private[sql] trait SqlApiConf {
   def datetimeJava8ApiEnabled: Boolean
   def sessionLocalTimeZone: String
   def legacyTimeParserPolicy: LegacyBehaviorPolicy.Value
+  def releaseAntlrCacheAfterParse: Boolean
 }
 
 private[sql] object SqlApiConf {
@@ -77,4 +78,5 @@ private[sql] object DefaultSqlApiConf extends SqlApiConf {
   override def datetimeJava8ApiEnabled: Boolean = false
   override def sessionLocalTimeZone: String = TimeZone.getDefault.getID
   override def legacyTimeParserPolicy: LegacyBehaviorPolicy.Value = LegacyBehaviorPolicy.EXCEPTION
+  override def releaseAntlrCacheAfterParse: Boolean = false
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConf.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConf.scala
@@ -43,7 +43,7 @@ private[sql] trait SqlApiConf {
   def datetimeJava8ApiEnabled: Boolean
   def sessionLocalTimeZone: String
   def legacyTimeParserPolicy: LegacyBehaviorPolicy.Value
-  def releaseAntlrCacheAfterParse: Boolean
+  def releaseAntlrCacheAfterParsing: Boolean
 }
 
 private[sql] object SqlApiConf {
@@ -78,5 +78,5 @@ private[sql] object DefaultSqlApiConf extends SqlApiConf {
   override def datetimeJava8ApiEnabled: Boolean = false
   override def sessionLocalTimeZone: String = TimeZone.getDefault.getID
   override def legacyTimeParserPolicy: LegacyBehaviorPolicy.Value = LegacyBehaviorPolicy.EXCEPTION
-  override def releaseAntlrCacheAfterParse: Boolean = false
+  override def releaseAntlrCacheAfterParsing: Boolean = false
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4590,13 +4590,13 @@ object SQLConf {
       .createWithDefault("versionAsOf")
 
   val RELEASE_ANTLR_CACHE_AFTER_PARSE =
-    buildConf("spark.sql.releaseAntlrCacheAfterParse")
+    buildConf("spark.sql.parser.releaseAntlrCacheAfterParsing")
       .doc("When true, release the ANTLR cache after parsing a SQL query. ANTLR parsers retain a " +
         "DFA cache designed to speed up parsing future input. However, there is no limit to how " +
         "large this cache can become and parsing large SQL statements can lead to an " +
-        "accumulation of objects in the cache that are unlikely to be reused.  This can deplete " +
+        "accumulation of objects in the cache that are unlikely to be reused. This can deplete " +
         "the available heap on the driver, leading to high GC overhead and evenatually OOMs. Set " +
-        "this to `true` to release the cache after every SQL statement.  On a long-lived driver, " +
+        "this to `true` to release the cache after every SQL statement. On a long-lived driver, " +
         "it may be beneficial to periodically set this to `true`, run a query to clear the " +
         "cache, and revert it to `false`.")
       .version("4.0.0")
@@ -5140,7 +5140,7 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def broadcastHashJoinOutputPartitioningExpandLimit: Int =
     getConf(BROADCAST_HASH_JOIN_OUTPUT_PARTITIONING_EXPAND_LIMIT)
 
-  override def releaseAntlrCacheAfterParse: Boolean = getConf(RELEASE_ANTLR_CACHE_AFTER_PARSE)
+  override def releaseAntlrCacheAfterParsing: Boolean = getConf(RELEASE_ANTLR_CACHE_AFTER_PARSE)
 
   /**
    * Returns the [[Resolver]] for the current configuration, which can be used to determine if two

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4589,6 +4589,20 @@ object SQLConf {
       .stringConf
       .createWithDefault("versionAsOf")
 
+  val RELEASE_ANTLR_CACHE_AFTER_PARSE =
+    buildConf("spark.sql.releaseAntlrCacheAfterParse")
+      .doc("When true, release the ANTLR cache after parsing a SQL query. ANTLR parsers retain a " +
+        "DFA cache designed to speed up parsing future input. However, there is no limit to how " +
+        "large this cache can become and parsing large SQL statements can lead to an " +
+        "accumulation of objects in the cache that are unlikely to be reused.  This can deplete " +
+        "the available heap on the driver, leading to high GC overhead and evenatually OOMs. Set " +
+        "this to `true` to release the cache after every SQL statement.  On a long-lived driver, " +
+        "it may be beneficial to periodically set this to `true`, run a query to clear the " +
+        "cache, and revert it to `false`.")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val LEGACY_PERCENTILE_DISC_CALCULATION = buildConf("spark.sql.legacy.percentileDiscCalculation")
     .internal()
     .doc("If true, the old bogus percentile_disc calculation is used. The old calculation " +
@@ -5125,6 +5139,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def broadcastHashJoinOutputPartitioningExpandLimit: Int =
     getConf(BROADCAST_HASH_JOIN_OUTPUT_PARTITIONING_EXPAND_LIMIT)
+
+  override def releaseAntlrCacheAfterParse: Boolean = getConf(RELEASE_ANTLR_CACHE_AFTER_PARSE)
 
   /**
    * Returns the [[Resolver]] for the current configuration, which can be used to determine if two

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4589,7 +4589,7 @@ object SQLConf {
       .stringConf
       .createWithDefault("versionAsOf")
 
-  val RELEASE_ANTLR_CACHE_AFTER_PARSE =
+  val RELEASE_ANTLR_CACHE_AFTER_PARSING =
     buildConf("spark.sql.parser.releaseAntlrCacheAfterParsing")
       .doc("When true, release the ANTLR cache after parsing a SQL query. ANTLR parsers retain a " +
         "DFA cache designed to speed up parsing future input. However, there is no limit to how " +
@@ -5140,7 +5140,7 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def broadcastHashJoinOutputPartitioningExpandLimit: Int =
     getConf(BROADCAST_HASH_JOIN_OUTPUT_PARTITIONING_EXPAND_LIMIT)
 
-  override def releaseAntlrCacheAfterParsing: Boolean = getConf(RELEASE_ANTLR_CACHE_AFTER_PARSE)
+  override def releaseAntlrCacheAfterParsing: Boolean = getConf(RELEASE_ANTLR_CACHE_AFTER_PARSING)
 
   /**
    * Returns the [[Resolver]] for the current configuration, which can be used to determine if two


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add hooks to release the ANTLR DFA cache after parsing SQL

### Why are the changes needed?
ANTLR builds a DFA cache while parsing to speed up parsing of similar future inputs. However, this cache is never cleared and can only grow. Extremely large SQL inputs can lead to very large DFA caches (>20GiB in one extreme case I've seen).

Spark’s ANTLR SQL parser is derived from the Presto ANTLR SQL Parser (see [SPARK-13713](https://issues.apache.org/jira/browse/SPARK-13713) and https://github.com/apache/spark/pull/11557), and Presto has added hooks to be able to clear this DFA cache (https://github.com/trinodb/trino/pull/3186). I think Spark should have similar hooks.

### Does this PR introduce _any_ user-facing change?
New `SQLConf` to control the behaviour (`spark.sql.parser.releaseAntlrCacheAfterParse`)

### How was this patch tested?
New unit test

### Was this patch authored or co-authored using generative AI tooling?
No