### PR TITLE
[SPARK-43435][PYTHON][CONNECT][TESTS] Reenable doctest `pyspark.sql.connect.dataframe.DataFrame.writeStream`

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -2248,9 +2248,6 @@ def _test() -> None:
     # TODO(SPARK-41888): Support StreamingQueryListener for DataFrame.observe
     del pyspark.sql.connect.dataframe.DataFrame.observe.__doc__
 
-    # TODO(SPARK-43435): should reenable this test
-    del pyspark.sql.connect.dataframe.DataFrame.writeStream.__doc__
-
     globs["spark"] = (
         PySparkSession.builder.appName("sql.connect.dataframe tests")
         .remote("local[4]")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Reenable doctest `pyspark.sql.connect.dataframe.DataFrame.writeStream`

### Why are the changes needed?
for test coverage




### Does this PR introduce _any_ user-facing change?
no, test only


### How was this patch tested?
I manually test it 10 times locally

`python/run-tests -k --python-executables python3 --testnames 'pyspark.sql.connect.dataframe'`

It seems this test is no longer flaky


### Was this patch authored or co-authored using generative AI tooling?
no
