### PR TITLE
[SPARK-47635][K8S] Use Java `21` instead of `21-jre` image in K8s Dockerfile

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ARG java_image_tag=21-jre
+ARG java_image_tag=21
 
 FROM azul/zulu-openjdk:${java_image_tag}
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java 21 instead of 21-jre in K8s Dockerfile .

### Why are the changes needed?

Since Apache Spark 3.5.0, SPARK-44153 starts to use `jmap` like the following.

https://github.com/apache/spark/blob/c832e2ac1d04668c77493577662c639785808657/core/src/main/scala/org/apache/spark/util/Utils.scala#L2030

```
$ docker run -it --rm azul/zulu-openjdk:21-jre jmap
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "jmap": executable file not found in $PATH: unknown.
```

```
$ docker run -it --rm azul/zulu-openjdk:21 jmap | head -n2
Usage:
    jmap -clstats <pid>
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.