### PR TITLE
[MINOR] Improve SparkPi example

### DIFF
--- a/examples/src/main/scala/org/apache/spark/examples/SparkPi.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkPi.scala
@@ -26,12 +26,23 @@ import org.apache.spark.sql.functions.{lit, random, sum, when}
 /** Computes an approximation to pi */
 object SparkPi {
   def main(args: Array[String]): Unit = {
+    if (args.length == 0) {
+      System.out.println("Consider providing number of partitions and size of each partition " +
+        "as first and second argument.")
+    }
+
+    val partitions = if (args.length > 0) args(0).toInt else 2
+    val samplesPerPartition = if (args.length > 1) args(1).toLong else 100000L
+
+    System.out.println("Computing PI with " +
+      partitions + " partitions" + (if (args.length < 1) " (default)" else "") + " and " +
+      samplesPerPartition + " samples per partition" + (if (args.length < 2) " (default)" else "")
+    )
+
     val spark = SparkSession
       .builder()
       .appName("Spark Pi")
       .getOrCreate()
-    val partitions = if (args.length > 0) args(0).toInt else 2
-    val samplesPerPartition = if (args.length > 1) args(1).toLong else 100000L
     val N = samplesPerPartition * partitions
     val rand = random() * 2 - 1
     val count = spark.range(0, N, 1, partitions)

--- a/examples/src/main/scala/org/apache/spark/examples/SparkPi.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkPi.scala
@@ -31,7 +31,8 @@ object SparkPi {
       .appName("Spark Pi")
       .getOrCreate()
     val partitions = if (args.length > 0) args(0).toInt else 2
-    val N = 100000L * partitions
+    val samplesPerPartition = if (args.length > 1) args(1).toLong else 100000L
+    val N = samplesPerPartition * partitions
     val rand = random() * 2 - 1
     val count = spark.range(0, N, 1, partitions)
       .select(rand.as("x"), rand.as("y"))

--- a/examples/src/main/scala/org/apache/spark/examples/SparkPi.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkPi.scala
@@ -44,13 +44,12 @@ object SparkPi {
     import spark.implicits._
 
     val N = rowsPerPartition * partitions
-    val rand = random() * 2 - 1
     val count = spark.range(0, N, 1, partitions)
-      .select(rand.as("x"), rand.as("y"))
+      .select((random() * 2 - 1).as("x"), (random() * 2 - 1).as("y"))
       .select(sum(when($"x" * $"x" + $"y" * $"y" <= 1, lit(1))))
       .as[Long]
       .head()
-    println(s"Pi is roughly ${4.0 * count / (N - 1)}")
+    println(s"Pi is roughly ${4.0 * count / N}")
     spark.stop()
   }
 }

--- a/examples/src/main/scala/org/apache/spark/examples/SparkPi.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkPi.scala
@@ -30,11 +30,11 @@ object SparkPi {
     }
 
     val partitions = if (args.length > 0) args(0).toInt else 2
-    val samplesPerPartition = if (args.length > 1) args(1).toLong else 100000L
+    val rowsPerPartition = if (args.length > 1) args(1).toLong else 100000L
 
-    System.out.println("Computing PI with " +
+    System.out.println("Computing Pi with " +
       partitions + " partitions" + (if (args.length < 1) " (default)" else "") + " and " +
-      samplesPerPartition + " samples per partition" + (if (args.length < 2) " (default)" else "")
+      rowsPerPartition + " rows per partition" + (if (args.length < 2) " (default)" else "")
     )
 
     val spark = SparkSession
@@ -43,7 +43,7 @@ object SparkPi {
       .getOrCreate()
     import spark.implicits._
 
-    val N = samplesPerPartition * partitions
+    val N = rowsPerPartition * partitions
     val rand = random() * 2 - 1
     val count = spark.range(0, N, 1, partitions)
       .select(rand.as("x"), rand.as("y"))

--- a/examples/src/main/scala/org/apache/spark/examples/SparkPi.scala
+++ b/examples/src/main/scala/org/apache/spark/examples/SparkPi.scala
@@ -18,8 +18,6 @@
 // scalastyle:off println
 package org.apache.spark.examples
 
-import scala.math.random
-
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions.{lit, random, sum, when}
 
@@ -43,6 +41,8 @@ object SparkPi {
       .builder()
       .appName("Spark Pi")
       .getOrCreate()
+    import spark.implicits._
+
     val N = samplesPerPartition * partitions
     val rand = random() * 2 - 1
     val count = spark.range(0, N, 1, partitions)


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Allow setting partition size (samples per partition)
- Print available options

### Why are the changes needed?
The partitions are very small (100k rows), which is not suitable to exemplify compute-expensive workload. These changes allow to run the `SparkPi` example for long durations with high CPU load.

### Does this PR introduce _any_ user-facing change?
Adds another option to the `SparkPi` example.

### How was this patch tested?
Manually.

### Was this patch authored or co-authored using generative AI tooling?
No