### PR TITLE
[SPARK-47700][SQL] Fix formatting of error messages with treeNode

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -4497,7 +4497,8 @@
     "subClass" : {
       "ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED" : {
         "message" : [
-          "Accessing outer query column is not allowed in this location:\n<treeNode>."
+          "Accessing outer query column is not allowed in this location:",
+          "<treeNode>"
         ]
       },
       "AGGREGATE_FUNCTION_MIXED_OUTER_LOCAL_REFERENCES" : {
@@ -4507,7 +4508,8 @@
       },
       "CORRELATED_COLUMN_IS_NOT_ALLOWED_IN_PREDICATE" : {
         "message" : [
-          "Correlated column is not allowed in predicate:\n<treeNode>."
+          "Correlated column is not allowed in predicate:",
+          "<treeNode>"
         ]
       },
       "CORRELATED_COLUMN_NOT_FOUND" : {
@@ -4542,7 +4544,8 @@
       },
       "NON_DETERMINISTIC_LATERAL_SUBQUERIES" : {
         "message" : [
-          "Non-deterministic lateral subqueries are not supported when joining with outer relations that produce more than one row:\n<treeNode>."
+          "Non-deterministic lateral subqueries are not supported when joining with outer relations that produce more than one row:",
+          "<treeNode>"
         ]
       },
       "UNSUPPORTED_CORRELATED_REFERENCE_DATA_TYPE" : {
@@ -4552,17 +4555,20 @@
       },
       "UNSUPPORTED_CORRELATED_SCALAR_SUBQUERY" : {
         "message" : [
-          "Correlated scalar subqueries can only be used in filters, aggregations, projections, and UPDATE/MERGE/DELETE commands:\n<treeNode>."
+          "Correlated scalar subqueries can only be used in filters, aggregations, projections, and UPDATE/MERGE/DELETE commands:",
+          "<treeNode>"
         ]
       },
       "UNSUPPORTED_IN_EXISTS_SUBQUERY" : {
         "message" : [
-          "IN/EXISTS predicate subqueries can only be used in filters, joins, aggregations, window functions, projections, and UPDATE/MERGE/DELETE commands:\n<treeNode>."
+          "IN/EXISTS predicate subqueries can only be used in filters, joins, aggregations, window functions, projections, and UPDATE/MERGE/DELETE commands:",
+          "<treeNode>"
         ]
       },
       "UNSUPPORTED_TABLE_ARGUMENT" : {
         "message" : [
-          "Table arguments are used in a function where they are not supported:\n<treeNode>."
+          "Table arguments are used in a function where they are not supported:",
+          "<treeNode>"
         ]
       }
     },

