### PR TITLE
[SPARK-47638][PS][CONNECT] Skip column name validation in PS

### DIFF
--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -609,7 +609,7 @@ def lazy_property(fn: Callable[[Any], Any]) -> property:
 def scol_for(sdf: PySparkDataFrame, column_name: str) -> Column:
     """Return Spark Column for the given column name."""
     if is_remote():
-        return sdf._col("`{}`".format(column_name))
+        return sdf._col("`{}`".format(column_name))  # type: ignore[operator]
     else:
         return sdf["`{}`".format(column_name)]
 

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -608,7 +608,10 @@ def lazy_property(fn: Callable[[Any], Any]) -> property:
 
 def scol_for(sdf: PySparkDataFrame, column_name: str) -> Column:
     """Return Spark Column for the given column name."""
-    return sdf["`{}`".format(column_name)]
+    if is_remote():
+        return sdf._col("`{}`".format(column_name))
+    else:
+        return sdf["`{}`".format(column_name)]
 
 
 def column_labels_level(column_labels: List[Label]) -> int:

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -645,7 +645,7 @@ class DataFrame:
             if isinstance(col, Column):
                 return col
             else:
-                return Column(ColumnReference(col, df._plan._plan_id))
+                return df._col(col)
 
         return DataFrame(
             plan.AsOfJoin(
@@ -1715,12 +1715,7 @@ class DataFrame:
                 error_class="ATTRIBUTE_NOT_SUPPORTED", message_parameters={"attr_name": name}
             )
 
-        return Column(
-            ColumnReference(
-                unparsed_identifier=name,
-                plan_id=self._plan._plan_id,
-            )
-        )
+        return self._col(name)
 
     __getattr__.__doc__ = PySparkDataFrame.__getattr__.__doc__
 
@@ -1756,12 +1751,7 @@ class DataFrame:
                     if item not in self.columns:
                         self.select(item).isLocal()
 
-                return Column(
-                    ColumnReference(
-                        unparsed_identifier=item,
-                        plan_id=self._plan._plan_id,
-                    )
-                )
+                return self._col(item)
         elif isinstance(item, Column):
             return self.filter(item)
         elif isinstance(item, (list, tuple)):
@@ -1773,6 +1763,14 @@ class DataFrame:
                 error_class="NOT_COLUMN_OR_INT_OR_LIST_OR_STR_OR_TUPLE",
                 message_parameters={"arg_name": "item", "arg_type": type(item).__name__},
             )
+
+    def _col(self, name: str) -> Column:
+        return Column(
+            ColumnReference(
+                unparsed_identifier=name,
+                plan_id=self._plan._plan_id,
+            )
+        )
 
     def __dir__(self) -> List[str]:
         attrs = set(super().__dir__())


### PR DESCRIPTION
### What changes were proposed in this pull request?
Skip column name validation in PS


### Why are the changes needed?
`scol_for` is an internal method, not exposed to users, so this eager validation seems unnecessary

when a bad column name is used

before: `scol_for` immediately fails

after: silent at `scol_for` call, fail later at analysis (e.g. dtypes/schema) or execution

### Does this PR introduce _any_ user-facing change?
no, test only

### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no