### PR TITLE
[SPARK-47462][SQL] Align mappings of other unsigned numeric types with TINYINT in MySQLDialect

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
@@ -48,11 +48,19 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite {
 
     conn.prepareStatement("CREATE TABLE numbers (onebit BIT(1), tenbits BIT(10), "
       + "small SMALLINT, med MEDIUMINT, nor INT, big BIGINT, deci DECIMAL(40,20), flt FLOAT, "
-      + "dbl DOUBLE, tiny TINYINT, u_tiny TINYINT UNSIGNED)").executeUpdate()
+      + "dbl DOUBLE, tiny TINYINT)").executeUpdate()
 
     conn.prepareStatement("INSERT INTO numbers VALUES (b'0', b'1000100101', "
       + "17, 77777, 123456789, 123456789012345, 123456789012345.123456789012345, "
-      + "42.75, 1.0000000000000002, -128, 255)").executeUpdate()
+      + "42.75, 1.0000000000000002, -128)").executeUpdate()
+
+    conn.prepareStatement("CREATE TABLE unsigned_numbers (" +
+      "tiny TINYINT UNSIGNED, small SMALLINT UNSIGNED, med MEDIUMINT UNSIGNED," +
+      "nor INT UNSIGNED, big BIGINT UNSIGNED, deci DECIMAL(40,20) UNSIGNED," +
+      "dbl DOUBLE UNSIGNED)").executeUpdate()
+
+    conn.prepareStatement("INSERT INTO unsigned_numbers VALUES (255, 65535, 16777215, 4294967295," +
+      "9223372036854775808, 123456789012345.123456789012345, 1.0000000000000002)").executeUpdate()
 
     conn.prepareStatement("CREATE TABLE dates (d DATE, t TIME, dt DATETIME, ts TIMESTAMP, "
       + "yr YEAR)").executeUpdate()
