### PR TITLE
[SPARK-47502][INFRA] Make output the installation packages in `descending size`, add `titles`, and remove `unused` packages

### DIFF
--- a/dev/free_disk_space
+++ b/dev/free_disk_space
@@ -21,8 +21,8 @@ echo "=================================="
 echo "Free up disk space on CI system"
 echo "=================================="
 
-echo "Listing 100 largest packages"
-dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
+echo "Listing top 100 largest packages (from large to small)"
+dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n -r | head -n 100
 df -h
 
 echo "Removing large packages"

--- a/dev/free_disk_space
+++ b/dev/free_disk_space
@@ -22,6 +22,7 @@ echo "Free up disk space on CI system"
 echo "=================================="
 
 echo "Listing top 100 largest packages (from large to small)"
+printf "Installed-Size\tPackage\n"
 dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n -r | head -n 100
 df -h
 

--- a/dev/free_disk_space_container
+++ b/dev/free_disk_space_container
@@ -21,8 +21,8 @@ echo "=================================="
 echo "Free up disk space on CI system"
 echo "=================================="
 
-echo "Listing 100 largest packages"
-dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
+echo "Listing top 100 largest packages (from large to small)"
+dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n -r | head -n 100
 df -h
 
 echo "Removing large packages"

--- a/dev/free_disk_space_container
+++ b/dev/free_disk_space_container
@@ -22,6 +22,7 @@ echo "Free up disk space on CI system"
 echo "=================================="
 
 echo "Listing top 100 largest packages (from large to small)"
+printf "Installed-Size\tPackage\n"
 dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n -r | head -n 100
 df -h
 
@@ -29,5 +30,15 @@ echo "Removing large packages"
 rm -rf /__t/CodeQL
 rm -rf /__t/go
 rm -rf /__t/node
+
+apt-get remove --purge -y '^aspnet.*'
+apt-get remove --purge -y '^dotnet-.*'
+apt-get remove --purge -y '^llvm-.*'
+apt-get remove --purge -y 'php.*'
+apt-get remove --purge -y '^mongodb-.*'
+apt-get remove --purge -y snapd google-chrome-stable microsoft-edge-stable firefox
+apt-get remove --purge -y azure-cli google-cloud-sdk mono-devel powershell libgl1-mesa-dri
+apt-get autoremove --purge -y
+apt-get clean
 
 df -h


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to:
- make the `size` of the `installed packages` output in the script `free_disk_space` and `free_disk_space_container` be output in `descending order`, and add `a header`.
- remove some unused installation packages in the container.

### Why are the changes needed?
Make the output content more `intuitive` and `natural`.

- Before:
  <img width="419" alt="image" src="https://github.com/apache/spark/assets/15246973/4a235903-e2e0-47be-b943-962d44e2ecba">

- After:
  <img width="547" alt="image" src="https://github.com/apache/spark/assets/15246973/36c1bdc6-c91b-4c04-ae66-46a403a4a2d1">

### Does this PR introduce _any_ user-facing change?
Yes, only for dev.


### How was this patch tested?
- Pass GA.
- Manually test.


### Was this patch authored or co-authored using generative AI tooling?
No.
