### PR TITLE
[SPARK-47366][PYTHON] Add pyspark and dataframe parse_json aliases

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -6965,6 +6965,17 @@ object functions {
   }
 
   /**
+   * Parses a JSON string and constructs a Variant value.
+   *
+   * @param json
+   *   a string column that contains JSON data.
+   *
+   * @group json_funcs
+   * @since 4.0.0
+   */
+  def parse_json(json: Column): Column = Column.fn("parse_json", json)
+
+  /**
    * Parses a JSON string and infers its schema in DDL format.
    *
    * @param json

--- a/python/docs/source/reference/pyspark.sql/functions.rst
+++ b/python/docs/source/reference/pyspark.sql/functions.rst
@@ -532,6 +532,7 @@ JSON Functions
     json_array_length
     json_object_keys
     json_tuple
+    parse_json
     schema_of_json
     to_json
 

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -2029,6 +2029,12 @@ def str_to_map(
 str_to_map.__doc__ = pysparkfuncs.str_to_map.__doc__
 
 
+def parse_json(col: "ColumnOrName") -> Column:
+    return _invoke_function("parse_json", _to_col(col))
+
+
+parse_json.__doc__ = pysparkfuncs.parse_json.__doc__
+
 def posexplode(col: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("posexplode", col)
 

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -2035,6 +2035,7 @@ def parse_json(col: "ColumnOrName") -> Column:
 
 parse_json.__doc__ = pysparkfuncs.parse_json.__doc__
 
+
 def posexplode(col: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("posexplode", col)
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -15099,6 +15099,38 @@ def from_json(
 
 
 @_try_remote_functions
+def parse_json(
+    col: "ColumnOrName",
+) -> Column:
+    """
+    Parses a column containing a JSON string into a :class:`VariantType`.
+
+    .. versionadded:: 4.0.0
+
+    Parameters
+    ----------
+    col : :class:`~pyspark.sql.Column` or str
+        a column or column name JSON formatted strings
+
+        .. # noqa
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        a new column of VariantType.
+
+    Examples
+    --------
+    >>> from pyspark.sql.types import *
+    >>> df = spark.createDataFrame([ {'json': '''{ "a" : 1 }'''} ])
+    >>> df.select(to_json(parse_json(df.json)).alias("v")).collect()
+    [Row(v='{"a":1}')]
+    """
+
+    return _invoke_function("parse_json", _to_java_column(col))
+
+
+@_try_remote_functions
 def to_json(col: "ColumnOrName", options: Optional[Dict[str, str]] = None) -> Column:
     """
     Converts a column containing a :class:`StructType`, :class:`ArrayType` or a :class:`MapType`

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -15112,8 +15112,6 @@ def parse_json(
     col : :class:`~pyspark.sql.Column` or str
         a column or column name JSON formatted strings
 
-        .. # noqa
-
     Returns
     -------
     :class:`~pyspark.sql.Column`
@@ -15121,10 +15119,9 @@ def parse_json(
 
     Examples
     --------
-    >>> from pyspark.sql.types import *
     >>> df = spark.createDataFrame([ {'json': '''{ "a" : 1 }'''} ])
-    >>> df.select(to_json(parse_json(df.json)).alias("v")).collect()
-    [Row(v='{"a":1}')]
+    >>> df.select(to_json(parse_json(df.json))).collect()
+    [Row(to_json(parse_json(json))='{"a":1}')]
     """
 
     return _invoke_function("parse_json", _to_java_column(col))

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1305,6 +1305,16 @@ class FunctionsTestsMixin:
         self.assertEqual({**expected, **expected2}, dict(actual["merged"]))
         self.assertEqual(expected, actual["from_items"])
 
+    def test_parse_json(self):
+        df = self.spark.createDataFrame([ {'json': '''{ "a" : 1 }'''} ])
+        actual = df.select(
+            F.to_json(F.parse_json(df.json)).alias("var"),
+            F.to_json(F.parse_json(F.lit('''{"b": [{"c": "str2"}]}'''))).alias("var_lit"),
+        ).first()
+
+        self.assertEqual('''{"a":1}''', actual["var"])
+        self.assertEqual('''{"b":[{"c":"str2"}]}''', actual["var_lit"])
+
     def test_schema_of_json(self):
         with self.assertRaises(PySparkTypeError) as pe:
             F.schema_of_json(1)

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1306,14 +1306,14 @@ class FunctionsTestsMixin:
         self.assertEqual(expected, actual["from_items"])
 
     def test_parse_json(self):
-        df = self.spark.createDataFrame([ {'json': '''{ "a" : 1 }'''} ])
+        df = self.spark.createDataFrame([{"json": """{ "a" : 1 }"""}])
         actual = df.select(
             F.to_json(F.parse_json(df.json)).alias("var"),
-            F.to_json(F.parse_json(F.lit('''{"b": [{"c": "str2"}]}'''))).alias("var_lit"),
+            F.to_json(F.parse_json(F.lit("""{"b": [{"c": "str2"}]}"""))).alias("var_lit"),
         ).first()
 
-        self.assertEqual('''{"a":1}''', actual["var"])
-        self.assertEqual('''{"b":[{"c":"str2"}]}''', actual["var_lit"])
+        self.assertEqual("""{"a":1}""", actual["var"])
+        self.assertEqual("""{"b":[{"c":"str2"}]}""", actual["var_lit"])
 
     def test_schema_of_json(self):
         with self.assertRaises(PySparkTypeError) as pe:

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -6599,6 +6599,7 @@ object functions {
    *
    * @param json a string column that contains JSON data.
    *
+   * @group json_funcs
    * @since 4.0.0
    */
   def parse_json(json: Column): Column = Column.fn("parse_json", json)

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -6595,6 +6595,24 @@ object functions {
   }
 
   /**
+   * Parses a JSON string and constructs a Variant value.
+   *
+   * @param json a JSON string.
+   *
+   * @since 4.0.0
+   */
+  def parse_json(json: String): Column = parse_json(lit(json))
+
+  /**
+   * Parses a JSON string and constructs a Variant value.
+   *
+   * @param json a string column that contains JSON data.
+   *
+   * @since 4.0.0
+   */
+  def parse_json(json: Column): Column = Column.fn("parse_json", json)
+
+  /**
    * Parses a JSON string and infers its schema in DDL format.
    *
    * @param json a JSON string.

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -6597,15 +6597,6 @@ object functions {
   /**
    * Parses a JSON string and constructs a Variant value.
    *
-   * @param json a JSON string.
-   *
-   * @since 4.0.0
-   */
-  def parse_json(json: String): Column = parse_json(lit(json))
-
-  /**
-   * Parses a JSON string and constructs a Variant value.
-   *
    * @param json a string column that contains JSON data.
    *
    * @since 4.0.0

--- a/sql/core/src/test/scala/org/apache/spark/sql/VariantSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/VariantSuite.scala
@@ -20,12 +20,14 @@ package org.apache.spark.sql
 import java.io.File
 
 import scala.collection.mutable
+import scala.jdk.CollectionConverters._
 import scala.util.Random
 
 import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode
+import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{StringType, StructType}
 import org.apache.spark.unsafe.types.VariantVal
 import org.apache.spark.util.ArrayImplicits._
 
@@ -49,6 +51,17 @@ class VariantSuite extends QueryTest with SharedSparkSession {
       query.write.parquet(tempDir)
       verifyResult(spark.read.parquet(tempDir))
     }
+  }
+
+  test("basic parse_json alias") {
+    val df = spark.createDataFrame(Seq(Row("""{ "a" : 1 }""")).asJava,
+      new StructType().add("json", StringType))
+    val actual = df.select(
+      to_json(parse_json(col("json"))),
+      to_json(parse_json(lit("""{"b": [{"c": "str2"}]}""")))).collect().head
+
+    assert(actual.getString(0) == """{"a":1}""")
+    assert(actual.getString(1) == """{"b":[{"c":"str2"}]}""")
   }
 
   test("round trip tests") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added the `parse_json` function alias for pyspark and dataframe APIs.

### Why are the changes needed?

Improves usability of the `parse_json` function.

### Does this PR introduce _any_ user-facing change?
Before this change, the following would not be possible:
```
df.select(parse_json(df.json)).collect()
```

### How was this patch tested?
Added unit tests and manual testing.

### Was this patch authored or co-authored using generative AI tooling?
no
