### PR TITLE
[SPARK-47433][PYTHON][DOCS][INFRA][3.4] Update PySpark package dependency with version ranges

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -3,7 +3,7 @@ py4j
 
 # PySpark dependencies (optional)
 numpy
-pyarrow
+pyarrow<13.0.0
 pandas
 scipy
 plotly

--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -153,15 +153,15 @@ To install PySpark from source, refer to |building_spark|_.
 Dependencies
 ------------
 ========================== ========================= ======================================================================================
-Package                    Minimum supported version Note
+Package                    Supported version         Note
 ========================== ========================= ======================================================================================
-`py4j`                     0.10.9.7                  Required
-`pandas`                   1.0.5                     Required for pandas API on Spark and Spark Connect; Optional for Spark SQL
-`pyarrow`                  1.0.0                     Required for pandas API on Spark and Spark Connect; Optional for Spark SQL
-`numpy`                    1.15                      Required for pandas API on Spark and MLLib DataFrame-based API; Optional for Spark SQL
-`grpc`                     1.48.1                    Required for Spark Connect
-`grpcio-status`            1.48.1                    Required for Spark Connect
-`googleapis-common-protos` 1.56.4                    Required for Spark Connect
+`py4j`                     >=0.10.9.7                Required
+`pandas`                   >=1.0.5                   Required for pandas API on Spark and Spark Connect; Optional for Spark SQL
+`pyarrow`                  >=1.0.0,<13.0.0           Required for pandas API on Spark and Spark Connect; Optional for Spark SQL
+`numpy`                    >=1.15                    Required for pandas API on Spark and MLLib DataFrame-based API; Optional for Spark SQL
+`grpcio`                   >=1.48,<1.57              Required for Spark Connect
+`grpcio-status`            >=1.48,<1.57              Required for Spark Connect
+`googleapis-common-protos` ==1.56.4                  Required for Spark Connect
 ========================== ========================= ======================================================================================
 
 Note that PySpark requires Java 8 or later with ``JAVA_HOME`` properly set.  


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `PySpark` package dependency with version ranges.

### Why are the changes needed?

Like Apache Spark 3.5+, we had better clarify the range of supported versions.

This is a logical backport of subset of #41997 and #45553

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.