### PR TITLE
[SPARK-47503][SQL][3.5] Make makeDotNode escape graph node name always

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ui/SparkPlanGraph.scala
@@ -189,7 +189,8 @@ class SparkPlanGraphNode(
     } else {
       // SPARK-30684: when there is no metrics, add empty lines to increase the height of the node,
       // so that there won't be gaps between an edge and a small node.
-      s"""  $id [labelType="html" label="<br><b>$name</b><br><br>"];"""
+      val escapedName = StringEscapeUtils.escapeJava(name)
+      s"""  $id [labelType="html" label="<br><b>$escapedName</b><br><br>"];"""
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SparkPlanGraphSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ui/SparkPlanGraphSuite.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.ui
+
+import org.apache.spark.SparkFunSuite
+
+class SparkPlanGraphSuite extends SparkFunSuite {
+  test("SPARK-47503: name of a node should be escaped even if there is no metrics") {
+    val planGraphNode = new SparkPlanGraphNode(
+      id = 24,
+      name = "Scan JDBCRelation(\"test-schema\".tickets) [numPartitions=1]",
+      desc = "Scan JDBCRelation(\"test-schema\".tickets) [numPartitions=1] " +
+        "[ticket_no#0] PushedFilters: [], ReadSchema: struct<ticket_no:string>",
+      metrics = List(
+        SQLPlanMetric(
+          name = "number of output rows",
+          accumulatorId = 75,
+          metricType = "sum"
+        ),
+        SQLPlanMetric(
+          name = "JDBC query execution time",
+          accumulatorId = 35,
+          metricType = "nsTiming")))
+    val dotNode = planGraphNode.makeDotNode(Map.empty[Long, String])
+    val expectedDotNode = "  24 [labelType=\"html\" label=\"<br><b>" +
+      "Scan JDBCRelation(\\\"test-schema\\\".tickets) [numPartitions=1]</b><br><br>\"];"
+
+    assertResult(expectedDotNode)(dotNode)
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a backport of https://github.com/apache/spark/pull/45640

To prevent corruption of dot file a node name should be escaped even if there is no metrics to display

### Why are the changes needed?

This pr fixes a bug in spark history server which fails to display query for cached JDBC relation named in quotes.

### Does this PR introduce any user-facing change?
No.

### How was this patch tested?
Unit test.

### Was this patch authored or co-authored using generative AI tooling?
 No.