### PR TITLE
[MINOR][CORE] Fix a comment typo `slf4j-to-jul` to `jul-to-slf4j`

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
@@ -196,7 +196,7 @@ private[spark] object Logging {
   val initLock = new Object()
   try {
     // We use reflection here to handle the case where users remove the
-    // slf4j-to-jul bridge order to route their logs to JUL.
+    // jul-to-slf4j bridge order to route their logs to JUL.
     val bridgeClass = SparkClassUtils.classForName("org.slf4j.bridge.SLF4JBridgeHandler")
     bridgeClass.getMethod("removeHandlersForRootLogger").invoke(null)
     val installed = bridgeClass.getMethod("isInstalled").invoke(null).asInstanceOf[Boolean]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix a typo `slf4j-to-jul` to `jul-to-slf4j`. There exists only one.

```
$ git grep slf4j-to-jul
common/utils/src/main/scala/org/apache/spark/internal/Logging.scala:    // slf4j-to-jul bridge order to route their logs to JUL.
```

Apache Spark uses `jul-to-slf4j` which includes a `java.util.logging` (jul) handler, namely `SLF4JBridgeHandler`, which routes all incoming jul records to the SLF4j API.

https://github.com/apache/spark/blob/bb3e27581887a094ead0d2f7b4a6b2a17ee84b6f/pom.xml#L735

### Why are the changes needed?

This typo was there since Apache Spark 1.0.0.

### Does this PR introduce _any_ user-facing change?

No, this is a comment fix.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.