### PR TITLE
[SPARK-47648][SQL][TESTS] Use `checkError()` to check Exception in `[CSV|Json|Xml]Suite` and `[Csv|Json]FunctionsSuite`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala
@@ -845,13 +845,16 @@ class JsonFunctionsSuite extends QueryTest with SharedSparkSession {
           "failFastMode" -> "FAILFAST")
       )
 
-      val exception2 = intercept[AnalysisException] {
-        df.select(from_json($"value", schema, Map("mode" -> "DROPMALFORMED")))
-          .collect()
-      }.getMessage
-      assert(exception2.contains(
-        "from_json() doesn't support the DROPMALFORMED mode. " +
-          "Acceptable modes are PERMISSIVE and FAILFAST."))
+      checkError(
+        exception = intercept[AnalysisException] {
+          df.select(from_json($"value", schema, Map("mode" -> "DROPMALFORMED"))).collect()
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1099",
+        parameters = Map(
+          "funcName" -> "from_json",
+          "mode" -> "DROPMALFORMED",
+          "permissiveMode" -> "PERMISSIVE",
+          "failFastMode" -> "FAILFAST"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -35,7 +35,7 @@ import org.apache.hadoop.io.SequenceFile.CompressionType
 import org.apache.hadoop.io.compress.GzipCodec
 import org.apache.logging.log4j.Level
 
-import org.apache.spark.{SparkConf, SparkException, SparkRuntimeException, SparkUpgradeException, TestUtils}
+import org.apache.spark.{SparkConf, SparkException, SparkIllegalArgumentException, SparkRuntimeException, SparkUpgradeException, TestUtils}
 import org.apache.spark.sql.{AnalysisException, Column, DataFrame, Encoders, QueryTest, Row}
 import org.apache.spark.sql.catalyst.csv.CSVOptions
 import org.apache.spark.sql.catalyst.util.{DateTimeTestUtils, DateTimeUtils, HadoopCompressionCodec}
@@ -378,7 +378,10 @@ abstract class CSVSuite
           .options(Map("header" -> "true", "mode" -> "failfast"))
           .load(testFile(carsFile)).collect()
       }
-      assert(e1.getErrorClass.startsWith("FAILED_READ_FILE"))
+      checkErrorMatchPVals(
+        exception = e1,
+        errorClass = "FAILED_READ_FILE.NO_HINT",
+        parameters = Map("path" -> s".*$carsFile.*"))
       val e2 = e1.getCause.asInstanceOf[SparkException]
       assert(e2.getErrorClass == "MALFORMED_RECORD_IN_PARSING.WITHOUT_SUGGESTION")
       checkError(
@@ -1485,6 +1488,11 @@ abstract class CSVSuite
         val e = intercept[SparkException] {
           spark.read.csv(inputFile.toURI.toString).collect()
         }
+        checkError(
+          exception = e,
+          errorClass = "FAILED_READ_FILE.NO_HINT",
+          parameters = Map("path" -> inputFile.toPath.toUri.toString)
+        )
         assert(e.getCause.isInstanceOf[EOFException])
         assert(e.getCause.getMessage === "Unexpected end of input stream")
         val e2 = intercept[SparkException] {
@@ -1512,7 +1520,7 @@ abstract class CSVSuite
             df.collect()
           },
           errorClass = "FAILED_READ_FILE.FILE_NOT_EXIST",
-          parameters = Map("path" -> ".*")
+          parameters = Map("path" -> s".*$dir.*")
         )
       }
 
@@ -1657,6 +1665,10 @@ abstract class CSVSuite
         .csv(Seq("10u12").toDS())
         .collect()
     }
