### PR TITLE
[SPARK-47655][SS] Integrate timer with Initial State handling for state-v2

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessor.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessor.scala
@@ -107,6 +107,8 @@ trait StatefulProcessorWithInitialState[K, I, O, S] extends StatefulProcessor[K,
    *
    * @param key - grouping key
    * @param initialState - A row in the initial state to be processed
+   * @param timerValues  - instance of TimerValues that provides access to current processing/event
+   *                     time if available
    */
-  def handleInitialState(key: K, initialState: S): Unit
+  def handleInitialState(key: K, initialState: S, timerValues: TimerValues): Unit
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessor.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessor.scala
@@ -100,7 +100,7 @@ private[sql] trait StatefulProcessor[K, I, O] extends Serializable {
  */
 @Experimental
 @Evolving
-trait StatefulProcessorWithInitialState[K, I, O, S] extends StatefulProcessor[K, I, O] {
+private[sql] trait StatefulProcessorWithInitialState[K, I, O, S] extends StatefulProcessor[K, I, O] {
 
   /**
    * Function that will be invoked only in the first batch for users to process initial states.

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessor.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessor.scala
@@ -100,7 +100,8 @@ private[sql] trait StatefulProcessor[K, I, O] extends Serializable {
  */
 @Experimental
 @Evolving
-private[sql] trait StatefulProcessorWithInitialState[K, I, O, S] extends StatefulProcessor[K, I, O] {
+private[sql] trait StatefulProcessorWithInitialState[K, I, O, S]
+  extends StatefulProcessor[K, I, O] {
 
   /**
    * Function that will be invoked only in the first batch for users to process initial states.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -172,7 +172,8 @@ case class TransformWithStateExec(
       seenInitStateOnKey = true
       statefulProcessor
         .asInstanceOf[StatefulProcessorWithInitialState[Any, Any, Any, Any]]
-        .handleInitialState(keyObj, initState)
+        .handleInitialState(keyObj, initState,
+          new TimerValuesImpl(batchTimestampMs, eventTimeWatermarkForEviction))
     }
     ImplicitGroupingKeyTracker.removeImplicitKey()
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateInitialStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateInitialStateSuite.scala
@@ -130,8 +130,9 @@ class InitialStateInMemoryTestClass
 }
 
 /**
- * Class to verify stateful processor usage with updating processing time timers
- * can also handle initial state.
+ * Class to test stateful processor with initial state with processing timers.
+ * Timers can be registered during initial state handling and can be emitted after timer
+ * expires even if the grouping key in initial state is not seen in new input rows.
  */
 class StatefulProcessorWithInitialStateProcTimerClass
   extends RunningCountStatefulProcessorWithProcTimeTimerUpdates
@@ -147,8 +148,9 @@ class StatefulProcessorWithInitialStateProcTimerClass
 }
 
 /**
- * Class to verify stateful processor usage with updating event time timers
- * can also handle initial state.
+ * Class to test stateful processor with initial state with event timers.
+ * Timers can be registered during initial state handling and can be emitted after timer
+ * expires even if the grouping key in initial state is not seen in new input rows.
  */
 class StatefulProcessorWithInitialStateEventTimerClass extends MaxEventTimeStatefulProcessor
   with StatefulProcessorWithInitialState[String, (String, Long), (String, Int), (String, Long)]{

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateInitialStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateInitialStateSuite.scala
@@ -131,8 +131,9 @@ class InitialStateInMemoryTestClass
 
 /**
  * Class to test stateful processor with initial state and processing timers.
- * Timers can be registered during initial state handling and can be emitted after timer
- * expires even if the grouping key in initial state is not seen in new input rows.
+ * Timers can be registered during initial state handling and output rows can be
+ * emitted after timer expires even if the grouping key in initial state is not
+ * seen in new input rows.
  */
 class StatefulProcessorWithInitialStateProcTimerClass
   extends RunningCountStatefulProcessorWithProcTimeTimerUpdates
@@ -149,8 +150,9 @@ class StatefulProcessorWithInitialStateProcTimerClass
 
 /**
  * Class to test stateful processor with initial state and event timers.
- * Timers can be registered during initial state handling and can be emitted after timer
- * expires even if the grouping key in initial state is not seen in new input rows.
+ * Timers can be registered during initial state handling and output rows can be
+ * emitted after timer expires even if the grouping key in initial state is not
+ * seen in new input rows.
  */
 class StatefulProcessorWithInitialStateEventTimerClass extends MaxEventTimeStatefulProcessor
   with StatefulProcessorWithInitialState[String, (String, Long), (String, Int), (String, Long)]{

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateInitialStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateInitialStateSuite.scala
@@ -130,7 +130,7 @@ class InitialStateInMemoryTestClass
 }
 
 /**
- * Class to test stateful processor with initial state with processing timers.
+ * Class to test stateful processor with initial state and processing timers.
  * Timers can be registered during initial state handling and can be emitted after timer
  * expires even if the grouping key in initial state is not seen in new input rows.
  */
@@ -148,7 +148,7 @@ class StatefulProcessorWithInitialStateProcTimerClass
 }
 
 /**
- * Class to test stateful processor with initial state with event timers.
+ * Class to test stateful processor with initial state and event timers.
  * Timers can be registered during initial state handling and can be emitted after timer
  * expires even if the grouping key in initial state is not seen in new input rows.
  */

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateInitialStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateInitialStateSuite.scala
@@ -18,10 +18,12 @@
 package org.apache.spark.sql.streaming
 
 import org.apache.spark.SparkUnsupportedOperationException
-import org.apache.spark.sql.{Encoders, KeyValueGroupedDataset}
+import org.apache.spark.sql.{Dataset, Encoders, KeyValueGroupedDataset}
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.execution.streaming.state.{AlsoTestWithChangelogCheckpointingEnabled, RocksDBStateStoreProvider}
+import org.apache.spark.sql.functions.timestamp_seconds
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.streaming.util.StreamManualClock
 
 case class InitInputRow(key: String, action: String, value: Double)
 case class InputRowForInitialState(
@@ -86,7 +88,8 @@ class AccumulateStatefulProcessorWithInitState
     extends StatefulProcessorWithInitialStateTestClass[(String, Double)] {
   override def handleInitialState(
       key: String,
-      initialState: (String, Double)): Unit = {
+      initialState: (String, Double),
+      timerValues: TimerValues): Unit = {
     _valState.update(initialState._2)
   }
 
@@ -115,13 +118,37 @@ class InitialStateInMemoryTestClass
   extends StatefulProcessorWithInitialStateTestClass[InputRowForInitialState] {
   override def handleInitialState(
       key: String,
-      initialState: InputRowForInitialState): Unit = {
+      initialState: InputRowForInitialState,
+      timerValues: TimerValues): Unit = {
     _valState.update(initialState.value)
     _listState.appendList(initialState.entries.toArray)
     val inMemoryMap = initialState.mapping
     inMemoryMap.foreach { kvPair =>
       _mapState.updateValue(kvPair._1, kvPair._2)
     }
+  }
+}
+
+class StatefulProcessorWithInitialStateProcTimerClass
+  extends RunningCountStatefulProcessorWithProcTimeTimerUpdates
+    with StatefulProcessorWithInitialState[String, String, (String, String), String] {
+  override def handleInitialState(
+      key: String,
+      initialState: String,
+      timerValues: TimerValues): Unit = {
+    processUnexpiredRows(key, 0L, 1L, timerValues)
+  }
+}
+
+class StatefulProcessorWithInitialStateEventTimerClass extends MaxEventTimeStatefulProcessor
+  with StatefulProcessorWithInitialState[String, (String, Long), (String, Int), (String, Long)]{
+  override def handleInitialState(
+      key: String,
+      initialState: (String, Long),
+      timerValues: TimerValues): Unit = {
+    val maxEventTimeSec = math.max(initialState._2,
+      _maxEventTimeState.getOption().getOrElse(0L))
+    processUnexpiredRows(maxEventTimeSec)
   }
 }
 
@@ -287,6 +314,81 @@ class TransformWithStateInitialStateSuite extends StateStoreMetricsTest
             parameters = Map("groupingKey" -> "init_1")
           )
         }
+      )
+    }
+  }
+
+  test("transformWithStateWithInitialState - streaming with processing time timer, " +
+    "can emit expired initial state rows when grouping key is not received for new input rows") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName) {
+      val clock = new StreamManualClock
+
+      val initDf = Seq("a", "b").toDS().groupByKey(x => x)
+      val inputData = MemoryStream[String]
+      val result = inputData.toDS().groupByKey(x => x)
+        .transformWithState(
+          new StatefulProcessorWithInitialStateProcTimerClass(),
+          TimeoutMode.ProcessingTime(),
+          OutputMode.Update(),
+          initDf)
+
+      testStream(result, OutputMode.Update())(
+        StartStream(Trigger.ProcessingTime("1 second"), triggerClock = clock),
+        AddData(inputData, "c"),
+        AdvanceManualClock(1 * 1000),
+        // registered timer for "a" and "b" is 6000, first batch is processed at ts = 1000
+        CheckNewAnswer(("c", "1")),
+
+        AddData(inputData, "c"),
+        AdvanceManualClock(6 * 1000), // ts = 7000, "a" expires
+        // "a" is never received for new input rows, but emit here because it expires
+        CheckNewAnswer(("a", "-1"), ("c", "2")),
+
+        AddData(inputData, "a", "a"),
+        AdvanceManualClock(1 * 1000), // ts = 8000, register timer for "a" as ts = 15500
+        CheckNewAnswer(("a", "3")),
+
+        AddData(inputData, "b"),
+        AdvanceManualClock(8 * 1000), // ts = 16000, timer for "a" expired
+        CheckNewAnswer(("a", "-1"), ("b", "2")), // initial state for "b" is also processed
+        StopStream
+      )
+    }
+  }
+
+  test("transformWithStateWithInitialState - streaming with event time timer, " +
+    "can emit expired initial state rows when grouping key is not received for new input rows") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName) {
+
+      def eventTimeDf(ds: Dataset[(String, Int)]): KeyValueGroupedDataset[String, (String, Long)] =
+        ds.select($"_1".as("key"), timestamp_seconds($"_2").as("eventTime"))
+          .withWatermark("eventTime", "10 seconds")
+          .as[(String, Long)].groupByKey(_._1)
+
+      val initDf = eventTimeDf(Seq(("a", 11), ("b", 5)).toDS())
+
+      val inputData = MemoryStream[(String, Int)]
+      val result = eventTimeDf(inputData.toDS())
+        .transformWithState(
+          new StatefulProcessorWithInitialStateEventTimerClass(),
+          TimeoutMode.EventTime(),
+          OutputMode.Update(),
+          initDf)
+
+      testStream(result, OutputMode.Update())(
+        StartStream(),
+        AddData(inputData, ("a", 13), ("a", 15)),
+        CheckNewAnswer(("a", 15)), // Output = max event time of a
+
+        AddData(inputData, ("c", 7)), // Add data older than watermark for "a" and "b"
+        CheckNewAnswer(("c", 7)),
+
+        AddData(inputData, ("d", 31)), // Add data newer than watermark
+        // "b" is never received for new input rows, but emit here because it expired
+        CheckNewAnswer(("a", -1), ("b", -1), ("c", -1), ("d", 31)),
+        StopStream
       )
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateInitialStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateInitialStateSuite.scala
@@ -129,6 +129,10 @@ class InitialStateInMemoryTestClass
   }
 }
 
