### PR TITLE
[SPARK-47693][SQL] Add optimization for lowercase comparison of UTF8String used in UTF8_BINARY_LCASE collation

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
@@ -148,7 +148,7 @@ public final class CollationFactory {
     collationTable[1] = new Collation(
       "UTF8_BINARY_LCASE",
       null,
-      (s1, s2) -> s1.toLowerCase().binaryCompare(s2.toLowerCase()),
+      UTF8String::compareLowercase,
       "1.0",
       (s) -> (long)s.toLowerCase().hashCode(),
       false,

--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
@@ -148,7 +148,7 @@ public final class CollationFactory {
     collationTable[1] = new Collation(
       "UTF8_BINARY_LCASE",
       null,
-      UTF8String::compareLowercase,
+      UTF8String::compareLowerCase,
       "1.0",
       (s) -> (long)s.toLowerCase().hashCode(),
       false,

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -424,7 +424,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     if (numBytes == 0) {
       return EMPTY_UTF8;
     }
-    // skip allocation if we need to fallback in case of non-ASCII occurrences
+    // Optimization - do char level uppercase conversion in case of chars in ASCII range
     for (int i = 0; i < numBytes; i++) {
       if (getByte(i) < 0) {
         // non-ASCII
@@ -444,13 +444,14 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
 
   /**
    * Optimized lowercase comparison for UTF8_BINARY_LCASE collation
+   * a.compareLowerCase(b) is equivalent to a.toLowerCase().binaryCompare(b.toLowerCase())
    */
-  public int compareLowercase(UTF8String other) {
+  public int compareLowerCase(UTF8String other) {
     int curr;
     for (curr = 0; curr < numBytes && curr < other.numBytes; curr++) {
       byte left, right;
       if ((left = getByte(curr)) < 0 || (right = other.getByte(curr)) < 0) {
-        return compareLowercaseSuffixSlow(other, curr);
+        return compareLowerCaseSuffixSlow(other, curr);
       }
       int lowerLeft = Character.toLowerCase(left);
       int lowerRight = Character.toLowerCase(right);
@@ -461,7 +462,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     return numBytes - other.numBytes;
   }
 
-  private int compareLowercaseSuffixSlow(UTF8String other, int pref) {
+  private int compareLowerCaseSuffixSlow(UTF8String other, int pref) {
     UTF8String suffixLeft = UTF8String.fromAddress(base, offset + pref,
       numBytes - pref);
     UTF8String suffixRight = UTF8String.fromAddress(other.base, other.offset + pref,
@@ -476,7 +477,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     if (numBytes == 0) {
       return EMPTY_UTF8;
     }
-    // skip allocation if we need to fallback in case of non-ASCII occurrences
+    // Optimization - do char level lowercase conversion in case of chars in ASCII range
     for (int i = 0; i < numBytes; i++) {
       if (getByte(i) < 0) {
         // non-ASCII
@@ -501,7 +502,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     if (numBytes == 0) {
       return EMPTY_UTF8;
     }
-    // skip allocation if we need to fallback in case of non-ASCII occurrences
+    // Optimization - in case of ASCII chars we can skip copying the data to and from StringBuilder
     byte prev = ' ', curr;
     for (int i = 0; i < numBytes; i++) {
       curr = getByte(i);

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -475,7 +475,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
             numBytes - pref);
     UTF8String suffixRight = UTF8String.fromAddress(other.base, other.offset + pref,
             other.numBytes - pref);
-    return suffixLeft.toLowerCaseSlow().compareTo(suffixRight.toLowerCaseSlow());
+    return suffixLeft.toLowerCaseSlow().binaryCompare(suffixRight.toLowerCaseSlow());
   }
 
   /**

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -424,7 +424,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     if (numBytes == 0) {
       return EMPTY_UTF8;
     }
-    // skip allocation if we need to fallback
+    // skip allocation if we need to fallback in case of non-ASCII occurrences
     for (int i = 0; i < numBytes; i++) {
       if (getByte(i) < 0) {
         // non-ASCII
@@ -476,7 +476,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     if (numBytes == 0) {
       return EMPTY_UTF8;
     }
-    // skip allocation if we need to fallback
+    // skip allocation if we need to fallback in case of non-ASCII occurrences
     for (int i = 0; i < numBytes; i++) {
       if (getByte(i) < 0) {
         // non-ASCII
@@ -501,7 +501,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     if (numBytes == 0) {
       return EMPTY_UTF8;
     }
-    // skip allocation if we need to fallback
+    // skip allocation if we need to fallback in case of non-ASCII occurrences
     byte prev = ' ', curr;
     for (int i = 0; i < numBytes; i++) {
       curr = getByte(i);

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -472,9 +472,9 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
 
   private int compareLowercaseSuffixSlow(UTF8String other, int pref) {
     UTF8String suffixLeft = UTF8String.fromAddress(base, offset + pref,
-            numBytes - pref);
+      numBytes - pref);
     UTF8String suffixRight = UTF8String.fromAddress(other.base, other.offset + pref,
-            other.numBytes - pref);
+      other.numBytes - pref);
     return suffixLeft.toLowerCaseSlow().binaryCompare(suffixRight.toLowerCaseSlow());
   }
 

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
@@ -111,23 +111,23 @@ public class UTF8StringSuite {
   public void lowercaseComparison() {
     // SPARK-47693: Test optimized lowercase comparison of UTF8String instances
     // ASCII
-    assertEquals(fromString("aaa").compareLowercase(fromString("AAA")), 0);
-    assertTrue(fromString("aaa").compareLowercase(fromString("AAAA")) < 0);
-    assertTrue(fromString("AAA").compareLowercase(fromString("aaaa")) < 0);
-    assertTrue(fromString("a").compareLowercase(fromString("B")) < 0);
-    assertTrue(fromString("b").compareLowercase(fromString("A")) > 0);
-    assertEquals(fromString("aAa").compareLowercase(fromString("AaA")), 0);
-    assertTrue(fromString("abcd").compareLowercase(fromString("abC")) > 0);
-    assertTrue(fromString("ABC").compareLowercase(fromString("abcd")) < 0);
-    assertEquals(fromString("abcd").compareLowercase(fromString("abcd")), 0);
+    assertEquals(fromString("aaa").compareLowerCase(fromString("AAA")), 0);
+    assertTrue(fromString("aaa").compareLowerCase(fromString("AAAA")) < 0);
+    assertTrue(fromString("AAA").compareLowerCase(fromString("aaaa")) < 0);
+    assertTrue(fromString("a").compareLowerCase(fromString("B")) < 0);
+    assertTrue(fromString("b").compareLowerCase(fromString("A")) > 0);
+    assertEquals(fromString("aAa").compareLowerCase(fromString("AaA")), 0);
+    assertTrue(fromString("abcd").compareLowerCase(fromString("abC")) > 0);
+    assertTrue(fromString("ABC").compareLowerCase(fromString("abcd")) < 0);
+    assertEquals(fromString("abcd").compareLowerCase(fromString("abcd")), 0);
     // non-ASCII
-    assertEquals(fromString("ü").compareLowercase(fromString("Ü")), 0);
-    assertEquals(fromString("Äü").compareLowercase(fromString("äÜ")), 0);
-    assertTrue(fromString("a").compareLowercase(fromString("ä")) < 0);
-    assertTrue(fromString("a").compareLowercase(fromString("Ä")) < 0);
-    assertTrue(fromString("A").compareLowercase(fromString("ä")) < 0);
-    assertTrue(fromString("bä").compareLowercase(fromString("aü")) > 0);
-    assertTrue(fromString("bxxxxxxxxxx").compareLowercase(fromString("bü")) < 0);
+    assertEquals(fromString("ü").compareLowerCase(fromString("Ü")), 0);
+    assertEquals(fromString("Äü").compareLowerCase(fromString("äÜ")), 0);
+    assertTrue(fromString("a").compareLowerCase(fromString("ä")) < 0);
+    assertTrue(fromString("a").compareLowerCase(fromString("Ä")) < 0);
+    assertTrue(fromString("A").compareLowerCase(fromString("ä")) < 0);
+    assertTrue(fromString("bä").compareLowerCase(fromString("aü")) > 0);
+    assertTrue(fromString("bxxxxxxxxxx").compareLowerCase(fromString("bü")) < 0);
   }
 
   protected static void testUpperandLower(String upper, String lower) {

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
@@ -109,6 +109,7 @@ public class UTF8StringSuite {
 
   @Test
   public void lowercaseComparison() {
+    // SPARK-47693: Test optimized lowercase comparison of UTF8String instances
     // ASCII
     assertEquals(fromString("aaa").compareLowercase(fromString("AAA")), 0);
     assertTrue(fromString("aaa").compareLowercase(fromString("AAAA")) < 0);

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
@@ -107,6 +107,28 @@ public class UTF8StringSuite {
     assertTrue(fromString("你好123").binaryCompare(fromString("你好122")) > 0);
   }
 
+  @Test
+  public void lowercaseComparison() {
+    // ASCII
+    assertEquals(fromString("aaa").compareLowercase(fromString("AAA")), 0);
+    assertTrue(fromString("aaa").compareLowercase(fromString("AAAA")) < 0);
+    assertTrue(fromString("AAA").compareLowercase(fromString("aaaa")) < 0);
+    assertTrue(fromString("a").compareLowercase(fromString("B")) < 0);
+    assertTrue(fromString("b").compareLowercase(fromString("A")) > 0);
+    assertEquals(fromString("aAa").compareLowercase(fromString("AaA")), 0);
+    assertTrue(fromString("abcd").compareLowercase(fromString("abC")) > 0);
+    assertTrue(fromString("ABC").compareLowercase(fromString("abcd")) < 0);
+    assertEquals(fromString("abcd").compareLowercase(fromString("abcd")), 0);
+    // non-ASCII
+    assertEquals(fromString("ü").compareLowercase(fromString("Ü")), 0);
+    assertEquals(fromString("Äü").compareLowercase(fromString("äÜ")), 0);
+    assertTrue(fromString("a").compareLowercase(fromString("ä")) < 0);
+    assertTrue(fromString("a").compareLowercase(fromString("Ä")) < 0);
+    assertTrue(fromString("A").compareLowercase(fromString("ä")) < 0);
+    assertTrue(fromString("bä").compareLowercase(fromString("aü")) > 0);
+    assertTrue(fromString("bxxxxxxxxxx").compareLowercase(fromString("bü")) < 0);
+  }
+
   protected static void testUpperandLower(String upper, String lower) {
     UTF8String us = fromString(upper);
     UTF8String ls = fromString(lower);

--- a/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
@@ -2,26 +2,26 @@ OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                    6963           6979          22          0.0       69628.9       1.0X
-UNICODE                                              4345           4345           0          0.0       43448.5       1.6X
-UTF8_BINARY                                          4338           4341           4          0.0       43382.1       1.6X
-UNICODE_CI                                          46826          46882          80          0.0      468255.1       0.1X
+UTF8_BINARY_LCASE                                    6910           6912           3          0.0       69099.7       1.0X
+UNICODE                                              4367           4368           1          0.0       43669.6       1.6X
+UTF8_BINARY                                          4361           4364           4          0.0       43606.5       1.6X
+UNICODE_CI                                          46480          46526          66          0.0      464795.7       0.1X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                     6461           6469          11          0.0       64614.0       1.0X
-UNICODE                                              47730          47750          27          0.0      477303.7       0.1X
-UTF8_BINARY                                           7470           7472           3          0.0       74696.5       0.9X
-UNICODE_CI                                           48643          48771         182          0.0      486427.3       0.1X
+UTF8_BINARY_LCASE                                     6522           6526           4          0.0       65223.9       1.0X
+UNICODE                                              45792          45797           7          0.0      457922.3       0.1X
+UTF8_BINARY                                           7092           7112          29          0.0       70921.7       0.9X
+UNICODE_CI                                           47548          47564          22          0.0      475476.7       0.1X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                 11403          11471          96          0.0      114033.4       1.0X
-UNICODE                                          180232         180272          57          0.0     1802316.8       0.1X
-UTF8_BINARY                                       10914          10922          12          0.0      109139.0       1.0X
-UNICODE_CI                                       157745         157766          31          0.0     1577445.3       0.1X
+UTF8_BINARY_LCASE                                 11716          11716           1          0.0      117157.9       1.0X
+UNICODE                                          180133         180137           5          0.0     1801332.1       0.1X
+UTF8_BINARY                                       10476          10477           1          0.0      104757.4       1.1X
+UNICODE_CI                                       148171         148190          28          0.0     1481705.6       0.1X
 

--- a/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
@@ -2,26 +2,26 @@ OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                   29904          29937          47          0.0      299036.1       1.0X
-UNICODE                                              3886           3893          10          0.0       38863.0       7.7X
-UTF8_BINARY                                          3945           3945           0          0.0       39449.6       7.6X
-UNICODE_CI                                          45321          45330          12          0.0      453210.3       0.7X
+UTF8_BINARY_LCASE                                    6927           6941          19          0.0       69274.1       1.0X
+UNICODE                                              4281           4282           1          0.0       42811.0       1.6X
+UTF8_BINARY                                          4279           4280           1          0.0       42790.3       1.6X
+UNICODE_CI                                          43556          43602          64          0.0      435560.1       0.2X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                    29807          29818          17          0.0      298065.0       1.0X
-UNICODE                                              45704          45723          27          0.0      457036.2       0.7X
-UTF8_BINARY                                           6460           6464           7          0.0       64597.9       4.6X
-UNICODE_CI                                           45498          45508          14          0.0      454977.6       0.7X
+UTF8_BINARY_LCASE                                     4994           4995           1          0.0       49937.1       1.0X
+UNICODE                                              46695          46713          27          0.0      466947.2       0.1X
+UTF8_BINARY                                           7641           7649          12          0.0       76406.8       0.7X
+UNICODE_CI                                           48337          48350          18          0.0      483369.1       0.1X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                 23553          23595          59          0.0      235531.8       1.0X
-UNICODE                                          197303         197309           8          0.0     1973034.1       0.1X
-UTF8_BINARY                                       14389          14391           2          0.0      143891.2       1.6X
-UNICODE_CI                                       166880         166885           7          0.0     1668799.5       0.1X
+UTF8_BINARY_LCASE                                 11611          11619          11          0.0      116111.3       1.0X
+UNICODE                                          183518         183661         203          0.0     1835176.2       0.1X
+UTF8_BINARY                                       10758          10768          14          0.0      107576.5       1.1X
+UNICODE_CI                                       149072         149165         132          0.0     1490717.5       0.1X
 

--- a/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
@@ -1,27 +1,27 @@
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                    6927           6941          19          0.0       69274.1       1.0X
-UNICODE                                              4281           4282           1          0.0       42811.0       1.6X
-UTF8_BINARY                                          4279           4280           1          0.0       42790.3       1.6X
-UNICODE_CI                                          43556          43602          64          0.0      435560.1       0.2X
+UTF8_BINARY_LCASE                                    6963           6979          22          0.0       69628.9       1.0X
+UNICODE                                              4345           4345           0          0.0       43448.5       1.6X
+UTF8_BINARY                                          4338           4341           4          0.0       43382.1       1.6X
+UNICODE_CI                                          46826          46882          80          0.0      468255.1       0.1X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                     4994           4995           1          0.0       49937.1       1.0X
-UNICODE                                              46695          46713          27          0.0      466947.2       0.1X
-UTF8_BINARY                                           7641           7649          12          0.0       76406.8       0.7X
-UNICODE_CI                                           48337          48350          18          0.0      483369.1       0.1X
+UTF8_BINARY_LCASE                                     6461           6469          11          0.0       64614.0       1.0X
+UNICODE                                              47730          47750          27          0.0      477303.7       0.1X
+UTF8_BINARY                                           7470           7472           3          0.0       74696.5       0.9X
+UNICODE_CI                                           48643          48771         182          0.0      486427.3       0.1X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                 11611          11619          11          0.0      116111.3       1.0X
-UNICODE                                          183518         183661         203          0.0     1835176.2       0.1X
-UTF8_BINARY                                       10758          10768          14          0.0      107576.5       1.1X
-UNICODE_CI                                       149072         149165         132          0.0     1490717.5       0.1X
+UTF8_BINARY_LCASE                                 11403          11471          96          0.0      114033.4       1.0X
+UNICODE                                          180232         180272          57          0.0     1802316.8       0.1X
+UTF8_BINARY                                       10914          10922          12          0.0      109139.0       1.0X
+UNICODE_CI                                       157745         157766          31          0.0     1577445.3       0.1X
 

--- a/sql/core/benchmarks/CollationBenchmark-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-results.txt
@@ -2,26 +2,26 @@ OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                   34122          34152          42          0.0      341224.2       1.0X
-UNICODE                                              4520           4522           2          0.0       45201.8       7.5X
-UTF8_BINARY                                          4524           4526           2          0.0       45243.0       7.5X
-UNICODE_CI                                          52706          52711           7          0.0      527056.1       0.6X
+UTF8_BINARY_LCASE                                    8006           8022          24          0.0       80056.6       1.0X
+UNICODE                                              3151           3152           3          0.0       31505.3       2.5X
+UTF8_BINARY                                          3152           3164          17          0.0       31517.9       2.5X
+UNICODE_CI                                          54159          54258         140          0.0      541591.6       0.1X
 
 OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                    33467          33474          10          0.0      334671.7       1.0X
-UNICODE                                              51168          51168           1          0.0      511677.4       0.7X
-UTF8_BINARY                                           5561           5593          45          0.0       55610.9       6.0X
-UNICODE_CI                                           51929          51955          36          0.0      519291.8       0.6X
+UTF8_BINARY_LCASE                                    11169          11175           8          0.0      111691.2       1.0X
+UNICODE                                              49021          49052          45          0.0      490209.1       0.2X
+UTF8_BINARY                                           6415           6415           0          0.0       64145.8       1.7X
+UNICODE_CI                                           50373          50385          18          0.0      503725.4       0.2X
 
 OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                 22079          22083           5          0.0      220786.7       1.0X
-UNICODE                                          177636         177709         103          0.0     1776363.9       0.1X
-UTF8_BINARY                                       11954          11956           3          0.0      119536.7       1.8X
-UNICODE_CI                                       158014         158038          35          0.0     1580135.7       0.1X
+UTF8_BINARY_LCASE                                 24485          24506          30          0.0      244846.2       1.0X
+UNICODE                                          178005         178052          66          0.0     1780050.9       0.1X
+UTF8_BINARY                                       14111          14114           5          0.0      141108.7       1.7X
+UNICODE_CI                                       155499         155581         116          0.0     1554986.6       0.2X
 

--- a/sql/core/benchmarks/CollationBenchmark-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-results.txt
@@ -1,27 +1,27 @@
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                    8006           8022          24          0.0       80056.6       1.0X
-UNICODE                                              3151           3152           3          0.0       31505.3       2.5X
-UTF8_BINARY                                          3152           3164          17          0.0       31517.9       2.5X
-UNICODE_CI                                          54159          54258         140          0.0      541591.6       0.1X
+UTF8_BINARY_LCASE                                    7692           7731          55          0.0       76919.2       1.0X
+UNICODE                                              4378           4379           0          0.0       43784.6       1.8X
+UTF8_BINARY                                          4382           4396          19          0.0       43821.6       1.8X
+UNICODE_CI                                          48344          48360          23          0.0      483436.5       0.2X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                    11169          11175           8          0.0      111691.2       1.0X
-UNICODE                                              49021          49052          45          0.0      490209.1       0.2X
-UTF8_BINARY                                           6415           6415           0          0.0       64145.8       1.7X
-UNICODE_CI                                           50373          50385          18          0.0      503725.4       0.2X
+UTF8_BINARY_LCASE                                     9819           9820           0          0.0       98194.9       1.0X
+UNICODE                                              49507          49518          17          0.0      495066.2       0.2X
+UTF8_BINARY                                           7354           7365          17          0.0       73536.3       1.3X
+UNICODE_CI                                           52149          52163          20          0.0      521489.4       0.2X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                 24485          24506          30          0.0      244846.2       1.0X
-UNICODE                                          178005         178052          66          0.0     1780050.9       0.1X
-UTF8_BINARY                                       14111          14114           5          0.0      141108.7       1.7X
-UNICODE_CI                                       155499         155581         116          0.0     1554986.6       0.2X
+UTF8_BINARY_LCASE                                 18110          18127          24          0.0      181103.9       1.0X
+UNICODE                                          171375         171435          85          0.0     1713752.3       0.1X
+UTF8_BINARY                                       14012          14030          26          0.0      140116.7       1.3X
+UNICODE_CI                                       153847         153901          76          0.0     1538471.1       0.1X
 

--- a/sql/core/benchmarks/CollationNonASCIIBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/CollationNonASCIIBenchmark-jdk21-results.txt
@@ -1,0 +1,27 @@
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
+AMD EPYC 7763 64-Core Processor
+collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------
+UTF8_BINARY_LCASE                                   18244          18258          20          0.0      456096.4       1.0X
+UNICODE                                               498            498           0          0.1       12440.3      36.7X
+UTF8_BINARY                                           499            500           1          0.1       12467.7      36.6X
+UNICODE_CI                                          13429          13443          19          0.0      335725.4       1.4X
+
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
+AMD EPYC 7763 64-Core Processor
+collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------
+UTF8_BINARY_LCASE                                    18377          18399          31          0.0      459430.5       1.0X
+UNICODE                                              14238          14240           3          0.0      355957.4       1.3X
+UTF8_BINARY                                            975            976           1          0.0       24371.3      18.9X
+UNICODE_CI                                           13819          13826          10          0.0      345482.6       1.3X
+
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
+AMD EPYC 7763 64-Core Processor
+collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+UTF8_BINARY_LCASE                                  9183           9230          67          0.0      229564.0       1.0X
+UNICODE                                           38937          38952          22          0.0      973421.3       0.2X
+UTF8_BINARY                                        1376           1376           0          0.0       34397.5       6.7X
+UNICODE_CI                                        32881          32882           1          0.0      822027.4       0.3X
+

--- a/sql/core/benchmarks/CollationNonASCIIBenchmark-results.txt
+++ b/sql/core/benchmarks/CollationNonASCIIBenchmark-results.txt
@@ -1,0 +1,27 @@
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
+AMD EPYC 7763 64-Core Processor
+collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------
+UTF8_BINARY_LCASE                                   17881          17885           6          0.0      447017.7       1.0X
+UNICODE                                               493            495           2          0.1       12328.9      36.3X
+UTF8_BINARY                                           493            494           1          0.1       12331.4      36.3X
+UNICODE_CI                                          13731          13737           8          0.0      343284.6       1.3X
+
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
+AMD EPYC 7763 64-Core Processor
+collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+---------------------------------------------------------------------------------------------------------------------------
+UTF8_BINARY_LCASE                                    18041          18047           8          0.0      451030.2       1.0X
+UNICODE                                              14023          14047          34          0.0      350573.9       1.3X
+UTF8_BINARY                                           1387           1397          14          0.0       34680.4      13.0X
+UNICODE_CI                                           14232          14242          14          0.0      355808.4       1.3X
+
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
+AMD EPYC 7763 64-Core Processor
+collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------
+UTF8_BINARY_LCASE                                 10494          10499           6          0.0      262360.0       1.0X
+UNICODE                                           40410          40422          17          0.0     1010261.8       0.3X
+UTF8_BINARY                                        2035           2035           1          0.0       50877.8       5.2X
+UNICODE_CI                                        31470          31493          32          0.0      786752.4       0.3X
+

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
@@ -22,31 +22,11 @@ import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
 import org.apache.spark.sql.catalyst.util.CollationFactory
 import org.apache.spark.unsafe.types.UTF8String
 
-/**
- * Benchmark to measure performance for comparisons between collated strings. To run this benchmark:
- * {{{
- *   1. without sbt:
- *      bin/spark-submit --class <this class>
- *        --jars <spark core test jar>,<spark catalyst test jar> <spark sql test jar>
- *   2. build/sbt "sql/Test/runMain org.apache.spark.sql.execution.benchmark.CollationBenchmark"
- *   3. generate result:
- *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/Test/runMain <this class>"
- *      Results will be written to "benchmarks/CollationBenchmark-results.txt".
- * }}}
- */
+abstract class CollationBenchmarkBase extends BenchmarkBase {
+  protected val collationTypes: Seq[String] =
+    Seq("UTF8_BINARY_LCASE", "UNICODE", "UTF8_BINARY", "UNICODE_CI")
 
-object CollationBenchmark extends BenchmarkBase {
-  private val collationTypes = Seq("UTF8_BINARY_LCASE", "UNICODE", "UTF8_BINARY", "UNICODE_CI")
-
-  def generateSeqInput(n: Long): Seq[UTF8String] = {
-    val input = Seq("ABC", "ABC", "aBC", "aBC", "abc", "abc", "DEF", "DEF", "def", "def",
-      "GHI", "ghi", "JKL", "jkl", "MNO", "mno", "PQR", "pqr", "STU", "stu", "VWX", "vwx",
-      "ABC", "ABC", "aBC", "aBC", "abc", "abc", "DEF", "DEF", "def", "def", "GHI", "ghi",
-      "JKL", "jkl", "MNO", "mno", "PQR", "pqr", "STU", "stu", "VWX", "vwx", "YZ")
-      .map(UTF8String.fromString)
-    val inputLong: Seq[UTF8String] = (0L until n).map(i => input(i.toInt % input.size))
-    inputLong
-  }
+  def generateSeqInput(n: Long): Seq[UTF8String]
 
   def benchmarkUTFStringEquals(collationTypes: Seq[String], utf8Strings: Seq[UTF8String]): Unit = {
     val sublistStrings = utf8Strings
@@ -120,10 +100,60 @@ object CollationBenchmark extends BenchmarkBase {
     )
     benchmark.run()
   }
+}
+
+/**
+ * Benchmark to measure performance for comparisons between collated strings. To run this benchmark:
+ * {{{
+ *   1. without sbt:
+ *      bin/spark-submit --class <this class>
+ *        --jars <spark core test jar>,<spark catalyst test jar> <spark sql test jar>
+ *   2. build/sbt "sql/Test/runMain org.apache.spark.sql.execution.benchmark.CollationBenchmark"
+ *   3. generate result:
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/Test/runMain <this class>"
+ *      Results will be written to "benchmarks/CollationBenchmark-results.txt".
+ * }}}
+ */
+object CollationBenchmark extends CollationBenchmarkBase {
+
+  override def generateSeqInput(n: Long): Seq[UTF8String] = {
+    val input = Seq("ABC", "ABC", "aBC", "aBC", "abc", "abc", "DEF", "DEF", "def", "def",
+      "GHI", "ghi", "JKL", "jkl", "MNO", "mno", "PQR", "pqr", "STU", "stu", "VWX", "vwx",
+      "ABC", "ABC", "aBC", "aBC", "abc", "abc", "DEF", "DEF", "def", "def", "GHI", "ghi",
+      "JKL", "jkl", "MNO", "mno", "PQR", "pqr", "STU", "stu", "VWX", "vwx", "YZ")
+      .map(UTF8String.fromString)
+    val inputLong: Seq[UTF8String] = (0L until n).map(i => input(i.toInt % input.size))
+    inputLong
+  }
 
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
     benchmarkUTFStringEquals(collationTypes, generateSeqInput(10000L))
     benchmarkUTFStringCompare(collationTypes, generateSeqInput(10000L))
     benchmarkUTFStringHashFunction(collationTypes, generateSeqInput(10000L))
+  }
+}
+
+/**
+ * Measure performance of collation comparisons of non-ASCII strings.
+ */
+object CollationNonASCIIBenchmark extends CollationBenchmarkBase {
+
+  override def generateSeqInput(n: Long): Seq[UTF8String] = {
+    // scalastyle:off nonascii
+    val inputSet = Seq("A", "a", "Ä", "ä")
+    // lowercase and uppercase plain and umlaut A combinations of 3 letters (AAA, aäA, ...)
+    val input = (for {
+      x <- inputSet
+      y <- inputSet
+      z <- inputSet } yield x + y + z).map(UTF8String.fromString)
+    val inputLong: Seq[UTF8String] = (0L until n).map(i => input(i.toInt % input.size))
+    inputLong
+    // scalastyle:on nonascii
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    benchmarkUTFStringEquals(collationTypes, generateSeqInput(4000L))
+    benchmarkUTFStringCompare(collationTypes, generateSeqInput(4000L))
+    benchmarkUTFStringHashFunction(collationTypes, generateSeqInput(4000L))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
@@ -34,7 +34,7 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
     val benchmark = new Benchmark(
       "collation unit benchmarks - equalsFunction",
       utf8Strings.size * 10,
-      warmupTime = 4.seconds,
+      warmupTime = 10.seconds,
       output = output)
     collationTypes.foreach(collationType => {
       val collation = CollationFactory.fetchCollation(collationType)
@@ -57,7 +57,7 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
     val benchmark = new Benchmark(
       "collation unit benchmarks - compareFunction",
       utf8Strings.size * 10,
-      warmupTime = 4.seconds,
+      warmupTime = 10.seconds,
       output = output)
     collationTypes.foreach(collationType => {
       val collation = CollationFactory.fetchCollation(collationType)
@@ -83,7 +83,7 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
     val benchmark = new Benchmark(
       "collation unit benchmarks - hashFunction",
       utf8Strings.size * 10,
-      warmupTime = 4.seconds,
+      warmupTime = 10.seconds,
       output = output)
     collationTypes.foreach(collationType => {
       val collation = CollationFactory.fetchCollation(collationType)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Current collation [benchmarks](https://github.com/apache/spark/blob/e9f204ae93061a862e4da52c128eaf3512a66c7b/sql/core/benchmarks/CollationBenchmark-results.txt) indicate that `UTF8_BINARY_LCASE` collation comparisons are order of magnitude slower (~7-10x) than plain binary comparisons. Improve the performance by optimizing lowercase comparison function for `UTF8String` instances instead of performing full lowercase conversion before binary comparison.

Optimization is based on similar method used in `toLowerCase` where we check character by character if conversion is valid under ASCII and fallback to slow comparison of native strings. In latter case, we only take into consideration suffixes that are left to compare.

Benchmarks from `CollationBenchmark` ran locally show substantial performance increase:
```
[info] collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
[info] --------------------------------------------------------------------------------------------------------------------------
[info] UTF8_BINARY_LCASE                                    7199           7209          14          0.0       71988.8       1.0X
[info] UNICODE                                              3925           3929           5          0.0       39250.4       1.8X
[info] UTF8_BINARY                                          3935           3950          21          0.0       39351.2       1.8X
[info] UNICODE_CI                                          45248          51404        8706          0.0      452484.7       0.2X
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To improve performance of comparisons of strings under UTF8_BINARY_LCASE collation.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added unit tests to `UTF8StringSuite`.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.