+    checkError(
+      exception = exception,
+      errorClass = "MALFORMED_RECORD_IN_PARSING.WITHOUT_SUGGESTION",
+      parameters = Map("badRecord" -> "[null]", "failFastMode" -> "FAILFAST"))
     assert(exception.getCause.getMessage.contains("""input string: "10u12""""))
 
     val count = spark.read.schema("a FLOAT")
@@ -1935,7 +1947,10 @@ abstract class CSVSuite
             .csv(path.getCanonicalPath)
             .collect()
         }
-        assert(exception.getErrorClass.startsWith("FAILED_READ_FILE"))
+        checkErrorMatchPVals(
+          exception = exception,
+          errorClass = "FAILED_READ_FILE.NO_HINT",
+          parameters = Map("path" -> s".*${path.getCanonicalPath}.*"))
         assert(exception.getCause.getMessage.contains("CSV header does not conform to the schema"))
 
         val shortSchema = new StructType().add("f1", DoubleType)
@@ -1948,7 +1963,10 @@ abstract class CSVSuite
             .csv(path.getCanonicalPath)
             .collect()
         }
-        assert(exception.getErrorClass.startsWith("FAILED_READ_FILE"))
+        checkErrorMatchPVals(
+          exception = exceptionForShortSchema,
+          errorClass = "FAILED_READ_FILE.NO_HINT",
+          parameters = Map("path" -> s".*${path.getCanonicalPath}.*"))
         assert(exceptionForShortSchema.getCause.getMessage.contains(
           "Number of column in CSV header is not equal to number of fields in the schema"))
 
@@ -1966,7 +1984,10 @@ abstract class CSVSuite
             .csv(path.getCanonicalPath)
             .collect()
         }
-        assert(exceptionForLongSchema.getErrorClass.startsWith("FAILED_READ_FILE"))
+        checkErrorMatchPVals(
+          exception = exceptionForLongSchema,
+          errorClass = "FAILED_READ_FILE.NO_HINT",
+          parameters = Map("path" -> s".*${path.getCanonicalPath}.*"))
         assert(exceptionForLongSchema.getCause.getMessage.contains(
           "Header length: 2, schema size: 3"))
 
@@ -1980,7 +2001,10 @@ abstract class CSVSuite
             .csv(path.getCanonicalPath)
             .collect()
         }
-        assert(caseSensitiveException.getErrorClass.startsWith("FAILED_READ_FILE"))
+        checkErrorMatchPVals(
+          exception = caseSensitiveException,
+          errorClass = "FAILED_READ_FILE.NO_HINT",
+          parameters = Map("path" -> s".*${path.getCanonicalPath}.*"))
         assert(caseSensitiveException.getCause.getMessage.contains(
           "CSV header does not conform to the schema"))
       }
