### PR TITLE
[SPARK-47448][CORE] Enable `spark.shuffle.service.removeShuffle` by default

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -737,7 +737,7 @@ package object config {
         "application ends.")
       .version("3.3.0")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   private[spark] val SHUFFLE_SERVICE_FETCH_RDD_ENABLED =
     ConfigBuilder(Constants.SHUFFLE_SERVICE_FETCH_RDD_ENABLED)

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -936,6 +936,7 @@ class MapOutputTrackerSuite extends SparkFunSuite with LocalSparkContext {
     val newConf = new SparkConf
     newConf.set("spark.shuffle.push.enabled", "true")
     newConf.set("spark.shuffle.service.enabled", "true")
+    newConf.set("spark.shuffle.service.removeShuffle", "false")
     newConf.set(SERIALIZER, "org.apache.spark.serializer.KryoSerializer")
     newConf.set(IS_TESTING, true)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1152,7 +1152,7 @@ Apart from these, the following properties are also available, and may be useful
 </tr>
 <tr>
   <td><code>spark.shuffle.service.removeShuffle</code></td>
-  <td>false</td>
+  <td>true</td>
   <td>
     Whether to use the ExternalShuffleService for deleting shuffle blocks for
     deallocated executors when the shuffle is no longer needed. Without this enabled,

--- a/docs/core-migration-guide.md
+++ b/docs/core-migration-guide.md
@@ -40,6 +40,8 @@ license: |
 
 - Since Spark 4.0, Spark uses `~/.ivy2.5.2` as Ivy user directory by default to isolate the existing systems from Apache Ivy's incompatibility. To restore the legacy behavior, you can set `spark.jars.ivy` to `~/.ivy2`.
 
+- Since Spark 4.0, Spark uses the external shuffle service for deleting shuffle blocks for deallocated executors when the shuffle is no longer needed. To restore the legacy behavior, you can set `spark.shuffle.service.removeShuffle` to `false`.
+
 ## Upgrading from Core 3.4 to 3.5
 
 - Since Spark 3.5, `spark.yarn.executor.failuresValidityInterval` is deprecated. Use `spark.executor.failuresValidityInterval` instead.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable `spark.shuffle.service.removeShuffle` for Apache Spark 4.0.0.

### Why are the changes needed?

Since Apache Spark 3.3.0, Apache Spark has been supporting `spark.shuffle.service.removeShuffle` via SPARK-37618.

- #35085

We can use it when external shuffle service is available.

### Does this PR introduce _any_ user-facing change?

By default, no because `spark.shuffle.service.enabled` is still disabled.

Only for the existing shuffle service users, this PR works.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.