### PR TITLE
[SPARK-47687][SQL] When creating a table through ThriftServer, set the table owner to the connected user

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveClientImpl.scala
@@ -203,7 +203,7 @@ private[hive] class HiveClientImpl(
     hiveConf
   }
 
-  override val userName = UserGroupInformation.getCurrentUser.getShortUserName
+  override def userName: String = UserGroupInformation.getCurrentUser.getShortUserName
 
   override def getConf(key: String, defaultValue: String): String = {
     conf.get(key, defaultValue)


### PR DESCRIPTION
### What changes were proposed in this pull request?
In org.apache.spark.sql.hive.client.HiveClientImpl, get the current UserGroupInformation in real time


### Why are the changes needed?
Fix table owner inconsistency


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
ThriftServer connection operation is not convenient for writing tests.
Tested locally using the steps in the issue.


### Was this patch authored or co-authored using generative AI tooling?
No
