### PR TITLE
[SPARK-47639] Support codegen for json_tuple.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -549,30 +549,24 @@ case class JsonTuple(children: Seq[Expression])
            """.stripMargin
       }
     } else {
-      val cacheName = ctx.freshName("foldableFieldNames")
-      val ref =
-        ctx.addReferenceObj(cacheName, foldableFieldNames.toBuffer.asJava)
-      val codeList = ArrayBuffer(s"""$fieldNames = $ref;""")
       // if there is a mix of constant and non-constant expressions
       // prefer the cached copy when available
-      foldableFieldNames.zip(fieldExpressions).zipWithIndex.foreach {
+      foldableFieldNames.zip(fieldExpressions).zipWithIndex.map {
         case ((null, e), i) =>
           val eval = e.genCode(ctx)
-          codeList +=
-            s"""
-               |${eval.code}
-               |if (${eval.isNull}) {
-               |  $fieldNames.add($i, null);
-               |} else {
-               |  $fieldNames.add($i, ${eval.value}.toString());
-               |}
+          s"""
+             |${eval.code}
+             |if (${eval.isNull}) {
+             |  $fieldNames.add($i, null);
+             |} else {
+             |  $fieldNames.add($i, ${eval.value}.toString());
+             |}
            """.stripMargin
         case ((fieldName, _), i) =>
           s"""
              |$fieldNames.add($i, ${fieldName.orNull});
              |""".stripMargin
       }
-      codeList
     }
 
     val splitParseCode = ctx.splitExpressionsWithCurrentInputs(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import java.io._
+import java.util.stream.Collectors
 
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
@@ -432,6 +433,8 @@ class GetJsonObjectEvaluator(cachedPath: UTF8String) {
   }
 }
 
