### PR TITLE
[SPARK-47345][SQL][TESTS][FOLLOW-UP] Rename JSON to XML within XmlFunctionsSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/XmlFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/XmlFunctionsSuite.scala
@@ -450,7 +450,7 @@ class XmlFunctionsSuite extends QueryTest with SharedSparkSession {
     )
   }
 
-  test("schema_of_xml - infers the schema of foldable JSON string") {
+  test("schema_of_xml - infers the schema of foldable XML string") {
     val input = regexp_replace(
       lit("""<ROW><item_id>1</item_id><item_price>0.1</item_price></ROW>"""), "item_", "")
     checkAnswer(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/45466 that addresses https://github.com/apache/spark/pull/45466#discussion_r1529511772. It renames a test name from JSON to XML within `XmlFunctionsSuite`

### Why are the changes needed?

To have the correct test title so we don't get confused why/which test failed.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

CI in this PR should validate the change.

### Was this patch authored or co-authored using generative AI tooling?

No.
