### PR TITLE
[SPARK-47533][BUILD] Migrate scalafmt dialect to `scala213`

### DIFF
--- a/dev/.scalafmt.conf
+++ b/dev/.scalafmt.conf
@@ -26,10 +26,5 @@ optIn = {
 danglingParentheses.preset = false
 docstrings.style = Asterisk
 maxColumn = 98
-runner.dialect = scala212
-fileOverride {
-  "glob:**/src/**/scala-2.13/**.scala" {
-    runner.dialect = scala213
-  }
-}
+runner.dialect = scala213
 version = 3.8.0


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to migrate `scalafmt dialect` from `scala212` to `scala213`.

### Why are the changes needed?
In the Spark version `4.0.0`, the version  `scala2.12 ` is no longer supported.  During our migration from `scala2.12` to `scala2.13`, this should be migrated synchronously.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Manually test.
- Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
