### PR TITLE
[SPARK-47464][INFRA] Update `labeler.yml` for module `common/sketch` and `common/variant`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -101,6 +101,8 @@ SQL:
     ]
     - any-glob-to-any-file: [
      'common/unsafe/**/*',
+     'common/sketch/**/*',
+     'common/variant/**/*',
      'bin/spark-sql*',
      'bin/beeline*',
      'sbin/*thriftserver*.sh',


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to update `labeler.yml` for module `common/sketch` and `common/variant`.


### Why are the changes needed?
Currently, the above modules are not classified in the file `labeler.yml`, and the GitHub action label cannot automatically tag the submitted PR.


### Does this PR introduce _any_ user-facing change?
Yes, only for dev.


### How was this patch tested?
Manually test: after this PR is merged, continue to observe.


### Was this patch authored or co-authored using generative AI tooling?
No.
