### PR TITLE
[SPARK-44708][PYTHON] Migrate test_reset_index assert_eq to use assertDataFrameEqual

### DIFF
--- a/python/pyspark/pandas/tests/indexes/test_reset_index.py
+++ b/python/pyspark/pandas/tests/indexes/test_reset_index.py
@@ -22,7 +22,7 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
-from pyspark.testing.utils import assertDataFrameEqual
+from pyspark.pandas.testing import assert_frame_equal
 
 
 class FrameResetIndexMixin:
@@ -43,9 +43,9 @@ class FrameResetIndexMixin:
         pdf = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=np.random.rand(3))
         psdf = ps.from_pandas(pdf)
 
-        assertDataFrameEqual(psdf.reset_index(), pdf.reset_index())
-        assertDataFrameEqual(psdf.reset_index().index, pdf.reset_index().index)
-        assertDataFrameEqual(psdf.reset_index(drop=True), pdf.reset_index(drop=True))
+        assert_frame_equal(psdf.reset_index(), pdf.reset_index())
+        assert_frame_equal(psdf.reset_index().index, pdf.reset_index().index)
+        assert_frame_equal(psdf.reset_index(drop=True), pdf.reset_index(drop=True))
 
         pdf.index.name = "a"
         psdf.index.name = "a"
@@ -53,33 +53,33 @@ class FrameResetIndexMixin:
         with self.assertRaisesRegex(ValueError, "cannot insert a, already exists"):
             psdf.reset_index()
 
-        assertDataFrameEqual(psdf.reset_index(drop=True), pdf.reset_index(drop=True))
+        assert_frame_equal(psdf.reset_index(drop=True), pdf.reset_index(drop=True))
 
         # inplace
         pser = pdf.a
         psser = psdf.a
         pdf.reset_index(drop=True, inplace=True)
         psdf.reset_index(drop=True, inplace=True)
-        assertDataFrameEqual(psdf, pdf)
-        assertDataFrameEqual(psser, pser)
+        assert_frame_equal(psdf, pdf)
+        assert_frame_equal(psser, pser)
 
         pdf.columns = ["index", "b"]
         psdf.columns = ["index", "b"]
-        assertDataFrameEqual(psdf.reset_index(), pdf.reset_index())
+        assert_frame_equal(psdf.reset_index(), pdf.reset_index())
 
     def test_reset_index_with_default_index_types(self):
         pdf = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=np.random.rand(3))
         psdf = ps.from_pandas(pdf)
 
         with ps.option_context("compute.default_index_type", "sequence"):
-            assertDataFrameEqual(psdf.reset_index(), pdf.reset_index())
+            assert_frame_equal(psdf.reset_index(), pdf.reset_index())
 
         with ps.option_context("compute.default_index_type", "distributed-sequence"):
-            assertDataFrameEqual(psdf.reset_index(), pdf.reset_index())
+            assert_frame_equal(psdf.reset_index(), pdf.reset_index())
 
         with ps.option_context("compute.default_index_type", "distributed"):
             # the index is different.
-            assertDataFrameEqual(
+            assert_frame_equal(
                 psdf.reset_index()._to_pandas().reset_index(drop=True), pdf.reset_index()
             )
 
@@ -96,18 +96,18 @@ class FrameResetIndexMixin:
         )
         psdf = ps.from_pandas(pdf)
 
