### PR TITLE
[SPARK-47512][SS] Tag operation type used with RocksDB state store instance lock acquisition/release

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -244,7 +244,7 @@
       },
       "UNRELEASED_THREAD_ERROR" : {
         "message" : [
-          "<loggingId>: RocksDB instance could not be acquired by <newAcquiredThreadInfo> as it was not released by <acquiredThreadInfo> after <timeWaitedMs> ms.",
+          "<loggingId>: RocksDB instance could not be acquired by <newAcquiredThreadInfo> for operationType=<operationType> as it was not released by <acquiredThreadInfo> after <timeWaitedMs> ms.",
           "Thread holding the lock has trace: <stackTraceOutput>"
         ]
       }

--- a/docs/sql-error-conditions-cannot-load-state-store-error-class.md
+++ b/docs/sql-error-conditions-cannot-load-state-store-error-class.md
@@ -68,7 +68,7 @@ Version cannot be `<version>` because it is less than 0.
 
 ## UNRELEASED_THREAD_ERROR
 
-`<loggingId>`: RocksDB instance could not be acquired by `<newAcquiredThreadInfo>` as it was not released by `<acquiredThreadInfo>` after `<timeWaitedMs>` ms.
+`<loggingId>`: RocksDB instance could not be acquired by `<newAcquiredThreadInfo>` for operationType=`<operationType>` as it was not released by `<acquiredThreadInfo>` after `<timeWaitedMs>` ms.
 Thread holding the lock has trace: `<stackTraceOutput>`
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2561,6 +2561,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
 
   def unreleasedThreadError(
       loggingId: String,
+      opType: String,
       newAcquiredThreadInfo: String,
       acquiredThreadInfo: String,
       timeWaitedMs: Long,
@@ -2569,6 +2570,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       errorClass = "CANNOT_LOAD_STATE_STORE.UNRELEASED_THREAD_ERROR",
       messageParameters = Map(
         "loggingId" -> loggingId,
+        "operationType" -> opType,
         "newAcquiredThreadInfo" -> newAcquiredThreadInfo,
         "acquiredThreadInfo" -> acquiredThreadInfo,
         "timeWaitedMs" -> timeWaitedMs.toString,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -40,6 +40,16 @@ import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.util.{NextIterator, Utils}
 
+// RocksDB operations that could acquire/release the instance lock
+sealed abstract class RocksDBOpType(name: String) {
+  override def toString: String = name
+}
+case object LoadStore extends RocksDBOpType("load_store")
+case object RollbackStore extends RocksDBOpType("rollback_store")
+case object CloseStore extends RocksDBOpType("close_store")
+case object ReportStoreMetrics extends RocksDBOpType("report_store_metrics")
+case object StoreTaskCompletionListener extends RocksDBOpType("store_task_completion_listener")
+
 /**
  * Class representing a RocksDB instance that checkpoints version of data to DFS.
  * After a set of updates, a new version can be committed by calling `commit()`.
@@ -163,7 +173,7 @@ class RocksDB(
    */
   def load(version: Long, readOnly: Boolean = false): RocksDB = {
     assert(version >= 0)
-    acquire("load_store")
+    acquire(LoadStore)
     recordedMetrics = None
     logInfo(s"Loading $version")
     try {
@@ -607,7 +617,7 @@ class RocksDB(
     } finally {
       // reset resources as either 1) we already pushed the changes and it has been committed or
       // 2) commit has failed and the current version is "invalidated".
-      release()
+      release(LoadStore)
     }
   }
 
@@ -646,13 +656,13 @@ class RocksDB(
    * Drop uncommitted changes, and roll back to previous version.
    */
   def rollback(): Unit = {
-    acquire("rollback_store")
+    acquire(RollbackStore)
     numKeysOnWritingVersion = numKeysOnLoadedVersion
     loadedVersion = -1L
     changelogWriter.foreach(_.abort())
     // Make sure changelogWriter gets recreated next time.
     changelogWriter = None
-    release()
+    release(RollbackStore)
     logInfo(s"Rolled back to $loadedVersion")
   }
 
@@ -670,7 +680,7 @@ class RocksDB(
   def close(): Unit = {
     try {
       // Acquire DB instance lock and release at the end to allow for synchronized access
-      acquire("close_store")
+      acquire(CloseStore)
       closeDB()
 
       readOptions.close()
@@ -686,7 +696,7 @@ class RocksDB(
       case e: Exception =>
         logWarning("Error closing RocksDB", e)
     } finally {
-      release()
+      release(CloseStore)
     }
   }
 
@@ -759,18 +769,24 @@ class RocksDB(
   def metricsOpt: Option[RocksDBMetrics] = {
     var rocksDBMetricsOpt: Option[RocksDBMetrics] = None
     try {
-      acquire("report_store_metrics")
+      acquire(ReportStoreMetrics)
       rocksDBMetricsOpt = recordedMetrics
     } catch {
       case ex: Exception =>
         logInfo(s"Failed to acquire metrics with exception=$ex")
     } finally {
-      release()
+      release(ReportStoreMetrics)
     }
     rocksDBMetricsOpt
   }
 
-  private def acquire(opType: String): Unit = acquireLock.synchronized {
+  /**
+   * Function to acquire RocksDB instance lock that allows for synchronized access to the state
+   * store instance
+   *
+   * @param opType - operation type requesting the lock
+   */
+  private def acquire(opType: RocksDBOpType): Unit = acquireLock.synchronized {
     val newAcquiredThreadInfo = AcquiredThreadInfo()
     val waitStartTime = System.currentTimeMillis
     def timeWaitedMs = System.currentTimeMillis - waitStartTime
@@ -783,18 +799,27 @@ class RocksDB(
     }
     if (isAcquiredByDifferentThread) {
       val stackTraceOutput = acquiredThreadInfo.threadRef.get.get.getStackTrace.mkString("\n")
-      throw QueryExecutionErrors.unreleasedThreadError(loggingId, opType,
+      throw QueryExecutionErrors.unreleasedThreadError(loggingId, opType.toString,
         newAcquiredThreadInfo.toString(), acquiredThreadInfo.toString(), timeWaitedMs,
         stackTraceOutput)
     } else {
       acquiredThreadInfo = newAcquiredThreadInfo
       // Add a listener to always release the lock when the task (if active) completes
-      Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit] { _ => this.release() })
-      logInfo(s"RocksDB instance was acquired by $acquiredThreadInfo for opType=$opType")
+      Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit] {
+        _ => this.release(StoreTaskCompletionListener)
+      })
+      logInfo(s"RocksDB instance was acquired by $acquiredThreadInfo for opType=${opType.toString}")
     }
   }
 
-  private def release(): Unit = acquireLock.synchronized {
+  /**
+   * Function to release RocksDB instance lock that allows for synchronized access to the state
+   * store instance
+   *
+   * @param opType - operation type releasing the lock
+   */
+  private def release(opType: RocksDBOpType): Unit = acquireLock.synchronized {
+    logInfo(s"RocksDB instance was released by $acquiredThreadInfo for opType=${opType.toString}")
     acquiredThreadInfo = null
     acquireLock.notifyAll()
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -1337,6 +1337,7 @@ class RocksDBSuite extends AlsoTestWithChangelogCheckpointingEnabled with Shared
           errorClass = "CANNOT_LOAD_STATE_STORE.UNRELEASED_THREAD_ERROR",
           parameters = Map(
             "loggingId" -> "\\[Thread-\\d+\\]",
+            "operationType" -> "load_store",
             "newAcquiredThreadInfo" -> "\\[ThreadId: Some\\(\\d+\\)\\]",
             "acquiredThreadInfo" -> "\\[ThreadId: Some\\(\\d+\\)\\]",
             "timeWaitedMs" -> "\\d+",
@@ -1364,6 +1365,7 @@ class RocksDBSuite extends AlsoTestWithChangelogCheckpointingEnabled with Shared
           errorClass = "CANNOT_LOAD_STATE_STORE.UNRELEASED_THREAD_ERROR",
           parameters = Map(
             "loggingId" -> "\\[Thread-\\d+\\]",
+            "operationType" -> "load_store",
             "newAcquiredThreadInfo" -> "\\[ThreadId: Some\\(\\d+\\)\\]",
             "acquiredThreadInfo" -> "\\[ThreadId: Some\\(\\d+\\)\\]",
             "timeWaitedMs" -> "\\d+",


### PR DESCRIPTION
### What changes were proposed in this pull request?
Tag operation type used with RocksDB state store instance lock acquisition/release

### Why are the changes needed?
Currently its impossible to tell which operation/thread tried to acquire/release the RocksDB instance lock which is crucial in debugging issues around RocksDB instance lock acquisition


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added unit tests

```
[info] RocksDBSuite:
12:34:41.365 WARN org.apache.hadoop.util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
[info] - disallow concurrent updates to the same RocksDB instance - with colFamiliesEnabled=true (with changelog checkpointing) (1 second, 634 milliseconds)
[info] - disallow concurrent updates to the same RocksDB instance - with colFamiliesEnabled=true (without changelog checkpointing) (654 milliseconds)
[info] - disallow concurrent updates to the same RocksDB instance - with colFamiliesEnabled=false (with changelog checkpointing) (609 milliseconds)
[info] - disallow concurrent updates to the same RocksDB instance - with colFamiliesEnabled=false (without changelog checkpointing) (584 milliseconds)
12:34:45.319 WARN org.apache.spark.sql.execution.streaming.state.RocksDBSuite:
```

Verified updated logs
```
sql/core/target/unit-tests.log:1958:13:38:41.698 concurrent-test-thread-3 INFO RocksDB [Thread-17]: RocksDB instance was acquired by [ThreadId: Some(158)] for opType=load_store
sql/core/target/unit-tests.log:2235:13:38:41.886 concurrent-test-thread-3 INFO RocksDB [Thread-17]: RocksDB instance was released by [ThreadId: Some(158)] for opType=load_store
sql/core/target/unit-tests.log:2236:13:38:41.886 pool-1-thread-1-ScalaTest-running-RocksDBSuite INFO RocksDB [Thread-17]: RocksDB instance was acquired by [ThreadId: Some(17)] for opType=close_store
sql/core/target/unit-tests.log:2239:13:38:41.889 pool-1-thread-1-ScalaTest-running-RocksDBSuite INFO RocksDB [Thread-17]: RocksDB instance was released by [ThreadId: Some(17)] for opType=close_store
sql/core/target/unit-tests.log:2249:13:38:41.896 pool-1-thread-1-ScalaTest-running-RocksDBSuite INFO RocksDB [Thread-17]: RocksDB instance was acquired by [ThreadId: Some(17)] for opType=load_store
sql/core/target/unit-tests.log:2518:13:38:41.950 pool-1-thread-1-ScalaTest-running-RocksDBSuite INFO RocksDB [Thread-17]: RocksDB instance was acquired by [ThreadId: Some(17)] for opType=load_store
sql/core/target/unit-tests.log:2562:13:38:42.139 pool-1-thread-1-ScalaTest-running-RocksDBSuite INFO RocksDB [Thread-17]: RocksDB instance was released by [ThreadId: Some(17)] for opType=load_store
sql/core/target/unit-tests.log:2563:13:38:42.139 concurrent-test-thread-2 INFO RocksDB [Thread-17]: RocksDB instance was acquired by [ThreadId: Some(181)] for opType=load_store
sql/core/target/unit-tests.log:2607:13:38:42.293 concurrent-test-thread-2 INFO RocksDB [Thread-17]: RocksDB instance was released by [ThreadId: Some(181)] for opType=load_store
sql/core/target/unit-tests.log:2608:13:38:42.293 pool-1-thread-1-ScalaTest-running-RocksDBSuite INFO RocksDB [Thread-17]: RocksDB instance was acquired by [ThreadId: Some(17)] for opType=load_store
sql/core/target/unit-tests.log:2611:13:38:42.319 pool-1-thread-1-ScalaTest-running-RocksDBSuite INFO RocksDB [Thread-17]: RocksDB instance was acquired by [ThreadId: Some(17)] for opType=rollback_store
sql/core/target/unit-tests.log:2612:13:38:42.319 pool-1-thread-1-ScalaTest-running-RocksDBSuite INFO RocksDB [Thread-17]: RocksDB instance was released by [ThreadId: Some(17)] for opType=rollback_store
sql/core/target/unit-tests.log:2614:13:38:42.319 concurrent-test-thread-3 INFO RocksDB [Thread-17]: RocksDB instance was acquired by [ThreadId: Some(193)] for opType=load_store
sql/core/target/unit-tests.log:2942:13:38:42.525 concurrent-test-thread-3 INFO RocksDB [Thread-17]: RocksDB instance was released by [ThreadId: Some(193)] for opType=load_store
```

### Was this patch authored or co-authored using generative AI tooling?
No