### PR TITLE
protobuf google wrappers backport to scala 2.12

### DIFF
--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/ProtobufDeserializer.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/ProtobufDeserializer.scala
@@ -193,6 +193,11 @@ private[sql] class ProtobufDeserializer(
       case (INT, ShortType) =>
         (updater, ordinal, value) => updater.setShort(ordinal, value.asInstanceOf[Short])
 
+      case (INT, LongType) =>
+        (updater, ordinal, value) =>
+          updater.setLong(
+            ordinal,
+            Integer.toUnsignedLong(value.asInstanceOf[Int]))
       case  (
         MESSAGE | BOOLEAN | INT | FLOAT | DOUBLE | LONG | STRING | ENUM | BYTE_STRING,
         ArrayType(dataType: DataType, containsNull)) if protoType.isRepeated =>
@@ -200,6 +205,13 @@ private[sql] class ProtobufDeserializer(
 
       case (LONG, LongType) =>
         (updater, ordinal, value) => updater.setLong(ordinal, value.asInstanceOf[Long])
+
+      case (LONG, DecimalType.LongDecimal) =>
+        (updater, ordinal, value) =>
+          updater.setDecimal(
+            ordinal,
+            Decimal.fromString(
+              UTF8String.fromString(java.lang.Long.toUnsignedString(value.asInstanceOf[Long]))))
 
       case (FLOAT, FloatType) =>
         (updater, ordinal, value) => updater.setFloat(ordinal, value.asInstanceOf[Float])

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/ProtobufSerializer.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/ProtobufSerializer.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.protobuf
 
 import scala.collection.JavaConverters._
 
-import com.google.protobuf.{Duration, DynamicMessage, Timestamp}
+import com.google.protobuf.{Duration, DynamicMessage, Timestamp, WireFormat}
 import com.google.protobuf.Descriptors.{Descriptor, FieldDescriptor}
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType._
 
@@ -91,8 +91,17 @@ private[sql] class ProtobufSerializer(
         (getter, ordinal) => {
           getter.getInt(ordinal)
         }
+      case (LongType, INT) if fieldDescriptor.getLiteType == WireFormat.FieldType.UINT32 =>
+        (getter, ordinal) => {
+          getter.getLong(ordinal).toInt
+        }
       case (LongType, LONG) =>
         (getter, ordinal) => getter.getLong(ordinal)
+      case (DecimalType(), LONG)
+        if fieldDescriptor.getLiteType == WireFormat.FieldType.UINT64 =>
+        (getter, ordinal) => {
+          getter.getDecimal(ordinal, 20, 0).toUnscaledLong
+        }
       case (FloatType, FLOAT) =>
         (getter, ordinal) => getter.getFloat(ordinal)
       case (DoubleType, DOUBLE) =>

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/ProtobufSerializer.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/ProtobufSerializer.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.protobuf
 
 import scala.collection.JavaConverters._
 
-import com.google.protobuf.{Duration, DynamicMessage, Timestamp, WireFormat}
+import com.google.protobuf.{BoolValue, ByteString, BytesValue, DoubleValue, Duration, DynamicMessage, FloatValue, Int32Value, Int64Value, StringValue, Timestamp, UInt32Value, UInt64Value, WireFormat}
 import com.google.protobuf.Descriptors.{Descriptor, FieldDescriptor}
 import com.google.protobuf.Descriptors.FieldDescriptor.JavaType._
 
@@ -172,6 +172,52 @@ private[sql] class ProtobufSerializer(
           // `ArrayList` backed by the specified array without data copying.
           java.util.Arrays.asList(result: _*)
         }
+
+      // Handle serializing primitives back into well known wrapper types.
+      case (BooleanType, MESSAGE)
+        if fieldDescriptor.getMessageType.getFullName == BoolValue.getDescriptor.getFullName =>
+        (getter, ordinal) =>
+          BoolValue.of(getter.getBoolean(ordinal))
+
+      case (IntegerType, MESSAGE)
+        if fieldDescriptor.getMessageType.getFullName == Int32Value.getDescriptor.getFullName =>
+        (getter, ordinal) =>
+          Int32Value.of(getter.getInt(ordinal))
+
+      case (IntegerType, MESSAGE)
+        if fieldDescriptor.getMessageType.getFullName == UInt32Value.getDescriptor.getFullName =>
+        (getter, ordinal) =>
+          UInt32Value.of(getter.getInt(ordinal))
+
+      case (LongType, MESSAGE)
+        if fieldDescriptor.getMessageType.getFullName == Int64Value.getDescriptor.getFullName =>
+        (getter, ordinal) =>
+          Int64Value.of(getter.getLong(ordinal))
+
+      case (LongType, MESSAGE)
+        if fieldDescriptor.getMessageType.getFullName == UInt64Value.getDescriptor.getFullName =>
+        (getter, ordinal) =>
+          UInt64Value.of(getter.getLong(ordinal))
+
+      case (StringType, MESSAGE)
+        if fieldDescriptor.getMessageType.getFullName == StringValue.getDescriptor.getFullName =>
+        (getter, ordinal) =>
+          StringValue.of(getter.getUTF8String(ordinal).toString)
+
+      case (BinaryType, MESSAGE)
+        if fieldDescriptor.getMessageType.getFullName == BytesValue.getDescriptor.getFullName =>
+        (getter, ordinal) =>
+          BytesValue.of(ByteString.copyFrom(getter.getBinary(ordinal)))
+
+      case (FloatType, MESSAGE)
+        if fieldDescriptor.getMessageType.getFullName == FloatValue.getDescriptor.getFullName =>
+        (getter, ordinal) =>
+          FloatValue.of(getter.getFloat(ordinal))
+
+      case (DoubleType, MESSAGE)
+        if fieldDescriptor.getMessageType.getFullName == DoubleValue.getDescriptor.getFullName =>
+        (getter, ordinal) =>
+          DoubleValue.of(getter.getDouble(ordinal))
 
       case (st: StructType, MESSAGE) =>
         val structConverter =

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
@@ -168,6 +168,18 @@ private[sql] class ProtobufOptions(
   // instead of string, so use caution if changing existing parsing logic.
   val enumsAsInts: Boolean =
     parameters.getOrElse("enums.as.ints", false.toString).toBoolean
+
+  // Protobuf supports unsigned integer types uint32 and uint64. By default this library
+  // will serialize them as the signed IntegerType and LongType respectively. For very
+  // large unsigned values this can cause overflow, causing these numbers
+  // to be represented as negative (above 2^31 for uint32
+  // and above 2^63 for uint64).
+  //
+  // Enabling this option will upcast unsigned integers into a larger type,
+  // i.e. LongType for uint32 and Decimal(20, 0) for uint64 so their representation
+  // can contain large unsigned values without overflow.
+  val upcastUnsignedInts: Boolean =
+    parameters.getOrElse("upcast.unsigned.ints", false.toString).toBoolean
 }
 
 private[sql] object ProtobufOptions {

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/ProtobufOptions.scala
@@ -180,6 +180,33 @@ private[sql] class ProtobufOptions(
   // can contain large unsigned values without overflow.
   val upcastUnsignedInts: Boolean =
     parameters.getOrElse("upcast.unsigned.ints", false.toString).toBoolean
+
+  // Whether to unwrap the struct representation for well known primitve wrapper types when
+  // deserializing. By default, the wrapper types for primitives (i.e. google.protobuf.Int32Value,
+  // google.protobuf.Int64Value, etc.) will get deserialized as structs. We allow the option to
+  // deserialize them as their respective primitives.
+  // https://protobuf.dev/reference/protobuf/google.protobuf/
+  //
+  // For example, given a message like:
+  // ```
+  // syntax = "proto3";
+  // message Example {
+  //   google.protobuf.Int32Value int_val = 1;
+  // }
+  // ```
+  //
+  // The message Example(Int32Value(1)) would be deserialized by default as
+  // {int_val: {value: 5}}
+  //
+  // However, with this option set, it would be deserialized as
+  // {int_val: 5}
+  //
+  // NOTE: With `emit.default.values`, we won't fill in the default primitive value during
+  // this unwrapping; this behavior preserves as much information as possible.
+  // Concretely, the behavior with emit defaults and this option set is:
+  //    nil => nil, Int32Value(0) => 0, Int32Value(100) => 100.
+  val unwrapWellKnownTypes: Boolean =
+    parameters.getOrElse("unwrap.primitive.wrapper.types", false.toString).toBoolean
 }
 
 private[sql] object ProtobufOptions {

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/SchemaConverters.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/SchemaConverters.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.protobuf.utils
 
 import scala.collection.JavaConverters._
 
+import com.google.protobuf.{BoolValue, BytesValue, DoubleValue, FloatValue, Int32Value, Int64Value, StringValue, UInt32Value, UInt64Value}
 import com.google.protobuf.Descriptors.{Descriptor, FieldDescriptor}
 import com.google.protobuf.WireFormat
 
@@ -103,8 +104,46 @@ object SchemaConverters extends Logging {
           fd.getMessageType.getFields.get(1).getName.equals("nanos")) =>
         Some(TimestampType)
       case MESSAGE if protobufOptions.convertAnyFieldsToJson &&
-            fd.getMessageType.getFullName == "google.protobuf.Any" =>
+        fd.getMessageType.getFullName == "google.protobuf.Any" =>
         Some(StringType) // Any protobuf will be parsed and converted to json string.
+
+      // Unwrap well known primitive wrapper types if the option has been set.
+      case MESSAGE if fd.getMessageType.getFullName == BoolValue.getDescriptor.getFullName
+        && protobufOptions.unwrapWellKnownTypes =>
+        Some(BooleanType)
+      case MESSAGE if fd.getMessageType.getFullName == Int32Value.getDescriptor.getFullName
+        && protobufOptions.unwrapWellKnownTypes =>
+        Some(IntegerType)
+      case MESSAGE if fd.getMessageType.getFullName == UInt32Value.getDescriptor.getFullName
+        && protobufOptions.unwrapWellKnownTypes =>
+        if (protobufOptions.upcastUnsignedInts) {
+          Some(LongType)
+        } else {
+          Some(IntegerType)
+        }
+      case MESSAGE if fd.getMessageType.getFullName == Int64Value.getDescriptor.getFullName
+        && protobufOptions.unwrapWellKnownTypes =>
+        Some(LongType)
+      case MESSAGE if fd.getMessageType.getFullName == UInt64Value.getDescriptor.getFullName
+        && protobufOptions.unwrapWellKnownTypes =>
+        if (protobufOptions.upcastUnsignedInts) {
+          Some(DecimalType.LongDecimal)
+        } else {
+          Some(LongType)
+        }
+      case MESSAGE if fd.getMessageType.getFullName == StringValue.getDescriptor.getFullName
+        && protobufOptions.unwrapWellKnownTypes =>
+        Some(StringType)
+      case MESSAGE if fd.getMessageType.getFullName == BytesValue.getDescriptor.getFullName
+        && protobufOptions.unwrapWellKnownTypes =>
+        Some(BinaryType)
+      case MESSAGE if fd.getMessageType.getFullName == FloatValue.getDescriptor.getFullName
+        && protobufOptions.unwrapWellKnownTypes =>
+        Some(FloatType)
+      case MESSAGE if fd.getMessageType.getFullName == DoubleValue.getDescriptor.getFullName
+        && protobufOptions.unwrapWellKnownTypes =>
+        Some(DoubleType)
+
       case MESSAGE if fd.isRepeated && fd.getMessageType.getOptions.hasMapEntry =>
         var keyType: Option[DataType] = None
         var valueType: Option[DataType] = None

--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/SchemaConverters.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/utils/SchemaConverters.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.protobuf.utils
 import scala.collection.JavaConverters._
 
 import com.google.protobuf.Descriptors.{Descriptor, FieldDescriptor}
+import com.google.protobuf.WireFormat
 
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.internal.Logging
@@ -67,9 +68,22 @@ object SchemaConverters extends Logging {
       existingRecordNames: Map[String, Int],
       protobufOptions: ProtobufOptions): Option[StructField] = {
     import com.google.protobuf.Descriptors.FieldDescriptor.JavaType._
+
     val dataType = fd.getJavaType match {
-      case INT => Some(IntegerType)
-      case LONG => Some(LongType)
+      // When the protobuf type is unsigned and upcastUnsignedIntegers has been set,
+      // use a larger type (LongType and Decimal(20,0) for uint32 and uint64).
+      case INT =>
+        if (fd.getLiteType == WireFormat.FieldType.UINT32 && protobufOptions.upcastUnsignedInts) {
+          Some(LongType)
+        } else {
+          Some(IntegerType)
+        }
+      case LONG => if (fd.getLiteType == WireFormat.FieldType.UINT64
+          && protobufOptions.upcastUnsignedInts) {
+        Some(DecimalType.LongDecimal)
+      } else {
+        Some(LongType)
+      }
       case FLOAT => Some(FloatType)
       case DOUBLE => Some(DoubleType)
       case BOOLEAN => Some(BooleanType)

--- a/connector/protobuf/src/test/resources/protobuf/functions_suite.proto
+++ b/connector/protobuf/src/test/resources/protobuf/functions_suite.proto
@@ -27,6 +27,7 @@ import "timestamp.proto";
 import "duration.proto";
 import "basicmessage.proto";
 import "google/protobuf/any.proto";
+import "google/protobuf/wrappers.proto";
 
 option java_outer_classname = "SimpleMessageProtos";
 
@@ -323,4 +324,20 @@ message Proto3AllTypes {
     string option_b = 12;
   }
   map<string, string> map = 13;
+}
+
+message WellKnownWrapperTypes {
+  google.protobuf.BoolValue bool_val = 1;
+  google.protobuf.Int32Value int32_val = 2;
+  google.protobuf.UInt32Value uint32_val = 3;
+  google.protobuf.Int64Value int64_val = 4;
+  google.protobuf.UInt64Value uint64_val = 5;
+  google.protobuf.StringValue string_val = 6;
+  google.protobuf.BytesValue bytes_val = 7;
+  google.protobuf.FloatValue float_val = 8;
+  google.protobuf.DoubleValue double_val = 9;
+
+  // Sample repeated and map types
+  repeated google.protobuf.Int32Value int32_list = 10;
+  map<int32, google.protobuf.StringValue> wkt_map = 11;
 }

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
@@ -1590,6 +1590,52 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
     }
   }
 
+  test("test unsigned integer types") {
+    // Test that we correctly handle unsigned integer parsing.
+    // We're using Integer/Long's `MIN_VALUE` as it has a 1 in the sign bit.
+    val sample = spark.range(1).select(
+      lit(
+        SimpleMessage
+          .newBuilder()
+          .setUint32Value(Integer.MIN_VALUE)
+          .setUint64Value(Long.MinValue)
+          .build()
+          .toByteArray
+      ).as("raw_proto"))
+
+    val expectedWithoutFlag = spark.range(1).select(
+      lit(Integer.MIN_VALUE).as("uint32_value"),
+      lit(Long.MinValue).as("uint64_value")
+    )
+
+    val expectedWithFlag = spark.range(1).select(
+      lit(Integer.toUnsignedLong(Integer.MIN_VALUE).longValue).as("uint32_value"),
+      lit(BigDecimal(java.lang.Long.toUnsignedString(Long.MinValue))).as("uint64_value")
+    )
+
+    checkWithFileAndClassName("SimpleMessage") { case (name, descFilePathOpt) =>
+      List(
+        Map.empty[String, String],
+        Map("upcast.unsigned.ints" -> "false")).foreach(opts => {
+        checkAnswer(
+          sample.select(
+              from_protobuf_wrapper($"raw_proto", name, descFilePathOpt, opts).as("proto"))
+            .select("proto.uint32_value", "proto.uint64_value"),
+          expectedWithoutFlag)
+      })
+
+      checkAnswer(
+        sample.select(
+            from_protobuf_wrapper(
+              $"raw_proto",
+              name,
+              descFilePathOpt,
+              Map("upcast.unsigned.ints" -> "true")).as("proto"))
+          .select("proto.uint32_value", "proto.uint64_value"),
+        expectedWithFlag)
+    }
+  }
+
 
   def testFromProtobufWithOptions(
     df: DataFrame,

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
@@ -21,12 +21,12 @@ import java.time.Duration
 
 import scala.collection.JavaConverters._
 
-import com.google.protobuf.{Any => AnyProto, ByteString, DynamicMessage}
+import com.google.protobuf.{Any => AnyProto, BoolValue, ByteString, BytesValue, DoubleValue, DynamicMessage, FloatValue, Int32Value, Int64Value, StringValue, UInt32Value, UInt64Value}
 import org.json4s.StringInput
 import org.json4s.jackson.JsonMethods
 
 import org.apache.spark.sql.{AnalysisException, Column, DataFrame, QueryTest, Row}
-import org.apache.spark.sql.functions.{lit, struct, typedLit}
+import org.apache.spark.sql.functions.{array, lit, map, struct, typedLit}
 import org.apache.spark.sql.protobuf.protos.Proto2Messages.Proto2AllTypes
 import org.apache.spark.sql.protobuf.protos.SimpleMessageProtos._
 import org.apache.spark.sql.protobuf.protos.SimpleMessageProtos.SimpleMessageRepeated.NestedEnum
@@ -1636,6 +1636,281 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
     }
   }
 
+
+  test("well known types deserialization and round trip") {
+    val message = spark.range(1).select(
+      lit(WellKnownWrapperTypes
+        .newBuilder()
+        .setBoolVal(BoolValue.of(true))
+        .setInt32Val(Int32Value.of(100))
+        .setUint32Val(UInt32Value.of(200))
+        .setInt64Val(Int64Value.of(300))
+        .setUint64Val(UInt64Value.of(400))
+        .setStringVal(StringValue.of("string"))
+        .setBytesVal(BytesValue.of(ByteString.copyFromUtf8("bytes")))
+        .setFloatVal(FloatValue.of(1.23f))
+        .setDoubleVal(DoubleValue.of(4.56))
+        .addInt32List(Int32Value.of(1))
+        .addInt32List(Int32Value.of(2))
+        .putWktMap(1, StringValue.of("mapval"))
+        .build().toByteArray
+      ).as("raw_proto"))
+
+    // By default, well known wrapper types should come out as structs.
+    val expectedWithoutFlag = spark.range(1).select(
+      struct(
+        struct(lit(true) as ("value")).as("bool_val"),
+        struct(lit(100).as("value")).as("int32_val"),
+        struct(lit(200).as("value")).as("uint32_val"),
+        struct(lit(300).as("value")).as("int64_val"),
+        struct(lit(400).as("value")).as("uint64_val"),
+        struct(lit("string").as("value")).as("string_val"),
+        struct(lit("bytes".getBytes).as("value")).as("bytes_val"),
+        struct(lit(1.23f).as("value")).as("float_val"),
+        struct(lit(4.56).as("value")).as("double_val"),
+        array(struct(lit(1).as("value")), struct(lit(2).as("value"))).as("int32_list"),
+        map(lit(1), struct(lit("mapval").as("value"))).as("wkt_map")
+      ).as("proto")
+    )
+
+    // With the flag set, ensure that well known wrapper types get deserialized as primitives.
+    val expectedWithFlag = spark.range(1).select(
+      struct(
+        lit(true).as("bool_val"),
+        lit(100).as("int32_val"),
+        lit(200).as("uint32_val"),
+        lit(300).as("int64_val"),
+        lit(400).as("uint64_val"),
+        lit("string").as("string_val"),
+        lit("bytes".getBytes).as("bytes_val"),
+        lit(1.23f).as("float_val"),
+        lit(4.56).as("double_val"),
+        typedLit(List(1, 2)).as("int32_list"),
+        typedLit(Map(1 -> "mapval")).as("wkt_map")
+      ).as("proto")
+    )
+
+    checkWithFileAndClassName("WellKnownWrapperTypes") { case (name, descFilePathOpt) =>
+      // With the option as false, ensure that deserialization works, and the
+      // value can be round-tripped.
+      List(Map.empty[String, String], Map("unwrap.primitive.wrapper.types" -> "false"))
+        .foreach(opts => {
+        val parsed = message.select(from_protobuf_wrapper(
+          $"raw_proto",
+          name,
+          descFilePathOpt,
+          opts).as("parsed"))
+        checkAnswer(parsed, expectedWithoutFlag)
+
+        // Verify that round-tripping gives us the same parsed representation.
+        val reserialized = parsed.select(
+          to_protobuf_wrapper($"parsed", name, descFilePathOpt).as("reserialized"))
+        val reparsed = reserialized.select(
+          from_protobuf_wrapper($"reserialized", name, descFilePathOpt, opts).as("reparsed"))
+        checkAnswer(parsed, reparsed)
+      })
+
+      // Without the option not set or set as false, ensure that the deserialization is as
+      // expected and that round-tripping works.
+      val opt = Map("unwrap.primitive.wrapper.types" -> "true")
+      val parsed = message.select(from_protobuf_wrapper(
+        $"raw_proto",
+        name,
+        descFilePathOpt,
+        opt).as("parsed"))
+      checkAnswer(parsed, expectedWithFlag)
+
+      val reserialized = parsed.select(
+        to_protobuf_wrapper($"parsed", name, descFilePathOpt).as("reserialized"))
+      val reparsed = reserialized.select(
+        from_protobuf_wrapper($"reserialized", name, descFilePathOpt, opt).as("reparsed"))
+      checkAnswer(parsed, reparsed)
+    }
+  }
+
+  test("test well known wrappers with emit defaults") {
+    // Test that the emit defaults behavior and unwrap primitives behavior work correctly together.
+    // We'll go through when a well known wrapper type is not set, set to zero, or set to nonzero
+    // and show the behavior of deserialization under every combination of the
+    // "unwrap.primitive.wrapper.types" and "emit.default.values" flags.
+
+    // Setup test data for the three cases of unset, explicitly zero, and non-zero.
+    val unset = spark.range(1).select(
+      lit(
+        WellKnownWrapperTypes.newBuilder().build().toByteArray
+      ).as("raw_proto"))
+
+    val explicitZero = spark.range(1).select(
+      lit(
+        WellKnownWrapperTypes.newBuilder().setInt32Val(Int32Value.of(0)).build().toByteArray
+      ).as("raw_proto"))
+
+    val explicitNonzero = spark.range(1).select(
+      lit(
+        WellKnownWrapperTypes.newBuilder().setInt32Val(Int32Value.of(100)).build().toByteArray
+      ).as("raw_proto"))
+
+    val expectedEmpty = spark.range(1).select(lit(null).as("int32_val"))
+
+    // For all combinations of unwrap / emitDefaults, check that we get back the expected values.
+    checkWithFileAndClassName("WellKnownWrapperTypes") { case (name, descFilePathOpt) =>
+      for {
+        unwrap <- Seq("true", "false")
+        defaults <- Seq("true", "false")
+      } {
+        // For unset values, we'll always get back null.
+        checkAnswer(
+          unset.select(
+            from_protobuf_wrapper(
+              $"raw_proto",
+              name,
+              descFilePathOpt,
+              Map("unwrap.primitive.wrapper.types" -> unwrap, "emit.default.values" -> defaults)
+            ).as("proto")
+          ).select("proto.int32_val"),
+          expectedEmpty
+        )
+
+        // For explicit zero, we should get back null or zero based on emit default values.
+        val parsedExplicitZero =
+          explicitZero.select(
+            from_protobuf_wrapper(
+              $"raw_proto",
+              name,
+              descFilePathOpt,
+              Map("unwrap.primitive.wrapper.types" -> unwrap, "emit.default.values" -> defaults)
+            ).as("proto")
+          ).select("proto.int32_val")
+
+        if (unwrap == "false") {
+          if (defaults == "false") {
+            checkAnswer(
+              parsedExplicitZero,
+              spark.range(1).select(
+                struct(lit(null).as("value"))
+              ).as("int32_val")
+            )
+          } else {
+            checkAnswer(
+              parsedExplicitZero,
+              spark.range(1).select(
+                struct(lit(0).as("value"))
+              ).as("int32_val")
+            )
+          }
+        } else {
+          if (defaults == "false") {
+            checkAnswer(parsedExplicitZero, expectedEmpty)
+          } else {
+            checkAnswer(parsedExplicitZero, Seq((0)).toDF("int32_val"))
+          }
+        }
+
+        // For nonzero, we should get back the number or wrapped version regardless
+        // of the value of emit defaults.
+        val parsedNonzero =
+          explicitNonzero.select(
+            from_protobuf_wrapper(
+              $"raw_proto",
+              name,
+              descFilePathOpt,
+              Map("unwrap.primitive.wrapper.types" -> unwrap, "emit.default.values" -> defaults)
+            ).as("proto")
+          ).select("proto.int32_val")
+
+        if (unwrap == "true") {
+          checkAnswer(parsedNonzero, Seq((100)).toDF("int32_val"))
+        } else {
+          checkAnswer(
+            parsedNonzero,
+            spark.range(1).select(
+              struct(lit(100).as("value")).as("int32_val")
+            )
+          )
+        }
+      }
+    }
+  }
+
+  test("test well known wrappers with upcast ints") {
+    // Test that the unwrap primitives behavior and upcast uint64 work correctly together.
+    // We'll check the deserialization behavior under every combination of the
+    // "unwrap.primitive.wrapper.types" and "emit.default.values" flags.
+
+    // Set up an example df with negative integer/long values, which have 1 in the largest bit.
+    // When interpreted as unsigned instead, they'd be large numbers.
+    // Integer.MIN_VALUE + 4 = 1000 <28 0s> 0100 = -2147483644 = 2147483652
+    // Long.MinValue + 4 = 1000 <60 0s> 0100 = -9223372036854775804 = 9223372036854775812
+    val originalInt = Integer.MIN_VALUE + 4
+    val originalLong = Long.MinValue + 4
+    val unsignedInt = 2147483652L
+    val unsignedLong = BigDecimal("9223372036854775812")
+
+    val unsigned = spark.range(1).select(
+      lit(
+        WellKnownWrapperTypes.newBuilder()
+          .setUint32Val(UInt32Value.of(originalInt))
+          .setUint64Val(UInt64Value.of(originalLong))
+          .build().toByteArray
+      ).as("raw_proto"))
+
+
+    // For every combination of unwrap/upcast, check that we get the correct values back.
+    checkWithFileAndClassName("WellKnownWrapperTypes") { case (name, descFilePathOpt) =>
+      for {
+        unwrap <- Seq("true", "false")
+        upcast <- Seq("true", "false")
+      } {
+        val parsed = unsigned.select(
+          from_protobuf_wrapper(
+            $"raw_proto",
+            name,
+            descFilePathOpt,
+            Map("unwrap.primitive.wrapper.types" -> unwrap, "upcast.unsigned.ints" -> upcast)
+          ).as("proto")
+        ).select("proto.uint32_val", "proto.uint64_val")
+
+        if (unwrap == "false") {
+          if (upcast == "false") {
+            // unwrap=false, upcast=false should give back negative numbers in struct format.
+            checkAnswer(
+              parsed,
+              spark.range(1).select(
+                struct(lit(originalInt).as("value")).as("uint32_value"),
+                struct(lit(originalLong).as("value")).as("uint64_value")
+              ).as("int32_val")
+            )
+          } else {
+            // unwrap=false, upcast=true should give back large positive numbers in struct format.
+            checkAnswer(
+              parsed,
+              spark.range(1).select(
+                 struct(lit(unsignedInt).as("value")).as("uint32_value"),
+                 struct(lit(unsignedLong).as("value")).as("uint64_value")
+              ).as("int32_val")
+            )
+          }
+        }
+        else {
+          // unwrap=true, upcast=false should give back negative primitives.
+          if (upcast == "false") {
+            checkAnswer(parsed,
+              spark.range(1).select(
+                lit(originalInt).as("uint32_value"),
+                lit(originalLong).as("uint64_value")
+              ))
+          } else {
+            // unwrap=true, upcast=true should give back large positive primitives.
+            checkAnswer(parsed,
+              spark.range(1).select(
+                lit(unsignedInt).as("uint32_value"),
+                lit(unsignedLong).as("uint64_value")
+              ))
+          }
+        }
+      }
+    }
+  }
 
   def testFromProtobufWithOptions(
     df: DataFrame,


### PR DESCRIPTION
## Custom Spark-Protobuf module fork

We have a custom fork of spark-protobuf module maintained by ibises with couple cherry-picked changes from main branch into 3.5 branch. Namely:
[SPARK-43427][PROTOBUF] spark protobuf: allow upcasting unsigned integer types
[SPARK-44001][PROTOBUF] Add option to allow unwrapping protobuf well known wrapper types

Spark has dropped support for Scala version 2.12 which is needed to run our app on AWS EMR 