### PR TITLE
[SPARK-46575][SQL][FOLLOWUP] Add back `HiveThriftServer2.startWithContext(SQLContext)` method for compatibility 

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -85,7 +85,7 @@ object HiveThriftServer2 extends Logging {
   @Since("2.0.0")
   @DeveloperApi
   def startWithContext(sqlContext: SQLContext): HiveThriftServer2 = {
-    startWithContext(sqlContext, exitOnError)
+    startWithContext(sqlContext, exitOnError = true)
   }
 
   private def createListenerAndUI(server: HiveThriftServer2, sc: SparkContext): Unit = {

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -27,7 +27,7 @@ import org.apache.hive.service.cli.thrift.{ThriftBinaryCLIService, ThriftHttpCLI
 import org.apache.hive.service.server.HiveServer2
 
 import org.apache.spark.SparkContext
-import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.annotation.{DeveloperApi, Since}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.UI.UI_ENABLED
 import org.apache.spark.sql.SQLContext
@@ -56,6 +56,7 @@ object HiveThriftServer2 extends Logging {
    *                    the call logs the error and exits the JVM with exit code -1. When false, the
    *                    call throws an exception instead.
    */
+  @Since("3.5.2")
   @DeveloperApi
   def startWithContext(sqlContext: SQLContext, exitOnError: Boolean): HiveThriftServer2 = {
     systemExitOnError.set(exitOnError)
@@ -81,6 +82,7 @@ object HiveThriftServer2 extends Logging {
    *
    * @param sqlContext SQLContext to use for the server
    */
+  @Since("2.0.0")
   @DeveloperApi
   def startWithContext(sqlContext: SQLContext): HiveThriftServer2 = {
     startWithContext(sqlContext, exitOnError)

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -57,7 +57,7 @@ object HiveThriftServer2 extends Logging {
    *                    call throws an exception instead.
    */
   @DeveloperApi
-  def startWithContext(sqlContext: SQLContext, exitOnError: Boolean = true): HiveThriftServer2 = {
+  def startWithContext(sqlContext: SQLContext, exitOnError: Boolean): HiveThriftServer2 = {
     systemExitOnError.set(exitOnError)
 
     val executionHive = HiveUtils.newClientForExecution(
@@ -73,6 +73,17 @@ object HiveThriftServer2 extends Logging {
     logInfo("HiveThriftServer2 started")
     createListenerAndUI(server, sqlContext.sparkContext)
     server
+  }
+
+  /**
+   * :: DeveloperApi ::
+   * Starts a new thrift server with the given context.
+   *
+   * @param sqlContext SQLContext to use for the server
+   */
+  @DeveloperApi
+  def startWithContext(sqlContext: SQLContext): HiveThriftServer2 = {
+    startWithContext(sqlContext, exitOnError)
   }
 
   private def createListenerAndUI(server: HiveThriftServer2, sc: SparkContext): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://github.com/apache/spark/pull/44575 added a default parameter to `HiveThriftServer2.startWithContext` API. Although this is source-compatible, this is not binary-compatible - for eg. a binary built with new code won't be able to run with the old code. In this PR, we maintain forward and backward compatibility by keeping the API same and introducing a separate API for the additional parameter.

### Why are the changes needed?
See above


### Does this PR introduce _any_ user-facing change?
only developer API change


### How was this patch tested?
Existing tests


### Was this patch authored or co-authored using generative AI tooling?
no
