### PR TITLE
[SPARK-47675][K8S][TESTS] Use AWS SDK v2 `2.23.19` in K8s IT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,7 @@
     <aws.kinesis.client.version>1.12.0</aws.kinesis.client.version>
     <!-- Should be consistent with Kinesis client dependency -->
     <aws.java.sdk.version>1.11.655</aws.java.sdk.version>
+    <aws.java.sdk.v2.version>2.20.160</aws.java.sdk.v2.version>
     <!-- the producer is used in tests -->
     <aws.kinesis.producer.version>0.12.8</aws.kinesis.producer.version>
     <gcs-connector.version>hadoop3-2.2.20</gcs-connector.version>

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
     <aws.kinesis.client.version>1.12.0</aws.kinesis.client.version>
     <!-- Should be consistent with Kinesis client dependency -->
     <aws.java.sdk.version>1.11.655</aws.java.sdk.version>
-    <aws.java.sdk.v2.version>2.20.160</aws.java.sdk.v2.version>
+    <aws.java.sdk.v2.version>2.23.19</aws.java.sdk.v2.version>
     <!-- the producer is used in tests -->
     <aws.kinesis.producer.version>0.12.8</aws.kinesis.producer.version>
     <gcs-connector.version>hadoop3-2.2.20</gcs-connector.version>

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,6 @@
     <aws.kinesis.client.version>1.12.0</aws.kinesis.client.version>
     <!-- Should be consistent with Kinesis client dependency -->
     <aws.java.sdk.version>1.11.655</aws.java.sdk.version>
-    <aws.java.sdk.v2.version>2.20.160</aws.java.sdk.v2.version>
     <!-- the producer is used in tests -->
     <aws.kinesis.producer.version>0.12.8</aws.kinesis.producer.version>
     <gcs-connector.version>hadoop3-2.2.20</gcs-connector.version>

--- a/resource-managers/kubernetes/integration-tests/pom.xml
+++ b/resource-managers/kubernetes/integration-tests/pom.xml
@@ -212,7 +212,6 @@
         <dependency>
           <groupId>software.amazon.awssdk</groupId>
           <artifactId>bundle</artifactId>
-          <version>${aws.java.sdk.v2.version}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/resource-managers/kubernetes/integration-tests/pom.xml
+++ b/resource-managers/kubernetes/integration-tests/pom.xml
@@ -212,6 +212,7 @@
         <dependency>
           <groupId>software.amazon.awssdk</groupId>
           <artifactId>bundle</artifactId>
+          <version>${aws.java.sdk.v2.version}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use AWS SDK v2 `2.23.19` in `kubernetes/integration-tests` which is consistent with SPARK-45393.

### Why are the changes needed?

Since SPARK-45393, Apache Spark uses `software.amazon.awssdk:bundle:2.23.19` which is higher than the current value of `aws.java.sdk.v2.version`, `2.20.160`.

https://github.com/apache/spark/blob/e86c499b008ccc96b49f3fb9343ce67ff642c204/dev/deps/spark-deps-hadoop-3-hive-2.3#L34

### Does this PR introduce _any_ user-facing change?

No. This property is used in the K8s integration test only.

### How was this patch tested?

No.

### Was this patch authored or co-authored using generative AI tooling?

No.