### PR TITLE
[SPARK-47456][SQL] Support ORC Brotli codec

### DIFF
--- a/docs/sql-data-sources-orc.md
+++ b/docs/sql-data-sources-orc.md
@@ -241,7 +241,7 @@ Data source options of ORC can be set via:
   <tr>
     <td><code>compression</code></td>
     <td><code>zstd</code></td>
-    <td>compression codec to use when saving to file. This can be one of the known case-insensitive shorten names (none, snappy, zlib, lzo, zstd, lz4 and brotli). This will override <code>orc.compress</code> and <code>spark.sql.orc.compression.codec</code>.</td>
+    <td>compression codec to use when saving to file. This can be one of the known case-insensitive shorten names (none, snappy, zlib, lzo, zstd, lz4 and brotli). This will override <code>orc.compress</code> and <code>spark.sql.orc.compression.codec</code>. Note that <code>brotli</code> requires <code>brotli4j</code> to be installed.</td>
     <td>write</td>
   </tr>
 </table>

--- a/docs/sql-data-sources-orc.md
+++ b/docs/sql-data-sources-orc.md
@@ -241,7 +241,7 @@ Data source options of ORC can be set via:
   <tr>
     <td><code>compression</code></td>
     <td><code>zstd</code></td>
-    <td>compression codec to use when saving to file. This can be one of the known case-insensitive shorten names (none, snappy, zlib, lzo, zstd and lz4). This will override <code>orc.compress</code> and <code>spark.sql.orc.compression.codec</code>.</td>
+    <td>compression codec to use when saving to file. This can be one of the known case-insensitive shorten names (none, snappy, zlib, lzo, zstd, lz4 and brotli). This will override <code>orc.compress</code> and <code>spark.sql.orc.compression.codec</code>.</td>
     <td>write</td>
   </tr>
 </table>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1203,11 +1203,11 @@ object SQLConf {
     .doc("Sets the compression codec used when writing ORC files. If either `compression` or " +
       "`orc.compress` is specified in the table-specific options/properties, the precedence " +
       "would be `compression`, `orc.compress`, `spark.sql.orc.compression.codec`." +
-      "Acceptable values include: none, uncompressed, snappy, zlib, lzo, zstd, lz4.")
+      "Acceptable values include: none, uncompressed, snappy, zlib, lzo, zstd, lz4, brotli.")
     .version("2.3.0")
     .stringConf
     .transform(_.toLowerCase(Locale.ROOT))
-    .checkValues(Set("none", "uncompressed", "snappy", "zlib", "lzo", "zstd", "lz4"))
+    .checkValues(Set("none", "uncompressed", "snappy", "zlib", "lzo", "zstd", "lz4", "brotli"))
     .createWithDefault("zstd")
 
   val ORC_IMPLEMENTATION = buildConf("spark.sql.orc.impl")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcCompressionCodec.java
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcCompressionCodec.java
@@ -34,7 +34,8 @@ public enum OrcCompressionCodec {
   SNAPPY(CompressionKind.SNAPPY),
   LZO(CompressionKind.LZO),
   LZ4(CompressionKind.LZ4),
-  ZSTD(CompressionKind.ZSTD);
+  ZSTD(CompressionKind.ZSTD),
+  BROTLI(CompressionKind.BROTLI);
 
   private final CompressionKind compressionKind;
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -55,7 +55,8 @@ object OrcUtils extends Logging {
     OrcCompressionCodec.ZLIB.name() -> ".zlib",
     OrcCompressionCodec.ZSTD.name() -> ".zstd",
     OrcCompressionCodec.LZ4.name() -> ".lz4",
-    OrcCompressionCodec.LZO.name() -> ".lzo")
+    OrcCompressionCodec.LZO.name() -> ".lzo",
+    OrcCompressionCodec.BROTLI.name() -> ".brotli")
 
   val CATALYST_TYPE_ATTRIBUTE_NAME = "spark.sql.catalyst.type"
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceCodecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/FileSourceCodecSuite.scala
@@ -71,6 +71,9 @@ class OrcCodecSuite extends FileSourceCodecSuite {
 
   override def format: String = "orc"
   override val codecConfigName: String = SQLConf.ORC_COMPRESSION.key
+  // Exclude "BROTLI" because its dependencies
+  // require adding different jars according to different OSs
   override protected def availableCodecs =
-    OrcCompressionCodec.values().map(_.lowerCaseName()).toSeq
+    OrcCompressionCodec.values().filter(_ != OrcCompressionCodec.BROTLI)
+      .map(_.lowerCaseName()).toSeq
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to support ORC Brotli codec.

### Why are the changes needed?
Currently, the master branch of Spark has used ORC 2.0.0 version and supports brotli compression encoding. ([SPARK-44115](https://issues.apache.org/jira/browse/SPARK-44115))
However, due to some hardcode checks in Spark, brotli cannot be used normally.

```sql
set spark.sql.orc.compression.codec=BROTLI;
```

```
java.lang.IllegalArgumentException: The value of spark.sql.orc.compression.codec should be one of uncompressed, lz4, lzo, snappy, zlib, none, zstd, but was brotli
```

See https://github.com/apache/orc/pull/1714

### Does this PR introduce _any_ user-facing change?
Yes

In this PR, add the corresponding brotli jar package, we can use orc brotli encoding.

```xml
    <dependency>
      <groupId>com.aayushatharva.brotli4j</groupId>
      <artifactId>brotli4j</artifactId>
    </dependency>
```

REF: https://github.com/netty/netty/blob/3cd364107167600e8eb4b0b85553ed895519e2ed/codec/pom.xml#L91-L125

### How was this patch tested?
local test

<img width="850" alt="image" src="https://github.com/apache/spark/assets/3898450/4e4f9422-1cf2-45ef-8bcc-8bae6188beb7">


### Was this patch authored or co-authored using generative AI tooling?
No