### PR TITLE
[SPARK-47684][SQL][FOLLOWUP] Fix PostgresIntegrationSuite

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/PostgresIntegrationSuite.scala
@@ -184,7 +184,7 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationSuite {
     assert(rows.length == 2)
     // Test the types, and values using the first row.
     val types = rows(0).toSeq.map(x => x.getClass)
-    assert(types.length == 42)
+    assert(types.length == 45)
     assert(classOf[String].isAssignableFrom(types(0)))
     assert(classOf[java.lang.Integer].isAssignableFrom(types(1)))
     assert(classOf[java.lang.Double].isAssignableFrom(types(2)))


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to  fix `PostgresIntegrationSuite`.

### Why are the changes needed?
At present, the GA of the master branch has break. Let's restore it first.
https://github.com/yaooqinn/spark/actions/runs/8518017152/job/23329558427
<img width="958" alt="image" src="https://github.com/apache/spark/assets/15246973/5b7efe97-24ef-4cd9-8faf-dce76e37d5d7">

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
