### PR TITLE
[SPARK-47685][SQL] Restore the support for `Stream` type in `Dataset#groupBy`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql
 
 import java.util.Locale
 
+import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.SparkRuntimeException
@@ -58,10 +59,12 @@ class RelationalGroupedDataset protected[sql](
   import RelationalGroupedDataset._
 
   private[this] def toDF(aggExprs: Seq[Expression]): DataFrame = {
+    @nowarn("cat=deprecation")
     val aggregates = if (df.sparkSession.sessionState.conf.dataFrameRetainGroupColumns) {
       groupingExprs match {
-        // call `toList` because `LazyList` can't serialize in scala 2.13
+        // call `toList` because `Stream` and `LazyList` can't serialize in scala 2.13
         case s: LazyList[Expression] => s.toList ++ aggExprs
+        case s: Stream[Expression] => s.toList ++ aggExprs
         case other => other ++ aggExprs
       }
     } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/RelationalGroupedDataset.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql
 
 import java.util.Locale
 
-import scala.annotation.nowarn
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.SparkRuntimeException
@@ -59,7 +58,7 @@ class RelationalGroupedDataset protected[sql](
   import RelationalGroupedDataset._
 
   private[this] def toDF(aggExprs: Seq[Expression]): DataFrame = {
-    @nowarn("cat=deprecation")
+    @scala.annotation.nowarn("cat=deprecation")
     val aggregates = if (df.sparkSession.sessionState.conf.dataFrameRetainGroupColumns) {
       groupingExprs match {
         // call `toList` because `Stream` and `LazyList` can't serialize in scala 2.13

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -1666,8 +1666,14 @@ class DataFrameAggregateSuite extends QueryTest
     assert(spark.range(2).where("id > 2").agg(emptyAgg).limit(1).count() == 1)
   }
 
-  test("SPARK-38221: group by stream of complex expressions should not fail") {
+  test("SPARK-45685: group by `LazyList` of complex expressions should not fail") {
     val df = Seq(1).toDF("id").groupBy(LazyList($"id" + 1, $"id" + 2): _*).sum("id")
+    checkAnswer(df, Row(2, 3, 1))
+  }
+
+  test("SPARK-38221: group by `Stream` of complex expressions should not fail") {
+    @scala.annotation.nowarn("cat=deprecation")
+    val df = Seq(1).toDF("id").groupBy(Stream($"id" + 1, $"id" + 2): _*).sum("id")
     checkAnswer(df, Row(2, 3, 1))
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
When I reviewed the changes in SPARK-45685, I found an old user case that is no longer supported:

```scala
Seq(1).toDF("id").groupBy(Stream($"id" + 1, $"id" + 2): _*).sum("id")
```

```
[info] - SPARK-38221: group by `Stream` of complex expressions should not fail *** FAILED *** (51 milliseconds)
[info]   org.apache.spark.SparkException: Task not serializable
[info]   at org.apache.spark.util.SparkClosureCleaner$.clean(SparkClosureCleaner.scala:45)
[info]   at org.apache.spark.SparkContext.clean(SparkContext.scala:2718)
[info]   at org.apache.spark.rdd.RDD.$anonfun$mapPartitionsWithIndex$1(RDD.scala:908)
[info]   at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
[info]   at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:112)
[info]   at org.apache.spark.rdd.RDD.withScope(RDD.scala:411)
[info]   at org.apache.spark.rdd.RDD.mapPartitionsWithIndex(RDD.scala:907)
[info]   at org.apache.spark.sql.execution.WholeStageCodegenExec.doExecute(WholeStageCodegenExec.scala:762)
...
```

Since this is a historical user usage, and although the `Stream` type has been deprecated after Scala 2.13.0, it has not been removed, so this PR restores the support for `Stream` type in `Dataset#groupBy`.


### Why are the changes needed?
Restore the support for `Stream` type in `Dataset#groupBy`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- Restored the test case for dataset group by `Stream`.


### Was this patch authored or co-authored using generative AI tooling?
No
