### PR TITLE
[SPARK-47674][CORE] Enable `spark.metrics.appStatusSource.enabled` by default

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/Status.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/Status.scala
@@ -69,7 +69,7 @@ private[spark] object Status {
         "will be reported for the status of the running spark app.")
       .version("3.0.0")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val LIVE_UI_LOCAL_STORE_DIR = ConfigBuilder("spark.ui.store.path")
     .doc("Local directory where to cache application information for live UI. By default this is " +

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1187,7 +1187,7 @@ This is the component with the largest amount of instrumented metrics
 
 - namespace=appStatus (all metrics of type=counter)
   - **note:** Introduced in Spark 3.0. Conditional to a configuration parameter:
-   `spark.metrics.appStatusSource.enabled` (default is false)
+   `spark.metrics.appStatusSource.enabled` (default is true)
   - stages.failedStages.count
   - stages.skippedStages.count
   - stages.completedStages.count


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable `spark.metrics.appStatusSource.enabled` by default.

### Why are the changes needed?

`spark.metrics.appStatusSource.enabled` was introduced at `Apache Spark 3.0.0` and has been used usefully in the production in order to expose app status. We had better enable it by default in `Apache Spark 4.0.0`.

### Does this PR introduce _any_ user-facing change?

This will expose additional metrics.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.