@@ -2030,11 +2054,17 @@ abstract class CSVSuite
   test("SPARK-23786: check header on parsing of dataset of strings") {
     val ds = Seq("columnA,columnB", "1.0,1000.0").toDS()
     val ischema = new StructType().add("columnB", DoubleType).add("columnA", DoubleType)
-    val exception = intercept[IllegalArgumentException] {
-      spark.read.schema(ischema).option("header", true).option("enforceSchema", false).csv(ds)
-    }
-
-    assert(exception.getMessage.contains("CSV header does not conform to the schema"))
+    checkError(
+      exception = intercept[SparkIllegalArgumentException] {
+        spark.read.schema(ischema).option("header", true).option("enforceSchema", false).csv(ds)
+      },
+      errorClass = "_LEGACY_ERROR_TEMP_3241",
+      parameters = Map("msg" ->
+        """CSV header does not conform to the schema.
+          | Header: columnA, columnB
+          | Schema: columnB, columnA
+          |Expected: columnB but found: columnA
+          |CSV source: [value: string]""".stripMargin))
   }
 
   test("SPARK-23786: enforce inferred schema") {
@@ -2058,15 +2088,22 @@ abstract class CSVSuite
     assert(ds.schema == schema)
     checkAnswer(ds, Seq(Row(1.0, "a")))
 
-    val exception = intercept[IllegalArgumentException] {
-      spark.read
-        .option("inferSchema", true)
-        .option("enforceSchema", false)
-        .option("header", true)
-        .schema(schema)
-        .csv(Seq("col1,col2", "1.0,a").toDS())
-    }
-    assert(exception.getMessage.contains("CSV header does not conform to the schema"))
+    checkError(
+      exception = intercept[SparkIllegalArgumentException] {
+        spark.read
+          .option("inferSchema", true)
+          .option("enforceSchema", false)
+          .option("header", true)
+          .schema(schema)
+          .csv(Seq("col1,col2", "1.0,a").toDS())
+      },
+      errorClass = "_LEGACY_ERROR_TEMP_3241",
+      parameters = Map("msg" ->
+        """CSV header does not conform to the schema.
+          | Header: col1, col2
+          | Schema: colA, colB
+          |Expected: colA but found: col1
+          |CSV source: [value: string]""".stripMargin))
   }
 
   test("SPARK-23786: warning should be printed if CSV header doesn't conform to schema") {
@@ -2677,10 +2714,14 @@ abstract class CSVSuite
       .option("timestampFormat", "yyyy-MM-dd'T'HH:mm:ss.SSSz")
       .schema("t timestamp").csv(ds)
     withSQLConf(SQLConf.LEGACY_TIME_PARSER_POLICY.key -> "exception") {
-      val msg = intercept[SparkUpgradeException] {
-        csv.collect()
-      }.getMessage
-      assert(msg.contains("Fail to parse"))
+      checkError(
+        exception = intercept[SparkUpgradeException] {
+          csv.collect()
+        },
+        errorClass = "INCONSISTENT_BEHAVIOR_CROSS_VERSION.PARSE_DATETIME_BY_NEW_PARSER",
+        parameters = Map(
+          "datetime" -> "'2020-01-27T20:06:11.847-08000'",
+          "config" -> "\"spark.sql.legacy.timeParserPolicy\""))
     }
     withSQLConf(SQLConf.LEGACY_TIME_PARSER_POLICY.key -> "legacy") {
       checkAnswer(csv, Row(Timestamp.valueOf("2020-01-27 20:06:11.847")))
@@ -3127,14 +3168,13 @@ abstract class CSVSuite
   test("SPARK-42237: change binary to unsupported dataType") {
     withTempPath { path =>
       val colName: String = "value"
-      val exception = intercept[AnalysisException] {
-        Seq(Array[Byte](1, 2))
-          .toDF(colName)
-          .write
-          .csv(path.getCanonicalPath)
-      }
       checkError(
-        exception = exception,
+        exception = intercept[AnalysisException] {
+          Seq(Array[Byte](1, 2))
+            .toDF(colName)
+            .write
+            .csv(path.getCanonicalPath)
+        },
         errorClass = "UNSUPPORTED_DATA_TYPE_FOR_DATASOURCE",
         parameters = Map(
           "columnName" -> s"`$colName`",
@@ -3319,7 +3359,10 @@ class CSVv1Suite extends CSVSuite {
           .options(Map("header" -> "true", "mode" -> "failfast"))
           .load(testFile(carsFile)).collect()
       }
-      assert(ex.getErrorClass.startsWith("FAILED_READ_FILE"))
+      checkErrorMatchPVals(
+        exception = ex,
+        errorClass = "FAILED_READ_FILE.NO_HINT",
+        parameters = Map("path" -> s".*$carsFile"))
       checkError(
         exception = ex.getCause.asInstanceOf[SparkException],
         errorClass = "MALFORMED_RECORD_IN_PARSING.WITHOUT_SUGGESTION",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources.json
 
 import java.io._
 import java.nio.charset.{Charset, StandardCharsets, UnsupportedCharsetException}
-import java.nio.file.Files
+import java.nio.file.{Files, Path => JPath}
 import java.sql.{Date, Timestamp}
 import java.time.{Duration, Instant, LocalDate, LocalDateTime, Period, ZoneId}
 import java.util.Locale
@@ -1063,13 +1063,15 @@ abstract class JsonSuite
 
   test("Corrupt records: FAILFAST mode") {
     // `FAILFAST` mode should throw an exception for corrupt records.
-    val exceptionOne = intercept[SparkException] {
-      spark.read
-        .option("mode", "FAILFAST")
-        .json(corruptRecords)
-    }.getMessage
-    assert(exceptionOne.contains(
-      "Malformed records are detected in schema inference. Parse Mode: FAILFAST."))
+    checkError(
+      exception = intercept[SparkException] {
+        spark.read
+          .option("mode", "FAILFAST")
+          .json(corruptRecords)
+      },
+      errorClass = "_LEGACY_ERROR_TEMP_2165",
+      parameters = Map("failFastMode" -> "FAILFAST")
+    )
 
     checkError(
       exception = intercept[SparkException] {
@@ -1922,6 +1924,10 @@ abstract class JsonSuite
         val e = intercept[SparkException] {
           spark.read.json(inputFile.toURI.toString).collect()
         }
+        checkError(
+          exception = e,
+          errorClass = "FAILED_READ_FILE.NO_HINT",
+          parameters = Map("path" -> inputFile.toPath.toUri.toString))
         assert(e.getCause.isInstanceOf[EOFException])
         assert(e.getCause.getMessage === "Unexpected end of input stream")
         val e2 = intercept[SparkException] {
@@ -2027,14 +2033,15 @@ abstract class JsonSuite
       val schema = new StructType().add("dummy", StringType)
 
       // `FAILFAST` mode should throw an exception for corrupt records.
-      val exceptionOne = intercept[SparkException] {
-        spark.read
-          .option("multiLine", true)
-          .option("mode", "FAILFAST")
-          .json(path)
-      }
-      assert(exceptionOne.getMessage.contains("Malformed records are detected in schema " +
-        "inference. Parse Mode: FAILFAST."))
+      checkError(
+        exception = intercept[SparkException] {
+          spark.read
+            .option("multiLine", true)
+            .option("mode", "FAILFAST")
+            .json(path)
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_2167",
+        parameters = Map("failFastMode" -> "FAILFAST", "dataType" -> "string"))
 
       val ex = intercept[SparkException] {
         spark.read
@@ -2062,39 +2069,46 @@ abstract class JsonSuite
         StructField("a", StringType, true) ::
         StructField("b", StringType, true) ::
         StructField("c", StringType, true) :: Nil)
-    val errMsg = intercept[AnalysisException] {
-      spark.read
-        .option("mode", "Permissive")
-        .option("columnNameOfCorruptRecord", columnNameOfCorruptRecord)
-        .schema(schema)
-        .json(corruptRecords)
-    }.getMessage
-    assert(errMsg.startsWith("The field for corrupt records must be string type and nullable"))
+
+    checkError(
+      exception = intercept[AnalysisException] {
+        spark.read
+          .option("mode", "Permissive")
+          .option("columnNameOfCorruptRecord", columnNameOfCorruptRecord)
+          .schema(schema)
+          .json(corruptRecords)
+      },
+      errorClass = "_LEGACY_ERROR_TEMP_1097",
+      parameters = Map.empty
+    )
 
     // We use `PERMISSIVE` mode by default if invalid string is given.
     withTempPath { dir =>
       val path = dir.getCanonicalPath
       corruptRecords.toDF("value").write.text(path)
-      val errMsg = intercept[AnalysisException] {
-        spark.read
-          .option("mode", "permm")
-          .option("columnNameOfCorruptRecord", columnNameOfCorruptRecord)
-          .schema(schema)
-          .json(path)
-          .collect()
-      }.getMessage
-      assert(errMsg.startsWith("The field for corrupt records must be string type and nullable"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          spark.read
+            .option("mode", "permm")
+            .option("columnNameOfCorruptRecord", columnNameOfCorruptRecord)
+            .schema(schema)
+            .json(path)
+            .collect()
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1097",
+        parameters = Map.empty
+      )
     }
   }
 
   test("SPARK-18772: Parse special floats correctly") {
-    val jsons = Seq(
-      """{"a": "NaN"}""",
-      """{"a": "+INF"}""",
-      """{"a": "-INF"}""",
-      """{"a": "Infinity"}""",
-      """{"a": "+Infinity"}""",
-      """{"a": "-Infinity"}""")
+    val jsonFieldValues = Seq(
+      ("""{"a": "NaN"}""", """'NaN'"""),
+      ("""{"a": "+INF"}""", """'+INF'"""),
+      ("""{"a": "-INF"}""", """'-INF'"""),
+      ("""{"a": "Infinity"}""", """'Infinity'"""),
+      ("""{"a": "+Infinity"}""", """'+Infinity'"""),
+      ("""{"a": "-Infinity"}""", """'-Infinity'"""))
 
     // positive cases
     val checks: Seq[Double => Boolean] = Seq(
@@ -2106,10 +2120,10 @@ abstract class JsonSuite
       _.isNegInfinity)
 
     Seq(FloatType, DoubleType).foreach { dt =>
-      jsons.zip(checks).foreach { case (json, check) =>
+      jsonFieldValues.zip(checks).foreach { case (jsonFieldValue, check) =>
         val ds = spark.read
           .schema(StructType(Seq(StructField("a", dt))))
-          .json(Seq(json).toDS())
+          .json(Seq(jsonFieldValue._1).toDS())
           .select($"a".cast(DoubleType)).as[Double]
         assert(check(ds.first()))
       }
@@ -2117,17 +2131,27 @@ abstract class JsonSuite
 
     // negative cases
     Seq(FloatType, DoubleType).foreach { dt =>
-      val lowerCasedJsons = jsons.map(_.toLowerCase(Locale.ROOT))
+      val lowerCasedJsonFieldValues = jsonFieldValues.map(j =>
+        (j._1.toLowerCase(Locale.ROOT), j._2.toLowerCase(Locale.ROOT)))
       // The special floats are case-sensitive so these cases below throw exceptions.
-      lowerCasedJsons.foreach { lowerCasedJson =>
-        val e = intercept[SparkRuntimeException] {
-          spark.read
-            .option("mode", "FAILFAST")
-            .schema(StructType(Seq(StructField("a", dt))))
-            .json(Seq(lowerCasedJson).toDS())
-            .collect()
-        }
-        assert(e.getMessage.contains("Cannot parse"))
+      lowerCasedJsonFieldValues.foreach { lowerCasedJsonFieldValue =>
+        checkError(
+          exception = intercept[SparkRuntimeException] {
+            spark.read
+              .option("mode", "FAILFAST")
+              .schema(StructType(Seq(StructField("a", dt))))
+              .json(Seq(lowerCasedJsonFieldValue._1).toDS())
+              .collect()
+          },
+          errorClass = "MALFORMED_RECORD_IN_PARSING.CANNOT_PARSE_STRING_AS_DATATYPE",
+          parameters = Map(
+            "failFastMode" -> "FAILFAST",
+            "badRecord" -> lowerCasedJsonFieldValue._1,
+            "fieldValue" -> lowerCasedJsonFieldValue._2,
+            "fieldName" -> "`a`",
+            "targetType" -> dt.toString,
+            "inputType" -> "StringType")
+        )
       }
     }
   }
@@ -2143,10 +2167,13 @@ abstract class JsonSuite
       Seq(data).toDF().repartition(1).write.text(path)
       val schema = new StructType().add("field", ByteType).add("_corrupt_record", StringType)
       // negative cases
-      val msg = intercept[AnalysisException] {
-        spark.read.schema(schema).json(path).select("_corrupt_record").collect()
-      }.getMessage
-      assert(msg.contains("only include the internal corrupt record column"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          spark.read.schema(schema).json(path).select("_corrupt_record").collect()
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_1285",
+        parameters = Map.empty
+      )
 
       // workaround
       val df = spark.read.schema(schema).json(path).cache()
@@ -2329,17 +2356,24 @@ abstract class JsonSuite
   test("SPARK-23723: specified encoding is not matched to actual encoding") {
     val fileName = "test-data/utf16LE.json"
     val schema = new StructType().add("firstName", StringType).add("lastName", StringType)
+    val inputFile = testFile(fileName)
     val exception = intercept[SparkException] {
       spark.read.schema(schema)
         .option("mode", "FAILFAST")
         .option("multiline", "true")
         .options(Map("encoding" -> "UTF-16BE"))
-        .json(testFile(fileName))
+        .json(inputFile)
         .count()
     }
-    assert(exception.getErrorClass.startsWith("FAILED_READ_FILE"))
-    assert(exception.getCause.getMessage.contains(
-      "Malformed records are detected in record parsing"))
+    checkError(
+      exception = exception,
+      errorClass = "FAILED_READ_FILE.NO_HINT",
+      parameters = Map("path" -> JPath.of(inputFile).toUri.toString))
+    checkError(
+      exception = exception.getCause.asInstanceOf[SparkException],
+      errorClass = "MALFORMED_RECORD_IN_PARSING.WITHOUT_SUGGESTION",
+      parameters = Map("badRecord" -> "[empty row]", "failFastMode" -> "FAILFAST")
+    )
   }
 
   def checkEncoding(expectedEncoding: String, pathToJsonFiles: String,
@@ -2811,10 +2845,14 @@ abstract class JsonSuite
       .option("timestampFormat", "yyyy-MM-dd'T'HH:mm:ss.SSSz")
       .json(ds)
     withSQLConf(SQLConf.LEGACY_TIME_PARSER_POLICY.key -> "exception") {
-      val msg = intercept[SparkUpgradeException] {
-        json.collect()
-      }.getMessage
-      assert(msg.contains("Fail to parse"))
+      checkError(
+        exception = intercept[SparkUpgradeException] {
+          json.collect()
+        },
+        errorClass = "INCONSISTENT_BEHAVIOR_CROSS_VERSION.PARSE_DATETIME_BY_NEW_PARSER",
+        parameters = Map(
+          "datetime" -> "'2020-01-27T20:06:11.847-08000'",
+          "config" -> "\"spark.sql.legacy.timeParserPolicy\""))
     }
     withSQLConf(SQLConf.LEGACY_TIME_PARSER_POLICY.key -> "legacy") {
       checkAnswer(json, Row(Timestamp.valueOf("2020-01-27 20:06:11.847")))
@@ -2995,10 +3033,15 @@ abstract class JsonSuite
     val exp = spark.sql("select timestamp_ntz'2020-12-12 12:12:12' as col0")
     for (pattern <- patterns) {
       withTempPath { path =>
+        val actualPath = path.toPath.toUri.toURL.toString
         val err = intercept[SparkException] {
           exp.write.option("timestampNTZFormat", pattern).json(path.getAbsolutePath)
         }
-        assert(err.getErrorClass == "TASK_WRITE_FAILED")
+        checkError(
+          exception = err,
+          errorClass = "TASK_WRITE_FAILED",
+          parameters = Map("path" -> actualPath))
+
         val msg = err.getCause.getMessage
         assert(
           msg.contains("Unsupported field: OffsetSeconds") ||
@@ -3265,7 +3308,12 @@ abstract class JsonSuite
       spark.read.option("mode", "failfast")
         .schema("a string").json(Seq("""[{"a": "str"}, null]""").toDS()).collect()
     }
-    assert(exception.getMessage.contains("Malformed records are detected"))
+
+    checkError(
+      exception = exception,
+      errorClass = "MALFORMED_RECORD_IN_PARSING.WITHOUT_SUGGESTION",
+      parameters = Map("badRecord" -> "[null]", "failFastMode" -> "FAILFAST")
+    )
 
     checkError(
       exception = ExceptionUtils.getRootCause(exception).asInstanceOf[SparkRuntimeException],
@@ -3746,18 +3794,24 @@ abstract class JsonSuite
       withTempDir { dir =>
         val colName = "col"
         val msg = "can only contain STRING as a key type for a MAP"
+        val jsonDataSchema = StructType(Seq(StructField(colName, schema)))
 
-        val thrown1 = intercept[AnalysisException](
-          spark.read.schema(StructType(Seq(StructField(colName, schema))))
-            .json(Seq(jsonData).toDS()).collect())
-        assert(thrown1.getMessage.contains(msg))
+        checkError(
+          exception = intercept[AnalysisException](
+            spark.read.schema(jsonDataSchema).json(Seq(jsonData).toDS()).collect()
+          ),
+          errorClass = "INVALID_JSON_SCHEMA_MAP_TYPE",
+          parameters = Map("jsonSchema" -> toSQLType(jsonDataSchema)))
 
         val jsonDir = new File(dir, "json").getCanonicalPath
         Seq(jsonData).toDF(colName).write.json(jsonDir)
-        val thrown2 = intercept[AnalysisException](
-          spark.read.schema(StructType(Seq(StructField(colName, schema))))
-            .json(jsonDir).collect())
-        assert(thrown2.getMessage.contains(msg))
+        val jsonDirSchema = StructType(Seq(StructField(colName, schema)))
+        checkError(
+          exception = intercept[AnalysisException](
+            spark.read.schema(jsonDirSchema).json(jsonDir).collect()
+          ),
+          errorClass = "INVALID_JSON_SCHEMA_MAP_TYPE",
+          parameters = Map("jsonSchema" -> toSQLType(jsonDirSchema)))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
@@ -1315,12 +1315,11 @@ class XmlSuite
   }
 
   test("schema_of_xml with DROPMALFORMED parse error test") {
-    val e = intercept[AnalysisException] {
-       spark.sql(s"""SELECT schema_of_xml('<ROW><a>1<ROW>', map('mode', 'DROPMALFORMED'))""")
-         .collect()
-    }
     checkError(
-      exception = e,
+      exception = intercept[AnalysisException] {
+        spark.sql(s"""SELECT schema_of_xml('<ROW><a>1<ROW>', map('mode', 'DROPMALFORMED'))""")
+          .collect()
+      },
       errorClass = "_LEGACY_ERROR_TEMP_1099",
       parameters = Map(
         "funcName" -> "schema_of_xml",
@@ -1331,12 +1330,11 @@ class XmlSuite
   }
 
   test("schema_of_xml with FAILFAST parse error test") {
-    val e = intercept[SparkException] {
-       spark.sql(s"""SELECT schema_of_xml('<ROW><a>1<ROW>', map('mode', 'FAILFAST'))""")
-         .collect()
-    }
     checkError(
-      exception = e,
+      exception = intercept[SparkException] {
+        spark.sql(s"""SELECT schema_of_xml('<ROW><a>1<ROW>', map('mode', 'FAILFAST'))""")
+          .collect()
+      },
       errorClass = "_LEGACY_ERROR_TEMP_2165",
       parameters = Map(
         "failFastMode" -> FailFastMode.name)
@@ -1729,19 +1727,17 @@ class XmlSuite
   }
 
   test("Issue 588: Ensure fails when data is not present, with or without schema") {
-    val exception1 = intercept[AnalysisException] {
-      spark.read.xml("/this/file/does/not/exist")
-    }
     checkError(
-      exception = exception1,
+      exception = intercept[AnalysisException] {
+        spark.read.xml("/this/file/does/not/exist")
+      },
       errorClass = "PATH_NOT_FOUND",
       parameters = Map("path" -> "file:/this/file/does/not/exist")
     )
-    val exception2 = intercept[AnalysisException] {
-      spark.read.schema(buildSchema(field("dummy"))).xml("/this/file/does/not/exist")
-    }
     checkError(
-      exception = exception2,
+      exception = intercept[AnalysisException] {
+        spark.read.schema(buildSchema(field("dummy"))).xml("/this/file/does/not/exist")
+      },
       errorClass = "PATH_NOT_FOUND",
       parameters = Map("path" -> "file:/this/file/does/not/exist")
     )
@@ -2858,7 +2854,7 @@ class XmlSuite
             df.collect()
           },
           errorClass = "FAILED_READ_FILE.FILE_NOT_EXIST",
-          parameters = Map("path" -> ".*")
+          parameters = Map("path" -> s".*$dir.*")
         )
       }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to 
- use `checkError()` to check Exception in `[CSV|Json|Xml]Suite` and `[Csv|Json]FunctionsSuite`
-  Fix `typo` about `CSVSuite`.

### Why are the changes needed?
- The changes improve the error framework.
- Fix `typ`o about `CSVSuite`.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
