### PR TITLE
[SPARK-47658][BUILD] Upgrade `tink` to 1.12.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -266,7 +266,7 @@ stax-api/1.0.1//stax-api-1.0.1.jar
 stream/2.9.6//stream-2.9.6.jar
 super-csv/2.2.0//super-csv-2.2.0.jar
 threeten-extra/1.7.1//threeten-extra-1.7.1.jar
-tink/1.9.0//tink-1.9.0.jar
+tink/1.12.0//tink-1.12.0.jar
 transaction-api/1.1//transaction-api-1.1.jar
 txw2/3.0.2//txw2-3.0.2.jar
 univocity-parsers/2.9.1//univocity-parsers-2.9.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <commons-cli.version>1.6.0</commons-cli.version>
     <bouncycastle.version>1.77</bouncycastle.version>
-    <tink.version>1.9.0</tink.version>
+    <tink.version>1.12.0</tink.version>
     <datasketches.version>5.0.1</datasketches.version>
     <netty.version>4.1.108.Final</netty.version>
     <netty-tcnative.version>2.0.65.Final</netty-tcnative.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `tink` from `1.9.0` to `1.12.0`.

### Why are the changes needed?
The last update occurred 11 months ago, as follows: https://github.com/apache/spark/pull/40878.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
