### PR TITLE
[SPARK-47471][SQL] Support order-insensitive lateral column alias

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -427,8 +427,11 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
         result
       case other => resolve(other)
     }.map {
-      case e: Expression if e.resolved => e
+      case e: Expression if e.resolved || e.containsPattern(LATERAL_COLUMN_ALIAS_REFERENCE) => e
       // Resolve again to support order-insensitive lateral column alias
+      case a: Alias =>
+        aliasMap.remove(a.name.toLowerCase(Locale.ROOT))
+        resolve(a)
       case other => resolve(other)
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -426,6 +426,10 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
         }
         result
       case other => resolve(other)
+    }.map {
+      case e: Expression if e.resolved => e
+      // Resolve again to support order-insensitive lateral column alias
+      case other => resolve(other)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/LateralColumnAliasSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/LateralColumnAliasSuite.scala
@@ -1284,4 +1284,14 @@ class LateralColumnAliasSuite extends LateralColumnAliasSuiteBase {
       Row(2) :: Nil
     )
   }
+
+  test("SPARK-47471: support order-insensitive lateral column alias") {
+    checkAnswerWhenOnAndExceptionWhenOff(
+      s"select d + 1 as e, dept as d from $testTable where name = 'amy'",
+      Row(2, 1) :: Nil)
+
+    checkAnswerWhenOnAndExceptionWhenOff(
+      s"select e + 1 as f, d + 1 as e, dept as d from $testTable where name = 'amy'",
+      Row(3, 2, 1) :: Nil)
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes it support order-insensitive lateral column alias. For example:
```sql
SELECT base_salary + bonus AS total_salary, salary AS base_salary
FROM employee
```

### Why are the changes needed?

At least Teradata supports this case.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.


### Was this patch authored or co-authored using generative AI tooling?

No.