### PR TITLE
[SPARK-47530][BUILD][TESTS] Add `bcpkix-jdk18on` test dependencies to `hive` module for Hadoop 3.4.0

### DIFF
--- a/sql/hive/pom.xml
+++ b/sql/hive/pom.xml
@@ -73,6 +73,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <version>${bouncycastle.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-hadoop</artifactId>
       <version>${parquet.version}</version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `bcpkix-jdk18on` test dependencies to `hive` module for Hadoop 3.4.0

### Why are the changes needed?

Currently, Maven CI fails at `hive` testing.
- https://github.com/apache/spark/actions/runs/8375388663/job/22968799123

Like #45317 , it seems that we need this in `hive` module for Maven testing.

- #45317

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test

**BEFORE**
```
$ build/mvn --pl sql/hive -Dtest=none -DwildcardSuites=org.apache.spark.sql.hive.StatisticsSuite test
...
Run completed in 36 seconds, 868 milliseconds.
Total number of tests run: 52
Suites: completed 2, aborted 0
Tests: succeeded 51, failed 1, canceled 0, ignored 0, pending 0
*** 1 TEST FAILED ***
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:01 min
[INFO] Finished at: 2024-03-23T20:03:50-07:00
[INFO] ------------------------------------------------------------------------
```

**AFTER**
```
$ build/mvn --pl sql/hive -Dtest=none -DwildcardSuites=org.apache.spark.sql.hive.StatisticsSuite test
...
Run completed in 37 seconds, 962 milliseconds.
Total number of tests run: 52
Suites: completed 2, aborted 0
Tests: succeeded 52, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  52.897 s
[INFO] Finished at: 2024-03-23T19:53:55-07:00
[INFO] ------------------------------------------------------------------------
```

### Was this patch authored or co-authored using generative AI tooling?

No.