### PR TITLE
[MINOR][DOCS] Fix typo in spark connect overview

### DIFF
--- a/docs/spark-connect-overview.md
+++ b/docs/spark-connect-overview.md
@@ -224,7 +224,7 @@ For the Scala shell, we use an Ammonite-based REPL that is currently not include
 To set up the new Scala shell, first download and install [Coursier CLI](https://get-coursier.io/docs/cli-installation).
 Then, install the REPL using the following command in a terminal window:
 {% highlight bash %}
-cs install –-contrib spark-connect-repl
+cs install --contrib spark-connect-repl
 {% endhighlight %}
 
 And now you can start the Ammonite-based Scala REPL/shell to connect to your Spark server like this:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix typo in the command to install the `spark-connect-repl` by substituting the `en-dash` char by the `hyphen-minus`.

### Why are the changes needed?
It doesn't work with the `en-dash`.

### Does this PR introduce _any_ user-facing change?
Only documentation.

### How was this patch tested?
The documentation was built and the output checked manually.

### Was this patch authored or co-authored using generative AI tooling?
No.
