### PR TITLE
[SPARK-47511][SQL] Canonicalize With expressions by re-assigning IDs

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/With.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/With.scala
@@ -40,7 +40,7 @@ case class With(child: Expression, defs: Seq[CommonExpressionDef])
    * Builds a map of ids (originally assigned ids -> canonicalized ids) to be re-assigned during
    * canonicalization.
    */
-  protected lazy val canonicalizationIdMap: Map[Long, Long] = {
+  private lazy val canonicalizationIdMap: Map[Long, Long] = {
     // Start numbering after taking into account all nested With expression id maps.
     var currentId = child.map {
       case w: With => w.canonicalizationIdMap.size

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/With.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/With.scala
@@ -35,12 +35,84 @@ case class With(child: Expression, defs: Seq[CommonExpressionDef])
       newChildren: IndexedSeq[Expression]): Expression = {
     copy(child = newChildren.head, defs = newChildren.tail.map(_.asInstanceOf[CommonExpressionDef]))
   }
+
+  /**
+   * Builds a map of ids (originally assigned ids -> canonicalized ids) to be re-assigned during
+   * canonicalization.
+   */
+  protected lazy val canonicalizationIdMap: Map[Long, Long] = {
+    // Start numbering after taking into account all nested With expression id maps.
+    var currentId = child.map {
+      case w: With => w.canonicalizationIdMap.size
+      case _ => 0L
+    }.sum
+    defs.map { d =>
+      currentId += 1
+      d.id.id -> currentId
+    }.toMap
+  }
+
+  /**
+   * Canonicalize by re-assigning all ids in CommonExpressionRef's and CommonExpressionDef's
+   * starting from 0. This uses [[canonicalizationIdMap]], which contains all mappings for
+   * CommonExpressionDef's defined in this scope.
+   * Note that this takes into account nested With expressions by sharing a numbering scope (see
+   * [[canonicalizationIdMap]].
+   */
+  override lazy val canonicalized: Expression = copy(
+    child = child.transformWithPruning(_.containsPattern(COMMON_EXPR_REF)) {
+      case r: CommonExpressionRef if !r.id.canonicalized =>
+        r.copy(id = r.id.canonicalize(canonicalizationIdMap))
+    }.canonicalized,
+    defs = defs.map {
+      case d: CommonExpressionDef if !d.id.canonicalized =>
+        d.copy(id = d.id.canonicalize(canonicalizationIdMap)).canonicalized
+          .asInstanceOf[CommonExpressionDef]
+      case d => d.canonicalized.asInstanceOf[CommonExpressionDef]
+    }
+  )
+}
+
+object With {
+  /**
+   * Helper function to create a [[With]] statement with an arbitrary number of common expressions.
+   * Note that the number of arguments in `commonExprs` should be the same as the number of
+   * arguments taken by `replaced`.
+   *
+   * @param commonExprs list of common expressions
+   * @param replaced    closure that defines the common expressions in the main expression
+   * @return the expression returned by replaced with its arguments replaced by commonExprs in order
+   */
+  def apply(commonExprs: Expression*)(replaced: Seq[Expression] => Expression): With = {
+    val commonExprDefs = commonExprs.map(CommonExpressionDef(_))
+    val commonExprRefs = commonExprDefs.map(new CommonExpressionRef(_))
+    With(replaced(commonExprRefs), commonExprDefs)
+  }
+}
+
+case class CommonExpressionId(id: Long = CommonExpressionId.newId, canonicalized: Boolean = false) {
+  /**
+   * Re-assign to a canonicalized id based on idMap. If it is not found in idMap, the id is defined
+   * in an outer scope and will be replaced later.
+   */
+  def canonicalize(idMap: Map[Long, Long]): CommonExpressionId = {
+    if (idMap.contains(id)) {
+      copy(id = idMap(id), canonicalized = true)
+    } else {
+      this
+    }
+  }
+}
+
+object CommonExpressionId {
+  private[sql] val curId = new java.util.concurrent.atomic.AtomicLong()
+  def newId: Long = curId.getAndIncrement()
 }
 
 /**
  * A wrapper of common expression to carry the id.
  */
-case class CommonExpressionDef(child: Expression, id: Long = CommonExpressionDef.newId)
+case class CommonExpressionDef(child: Expression, id: CommonExpressionId = new CommonExpressionId())
   extends UnaryExpression with Unevaluable {
   override def dataType: DataType = child.dataType
   override protected def withNewChildInternal(newChild: Expression): Expression =
@@ -51,13 +123,8 @@ case class CommonExpressionDef(child: Expression, id: Long = CommonExpressionDef
  * A reference to the common expression by its id. Only resolved common expressions can be
  * referenced, so that we can determine the data type and nullable of the reference node.
  */
-case class CommonExpressionRef(id: Long, dataType: DataType, nullable: Boolean)
+case class CommonExpressionRef(id: CommonExpressionId, dataType: DataType, nullable: Boolean)
   extends LeafExpression with Unevaluable {
   def this(exprDef: CommonExpressionDef) = this(exprDef.id, exprDef.dataType, exprDef.nullable)
   override val nodePatterns: Seq[TreePattern] = Seq(COMMON_EXPR_REF)
-}
-
-object CommonExpressionDef {
-  private[sql] val curId = new java.util.concurrent.atomic.AtomicLong()
-  def newId: Long = curId.getAndIncrement()
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3372,6 +3372,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val REPLACE_NULLIF_USING_WITH_EXPR =
+    buildConf("spark.databricks.sql.replaceNullIfUsingWithExpr")
+      .internal()
+      .doc("When true, NullIf expressions are rewritten using With expressions to avoid " +
+        "expression duplication.")
+      .booleanConf
+      .createWithDefault(true)
+
   val USE_NULLS_FOR_MISSING_DEFAULT_COLUMN_VALUES =
     buildConf("spark.sql.defaultColumn.useNullsForMissingDefaultValues")
       .internal()

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CanonicalizeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CanonicalizeSuite.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.plans.logical.Range
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.MULTI_COMMUTATIVE_OP_OPT_THRESHOLD
-import org.apache.spark.sql.types.{BooleanType, Decimal, DecimalType, IntegerType, LongType, StringType, StructField, StructType, TimestampNTZType, TimestampType}
+import org.apache.spark.sql.types.{BooleanType, Decimal, DecimalType, DoubleType, IntegerType, LongType, StringType, StructField, StructType, TimestampNTZType, TimestampType}
 
 class CanonicalizeSuite extends SparkFunSuite {
 
@@ -350,5 +350,108 @@ class CanonicalizeSuite extends SparkFunSuite {
     val op = Add(literal1, Add(literal2, literal3))
     assert(op.canonicalized.toJSON.nonEmpty)
     SQLConf.get.setConfString(MULTI_COMMUTATIVE_OP_OPT_THRESHOLD.key, default.toString)
+  }
+
+  test("canonicalization of With expressions with one common expression") {
+    val expr = Divide(Literal.create(1, IntegerType), AttributeReference("a", IntegerType)())
+    val common1 = IsNull(With(expr.copy()) { case Seq(expr) =>
+      If(EqualTo(expr, Literal.create(0.0, DoubleType)), Literal.create(0.0, DoubleType), expr)
+    })
+    val common2 = IsNull(With(expr.copy()) { case Seq(expr) =>
+      If(EqualTo(expr, Literal.create(0.0, DoubleType)), Literal.create(0.0, DoubleType), expr)
+    })
+    // Check that canonicalization is consistent across multiple executions.
+    assert(common1.canonicalized == common2.canonicalized)
+    // Check that CommonExpressionDef starts ID'ing at 1 and that its child is canonicalized.
+    assert(common1.canonicalized.exists {
+      case d: CommonExpressionDef => d.id.id == 1 && d.child == expr.canonicalized
+      case _ => false
+    })
+    // Check that CommonExpressionRef ID corresponds to the def.
+    assert(common1.canonicalized.exists {
+      case r: CommonExpressionRef => r.id.id == 1
+      case _ => false
+    })
+  }
+
+  test("canonicalization of With expressions with multiple common expressions") {
+    val expr1 = Divide(Literal.create(1, IntegerType), AttributeReference("a", IntegerType)())
+    val expr2 = Multiply(Literal.create(2, IntegerType), AttributeReference("a", IntegerType)())
+    val common1 = With(expr1.copy(), expr2.copy()) { case Seq(expr1, expr2) =>
+      If(EqualTo(expr1, expr2), expr1, expr2)
+    }
+    val common2 = With(expr1.copy(), expr2.copy()) { case Seq(expr1, expr2) =>
+      If(EqualTo(expr1, expr2), expr1, expr2)
+    }
+    // Check that canonicalization is consistent across multiple executions.
+    assert(common1.canonicalized == common2.canonicalized)
+    // Check that CommonExpressionDef starts ID'ing at 1 and that its child is canonicalized.
+    assert(common1.canonicalized.exists {
+      case d: CommonExpressionDef => d.id.id == 1 && d.child == expr1.canonicalized
+      case _ => false
+    })
+    assert(common1.canonicalized.exists {
+      case d: CommonExpressionDef => d.id.id == 2 && d.child == expr2.canonicalized
+      case _ => false
+    })
+    // Check that CommonExpressionRef ID corresponds to the def.
+    assert(common1.canonicalized.exists {
+      case r: CommonExpressionRef => r.id.id == 1
+      case _ => false
+    })
+    assert(common1.canonicalized.exists {
+      case r: CommonExpressionRef => r.id.id == 2
+      case _ => false
+    })
+  }
+
+  test("canonicalization of With expressions with nested common expressions") {
+    val expr1 = AttributeReference("a", BooleanType)()
+    val expr2 = AttributeReference("b", BooleanType)()
+
+    val common1 = With(expr1) { case Seq(expr1) =>
+      Or(With(expr2) { case Seq(expr2) =>
+        And(EqualTo(expr1, expr2), EqualTo(expr1, expr2))
+      }, expr1)
+    }
+    val common2 = With(expr1) { case Seq(expr1) =>
+      Or(With(expr2) { case Seq(expr2) =>
+        And(EqualTo(expr1, expr2), EqualTo(expr1, expr2))
+      }, expr1)
+    }
+    // Check that canonicalization is consistent across multiple executions.
+    assert(common1.canonicalized == common2.canonicalized)
+    // Check that CommonExpressionDef starts ID'ing at 1 and that its child is canonicalized.
+    assert(common1.canonicalized.exists {
+      case d: CommonExpressionDef => d.id.id == 1 && d.child == expr2.canonicalized
+      case _ => false
+    })
+    assert(common1.canonicalized.exists {
+      case d: CommonExpressionDef => d.id.id == 2 && d.child == expr1.canonicalized
+      case _ => false
+    })
+    // Check that CommonExpressionRef ID corresponds to the def.
+    assert(common1.canonicalized.exists {
+      case r: CommonExpressionRef => r.id.id == 1
+      case _ => false
+    })
+    assert(common1.canonicalized.exists {
+      case r: CommonExpressionRef => r.id.id == 2
+      case _ => false
+    })
+
+    val common3 = With(expr1.newInstance()) { case Seq(expr1) =>
+      Or(With(expr2.newInstance()) { case Seq(expr2) =>
+        And(EqualTo(expr1, expr2), EqualTo(expr1, expr2))
+      }, expr1)
+    }
+    val common4 = With(expr1.newInstance()) { case Seq(expr1) =>
+      Or(With(expr2.newInstance()) { case Seq(expr2) =>
+        And(EqualTo(expr2, expr1), EqualTo(expr2, expr1))
+      }, expr1)
+    }
+    // Check that canonicalization for two different expressions with similar structures is
+    // different.
+    assert(common3.canonicalized != common4.canonicalized)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR changes the canonicalization of `With` expressions to re-assign IDs starting from 0.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This ensures that the canonicalization of `With` expressions is consistent.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added unit tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.