### PR TITLE
[Deprecated][SQL] Add support for collation for StringTrim type of functions/expressions

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
@@ -176,11 +176,11 @@ public final class CollationFactory {
    */
 
   public static StringSearch getStringSearch(
-      final UTF8String left,
-      final UTF8String right,
+      final UTF8String targetString,
+      final UTF8String patternString,
       final int collationId) {
-    String pattern = right.toString();
-    CharacterIterator target = new StringCharacterIterator(left.toString());
+    String pattern = patternString.toString();
+    CharacterIterator target = new StringCharacterIterator(targetString.toString());
     Collator collator = CollationFactory.fetchCollation(collationId).collator;
     return new StringSearch(pattern, target, (RuleBasedCollator) collator);
   }

--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
@@ -175,12 +175,19 @@ public final class CollationFactory {
    * Auxiliary methods for collation aware string operations.
    */
 
+  /**
+   * Creates an instance of ICU's StringSearch with provided parameters.
+   * @param targetUTF8String UTF8String representation of the string to be searched.
+   * @param patternUTF8String UTF8String representation of the string to search for.
+   * @param collationId ID of the collation to use.
+   * @return Created instance of StringSearch.
+   */
   public static StringSearch getStringSearch(
-      final UTF8String targetString,
-      final UTF8String patternString,
+      final UTF8String targetUTF8String,
+      final UTF8String patternUTF8String,
       final int collationId) {
-    String pattern = patternString.toString();
-    CharacterIterator target = new StringCharacterIterator(targetString.toString());
+    String pattern = patternUTF8String.toString();
+    CharacterIterator target = new StringCharacterIterator(targetUTF8String.toString());
     Collator collator = CollationFactory.fetchCollation(collationId).collator;
     return new StringSearch(pattern, target, (RuleBasedCollator) collator);
   }

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -585,6 +585,16 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     return copyUTF8String(s, e);
   }
 
+  public UTF8String trim(int collationId) {
+    if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality
+        || CollationFactory.UTF8_BINARY_LCASE_COLLATION_ID == collationId) {
+      return trim();
+    }
+    else {
+      return trim(UTF8String.fromString(" "), collationId);
+    }
+  }
+
   /**
    * Trims whitespace ASCII characters from both ends of this string.
    *
@@ -628,6 +638,18 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     }
   }
 
+  public UTF8String trim(UTF8String trimString, int collationId) {
+    if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality) {
+      return trim(trimString);
+    }
+
+    if (CollationFactory.UTF8_BINARY_LCASE_COLLATION_ID == collationId) {
+      return lowercaseTrimLeft(trimString).lowercaseTrimRight(trimString);
+    }
+
+    return trimLeft(trimString, collationId).trimRight(trimString, collationId);
+  }
+
   /**
    * Trims space characters (ASCII 32) from the start of this string.
    *
@@ -646,6 +668,16 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
       return EMPTY_UTF8;
     }
     return copyUTF8String(s, this.numBytes - 1);
+  }
+
+  public UTF8String trimLeft(int collationId) {
+    if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality
+        || CollationFactory.UTF8_BINARY_LCASE_COLLATION_ID == collationId) {
+      return trimLeft();
+    }
+    else {
+      return trimLeft(UTF8String.fromString(" "), collationId);
+    }
   }
 
   /**
@@ -686,6 +718,28 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     return copyUTF8String(trimIdx, numBytes - 1);
   }
 
+  public UTF8String trimLeft(UTF8String trimString, int collationId) {
+    if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality) {
+      return trimLeft(trimString);
+    }
+
+    if (CollationFactory.UTF8_BINARY_LCASE_COLLATION_ID == collationId) {
+      return lowercaseTrimLeft(trimString);
+    }
+
+    return collatedTrimLeft(trimString, collationId);
+  }
+
+  public UTF8String lowercaseTrimLeft(UTF8String trimString) {
+    // TODO
+    return EMPTY_UTF8;
+  }
+
+  public UTF8String collatedTrimLeft(UTF8String trimString, int collationId) {
+    // TODO
+    return EMPTY_UTF8;
+  }
+
   /**
    * Trims space characters (ASCII 32) from the end of this string.
    *
@@ -704,6 +758,16 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
       return EMPTY_UTF8;
     }
     return copyUTF8String(0, e);
+  }
+
+  public UTF8String trimRight(int collationId) {
+    if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality
+        || CollationFactory.UTF8_BINARY_LCASE_COLLATION_ID == collationId) {
+      return trimRight();
+    }
+    else {
+      return trimRight(UTF8String.fromString(" "), collationId);
+    }
   }
 
   /**
@@ -765,6 +829,28 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
       return EMPTY_UTF8;
     }
     return copyUTF8String(0, trimEnd);
+  }
+
+  public UTF8String trimRight(UTF8String trimString, int collationId) {
+    if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality) {
+      return trimRight(trimString);
+    }
+
+    if (CollationFactory.UTF8_BINARY_LCASE_COLLATION_ID == collationId) {
+      return lowercaseTrimRight(trimString);
+    }
+
+    return collatedTrimRight(trimString, collationId);
+  }
+
+  public UTF8String lowercaseTrimRight(UTF8String trimString) {
+    // TODO
+    return EMPTY_UTF8;
+  }
+
+  public UTF8String collatedTrimRight(UTF8String trimString, int collationId) {
+    // TODO
+    return EMPTY_UTF8;
   }
 
   public UTF8String reverse() {

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -698,7 +698,6 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
       UTF8String searchChar = copyUTF8String(
           searchIdx, searchIdx + numBytesForFirstByte(this.getByte(searchIdx)) - 1);
       int searchCharBytes = searchChar.numBytes;
-
       // try to find the matching for the searchChar in the trimString set
       if (trimString.find(searchChar, 0) >= 0) {
         trimIdx += searchCharBytes;
@@ -708,7 +707,6 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
       }
       searchIdx += searchCharBytes;
     }
-
     if (searchIdx == 0) {
       // Nothing trimmed
       return this;
@@ -873,30 +871,27 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     int[] stringCharLen = new int[numBytes];
     // array of the first byte position for each character in the source string
     int[] stringCharPos = new int[numBytes];
-
     // build the position and length array
     while (charIdx < numBytes) {
       stringCharPos[numChars] = charIdx;
       stringCharLen[numChars] = numBytesForFirstByte(getByte(charIdx));
       charIdx += stringCharLen[numChars];
-      numChars++;
+      numChars ++;
     }
 
     // index trimEnd points to the first no matching byte position from the right side of
     // the source string.
     int trimEnd = numBytes - 1;
-
     while (numChars > 0) {
       UTF8String searchChar = copyUTF8String(
           stringCharPos[numChars - 1],
           stringCharPos[numChars - 1] + stringCharLen[numChars - 1] - 1);
-
       if (trimString.find(searchChar, 0) >= 0) {
         trimEnd -= stringCharLen[numChars - 1];
       } else {
         break;
       }
-      numChars--;
+      numChars --;
     }
 
     if (trimEnd == numBytes - 1) {

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -597,8 +597,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality
         || CollationFactory.UTF8_BINARY_LCASE_COLLATION_ID == collationId) {
       return trim();
-    }
-    else {
+    } else {
       return trim(UTF8String.fromString(" "), collationId);
     }
   }
@@ -699,8 +698,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality
         || CollationFactory.UTF8_BINARY_LCASE_COLLATION_ID == collationId) {
       return trimLeft();
-    }
-    else {
+    } else {
       return trimLeft(UTF8String.fromString(" "), collationId);
     }
   }
@@ -761,7 +759,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
       return lowercaseTrimLeft(trimString);
     }
 
-    return collatedTrimLeft(trimString, collationId);
+    return collationAwareTrimLeft(trimString, collationId);
   }
 
   private UTF8String lowercaseTrimLeft(UTF8String trimString) {
@@ -787,8 +785,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
       if (trimString.find(searchChar.toLowerCase(), 0) >= 0) {
         trimByteIdx += searchCharBytes;
         searchIdx += searchCharBytes;
-      }
-      else {
+      } else {
         // No matching, exit the search
         break;
       }
@@ -805,7 +802,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     return copyUTF8String(trimByteIdx, numBytes - 1);
   }
 
-  private UTF8String collatedTrimLeft(UTF8String trimString, int collationId) {
+  private UTF8String collationAwareTrimLeft(UTF8String trimString, int collationId) {
     if (trimString == null) {
       return null;
     }
@@ -830,8 +827,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
           && stringSearch.getMatchLength() == stringSearch.getPattern().length()) {
         trimByteIdx += searchCharBytes;
         searchIdx += searchCharBytes;
-      }
-      else {
+      } else {
         // No matching, exit the search
         break;
       }
@@ -880,8 +876,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality
         || CollationFactory.UTF8_BINARY_LCASE_COLLATION_ID == collationId) {
       return trimRight();
-    }
-    else {
+    } else {
       return trimRight(UTF8String.fromString(" "), collationId);
     }
   }
@@ -965,7 +960,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
       return lowercaseTrimRight(trimString);
     }
 
-    return collatedTrimRight(trimString, collationId);
+    return collationAwareTrimRight(trimString, collationId);
   }
 
   private UTF8String lowercaseTrimRight(UTF8String trimString) {
@@ -1006,8 +1001,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
       if (trimString.find(searchChar.toLowerCase(), 0) >= 0) {
         trimByteIdx -= stringCharLen[numChars - 1];
         numChars--;
-      }
-      else {
+      } else {
         break;
       }
     }
@@ -1023,7 +1017,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     return copyUTF8String(0, trimByteIdx);
   }
 
-  private UTF8String collatedTrimRight(UTF8String trimString, int collationId) {
+  private UTF8String collationAwareTrimRight(UTF8String trimString, int collationId) {
     if (trimString == null) {
       return null;
     }
@@ -1063,8 +1057,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
           && stringSearch.getMatchLength() == stringSearch.getPattern().length()) {
         trimByteIdx -= stringCharLen[numChars - 1];
         numChars--;
-      }
-      else {
+      } else {
         break;
       }
     }

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -585,6 +585,14 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     return copyUTF8String(s, e);
   }
 
+  /**
+   * Trims space characters from both ends of this string - same as {@link UTF8String#trim()}.
+   * This variant of the method additionally applies provided collation to this string
+   * and space character before searching.
+   *
+   * @param collationId Id of the collation to use.
+   * @return this string with no spaces at the start or end.
+   */
   public UTF8String trim(int collationId) {
     if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality
         || CollationFactory.UTF8_BINARY_LCASE_COLLATION_ID == collationId) {
@@ -638,6 +646,15 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     }
   }
 
