### PR TITLE
[SPARK-27950][DSTREAM] Configurable dynamodb url so kinesis-asl works with localstack

### DIFF
--- a/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisInputDStream.scala
+++ b/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisInputDStream.scala
@@ -47,7 +47,8 @@ private[kinesis] class KinesisInputDStream[T: ClassTag](
     val dynamoDBCreds: Option[SparkAWSCredentials],
     val cloudWatchCreds: Option[SparkAWSCredentials],
     val metricsLevel: MetricsLevel,
-    val metricsEnabledDimensions: Set[String]
+    val metricsEnabledDimensions: Set[String],
+    val dynamoDBEndpointUrl: Option[String]
   ) extends ReceiverInputDStream[T](_ssc) {
 
   private[streaming]
@@ -82,7 +83,7 @@ private[kinesis] class KinesisInputDStream[T: ClassTag](
     new KinesisReceiver(streamName, endpointUrl, regionName, initialPosition,
       checkpointAppName, checkpointInterval, _storageLevel, messageHandler,
       kinesisCreds, dynamoDBCreds, cloudWatchCreds,
-      metricsLevel, metricsEnabledDimensions)
+      metricsLevel, metricsEnabledDimensions, dynamoDBEndpointUrl)
   }
 }
 
@@ -109,6 +110,7 @@ object KinesisInputDStream {
     private var cloudWatchCredsProvider: Option[SparkAWSCredentials] = None
     private var metricsLevel: Option[MetricsLevel] = None
     private var metricsEnabledDimensions: Option[Set[String]] = None
+    private var dynamoDBEndpointUrl: Option[String] = None
 
     /**
      * Sets the StreamingContext that will be used to construct the Kinesis DStream. This is a
@@ -286,6 +288,17 @@ object KinesisInputDStream {
       this.metricsLevel = Option(metricsLevel)
       this
     }
+    /**
+     * Sets the AWS DynamoDB endpoint URL. Defaults to
+     * "https://dynamodb.us-east-1.amazonaws.com" if no custom value is specified
+     *
+     * @param url DynamoDB endpoint URL to use
+     * @return Reference to this [[KinesisInputDStream.Builder]]
+     */
+    def dynamoDBEndpointUrl(url: String): Builder = {
+      dynamoDBEndpointUrl = Option(url)
+      this
+    }
 
     /**
      * Sets the enabled CloudWatch metrics dimensions. Defaults to
@@ -327,7 +340,8 @@ object KinesisInputDStream {
         dynamoDBCredsProvider,
         cloudWatchCredsProvider,
         metricsLevel.getOrElse(DEFAULT_METRICS_LEVEL),
-        metricsEnabledDimensions.getOrElse(DEFAULT_METRICS_ENABLED_DIMENSIONS))
+        metricsEnabledDimensions.getOrElse(DEFAULT_METRICS_ENABLED_DIMENSIONS),
+        dynamoDBEndpointUrl)
     }
 
     /**

--- a/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisReceiver.scala
+++ b/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisReceiver.scala
@@ -82,6 +82,8 @@ import org.apache.spark.util.Utils
  * @param dynamoDBCreds Optional SparkAWSCredentials instance that will be used to generate the
  *                      AWSCredentialsProvider passed to the KCL to authorize DynamoDB API calls.
  *                      Will use kinesisCreds if value is None.
+ * @param dynamoDBEndpointUrl Optional Url of DynamoDB service
+ *                           (e.g., https://dynamodb.us-east-1.amazonaws.com)
  */
 private[kinesis] class KinesisReceiver[T](
     val streamName: String,
@@ -96,7 +98,8 @@ private[kinesis] class KinesisReceiver[T](
     dynamoDBCreds: Option[SparkAWSCredentials],
     cloudWatchCreds: Option[SparkAWSCredentials],
     metricsLevel: MetricsLevel,
-    metricsEnabledDimensions: Set[String])
+    metricsEnabledDimensions: Set[String],
+    dynamoDBEndpointUrl: Option[String])
   extends Receiver[T](storageLevel) with Logging { receiver =>
 
   /*
@@ -169,13 +172,19 @@ private[kinesis] class KinesisReceiver[T](
         .withMetricsLevel(metricsLevel)
         .withMetricsEnabledDimensions(metricsEnabledDimensions.asJava)
 
+      val withOptionalConfiguration = dynamoDBEndpointUrl match {
+        case Some(endpoint) => baseClientLibConfiguration
+          .withDynamoDBEndpoint(endpoint).withMetricsLevel(metricsLevel)
+        case _ => baseClientLibConfiguration
+      }
+
       // Update the Kinesis client lib config with timestamp
       // if InitialPositionInStream.AT_TIMESTAMP is passed
       initialPosition match {
         case ts: AtTimestamp =>
-          baseClientLibConfiguration.withTimestampAtInitialPositionInStream(ts.getTimestamp)
+          withOptionalConfiguration.withTimestampAtInitialPositionInStream(ts.getTimestamp)
         case _ =>
-          baseClientLibConfiguration.withInitialPositionInStream(initialPosition.getPosition)
+          withOptionalConfiguration.withInitialPositionInStream(initialPosition.getPosition)
       }
     }
 

--- a/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisReceiver.scala
+++ b/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisReceiver.scala
@@ -174,7 +174,7 @@ private[kinesis] class KinesisReceiver[T](
 
       val withOptionalConfiguration = dynamoDBEndpointUrl match {
         case Some(endpoint) => baseClientLibConfiguration
-          .withDynamoDBEndpoint(endpoint).withMetricsLevel(metricsLevel)
+          .withDynamoDBEndpoint(endpoint)
         case _ => baseClientLibConfiguration
       }
 

--- a/connector/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisInputDStreamBuilderSuite.scala
+++ b/connector/kinesis-asl/src/test/scala/org/apache/spark/streaming/kinesis/KinesisInputDStreamBuilderSuite.scala
@@ -87,6 +87,7 @@ class KinesisInputDStreamBuilderSuite extends TestSuiteBase with BeforeAndAfterE
     assert(dstream.cloudWatchCreds == None)
     assert(dstream.metricsLevel == DEFAULT_METRICS_LEVEL)
     assert(dstream.metricsEnabledDimensions == DEFAULT_METRICS_ENABLED_DIMENSIONS)
+    assert(dstream.dynamoDBEndpointUrl == None)
   }
 
   test("should propagate custom non-auth values to KinesisInputDStream") {
@@ -102,6 +103,7 @@ class KinesisInputDStreamBuilderSuite extends TestSuiteBase with BeforeAndAfterE
     val customMetricsLevel = MetricsLevel.NONE
     val customMetricsEnabledDimensions =
       KinesisClientLibConfiguration.METRICS_ALWAYS_ENABLED_DIMENSIONS.asScala.toSet
+    val customDynamoDBEndpointUrl = "https://dynamodb.us-west-2.amazonaws.com"
 
     val dstream = builder
       .endpointUrl(customEndpointUrl)
@@ -115,6 +117,7 @@ class KinesisInputDStreamBuilderSuite extends TestSuiteBase with BeforeAndAfterE
       .cloudWatchCredentials(customCloudWatchCreds)
       .metricsLevel(customMetricsLevel)
       .metricsEnabledDimensions(customMetricsEnabledDimensions)
+      .dynamoDBEndpointUrl(customDynamoDBEndpointUrl)
       .build()
     assert(dstream.endpointUrl == customEndpointUrl)
     assert(dstream.regionName == customRegion)
@@ -127,6 +130,7 @@ class KinesisInputDStreamBuilderSuite extends TestSuiteBase with BeforeAndAfterE
     assert(dstream.cloudWatchCreds == Option(customCloudWatchCreds))
     assert(dstream.metricsLevel == customMetricsLevel)
     assert(dstream.metricsEnabledDimensions == customMetricsEnabledDimensions)
+    assert(dstream.dynamoDBEndpointUrl == Option(customDynamoDBEndpointUrl))
 
     // Testing with AtTimestamp
     val cal = Calendar.getInstance()


### PR DESCRIPTION
This PR is a rebased and updated version of a [previous pr](https://github.com/apache/spark/pull/24801) by @etspaceman from 2019. This PR allows the spark kinesis library to work with localstack instances of kinesis.

I have not added any changes to @etspaceman 's original code, except to remove the `cloudwatchMetricsLevel` value in the original PR, as subsequent PRs have added that same value in since.

### What changes were proposed in this pull request?

Currently the spark kinesis library allows you to override the kinesis endpoint, but not the dynamodb endpoint the kinesis consumer will use to manage leases. This PR adds that configurable url into the kinesis input stream builder.

### Why are the changes needed?

Localstack has only become more popular for integration testing since the original PR. Currently, one cannot use spark streaming and localstack kinesis together, as the kinesis consumer will only attempt to manage leases through a remote aws dynamo instance.

### Does this PR introduce _any_ user-facing change?

This PR will allow the user to specify their own dynamo endpoint, much like how they can currently specify their own kinesis endpoint.

### How was this patch tested?

This PR adds unit tests to cover this new value.
