### PR TITLE
[SPARK-47563][SQL] Add map normalization on creation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NormalizeFloatingNumbers.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NormalizeFloatingNumbers.scala
@@ -94,7 +94,7 @@ object NormalizeFloatingNumbers extends Rule[LogicalPlan] {
     case _ => needNormalize(expr.dataType)
   }
 
-  def needNormalize(dt: DataType): Boolean = dt match {
+  private def needNormalize(dt: DataType): Boolean = dt match {
     case FloatType | DoubleType => true
     case StructType(fields) => fields.exists(f => needNormalize(f.dataType))
     case ArrayType(et, _) => needNormalize(et)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NormalizeFloatingNumbers.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/NormalizeFloatingNumbers.scala
@@ -94,7 +94,7 @@ object NormalizeFloatingNumbers extends Rule[LogicalPlan] {
     case _ => needNormalize(expr.dataType)
   }
 
-  private def needNormalize(dt: DataType): Boolean = dt match {
+  def needNormalize(dt: DataType): Boolean = dt match {
     case FloatType | DoubleType => true
     case StructType(fields) => fields.exists(f => needNormalize(f.dataType))
     case ArrayType(et, _) => needNormalize(et)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapBuilder.scala
@@ -21,6 +21,8 @@ import scala.collection.mutable
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.catalyst.optimizer.NormalizeFloatingNumbers
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -52,18 +54,34 @@ class ArrayBasedMapBuilder(keyType: DataType, valueType: DataType) extends Seria
 
   private val mapKeyDedupPolicy = SQLConf.get.getConf(SQLConf.MAP_KEY_DEDUP_POLICY)
 
+  def normalize(value: Any, dataType: DataType): Any = dataType match {
+    case FloatType => NormalizeFloatingNumbers.FLOAT_NORMALIZER(value)
+    case DoubleType => NormalizeFloatingNumbers.DOUBLE_NORMALIZER(value)
+    case ArrayType(dt, _) =>
+      new GenericArrayData(value.asInstanceOf[GenericArrayData].array.map { element =>
+        normalize(element, dt)
+      })
+    case StructType(sf) =>
+      new GenericInternalRow(
+        value.asInstanceOf[GenericInternalRow].values.zipWithIndex.map { element =>
+        normalize(element._1, sf(element._2).dataType)
+      })
+    case _ => value
+  }
+
   def put(key: Any, value: Any): Unit = {
     if (key == null) {
       throw QueryExecutionErrors.nullAsMapKeyNotAllowedError()
     }
 
-    val index = keyToIndex.getOrDefault(key, -1)
+    val keyNormalized = normalize(key, keyType)
+    val index = keyToIndex.getOrDefault(keyNormalized, -1)
     if (index == -1) {
       if (size >= ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH) {
         throw QueryExecutionErrors.exceedMapSizeLimitError(size)
       }
-      keyToIndex.put(key, values.length)
-      keys.append(key)
+      keyToIndex.put(keyNormalized, values.length)
+      keys.append(keyNormalized)
       values.append(value)
     } else {
       if (mapKeyDedupPolicy == SQLConf.MapKeyDedupPolicy.EXCEPTION.toString) {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapBuilderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapBuilderSuite.scala
@@ -92,6 +92,19 @@ class ArrayBasedMapBuilderSuite extends SparkFunSuite with SQLHelper {
         "key" -> "[0.0]",
         "mapKeyDedupPolicy" -> "\"spark.sql.mapKeyDedupPolicy\"")
     )
+
+    val builderStructWithArray = new ArrayBasedMapBuilder(
+      new StructType().add("array", ArrayType(DoubleType) ), IntegerType)
+    builderStructWithArray.put(InternalRow(new GenericArrayData(Seq(-0.0))), 1)
+    checkError(
+      exception = intercept[SparkRuntimeException](
+        builderStructWithArray.put(InternalRow(new GenericArrayData(Seq(0.0))), 1)),
+      errorClass = "DUPLICATED_MAP_KEY",
+      parameters = Map(
+        "key" -> "[[0.0]]",
+        "mapKeyDedupPolicy" -> "\"spark.sql.mapKeyDedupPolicy\"")
+    )
+
   }
 
   test("remove duplicated keys with last wins policy") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapBuilderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapBuilderSuite.scala
@@ -70,40 +70,6 @@ class ArrayBasedMapBuilderSuite extends SparkFunSuite with SQLHelper {
         "key" -> "0.0",
         "mapKeyDedupPolicy" -> "\"spark.sql.mapKeyDedupPolicy\"")
     )
-
-    val builderArray = new ArrayBasedMapBuilder(ArrayType(DoubleType), IntegerType)
-    builderArray.put(new GenericArrayData(Seq(-0.0)), 1)
-    checkError(
-      exception = intercept[SparkRuntimeException](
-        builderArray.put(new GenericArrayData(Seq(0.0)), 1)),
-      errorClass = "DUPLICATED_MAP_KEY",
-      parameters = Map(
-        "key" -> "[0.0]",
-        "mapKeyDedupPolicy" -> "\"spark.sql.mapKeyDedupPolicy\"")
-    )
-
-    val builderStruct = new ArrayBasedMapBuilder(new StructType().add("i", "double"), IntegerType)
-    builderStruct.put(InternalRow(-0.0), 1)
-    // By default duplicated map key fails the query.
-    checkError(
-      exception = intercept[SparkRuntimeException](builderStruct.put(InternalRow(0.0), 3)),
-      errorClass = "DUPLICATED_MAP_KEY",
-      parameters = Map(
-        "key" -> "[0.0]",
-        "mapKeyDedupPolicy" -> "\"spark.sql.mapKeyDedupPolicy\"")
-    )
-
-    val builderStructWithArray = new ArrayBasedMapBuilder(
-      new StructType().add("array", ArrayType(DoubleType) ), IntegerType)
-    builderStructWithArray.put(InternalRow(new GenericArrayData(Seq(-0.0))), 1)
-    checkError(
-      exception = intercept[SparkRuntimeException](
-        builderStructWithArray.put(InternalRow(new GenericArrayData(Seq(0.0))), 1)),
-      errorClass = "DUPLICATED_MAP_KEY",
-      parameters = Map(
-        "key" -> "[[0.0]]",
-        "mapKeyDedupPolicy" -> "\"spark.sql.mapKeyDedupPolicy\"")
-    )
   }
 
   test("successful map normalization on build") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapBuilderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/ArrayBasedMapBuilderSuite.scala
@@ -104,7 +104,14 @@ class ArrayBasedMapBuilderSuite extends SparkFunSuite with SQLHelper {
         "key" -> "[[0.0]]",
         "mapKeyDedupPolicy" -> "\"spark.sql.mapKeyDedupPolicy\"")
     )
+  }
 
+  test("successful map normalization on build") {
+    val builder = new ArrayBasedMapBuilder(DoubleType, IntegerType)
+    builder.put(-0.0, 1)
+    val map = builder.build()
+    assert(map.numElements() == 1)
+    assert(ArrayBasedMapData.toScalaMap(map) == Map(0.0 -> 1))
   }
 
   test("remove duplicated keys with last wins policy") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added normalization of map keys when they are put in `ArrayBasedMapBuilder`. 


### Why are the changes needed?
As map keys need to be unique, we need to add normalization on floating point numbers and prevent the following case when building a map: `Map(0.0, -0.0)`.
This further unblocks GROUP BY statement for Map Types as per [this discussion](https://github.com/apache/spark/pull/45549#discussion_r1537803505).


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
New UTs in `ArrayBasedMapBuilderSuite`


### Was this patch authored or co-authored using generative AI tooling?
No