--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -4497,7 +4497,7 @@
     "subClass" : {
       "ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED" : {
         "message" : [
-          "Accessing outer query column is not allowed in this location<treeNode>."
+          "Accessing outer query column is not allowed in this location:\n<treeNode>."
         ]
       },
       "AGGREGATE_FUNCTION_MIXED_OUTER_LOCAL_REFERENCES" : {
@@ -4507,7 +4507,7 @@
       },
       "CORRELATED_COLUMN_IS_NOT_ALLOWED_IN_PREDICATE" : {
         "message" : [
-          "Correlated column is not allowed in predicate: <treeNode>."
+          "Correlated column is not allowed in predicate:\n<treeNode>."
         ]
       },
       "CORRELATED_COLUMN_NOT_FOUND" : {
@@ -4542,7 +4542,7 @@
       },
       "NON_DETERMINISTIC_LATERAL_SUBQUERIES" : {
         "message" : [
-          "Non-deterministic lateral subqueries are not supported when joining with outer relations that produce more than one row<treeNode>."
+          "Non-deterministic lateral subqueries are not supported when joining with outer relations that produce more than one row:\n<treeNode>."
         ]
       },
       "UNSUPPORTED_CORRELATED_REFERENCE_DATA_TYPE" : {
@@ -4552,17 +4552,17 @@
       },
       "UNSUPPORTED_CORRELATED_SCALAR_SUBQUERY" : {
         "message" : [
-          "Correlated scalar subqueries can only be used in filters, aggregations, projections, and UPDATE/MERGE/DELETE commands<treeNode>."
+          "Correlated scalar subqueries can only be used in filters, aggregations, projections, and UPDATE/MERGE/DELETE commands:\n<treeNode>."
         ]
       },
       "UNSUPPORTED_IN_EXISTS_SUBQUERY" : {
         "message" : [
-          "IN/EXISTS predicate subqueries can only be used in filters, joins, aggregations, window functions, projections, and UPDATE/MERGE/DELETE commands<treeNode>."
+          "IN/EXISTS predicate subqueries can only be used in filters, joins, aggregations, window functions, projections, and UPDATE/MERGE/DELETE commands:\n<treeNode>."
         ]
       },
       "UNSUPPORTED_TABLE_ARGUMENT" : {
         "message" : [
-          "Table arguments are used in a function where they are not supported<treeNode>."
+          "Table arguments are used in a function where they are not supported:\n<treeNode>."
         ]
       }
     },

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -150,6 +150,8 @@ class SparkThrowableSuite extends SparkFunSuite {
     }
     messageSeq.foreach { message =>
       message.foreach { msg =>
+        // Error messages in the JSON file should not contain newline characters:
+        // newlines are delineated as different elements in the array.
         assert(!msg.contains("\n"))
         assert(msg.trim == msg)
       }

--- a/docs/sql-error-conditions-unsupported-subquery-expression-category-error-class.md
+++ b/docs/sql-error-conditions-unsupported-subquery-expression-category-error-class.md
@@ -32,7 +32,8 @@ This error class has the following derived error classes:
 
 ## ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED
 
-Accessing outer query column is not allowed in this location`<treeNode>`.
+Accessing outer query column is not allowed in this location:
+`<treeNode>`
 
 ## AGGREGATE_FUNCTION_MIXED_OUTER_LOCAL_REFERENCES
 
@@ -40,7 +41,8 @@ Found an aggregate function in a correlated predicate that has both outer and lo
 
 ## CORRELATED_COLUMN_IS_NOT_ALLOWED_IN_PREDICATE
 
-Correlated column is not allowed in predicate: `<treeNode>`.
+Correlated column is not allowed in predicate:
+`<treeNode>`
 
 ## CORRELATED_COLUMN_NOT_FOUND
 
@@ -68,7 +70,8 @@ A GROUP BY clause in a scalar correlated subquery cannot contain non-correlated 
 
 ## NON_DETERMINISTIC_LATERAL_SUBQUERIES
 
-Non-deterministic lateral subqueries are not supported when joining with outer relations that produce more than one row`<treeNode>`.
+Non-deterministic lateral subqueries are not supported when joining with outer relations that produce more than one row:
+`<treeNode>`
 
 ## UNSUPPORTED_CORRELATED_REFERENCE_DATA_TYPE
 
@@ -76,14 +79,17 @@ Correlated column reference '`<expr>`' cannot be `<dataType>` type.
 
 ## UNSUPPORTED_CORRELATED_SCALAR_SUBQUERY
 
-Correlated scalar subqueries can only be used in filters, aggregations, projections, and UPDATE/MERGE/DELETE commands`<treeNode>`.
+Correlated scalar subqueries can only be used in filters, aggregations, projections, and UPDATE/MERGE/DELETE commands:
+`<treeNode>`
 
 ## UNSUPPORTED_IN_EXISTS_SUBQUERY
 
-IN/EXISTS predicate subqueries can only be used in filters, joins, aggregations, window functions, projections, and UPDATE/MERGE/DELETE commands`<treeNode>`.
+IN/EXISTS predicate subqueries can only be used in filters, joins, aggregations, window functions, projections, and UPDATE/MERGE/DELETE commands:
+`<treeNode>`
 
 ## UNSUPPORTED_TABLE_ARGUMENT
 
-Table arguments are used in a function where they are not supported`<treeNode>`.
+Table arguments are used in a function where they are not supported:
+`<treeNode>`
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix formatting of error messages.

Example: In several error messages, we are concatenating the plan without any separation: `in this locationFilter (dept_id#652`. We should add a colon and space or newline in between. 

Before:
```
org.apache.spark.sql.catalyst.ExtendedAnalysisException: [UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED] Unsupported subquery expression: Accessing outer query column is not allowed in this locationFilter (dept_id#22 = outer(dept_id#16))
+- SubqueryAlias dept
   +- View (`DEPT`, [dept_id#22, dept_name#23, state#24])
      +- Project [cast(dept_id#25 as int) AS dept_id#22, cast(dept_name#26 as string) AS dept_name#23, cast(state#27 as string) AS state#24]
         +- Project [dept_id#25, dept_name#26, state#27]
            +- SubqueryAlias DEPT
               +- LocalRelation [dept_id#25, dept_name#26, state#27]
. SQLSTATE: 0A000; line 3 pos 19;
```
After:
```
org.apache.spark.sql.catalyst.ExtendedAnalysisException: [UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.ACCESSING_OUTER_QUERY_COLUMN_IS_NOT_ALLOWED] Unsupported subquery expression: Accessing outer query column is not allowed in this location:
Filter (dept_id#71 = outer(dept_id#65))
+- SubqueryAlias dept
   +- View (`DEPT`, [dept_id#71, dept_name#72, state#73])
      +- Project [cast(dept_id#74 as int) AS dept_id#71, cast(dept_name#75 as string) AS dept_name#72, cast(state#76 as string) AS state#73]
         +- Project [dept_id#74, dept_name#75, state#76]
            +- SubqueryAlias DEPT
               +- LocalRelation [dept_id#74, dept_name#75, state#76]
. SQLSTATE: 0A000; line 3 pos 19;
```

### Why are the changes needed?
Improve error messages readability.

### Does this PR introduce _any_ user-facing change?
Improve error messages readability.

### How was this patch tested?
Unit tests

### Was this patch authored or co-authored using generative AI tooling?
No