### PR TITLE
[SPARK-47490][SS] Fix RocksDB Logger constructor use to avoid deprecation warning

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -848,7 +848,7 @@ class RocksDB(
 
   /** Create a native RocksDB logger that forwards native logs to log4j with correct log levels. */
   private def createLogger(): Logger = {
-    val dbLogger = new Logger(dbOptions) {
+    val dbLogger = new Logger(dbOptions.infoLogLevel()) {
       override def log(infoLogLevel: InfoLogLevel, logMsg: String) = {
         // Map DB log level to log4j levels
         // Warn is mapped to info because RocksDB warn is too verbose


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix RocksDB Logger constructor use to avoid deprecation warning


### Why are the changes needed?
With the latest RocksDB upgrade, the Logger constructor used was deprecated which was throwing a compiler warning.
```
[warn]     val dbLogger = new Logger(dbOptions) {
[warn]                        ^
[warn] one warning found
[warn] two warnings found
[info] compiling 36 Scala sources and 16 Java sources to /Users/anish.shrigondekar/spark/spark/sql/core/target/scala-2.13/classes ...
[warn] -target is deprecated: Use -release instead to compile against the correct platform API.
[warn] Applicable -Wconf / @nowarn filters for this warning: msg=<part of the message>, cat=deprecation
[warn] /Users/anish.shrigondekar/spark/spark/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala:851:24: constructor Logger in class Logger is deprecated
[warn] Applicable -Wconf / @nowarn filters for this warning: msg=<part of the message>, cat=deprecation, site=org.apache.spark.sql.execution.streaming.state.RocksDB.createLogger.dbLogger, origin=org.rocksdb.Logger.<init>
```

Updated to use the new recommendation as mentioned here - https://javadoc.io/doc/org.rocksdb/rocksdbjni/latest/org/rocksdb/Logger.html

Recommendation:
```
[Logger](https://javadoc.io/static/org.rocksdb/rocksdbjni/8.11.3/org/rocksdb/Logger.html#Logger-org.rocksdb.DBOptions-)([DBOptions](https://javadoc.io/static/org.rocksdb/rocksdbjni/8.11.3/org/rocksdb/DBOptions.html) dboptions)
Deprecated. 
Use [Logger(InfoLogLevel)](https://javadoc.io/static/org.rocksdb/rocksdbjni/8.11.3/org/rocksdb/Logger.html#Logger-org.rocksdb.InfoLogLevel-) instead, e.g. new Logger(dbOptions.infoLogLevel()).
```

After the fix, the warning is not seen.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing unit tests


### Was this patch authored or co-authored using generative AI tooling?
No
