### PR TITLE
[SPARK-47457][SQL] Fix `IsolatedClientLoader.supportsHadoopShadedClient` to handle Hadoop 3.4+

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
@@ -107,6 +107,8 @@ private[hive] object IsolatedClientLoader extends Logging {
     VersionUtils.majorMinorPatchVersion(hadoopVersion).exists {
       case (3, 2, v) if v >= 2 => true
       case (3, 3, v) if v >= 1 => true
+      case (3, v, _) if v >= 4 => true
+      case (v, _, _) if v >= 4 => true
       case _ => false
     }
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HadoopVersionInfoSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HadoopVersionInfoSuite.scala
@@ -72,12 +72,12 @@ class HadoopVersionInfoSuite extends SparkFunSuite {
   }
 
   test("SPARK-32212: test supportHadoopShadedClient()") {
-    Seq("3.2.2", "3.2.3", "3.2.2.1", "3.2.2-XYZ", "3.2.2.4-SNAPSHOT").foreach { version =>
+    Seq("4", "3.2.2", "3.2.3", "3.2.2.1", "3.2.2-XYZ", "3.2.2.4-SNAPSHOT").foreach { version =>
       assert(IsolatedClientLoader.supportsHadoopShadedClient(version), s"version $version")
     }
 
     // negative cases
-    Seq("3.1.3", "3.2", "3.2.1", "4").foreach { version =>
+    Seq("3.1.3", "3.2", "3.2.1").foreach { version =>
       assert(!IsolatedClientLoader.supportsHadoopShadedClient(version), s"version $version")
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `IsolatedClientLoader.supportsHadoopShadedClient` to handle Hadoop 3.4+ correctly.

### Why are the changes needed?

Apache Spark 3.4+ support shaded clients, but currently `supportsHadoopShadedClient` returns `false`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.