### PR TITLE
[SPARK-47546][SQL] Improve validation when reading Variant from Parquet

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetSchemaConverter.scala
@@ -402,7 +402,7 @@ class ParquetToSparkSchemaConverter(
   }
 
   private def convertVariantField(groupColumn: GroupColumnIO): ParquetColumn = {
-    if (groupColumn.getChildrenCount != 2 ) {
+    if (groupColumn.getChildrenCount != 2) {
       // We may allow more than two children in the future, so consider this unsupported.
       throw QueryCompilationErrors.
         parquetTypeUnsupportedYetError("variant with more than two fields")
@@ -417,8 +417,8 @@ class ParquetToSparkSchemaConverter(
       val child = groupColumn.getChild(idx.get)
       // The value and metadata cannot be individually null, only the full struct can.
       if (child.getType.getRepetition != REQUIRED ||
-        !child.isInstanceOf[PrimitiveColumnIO] ||
-        child.asInstanceOf[PrimitiveColumnIO].getPrimitive != BINARY) {
+          !child.isInstanceOf[PrimitiveColumnIO] ||
+          child.asInstanceOf[PrimitiveColumnIO].getPrimitive != BINARY) {
         throw QueryCompilationErrors.illegalParquetTypeError(
           s"variant $colName must be a non-nullable binary")
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/VariantSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/VariantSuite.scala
@@ -193,7 +193,7 @@ class VariantSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("invalid variant binary") {
+  test("SPARK-47546: invalid variant binary") {
     // Write a struct-of-binary that looks like a Variant, but with minor variations that may make
     // it invalid to read.
     // Test cases:

--- a/sql/core/src/test/scala/org/apache/spark/sql/VariantSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/VariantSuite.scala
@@ -23,7 +23,6 @@ import scala.collection.mutable
 import scala.util.Random
 
 import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
-import org.apache.spark.sql.execution.datasources.SchemaColumnConvertNotSupportedException
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{StructField, StructType, VariantType}
@@ -231,8 +230,8 @@ class VariantSuite extends QueryTest with SharedSparkSession {
           checkAnswer(result, Seq.fill(10)(Row("false")))
         } else {
           val e = intercept[org.apache.spark.SparkException](result.collect())
-          assert(e.getCause.isInstanceOf[AnalysisException] ||
-            e.getCause.isInstanceOf[SchemaColumnConvertNotSupportedException])
+          assert(
+            e.getCause.isInstanceOf[AnalysisException], e.printStackTrace)
         }
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

The parquet schema converter for Variant assumes that the first two fields in a parquet struct are the value and metadata for Variant, respectively. This isn't very robust, and could break if other writers wrote them in a different order, or if a future extension added new fields to the Variant structure. This PR adds more careful validation of the Variant column based on field names, and fails if there are any unexpected columns.

### Why are the changes needed?

Make Variant more robust to issues in the parquet schema.

### Does this PR introduce _any_ user-facing change?

No, Variant isn't released yet.

### How was this patch tested?

Added a unit test.

### Was this patch authored or co-authored using generative AI tooling?

No.