### PR TITLE
[SPARK-47623][PYTHON][CONNECT][TESTS] Use `QuietTest` in parity tests

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_arrow.py
+++ b/python/pyspark/sql/tests/connect/test_parity_arrow.py
@@ -36,17 +36,11 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase, PandasOnSparkTest
     def test_createDataFrame_fallback_enabled(self):
         super().test_createDataFrame_fallback_enabled()
 
-    def test_createDataFrame_with_incorrect_schema(self):
-        self.check_createDataFrame_with_incorrect_schema()
-
     def test_createDataFrame_with_map_type(self):
         self.check_createDataFrame_with_map_type(True)
 
     def test_createDataFrame_with_ndarray(self):
         self.check_createDataFrame_with_ndarray(True)
-
-    def test_createDataFrame_with_single_data_type(self):
-        self.check_createDataFrame_with_single_data_type()
 
     @unittest.skip("Spark Connect does not support RDD but the tests depend on them.")
     def test_no_partition_frame(self):
@@ -66,9 +60,6 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase, PandasOnSparkTest
             no_self_destruct_pdf = df.toPandas()
 
         self.assert_eq(self_destruct_pdf, no_self_destruct_pdf)
-
-    def test_propagates_spark_exception(self):
-        self.check_propagates_spark_exception()
 
     @unittest.skip("Spark Connect does not support RDD but the tests depend on them.")
     def test_toPandas_batch_order(self):

--- a/python/pyspark/sql/tests/connect/test_parity_arrow_cogrouped_map.py
+++ b/python/pyspark/sql/tests/connect/test_parity_arrow_cogrouped_map.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import contextlib
+
 import unittest
 
 from pyspark.sql.tests.test_arrow_cogrouped_map import CogroupedMapInArrowTestsMixin
@@ -22,9 +22,7 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class CogroupedMapInArrowParityTests(CogroupedMapInArrowTestsMixin, ReusedConnectTestCase):
-    def quiet_test(self):
-        # No-op
-        return contextlib.nullcontext()
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/connect/test_parity_arrow_grouped_map.py
+++ b/python/pyspark/sql/tests/connect/test_parity_arrow_grouped_map.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import contextlib
+
 import unittest
 
 from pyspark.sql.tests.test_arrow_grouped_map import GroupedMapInArrowTestsMixin
@@ -22,9 +22,7 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class GroupedApplyInArrowParityTests(GroupedMapInArrowTestsMixin, ReusedConnectTestCase):
-    def quiet_test(self):
-        # No-op
-        return contextlib.nullcontext()
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/connect/test_parity_arrow_map.py
+++ b/python/pyspark/sql/tests/connect/test_parity_arrow_map.py
@@ -22,8 +22,7 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class ArrowMapParityTests(MapInArrowTestsMixin, ReusedConnectTestCase):
-    def test_other_than_recordbatch_iter(self):
-        self.check_other_than_recordbatch_iter()
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/connect/test_parity_collection.py
+++ b/python/pyspark/sql/tests/connect/test_parity_collection.py
@@ -23,9 +23,6 @@ class DataFrameCollectionParityTests(
     DataFrameCollectionTestsMixin,
     ReusedConnectTestCase,
 ):
-    def test_to_local_iterator_not_fully_consumed(self):
-        self.check_to_local_iterator_not_fully_consumed()
-
     def test_to_pandas_for_array_of_struct(self):
         # Spark Connect's implementation is based on Arrow.
         super().check_to_pandas_for_array_of_struct(True)

