### PR TITLE
[SPARK-47672][SQL] Avoid double eval from filter pushDown

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CallMethodViaReflection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/CallMethodViaReflection.scala
@@ -65,6 +65,9 @@ case class CallMethodViaReflection(
   with CodegenFallback
   with QueryErrorsBase {
 
+  // Pretty UDF-like
+  override protected[spark] def expectedCost = 200
+
   def this(children: Seq[Expression]) =
     this(children, true)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -374,6 +374,16 @@ abstract class Expression extends TreeNode[Expression] {
     } else {
       ""
     }
+
+  /**
+   * A _very rough_ indication of the expected cost of evaluating an expression.
+   * This can be used by the optimizer to decide if an element should be double
+   * evaluated for pre-emptive row filtering, in ordering filter expression, etc.
+   * This is an internal API and may go away at any time.
+   */
+  protected def expectedCost: Int = _expectedCost
+
+  private lazy val _expectedCost = children.map(_.expectedCost).sum
 }
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -381,9 +381,9 @@ abstract class Expression extends TreeNode[Expression] {
    * evaluated for pre-emptive row filtering, in ordering filter expression, etc.
    * This is an internal API and may go away at any time.
    */
-  protected def expectedCost: Int = _expectedCost
+  protected[spark] def expectedCost: Int = _expectedCost
 
-  private lazy val _expectedCost = children.map(_.expectedCost).sum
+  private lazy val _expectedCost = children.map(_.expectedCost).sum + 1
 }
 
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
@@ -1211,5 +1211,5 @@ case class ScalaUDF(
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): ScalaUDF =
     copy(children = newChildren)
 
-  override protected def expectedCost = 2000
+  override protected[spark] def expectedCost = 2000
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
@@ -1210,4 +1210,6 @@ case class ScalaUDF(
 
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): ScalaUDF =
     copy(children = newChildren)
+
+  override protected def expectedCost = 2000
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala
@@ -1178,6 +1178,8 @@ object ArraySortLike {
 case class SortArray(base: Expression, ascendingOrder: Expression)
   extends BinaryExpression with ArraySortLike with NullIntolerant with QueryErrorsBase {
 
+  override protected[spark] def expectedCost = 150
+
   def this(e: Expression) = this(e, Literal(true))
 
   override def left: Expression = base
@@ -2152,6 +2154,8 @@ case class ArrayJoin(
   override def dataType: DataType = StringType
 
   override def prettyName: String = "array_join"
+
+  override protected[spark] def expectedCost = 200
 }
 
 /**
@@ -4405,6 +4409,8 @@ case class ArrayUnion(left: Expression, right: Expression) extends ArrayBinaryLi
 case class ArrayIntersect(left: Expression, right: Expression) extends ArrayBinaryLike
   with ComplexTypeMergingExpression {
 
+  override protected[spark] def expectedCost = 200
+
   private lazy val internalDataType: DataType = {
     dataTypeCheck
     ArrayType(elementType, leftArrayElementNullable && rightArrayElementNullable)
@@ -4636,6 +4642,8 @@ case class ArrayIntersect(left: Expression, right: Expression) extends ArrayBina
   since = "2.4.0")
 case class ArrayExcept(left: Expression, right: Expression) extends ArrayBinaryLike
   with ComplexTypeMergingExpression {
+
+  override protected[spark] def expectedCost = 200
 
   private lazy val internalDataType: DataType = {
     dataTypeCheck

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
@@ -619,6 +619,8 @@ case class StringToMap(text: Expression, pairDelim: Expression, keyValueDelim: E
     pairDelim = newSecond,
     keyValueDelim = newThird
   )
+
+  override protected[spark] def expectedCost = 100
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/jsonExpressions.scala
@@ -207,6 +207,8 @@ case class GetJsonObject(json: Expression, path: Expression)
   override protected def withNewChildrenInternal(
       newLeft: Expression, newRight: Expression): GetJsonObject =
     copy(json = newLeft, path = newRight)
+
+  override protected[spark] def expectedCost = 100
 }
 
 class GetJsonObjectEvaluator(cachedPath: UTF8String) {
@@ -637,6 +639,8 @@ case class JsonToStructs(
   with NullIntolerant
   with QueryErrorsBase {
 
+  override protected[spark] def expectedCost = 200
+
   // The JSON input data might be missing certain fields. We force the nullability
   // of the user-provided schema to avoid data corruptions. In particular, the parquet-mr encoder
   // can generate incorrect files if values are missing in columns declared as non-nullable.
@@ -767,6 +771,8 @@ case class StructsToJson(
   with ExpectsInputTypes
   with NullIntolerant
   with QueryErrorsBase {
+
+  override protected[spark] def expectedCost = 200
 
   override def nullable: Boolean = true
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -393,6 +393,8 @@ case class AesEncrypt(
     aad: Expression)
   extends RuntimeReplaceable with ImplicitCastInputTypes {
 
+  override protected[spark] def expectedCost = 100
+
   override lazy val replacement: Expression = StaticInvoke(
     classOf[ExpressionImplUtils],
     BinaryType,
@@ -469,6 +471,8 @@ case class AesDecrypt(
     padding: Expression,
     aad: Expression)
   extends RuntimeReplaceable with ImplicitCastInputTypes {
+
+  override protected[spark] def expectedCost = 200
 
   override lazy val replacement: Expression = StaticInvoke(
     classOf[ExpressionImplUtils],

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -76,7 +76,7 @@ abstract class StringRegexExpression extends BinaryExpression
     }
   }
 
-  override protected def expectedCost: Int = 100
+  override protected[spark] def expectedCost: Int = 100
 }
 
 // scalastyle:off line.contains.tab line.size.limit

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -75,6 +75,8 @@ abstract class StringRegexExpression extends BinaryExpression
       matches(regex, input1.asInstanceOf[UTF8String].toString)
     }
   }
+
+  override protected def expectedCost: Int = 100
 }
 
 // scalastyle:off line.contains.tab line.size.limit

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/variantExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/variantExpressions.scala
@@ -50,6 +50,8 @@ import org.apache.spark.unsafe.types._
 case class ParseJson(child: Expression)
   extends UnaryExpression with ExpectsInputTypes with RuntimeReplaceable {
 
+  override protected[spark] def expectedCost = 200
+
   override lazy val replacement: Expression = StaticInvoke(
     VariantExpressionEvalUtils.getClass,
     VariantType,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xmlExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xmlExpressions.scala
@@ -62,6 +62,8 @@ case class XmlToStructs(
   with NullIntolerant
   with QueryErrorsBase {
 
+  override protected[spark] def expectedCost = 200
+
   def this(child: Expression, schema: Expression, options: Map[String, String]) =
     this(
       schema = ExprUtils.evalSchemaExpr(schema),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1782,10 +1782,11 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
       }
 
       if (stayUp.isEmpty) {
-        project.copy(child = Filter(replaceAlias(condition, aliasMap), grandChild))
+        val childCondition = replaceAlias(condition, aliasMap)
+        project.copy(child = Filter(childCondition, grandChild))
       } else if (!pushDown.isEmpty) {
-        Filter(stayUp.reduce(And),
-          project.copy(child = Filter(pushDown.reduce(And), grandChild)))
+        val childCondition = replaceAlias(pushDown.reduce(And), aliasMap)
+        Filter(stayUp.reduce(And), project.copy(child = Filter(childCondition, grandChild)))
       } else {
         f
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1762,7 +1762,17 @@ object PushPredicateThroughNonJoin extends Rule[LogicalPlan] with PredicateHelpe
     // This also applies to Aggregate.
     case Filter(condition, project @ Project(fields, grandChild))
       if fields.forall(_.deterministic) && canPushThroughCondition(grandChild, condition) =>
+      println(s"Filter push $condition over $project")
       val aliasMap = getAliasMap(project)
+      // SPARK-47672: If an operation is expensive and computed inside of the project
+      // we don't want to push it since that would lead to a double execution (and slower eval)
+      val (pushDown, stayUp) = splitConjunctivePredicates(condition).partition { cond =>
+        val replaced = replaceAlias(cond, aliasMap)
+        println(s"Inner cond $cond became $replaced")
+        true
+      }
+
+
       project.copy(child = Filter(replaceAlias(condition, aliasMap), grandChild))
 
     case filter @ Filter(condition, aggregate: Aggregate)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Changes the filter pushDown optimizer to not push down past projections of the same element if we reasonable expect that computing that element is likely to be expensive.

This introduces an "expectedCost" mechanism which we may or may not want. Previous filter ordering work used filter pushdowns as an approximation of expression cost but here we need more granularity. As an alternative we could introduce a flag for expensive rather than numeric operations.

### Future Work / What else remains to do?

Right now if a cond is expensive and it references something in the projection we don't push-down. We could probably do better and gate this on if the thing we are reference is expensive rather than the condition it's self. We could do this as a follow up item or as part of this PR.

### Why are the changes needed?

Currently Spark may double compute expensive operations (like json parsing, UDF eval, etc.) as a result of filter pushdown past projections.

### Does this PR introduce _any_ user-facing change?

SQL optimizer change may impact some user queries, results should be the same and hopefully a little faster.

### How was this patch tested?

New tests were added to the FilterPushDownSuite, and the initial problem of double evaluation was confirmed with a github gist 

### Was this patch authored or co-authored using generative AI tooling?

No