+  /**
+   * Trims characters of the given trim string from both ends of this string.
+   * This variant of the method additionally applies provided collation to this string
+   * and trim characters before searching.
+   *
+   * @param trimString The trim characters string.
+   * @param collationId Id of the collation to use.
+   * @return this string with no occurrences of the characters from trim string.
+   */
   public UTF8String trim(UTF8String trimString, int collationId) {
     if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality) {
       return trim(trimString);
@@ -670,6 +687,14 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     return copyUTF8String(s, this.numBytes - 1);
   }
 
+  /**
+   * Trims space characters from the start of this string - same as {@link UTF8String#trimLeft()}.
+   * This variant of the method additionally applies provided collation to this string
+   * and space character before searching.
+   *
+   * @param collationId Id of the collation to use.
+   * @return this string with no spaces at the start.
+   */
   public UTF8String trimLeft(int collationId) {
     if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality
         || CollationFactory.UTF8_BINARY_LCASE_COLLATION_ID == collationId) {
@@ -718,6 +743,15 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     return copyUTF8String(trimIdx, numBytes - 1);
   }
 
+  /**
+   * Trims characters of the given trim string from the start of this string.
+   * This variant of the method additionally applies provided collation to this string
+   * and trim characters before searching.
+   *
+   * @param trimString The trim characters string.
+   * @param collationId Id of the collation to use.
+   * @return this string with no occurrences of the trim characters at the start.
+   */
   public UTF8String trimLeft(UTF8String trimString, int collationId) {
     if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality) {
       return trimLeft(trimString);
@@ -834,6 +868,14 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     return copyUTF8String(0, e);
   }
 
