### PR TITLE
[SPARK-47678][CORE]  Check `spark.shuffle.readHostLocalDisk` when reading shuffle blocks

### DIFF
--- a/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/BlockStoreShuffleReader.scala
@@ -88,7 +88,8 @@ private[spark] class BlockStoreShuffleReader[K, C](
       SparkEnv.get.conf.get(config.SHUFFLE_CHECKSUM_ENABLED),
       SparkEnv.get.conf.get(config.SHUFFLE_CHECKSUM_ALGORITHM),
       readMetrics,
-      fetchContinuousBlocksInBatch).toCompletionIterator
+      fetchContinuousBlocksInBatch,
+      SparkEnv.get.conf.get(config.SHUFFLE_HOST_LOCAL_DISK_READING_ENABLED)).toCompletionIterator
 
     val serializerInstance = dep.serializer.newInstance()
 

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -101,6 +101,7 @@ final class ShuffleBlockFetcherIterator(
     checksumAlgorithm: String,
     shuffleMetrics: ShuffleReadMetricsReporter,
     doBatchFetch: Boolean,
+    doLocalDiskRead: Boolean = true,
   clock: Clock = new SystemClock())
   extends Iterator[(BlockId, InputStream)] with DownloadFileManager with Logging {
 
@@ -417,7 +418,7 @@ final class ShuffleBlockFetcherIterator(
         numBlocksToFetch += mergedBlockInfos.size
         localBlocks ++= mergedBlockInfos.map(info => (info.blockId, info.mapIndex))
         localBlockBytes += mergedBlockInfos.map(_.size).sum
-      } else if (blockManager.hostLocalDirManager.isDefined &&
+      } else if (doLocalDiskRead && blockManager.hostLocalDirManager.isDefined &&
         address.host == blockManager.blockManagerId.host) {
         val mergedBlockInfos = mergeContinuousShuffleBlockIdsIfNeeded(
           blockInfos.map(info => FetchBlockInfo(info._1, info._2, info._3)), doBatchFetch)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Check `spark.shuffle.readHostLocalDisk` config to determine whether read shuffle block from same local host machine.


### Why are the changes needed?

Spark has a special shuffle optimization to check whether the shuffle block is on the same local host machine, and read from local disk when possible. This local host machine check is done by comparing block ip address with current host ip address. This will cause issue when running Spark on Kubernetes, because Kubernetes may reuse pod ip when some old executor exits and the new executor starts.

Consider following sequence:

1. Executor 1 starts with IP address 10.0.0.1.
2. Some shuffle block (e.g. block1) is written on Executor 1.
3. Executor 1 terminates.
4. Executor 2 starts with same IP address 10.0.0.1 (this is rare, but did happen in our test, because Kubernetes may reuse ip when launching pods).
5. Executor 2 tries to read block1. It finds block1's address is same as current host address, thus assumes block1 exists on its local disk.
6. Executor 2 will read from local disk and get error, since block1 is not there (block1 is on Executor 1, which is gone)

This is already a Spark config (spark.shuffle.readHostLocalDisk). We can reuse this config and check it in BlockStoreShuffleReader.


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.
