### PR TITLE
[SPARK-47461][CORE] Remove private function `totalRunningTasksPerResourceProfile` from `ExecutorAllocationManager`

### DIFF
--- a/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
+++ b/core/src/main/scala/org/apache/spark/ExecutorAllocationManager.scala
@@ -320,10 +320,6 @@ private[spark] class ExecutorAllocationManager(
     }
   }
 
-  private def totalRunningTasksPerResourceProfile(id: Int): Int = synchronized {
-    listener.totalRunningTasksPerResourceProfile(id)
-  }
-
   /**
    * This is called at a fixed interval to regulate the number of pending executor requests
    * and number of executors running.

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -1934,8 +1934,6 @@ private object ExecutorAllocationManagerSuite extends PrivateMethodTester {
     PrivateMethod[Map[Int, Map[String, Int]]](Symbol("rpIdToHostToLocalTaskCount"))
   private val _onSpeculativeTaskSubmitted =
     PrivateMethod[Unit](Symbol("onSpeculativeTaskSubmitted"))
-  private val _totalRunningTasksPerResourceProfile =
-    PrivateMethod[Int](Symbol("totalRunningTasksPerResourceProfile"))
 
   private val defaultProfile = ResourceProfile.getOrCreateDefaultProfile(new SparkConf)
 
@@ -2043,7 +2041,7 @@ private object ExecutorAllocationManagerSuite extends PrivateMethodTester {
   }
 
   private def totalRunningTasksPerResourceProfile(manager: ExecutorAllocationManager): Int = {
-    manager invokePrivate _totalRunningTasksPerResourceProfile(defaultProfile.id)
+    manager.listener.totalRunningTasksPerResourceProfile(defaultProfile.id)
   }
 
   private def hostToLocalTaskCount(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr remove private function `totalRunningTasksPerResourceProfile` from `ExecutorAllocationManager`.

This function only used by test in `ExecutorAllocationManagerSuite` and this pr also change the test function to directly call `manager.listener.totalRunningTasksPerResourceProfile` instead of invoking the private function `ExecutorAllocationManager#totalRunningTasksPerResourceProfile` through reflection.

### Why are the changes needed?
Code clean up


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No