### PR TITLE
[SPARK-47611][SQL] Cleanup dead code in MySQLDialect.getCatalystType

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MySQLIntegrationSuite.scala
@@ -64,10 +64,11 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite {
     conn.prepareStatement("CREATE TABLE unsigned_numbers (" +
       "tiny TINYINT UNSIGNED, small SMALLINT UNSIGNED, med MEDIUMINT UNSIGNED," +
       "nor INT UNSIGNED, big BIGINT UNSIGNED, deci DECIMAL(40,20) UNSIGNED," +
-      "dbl DOUBLE UNSIGNED)").executeUpdate()
+      "dbl DOUBLE UNSIGNED, tiny1u TINYINT(1) UNSIGNED)").executeUpdate()
 
     conn.prepareStatement("INSERT INTO unsigned_numbers VALUES (255, 65535, 16777215, 4294967295," +
-      "9223372036854775808, 123456789012345.123456789012345, 1.0000000000000002)").executeUpdate()
+      "9223372036854775808, 123456789012345.123456789012345, 1.0000000000000002, 0)")
+      .executeUpdate()
 
     conn.prepareStatement("CREATE TABLE dates (d DATE, t TIME, dt DATETIME, ts TIMESTAMP, "
       + "yr YEAR)").executeUpdate()
@@ -150,6 +151,13 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite {
     assert(rows.get(4).isInstanceOf[BigDecimal])
     assert(rows.get(5).isInstanceOf[BigDecimal])
     assert(rows.get(6).isInstanceOf[Double])
+    // Unlike MySQL, MariaDB seems not to distinguish signed and unsigned tinyint(1).
+    val isMaria = jdbcUrl.indexOf("disableMariaDbDriver") == -1
+    if (isMaria) {
+      assert(rows.get(7).isInstanceOf[Boolean])
+    } else {
+      assert(rows.get(7).isInstanceOf[Short])
+    }
     assert(rows.getShort(0) === 255)
     assert(rows.getInt(1) === 65535)
     assert(rows.getInt(2) === 16777215)
@@ -157,6 +165,11 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite {
     assert(rows.getAs[BigDecimal](4).equals(new BigDecimal("9223372036854775808")))
     assert(rows.getAs[BigDecimal](5).equals(new BigDecimal("123456789012345.12345678901234500000")))
     assert(rows.getDouble(6) === 1.0000000000000002)
+    if (isMaria) {
+      assert(rows.getBoolean(7) === false)
+    } else {
+      assert(rows.getShort(7) === 0)
+    }
   }
 
   test("Date types") {
@@ -260,6 +273,21 @@ class MySQLIntegrationSuite extends DockerJDBCIntegrationSuite {
   test("SPARK-47478: all boolean synonyms read-write roundtrip") {
     val df = sqlContext.read.jdbc(jdbcUrl, "bools", new Properties)
     checkAnswer(df, Row(true, true, true))
+
+    val properties0 = new Properties()
+    properties0.setProperty("transformedBitIsBoolean", "false")
+    properties0.setProperty("tinyInt1isBit", "true")
+
+    checkAnswer(spark.read.jdbc(jdbcUrl, "bools", properties0), Row(true, true, true))
+    val properties1 = new Properties()
+    properties1.setProperty("transformedBitIsBoolean", "true")
+    properties1.setProperty("tinyInt1isBit", "true")
+    checkAnswer(spark.read.jdbc(jdbcUrl, "bools", properties1), Row(true, true, true))
+
+    val properties2 = new Properties()
+    properties2.setProperty("tinyInt1isBit", "false")
+    checkAnswer(sqlContext.read.jdbc(jdbcUrl, "bools", properties2), Row(1, true, 1))
+
     df.write.mode("append").jdbc(jdbcUrl, "bools", new Properties)
     checkAnswer(df, Seq(Row(true, true, true), Row(true, true, true)))
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MySQLDialect.scala
@@ -103,8 +103,6 @@ private case class MySQLDialect() extends JdbcDialect with SQLConfHelper {
         // MySQL connector behaviour
         md.putLong("binarylong", 1)
         Some(LongType)
-      case Types.BIT if "TINYINT".equalsIgnoreCase(typeName) =>
-        Some(BooleanType)
       case Types.VARCHAR if "TINYTEXT".equalsIgnoreCase(typeName) =>
         // TINYTEXT is Types.VARCHAR(63) from mysql jdbc, but keep it AS-IS for historical reason
         Some(StringType)

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -934,8 +934,6 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
       Some(LongType))
     assert(metadata.build().contains("binarylong"))
     assert(mySqlDialect.getCatalystType(java.sql.Types.VARBINARY, "BIT", 1, metadata) == None)
-    assert(mySqlDialect.getCatalystType(java.sql.Types.BIT, "TINYINT", 1, metadata) ==
-      Some(BooleanType))
     assert(mySqlDialect.getCatalystType(java.sql.Types.TINYINT, "TINYINT", 1, metadata) ==
       Some(ByteType))
     assert(mySqlDialect.getCatalystType(java.sql.Types.REAL, "FLOAT", 1, metadata) ===


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR removes an unnecessary case-match branch for Types.BIT in MySQLDialect.getCatalystType, this is a special case for Maria Connector/J and can be handled in defaults as we have matched and handled Types.BIT&size > 1 before this.

Additionally, we add some new tests for this corner case and other MySQL/Maria quirks

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

code refactoring and test improvement


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

new tests
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no