### PR TITLE
[SPARK-47543][CONNECT][PYTHON][TESTS][FOLLOW-UP] Skip the test if pandas and PyArrow are unavailable

### DIFF
--- a/python/pyspark/sql/tests/test_creation.py
+++ b/python/pyspark/sql/tests/test_creation.py
@@ -20,6 +20,7 @@ from decimal import Decimal
 import os
 import time
 import unittest
+from typing import cast
 
 from pyspark.sql import Row
 import pyspark.sql.functions as F
@@ -35,7 +36,9 @@ from pyspark.errors import (
 from pyspark.testing.sqlutils import (
     ReusedSQLTestCase,
     have_pandas,
+    have_pyarrow,
     pandas_requirement_message,
+    pyarrow_requirement_message,
 )
 
 
@@ -157,10 +160,15 @@ class DataFrameCreationTestsMixin:
             message_parameters={},
         )
 
+    @unittest.skipIf(
+        not have_pandas or not have_pyarrow,
+        cast(str, pandas_requirement_message or pyarrow_requirement_message),
+    )
     def test_schema_inference_from_pandas_with_dict(self):
         # SPARK-47543: test for verifying if inferring `dict` as `MapType` work properly.
         import pandas as pd
 
+        cast
         pdf = pd.DataFrame({"str_col": ["second"], "dict_col": [{"first": 0.7, "second": 0.3}]})
 
         with self.sql_conf(

--- a/python/pyspark/sql/tests/test_creation.py
+++ b/python/pyspark/sql/tests/test_creation.py
@@ -168,7 +168,6 @@ class DataFrameCreationTestsMixin:
         # SPARK-47543: test for verifying if inferring `dict` as `MapType` work properly.
         import pandas as pd
 
-        cast
         pdf = pd.DataFrame({"str_col": ["second"], "dict_col": [{"first": 0.7, "second": 0.3}]})
 
         with self.sql_conf(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/45699 that adds pandas/arrow check (and skips the test if not installed).

Currently, scheduled PyPy build is broken https://github.com/apache/spark/actions/runs/8469356110/job/23208888581.

### Why are the changes needed?

To make the PySpark tests runnable without optional dependencies.
To fix up the scheduled build for PyPy.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.
