### PR TITLE
[SPARK-47535][INFRA] Update `publish_snapshot.yml` to publish twice per day

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -21,7 +21,7 @@ name: Publish Snapshot
 
 on:
   schedule:
-  - cron: '0 0 * * *'
+  - cron: '0 0,12 * * *'
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to publish Apache Spark snapshot twice per day instead of once.

### Why are the changes needed?

To catch up the change more frequently during Apache Spark 4.0.0 preparation, for example, like the following PR
- https://github.com/apache/spark/pull/45685

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.