### PR TITLE
[SPARK-47630][BUILD] Upgrade `zstd-jni` to 1.5.6-1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -276,4 +276,4 @@ xz/1.9//xz-1.9.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.9.2//zookeeper-jute-3.9.2.jar
 zookeeper/3.9.2//zookeeper-3.9.2.jar
-zstd-jni/1.5.5-11//zstd-jni-1.5.5-11.jar
+zstd-jni/1.5.6-1//zstd-jni-1.5.6-1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -2621,6 +2621,10 @@
             <artifactId>orc-format</artifactId>
           </exclusion>
           <exclusion>
+            <groupId>com.github.luben</groupId>
+            <artifactId>zstd-jni</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>com.aayushatharva.brotli4j</groupId>
             <artifactId>brotli4j</artifactId>
           </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -786,7 +786,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.5.5-11</version>
+        <version>1.5.6-1</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `zstd-jni` to 1.5.6-1.

### Why are the changes needed?

This release has the following memory-leak bug fix.

- https://github.com/luben/zstd-jni/releases/tag/v1.5.6-1
  - https://github.com/luben/zstd-jni/pull/303

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.