### PR TITLE
[SPARK-47632][BUILD] Ban `com.amazonaws:aws-java-sdk-bundle` dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2935,6 +2935,7 @@
                       <exclude>org.apache.hadoop:hadoop-mapreduce-client-jobclient</exclude>
                       <exclude>org.jboss.netty</exclude>
                       <exclude>org.codehaus.groovy</exclude>
+                      <exclude>com.amazonaws:aws-java-sdk-bundle</exclude>
                       <exclude>*:*_2.12</exclude>
                       <exclude>*:*_2.11</exclude>
                       <exclude>*:*_2.10</exclude>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to ban `AWS SKD for Java v1`. We migrated to v2 via the following.
- #45583
- #43510

### Why are the changes needed?

To ensure the migration to AWS SDK for Java v2 because of the following the end of support schedule. `v2` is strongly recommended since July.
- https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-java-v1-x-on-december-31-2025/
> AWS SDK for Java v1.x will enter maintenance mode on July 31, 2024, and reach end-of-support on December 31, 2025.

### Does this PR introduce _any_ user-facing change?

No, this PR only prevents mixing this old dependency in the future.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.