### PR TITLE
[MINOR][PYTHON][DOCS] Fix a `pandas_udf` example

### DIFF
--- a/python/pyspark/sql/pandas/functions.py
+++ b/python/pyspark/sql/pandas/functions.py
@@ -153,7 +153,7 @@ def pandas_udf(f=None, returnType=None, functionType=None):
         +------------------+
         |split_expand(name)|
         +------------------+
-        |       [John, Doe]|
+        |       {John, Doe}|
         +------------------+
 
         This type of Pandas UDF can use keyword arguments:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix a `pandas_udf` example


### Why are the changes needed?
checked in both spark connect and vanilla spark, the return type is a struct type other than array type

```
In [33]:         >>> @pandas_udf("first string, last string")
    ...:         ... def split_expand(s: pd.Series) -> pd.DataFrame:
    ...:         ...     return s.str.split(expand=True)
    ...:         ...
    ...:         >>> df = spark.createDataFrame([("John Doe",)], ("name",))
    ...:         >>> df.select(split_expand("name")).show()
+------------------+
|split_expand(name)|
+------------------+
|       {John, Doe}|
+------------------+


In [34]: df.select(split_expand("name")).printSchema()
root
 |-- split_expand(name): struct (nullable = true)
 |    |-- first: string (nullable = true)
 |    |-- last: string (nullable = true)
```

other pandas udf examples in this file are fine

### Does this PR introduce _any_ user-facing change?
yes, doc changes


### How was this patch tested?
manually check

### Was this patch authored or co-authored using generative AI tooling?
no
