### PR TITLE
[SPARK-46575][SQL][FOLLOWUP] Correct @since annotation for HiveThriftServer2.startWithContext(SQLContext, exitonError)

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -56,7 +56,7 @@ object HiveThriftServer2 extends Logging {
    *                    the call logs the error and exits the JVM with exit code -1. When false, the
    *                    call throws an exception instead.
    */
-  @Since("3.5.2")
+  @Since("4.0.0")
   @DeveloperApi
   def startWithContext(sqlContext: SQLContext, exitOnError: Boolean): HiveThriftServer2 = {
     systemExitOnError.set(exitOnError)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes the incorrect `@since` annotation for ` HiveThriftServer2.startWithContext(SQLContext, exitonError)` In the original [PR](https://github.com/apache/spark/pull/45727/files).


### Why are the changes needed?
See above


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests


### Was this patch authored or co-authored using generative AI tooling?
No