### PR TITLE
[SPARK-47548][BUILD] Remove unused `commons-beanutils` dependency

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -204,7 +204,6 @@
 This project bundles some components that are also licensed under the Apache
 License Version 2.0:
 
-commons-beanutils:commons-beanutils
 org.apache.zookeeper:zookeeper
 oro:oro
 commons-configuration:commons-configuration

--- a/pom.xml
+++ b/pom.xml
@@ -647,11 +647,6 @@
         <version>${commons.collections4.version}</version>
       </dependency>
       <dependency>
-        <groupId>commons-beanutils</groupId>
-        <artifactId>commons-beanutils</artifactId>
-        <version>1.9.4</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.ivy</groupId>
         <artifactId>ivy</artifactId>
         <version>${ivy.version}</version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove unused `commons-beanutils` dependency from `pom.xml` and `LICENSE-binary`.

### Why are the changes needed?

#30701 removed `commons-beanutils` from `hadoop-3` profile at Apache Spark 3.2.0.
- https://github.com/apache/spark/pull/30701

#40788 removed `hadoop-2` profile from Apache Spark 3.5.0
- https://github.com/apache/spark/pull/40788


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.