### PR TITLE
[SPARK-47641][SQL] Improve the performance for `UnaryMinus` and `Abs`

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/MathUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/MathUtils.scala
@@ -61,6 +61,20 @@ object MathUtils {
     withOverflow(Math.multiplyExact(a, b), hint = "try_multiply", context)
   }
 
+  def negateExact(a: Byte): Byte = {
+    if (a == Byte.MinValue) {
+      throw ExecutionErrors.arithmeticOverflowError("byte overflow")
+    }
+    (-a).toByte
+  }
+
+  def negateExact(a: Short): Short = {
+    if (a == Short.MinValue) {
+      throw ExecutionErrors.arithmeticOverflowError("short overflow")
+    }
+    (-a).toShort
+  }
+
   def negateExact(a: Int): Int = withOverflow(Math.negateExact(a))
 
   def negateExact(a: Long): Long = withOverflow(Math.negateExact(a))

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/MathUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/MathUtils.scala
@@ -62,14 +62,14 @@ object MathUtils {
   }
 
   def negateExact(a: Byte): Byte = {
-    if (a == Byte.MinValue) {
+    if (a == Byte.MinValue) { // if and only if x is Byte.MinValue, overflow can happen
       throw ExecutionErrors.arithmeticOverflowError("byte overflow")
     }
     (-a).toByte
   }
 
   def negateExact(a: Short): Short = {
-    if (a == Short.MinValue) {
+    if (a == Short.MinValue) { // if and only if x is Short.MinValue, overflow can happen
       throw ExecutionErrors.arithmeticOverflowError("short overflow")
     }
     (-a).toShort

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.types
 import scala.math.Numeric._
 
 import org.apache.spark.sql.catalyst.util.{MathUtils, SQLOrderingUtil}
-import org.apache.spark.sql.errors.{ExecutionErrors, QueryExecutionErrors}
+import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.types.Decimal.DecimalIsConflicted
 
 private[sql] object ByteExactNumeric extends ByteIsIntegral with Ordering.ByteOrdering {
@@ -49,10 +49,7 @@ private[sql] object ByteExactNumeric extends ByteIsIntegral with Ordering.ByteOr
   }
 
   override def negate(x: Byte): Byte = {
-    if (x == Byte.MinValue) { // if and only if x is Byte.MinValue, overflow can happen
-      throw ExecutionErrors.arithmeticOverflowError("byte overflow")
-    }
-    (-x).toByte
+    MathUtils.negateExact(x)
   }
 }
 
@@ -83,10 +80,7 @@ private[sql] object ShortExactNumeric extends ShortIsIntegral with Ordering.Shor
   }
 
   override def negate(x: Short): Short = {
-    if (x == Short.MinValue) { // if and only if x is Byte.MinValue, overflow can happen
-      throw ExecutionErrors.arithmeticOverflowError("short overflow")
-    }
-    (-x).toShort
+    MathUtils.negateExact(x)
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to improve the `performance` for `UnaryMinus` and `Abs`.


### Why are the changes needed?
We can further `improve the performance` of `UnaryMinus` and `Abs` by the following suggestions:
<img width="905" alt="image" src="https://github.com/apache/spark/assets/15246973/456b142d-a15d-408e-8aad-91b53841fc16">


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Manually test.
- Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