-        assertDataFrameEqual(psdf, pdf)
-        assertDataFrameEqual(psdf.reset_index(), pdf.reset_index())
-        assertDataFrameEqual(psdf.reset_index(level="class"), pdf.reset_index(level="class"))
-        assertDataFrameEqual(
+        assert_frame_equal(psdf, pdf)
+        assert_frame_equal(psdf.reset_index(), pdf.reset_index())
+        assert_frame_equal(psdf.reset_index(level="class"), pdf.reset_index(level="class"))
+        assert_frame_equal(
             psdf.reset_index(level="class", col_level=1),
             pdf.reset_index(level="class", col_level=1),
         )
-        assertDataFrameEqual(
+        assert_frame_equal(
             psdf.reset_index(level="class", col_level=1, col_fill="species"),
             pdf.reset_index(level="class", col_level=1, col_fill="species"),
         )
-        assertDataFrameEqual(
+        assert_frame_equal(
             psdf.reset_index(level="class", col_level=1, col_fill="genus"),
             pdf.reset_index(level="class", col_level=1, col_fill="genus"),
         )
@@ -118,19 +118,19 @@ class FrameResetIndexMixin:
         pdf.index.names = [("x", "class"), ("y", "name")]
         psdf.index.names = [("x", "class"), ("y", "name")]
 
-        assertDataFrameEqual(psdf.reset_index(), pdf.reset_index())
+        assert_frame_equal(psdf.reset_index(), pdf.reset_index())
 
         with self.assertRaisesRegex(ValueError, "Item must have length equal to number of levels."):
             psdf.reset_index(col_level=1)
 
     def test_index_to_frame_reset_index(self):
         def check(psdf, pdf):
-            assertDataFrameEqual(psdf.reset_index(), pdf.reset_index())
-            assertDataFrameEqual(psdf.reset_index(drop=True), pdf.reset_index(drop=True))
+            assert_frame_equal(psdf.reset_index(), pdf.reset_index())
+            assert_frame_equal(psdf.reset_index(drop=True), pdf.reset_index(drop=True))
 
             pdf.reset_index(drop=True, inplace=True)
             psdf.reset_index(drop=True, inplace=True)
-            assertDataFrameEqual(psdf, pdf)
+            assert_frame_equal(psdf, pdf)
 
         pdf, psdf = self.df_pair
         check(psdf.index.to_frame(), pdf.index.to_frame())

--- a/python/pyspark/pandas/tests/indexes/test_reset_index.py
+++ b/python/pyspark/pandas/tests/indexes/test_reset_index.py
@@ -22,7 +22,7 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
-from pyspark.pandas.testing import assert_frame_equal
+from pyspark.pandas.testing import assert_frame_equal, assert_index_equal
 
 
 class FrameResetIndexMixin:
@@ -44,7 +44,7 @@ class FrameResetIndexMixin:
         psdf = ps.from_pandas(pdf)
 
         assert_frame_equal(psdf.reset_index(), pdf.reset_index())
-        assert_frame_equal(psdf.reset_index().index, pdf.reset_index().index)
+        assert_index_equal(psdf.reset_index().index, pdf.reset_index().index)
         assert_frame_equal(psdf.reset_index(drop=True), pdf.reset_index(drop=True))
 
         pdf.index.name = "a"

--- a/python/pyspark/pandas/tests/indexes/test_reset_index.py
+++ b/python/pyspark/pandas/tests/indexes/test_reset_index.py
@@ -22,7 +22,7 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
-from pyspark.pandas.testing import assert_frame_equal, assert_index_equal
+from pyspark.pandas.testing import assert_frame_equal, assert_index_equal, assert_series_equal
 
 
 class FrameResetIndexMixin:
@@ -61,7 +61,7 @@ class FrameResetIndexMixin:
         pdf.reset_index(drop=True, inplace=True)
         psdf.reset_index(drop=True, inplace=True)
         assert_frame_equal(psdf, pdf)
-        assert_frame_equal(psser, pser)
+        assert_series_equal(psser, pser)
 
         pdf.columns = ["index", "b"]
         psdf.columns = ["index", "b"]

--- a/python/pyspark/pandas/tests/indexes/test_reset_index.py
+++ b/python/pyspark/pandas/tests/indexes/test_reset_index.py
@@ -22,6 +22,7 @@ import pandas as pd
 from pyspark import pandas as ps
 from pyspark.testing.pandasutils import PandasOnSparkTestCase
 from pyspark.testing.sqlutils import SQLTestUtils
+from pyspark.testing.utils import assertDataFrameEqual
 
 
 class FrameResetIndexMixin:
@@ -42,9 +43,9 @@ class FrameResetIndexMixin:
         pdf = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=np.random.rand(3))
         psdf = ps.from_pandas(pdf)
 
-        self.assert_eq(psdf.reset_index(), pdf.reset_index())
-        self.assert_eq(psdf.reset_index().index, pdf.reset_index().index)
-        self.assert_eq(psdf.reset_index(drop=True), pdf.reset_index(drop=True))
+        assertDataFrameEqual(psdf.reset_index(), pdf.reset_index())
+        assertDataFrameEqual(psdf.reset_index().index, pdf.reset_index().index)
+        assertDataFrameEqual(psdf.reset_index(drop=True), pdf.reset_index(drop=True))
 
         pdf.index.name = "a"
         psdf.index.name = "a"
@@ -52,33 +53,33 @@ class FrameResetIndexMixin:
         with self.assertRaisesRegex(ValueError, "cannot insert a, already exists"):
             psdf.reset_index()
 
-        self.assert_eq(psdf.reset_index(drop=True), pdf.reset_index(drop=True))
+        assertDataFrameEqual(psdf.reset_index(drop=True), pdf.reset_index(drop=True))
 
         # inplace
         pser = pdf.a
         psser = psdf.a
         pdf.reset_index(drop=True, inplace=True)
         psdf.reset_index(drop=True, inplace=True)
-        self.assert_eq(psdf, pdf)
-        self.assert_eq(psser, pser)
+        assertDataFrameEqual(psdf, pdf)
+        assertDataFrameEqual(psser, pser)
 
         pdf.columns = ["index", "b"]
         psdf.columns = ["index", "b"]
-        self.assert_eq(psdf.reset_index(), pdf.reset_index())
+        assertDataFrameEqual(psdf.reset_index(), pdf.reset_index())
 
     def test_reset_index_with_default_index_types(self):
         pdf = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=np.random.rand(3))
         psdf = ps.from_pandas(pdf)
 
         with ps.option_context("compute.default_index_type", "sequence"):
-            self.assert_eq(psdf.reset_index(), pdf.reset_index())
+            assertDataFrameEqual(psdf.reset_index(), pdf.reset_index())
 
         with ps.option_context("compute.default_index_type", "distributed-sequence"):
-            self.assert_eq(psdf.reset_index(), pdf.reset_index())
+            assertDataFrameEqual(psdf.reset_index(), pdf.reset_index())
 
         with ps.option_context("compute.default_index_type", "distributed"):
             # the index is different.
-            self.assert_eq(
+            assertDataFrameEqual(
                 psdf.reset_index()._to_pandas().reset_index(drop=True), pdf.reset_index()
             )
 
@@ -95,18 +96,18 @@ class FrameResetIndexMixin:
         )
         psdf = ps.from_pandas(pdf)
 
-        self.assert_eq(psdf, pdf)
-        self.assert_eq(psdf.reset_index(), pdf.reset_index())
-        self.assert_eq(psdf.reset_index(level="class"), pdf.reset_index(level="class"))
-        self.assert_eq(
+        assertDataFrameEqual(psdf, pdf)
+        assertDataFrameEqual(psdf.reset_index(), pdf.reset_index())
+        assertDataFrameEqual(psdf.reset_index(level="class"), pdf.reset_index(level="class"))
+        assertDataFrameEqual(
             psdf.reset_index(level="class", col_level=1),
             pdf.reset_index(level="class", col_level=1),
         )
-        self.assert_eq(
+        assertDataFrameEqual(
             psdf.reset_index(level="class", col_level=1, col_fill="species"),
             pdf.reset_index(level="class", col_level=1, col_fill="species"),
         )
-        self.assert_eq(
+        assertDataFrameEqual(
             psdf.reset_index(level="class", col_level=1, col_fill="genus"),
             pdf.reset_index(level="class", col_level=1, col_fill="genus"),
         )
@@ -117,19 +118,19 @@ class FrameResetIndexMixin:
         pdf.index.names = [("x", "class"), ("y", "name")]
         psdf.index.names = [("x", "class"), ("y", "name")]
 
-        self.assert_eq(psdf.reset_index(), pdf.reset_index())
+        assertDataFrameEqual(psdf.reset_index(), pdf.reset_index())
 
         with self.assertRaisesRegex(ValueError, "Item must have length equal to number of levels."):
             psdf.reset_index(col_level=1)
 
     def test_index_to_frame_reset_index(self):
         def check(psdf, pdf):
-            self.assert_eq(psdf.reset_index(), pdf.reset_index())
-            self.assert_eq(psdf.reset_index(drop=True), pdf.reset_index(drop=True))
+            assertDataFrameEqual(psdf.reset_index(), pdf.reset_index())
+            assertDataFrameEqual(psdf.reset_index(drop=True), pdf.reset_index(drop=True))
 
             pdf.reset_index(drop=True, inplace=True)
             psdf.reset_index(drop=True, inplace=True)
-            self.assert_eq(psdf, pdf)
+            assertDataFrameEqual(psdf, pdf)
 
         pdf, psdf = self.df_pair
         check(psdf.index.to_frame(), pdf.index.to_frame())


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR updates the [python/pyspark/pandas/tests/test_sql.py](https://github.com/apache/spark/blob/42e5daddf3ba16ff7d08e82e51cd8924cc56e180/python/pyspark/pandas/tests/indexes/test_reset_index.py#L46) to use the new PySpark test util function, assertDataFrameEqual, introduced in [SPARK-44042](https://issues.apache.org/jira/browse/SPARK-44042).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Use the new `assertDataFrameEqual` util function across all tests in PySpark

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing Tests 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No