### PR TITLE
[MINOR][CORE] Replace `get+getOrElse` with `getOrElse` with default value in `StreamingQueryException`

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryException.scala
+++ b/common/utils/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryException.scala
@@ -48,11 +48,11 @@ class StreamingQueryException private[sql](
       errorClass: String,
       messageParameters: Map[String, String]) = {
     this(
-      messageParameters.get("queryDebugString").getOrElse(""),
+      messageParameters.getOrElse("queryDebugString", ""),
       message,
       cause,
-      messageParameters.get("startOffset").getOrElse(""),
-      messageParameters.get("endOffset").getOrElse(""),
+      messageParameters.getOrElse("startOffset", ""),
+      messageParameters.getOrElse("endOffset", ""),
       errorClass,
       messageParameters)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR replaces `get + getOrElse` with `getOrElse` with a default value in `StreamingQueryException`.

### Why are the changes needed?
Simplify code


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No