### PR TITLE
[SPARK-47618][CORE] Use `Magic Committer` for all S3 buckets by default

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkContextSuite.scala
@@ -1270,53 +1270,6 @@ class SparkContextSuite extends SparkFunSuite with LocalSparkContext with Eventu
     }
   }
 
-  test("SPARK-35383: Fill missing S3A magic committer configs if needed") {
-    val c1 = new SparkConf().setAppName("s3a-test").setMaster("local")
-    sc = new SparkContext(c1)
-    assert(!sc.getConf.contains("spark.hadoop.fs.s3a.committer.name"))
-
-    resetSparkContext()
-    val c2 = c1.clone.set("spark.hadoop.fs.s3a.bucket.mybucket.committer.magic.enabled", "false")
-    sc = new SparkContext(c2)
-    assert(!sc.getConf.contains("spark.hadoop.fs.s3a.committer.name"))
-
-    resetSparkContext()
-    val c3 = c1.clone.set("spark.hadoop.fs.s3a.bucket.mybucket.committer.magic.enabled", "true")
-    sc = new SparkContext(c3)
-    Seq(
-      "spark.hadoop.fs.s3a.committer.magic.enabled" -> "true",
-      "spark.hadoop.fs.s3a.committer.name" -> "magic",
-      "spark.hadoop.mapreduce.outputcommitter.factory.scheme.s3a" ->
-        "org.apache.hadoop.fs.s3a.commit.S3ACommitterFactory",
-      "spark.sql.parquet.output.committer.class" ->
-        "org.apache.spark.internal.io.cloud.BindingParquetOutputCommitter",
-      "spark.sql.sources.commitProtocolClass" ->
-        "org.apache.spark.internal.io.cloud.PathOutputCommitProtocol"
-    ).foreach { case (k, v) =>
-      assert(v == sc.getConf.get(k))
-    }
-
-    // Respect a user configuration
-    resetSparkContext()
-    val c4 = c1.clone
-      .set("spark.hadoop.fs.s3a.committer.magic.enabled", "false")
-      .set("spark.hadoop.fs.s3a.bucket.mybucket.committer.magic.enabled", "true")
-    sc = new SparkContext(c4)
-    Seq(
-      "spark.hadoop.fs.s3a.committer.magic.enabled" -> "false",
-      "spark.hadoop.fs.s3a.committer.name" -> null,
-      "spark.hadoop.mapreduce.outputcommitter.factory.scheme.s3a" -> null,
-      "spark.sql.parquet.output.committer.class" -> null,
-      "spark.sql.sources.commitProtocolClass" -> null
-    ).foreach { case (k, v) =>
-      if (v == null) {
-        assert(!sc.getConf.contains(k))
-      } else {
-        assert(v == sc.getConf.get(k))
-      }
-    }
-  }
-
   test("SPARK-35691: addFile/addJar/addDirectory should put CanonicalFile") {
     withTempDir { dir =>
       try {

--- a/docs/core-migration-guide.md
+++ b/docs/core-migration-guide.md
@@ -24,6 +24,8 @@ license: |
 
 ## Upgrading from Core 3.5 to 4.0
 
+- Since Spark 4.0, Spark uses Apache Hadoop Magic Committer for all S3 buckets by default. To restore the behavior before Spark 4.0, you can set `spark.hadoop.fs.s3a.committer.magic.enabled=false`.
+
 - Since Spark 4.0, Spark migrated all its internal reference of servlet API from `javax` to `jakarta` 
 
 - Since Spark 4.0, Spark will roll event logs to archive them incrementally. To restore the behavior before Spark 4.0, you can set `spark.eventLog.rolling.enabled` to `false`.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Apache Hadoop `Magic Committer` for all S3 buckets by default in Apache Spark 4.0.0.

### Why are the changes needed?

Apache Hadoop `Magic Committer` has been used for S3 buckets to get the best performance since [S3 became fully consistent on December 1st, 2020](https://aws.amazon.com/blogs/aws/amazon-s3-update-strong-read-after-write-consistency/).
- https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html#ConsistencyModel
> Amazon S3 provides strong read-after-write consistency for PUT and DELETE requests of objects in your Amazon S3 bucket in all AWS Regions. This behavior applies to both writes to new objects as well as PUT requests that overwrite existing objects and DELETE requests. In addition, read operations on Amazon S3 Select, Amazon S3 access controls lists (ACLs), Amazon S3 Object Tags, and object metadata (for example, the HEAD object) are strongly consistent.

### Does this PR introduce _any_ user-facing change?

Yes, the migration guide is updated.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.