### PR TITLE
[SPARK-47439][PYTHON] Document Python Data Source API in API reference page

### DIFF
--- a/python/docs/source/reference/pyspark.sql/datasource.rst
+++ b/python/docs/source/reference/pyspark.sql/datasource.rst
@@ -16,36 +16,29 @@
     under the License.
 
 
-============
-Core Classes
-============
-.. currentmodule:: pyspark.sql
+==================
+Python Data Source
+==================
+
+.. currentmodule:: pyspark.sql.datasource
 
 .. autosummary::
     :toctree: api/
 
-    SparkSession
-    Catalog
-    DataFrame
-    Column
-    Observation
-    Row
-    GroupedData
-    PandasCogroupedOps
-    DataFrameNaFunctions
-    DataFrameStatFunctions
-    Window
-    DataFrameReader
-    DataFrameWriter
-    DataFrameWriterV2
-    UDFRegistration
-    UDTFRegistration
-    udf.UserDefinedFunction
-    udtf.UserDefinedTableFunction
-    datasource.DataSource
-    datasource.DataSourceReader
-    datasource.DataSourceStreamReader
-    datasource.DataSourceWriter
-    datasource.DataSourceRegistration
-    datasource.InputPartition
-    datasource.WriterCommitMessage
+    DataSource.name
+    DataSource.reader
+    DataSource.schema
+    DataSource.streamReader
+    DataSource.writer
+    DataSourceReader.partitions
+    DataSourceReader.read
+    DataSourceRegistration.register
+    DataSourceStreamReader.commit
+    DataSourceStreamReader.initialOffset
+    DataSourceStreamReader.latestOffset
+    DataSourceStreamReader.partitions
+    DataSourceStreamReader.read
+    DataSourceStreamReader.stop
+    DataSourceWriter.abort
+    DataSourceWriter.commit
+    DataSourceWriter.write

--- a/python/docs/source/reference/pyspark.sql/index.rst
+++ b/python/docs/source/reference/pyspark.sql/index.rst
@@ -42,3 +42,4 @@ This page gives an overview of all public Spark SQL API.
     udf
     udtf
     protobuf
+    datasource

--- a/python/docs/source/reference/pyspark.sql/spark_session.rst
+++ b/python/docs/source/reference/pyspark.sql/spark_session.rst
@@ -47,6 +47,7 @@ See also :class:`SparkSession`.
     SparkSession.catalog
     SparkSession.conf
     SparkSession.createDataFrame
+    SparkSession.dataSource
     SparkSession.getActiveSession
     SparkSession.newSession
     SparkSession.profile


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to document Python Data Source API in Python API reference page.

### Why are the changes needed?

For users/developers to know how to use them.

### Does this PR introduce _any_ user-facing change?

Yes, it documents Python Data Source API.

### How was this patch tested?

Manually checked the output from Python API reference build

```bash
cd python/docs
make clean html
open build/html/index.html
```

### Was this patch authored or co-authored using generative AI tooling?

No.