+  /**
+   * Trims space characters from the end of this string - same as {@link UTF8String#trimRight()}.
+   * This variant of the method additionally applies provided collation to this string
+   * and space character before searching.
+   *
+   * @param collationId Id of the collation to use.
+   * @return this string with no spaces at the end.
+   */
   public UTF8String trimRight(int collationId) {
     if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality
         || CollationFactory.UTF8_BINARY_LCASE_COLLATION_ID == collationId) {
@@ -905,6 +947,15 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     return copyUTF8String(0, trimEnd);
   }
 
+  /**
+   * Trims characters of the given trim string from the end of this string.
+   * This variant of the method additionally applies provided collation to this string
+   * and trim characters before searching.
+   *
+   * @param trimString The trim characters string.
+   * @param collationId Id of the collation to use.
+   * @return this string with no occurrences of the trim characters at the end.
+   */
   public UTF8String trimRight(UTF8String trimString, int collationId) {
     if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality) {
       return trimRight(trimString);

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -1049,7 +1049,6 @@ trait String2TrimExpression extends Expression with ImplicitCastInputTypes {
     trimStr match {
       case None => TypeCheckResult.TypeCheckSuccess
       case Some(trimChars) =>
-        val collationId = srcStr.dataType.asInstanceOf[StringType].collationId
         CollationTypeConstraints.checkCollationCompatibility(collationId, Seq(trimChars.dataType))
     }
   }
@@ -1219,8 +1218,6 @@ case class StringTrim(srcStr: Expression, trimStr: Option[Expression] = None)
 
   override protected def direction: String = "BOTH"
 
-  override val trimMethod: String = "trim"
-
   override def doEval(srcString: UTF8String): UTF8String = {
     if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality) {
       srcString.trim()
@@ -1238,6 +1235,8 @@ case class StringTrim(srcStr: Expression, trimStr: Option[Expression] = None)
       srcString.trim(trimString, collationId)
     }
   }
