### PR TITLE
[SPARK-47468][BUILD] Exclude `logback` dependency from SBT like Maven

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1078,6 +1078,7 @@ object ExcludedDependencies {
     // purpose only. Here we exclude them from the whole project scope and add them w/ yarn only.
     excludeDependencies ++= Seq(
       ExclusionRule(organization = "com.sun.jersey"),
+      ExclusionRule(organization = "ch.qos.logback"),
       ExclusionRule("javax.ws.rs", "jsr311-api"))
   )
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to exclude `logback` from SBT dependency like Maven to fix the following SBT issue.

```
[info]   stderr> SLF4J: Class path contains multiple SLF4J bindings.
[info]   stderr> SLF4J: Found binding in [jar:file:/home/runner/work/spark/spark/assembly/target/scala-2.13/jars/logback-classic-1.2.13.jar!/org/slf4j/impl/StaticLoggerBinder.class]
[info]   stderr> SLF4J: Found binding in [jar:file:/home/runner/.cache/coursier/v1/https/maven-central.storage-download.googleapis.com/maven2/ch/qos/logback/logback-classic/1.2.13/logback-classic-1.2.13.jar!/org/slf4j/impl/StaticLoggerBinder.class]
[info]   stderr> SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
[info]   stderr> SLF4J: Actual binding is of type [ch.qos.logback.classic.util.ContextSelectorStaticBinder]
```

### Why are the changes needed?

**Maven**
```
$ build/mvn dependency:tree --pl core | grep logback
Using `mvn` from path: /opt/homebrew/bin/mvn
Using SPARK_LOCAL_IP=localhost
```

**SBT (BEFORE)**
```
$ build/sbt "core/test:dependencyTree" | grep logback
Using SPARK_LOCAL_IP=localhost
[info]   |       +-ch.qos.logback:logback-classic:1.2.13
[info]   |       | +-ch.qos.logback:logback-core:1.2.13
[info]   |       +-ch.qos.logback:logback-core:1.2.13
[info]   | | +-ch.qos.logback:logback-classic:1.2.13
[info]   | | | +-ch.qos.logback:logback-core:1.2.13
[info]   | | +-ch.qos.logback:logback-core:1.2.13
[info]   | +-ch.qos.logback:logback-classic:1.2.13
[info]   | | +-ch.qos.logback:logback-core:1.2.13
[info]   | +-ch.qos.logback:logback-core:1.2.13
```

**SBT (AFTER)**
```
$ build/sbt "core/test:dependencyTree" | grep logback
Using SPARK_LOCAL_IP=localhost
```

### Does this PR introduce _any_ user-facing change?

No. This only fixes developer and CI issues.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.