### PR TITLE
[MINOR][PYTHON][DOCS] Fix typos in `PandasCogroupedOps.applyInArrow`

### DIFF
--- a/python/pyspark/sql/pandas/group_ops.py
+++ b/python/pyspark/sql/pandas/group_ops.py
@@ -641,7 +641,7 @@ class PandasCogroupedOps:
         a :class:`DataFrame`.
 
         The `schema` should be a :class:`StructType` describing the schema of the returned
-        `pandas.DataFrame`. The column labels of the returned `pandas.DataFrame` must either match
+        `pyarrow.Table`. The column labels of the returned `pyarrow.Table` must either match
         the field names in the defined schema if specified as strings, or match the
         field data types by position if not strings, e.g. integer indices.
         The length of the returned `pyarrow.Table` can be arbitrary.


### PR DESCRIPTION
### What changes were proposed in this pull request?
fix two typos

### Why are the changes needed?
the returned dataframe should be `pyarrow.Table` other than `pandas.DataFrame`


### Does this PR introduce _any_ user-facing change?
yes, doc fix


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no