### PR TITLE
[SPARK-47426][BUILD] Upgrade Guava used by the connect module to `33.1.0-jre`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,7 +288,7 @@
     <spark.test.docker.removePulledImage>true</spark.test.docker.removePulledImage>
 
     <!-- Version used in Connect -->
-    <connect.guava.version>33.0.0-jre</connect.guava.version>
+    <connect.guava.version>33.1.0-jre</connect.guava.version>
     <guava.failureaccess.version>1.0.2</guava.failureaccess.version>
     <io.grpc.version>1.62.2</io.grpc.version>
     <mima.version>1.1.3</mima.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade Guava used by the `connect` module to `33.1.0-jre`.


### Why are the changes needed?
- The new version bring some bug fixes and optimizations as follows:
cache: Fixed a bug that could cause https://github.com/google/guava/pull/6851#issuecomment-1931276822.
hash: Optimized Checksum-based hash functions for Java 9+. 

- The full release notes:
https://github.com/google/guava/releases/tag/v33.1.0


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
