### PR TITLE
[SPARK-47534][SQL] Move `o.a.s.variant` to `o.a.s.types.variant`

### DIFF
--- a/common/variant/src/main/java/org/apache/spark/types/variant/Variant.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/Variant.java
@@ -15,11 +15,26 @@
  * limitations under the License.
  */
 
-package org.apache.spark.variant;
+package org.apache.spark.types.variant;
 
 /**
- * An exception indicating that we are attempting to build a variant with it value or metadata
- * exceeding the 16MiB size limit.
+ * This class is structurally equivalent to {@link org.apache.spark.unsafe.types.VariantVal}. We
+ * define a new class to avoid depending on or modifying Spark.
  */
-public class VariantSizeLimitException extends RuntimeException {
+public final class Variant {
+  private final byte[] value;
+  private final byte[] metadata;
+
+  public Variant(byte[] value, byte[] metadata) {
+    this.value = value;
+    this.metadata = metadata;
+  }
+
+  public byte[] getValue() {
+    return value;
+  }
+
+  public byte[] getMetadata() {
+    return metadata;
+  }
 }

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.variant;
+package org.apache.spark.types.variant;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.exc.InputCoercionException;
 
-import static org.apache.spark.variant.VariantUtil.*;
+import static org.apache.spark.types.variant.VariantUtil.*;
 
 /**
  * Build variant value and metadata by parsing JSON values.

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantSizeLimitException.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantSizeLimitException.java
@@ -15,26 +15,11 @@
  * limitations under the License.
  */
 
-package org.apache.spark.variant;
+package org.apache.spark.types.variant;
 
 /**
- * This class is structurally equivalent to {@link org.apache.spark.unsafe.types.VariantVal}. We
- * define a new class to avoid depending on or modifying Spark.
+ * An exception indicating that we are attempting to build a variant with it value or metadata
+ * exceeding the 16MiB size limit.
  */
-public final class Variant {
-  private final byte[] value;
-  private final byte[] metadata;
-
-  public Variant(byte[] value, byte[] metadata) {
-    this.value = value;
-    this.metadata = metadata;
-  }
-
-  public byte[] getValue() {
-    return value;
-  }
-
-  public byte[] getMetadata() {
-    return metadata;
-  }
+public class VariantSizeLimitException extends RuntimeException {
 }

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantUtil.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantUtil.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.variant;
+package org.apache.spark.types.variant;
 
 /**
  * This class defines constants related to the variant format and provides functions for

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/variantExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/variantExpressions.scala
@@ -24,8 +24,8 @@ import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
 import org.apache.spark.sql.catalyst.util.BadRecordException
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.types._
+import org.apache.spark.types.variant.{VariantBuilder, VariantSizeLimitException, VariantUtil}
 import org.apache.spark.unsafe.types._
-import org.apache.spark.variant._
 
 // scalastyle:off line.size.limit
 @ExpressionDescription(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionSuite.scala
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.catalyst.expressions
+package org.apache.spark.sql.catalyst.expressions.variant
 
 import org.apache.spark.{SparkException, SparkFunSuite, SparkRuntimeException}
-import org.apache.spark.sql.catalyst.expressions.variant._
+import org.apache.spark.sql.catalyst.expressions.{ExpressionEvalHelper, Literal}
+import org.apache.spark.types.variant.VariantUtil._
 import org.apache.spark.unsafe.types.VariantVal
-import org.apache.spark.variant.VariantUtil._
 
 class VariantExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
   test("parse_json") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

According to https://github.com/apache/spark/pull/45479#pullrequestreview-1946939461, this PR aims to rename `variant` package and the corresponding test suite like the following.
```
- package org.apache.spark.variant;
+ package org.apache.spark.types.variant;
```

```
$ git diff master --stat
 common/variant/src/main/java/org/apache/spark/{ => types}/variant/Variant.java                                   | 2 +-
 common/variant/src/main/java/org/apache/spark/{ => types}/variant/VariantBuilder.java                            | 4 ++--
 common/variant/src/main/java/org/apache/spark/{ => types}/variant/VariantSizeLimitException.java                 | 2 +-
 common/variant/src/main/java/org/apache/spark/{ => types}/variant/VariantUtil.java                               | 2 +-
 sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/variantExpressions.scala           | 2 +-
 sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/{ => variant}/VariantExpressionSuite.scala | 6 +++---
 6 files changed, 9 insertions(+), 9 deletions(-)
```

### Why are the changes needed?

To make it clear that `variant` package is related to be a type.

### Does this PR introduce _any_ user-facing change?

No. This package is new in Apache Spark 4.0.0.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.