### PR TITLE
[SPARK-47446][CORE] Make `BlockManager` warn before `removeBlockInternal`

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -1561,8 +1561,8 @@ private[spark] class BlockManager(
           blockInfoManager.unlock(blockId)
         }
       } else {
-        removeBlockInternal(blockId, tellMaster = false)
         logWarning(s"Putting block $blockId failed")
+        removeBlockInternal(blockId, tellMaster = false)
       }
       res
     } catch {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `BlockManager` warn before invoking `removeBlockInternal` by switching the log position. To be clear,
1. For the case where `removeBlockInternal` succeeds, the log messages are identical before and after this PR.
2. For the case where `removeBlockInternal` fails, the user will see one additional warning message like the following which was hidden from the users before this PR.
```
logWarning(s"Putting block $blockId failed") 
```

### Why are the changes needed?

When `Put` operation fails, Apache Spark currently tries `removeBlockInternal` first before logging.

https://github.com/apache/spark/blob/ce93c9fd86715e2479552628398f6fc11e83b2af/core/src/main/scala/org/apache/spark/storage/BlockManager.scala#L1554-L1567

On top of that, if `removeBlockInternal` fails consecutively, Spark shows the warning like the following and fails the job.
```
24/03/18 18:40:46 WARN BlockManager: Putting block broadcast_0 failed due to exception java.nio.file.NoSuchFileException: /data/spark/blockmgr-56a6c418-90be-4d89-9707-ef45f7eaf74c/0e.
24/03/18 18:40:46 WARN BlockManager: Block broadcast_0 was not removed normally.
24/03/18 18:40:46 INFO TaskSchedulerImpl: Cancelling stage 0
24/03/18 18:40:46 INFO TaskSchedulerImpl: Killing all running tasks in stage 0: Stage cancelled
24/03/18 18:40:46 INFO DAGScheduler: ResultStage 0 (reduce at SparkPi.scala:38) failed in 0.264 s due to Job aborted due to stage failure: Task serialization failed: java.nio.file.NoSuchFileException: /data/spark/blockmgr-56a6c418-90be-4d89-9707-ef45f7eaf74c/0e
java.nio.file.NoSuchFileException: /data/spark/blockmgr-56a6c418-90be-4d89-9707-ef45f7eaf74c/0e
```

It's misleading although they might share the same root cause. Since `Put` operation fails before the above failure, we had better switch WARN message to make it clear.

### Does this PR introduce _any_ user-facing change?

No. This is a warning message change only.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.