### PR TITLE
[SPARK-47686][SQL][TESTS] Use `=!=` instead of `!==` in `JoinHintSuite`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinHintSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinHintSuite.scala
@@ -695,7 +695,7 @@ class JoinHintSuite extends PlanTest with SharedSparkSession with AdaptiveSparkP
     val hintAppender = new LogAppender(s"join hint check for equi-join")
     withLogAppender(hintAppender, level = Some(Level.WARN)) {
       assertBroadcastNLJoin(
-        df1.hint("SHUFFLE_HASH").join(df2, $"a1"=!= $"b1"), BuildRight)
+        df1.hint("SHUFFLE_HASH").join(df2, $"a1" =!= $"b1"), BuildRight)
     }
     withLogAppender(hintAppender, level = Some(Level.WARN)) {
       assertBroadcastNLJoin(

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinHintSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinHintSuite.scala
@@ -695,11 +695,11 @@ class JoinHintSuite extends PlanTest with SharedSparkSession with AdaptiveSparkP
     val hintAppender = new LogAppender(s"join hint check for equi-join")
     withLogAppender(hintAppender, level = Some(Level.WARN)) {
       assertBroadcastNLJoin(
-        df1.hint("SHUFFLE_HASH").join(df2, $"a1" !== $"b1"), BuildRight)
+        df1.hint("SHUFFLE_HASH").join(df2, $"a1"=!= $"b1"), BuildRight)
     }
     withLogAppender(hintAppender, level = Some(Level.WARN)) {
       assertBroadcastNLJoin(
-        df1.join(df2.hint("MERGE"), $"a1" !== $"b1"), BuildRight)
+        df1.join(df2.hint("MERGE"), $"a1" =!= $"b1"), BuildRight)
     }
     val logs = hintAppender.loggingEvents.map(_.getMessage.getFormattedMessage)
       .filter(_.contains("is not supported in the query:"))


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr use `=!=` instead of `!==` in `JoinHintSuite`. `!==`  is a deprecated API since 2.0.0, and its test already exists in `DeprecatedAPISuite`.

### Why are the changes needed?
Clean up deprecated API  usage.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No