### PR TITLE
[SPARK-47536][BUILD] Upgrade `jmock-junit5` to 2.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1202,7 +1202,7 @@
         <groupId>org.jmock</groupId>
         <artifactId>jmock-junit5</artifactId>
         <scope>test</scope>
-        <version>2.12.0</version>
+        <version>2.13.1</version>
       </dependency>
       <dependency>
         <groupId>org.scalacheck</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr upgrade `jmock-junit5` from 2.12.0 to 2.13.1. 


### Why are the changes needed?
`jmock-junit5` is a part of `jmock`, and this upgrade fixes a bug:

- https://github.com/jmock-developers/jmock-library/issues/155

The full release notes as follows:
- https://github.com/jmock-developers/jmock-library/releases/tag/2.13.0
- https://github.com/jmock-developers/jmock-library/releases/tag/2.13.1

### Does this PR introduce _any_ user-facing change?
No,just a test lib upgrade.


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
