### PR TITLE
[SPARK-47539][SQL][FOLLOWUP] Fix UT about `variant`

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ToPrettyStringSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ToPrettyStringSuite.scala
@@ -121,8 +121,7 @@ class ToPrettyStringSuite extends SparkFunSuite with ExpressionEvalHelper {
   }
 
   test("Variant as pretty strings") {
-    checkEvaluation(
-      ToPrettyString(Literal(new VariantVal(Array[Byte](1, 2, 3), Array[Byte](4, 5)))),
-      UTF8String.fromBytes(Array[Byte](1, 2, 3)).toString)
+    val v = new VariantVal(Array[Byte](1, 2, 3), Array[Byte](1, 1))
+    checkEvaluation(ToPrettyString(Literal(v)), UTF8String.fromString(v.toString))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix `conflict UT` by https://github.com/apache/spark/pull/45575 `Support to_json(variant)`

Closes #45697
Closes #45698

### Why are the changes needed?
Fix master GA break.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Manually test.
  <img width="1091" alt="image" src="https://github.com/apache/spark/assets/15246973/aa52542a-96f4-4f3a-86a5-d4f8b7bc209d">
  ./build/sbt "catalyst/testOnly org.apache.spark.sql.catalyst.expressions.ToPrettyStringSuite"
  <img width="516" alt="image" src="https://github.com/apache/spark/assets/15246973/58a16367-f324-4673-89d8-69e5ea61e32c">

- Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
No.
