### PR TITLE
[SPARK-47631][SQL] Remove unused `SQLConf.parquetOutputCommitterClass` method

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5212,8 +5212,6 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def isParquetSchemaRespectSummaries: Boolean = getConf(PARQUET_SCHEMA_RESPECT_SUMMARIES)
 
-  def parquetOutputCommitterClass: String = getConf(PARQUET_OUTPUT_COMMITTER_CLASS)
-
   def isParquetBinaryAsString: Boolean = getConf(PARQUET_BINARY_AS_STRING)
 
   def isParquetINT96AsTimestamp: Boolean = getConf(PARQUET_INT96_AS_TIMESTAMP)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove unused `SQLConf.parquetOutputCommitterClass` method.

### Why are the changes needed?

This method has been never used in Apache Spark 3.x.

### Does this PR introduce _any_ user-facing change?

No. `o.a.s.sql.internal.SQLConf` is an internal package.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.