+case class JsonPathIndex(index: Int, path: String)
+
 // scalastyle:off line.size.limit line.contains.tab
 @ExpressionDescription(
   usage = "_FUNC_(jsonStr, p1, p2, ..., pn) - Returns a tuple like the function get_json_object, but it takes multiple names. All the input parameters and output column types are string.",
@@ -463,9 +466,10 @@ case class JsonTuple(children: Seq[Expression])
   @transient private lazy val fieldExpressions: Seq[Expression] = children.tail
 
   // eagerly evaluate any foldable the field names
-  @transient private lazy val foldableFieldNames: IndexedSeq[Option[String]] = {
-    fieldExpressions.map {
-      case expr if expr.foldable => Option(expr.eval()).map(_.asInstanceOf[UTF8String].toString)
+  @transient private lazy val foldableFieldNames: IndexedSeq[Option[JsonPathIndex]] = {
+    fieldExpressions.zipWithIndex.map {
+      case (expr, index) if expr.foldable =>
+        Option(expr.eval()).map(p => JsonPathIndex(index, p.asInstanceOf[UTF8String].toString))
       case _ => null
     }.toIndexedSeq
   }
@@ -505,16 +509,23 @@ case class JsonTuple(children: Seq[Expression])
       foldableFieldNames.map(_.orNull)
     } else if (constantFields == 0) {
       // none are foldable so all field names need to be evaluated from the input row
-      fieldExpressions.map { expr =>
-        Option(expr.eval(input)).map(_.asInstanceOf[UTF8String].toString).orNull
+      fieldExpressions.zipWithIndex.map {
+        case (expr, index) =>
+          Option(expr.eval(input)).map {
+            path =>
+              JsonPathIndex(index, path.asInstanceOf[UTF8String].toString)
+          }.orNull
       }
     } else {
       // if there is a mix of constant and non-constant expressions
       // prefer the cached copy when available
-      foldableFieldNames.zip(fieldExpressions).map {
-        case (null, expr) =>
-          Option(expr.eval(input)).map(_.asInstanceOf[UTF8String].toString).orNull
-        case (fieldName, _) => fieldName.orNull
+      foldableFieldNames.zip(fieldExpressions).zipWithIndex.map {
+        case ((null, expr), index) =>
+          Option(expr.eval(input)).map {
+            path =>
+              JsonPathIndex(index, path.asInstanceOf[UTF8String].toString)
+          }.orNull
+        case ((fieldName, _), _) => fieldName.orNull
       }
     }
 
@@ -536,22 +547,22 @@ case class JsonTuple(children: Seq[Expression])
       Seq(s"""$fieldNames = $ref;""")
     } else if (constantFields == 0) {
       // none are foldable so all field names need to be evaluated from the input row
-      fieldExpressions.map {
-        e =>
+      fieldExpressions.zipWithIndex.map {
+        case (e, i) =>
           val eval = e.genCode(ctx)
           s"""
              |${eval.code}
-             |if (${eval.isNull}) {
-             |  $fieldNames.add(null);
-             |} else {
-             |  $fieldNames.add(${eval.value}.toString());
+             |if (!${eval.isNull}) {
+             |  $fieldNames.add(new JsonPathIndex($i, ${eval.value}.toString()));
              |}
            """.stripMargin
       }
     } else {
       val cacheName = ctx.freshName("foldableFieldNames")
       val ref =
-        ctx.addReferenceObj(cacheName, foldableFieldNames.map(_.orNull).toBuffer.asJava)
+        ctx.addReferenceObj(cacheName, foldableFieldNames.filter {
+          f => f != null && f.isDefined
+        }.map(_.get).toBuffer.asJava)
       val codeList = ArrayBuffer(s"""$fieldNames = $ref;""")
       // if there is a mix of constant and non-constant expressions
       // prefer the cached copy when available
@@ -561,10 +572,8 @@ case class JsonTuple(children: Seq[Expression])
           codeList +=
             s"""
                |${eval.code}
-               |if (${eval.isNull}) {
-               |  $fieldNames.add($i, null);
-               |} else {
-               |  $fieldNames.add($i, ${eval.value}.toString());
+               |if (!${eval.isNull}) {
+               |  $fieldNames.add(new JsonPathIndex($i, ${eval.value}.toString()));
                |}
            """.stripMargin
         case ((_, _), _) =>
@@ -575,14 +584,14 @@ case class JsonTuple(children: Seq[Expression])
     val splitParseCode = ctx.splitExpressionsWithCurrentInputs(
       expressions = parseCode.toSeq,
       funcName = "jsonTuple",
-      extraArguments = "java.util.List<String>" -> fieldNames :: Nil)
+      extraArguments = "java.util.List<JsonPathIndex>" -> fieldNames :: Nil)
 
     val resultType = "scala.collection.IterableOnce<InternalRow>"
     val refNullRow = ctx.addReferenceObj("nullRow", nullRow)
     ev.copy(code =
       code"""
             |$resultType ${ev.value};
-            |java.util.List<String> $fieldNames = new java.util.ArrayList<>();
+            |java.util.List<JsonPathIndex> $fieldNames = new java.util.ArrayList<>();
             |${jsonEval.code}
             |if (${jsonEval.isNull}) {
             |  ${ev.value} = $refNullRow;
@@ -596,7 +605,7 @@ case class JsonTuple(children: Seq[Expression])
   }
 }
 
-class JsonTupleEvaluator(jsonStr: UTF8String, fieldNames: java.util.List[String]) {
+class JsonTupleEvaluator(jsonStr: UTF8String, fieldNames: java.util.List[JsonPathIndex]) {
 
   import SharedFactory._
 
@@ -629,9 +638,12 @@ class JsonTupleEvaluator(jsonStr: UTF8String, fieldNames: java.util.List[String]
       if (parser.getCurrentToken == JsonToken.FIELD_NAME) {
         // check to see if this field is desired in the output
         val jsonField = parser.currentName
-        var idx = fieldNames.indexOf(jsonField)
-        if (idx >= 0) {
-          // it is, copy the child tree to the correct location in the output row
+        val matched = fieldNames
+          .stream()
+          .filter(_.path.equals(jsonField))
+          .map(_.index)
+          .collect(Collectors.toList[Int])
+        if (!matched.isEmpty) {
           val output = new ByteArrayOutputStream()
 
           // write the output directly to UTF8 encoded byte array
@@ -641,13 +653,10 @@ class JsonTupleEvaluator(jsonStr: UTF8String, fieldNames: java.util.List[String]
             }
 
             val jsonValue = UTF8String.fromBytes(output.toByteArray)
-
-            // SPARK-21804: json_tuple returns null values within repeated columns
-            // except the first one; so that we need to check the remaining fields.
-            do {
-              row(idx) = jsonValue
-              idx = fieldNames.indexOf(jsonField, idx + 1)
-            } while (idx >= 0)
+            matched.forEach {
+              idx =>
+                row(idx) = jsonValue
+            }
           }
         }
       }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
@@ -272,11 +272,6 @@ class JsonExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper with 
     assert(jt.eval(null).iterator.to(Seq).head === expected)
   }
 
-  test("json_tuple escaping") {
-    GenerateUnsafeProjection.generate(
-      JsonTuple(Literal("\"quote") ::  Literal("\"quote") :: Nil) :: Nil)
-  }
-
   test("json_tuple - hive key 1") {
     checkJsonTuple(
       JsonTuple(

--- a/sql/core/benchmarks/JsonBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/JsonBenchmark-jdk21-results.txt
@@ -7,124 +7,125 @@ OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 JSON schema inferring:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        2293           2316          37          2.2         458.6       1.0X
-UTF-8 is set                                       3389           3399          14          1.5         677.8       0.7X
+No encoding                                        2227           2295          69          2.2         445.4       1.0X
+UTF-8 is set                                       3397           3415          16          1.5         679.5       0.7X
 
 Preparing data for benchmarking ...
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 count a short column:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        1900           1931          36          2.6         380.1       1.0X
-UTF-8 is set                                       3049           3055           6          1.6         609.7       0.6X
+No encoding                                        1927           1945          17          2.6         385.4       1.0X
+UTF-8 is set                                       3140           3151          10          1.6         627.9       0.6X
 
 Preparing data for benchmarking ...
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 count a wide column:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        4662           4674          20          0.2        4661.7       1.0X
-UTF-8 is set                                       4492           4508          20          0.2        4491.8       1.0X
+No encoding                                        4483           4551          82          0.2        4483.0       1.0X
+UTF-8 is set                                       4089           4112          21          0.2        4088.5       1.1X
 
 Preparing data for benchmarking ...
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 select wide row:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        9989          10251         226          0.0      199788.0       1.0X
-UTF-8 is set                                      10872          10943          93          0.0      217437.4       0.9X
+No encoding                                        9343           9507         169          0.0      186867.7       1.0X
+UTF-8 is set                                      10800          10853          46          0.0      216004.3       0.9X
 
 Preparing data for benchmarking ...
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 Select a subset of 10 columns:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 10 columns                                  1724           1740          17          0.6        1723.6       1.0X
-Select 1 column                                    1345           1349           7          0.7        1344.6       1.3X
+Select 10 columns                                  1674           1682           9          0.6        1674.4       1.0X
+Select 1 column                                    1132           1140          13          0.9        1131.8       1.5X
 
 Preparing data for benchmarking ...
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 creation of JSON parser per line:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Short column without encoding                       633            640           9          1.6         632.9       1.0X
-Short column with UTF-8                             872            886          22          1.1         872.1       0.7X
-Wide column without encoding                       5266           5277          12          0.2        5266.2       0.1X
-Wide column with UTF-8                             6953           6959           8          0.1        6953.0       0.1X
+Short column without encoding                       622            627           5          1.6         621.7       1.0X
+Short column with UTF-8                             879            882           4          1.1         879.4       0.7X
+Wide column without encoding                       5134           5152          19          0.2        5134.2       0.1X
+Wide column with UTF-8                             6512           6536          26          0.2        6511.9       0.1X
 
 Preparing data for benchmarking ...
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 JSON functions:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                            58             61           4         17.2          58.2       1.0X
-from_json                                          1235           1257          21          0.8        1235.4       0.0X
-json_tuple                                         1101           1110          10          0.9        1100.5       0.1X
-get_json_object wholestage off                     1063           1068           6          0.9        1062.6       0.1X
-get_json_object wholestage on                       989            989           1          1.0         988.7       0.1X
+Text read                                            57             59           2         17.6          56.9       1.0X
+from_json                                          1174           1188          12          0.9        1173.9       0.0X
+json_tuple wholestage off                          1540           1559          18          0.6        1540.0       0.0X
+json_tuple wholestage on                           1253           1267          13          0.8        1253.1       0.0X
+get_json_object wholestage off                     1074           1091          18          0.9        1073.8       0.1X
+get_json_object wholestage on                      1010           1018           7          1.0        1009.6       0.1X
 
 Preparing data for benchmarking ...
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 Dataset of json strings:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                           230            236           8         21.7          46.1       1.0X
-schema inferring                                   1914           1921          11          2.6         382.7       0.1X
-parsing                                            2849           2856           9          1.8         569.8       0.1X
+Text read                                           230            233           3         21.7          46.1       1.0X
+schema inferring                                   1874           1881           6          2.7         374.8       0.1X
+parsing                                            2920           2933          12          1.7         584.0       0.1X
 
 Preparing data for benchmarking ...
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 Json files in the per-line mode:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                           536            548          14          9.3         107.1       1.0X
-Schema inferring                                   2366           2374           7          2.1         473.2       0.2X
-Parsing without charset                            2908           2911           3          1.7         581.6       0.2X
-Parsing with UTF-8                                 4059           4064           8          1.2         811.8       0.1X
+Text read                                           548            558          10          9.1         109.7       1.0X
+Schema inferring                                   2417           2428          15          2.1         483.5       0.2X
+Parsing without charset                            2930           2939           8          1.7         586.0       0.2X
+Parsing with UTF-8                                 4042           4054          19          1.2         808.5       0.1X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 Write dates and timestamps:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Create a dataset of timestamps                      106            112           9          9.4         105.9       1.0X
-to_json(timestamp)                                  744            747           4          1.3         743.6       0.1X
-write timestamps to files                           633            637           4          1.6         633.4       0.2X
-Create a dataset of dates                           124            128           5          8.1         123.8       0.9X
-to_json(date)                                       560            561           1          1.8         559.9       0.2X
-write dates to files                                453            466          12          2.2         452.7       0.2X
+Create a dataset of timestamps                      105            111           7          9.5         105.5       1.0X
+to_json(timestamp)                                  739            755          20          1.4         739.3       0.1X
+write timestamps to files                           658            661           3          1.5         658.4       0.2X
+Create a dataset of dates                           128            134           5          7.8         128.1       0.8X
+to_json(date)                                       547            551           6          1.8         547.0       0.2X
+write dates to files                                453            459           8          2.2         453.3       0.2X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 Read dates and timestamps:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-read timestamp text from files                                                   146            154           8          6.8         146.2       1.0X
-read timestamps from files                                                      1079           1084           5          0.9        1079.0       0.1X
-infer timestamps from files                                                     1977           1986          11          0.5        1976.8       0.1X
-read date text from files                                                        142            144           2          7.0         142.4       1.0X
-read date from files                                                             718            725           6          1.4         718.1       0.2X
-timestamp strings                                                                137            138           1          7.3         137.2       1.1X
-parse timestamps from Dataset[String]                                           1258           1275          14          0.8        1258.0       0.1X
-infer timestamps from Dataset[String]                                           2182           2186           6          0.5        2182.4       0.1X
-date strings                                                                     196            201           5          5.1         195.5       0.7X
-parse dates from Dataset[String]                                                1016           1025           7          1.0        1016.3       0.1X
-from_json(timestamp)                                                            1924           1953          38          0.5        1924.2       0.1X
-from_json(date)                                                                 1644           1696          74          0.6        1644.1       0.1X
-infer error timestamps from Dataset[String] with default format                 1463           1473           9          0.7        1463.1       0.1X
-infer error timestamps from Dataset[String] with user-provided format           1451           1459          12          0.7        1450.6       0.1X
-infer error timestamps from Dataset[String] with legacy format                  1486           1494           8          0.7        1486.3       0.1X
+read timestamp text from files                                                   138            144           5          7.2         138.2       1.0X
+read timestamps from files                                                      1111           1114           3          0.9        1110.9       0.1X
+infer timestamps from files                                                     2059           2063           5          0.5        2058.8       0.1X
+read date text from files                                                        131            135           5          7.7         130.5       1.1X
+read date from files                                                             709            713           3          1.4         709.2       0.2X
+timestamp strings                                                                134            138           5          7.5         133.7       1.0X
+parse timestamps from Dataset[String]                                           1318           1321           3          0.8        1317.6       0.1X
+infer timestamps from Dataset[String]                                           2241           2253          11          0.4        2240.6       0.1X
+date strings                                                                     209            211           2          4.8         209.0       0.7X
+parse dates from Dataset[String]                                                1029           1031           2          1.0        1029.3       0.1X
+from_json(timestamp)                                                            1836           1838           3          0.5        1836.2       0.1X
+from_json(date)                                                                 1523           1528           4          0.7        1523.5       0.1X
+infer error timestamps from Dataset[String] with default format                 1428           1430           4          0.7        1427.5       0.1X
+infer error timestamps from Dataset[String] with user-provided format           1437           1442           4          0.7        1437.4       0.1X
+infer error timestamps from Dataset[String] with legacy format                  1433           1445          14          0.7        1433.1       0.1X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 Filters pushdown:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-w/o filters                                        5708           5724          17          0.0       57078.7       1.0X
-pushdown disabled                                  5625           5646          20          0.0       56254.5       1.0X
-w/ filters                                          742            770          38          0.1        7418.9       7.7X
+w/o filters                                        5833           5844           9          0.0       58332.7       1.0X
+pushdown disabled                                  5674           5711          33          0.0       56738.3       1.0X
+w/ filters                                          701            708           6          0.1        7005.5       8.3X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 Partial JSON results:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-parse invalid JSON                                 2551           2628          90          0.0      255064.5       1.0X
+parse invalid JSON                                 2433           2550         179          0.0      243304.9       1.0X
 
 

--- a/sql/core/benchmarks/JsonBenchmark-results.txt
+++ b/sql/core/benchmarks/JsonBenchmark-results.txt
@@ -3,128 +3,129 @@ Benchmark for performance of JSON parsing
 ================================================================================================
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 JSON schema inferring:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        2456           2513          59          2.0         491.2       1.0X
-UTF-8 is set                                       3355           3365          15          1.5         671.1       0.7X
+No encoding                                        2585           4133        2420          1.9         517.0       1.0X
+UTF-8 is set                                       3503           4305        1376          1.4         700.5       0.7X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 count a short column:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        2162           2201          34          2.3         432.4       1.0X
-UTF-8 is set                                       3168           3178          17          1.6         633.5       0.7X
+No encoding                                        2160           2246         114          2.3         432.0       1.0X
+UTF-8 is set                                       3335           3365          32          1.5         666.9       0.6X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 count a wide column:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        3185           3258         122          0.3        3185.0       1.0X
-UTF-8 is set                                       4058           4093          42          0.2        4058.1       0.8X
+No encoding                                        3622           3653          43          0.3        3621.7       1.0X
+UTF-8 is set                                       4808           4839          39          0.2        4808.0       0.8X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 select wide row:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        9244           9334         132          0.0      184884.5       1.0X
-UTF-8 is set                                      10249          10258          10          0.0      204988.0       0.9X
+No encoding                                        9477          11539        2040          0.0      189544.7       1.0X
+UTF-8 is set                                      10330          11447        1267          0.0      206592.1       0.9X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Select a subset of 10 columns:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 10 columns                                  1641           1650           7          0.6        1641.4       1.0X
-Select 1 column                                    1118           1120           3          0.9        1117.9       1.5X
+Select 10 columns                                  1670           1677           7          0.6        1670.0       1.0X
+Select 1 column                                    1947           1960          12          0.5        1946.7       0.9X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 creation of JSON parser per line:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Short column without encoding                       627            635           7          1.6         626.7       1.0X
-Short column with UTF-8                             819            834          15          1.2         819.5       0.8X
-Wide column without encoding                       5191           5227          39          0.2        5191.4       0.1X
-Wide column with UTF-8                             6490           6506          17          0.2        6489.9       0.1X
+Short column without encoding                       628            633           5          1.6         628.2       1.0X
+Short column with UTF-8                             845            852           9          1.2         844.7       0.7X
+Wide column without encoding                       5448           5589         123          0.2        5448.2       0.1X
+Wide column with UTF-8                             7722           7823         113          0.1        7721.9       0.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 JSON functions:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                            57             58           0         17.4          57.4       1.0X
-from_json                                          1105           1118          17          0.9        1105.2       0.1X
-json_tuple                                         1151           1152           1          0.9        1151.2       0.0X
-get_json_object wholestage off                     1080           1081           2          0.9        1079.8       0.1X
-get_json_object wholestage on                      1018           1024           7          1.0        1018.3       0.1X
+Text read                                            66             71           5         15.1          66.1       1.0X
+from_json                                          1205           1226          22          0.8        1205.4       0.1X
+json_tuple wholestage off                          1562           1604          36          0.6        1562.1       0.0X
+json_tuple wholestage on                           1334           1348          12          0.7        1333.9       0.0X
+get_json_object wholestage off                     1198           1230          35          0.8        1198.5       0.1X
+get_json_object wholestage on                      1217           1238          25          0.8        1216.5       0.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Dataset of json strings:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                           255            257           1         19.6          51.1       1.0X
-schema inferring                                   1775           1776           2          2.8         355.0       0.1X
-parsing                                            2833           2835           3          1.8         566.6       0.1X
+Text read                                           258            269          10         19.4          51.6       1.0X
+schema inferring                                   1892           1945          86          2.6         378.3       0.1X
+parsing                                            2840           2996         186          1.8         568.1       0.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Json files in the per-line mode:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                           581            583           2          8.6         116.2       1.0X
-Schema inferring                                   2391           2397           6          2.1         478.2       0.2X
-Parsing without charset                            2973           2975           3          1.7         594.6       0.2X
-Parsing with UTF-8                                 3956           3969          17          1.3         791.2       0.1X
+Text read                                           799            855          50          6.3         159.7       1.0X
+Schema inferring                                   2601           2721         150          1.9         520.1       0.3X
+Parsing without charset                            3115           3134          28          1.6         623.1       0.3X
+Parsing with UTF-8                                 4120           4124           5          1.2         824.0       0.2X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Write dates and timestamps:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Create a dataset of timestamps                      109            119          13          9.2         109.3       1.0X
-to_json(timestamp)                                  795            800           6          1.3         794.8       0.1X
-write timestamps to files                           730            734           3          1.4         730.1       0.1X
-Create a dataset of dates                           133            143           8          7.5         133.3       0.8X
-to_json(date)                                       598            601           4          1.7         598.1       0.2X
-write dates to files                                475            478           3          2.1         474.6       0.2X
+Create a dataset of timestamps                      118            138          22          8.5         118.2       1.0X
+to_json(timestamp)                                  818            820           4          1.2         817.6       0.1X
+write timestamps to files                           970            986          14          1.0         970.0       0.1X
+Create a dataset of dates                           187            253         114          5.4         186.9       0.6X
+to_json(date)                                       616           1214         712          1.6         615.9       0.2X
+write dates to files                                620            623           3          1.6         619.7       0.2X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Read dates and timestamps:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-read timestamp text from files                                                   149            153           4          6.7         148.5       1.0X
-read timestamps from files                                                      1049           1057           8          1.0        1048.6       0.1X
-infer timestamps from files                                                     1942           1969          37          0.5        1942.4       0.1X
-read date text from files                                                        141            143           3          7.1         140.7       1.1X
-read date from files                                                             712            718           7          1.4         712.4       0.2X
-timestamp strings                                                                142            158          14          7.0         142.4       1.0X
-parse timestamps from Dataset[String]                                           1286           1291           5          0.8        1285.9       0.1X
-infer timestamps from Dataset[String]                                           2139           2145           6          0.5        2138.6       0.1X
-date strings                                                                     209            210           1          4.8         209.0       0.7X
-parse dates from Dataset[String]                                                1019           1026           6          1.0        1019.0       0.1X
-from_json(timestamp)                                                            1738           1741           5          0.6        1737.8       0.1X
-from_json(date)                                                                 1477           1482           6          0.7        1477.3       0.1X
-infer error timestamps from Dataset[String] with default format                 1380           1387           6          0.7        1380.4       0.1X
-infer error timestamps from Dataset[String] with user-provided format           1380           1388           7          0.7        1380.5       0.1X
-infer error timestamps from Dataset[String] with legacy format                  1442           1450           9          0.7        1442.3       0.1X
+read timestamp text from files                                                   186            189           5          5.4         186.0       1.0X
+read timestamps from files                                                      1358           1371          12          0.7        1357.5       0.1X
+infer timestamps from files                                                     2574           2670          96          0.4        2573.7       0.1X
+read date text from files                                                        178            183           7          5.6         177.9       1.0X
+read date from files                                                             771            784          16          1.3         770.7       0.2X
+timestamp strings                                                                160            164           4          6.2         160.3       1.2X
+parse timestamps from Dataset[String]                                           1135           1158          22          0.9        1135.2       0.2X
+infer timestamps from Dataset[String]                                           1981           2771        1260          0.5        1981.0       0.1X
+date strings                                                                     232            234           3          4.3         232.2       0.8X
+parse dates from Dataset[String]                                                 946            950           5          1.1         945.9       0.2X
+from_json(timestamp)                                                            1802           1805           3          0.6        1802.2       0.1X
+from_json(date)                                                                 1510           1510           1          0.7        1509.7       0.1X
+infer error timestamps from Dataset[String] with default format                 1361           1373          18          0.7        1360.7       0.1X
+infer error timestamps from Dataset[String] with user-provided format           1361           1379          19          0.7        1361.3       0.1X
+infer error timestamps from Dataset[String] with legacy format                  1378           1381           3          0.7        1377.8       0.1X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Filters pushdown:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-w/o filters                                        5828           5845          19          0.0       58278.4       1.0X
-pushdown disabled                                  5515           5536          32          0.0       55146.3       1.1X
-w/ filters                                          685            691           7          0.1        6845.1       8.5X
+w/o filters                                        9079           9284         354          0.0       90787.2       1.0X
+pushdown disabled                                  8281           8317          32          0.0       82813.6       1.1X
+w/ filters                                          685            702          18          0.1        6850.9      13.3X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
-AMD EPYC 7763 64-Core Processor
+OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
+Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
 Partial JSON results:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-parse invalid JSON                                 2346           2495         227          0.0      234637.6       1.0X
+parse invalid JSON                                 2813           2859          64          0.0      281270.5       1.0X
 
 

--- a/sql/core/benchmarks/JsonBenchmark-results.txt
+++ b/sql/core/benchmarks/JsonBenchmark-results.txt
@@ -3,129 +3,129 @@ Benchmark for performance of JSON parsing
 ================================================================================================
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
-Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+AMD EPYC 7763 64-Core Processor
 JSON schema inferring:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        2585           4133        2420          1.9         517.0       1.0X
-UTF-8 is set                                       3503           4305        1376          1.4         700.5       0.7X
+No encoding                                        2279           2300          27          2.2         455.9       1.0X
+UTF-8 is set                                       3262           3303          53          1.5         652.3       0.7X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
-Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+AMD EPYC 7763 64-Core Processor
 count a short column:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        2160           2246         114          2.3         432.0       1.0X
-UTF-8 is set                                       3335           3365          32          1.5         666.9       0.6X
+No encoding                                        2048           2146         113          2.4         409.6       1.0X
+UTF-8 is set                                       2968           2978           9          1.7         593.6       0.7X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
-Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+AMD EPYC 7763 64-Core Processor
 count a wide column:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        3622           3653          43          0.3        3621.7       1.0X
-UTF-8 is set                                       4808           4839          39          0.2        4808.0       0.8X
+No encoding                                        3131           3197          58          0.3        3130.7       1.0X
+UTF-8 is set                                       4018           4048          27          0.2        4018.5       0.8X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
-Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+AMD EPYC 7763 64-Core Processor
 select wide row:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-No encoding                                        9477          11539        2040          0.0      189544.7       1.0X
-UTF-8 is set                                      10330          11447        1267          0.0      206592.1       0.9X
+No encoding                                        8718           8869         134          0.0      174369.5       1.0X
+UTF-8 is set                                       9716           9819         104          0.0      194313.2       0.9X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
-Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+AMD EPYC 7763 64-Core Processor
 Select a subset of 10 columns:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Select 10 columns                                  1670           1677           7          0.6        1670.0       1.0X
-Select 1 column                                    1947           1960          12          0.5        1946.7       0.9X
+Select 10 columns                                  1475           1490          14          0.7        1475.3       1.0X
+Select 1 column                                    1277           1285          12          0.8        1276.9       1.2X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
-Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+AMD EPYC 7763 64-Core Processor
 creation of JSON parser per line:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Short column without encoding                       628            633           5          1.6         628.2       1.0X
-Short column with UTF-8                             845            852           9          1.2         844.7       0.7X
-Wide column without encoding                       5448           5589         123          0.2        5448.2       0.1X
-Wide column with UTF-8                             7722           7823         113          0.1        7721.9       0.1X
+Short column without encoding                       614            626          17          1.6         614.2       1.0X
+Short column with UTF-8                             785            787           2          1.3         785.3       0.8X
+Wide column without encoding                       5160           5204          58          0.2        5159.8       0.1X
+Wide column with UTF-8                             5627           5659          42          0.2        5626.8       0.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
-Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+AMD EPYC 7763 64-Core Processor
 JSON functions:                           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                            66             71           5         15.1          66.1       1.0X
-from_json                                          1205           1226          22          0.8        1205.4       0.1X
-json_tuple wholestage off                          1562           1604          36          0.6        1562.1       0.0X
-json_tuple wholestage on                           1334           1348          12          0.7        1333.9       0.0X
-get_json_object wholestage off                     1198           1230          35          0.8        1198.5       0.1X
-get_json_object wholestage on                      1217           1238          25          0.8        1216.5       0.1X
+Text read                                            60             61           1         16.8          59.5       1.0X
+from_json                                          1059           1072          14          0.9        1059.5       0.1X
+json_tuple wholestage off                          1512           1523          20          0.7        1511.6       0.0X
+json_tuple wholestage on                           1170           1176           6          0.9        1169.7       0.1X
+get_json_object wholestage off                     1047           1057          16          1.0        1047.2       0.1X
+get_json_object wholestage on                       970            977           6          1.0         969.9       0.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
-Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+AMD EPYC 7763 64-Core Processor
 Dataset of json strings:                  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                           258            269          10         19.4          51.6       1.0X
-schema inferring                                   1892           1945          86          2.6         378.3       0.1X
-parsing                                            2840           2996         186          1.8         568.1       0.1X
+Text read                                           237            245          12         21.1          47.5       1.0X
+schema inferring                                   1875           1888          17          2.7         375.0       0.1X
+parsing                                            2561           2582          20          2.0         512.1       0.1X
 
 Preparing data for benchmarking ...
-OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
-Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+AMD EPYC 7763 64-Core Processor
 Json files in the per-line mode:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Text read                                           799            855          50          6.3         159.7       1.0X
-Schema inferring                                   2601           2721         150          1.9         520.1       0.3X
-Parsing without charset                            3115           3134          28          1.6         623.1       0.3X
-Parsing with UTF-8                                 4120           4124           5          1.2         824.0       0.2X
+Text read                                           587            593           9          8.5         117.5       1.0X
+Schema inferring                                   2496           2507          17          2.0         499.2       0.2X
+Parsing without charset                            2845           2859          15          1.8         569.0       0.2X
+Parsing with UTF-8                                 3753           3779          22          1.3         750.6       0.2X
 
-OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
-Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+AMD EPYC 7763 64-Core Processor
 Write dates and timestamps:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-Create a dataset of timestamps                      118            138          22          8.5         118.2       1.0X
-to_json(timestamp)                                  818            820           4          1.2         817.6       0.1X
-write timestamps to files                           970            986          14          1.0         970.0       0.1X
-Create a dataset of dates                           187            253         114          5.4         186.9       0.6X
-to_json(date)                                       616           1214         712          1.6         615.9       0.2X
-write dates to files                                620            623           3          1.6         619.7       0.2X
+Create a dataset of timestamps                      108            116           8          9.3         108.1       1.0X
+to_json(timestamp)                                  809            815           6          1.2         809.5       0.1X
+write timestamps to files                           738            749          10          1.4         738.3       0.1X
+Create a dataset of dates                           152            158           7          6.6         151.7       0.7X
+to_json(date)                                       593            597           4          1.7         592.8       0.2X
+write dates to files                                494            499           5          2.0         494.3       0.2X
 
-OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
-Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+AMD EPYC 7763 64-Core Processor
 Read dates and timestamps:                                             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-read timestamp text from files                                                   186            189           5          5.4         186.0       1.0X
-read timestamps from files                                                      1358           1371          12          0.7        1357.5       0.1X
-infer timestamps from files                                                     2574           2670          96          0.4        2573.7       0.1X
-read date text from files                                                        178            183           7          5.6         177.9       1.0X
-read date from files                                                             771            784          16          1.3         770.7       0.2X
-timestamp strings                                                                160            164           4          6.2         160.3       1.2X
-parse timestamps from Dataset[String]                                           1135           1158          22          0.9        1135.2       0.2X
-infer timestamps from Dataset[String]                                           1981           2771        1260          0.5        1981.0       0.1X
-date strings                                                                     232            234           3          4.3         232.2       0.8X
-parse dates from Dataset[String]                                                 946            950           5          1.1         945.9       0.2X
-from_json(timestamp)                                                            1802           1805           3          0.6        1802.2       0.1X
-from_json(date)                                                                 1510           1510           1          0.7        1509.7       0.1X
-infer error timestamps from Dataset[String] with default format                 1361           1373          18          0.7        1360.7       0.1X
-infer error timestamps from Dataset[String] with user-provided format           1361           1379          19          0.7        1361.3       0.1X
-infer error timestamps from Dataset[String] with legacy format                  1378           1381           3          0.7        1377.8       0.1X
+read timestamp text from files                                                   152            155           4          6.6         151.6       1.0X
+read timestamps from files                                                      1018           1018           0          1.0        1017.6       0.1X
+infer timestamps from files                                                     1933           1947          16          0.5        1933.5       0.1X
+read date text from files                                                        147            152           9          6.8         146.8       1.0X
+read date from files                                                             705            709           3          1.4         704.8       0.2X
+timestamp strings                                                                170            172           2          5.9         169.6       0.9X
+parse timestamps from Dataset[String]                                           1223           1226           3          0.8        1223.2       0.1X
+infer timestamps from Dataset[String]                                           2113           2129          18          0.5        2112.5       0.1X
+date strings                                                                     235            236           1          4.3         234.8       0.6X
+parse dates from Dataset[String]                                                 998           1004           5          1.0         998.2       0.2X
+from_json(timestamp)                                                            1656           1661           5          0.6        1656.3       0.1X
+from_json(date)                                                                 1449           1456           6          0.7        1449.4       0.1X
+infer error timestamps from Dataset[String] with default format                 1371           1374           3          0.7        1371.0       0.1X
+infer error timestamps from Dataset[String] with user-provided format           1385           1388           2          0.7        1385.1       0.1X
+infer error timestamps from Dataset[String] with legacy format                  1401           1409           7          0.7        1400.6       0.1X
 
-OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
-Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+AMD EPYC 7763 64-Core Processor
 Filters pushdown:                         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-w/o filters                                        9079           9284         354          0.0       90787.2       1.0X
-pushdown disabled                                  8281           8317          32          0.0       82813.6       1.1X
-w/ filters                                          685            702          18          0.1        6850.9      13.3X
+w/o filters                                        5938           5959          21          0.0       59379.3       1.0X
+pushdown disabled                                  5778           5793          23          0.0       57782.8       1.0X
+w/ filters                                          689            700          15          0.1        6891.8       8.6X
 
-OpenJDK 64-Bit Server VM 17.0.9+0 on Mac OS X 12.6.7
-Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+AMD EPYC 7763 64-Core Processor
 Partial JSON results:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-parse invalid JSON                                 2813           2859          64          0.0      281270.5       1.0X
+parse invalid JSON                                 2317           2471         177          0.0      231690.5       1.0X
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -1422,26 +1422,50 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
   }
 
   test("json_tuple codegen - all foldable") {
-    val data =
-      Seq(("""{"name": "alice", "age": 5}""", "name")).toDF("a", "b")
-    val df =
-      data.selectExpr("json_tuple(a, 'name', 'age', 'sex', 'name')")
-    checkAnswer(df, Seq(Row("alice", "5", null, "alice")))
+    Seq("true", "false").foreach { enabled =>
+      withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> enabled) {
+        val data =
+          Seq(("""{"name": "alice", "age": 5}""", "name")).toDF("a", "b")
+        val df =
+          data.selectExpr("json_tuple(a, 'name', 'age', 'sex', 'name')")
+        checkAnswer(df, Seq(Row("alice", "5", null, "alice")))
+      }
+    }
   }
 
   test("json_tuple codegen - partially foldable") {
-    val data =
-      Seq(("""{"name": "alice", "age": 5}""", "name")).toDF("a", "b")
-    val df =
-      data.selectExpr("json_tuple(a, 'name', b, 'age', 'sex')")
-    checkAnswer(df, Seq(Row("alice", "alice", "5", null)))
+    Seq("true", "false").foreach { enabled =>
+      withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> enabled) {
+        val data =
+          Seq(("""{"name": "alice", "age": 5}""", "name")).toDF("a", "b")
+        val df =
+          data.selectExpr("json_tuple(a, 'name', b, 'age', 'sex')")
+        checkAnswer(df, Seq(Row("alice", "alice", "5", null)))
+      }
+    }
   }
 
   test("json_tuple codegen - all not foldable") {
-    val data =
-      Seq(("""{"name": "alice", "age": 5}""", "name", "age", "sex")).toDF("a", "b", "c", "d")
-    val df =
-      data.selectExpr("json_tuple(a, b, c, d)")
-    checkAnswer(df, Seq(Row("alice", "5", null)))
+    Seq("true", "false").foreach { enabled =>
+      withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> enabled) {
+        val data =
+          Seq(("""{"name": "alice", "age": 5}""", "name", "age", "sex")).toDF("a", "b", "c", "d")
+        val df =
+          data.selectExpr("json_tuple(a, b, c, d)")
+        checkAnswer(df, Seq(Row("alice", "5", null)))
+      }
+    }
+  }
+
+  test("json_tuple codegen - null path") {
+    Seq("true", "false").foreach { enabled =>
+      withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> enabled) {
+        val data =
+          Seq(("""{"name": "alice", "age": 5}""")).toDF("a")
+        val df = data.selectExpr(
+          "json_tuple(a, CAST(NULL AS STRING), 'name', CAST(NULL AS STRING), 'age')")
+        checkAnswer(df, Seq(Row(null, "alice", null, "5")))
+      }
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonBenchmark.scala
@@ -267,9 +267,18 @@ object JsonBenchmark extends SqlBasedBenchmark {
       from_json_ds.noop()
     }
 
-    benchmark.addCase("json_tuple", iters) { _ =>
-      val json_tuple_ds = in.select(json_tuple($"value", "a"))
-      json_tuple_ds.noop()
+    benchmark.addCase("json_tuple wholestage off", iters) { _ =>
+      withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "false") {
+        val json_tuple_ds = in.select(json_tuple($"value", "a"))
+        json_tuple_ds.noop()
+      }
+    }
+
+    benchmark.addCase("json_tuple wholestage on", iters) { _ =>
+      withSQLConf(SQLConf.WHOLESTAGE_CODEGEN_ENABLED.key -> "true") {
+        val json_tuple_ds = in.select(json_tuple($"value", "a"))
+        json_tuple_ds.noop()
+      }
     }
 
     benchmark.addCase("get_json_object wholestage off", iters) { _ =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support codegen for json_tuple.


### Why are the changes needed?
Sometimes using json_tuple may cause performance regression because it does not support whole stage codegen..


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing UTs.


### Was this patch authored or co-authored using generative AI tooling?
No.