@@ -82,10 +90,10 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite {
     val rows = df.collect()
     assert(rows.length == 1)
     val types = rows(0).toSeq.map(x => x.getClass.toString)
-    assert(types.length == 11)
+    assert(types.length == 10)
     assert(types(0).equals("class java.lang.Boolean"))
     assert(types(1).equals("class java.lang.Long"))
-    assert(types(2).equals("class java.lang.Integer"))
+    assert(types(2).equals("class java.lang.Short"))
     assert(types(3).equals("class java.lang.Integer"))
     assert(types(4).equals("class java.lang.Integer"))
     assert(types(5).equals("class java.lang.Long"))
@@ -93,7 +101,6 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite {
     assert(types(7).equals("class java.lang.Double"))
     assert(types(8).equals("class java.lang.Double"))
     assert(types(9).equals("class java.lang.Byte"))
-    assert(types(10).equals("class java.lang.Short"))
     assert(rows(0).getBoolean(0) == false)
     assert(rows(0).getLong(1) == 0x225)
     assert(rows(0).getInt(2) == 17)
@@ -105,7 +112,25 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite {
     assert(rows(0).getDouble(7) == 42.75)
     assert(rows(0).getDouble(8) == 1.0000000000000002)
     assert(rows(0).getByte(9) == 0x80.toByte)
-    assert(rows(0).getShort(10) == 0xff.toShort)
+  }
+
+  test("SPARK-47462: Unsigned numeric types") {
+    val df = sqlContext.read.jdbc(jdbcUrl, "unsigned_numbers", new Properties)
+    val rows = df.collect().head
+    assert(rows.get(0).isInstanceOf[Short])
+    assert(rows.get(1).isInstanceOf[Integer])
+    assert(rows.get(2).isInstanceOf[Integer])
+    assert(rows.get(3).isInstanceOf[Long])
+    assert(rows.get(4).isInstanceOf[BigDecimal])
+    assert(rows.get(5).isInstanceOf[BigDecimal])
+    assert(rows.get(6).isInstanceOf[Double])
+    assert(rows.getShort(0) == 255)
+    assert(rows.getInt(1) == 65535)
+    assert(rows.getInt(2) == 16777215)
+    assert(rows.getLong(3) == 4294967295L)
+    assert(rows.getAs[BigDecimal](4).equals(new BigDecimal("9223372036854775808")))
+    assert(rows.getAs[BigDecimal](5).equals(new BigDecimal("123456789012345.12345678901234500000")))
+    assert(rows.getDouble(6) == 1.0000000000000002)
   }
 
   test("Date types") {

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
@@ -103,7 +103,7 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite {
     assert(types(9).equals("class java.lang.Byte"))
     assert(rows(0).getBoolean(0) == false)
     assert(rows(0).getLong(1) == 0x225)
-    assert(rows(0).getInt(2) == 17)
+    assert(rows(0).getShort(2) == 17)
     assert(rows(0).getInt(3) == 77777)
     assert(rows(0).getInt(4) == 123456789)
     assert(rows(0).getLong(5) == 123456789012345L)

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
@@ -116,7 +116,7 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite {
 
   test("SPARK-47462: Unsigned numeric types") {
     val df = sqlContext.read.jdbc(jdbcUrl, "unsigned_numbers", new Properties)
-    val rows = df.collect().head
+    val rows = df.head()
     assert(rows.get(0).isInstanceOf[Short])
     assert(rows.get(1).isInstanceOf[Integer])
     assert(rows.get(2).isInstanceOf[Integer])
@@ -124,13 +124,13 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite {
     assert(rows.get(4).isInstanceOf[BigDecimal])
     assert(rows.get(5).isInstanceOf[BigDecimal])
     assert(rows.get(6).isInstanceOf[Double])
-    assert(rows.getShort(0) == 255)
-    assert(rows.getInt(1) == 65535)
-    assert(rows.getInt(2) == 16777215)
-    assert(rows.getLong(3) == 4294967295L)
+    assert(rows.getShort(0) === 255)
+    assert(rows.getInt(1) === 65535)
+    assert(rows.getInt(2) === 16777215)
+    assert(rows.getLong(3) === 4294967295L)
     assert(rows.getAs[BigDecimal](4).equals(new BigDecimal("9223372036854775808")))
     assert(rows.getAs[BigDecimal](5).equals(new BigDecimal("123456789012345.12345678901234500000")))
-    assert(rows.getDouble(6) == 1.0000000000000002)
+    assert(rows.getDouble(6) === 1.0000000000000002)
   }
 
   test("Date types") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -113,6 +113,16 @@ private case object MySQLDialect extends JdbcDialect with SQLConfHelper {
         } else {
           Some(ShortType)
         }
+      case Types.SMALLINT =>
+        if (md.build().getBoolean("isSigned")) {
+          Some(ShortType)
+        } else {
+          Some(IntegerType)
+        }
+      case Types.INTEGER if "MEDIUMINT UNSIGNED".equalsIgnoreCase(typeName) =>
+        // Signed values in [-8388608, 8388607] and unsigned values in [0, 16777215],
+        // both of them fit IntegerType
+        Some(IntegerType)
       case Types.TIMESTAMP if "DATETIME".equalsIgnoreCase(typeName) =>
         // scalastyle:off line.size.limit
         // In MYSQL, DATETIME is TIMESTAMP WITHOUT TIME ZONE


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Align mappings of other unsigned numeric types with TINYINT in MySQLDialect. TINYINT is mapping to ByteType and TINYINT UNSIGNED is mapping to ShortType.

In this PR, we 
- map SMALLINT to ShortType, SMALLINT UNSIGNED to IntegerType. W/o this, both of them are mapping to IntegerType
- map MEDIUMINT UNSIGNED to IntegerType, and MEDIUMINT is AS-IS. W/o this, MEDIUMINT UNSIGNED uses LongType


Other unsigned/signed types remain unchanged and only improve the test coverage.

 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Consistency and efficiency while reading MySQL numeric values

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

yes, the mappings described the 1st section.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

new tests


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->no
