### PR TITLE
[SPARK-47657][SQL] Implement collation filter push down support per file source

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
@@ -292,7 +292,7 @@ object DataSourceUtils extends PredicateHelper {
 
     isCollationPushDownSupported || !expression.exists {
       case childExpression @ (_: Attribute | _: GetStructField) =>
-        // don't push down filters for types with utf8 binary collation
+        // don't push down filters for types with non-binary sortable collation
         // as it could lead to incorrect results
         SchemaUtils.hasNonBinarySortableCollatedString(childExpression.dataType)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
@@ -284,12 +284,15 @@ object DataSourceUtils extends PredicateHelper {
    * Determines whether a filter should be pushed down to the data source or not.
    *
    * @param expression The filter expression to be evaluated.
+   * @param isCollationPushDownSupported Whether the data source supports collation push down.
    * @return A boolean indicating whether the filter should be pushed down or not.
    */
-  def shouldPushFilter(expression: Expression): Boolean = {
-    expression.deterministic && !expression.exists {
+  def shouldPushFilter(expression: Expression, isCollationPushDownSupported: Boolean): Boolean = {
+    if (!expression.deterministic) return false
+
+    isCollationPushDownSupported || !expression.exists {
       case childExpression @ (_: Attribute | _: GetStructField) =>
-        // don't push down filters for types with non-default collation
+        // don't push down filters for types with utf8 binary collation
         // as it could lead to incorrect results
         SchemaUtils.hasNonBinarySortableCollatedString(childExpression.dataType)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
@@ -228,7 +228,6 @@ trait FileFormat {
    * Returns whether the file format supports filter push down
    * for non utf8 binary collated columns.
    */
-
   def supportsCollationPushDown: Boolean = false
 }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
@@ -223,6 +223,13 @@ trait FileFormat {
    */
   def fileConstantMetadataExtractors: Map[String, PartitionedFile => Any] =
     FileFormat.BASE_METADATA_EXTRACTORS
+
+  /**
+   * Returns whether the file format supports filter push down
+   * for non utf8 binary collated columns.
+   */
+
+  def supportsCollationPushDown: Boolean = false
 }
 
 object FileFormat {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileSourceStrategy.scala
@@ -160,7 +160,8 @@ object FileSourceStrategy extends Strategy with PredicateHelper with Logging {
       //  - filters that need to be evaluated again after the scan
       val filterSet = ExpressionSet(filters)
 
-      val filtersToPush = filters.filter(f => DataSourceUtils.shouldPushFilter(f))
+      val filtersToPush = filters.filter(f =>
+          DataSourceUtils.shouldPushFilter(f, fsRelation.fileFormat.supportsCollationPushDown))
 
       val normalizedFilters = DataSourceStrategy.normalizeExprs(
         filtersToPush, l.output)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -63,7 +63,8 @@ private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
             _))
         if filters.nonEmpty && fsRelation.partitionSchema.nonEmpty =>
       val normalizedFilters = DataSourceStrategy.normalizeExprs(
-        filters.filter(f => f.deterministic && !SubqueryExpression.hasSubquery(f)),
+        filters.filter(f => !SubqueryExpression.hasSubquery(f) &&
+          DataSourceUtils.shouldPushFilter(f, fsRelation.fileFormat.supportsCollationPushDown)),
         logicalRelation.output)
       val (partitionKeyFilters, _) = DataSourceUtils
         .getPartitionFiltersAndDataFilters(partitionSchema, normalizedFilters)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/PruneFileSourcePartitions.scala
@@ -63,8 +63,7 @@ private[sql] object PruneFileSourcePartitions extends Rule[LogicalPlan] {
             _))
         if filters.nonEmpty && fsRelation.partitionSchema.nonEmpty =>
       val normalizedFilters = DataSourceStrategy.normalizeExprs(
-        filters.filter(f =>
-          !SubqueryExpression.hasSubquery(f) && DataSourceUtils.shouldPushFilter(f)),
+        filters.filter(f => f.deterministic && !SubqueryExpression.hasSubquery(f)),
         logicalRelation.output)
       val (partitionKeyFilters, _) = DataSourceUtils
         .getPartitionFiltersAndDataFilters(partitionSchema, normalizedFilters)

--- a/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FileBasedDataSourceSuite.scala
@@ -1243,54 +1243,54 @@ class FileBasedDataSourceSuite extends QueryTest
     }
   }
 
-  allFileBasedDataSources.foreach { format =>
-    test(s"disable filter push down for collated strings using $format") {
-      val tableName = s"dummy_$format"
-      val collation = "'UTF8_BINARY_LCASE'"
+  test("disable filter pushdown for collated strings") {
+    Seq("parquet").foreach { format =>
+      Seq(format, "").foreach { conf =>
+        withSQLConf(SQLConf.USE_V1_SOURCE_LIST.key -> conf) {
+          withTempPath { path =>
+            val collation = "'UTF8_BINARY_LCASE'"
+            val df = sql(
+              s"""SELECT
+                 |  COLLATE(c, $collation) as c1,
+                 |  struct(COLLATE(c, $collation)) as str,
+                 |  named_struct('f1', named_struct('f2',
+                 |    COLLATE(c, $collation), 'f3', 1)) as namedstr,
+                 |  array(COLLATE(c, $collation)) as arr,
+                 |  map(COLLATE(c, $collation), 1) as map1,
+                 |  map(1, COLLATE(c, $collation)) as map2
+                 |FROM VALUES ('aaa'), ('AAA'), ('bbb')
+                 |as data(c)
+                 |""".stripMargin)
 
-      withTable(tableName) {
-        sql(
-          s"""
-             |CREATE TABLE $tableName (c STRING)
-             |USING $format
-             |""".stripMargin
-        )
-        sql(s"INSERT INTO $tableName VALUES ('a'), ('A'), ('b')")
+            df.write.format(format).save(path.getAbsolutePath)
 
-        val df = sql(
-          s"""SELECT
-             |  COLLATE(c, $collation) as c1,
-             |  struct(COLLATE(c, $collation)) as str,
-             |  named_struct('f1', named_struct('f2', COLLATE(c, $collation), 'f3', 1)) as namedstr,
-             |  array(COLLATE(c, $collation)) as arr,
-             |  map(COLLATE(c, $collation), 1) as map1,
-             |  map(1, COLLATE(c, $collation)) as map2
-             |FROM VALUES ('aaa'), ('AAA'), ('bbb')
-             |as data(c)
-             |""".stripMargin)
+            // filter and expected result
+            val filters = Seq(
+              ("==", Seq(Row("aaa"), Row("AAA"))),
+              ("!=", Seq(Row("bbb"))),
+              ("<", Seq()),
+              ("<=", Seq(Row("aaa"), Row("AAA"))),
+              (">", Seq(Row("bbb"))),
+              (">=", Seq(Row("aaa"), Row("AAA"), Row("bbb"))))
 
-        // filter and expected result
-        val filters = Seq(
-          ("==", Seq(Row("aaa"), Row("AAA"))),
-          ("!=", Seq(Row("bbb"))),
-          ("<", Seq()),
-          ("<=", Seq(Row("aaa"), Row("AAA"))),
-          (">", Seq(Row("bbb"))),
-          (">=", Seq(Row("aaa"), Row("AAA"), Row("bbb"))))
+            filters.foreach { filter =>
+              val readback = spark.read
+                .format(format)
+                .load(path.getAbsolutePath)
+                .where(s"c1 ${filter._1} collate('aaa', $collation)")
+                .where(s"str ${filter._1} struct(collate('aaa', $collation))")
+                .where(s"namedstr.f1.f2 ${filter._1} collate('aaa', $collation)")
+                .where(s"arr ${filter._1} array(collate('aaa', $collation))")
+                .where(s"map_keys(map1) ${filter._1} array(collate('aaa', $collation))")
+                .where(s"map_values(map2) ${filter._1} array(collate('aaa', $collation))")
+                .select("c1")
 
-        filters.foreach { filter =>
-          val query = df
-            .where(s"c1 ${filter._1} collate('aaa', $collation)")
-            .where(s"str ${filter._1} struct(collate('aaa', $collation))")
-            .where(s"namedstr.f1.f2 ${filter._1} collate('aaa', $collation)")
-            .where(s"arr ${filter._1} array(collate('aaa', $collation))")
-            .where(s"map_keys(map1) ${filter._1} array(collate('aaa', $collation))")
-            .where(s"map_values(map2) ${filter._1} array(collate('aaa', $collation))")
-            .select("c1")
-
-          val explain = query.queryExecution.explainString(ExplainMode.fromString("extended"))
-          assert(explain.contains("PushedFilters: []"))
-          checkAnswer(query, filter._2)
+              val explain = readback.queryExecution.explainString(
+                ExplainMode.fromString("extended"))
+              assert(explain.contains("PushedFilters: []"))
+              checkAnswer(readback, filter._2)
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Previously in #45262 we completely disabled filter pushdown for any expression referencing non utf8 binary collated columns. However, we should make this more fine-grained so that individual data sources can decide to support pushing down these filters if they can.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To enable collation filter push down for an individual data source.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
With previously added unit test.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.