--- a/python/pyspark/sql/tests/connect/test_parity_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_cogrouped_map.py
@@ -29,22 +29,13 @@ class CogroupedApplyInPandasTests(CogroupedApplyInPandasTestsMixin, ReusedConnec
     def test_wrong_args(self):
         self.check_wrong_args()
 
-    def test_apply_in_pandas_not_returning_pandas_dataframe(self):
-        self.check_apply_in_pandas_not_returning_pandas_dataframe()
-
-    def test_apply_in_pandas_returning_wrong_column_names(self):
-        self.check_apply_in_pandas_returning_wrong_column_names()
-
-    def test_apply_in_pandas_returning_no_column_names_and_wrong_amount(self):
-        self.check_apply_in_pandas_returning_no_column_names_and_wrong_amount()
-
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_apply_in_pandas_returning_incompatible_type(self):
-        self.check_apply_in_pandas_returning_incompatible_type()
+        super().test_apply_in_pandas_returning_incompatible_type()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_wrong_return_type(self):
-        self.check_wrong_return_type()
+        super().test_wrong_return_type()
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/connect/test_parity_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_grouped_map.py
@@ -28,34 +28,19 @@ class GroupedApplyInPandasTests(GroupedApplyInPandasTestsMixin, ReusedConnectTes
 
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_wrong_return_type(self):
-        self.check_wrong_return_type()
+        super().test_wrong_return_type()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_wrong_args(self):
-        self.check_wrong_args()
+        super().test_wrong_args()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_unsupported_types(self):
-        self.check_unsupported_types()
-
-    def test_register_grouped_map_udf(self):
-        self.check_register_grouped_map_udf()
-
-    def test_column_order(self):
-        self.check_column_order()
-
-    def test_apply_in_pandas_returning_wrong_column_names(self):
-        self.check_apply_in_pandas_returning_wrong_column_names()
-
-    def test_apply_in_pandas_returning_no_column_names_and_wrong_amount(self):
-        self.check_apply_in_pandas_returning_no_column_names_and_wrong_amount()
+        super().test_unsupported_types()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_apply_in_pandas_returning_incompatible_type(self):
-        self.check_apply_in_pandas_returning_incompatible_type()
-
-    def test_apply_in_pandas_not_returning_pandas_dataframe(self):
-        self.check_apply_in_pandas_not_returning_pandas_dataframe()
+        super().test_apply_in_pandas_returning_incompatible_type()
 
     @unittest.skip("Spark Connect doesn't support RDD but the test depends on it.")
     def test_grouped_with_empty_partition(self):

--- a/python/pyspark/sql/tests/connect/test_parity_pandas_map.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_map.py
@@ -22,27 +22,9 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class MapInPandasParityTests(MapInPandasTestsMixin, ReusedConnectTestCase):
-    def test_other_than_dataframe_iter(self):
-        self.check_other_than_dataframe_iter()
-
-    def test_dataframes_with_other_column_names(self):
-        self.check_dataframes_with_other_column_names()
-
-    def test_dataframes_with_duplicate_column_names(self):
-        self.check_dataframes_with_duplicate_column_names()
-
-    def test_dataframes_with_less_columns(self):
-        self.check_dataframes_with_less_columns()
-
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_dataframes_with_incompatible_types(self):
-        self.check_dataframes_with_incompatible_types()
-
-    def test_empty_dataframes_with_less_columns(self):
-        self.check_empty_dataframes_with_less_columns()
-
-    def test_empty_dataframes_with_other_columns(self):
-        self.check_empty_dataframes_with_other_columns()
+        super().test_dataframes_with_incompatible_types()
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/connect/test_parity_pandas_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_udf_grouped_agg.py
@@ -24,10 +24,7 @@ class PandasUDFGroupedAggParityTests(GroupedAggPandasUDFTestsMixin, ReusedConnec
     # TODO(SPARK-43727): Parity returnType check in Spark Connect
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_unsupported_types(self):
-        self.check_unsupported_types()
-
-    def test_invalid_args(self):
-        self.check_invalid_args()
+        super().test_unsupported_types()
 
     @unittest.skip("Spark Connect doesn't support RDD but the test depends on it.")
     def test_grouped_with_empty_partition(self):

--- a/python/pyspark/sql/tests/connect/test_parity_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_udf_scalar.py
@@ -32,25 +32,10 @@ class PandasUDFScalarParityTests(ScalarPandasUDFTestsMixin, ReusedConnectTestCas
     def test_vectorized_udf_struct_with_empty_partition(self):
         super().test_vectorized_udf_struct_with_empty_partition()
 
-    def test_vectorized_udf_exception(self):
-        self.check_vectorized_udf_exception()
-
-    def test_vectorized_udf_nested_struct(self):
-        self.check_vectorized_udf_nested_struct()
-
-    def test_vectorized_udf_return_scalar(self):
-        self.check_vectorized_udf_return_scalar()
-
-    def test_scalar_iter_udf_close(self):
-        self.check_scalar_iter_udf_close()
-
     # TODO(SPARK-43727): Parity returnType check in Spark Connect
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_vectorized_udf_wrong_return_type(self):
-        self.check_vectorized_udf_wrong_return_type()
-
-    def test_vectorized_udf_invalid_length(self):
-        self.check_vectorized_udf_invalid_length()
+        super().test_vectorized_udf_wrong_return_type()
 
     def test_mixed_udf_and_sql(self):
         self._test_mixed_udf_and_sql(Column)

--- a/python/pyspark/sql/tests/connect/test_parity_pandas_udf_window.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_udf_window.py
@@ -25,7 +25,7 @@ class PandasUDFWindowParityTests(WindowPandasUDFTestsMixin, ReusedConnectTestCas
     #  AnalysisException
     @unittest.skip("Fails in Spark Connect, should enable.")
     def test_invalid_args(self):
-        self.check_invalid_args()
+        super().test_invalid_args()
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/connect/test_parity_udf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udf.py
@@ -64,12 +64,6 @@ class UDFParityTests(BaseUDFTestsMixin, ReusedConnectTestCase):
     def test_nondeterministic_udf3(self):
         super().test_nondeterministic_udf3()
 
-    def test_nondeterministic_udf_in_aggregate(self):
-        self.check_nondeterministic_udf_in_aggregate()
-
-    def test_udf_registration_return_type_not_none(self):
-        self.check_udf_registration_return_type_not_none()
-
     @unittest.skip("Spark Connect doesn't support RDD but the test depends on it.")
     def test_worker_original_stdin_closed(self):
         super().test_worker_original_stdin_closed()
@@ -85,12 +79,6 @@ class UDFParityTests(BaseUDFTestsMixin, ReusedConnectTestCase):
     @unittest.skip("Spark Connect does not support SQLContext but the test depends on it.")
     def test_udf_registration_returns_udf_on_sql_context(self):
         super().test_udf_registration_returns_udf_on_sql_context()
-
-    def test_err_udf_registration(self):
-        self.check_err_udf_registration()
-
-    def test_err_udf_init(self):
-        self.check_err_udf_init()
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
@@ -37,7 +37,6 @@ from pyspark.testing.sqlutils import (
     pandas_requirement_message,
     pyarrow_requirement_message,
 )
-from pyspark.testing.utils import QuietTest
 
 if have_pandas:
     import pandas as pd
@@ -139,7 +138,7 @@ class CogroupedApplyInPandasTestsMixin:
         self._test_merge(self.data1, self.data2, by=[])
 
     def test_different_group_key_cardinality(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_different_group_key_cardinality()
 
     def check_different_group_key_cardinality(self):
@@ -158,7 +157,7 @@ class CogroupedApplyInPandasTestsMixin:
             )
 
     def test_apply_in_pandas_not_returning_pandas_dataframe(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_apply_in_pandas_not_returning_pandas_dataframe()
 
     def check_apply_in_pandas_not_returning_pandas_dataframe(self):
@@ -191,7 +190,7 @@ class CogroupedApplyInPandasTestsMixin:
         self._test_merge(fn=merge_pandas)
 
     def test_apply_in_pandas_returning_wrong_column_names(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_apply_in_pandas_returning_wrong_column_names()
 
     def check_apply_in_pandas_returning_wrong_column_names(self):
@@ -210,7 +209,7 @@ class CogroupedApplyInPandasTestsMixin:
         )
 
     def test_apply_in_pandas_returning_no_column_names_and_wrong_amount(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_apply_in_pandas_returning_no_column_names_and_wrong_amount()
 
     def check_apply_in_pandas_returning_no_column_names_and_wrong_amount(self):
@@ -241,7 +240,7 @@ class CogroupedApplyInPandasTestsMixin:
         self._test_merge_empty(fn=merge_pandas)
 
     def test_apply_in_pandas_returning_incompatible_type(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_apply_in_pandas_returning_incompatible_type()
 
     def check_apply_in_pandas_returning_incompatible_type(self):
@@ -332,7 +331,7 @@ class CogroupedApplyInPandasTestsMixin:
         assert_frame_equal(expected, result)
 
     def test_wrong_return_type(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_wrong_return_type()
 
     def check_wrong_return_type(self):
@@ -347,7 +346,7 @@ class CogroupedApplyInPandasTestsMixin:
         )
 
     def test_wrong_args(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_wrong_args()
 
     def check_wrong_args(self):

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -60,7 +60,6 @@ from pyspark.testing.sqlutils import (
     pandas_requirement_message,
     pyarrow_requirement_message,
 )
-from pyspark.testing.utils import QuietTest
 
 if have_pandas:
     import pandas as pd
@@ -209,7 +208,7 @@ class GroupedApplyInPandasTestsMixin:
         assert_frame_equal(expected, result)
 
     def test_register_grouped_map_udf(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_register_grouped_map_udf()
 
     def check_register_grouped_map_udf(self):
@@ -279,7 +278,7 @@ class GroupedApplyInPandasTestsMixin:
         assert_frame_equal(expected, result)
 
     def test_apply_in_pandas_not_returning_pandas_dataframe(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_apply_in_pandas_not_returning_pandas_dataframe()
 
     def check_apply_in_pandas_not_returning_pandas_dataframe(self):
@@ -315,7 +314,7 @@ class GroupedApplyInPandasTestsMixin:
         self._test_apply_in_pandas(stats)
 
     def test_apply_in_pandas_returning_wrong_column_names(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_apply_in_pandas_returning_wrong_column_names()
 
     def check_apply_in_pandas_returning_wrong_column_names(self):
@@ -331,7 +330,7 @@ class GroupedApplyInPandasTestsMixin:
             )
 
     def test_apply_in_pandas_returning_no_column_names_and_wrong_amount(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_apply_in_pandas_returning_no_column_names_and_wrong_amount()
 
     def check_apply_in_pandas_returning_no_column_names_and_wrong_amount(self):
@@ -348,7 +347,7 @@ class GroupedApplyInPandasTestsMixin:
         self._test_apply_in_pandas_returning_empty_dataframe(pd.DataFrame())
 
     def test_apply_in_pandas_returning_incompatible_type(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_apply_in_pandas_returning_incompatible_type()
 
     def check_apply_in_pandas_returning_incompatible_type(self):
@@ -401,7 +400,7 @@ class GroupedApplyInPandasTestsMixin:
         assert_frame_equal(expected, result)
 
     def test_wrong_return_type(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_wrong_return_type()
 
     def check_wrong_return_type(self):
@@ -416,7 +415,7 @@ class GroupedApplyInPandasTestsMixin:
             )
 
     def test_wrong_args(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_wrong_args()
 
     def check_wrong_args(self):
@@ -440,7 +439,7 @@ class GroupedApplyInPandasTestsMixin:
             df.groupby("id").apply(pandas_udf(lambda x, y: x, DoubleType(), PandasUDFType.SCALAR))
 
     def test_unsupported_types(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_unsupported_types()
 
     def check_unsupported_types(self):
@@ -552,7 +551,7 @@ class GroupedApplyInPandasTestsMixin:
         assert_frame_equal(expected4, result4)
 
     def test_column_order(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_column_order()
 
     def check_column_order(self):
@@ -844,7 +843,7 @@ class GroupedApplyInPandasTestsMixin:
             self.assertEqual(24.5, row[1])
 
     def _test_apply_in_pandas_returning_empty_dataframe_error(self, empty_df, error):
-        with QuietTest(self.sc):
+        with self.quiet():
             with self.assertRaisesRegex(PythonException, error):
                 self._test_apply_in_pandas_returning_empty_dataframe(empty_df)
 

--- a/python/pyspark/sql/tests/pandas/test_pandas_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_map.py
@@ -31,7 +31,7 @@ from pyspark.testing.sqlutils import (
     pandas_requirement_message,
     pyarrow_requirement_message,
 )
-from pyspark.testing.utils import QuietTest, eventually
+from pyspark.testing.utils import eventually
 
 if have_pandas:
     import pandas as pd
@@ -138,7 +138,7 @@ class MapInPandasTestsMixin:
         self.assertEqual(set((r.a for r in actual)), set(range(100)))
 
     def test_other_than_dataframe_iter(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_other_than_dataframe_iter()
 
     def check_other_than_dataframe_iter(self):
@@ -163,7 +163,7 @@ class MapInPandasTestsMixin:
             (self.spark.range(10, numPartitions=3).mapInPandas(bad_iter_elem, "a int").count())
 
     def test_dataframes_with_other_column_names(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_dataframes_with_other_column_names()
 
     def check_dataframes_with_other_column_names(self):
@@ -185,7 +185,7 @@ class MapInPandasTestsMixin:
             )
 
     def test_dataframes_with_duplicate_column_names(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_dataframes_with_duplicate_column_names()
 
     def check_dataframes_with_duplicate_column_names(self):
@@ -208,7 +208,7 @@ class MapInPandasTestsMixin:
             )
 
     def test_dataframes_with_less_columns(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_dataframes_with_less_columns()
 
     def check_dataframes_with_less_columns(self):
@@ -247,7 +247,7 @@ class MapInPandasTestsMixin:
         self.assertEqual(actual, expected)
 
     def test_dataframes_with_incompatible_types(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_dataframes_with_incompatible_types()
 
     def check_dataframes_with_incompatible_types(self):
@@ -314,7 +314,7 @@ class MapInPandasTestsMixin:
         self.assertEqual(mapped.count(), 10)
 
     def test_empty_dataframes_with_less_columns(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_empty_dataframes_with_less_columns()
 
     def check_empty_dataframes_with_less_columns(self):
@@ -339,7 +339,7 @@ class MapInPandasTestsMixin:
         self.assertEqual(mapped.count(), 10)
 
     def test_empty_dataframes_with_other_columns(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_empty_dataframes_with_other_columns()
 
     def check_empty_dataframes_with_other_columns(self):

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf.py
@@ -30,7 +30,6 @@ from pyspark.testing.sqlutils import (
     pandas_requirement_message,
     pyarrow_requirement_message,
 )
-from pyspark.testing.utils import QuietTest
 
 
 @unittest.skipIf(
@@ -126,7 +125,7 @@ class PandasUDFTestsMixin:
         self.assertEqual(foo.evalType, PythonEvalType.SQL_SCALAR_PANDAS_UDF)
 
     def test_udf_wrong_arg(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_udf_wrong_arg()
 
             with self.assertRaises(ParseException):

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_grouped_agg.py
@@ -40,7 +40,7 @@ from pyspark.testing.sqlutils import (
     pandas_requirement_message,
     pyarrow_requirement_message,
 )
-from pyspark.testing.utils import QuietTest, assertDataFrameEqual
+from pyspark.testing.utils import assertDataFrameEqual
 
 
 if have_pandas:
@@ -176,7 +176,7 @@ class GroupedAggPandasUDFTestsMixin:
         assert_frame_equal(expected4.toPandas(), result4.toPandas())
 
     def test_unsupported_types(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_unsupported_types()
 
     def check_unsupported_types(self):
@@ -501,7 +501,7 @@ class GroupedAggPandasUDFTestsMixin:
         self.assertEqual(result1.first()["v2"], [1.0, 2.0])
 
     def test_invalid_args(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_invalid_args()
 
     def check_invalid_args(self):

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -58,7 +58,7 @@ from pyspark.testing.sqlutils import (
     pandas_requirement_message,
     pyarrow_requirement_message,
 )
-from pyspark.testing.utils import QuietTest, assertDataFrameEqual
+from pyspark.testing.utils import assertDataFrameEqual
 
 if have_pandas:
     import pandas as pd
@@ -544,7 +544,7 @@ class ScalarPandasUDFTestsMixin:
                 )
 
     def test_vectorized_udf_nested_struct(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_vectorized_udf_nested_struct()
 
     def check_vectorized_udf_nested_struct(self):
@@ -631,7 +631,7 @@ class ScalarPandasUDFTestsMixin:
             self.assertEqual(expected.collect(), res.collect())
 
     def test_vectorized_udf_exception(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_vectorized_udf_exception()
 
     def check_vectorized_udf_exception(self):
@@ -648,7 +648,7 @@ class ScalarPandasUDFTestsMixin:
                 df.select(raise_exception(col("id"))).collect()
 
     def test_vectorized_udf_invalid_length(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_vectorized_udf_invalid_length()
 
     def check_vectorized_udf_invalid_length(self):
@@ -723,7 +723,7 @@ class ScalarPandasUDFTestsMixin:
             self.assertEqual(expected, actual)
 
     def test_vectorized_udf_wrong_return_type(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_vectorized_udf_wrong_return_type()
 
     def check_vectorized_udf_wrong_return_type(self):
@@ -735,7 +735,7 @@ class ScalarPandasUDFTestsMixin:
                 pandas_udf(lambda x: x, ArrayType(YearMonthIntervalType()), udf_type)
 
     def test_vectorized_udf_return_scalar(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_vectorized_udf_return_scalar()
 
     def check_vectorized_udf_return_scalar(self):
@@ -1039,7 +1039,7 @@ class ScalarPandasUDFTestsMixin:
             self.assertTrue(result1["plus_ten(rand)"].equals(result1["rand"] + 10))
 
     def test_nondeterministic_vectorized_udf_in_aggregate(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_nondeterministic_analysis_exception()
 
     def check_nondeterministic_analysis_exception(self):
@@ -1100,7 +1100,7 @@ class ScalarPandasUDFTestsMixin:
             )
 
     def test_scalar_iter_udf_close(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_scalar_iter_udf_close()
 
     def check_scalar_iter_udf_close(self):
@@ -1135,7 +1135,7 @@ class ScalarPandasUDFTestsMixin:
                     assert generator_exit_caught, "Generator exit exception was not caught."
                     open(tmp_file, "a").close()
 
-            with QuietTest(self.sc):
+            with self.quiet():
                 with self.sql_conf(
                     {
                         "spark.sql.execution.arrow.maxRecordsPerBatch": 1,

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_window.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_window.py
@@ -40,7 +40,7 @@ from pyspark.testing.sqlutils import (
     pandas_requirement_message,
     pyarrow_requirement_message,
 )
-from pyspark.testing.utils import QuietTest, assertDataFrameEqual
+from pyspark.testing.utils import assertDataFrameEqual
 
 if have_pandas:
     from pandas.testing import assert_frame_equal
@@ -283,7 +283,7 @@ class WindowPandasUDFTestsMixin:
         self.assertEqual(result1.first()["v2"], [1.0, 2.0])
 
     def test_invalid_args(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_invalid_args()
 
     def check_invalid_args(self):

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -55,7 +55,6 @@ from pyspark.testing.sqlutils import (
     ExamplePoint,
     ExamplePointUDT,
 )
-from pyspark.testing.utils import QuietTest
 from pyspark.errors import ArithmeticException, PySparkTypeError, UnsupportedOperationException
 
 if have_pandas:
@@ -388,7 +387,7 @@ class ArrowTestsMixin:
         self.assertTrue(pdf.empty)
 
     def test_propagates_spark_exception(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_propagates_spark_exception()
 
     def check_propagates_spark_exception(self):
@@ -459,7 +458,7 @@ class ArrowTestsMixin:
         assert_frame_equal(pdf_arrow, pdf)
 
     def test_createDataFrame_with_incorrect_schema(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_createDataFrame_with_incorrect_schema()
 
     def check_createDataFrame_with_incorrect_schema(self):
@@ -506,7 +505,7 @@ class ArrowTestsMixin:
         self.assertEqual(columns[0], "b")
 
     def test_createDataFrame_with_single_data_type(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_createDataFrame_with_single_data_type()
 
     def check_createDataFrame_with_single_data_type(self):
@@ -599,7 +598,7 @@ class ArrowTestsMixin:
                 self.assertTrue(expected[r][e] == result[r][e])
 
     def test_createDataFrame_with_map_type(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             for arrow_enabled in [True, False]:
                 with self.subTest(arrow_enabled=arrow_enabled):
                     self.check_createDataFrame_with_map_type(arrow_enabled)
@@ -670,7 +669,7 @@ class ArrowTestsMixin:
             assert_frame_equal(pandas_df, df.toPandas(), check_dtype=False)
 
     def test_toPandas_with_map_type(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             for arrow_enabled in [True, False]:
                 with self.subTest(arrow_enabled=arrow_enabled):
                     self.check_toPandas_with_map_type(arrow_enabled)
@@ -692,7 +691,7 @@ class ArrowTestsMixin:
                 assert_frame_equal(origin, pdf)
 
     def test_toPandas_with_map_type_nulls(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             for arrow_enabled in [True, False]:
                 with self.subTest(arrow_enabled=arrow_enabled):
                     self.check_toPandas_with_map_type_nulls(arrow_enabled)

--- a/python/pyspark/sql/tests/test_arrow_cogrouped_map.py
+++ b/python/pyspark/sql/tests/test_arrow_cogrouped_map.py
@@ -26,8 +26,6 @@ from pyspark.testing.sqlutils import (
     have_pyarrow,
     pyarrow_requirement_message,
 )
-from pyspark.testing.utils import QuietTest
-
 
 if have_pyarrow:
     import pyarrow as pa
@@ -128,7 +126,7 @@ class CogroupedMapInArrowTestsMixin:
         def func(key, left, right):
             return key
 
-        with self.quiet_test():
+        with self.quiet():
             with self.assertRaisesRegex(
                 PythonException,
                 "Return type of the user-defined function should be pyarrow.Table, but is tuple",
@@ -147,7 +145,7 @@ class CogroupedMapInArrowTestsMixin:
             ("id long, v string", "column 'v' \\(expected string, actual int64\\)"),
         ]:
             with self.subTest(schema=schema):
-                with self.quiet_test():
+                with self.quiet():
                     with self.assertRaisesRegex(
                         PythonException,
                         f"Columns do not match in their data type: {expected}",
@@ -171,7 +169,7 @@ class CogroupedMapInArrowTestsMixin:
                 with self.sql_conf(
                     {"spark.sql.legacy.execution.pandas.groupedMap.assignColumnsByName": False}
                 ):
-                    with self.quiet_test():
+                    with self.quiet():
                         with self.assertRaisesRegex(
                             PythonException,
                             f"Columns do not match in their data type: {expected}",
@@ -191,7 +189,7 @@ class CogroupedMapInArrowTestsMixin:
                 }
             )
 
-        with self.quiet_test():
+        with self.quiet():
             with self.assertRaisesRegex(
                 PythonException,
                 "Column names of the returned pyarrow.Table do not match specified schema. "
@@ -227,7 +225,7 @@ class CogroupedMapInArrowTestsMixin:
                     {"id": [key[0].as_py()], "m": [pc.mean(left.column("v")).as_py()]}
                 )
 
-        with self.quiet_test():
+        with self.quiet():
             with self.assertRaisesRegex(
                 PythonException,
                 "Column names of the returned pyarrow.Table do not match specified schema. "
@@ -323,9 +321,6 @@ class CogroupedMapInArrowTests(CogroupedMapInArrowTestsMixin, ReusedSQLTestCase)
             os.environ["TZ"] = cls.tz_prev
         time.tzset()
         ReusedSQLTestCase.tearDownClass()
-
-    def quiet_test(self):
-        return QuietTest(self.sc)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/test_arrow_grouped_map.py
+++ b/python/pyspark/sql/tests/test_arrow_grouped_map.py
@@ -27,8 +27,6 @@ from pyspark.testing.sqlutils import (
     have_pyarrow,
     pyarrow_requirement_message,
 )
-from pyspark.testing.utils import QuietTest
-
 
 if have_pyarrow:
     import pyarrow as pa
@@ -111,7 +109,7 @@ class GroupedMapInArrowTestsMixin:
         def stats(key, _):
             return key
 
-        with self.quiet_test():
+        with self.quiet():
             with self.assertRaisesRegex(
                 PythonException,
                 "Return type of the user-defined function should be pyarrow.Table, but is tuple",
@@ -132,7 +130,7 @@ class GroupedMapInArrowTestsMixin:
             ("id long, v string", "column 'v' \\(expected string, actual int32\\)"),
         ]:
             with self.subTest(schema=schema):
-                with self.quiet_test():
+                with self.quiet():
                     with self.assertRaisesRegex(
                         PythonException,
                         f"Columns do not match in their data type: {expected}",
@@ -156,7 +154,7 @@ class GroupedMapInArrowTestsMixin:
                 with self.sql_conf(
                     {"spark.sql.legacy.execution.pandas.groupedMap.assignColumnsByName": False}
                 ):
-                    with self.quiet_test():
+                    with self.quiet():
                         with self.assertRaisesRegex(
                             PythonException,
                             f"Columns do not match in their data type: {expected}",
@@ -178,7 +176,7 @@ class GroupedMapInArrowTestsMixin:
                 }
             )
 
-        with self.quiet_test():
+        with self.quiet():
             with self.assertRaisesRegex(
                 PythonException,
                 "Column names of the returned pyarrow.Table do not match specified schema. "
@@ -214,7 +212,7 @@ class GroupedMapInArrowTestsMixin:
                     {"id": [key[0].as_py()], "m": [pc.mean(table.column("v")).as_py()]}
                 )
 
-        with self.quiet_test():
+        with self.quiet():
             with self.assertRaisesRegex(
                 PythonException,
                 "Column names of the returned pyarrow.Table do not match specified schema. "
@@ -279,9 +277,6 @@ class GroupedMapInArrowTests(GroupedMapInArrowTestsMixin, ReusedSQLTestCase):
             os.environ["TZ"] = cls.tz_prev
         time.tzset()
         ReusedSQLTestCase.tearDownClass()
-
-    def quiet_test(self):
-        return QuietTest(self.sc)
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/test_arrow_map.py
+++ b/python/pyspark/sql/tests/test_arrow_map.py
@@ -26,7 +26,6 @@ from pyspark.testing.sqlutils import (
     pandas_requirement_message,
     pyarrow_requirement_message,
 )
-from pyspark.testing.utils import QuietTest
 
 if have_pyarrow:
     import pyarrow as pa
@@ -91,7 +90,7 @@ class MapInArrowTestsMixin(object):
         self.assertEqual(set((r.a for r in actual)), set(range(100)))
 
     def test_other_than_recordbatch_iter(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_other_than_recordbatch_iter()
 
     def check_other_than_recordbatch_iter(self):

--- a/python/pyspark/sql/tests/test_collection.py
+++ b/python/pyspark/sql/tests/test_collection.py
@@ -35,7 +35,6 @@ from pyspark.testing.sqlutils import (
     pandas_requirement_message,
     pyarrow_requirement_message,
 )
-from pyspark.testing.utils import QuietTest
 
 
 class DataFrameCollectionTestsMixin:
@@ -145,7 +144,7 @@ class DataFrameCollectionTestsMixin:
 
     @unittest.skipIf(have_pandas, "Required Pandas was found.")
     def test_to_pandas_required_pandas_not_found(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             with self.assertRaisesRegex(ImportError, "Pandas >= .* must be installed"):
                 self._to_pandas()
 
@@ -309,7 +308,7 @@ class DataFrameCollectionTestsMixin:
         self.assertEqual(expected, list(it))
 
     def test_to_local_iterator_not_fully_consumed(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_to_local_iterator_not_fully_consumed()
 
     def check_to_local_iterator_not_fully_consumed(self):

--- a/python/pyspark/sql/tests/test_creation.py
+++ b/python/pyspark/sql/tests/test_creation.py
@@ -37,7 +37,6 @@ from pyspark.testing.sqlutils import (
     have_pandas,
     pandas_requirement_message,
 )
-from pyspark.testing.utils import QuietTest
 
 
 class DataFrameCreationTestsMixin:
@@ -71,7 +70,7 @@ class DataFrameCreationTestsMixin:
 
     @unittest.skipIf(have_pandas, "Required Pandas was found.")
     def test_create_dataframe_required_pandas_not_found(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             with self.assertRaisesRegex(
                 ImportError, "(Pandas >= .* must be installed|No module named '?pandas'?)"
             ):

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -45,7 +45,7 @@ from pyspark.testing.sqlutils import (
     test_compiled,
     test_not_compiled_message,
 )
-from pyspark.testing.utils import QuietTest, assertDataFrameEqual
+from pyspark.testing.utils import assertDataFrameEqual
 
 
 class BaseUDFTestsMixin(object):
@@ -110,7 +110,7 @@ class BaseUDFTestsMixin(object):
         self.assertEqual(row[0], 5)
 
     def test_udf_registration_return_type_not_none(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_udf_registration_return_type_not_none()
 
     def check_udf_registration_return_type_not_none(self):
@@ -169,7 +169,7 @@ class BaseUDFTestsMixin(object):
         self.assertFalse(deterministic)
 
     def test_nondeterministic_udf_in_aggregate(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_nondeterministic_udf_in_aggregate()
 
     def check_nondeterministic_udf_in_aggregate(self):
@@ -436,7 +436,7 @@ class BaseUDFTestsMixin(object):
         self.assertEqual(row.asDict(), Row(name="b", avg=102.0).asDict())
 
     def test_err_udf_registration(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_err_udf_registration()
 
     def check_err_udf_registration(self):
@@ -1055,7 +1055,7 @@ class BaseUDFTestsMixin(object):
                 self.spark.range(1).select(udf(lambda x: ctypes.string_at(0))("id")).collect()
 
     def test_err_udf_init(self):
-        with QuietTest(self.sc):
+        with self.quiet():
             self.check_err_udf_init()
 
     def check_err_udf_init(self):

--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -184,6 +184,7 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
             .remote(cls.master())
             .getOrCreate()
         )
+        cls._legacy_sc = PySparkSession._instantiatedSession._sc
         cls.tempdir = tempfile.NamedTemporaryFile(delete=False)
         os.unlink(cls.tempdir.name)
         cls.testData = [Row(key=i, value=str(i)) for i in range(100)]
@@ -198,3 +199,8 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
         from pyspark.sql import is_remote
 
         self.assertTrue(is_remote())
+
+    def quiet(self):
+        from pyspark.testing.utils import QuietTest
+
+        return QuietTest(self._legacy_sc)

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -184,6 +184,11 @@ class ReusedPySparkTestCase(unittest.TestCase):
 
         self.assertFalse(is_remote())
 
+    def quiet(self):
+        from pyspark.testing.utils import QuietTest
+
+        return QuietTest(self.sc)
+
 
 class ByteArrayOutput:
     def __init__(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, add `def quiet` in both `ReusedPySparkTestCase` and `ReusedConnectTestCase`;
2, replace existing `QuietTest(self.sc)` with `self.quiet()`;
3, remove unnecessary overridden parity tests;

### Why are the changes needed?
there are a lot of tests not enabled in parity test due to the usage of `sc` in `with QuietTest(self.sc)`, some of them were break into `def check_` and call the `check_` functions in the parity tests;
However, there are still such tests not enabled.

This PR aims to enable `QuietTest` within parity tests and make it easier to enable the remaining tests (`def check_` no longer needed).


### Does this PR introduce _any_ user-facing change?
no, test only

### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
