### PR TITLE
[SPARK-47560][PYTHON][CONNECT] Avoid RPC to validate column name with cached schema

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1736,7 +1736,10 @@ class DataFrame:
 
                 # validate the column name
                 if not hasattr(self._session, "is_mock_session"):
-                    self.select(item).isLocal()
+                    # Different from __getattr__, the name here can be quoted like df['`id`'].
+                    # Only validate the name when it is not in the cached schema.
+                    if item not in self.columns:
+                        self.select(item).isLocal()
 
                 return Column(
                     ColumnReference(


### PR DESCRIPTION
### What changes were proposed in this pull request?

If the column name exists in schema, avoid `df.select` validation



### Why are the changes needed?
https://github.com/apache/spark/commit/6f87fe2f513d1b1a022f0d03b6c81d73d7cfb228 caches the schema, so if the column name exists in schema, we don't not need to validate it with `df.select` which requires additional RPC


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no
