### PR TITLE
[SPARK-41625][PYTHON][CONNECT][TESTS] Enable doctest `pyspark.sql.connect.dataframe.DataFrame.isStreaming`

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -2243,9 +2243,6 @@ def _test() -> None:
 
     globs = pyspark.sql.connect.dataframe.__dict__.copy()
 
-    # TODO(SPARK-41625): Support Structured Streaming
-    del pyspark.sql.connect.dataframe.DataFrame.isStreaming.__doc__
-
     # TODO(SPARK-41888): Support StreamingQueryListener for DataFrame.observe
     del pyspark.sql.connect.dataframe.DataFrame.observe.__doc__
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable doctest `pyspark.sql.connect.dataframe.DataFrame.isStreaming`


### Why are the changes needed?
for test coverage

the related functions like `readStream` were already implemented

### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
