### PR TITLE
[SPARK-47517][INFRA][FOLLOWUP] Prevent `byteCountToDisplaySize` via Scalastyle

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -482,6 +482,11 @@ This file is divided into 3 sections:
     <customMessage>Avoid using CompoundOrdering due to CVE-2018-10237.</customMessage>
   </check>
 
+  <check customId="byteCountToDisplaySize" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+    <parameters><parameter name="regex">byteCountToDisplaySize</parameter></parameters>
+    <customMessage>Use Utils.bytesToString instead of byteCountToDisplaySize for consistency.</customMessage>
+  </check>
+
   <check customId="pathfromuri" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
     <parameters><parameter name="regex">new Path\(new URI\(</parameter></parameters>
     <customMessage><![CDATA[


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of https://github.com/apache/spark/pull/45660 .

### Why are the changes needed?

To prevent a future regression.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs. Also, I checked manually.
```
$ dev/scalastyle
Using SPARK_LOCAL_IP=localhost
Scalastyle checks passed.
```

### Was this patch authored or co-authored using generative AI tooling?

No.