### PR TITLE
[SPARK-47499][PYTHON][CONNECT][TESTS] Enable `test_help_command` test

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_dataframe.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-import pydoc
 import unittest
 
 from pyspark.sql.tests.test_dataframe import DataFrameTestsMixin
@@ -25,9 +24,7 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 class DataFrameParityTests(DataFrameTestsMixin, ReusedConnectTestCase):
     def test_help_command(self):
         df = self.spark.createDataFrame(data=[{"foo": "bar"}, {"foo": "baz"}])
-        # render_doc() reproduces the help() exception without printing output
-        pydoc.render_doc(df)
-        pydoc.render_doc(df.foo)
+        super().check_help_command(df)
 
     # Spark Connect throws `IllegalArgumentException` when calling `collect` instead of `sample`.
     def test_sample(self):

--- a/python/pyspark/sql/tests/connect/test_parity_dataframe.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import pydoc
 import unittest
 
 from pyspark.sql.tests.test_dataframe import DataFrameTestsMixin
@@ -22,6 +23,12 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class DataFrameParityTests(DataFrameTestsMixin, ReusedConnectTestCase):
+    def test_help_command(self):
+        df = self.spark.createDataFrame(data=[{"foo": "bar"}, {"foo": "baz"}])
+        # render_doc() reproduces the help() exception without printing output
+        pydoc.render_doc(df)
+        pydoc.render_doc(df.foo)
+
     # Spark Connect throws `IllegalArgumentException` when calling `collect` instead of `sample`.
     def test_sample(self):
         super().test_sample()

--- a/python/pyspark/sql/tests/connect/test_parity_dataframe.py
+++ b/python/pyspark/sql/tests/connect/test_parity_dataframe.py
@@ -22,10 +22,6 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class DataFrameParityTests(DataFrameTestsMixin, ReusedConnectTestCase):
-    @unittest.skip("Spark Connect does not support RDD but the tests depend on them.")
-    def test_help_command(self):
-        super().test_help_command()
-
     # Spark Connect throws `IllegalArgumentException` when calling `collect` instead of `sample`.
     def test_sample(self):
         super().test_sample()

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -139,6 +139,9 @@ class DataFrameTestsMixin:
         rdd = self.sc.parallelize(['{"foo":"bar"}', '{"foo":"baz"}'])
         df = self.spark.read.json(rdd)
         # render_doc() reproduces the help() exception without printing output
+        self.check_help_command(df)
+
+    def check_help_command(self, df):
         pydoc.render_doc(df)
         pydoc.render_doc(df.foo)
         pydoc.render_doc(df.take(1))

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -136,7 +136,8 @@ class DataFrameTestsMixin:
 
     def test_help_command(self):
         # Regression test for SPARK-5464
-        df = self.spark.createDataFrame([Row(foo="bar"), Row(foo="baz")])
+        rdd = self.sc.parallelize(['{"foo":"bar"}', '{"foo":"baz"}'])
+        df = self.spark.read.json(rdd)
         # render_doc() reproduces the help() exception without printing output
         pydoc.render_doc(df)
         pydoc.render_doc(df.foo)

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -136,8 +136,7 @@ class DataFrameTestsMixin:
 
     def test_help_command(self):
         # Regression test for SPARK-5464
-        rdd = self.sc.parallelize(['{"foo":"bar"}', '{"foo":"baz"}'])
-        df = self.spark.read.json(rdd)
+        df = self.spark.createDataFrame([Row(foo="bar"), Row(foo="baz")])
         # render_doc() reproduces the help() exception without printing output
         pydoc.render_doc(df)
         pydoc.render_doc(df.foo)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Reuse `test_help_command` in Connect


### Why are the changes needed?
for test coverage

I checked [SPARK-5464](https://issues.apache.org/jira/browse/SPARK-5464) that it seems doesn't have to create this test dataframe from python RDD


### Does this PR introduce _any_ user-facing change?
no, test-only


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
