### PR TITLE
[SPARK-47689][SQL] Do not wrap query execution error during data writing

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/sources/InsertSuite.scala
@@ -771,12 +771,10 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
         sql("create table t(b int) using parquet")
 
         val outOfRangeValue1 = (Int.MaxValue + 1L).toString
-        val e1 = intercept[SparkException] {
-          sql(s"insert into t values($outOfRangeValue1)")
-        }
-        assert(e1.getErrorClass == "TASK_WRITE_FAILED")
         checkError(
-          exception = e1.getCause.asInstanceOf[SparkArithmeticException],
+          exception = intercept[SparkArithmeticException] {
+            sql(s"insert into t values($outOfRangeValue1)")
+          },
           errorClass = "CAST_OVERFLOW_IN_TABLE_INSERT",
           parameters = Map(
             "sourceType" -> "\"BIGINT\"",
@@ -784,12 +782,10 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
             "columnName" -> "`b`"))
 
         val outOfRangeValue2 = (Int.MinValue - 1L).toString
-        val e2 = intercept[SparkException] {
-          sql(s"insert into t values($outOfRangeValue2)")
-        }
-        assert(e2.getErrorClass == "TASK_WRITE_FAILED")
         checkError(
-          exception = e2.getCause.asInstanceOf[SparkArithmeticException],
+          exception = intercept[SparkArithmeticException] {
+            sql(s"insert into t values($outOfRangeValue2)")
+          },
           errorClass = "CAST_OVERFLOW_IN_TABLE_INSERT",
           parameters = Map(
             "sourceType" -> "\"BIGINT\"",
@@ -806,12 +802,10 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
         sql("create table t(b long) using parquet")
 
         val outOfRangeValue1 = Math.nextUp(Long.MaxValue)
-        val e1 = intercept[SparkException] {
-          sql(s"insert into t values(${outOfRangeValue1}D)")
-        }
-        assert(e1.getErrorClass == "TASK_WRITE_FAILED")
         checkError(
-          exception = e1.getCause.asInstanceOf[SparkArithmeticException],
+          exception = intercept[SparkArithmeticException] {
+            sql(s"insert into t values(${outOfRangeValue1}D)")
+          },
           errorClass = "CAST_OVERFLOW_IN_TABLE_INSERT",
           parameters = Map(
             "sourceType" -> "\"DOUBLE\"",
@@ -819,12 +813,10 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
             "columnName" -> "`b`"))
 
         val outOfRangeValue2 = Math.nextDown(Long.MinValue)
-        val e2 = intercept[SparkException] {
-          sql(s"insert into t values(${outOfRangeValue2}D)")
-        }
-        assert(e2.getErrorClass == "TASK_WRITE_FAILED")
         checkError(
-          exception = e2.getCause.asInstanceOf[SparkArithmeticException],
+          exception = intercept[SparkArithmeticException] {
+            sql(s"insert into t values(${outOfRangeValue2}D)")
+          },
           errorClass = "CAST_OVERFLOW_IN_TABLE_INSERT",
           parameters = Map(
             "sourceType" -> "\"DOUBLE\"",
@@ -840,12 +832,10 @@ class InsertSuite extends DataSourceTest with SharedSparkSession {
       withTable("t") {
         sql("create table t(b decimal(3,2)) using parquet")
         val outOfRangeValue = "123.45"
-        val ex = intercept[SparkException] {
-          sql(s"insert into t values($outOfRangeValue)")
-        }
-        assert(ex.getErrorClass == "TASK_WRITE_FAILED")
         checkError(
-          exception = ex.getCause.asInstanceOf[SparkArithmeticException],
+          exception = intercept[SparkArithmeticException] {
+            sql(s"insert into t values($outOfRangeValue)")
+          },
           errorClass = "CAST_OVERFLOW_IN_TABLE_INSERT",
           parameters = Map(
             "sourceType" -> "\"DECIMAL(5,2)\"",

--- a/sql/hive/src/test/scala/org/apache/spark/sql/HiveCharVarcharTestSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/HiveCharVarcharTestSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.{SparkException, SparkRuntimeException}
 import org.apache.spark.sql.execution.command.CharVarcharDDLTestBase
 import org.apache.spark.sql.hive.test.TestHiveSingleton
 
@@ -86,23 +85,8 @@ class HiveCharVarcharTestSuite extends CharVarcharTestSuite with TestHiveSinglet
           sql(s"ALTER TABLE $tableName DROP PARTITION(c=$v)")
           checkAnswer(spark.table(tableName), Nil)
         }
-
-        checkError(
-          exception = intercept[SparkException] {
-            sql(s"INSERT OVERWRITE $tableName VALUES ('1', 100000)")
-          },
-          errorClass = "TASK_WRITE_FAILED",
-          parameters = Map("path" -> s".*$tableName.*"),
-          matchPVals = true
-        )
-
-        checkError(
-          exception = intercept[SparkRuntimeException] {
-            sql("ALTER TABLE t DROP PARTITION(c=100000)")
-          },
-          errorClass = "EXCEED_LIMIT_LENGTH",
-          parameters = Map("limit" -> "5")
-        )
+        assertLengthCheckFailure(s"INSERT OVERWRITE $tableName VALUES ('1', 100000)")
+        assertLengthCheckFailure("ALTER TABLE t DROP PARTITION(c=100000)")
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
It's quite confusing to report `TASK_WRITE_FAILED` error when the error was caused by input query execution. This PR updates the error wrapping code to not wrap with `TASK_WRITE_FAILED` if the error was from input query execution.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
better error reporting

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes, now people won't see `TASK_WRITE_FAILED` error if the error was from input query.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
updated tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no