### PR TITLE
[SPARK-47480][PYTHON][CONNECT][TESTS] Enable doctest for `createDataFrame`

### DIFF
--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -968,8 +968,6 @@ def _test() -> None:
     # Spark Connect does not support to set master together.
     pyspark.sql.connect.session.SparkSession.__doc__ = None
     del pyspark.sql.connect.session.SparkSession.Builder.master.__doc__
-    # RDD API is not supported in Spark Connect.
-    del pyspark.sql.connect.session.SparkSession.createDataFrame.__doc__
 
     # TODO(SPARK-41811): Implement SparkSession.sql's string formatter
     del pyspark.sql.connect.session.SparkSession.sql.__doc__


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable doctest for `createDataFrame`


### Why are the changes needed?
for test coverage

https://github.com/apache/spark/commit/536ac30d3ca4bc81dca6a31d1211e61f25cbbc14 had refined the doctests, and it can be reused in connect

### Does this PR introduce _any_ user-facing change?
no, test only

### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no