### PR TITLE
[SPARK-47484][SQL] Allow trailing comma in column definition list

### DIFF
--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -1165,7 +1165,7 @@ colType
     ;
 
 createOrReplaceTableColTypeList
-    : createOrReplaceTableColType (COMMA createOrReplaceTableColType)*
+    : createOrReplaceTableColType (COMMA createOrReplaceTableColType)* COMMA?
     ;
 
 createOrReplaceTableColType

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -3050,6 +3050,16 @@ class DDLParserSuite extends AnalysisTest {
         |USING parquet
         |""".stripMargin
 
+    val createSql2 =
+      """
+        |CREATE TABLE my_tbl (
+        |   a INT,
+        |   b STRING,
+        |--   c STRING,
+        |)
+        |USING parquet
+        |""".stripMargin
+
     val expectedPlan = CreateTable(
       UnresolvedIdentifier(Seq("my_tbl")),
       Seq(ColumnDefinition("a", IntegerType), ColumnDefinition("b", StringType)),
@@ -3065,5 +3075,6 @@ class DDLParserSuite extends AnalysisTest {
       false)
 
     parseCompare(createSql, expectedPlan)
+    parseCompare(createSql2, expectedPlan)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/DDLParserSuite.scala
@@ -3039,4 +3039,31 @@ class DDLParserSuite extends AnalysisTest {
       errorClass = "INTERNAL_ERROR",
       parameters = Map("message" -> "INSERT OVERWRITE DIRECTORY is not supported."))
   }
+
+  test("create table with trailing comma in column list") {
+    val createSql =
+      """
+        |CREATE TABLE my_tbl (
+        |   a INT,
+        |   b STRING,
+        |)
+        |USING parquet
+        |""".stripMargin
+
+    val expectedPlan = CreateTable(
+      UnresolvedIdentifier(Seq("my_tbl")),
+      Seq(ColumnDefinition("a", IntegerType), ColumnDefinition("b", StringType)),
+      Seq.empty[Transform],
+      UnresolvedTableSpec(
+        Map.empty[String, String],
+        Some("parquet"),
+        OptionList(Seq.empty),
+        None,
+        None,
+        None,
+        false),
+      false)
+
+    parseCompare(createSql, expectedPlan)
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
When experimenting with SQL queries, it's common to accidentally leave a trailing comma after the last column in a table definition, resulting in syntax errors. This often happens when developers comment out the last column and forget to remove the trailing comma, leading to unexpected syntax issues when creating tables.

This pull request addresses this issue by allowing trailing commas in column lists when creating tables, thus preventing syntax errors caused by inadvertent comma placement.
```
CREATE OR REPLACE TABLE test_tbl (
    c1 STRING,
    c2 INT,
--    c3 INT,
) 
USING PARQUET;
```
I see no reason why the above query should fail.

I explored a similar idea but for `SELECT` statement in #45541, but it turned out that making `from` a reserved keyword would break compatibility with older code using the word.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
These changes are needed because it's a handy feature already found in other databases like SQL Server and DuckDB. Bringing it to Spark would be a nice improvement for everyone.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, having a trailing comma will not result in a syntax error like it used to.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No