+/**
+ * Class to verify stateful processor usage with updating processing time timers
+ * can also handle initial state.
+ */
 class StatefulProcessorWithInitialStateProcTimerClass
   extends RunningCountStatefulProcessorWithProcTimeTimerUpdates
     with StatefulProcessorWithInitialState[String, String, (String, String), String] {
@@ -136,16 +140,24 @@ class StatefulProcessorWithInitialStateProcTimerClass
       key: String,
       initialState: String,
       timerValues: TimerValues): Unit = {
+    // keep a _countState to count the occurrence of grouping key
+    // Will register a timer if key "a" is met for the first time
     processUnexpiredRows(key, 0L, 1L, timerValues)
   }
 }
 
+/**
+ * Class to verify stateful processor usage with updating event time timers
+ * can also handle initial state.
+ */
 class StatefulProcessorWithInitialStateEventTimerClass extends MaxEventTimeStatefulProcessor
   with StatefulProcessorWithInitialState[String, (String, Long), (String, Int), (String, Long)]{
   override def handleInitialState(
       key: String,
       initialState: (String, Long),
       timerValues: TimerValues): Unit = {
+    // keep a _maxEventTimeState to track the max eventTime seen so far
+    // register a timer if bigger eventTime is seen
     val maxEventTimeSec = math.max(initialState._2,
       _maxEventTimeState.getOption().getOrElse(0L))
     processUnexpiredRows(maxEventTimeSec)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
We want to support timer feature during initial state handling. Currently, if grouping key introduced in initial state is never seen again in new input rows, those rows in initial state will never be emitted. We want to add a field in initial state handling function such that users can manipulate the timers with initial state rows.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
These changes are needed to support timer with initial state. The changes are part of the work around adding new stateful streaming operator for arbitrary state mgmt that provides a bunch of new features listed in the SPIP JIRA here - https://issues.apache.org/jira/browse/SPARK-45939

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. We add a new `timerValues` field in `StatefulProcessorWithInitialState`:
```
  /**
   * Function that will be invoked only in the first batch for users to process initial states.
   *
   * @param key - grouping key
   * @param initialState - A row in the initial state to be processed
   * @param timerValues  - instance of TimerValues that provides access to current processing/event
   *                     time if available
   */
  def handleInitialState(key: K, initialState: S, timerValues: TimerValues): Unit
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Add unit tests in `TransformWithStateWithInitialStateSuite`

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.