### PR TITLE
[SPARK-44740][CONNECT][TESTS][FOLLOWUP] Deduplicate `test_metadata`

### DIFF
--- a/python/pyspark/sql/tests/connect/test_connect_session.py
+++ b/python/pyspark/sql/tests/connect/test_connect_session.py
@@ -444,7 +444,7 @@ class ChannelBuilderTests(unittest.TestCase):
         md = chan.metadata()
         self.assertEqual([("param1", "120 21"), ("x-my-header", "abcd")], md)
 
-    def test_metadata(self):
+    def test_metadata_with_session_id(self):
         id = str(uuid.uuid4())
         chan = DefaultChannelBuilder(f"sc://host/;session_id={id}")
         self.assertEqual(id, chan.session_id)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Deduplicate `test_metadata`

https://github.com/apache/spark/commit/576d1698c7b52b2d9ce00fa2fc5912c92e8bbe67 added a test  with duplicated name `test_metadata`, so one of the two was skipped.


### Why are the changes needed?
manually check

before

```
grep test_metadata /Users/ruifeng.zheng/Dev/spark/python/target/9b1b140e-ad38-4e53-acae-031c152f2a42/python3__pyspark.sql.tests.connect.test_connect_session__55w2s1pn.log
  test_metadata (pyspark.sql.tests.connect.test_connect_session.ChannelBuilderTests.test_metadata) ... ok (0.000s)
```

after

```
grep test_metadata /Users/ruifeng.zheng/Dev/spark/python/target/79d78590-7275-480f-adc4-1acecc2c61de/python3__pyspark.sql.tests.connect.test_connect_session__4ei_cczz.log
  test_metadata (pyspark.sql.tests.connect.test_connect_session.ChannelBuilderTests.test_metadata) ... ok (0.000s)
  test_metadata_with_session_id (pyspark.sql.tests.connect.test_connect_session.ChannelBuilderTests.test_metadata_with_session_id) ... ok (0.000s)
```


### Does this PR introduce _any_ user-facing change?
no, test only


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no