+
+  override val trimMethod: String = "trim"
 
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression =
     copy(
@@ -1340,8 +1339,6 @@ case class StringTrimLeft(srcStr: Expression, trimStr: Option[Expression] = None
 
   override protected def direction: String = "LEADING"
 
-  override val trimMethod: String = "trimLeft"
-
   override def doEval(srcString: UTF8String): UTF8String = {
     if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality) {
       srcString.trimLeft()
@@ -1359,6 +1356,8 @@ case class StringTrimLeft(srcStr: Expression, trimStr: Option[Expression] = None
       srcString.trimLeft(trimString, collationId)
     }
   }
+
+  override val trimMethod: String = "trimLeft"
 
   override protected def withNewChildrenInternal(
       newChildren: IndexedSeq[Expression]): StringTrimLeft =
@@ -1414,8 +1413,6 @@ case class StringTrimRight(srcStr: Expression, trimStr: Option[Expression] = Non
 
   override protected def direction: String = "TRAILING"
 
-  override val trimMethod: String = "trimRight"
-
   override def doEval(srcString: UTF8String): UTF8String = {
     if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality) {
       srcString.trimRight()
@@ -1433,6 +1430,8 @@ case class StringTrimRight(srcStr: Expression, trimStr: Option[Expression] = Non
       srcString.trimRight(trimString, collationId)
     }
   }
+
+  override val trimMethod: String = "trimRight"
 
   override protected def withNewChildrenInternal(
       newChildren: IndexedSeq[Expression]): StringTrimRight =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -1197,8 +1197,7 @@ case class StringTrim(srcStr: Expression, trimStr: Option[Expression] = None)
   override def doEval(srcString: UTF8String): UTF8String = {
     if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality) {
       srcString.trim()
-    }
-    else {
+    } else {
       srcString.trim(collationId)
     }
   }
@@ -1206,8 +1205,7 @@ case class StringTrim(srcStr: Expression, trimStr: Option[Expression] = None)
   override def doEval(srcString: UTF8String, trimString: UTF8String): UTF8String = {
     if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality) {
       srcString.trim(trimString)
-    }
-    else {
+    } else {
       srcString.trim(trimString, collationId)
     }
   }
@@ -1318,8 +1316,7 @@ case class StringTrimLeft(srcStr: Expression, trimStr: Option[Expression] = None
   override def doEval(srcString: UTF8String): UTF8String = {
     if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality) {
       srcString.trimLeft()
-    }
-    else {
+    } else {
       srcString.trimLeft(collationId)
     }
   }
@@ -1327,8 +1324,7 @@ case class StringTrimLeft(srcStr: Expression, trimStr: Option[Expression] = None
   override def doEval(srcString: UTF8String, trimString: UTF8String): UTF8String = {
     if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality) {
       srcString.trimLeft(trimString)
-    }
-    else {
+    } else {
       srcString.trimLeft(trimString, collationId)
     }
   }
@@ -1392,8 +1388,7 @@ case class StringTrimRight(srcStr: Expression, trimStr: Option[Expression] = Non
   override def doEval(srcString: UTF8String): UTF8String = {
     if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality) {
       srcString.trimRight()
-    }
-    else {
+    } else {
       srcString.trimRight(collationId)
     }
   }
@@ -1401,8 +1396,7 @@ case class StringTrimRight(srcStr: Expression, trimStr: Option[Expression] = Non
   override def doEval(srcString: UTF8String, trimString: UTF8String): UTF8String = {
     if (CollationFactory.fetchCollation(collationId).supportsBinaryEquality) {
       srcString.trimRight(trimString)
-    }
-    else {
+    } else {
       srcString.trimRight(trimString, collationId)
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
@@ -86,8 +86,326 @@ class CollationStringExpressionsSuite extends QueryTest
     testRepeat("UNICODE_CI", 3, "abc", 2)
   }
 
-  // TODO: Add more tests for other string expressions
+  case class StringTrimTestCase(
+    collation: String,
+    trimFunc: String,
+    sourceString: String,
+    trimString: String,
+    expectedResultString: String)
 
+  test("string trim functions with collation - success") {
+    // scalastyle:off
+
+    val testCases = Seq(
+      // Basic test cases
+      StringTrimTestCase("UTF8_BINARY", "TRIM", "asd", null, "asd"),
+      StringTrimTestCase("UTF8_BINARY", "TRIM", "  asd  ", null, "asd"),
+      StringTrimTestCase("UTF8_BINARY", "TRIM", " a世a ", null, "a世a"),
+      StringTrimTestCase("UTF8_BINARY", "TRIM", "asd", "x", "asd"),
+      StringTrimTestCase("UTF8_BINARY", "TRIM", "xxasdxx", "x", "asd"),
+      StringTrimTestCase("UTF8_BINARY", "TRIM", "xa世ax", "x", "a世a"),
+
+      StringTrimTestCase("UTF8_BINARY", "BTRIM", "asd", null, "asd"),
+      StringTrimTestCase("UTF8_BINARY", "BTRIM", "  asd  ", null, "asd"),
+      StringTrimTestCase("UTF8_BINARY", "BTRIM", " a世a ", null, "a世a"),
+      StringTrimTestCase("UTF8_BINARY", "BTRIM", "asd", "x", "asd"),
+      StringTrimTestCase("UTF8_BINARY", "BTRIM", "xxasdxx", "x", "asd"),
+      StringTrimTestCase("UTF8_BINARY", "BTRIM", "xa世ax", "x", "a世a"),
+
+      StringTrimTestCase("UTF8_BINARY", "LTRIM", "asd", null, "asd"),
+      StringTrimTestCase("UTF8_BINARY", "LTRIM", "  asd  ", null, "asd  "),
+      StringTrimTestCase("UTF8_BINARY", "LTRIM", " a世a ", null, "a世a "),
+      StringTrimTestCase("UTF8_BINARY", "LTRIM", "asd", "x", "asd"),
+      StringTrimTestCase("UTF8_BINARY", "LTRIM", "xxasdxx", "x", "asdxx"),
+      StringTrimTestCase("UTF8_BINARY", "LTRIM", "xa世ax", "x", "a世ax"),
+
+      StringTrimTestCase("UTF8_BINARY", "RTRIM", "asd", null, "asd"),
+      StringTrimTestCase("UTF8_BINARY", "RTRIM", "  asd  ", null, "  asd"),
+      StringTrimTestCase("UTF8_BINARY", "RTRIM", " a世a ", null, " a世a"),
+      StringTrimTestCase("UTF8_BINARY", "RTRIM", "asd", "x", "asd"),
+      StringTrimTestCase("UTF8_BINARY", "RTRIM", "xxasdxx", "x", "xxasd"),
+      StringTrimTestCase("UTF8_BINARY", "RTRIM", "xa世ax", "x", "xa世a"),
+
+      StringTrimTestCase("UTF8_BINARY_LCASE", "TRIM", "asd", null, "asd"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "TRIM", "  asd  ", null, "asd"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "TRIM", " a世a ", null, "a世a"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "TRIM", "asd", "x", "asd"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "TRIM", "xxasdxx", "x", "asd"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "TRIM", "xa世ax", "x", "a世a"),
+
+      StringTrimTestCase("UTF8_BINARY_LCASE", "BTRIM", "asd", null, "asd"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "BTRIM", "  asd  ", null, "asd"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "BTRIM", " a世a ", null, "a世a"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "BTRIM", "asd", "x", "asd"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "BTRIM", "xxasdxx", "x", "asd"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "BTRIM", "xa世ax", "x", "a世a"),
+
+      StringTrimTestCase("UTF8_BINARY_LCASE", "LTRIM", "asd", null, "asd"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "LTRIM", "  asd  ", null, "asd  "),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "LTRIM", " a世a ", null, "a世a "),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "LTRIM", "asd", "x", "asd"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "LTRIM", "xxasdxx", "x", "asdxx"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "LTRIM", "xa世ax", "x", "a世ax"),
+
+      StringTrimTestCase("UTF8_BINARY_LCASE", "RTRIM", "asd", null, "asd"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "RTRIM", "  asd  ", null, "  asd"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "RTRIM", " a世a ", null, " a世a"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "RTRIM", "asd", "x", "asd"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "RTRIM", "xxasdxx", "x", "xxasd"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "RTRIM", "xa世ax", "x", "xa世a"),
+
+      StringTrimTestCase("UTF8_BINARY_LCASE", "TRIM", "asd", null, "asd"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "TRIM", "  asd  ", null, "asd"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "TRIM", " a世a ", null, "a世a"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "TRIM", "asd", "x", "asd"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "TRIM", "xxasdxx", "x", "asd"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "TRIM", "xa世ax", "x", "a世a"),
+
+      StringTrimTestCase("UNICODE", "BTRIM", "asd", null, "asd"),
+      StringTrimTestCase("UNICODE", "BTRIM", "  asd  ", null, "asd"),
+      StringTrimTestCase("UNICODE", "BTRIM", " a世a ", null, "a世a"),
+      StringTrimTestCase("UNICODE", "BTRIM", "asd", "x", "asd"),
+      StringTrimTestCase("UNICODE", "BTRIM", "xxasdxx", "x", "asd"),
+      StringTrimTestCase("UNICODE", "BTRIM", "xa世ax", "x", "a世a"),
+
+      StringTrimTestCase("UNICODE", "LTRIM", "asd", null, "asd"),
+      StringTrimTestCase("UNICODE", "LTRIM", "  asd  ", null, "asd  "),
+      StringTrimTestCase("UNICODE", "LTRIM", " a世a ", null, "a世a "),
+      StringTrimTestCase("UNICODE", "LTRIM", "asd", "x", "asd"),
+      StringTrimTestCase("UNICODE", "LTRIM", "xxasdxx", "x", "asdxx"),
+      StringTrimTestCase("UNICODE", "LTRIM", "xa世ax", "x", "a世ax"),
+
+      StringTrimTestCase("UNICODE", "RTRIM", "asd", null, "asd"),
+      StringTrimTestCase("UNICODE", "RTRIM", "  asd  ", null, "  asd"),
+      StringTrimTestCase("UNICODE", "RTRIM", " a世a ", null, " a世a"),
+      StringTrimTestCase("UNICODE", "RTRIM", "asd", "x", "asd"),
+      StringTrimTestCase("UNICODE", "RTRIM", "xxasdxx", "x", "xxasd"),
+      StringTrimTestCase("UNICODE", "RTRIM", "xa世ax", "x", "xa世a"),
+
+      StringTrimTestCase("UNICODE_CI", "TRIM", "asd", null, "asd"),
+      StringTrimTestCase("UNICODE_CI", "TRIM", "  asd  ", null, "asd"),
+      StringTrimTestCase("UNICODE_CI", "TRIM", " a世a ", null, "a世a"),
+      StringTrimTestCase("UNICODE_CI", "TRIM", "asd", "x", "asd"),
+      StringTrimTestCase("UNICODE_CI", "TRIM", "xxasdxx", "x", "asd"),
+      StringTrimTestCase("UNICODE_CI", "TRIM", "xa世ax", "x", "a世a"),
+
+      StringTrimTestCase("UNICODE_CI", "BTRIM", "asd", null, "asd"),
+      StringTrimTestCase("UNICODE_CI", "BTRIM", "  asd  ", null, "asd"),
+      StringTrimTestCase("UNICODE_CI", "BTRIM", " a世a ", null, "a世a"),
+      StringTrimTestCase("UNICODE_CI", "BTRIM", "asd", "x", "asd"),
+      StringTrimTestCase("UNICODE_CI", "BTRIM", "xxasdxx", "x", "asd"),
+      StringTrimTestCase("UNICODE_CI", "BTRIM", "xa世ax", "x", "a世a"),
+
+      StringTrimTestCase("UNICODE_CI", "LTRIM", "asd", null, "asd"),
+      StringTrimTestCase("UNICODE_CI", "LTRIM", "  asd  ", null, "asd  "),
+      StringTrimTestCase("UNICODE_CI", "LTRIM", " a世a ", null, "a世a "),
+      StringTrimTestCase("UNICODE_CI", "LTRIM", "asd", "x", "asd"),
+      StringTrimTestCase("UNICODE_CI", "LTRIM", "xxasdxx", "x", "asdxx"),
+      StringTrimTestCase("UNICODE_CI", "LTRIM", "xa世ax", "x", "a世ax"),
+
+      StringTrimTestCase("UNICODE_CI", "RTRIM", "asd", null, "asd"),
+      StringTrimTestCase("UNICODE_CI", "RTRIM", "  asd  ", null, "  asd"),
+      StringTrimTestCase("UNICODE_CI", "RTRIM", " a世a ", null, " a世a"),
+      StringTrimTestCase("UNICODE_CI", "RTRIM", "asd", "x", "asd"),
+      StringTrimTestCase("UNICODE_CI", "RTRIM", "xxasdxx", "x", "xxasd"),
+      StringTrimTestCase("UNICODE_CI", "RTRIM", "xa世ax", "x", "xa世a"),
+
+      // Test cases where trimString has more than one character
+      StringTrimTestCase("UTF8_BINARY", "TRIM", "ddsXXXaa", "asd", "XXX"),
+      StringTrimTestCase("UTF8_BINARY", "BTRIM", "ddsXXXaa", "asd", "XXX"),
+      StringTrimTestCase("UTF8_BINARY", "LTRIM", "ddsXXXaa", "asd", "XXXaa"),
+      StringTrimTestCase("UTF8_BINARY", "RTRIM", "ddsXXXaa", "asd", "ddsXXX"),
+
+      StringTrimTestCase("UTF8_BINARY_LCASE", "TRIM", "ddsXXXaa", "asd", "XXX"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "BTRIM", "ddsXXXaa", "asd", "XXX"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "LTRIM", "ddsXXXaa", "asd", "XXXaa"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "RTRIM", "ddsXXXaa", "asd", "ddsXXX"),
+
+      StringTrimTestCase("UNICODE", "TRIM", "ddsXXXaa", "asd", "XXX"),
+      StringTrimTestCase("UNICODE", "BTRIM", "ddsXXXaa", "asd", "XXX"),
+      StringTrimTestCase("UNICODE", "LTRIM", "ddsXXXaa", "asd", "XXXaa"),
+      StringTrimTestCase("UNICODE", "RTRIM", "ddsXXXaa", "asd", "ddsXXX"),
+
+      StringTrimTestCase("UNICODE_CI", "TRIM", "ddsXXXaa", "asd", "XXX"),
+      StringTrimTestCase("UNICODE_CI", "BTRIM", "ddsXXXaa", "asd", "XXX"),
+      StringTrimTestCase("UNICODE_CI", "LTRIM", "ddsXXXaa", "asd", "XXXaa"),
+      StringTrimTestCase("UNICODE_CI", "RTRIM", "ddsXXXaa", "asd", "ddsXXX"),
+
+      // Test cases specific to collation type
+      // uppercase trim, lowercase src
+      StringTrimTestCase("UTF8_BINARY", "TRIM", "asd", "A", "asd"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "TRIM", "asd", "A", "sd"),
+      StringTrimTestCase("UNICODE", "TRIM", "asd", "A", "asd"),
+      StringTrimTestCase("UNICODE_CI", "TRIM", "asd", "A", "sd"),
+
+      // lowercase trim, uppercase src
+      StringTrimTestCase("UTF8_BINARY", "TRIM", "ASD", "a", "ASD"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "TRIM", "ASD", "a", "SD"),
+      StringTrimTestCase("UNICODE", "TRIM", "ASD", "a", "ASD"),
+      StringTrimTestCase("UNICODE_CI", "TRIM", "ASD", "a", "SD"),
+
+      // uppercase and lowercase chars of different byte-length (utf8)
+      StringTrimTestCase("UTF8_BINARY", "TRIM", "ẞaaaẞ", "ß", "ẞaaaẞ"),
+      StringTrimTestCase("UTF8_BINARY", "BTRIM", "ẞaaaẞ", "ß", "ẞaaaẞ"),
+      StringTrimTestCase("UTF8_BINARY", "LTRIM", "ẞaaaẞ", "ß", "ẞaaaẞ"),
+      StringTrimTestCase("UTF8_BINARY", "RTRIM", "ẞaaaẞ", "ß", "ẞaaaẞ"),
+
+      StringTrimTestCase("UTF8_BINARY_LCASE", "TRIM", "ẞaaaẞ", "ß", "aaa"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "BTRIM", "ẞaaaẞ", "ß", "aaa"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "LTRIM", "ẞaaaẞ", "ß", "aaaẞ"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "RTRIM", "ẞaaaẞ", "ß", "ẞaaa"),
+
+      StringTrimTestCase("UNICODE", "TRIM", "ẞaaaẞ", "ß", "ẞaaaẞ"),
+      StringTrimTestCase("UNICODE", "BTRIM", "ẞaaaẞ", "ß", "ẞaaaẞ"),
+      StringTrimTestCase("UNICODE", "LTRIM", "ẞaaaẞ", "ß", "ẞaaaẞ"),
+      StringTrimTestCase("UNICODE", "RTRIM", "ẞaaaẞ", "ß", "ẞaaaẞ"),
+
+      StringTrimTestCase("UNICODE_CI", "TRIM", "ẞaaaẞ", "ß", "aaa"),
+      StringTrimTestCase("UNICODE_CI", "BTRIM", "ẞaaaẞ", "ß", "aaa"),
+      StringTrimTestCase("UNICODE_CI", "LTRIM", "ẞaaaẞ", "ß", "aaaẞ"),
+      StringTrimTestCase("UNICODE_CI", "RTRIM", "ẞaaaẞ", "ß", "ẞaaa"),
+
+      StringTrimTestCase("UTF8_BINARY", "TRIM", "ßaaaß", "ẞ", "ßaaaß"),
+      StringTrimTestCase("UTF8_BINARY", "BTRIM", "ßaaaß", "ẞ", "ßaaaß"),
+      StringTrimTestCase("UTF8_BINARY", "LTRIM", "ßaaaß", "ẞ", "ßaaaß"),
+      StringTrimTestCase("UTF8_BINARY", "RTRIM", "ßaaaß", "ẞ", "ßaaaß"),
+
+      StringTrimTestCase("UTF8_BINARY_LCASE", "TRIM", "ßaaaß", "ẞ", "aaa"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "BTRIM", "ßaaaß", "ẞ", "aaa"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "LTRIM", "ßaaaß", "ẞ", "aaaß"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "RTRIM", "ßaaaß", "ẞ", "ßaaa"),
+
+      StringTrimTestCase("UNICODE", "TRIM", "ßaaaß", "ẞ", "ßaaaß"),
+      StringTrimTestCase("UNICODE", "BTRIM", "ßaaaß", "ẞ", "ßaaaß"),
+      StringTrimTestCase("UNICODE", "LTRIM", "ßaaaß", "ẞ", "ßaaaß"),
+      StringTrimTestCase("UNICODE", "RTRIM", "ßaaaß", "ẞ", "ßaaaß"),
+
+      StringTrimTestCase("UNICODE_CI", "TRIM", "ßaaaß", "ẞ", "aaa"),
+      StringTrimTestCase("UNICODE_CI", "BTRIM", "ßaaaß", "ẞ", "aaa"),
+      StringTrimTestCase("UNICODE_CI", "LTRIM", "ßaaaß", "ẞ", "aaaß"),
+      StringTrimTestCase("UNICODE_CI", "RTRIM", "ßaaaß", "ẞ", "ßaaa"),
+
+      // different byte-length (utf8) chars trimmed
+      StringTrimTestCase("UTF8_BINARY", "TRIM", "Ëaaaẞ", "Ëẞ", "aaa"),
+      StringTrimTestCase("UTF8_BINARY", "BTRIM", "Ëaaaẞ", "Ëẞ", "aaa"),
+      StringTrimTestCase("UTF8_BINARY", "LTRIM", "Ëaaaẞ", "Ëẞ", "aaaẞ"),
+      StringTrimTestCase("UTF8_BINARY", "RTRIM", "Ëaaaẞ", "Ëẞ", "Ëaaa"),
+
+      StringTrimTestCase("UTF8_BINARY_LCASE", "TRIM", "Ëaaaẞ", "Ëẞ", "aaa"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "BTRIM", "Ëaaaẞ", "Ëẞ", "aaa"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "LTRIM", "Ëaaaẞ", "Ëẞ", "aaaẞ"),
+      StringTrimTestCase("UTF8_BINARY_LCASE", "RTRIM", "Ëaaaẞ", "Ëẞ", "Ëaaa"),
+
+      StringTrimTestCase("UNICODE", "TRIM", "Ëaaaẞ", "Ëẞ", "aaa"),
+      StringTrimTestCase("UNICODE", "BTRIM", "Ëaaaẞ", "Ëẞ", "aaa"),
+      StringTrimTestCase("UNICODE", "LTRIM", "Ëaaaẞ", "Ëẞ", "aaaẞ"),
+      StringTrimTestCase("UNICODE", "RTRIM", "Ëaaaẞ", "Ëẞ", "Ëaaa"),
+
+      StringTrimTestCase("UNICODE_CI", "TRIM", "Ëaaaẞ", "Ëẞ", "aaa"),
+      StringTrimTestCase("UNICODE_CI", "BTRIM", "Ëaaaẞ", "Ëẞ", "aaa"),
+      StringTrimTestCase("UNICODE_CI", "LTRIM", "Ëaaaẞ", "Ëẞ", "aaaẞ"),
+      StringTrimTestCase("UNICODE_CI", "RTRIM", "Ëaaaẞ", "Ëẞ", "Ëaaa")
+    )
+
+    testCases.foreach(testCase => {
+      var df: DataFrame = null
+
+      if (testCase.trimFunc.equalsIgnoreCase("BTRIM")) {
+        // BTRIM has arguments in (srcStr, trimStr) order
+        df = sql(s"SELECT ${testCase.trimFunc}(" +
+          s"COLLATE('${testCase.sourceString}', '${testCase.collation}')" +
+          (if (testCase.trimString == null) "" else s", COLLATE('${testCase.trimString}', '${testCase.collation}')") +
+          ")")
+      }
+      else {
+        // While other functions have arguments in (trimStr, srcStr) order
+        df = sql(s"SELECT ${testCase.trimFunc}(" +
+          (if (testCase.trimString == null) "" else s"COLLATE('${testCase.trimString}', '${testCase.collation}'), ") +
+          s"COLLATE('${testCase.sourceString}', '${testCase.collation}')" +
+          ")")
+      }
+
+      checkAnswer(df = df, expectedAnswer = Row(testCase.expectedResultString))
+    })
+
+    // scalastyle:on
+  }
+
+  test("string trim functions with collation - exceptions") {
+    // scalastyle:off
+
+    // TRIM
+    checkError(
+      exception = intercept[ExtendedAnalysisException] {
+        spark.sql(s"SELECT TRIM(COLLATE('trimStr', 'UTF8_BINARY_LCASE'), COLLATE('sourceStr', 'UNICODE'))")
+      },
+      errorClass = "DATATYPE_MISMATCH.COLLATION_MISMATCH",
+      sqlState = "42K09",
+      parameters = Map(
+        "collationNameLeft" -> "UNICODE",
+        "collationNameRight" -> "UTF8_BINARY_LCASE",
+        "sqlExpr" -> "\"TRIM(BOTH collate(trimStr) FROM collate(sourceStr))\""
+      ),
+      context = ExpectedContext(fragment =
+        "TRIM(COLLATE('trimStr', 'UTF8_BINARY_LCASE'), COLLATE('sourceStr', 'UNICODE'))",
+        start = 7, stop = 84)
+    )
+
+    // BTRIM
+    checkError(
+      exception = intercept[ExtendedAnalysisException] {
+        spark.sql(s"SELECT BTRIM(COLLATE('sourceStr', 'UTF8_BINARY_LCASE'), COLLATE('trimStr', 'UNICODE'))")
+      },
+      errorClass = "DATATYPE_MISMATCH.COLLATION_MISMATCH",
+      sqlState = "42K09",
+      parameters = Map(
+        "collationNameLeft" -> "UTF8_BINARY_LCASE",
+        "collationNameRight" -> "UNICODE",
+        "sqlExpr" -> "\"TRIM(BOTH collate(trimStr) FROM collate(sourceStr))\""
+      ),
+      context = ExpectedContext(fragment =
+        "BTRIM(COLLATE('sourceStr', 'UTF8_BINARY_LCASE'), COLLATE('trimStr', 'UNICODE'))",
+        start = 7, stop = 85)
+    )
+
+    // LTRIM
+    checkError(
+      exception = intercept[ExtendedAnalysisException] {
+        spark.sql(s"SELECT LTRIM(COLLATE('trimStr', 'UTF8_BINARY_LCASE'), COLLATE('sourceStr', 'UNICODE'))")
+      },
+      errorClass = "DATATYPE_MISMATCH.COLLATION_MISMATCH",
+      sqlState = "42K09",
+      parameters = Map(
+        "collationNameLeft" -> "UNICODE",
+        "collationNameRight" -> "UTF8_BINARY_LCASE",
+        "sqlExpr" -> "\"TRIM(LEADING collate(trimStr) FROM collate(sourceStr))\""
+      ),
+      context = ExpectedContext(fragment =
+        "LTRIM(COLLATE('trimStr', 'UTF8_BINARY_LCASE'), COLLATE('sourceStr', 'UNICODE'))",
+        start = 7, stop = 85)
+    )
+
+    // RTRIM
+    checkError(
+      exception = intercept[ExtendedAnalysisException] {
+        spark.sql(s"SELECT RTRIM(COLLATE('trimStr', 'UTF8_BINARY_LCASE'), COLLATE('sourceStr', 'UNICODE'))")
+      },
+      errorClass = "DATATYPE_MISMATCH.COLLATION_MISMATCH",
+      sqlState = "42K09",
+      parameters = Map(
+        "collationNameLeft" -> "UNICODE",
+        "collationNameRight" -> "UTF8_BINARY_LCASE",
+        "sqlExpr" -> "\"TRIM(TRAILING collate(trimStr) FROM collate(sourceStr))\""
+      ),
+      context = ExpectedContext(fragment =
+        "RTRIM(COLLATE('trimStr', 'UTF8_BINARY_LCASE'), COLLATE('sourceStr', 'UNICODE'))",
+        start = 7, stop = 85)
+    )
+
+    // scalastyle:on
+  }
+
+  // TODO: Add more tests for other string expressions
 }
 
 class CollationStringExpressionsANSISuite extends CollationRegexpExpressionsSuite {


### PR DESCRIPTION
### Left to do/discussion topics (to be removed by the PR completion)
- Handling of a lowercase (`utf8_binary_lcase`) collation type seems a bit grueling in the long run. This PR handles it the same way as in every other place, since I think it is out of the scope of this PR, but should we maybe create a work item to generalize this collation type better (if we don't have it already)?

### What changes were proposed in this pull request?
This PR is created to add support for collations to StringTrim family of functions/expressions, specifically:
- `StringTrim`
- `StringTrimBoth`
- `StringTrimLeft`
- `StringTrimRight`

Changes:
- `stringExpressions.scala`
  - Check input types to be of the same collation.
  - Route to proper endpoints in `UTF8String` - `doEval` and `doGenCode`.
- `UTF8String.java`
  - Implement logic for all trim functions (logic should be well commented-out in the code and mostly matches already existing implementations of `trimLeft` and `trimRight`).

Other minor changes in this PR:
- Change parameter names in `CollationFactory.getStringSearch()` to a more descriptive ones.

### Why are the changes needed?
We are incrementally adding collation support to a built-in string functions in Spark.

### Does this PR introduce _any_ user-facing change?
Yes:
- User should now be able to use non-default collations in string trim functions.
- User will receive `DATATYPE_MISMATCH.COLLATION_MISMATCH` exception if collations of two function parameters do not match.

### How was this patch tested?
Already existing tests + new unit/e2e tests.

### Was this patch authored or co-authored using generative AI tooling?
No.
