### PR TITLE
[SPARK-47826][SQL][PYTHON] Add VariantVal for PySpark

### DIFF
--- a/python/docs/source/reference/pyspark.sql/core_classes.rst
+++ b/python/docs/source/reference/pyspark.sql/core_classes.rst
@@ -49,3 +49,4 @@ Core Classes
     datasource.DataSourceRegistration
     datasource.InputPartition
     datasource.WriterCommitMessage
+    VariantVal

--- a/python/docs/source/reference/pyspark.sql/variant_val.rst
+++ b/python/docs/source/reference/pyspark.sql/variant_val.rst
@@ -16,31 +16,12 @@
     under the License.
 
 
-=========
-Spark SQL
-=========
+===
+VariantVal
+===
+.. currentmodule:: pyspark.sql
 
-This page gives an overview of all public Spark SQL API.
+.. autosummary::
+    :toctree: api/
 
-.. toctree::
-    :maxdepth: 2
-
-    core_classes
-    spark_session
-    configuration
-    io
-    dataframe
-    column
-    data_types
-    row
-    functions
-    window
-    grouping
-    catalog
-    avro
-    observation
-    udf
-    udtf
-    variant_val
-    protobuf
-    datasource
+    VariantVal.toPython

--- a/python/docs/source/reference/pyspark.sql/variant_val.rst
+++ b/python/docs/source/reference/pyspark.sql/variant_val.rst
@@ -16,9 +16,9 @@
     under the License.
 
 
-===
+==========
 VariantVal
-===
+==========
 .. currentmodule:: pyspark.sql
 
 .. autosummary::

--- a/python/pyspark/sql/__init__.py
+++ b/python/pyspark/sql/__init__.py
@@ -67,6 +67,7 @@ __all__ = [
     "Row",
     "DataFrameNaFunctions",
     "DataFrameStatFunctions",
+    "VariantVal",
     "Window",
     "WindowSpec",
     "DataFrameReader",

--- a/python/pyspark/sql/__init__.py
+++ b/python/pyspark/sql/__init__.py
@@ -39,7 +39,7 @@ Important classes of Spark SQL and DataFrames:
     - :class:`pyspark.sql.Window`
       For working with window functions.
 """
-from pyspark.sql.types import Row
+from pyspark.sql.types import Row, VariantVal
 from pyspark.sql.context import SQLContext, HiveContext, UDFRegistration, UDTFRegistration
 from pyspark.sql.session import SparkSession
 from pyspark.sql.column import Column

--- a/python/pyspark/sql/connect/conversion.py
+++ b/python/pyspark/sql/connect/conversion.py
@@ -301,9 +301,11 @@ class LocalDataToArrowConversion:
                     if not nullable:
                         raise PySparkValueError(f"input for {dataType} must not be None")
                     return None
-                elif (isinstance(value, dict) and
-                    all(key in value for key in ["value", "metadata"]) and
-                    all(isinstance(value[key], bytes) for key in ["value", "metadata"])):
+                elif (
+                    isinstance(value, dict)
+                    and all(key in value for key in ["value", "metadata"])
+                    and all(isinstance(value[key], bytes) for key in ["value", "metadata"])
+                ):
                     return VariantVal(value["value"], value["metadata"])
                 else:
                     raise PySparkValueError(error_class="MALFORMED_VARIANT")
@@ -515,9 +517,11 @@ class ArrowTableToRowsConversion:
             def convert_variant(value: Any) -> Any:
                 if value is None:
                     return None
-                elif (isinstance(value, dict) and
-                    all(key in value for key in ["value", "metadata"]) and
-                    all(isinstance(value[key], bytes) for key in ["value", "metadata"])):
+                elif (
+                    isinstance(value, dict)
+                    and all(key in value for key in ["value", "metadata"])
+                    and all(isinstance(value[key], bytes) for key in ["value", "metadata"])
+                ):
                     return VariantVal(value["value"], value["metadata"])
                 else:
                     raise PySparkValueError(error_class="MALFORMED_VARIANT")

--- a/python/pyspark/sql/connect/conversion.py
+++ b/python/pyspark/sql/connect/conversion.py
@@ -40,6 +40,8 @@ from pyspark.sql.types import (
     DecimalType,
     StringType,
     UserDefinedType,
+    VariantType,
+    VariantVal,
 )
 
 from pyspark.storagelevel import StorageLevel
@@ -94,6 +96,8 @@ class LocalDataToArrowConversion:
             # Coercion to StringType is allowed
             return True
         elif isinstance(dataType, UserDefinedType):
+            return True
+        elif isinstance(dataType, VariantType):
             return True
         else:
             return False
@@ -290,6 +294,22 @@ class LocalDataToArrowConversion:
 
             return convert_udt
 
+        elif isinstance(dataType, VariantType):
+
+            def convert_variant(value: Any) -> Any:
+                if value is None:
+                    if not nullable:
+                        raise PySparkValueError(f"input for {dataType} must not be None")
+                    return None
+                elif (isinstance(value, dict) and
+                    all(key in value for key in ["value", "metadata"]) and
+                    all(isinstance(value[key], bytes) for key in ["value", "metadata"])):
+                    return VariantVal(value["value"], value["metadata"])
+                else:
+                    raise PySparkValueError(error_class="MALFORMED_VARIANT")
+
+            return convert_variant
+
         elif not nullable:
 
             def convert_other(value: Any) -> Any:
@@ -380,6 +400,8 @@ class ArrowTableToRowsConversion:
             # Always remove the time zone info for now
             return True
         elif isinstance(dataType, UserDefinedType):
+            return True
+        elif isinstance(dataType, VariantType):
             return True
         else:
             return False
@@ -487,6 +509,20 @@ class ArrowTableToRowsConversion:
                     return udt.deserialize(conv(value))
 
             return convert_udt
+
+        elif isinstance(dataType, VariantType):
+
+            def convert_variant(value: Any) -> Any:
+                if value is None:
+                    return None
+                elif (isinstance(value, dict) and
+                    all(key in value for key in ["value", "metadata"]) and
+                    all(isinstance(value[key], bytes) for key in ["value", "metadata"])):
+                    return VariantVal(value["value"], value["metadata"])
+                else:
+                    raise PySparkValueError(error_class="MALFORMED_VARIANT")
+
+            return convert_variant
 
         else:
             return lambda value: value

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -47,6 +47,8 @@ from pyspark.sql.types import (
     NullType,
     DataType,
     UserDefinedType,
+    VariantType,
+    VariantVal,
     _create_row,
 )
 from pyspark.errors import PySparkTypeError, UnsupportedOperationException, PySparkValueError
@@ -108,6 +110,12 @@ def to_arrow_type(dt: DataType) -> "pa.DataType":
         arrow_type = pa.null()
     elif isinstance(dt, UserDefinedType):
         arrow_type = to_arrow_type(dt.sqlType())
+    elif type(dt) == VariantType:
+        fields = [
+            pa.field("value", pa.binary(), nullable=False),
+            pa.field("metadata", pa.binary(), nullable=False),
+        ]
+        arrow_type = pa.struct(fields)
     else:
         raise PySparkTypeError(
             error_class="UNSUPPORTED_DATA_TYPE_FOR_ARROW_CONVERSION",
@@ -762,6 +770,18 @@ def _create_converter_to_pandas(
                         return udt.deserialize(conv(value))
 
             return convert_udt
+
+        elif isinstance(dt, VariantType):
+
+            def convert_variant(value: Any) -> Any:
+                if (isinstance(value, dict) and
+                    all(key in value for key in ["value", "metadata"]) and
+                    all(isinstance(value[key], bytes) for key in ["value", "metadata"])):
+                    return VariantVal(value["value"], value["metadata"])
+                else:
+                    raise PySparkValueError(error_class="MALFORMED_VARIANT")
+
+            return convert_variant
 
         else:
             return None

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -774,9 +774,11 @@ def _create_converter_to_pandas(
         elif isinstance(dt, VariantType):
 
             def convert_variant(value: Any) -> Any:
-                if (isinstance(value, dict) and
-                    all(key in value for key in ["value", "metadata"]) and
-                    all(isinstance(value[key], bytes) for key in ["value", "metadata"])):
+                if (
+                    isinstance(value, dict)
+                    and all(key in value for key in ["value", "metadata"])
+                    and all(isinstance(value[key], bytes) for key in ["value", "metadata"])
+                ):
                     return VariantVal(value["value"], value["metadata"])
                 else:
                     raise PySparkValueError(error_class="MALFORMED_VARIANT")

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -58,6 +58,7 @@ from pyspark.sql.types import (
     BooleanType,
     NullType,
     VariantType,
+    VariantVal,
 )
 from pyspark.sql.types import (
     _array_signed_int_typecode_ctype_mappings,
@@ -1405,6 +1406,68 @@ class TypesTestsMixin:
     def test_calendar_interval_type_with_sf(self):
         schema1 = self.spark.range(1).select(F.make_interval(F.lit(1))).schema
         self.assertEqual(schema1.fields[0].dataType, CalendarIntervalType())
+
+    def test_variant_type(self):
+        from decimal import Decimal
+        self.assertEqual(VariantType().simpleString(), "variant")
+
+        # Holds a tuple of (key, json string value, python value)
+        expected_values = [
+            ("str", '"%s"' % ("0123456789" * 10), "0123456789" * 10),
+            ("short_str", '"abc"', "abc"),
+            ("null", "null", None),
+            ("true", "true", True),
+            ("false", "false", False),
+            ("int1", "1", 1),
+            ("-int1", "-5", -5),
+            ("int2", "257", 257),
+            ("-int2", "-124", -124),
+            ("int4", "65793", 65793),
+            ("-int4", "-69633", -69633),
+            ("int8", "4295033089", 4295033089),
+            ("-int8", "-4294967297", -4294967297),
+            ("float4", "1.23456789e-30", 1.23456789e-30),
+            ("-float4", "-4.56789e+29", -4.56789e+29),
+            ("dec4", "123.456", Decimal("123.456")),
+            ("-dec4", "-321.654", Decimal("-321.654")),
+            ("dec8", "429.4967297", Decimal("429.4967297")),
+            ("-dec8", "-5.678373902", Decimal("-5.678373902")),
+            ("dec16", "467440737095.51617", Decimal("467440737095.51617")),
+            ("-dec16", "-67.849438003827263", Decimal("-67.849438003827263")),
+            ("arr", '[1.1,"2",[3],{"4":5}]', [Decimal("1.1"), "2", [3], {"4": 5}]),
+            ("obj", '{"a":["123",{"b":2}],"c":3}', {"a": ["123", {"b": 2}], "c": 3}),
+        ]
+        json_str = "{%s}" % ",".join(['"%s": %s' % (t[0], t[1]) for t in expected_values])
+
+        df = self.spark.createDataFrame([({"json": json_str})])
+        row = df.select(F.parse_json(df.json).alias("v"),
+            F.array([F.parse_json(F.lit('{"a": 1}'))]).alias("a"),
+            F.struct([F.parse_json(F.lit('{"b": "2"}'))]).alias("s"),
+            F.create_map(
+                [F.lit("k"), F.parse_json(F.lit('{"c": true}'))]).alias("m")).collect()[0]
+        variants = [row["v"], row["a"][0], row["s"]["col1"], row["m"]["k"]]
+        for v in variants:
+            self.assertEqual(type(v), VariantVal)
+
+        # check str
+        as_string = str(variants[0])
+        for (key, expected, _) in expected_values:
+            self.assertTrue('"%s":%s' % (key, expected) in as_string)
+        self.assertEqual(str(variants[1]), '{"a":1}')
+        self.assertEqual(str(variants[2]), '{"b":"2"}')
+        self.assertEqual(str(variants[3]), '{"c":true}')
+
+        # check toPython
+        as_python = variants[0].toPython()
+        for (key, _, obj) in expected_values:
+            self.assertEqual(as_python[key], obj)
+        self.assertEqual(variants[1].toPython(), {"a": 1})
+        self.assertEqual(variants[2].toPython(), {"b": "2"})
+        self.assertEqual(variants[3].toPython(), {"c": True})
+
+        # check repr
+        self.assertEqual(str(variants[0]), str(eval(repr(variants[0]))))
+
 
     def test_from_ddl(self):
         self.assertEqual(DataType.fromDDL("long"), LongType())

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1348,9 +1348,10 @@ class VariantType(AtomicType):
     def needConversion(self) -> bool:
         return True
 
-    def fromInternal(self, obj: Dict) -> "VariantVal":
-        if obj is not None and all(key in obj for key in ["value", "metadata"]):
-            return VariantVal(obj["value"], obj["metadata"])
+    def fromInternal(self, obj: Dict) -> Optional["VariantVal"]:
+        if obj is None or all(key in obj for key in ["value", "metadata"]):
+            return None
+        return VariantVal(obj["value"], obj["metadata"])
 
 
 class UserDefinedType(DataType):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1478,6 +1478,27 @@ class UserDefinedType(DataType):
 class VariantVal:
     """
     A class to represent a Variant value in Python.
+
+    .. versionadded:: 4.0.0
+
+    Parameters
+    ----------
+    value : bytes
+        The bytes representing the value component of the Variant.
+    metadata : bytes
+        The bytes representing the metadata component of the Variant.
+
+    Methods
+    -------
+    toPython()
+        Convert the VariantVal to a Python data structure.
+
+    Examples
+    --------
+    >>> df = spark.createDataFrame([ {'json': '''{ "a" : 1 }'''} ])
+    >>> v = df.select(parse_json(df.json).alias("var")).collect()[0].var
+    >>> v.toPython()
+    {'a': 1}
     """
 
     def __init__(self, value: bytes, metadata: bytes):
@@ -1485,22 +1506,19 @@ class VariantVal:
         self.metadata = metadata
 
     def __str__(self) -> str:
-        return self.toString()
+        return VariantUtils.to_json(self.value, self.metadata)
 
     def __repr__(self) -> str:
         return "VariantVal(%s, %s)" % (self.value, self.metadata)
 
-    def toString(self) -> str:
-        """
-        Convert the VariantVal to a string.
-        :return: a string representation of the Variant
-        """
-        return VariantUtils.to_json(self.value, self.metadata)
-
-    def toPython(self) -> str:
+    def toPython(self) -> Any:
         """
         Convert the VariantVal to a Python data structure.
-        :return: a Python object
+
+        Returns
+        -------
+        Any
+            A Python object that represents the Variant.
         """
         return VariantUtils.to_python(self.value, self.metadata)
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -94,6 +94,7 @@ __all__ = [
     "StructField",
     "StructType",
     "VariantType",
+    "VariantVal",
 ]
 
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1349,7 +1349,7 @@ class VariantType(AtomicType):
         return True
 
     def fromInternal(self, obj: Dict) -> Optional["VariantVal"]:
-        if obj is None or all(key in obj for key in ["value", "metadata"]):
+        if obj is None or not all(key in obj for key in ["value", "metadata"]):
             return None
         return VariantVal(obj["value"], obj["metadata"])
 

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1495,6 +1495,7 @@ class VariantVal:
 
     Examples
     --------
+    >>> from pyspark.sql.functions import *
     >>> df = spark.createDataFrame([ {'json': '''{ "a" : 1 }'''} ])
     >>> v = df.select(parse_json(df.json).alias("var")).collect()[0].var
     >>> v.toPython()

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1349,9 +1349,8 @@ class VariantType(AtomicType):
         return True
 
     def fromInternal(self, obj: Dict) -> "VariantVal":
-        if obj is None or not all(key in obj for key in ["value", "metadata"]):
-            return
-        return VariantVal(obj["value"], obj["metadata"])
+        if obj is not None and all(key in obj for key in ["value", "metadata"]):
+            return VariantVal(obj["value"], obj["metadata"])
 
 
 class UserDefinedType(DataType):
@@ -1510,7 +1509,7 @@ class VariantVal:
         return VariantUtils.to_json(self.value, self.metadata)
 
     def __repr__(self) -> str:
-        return "VariantVal(%s, %s)" % (self.value, self.metadata)
+        return "VariantVal(%r, %r)" % (self.value, self.metadata)
 
     def toPython(self) -> Any:
         """

--- a/python/pyspark/sql/variant_utils.py
+++ b/python/pyspark/sql/variant_utils.py
@@ -1,0 +1,376 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import decimal
+import json
+import struct
+from array import array
+from typing import Any
+
+class VariantUtils:
+    """
+    A utility class for VariantVal.
+
+    Adapted from library at: org.apache.spark.types.variant.VariantUtil
+    """
+
+    BASIC_TYPE_BITS = 2
+    BASIC_TYPE_MASK = 0x3
+    TYPE_INFO_MASK = 0x3F
+    # The inclusive maximum value of the type info value. It is the size limit of `SHORT_STR`.
+    MAX_SHORT_STR_SIZE = 0x3F
+
+    # Below is all possible basic type values.
+    # Primitive value. The type info value must be one of the values in the below section.
+    PRIMITIVE = 0
+    # Short string value. The type info value is the string size, which must be in `[0,
+    # MAX_SHORT_STR_SIZE]`.
+    # The string content bytes directly follow the header byte.
+    SHORT_STR = 1
+    # Object value. The content contains a size, a list of field ids, a list of field offsets, and
+    # the actual field data. The length of the id list is `size`, while the length of the offset
+    # list is `size + 1`, where the last offset represent the total size of the field data. The
+    # fields in an object must be sorted by the field name in alphabetical order. Duplicate field
+    # names in one object are not allowed.
+    # We use 5 bits in the type info to specify the integer type of the object header: it should
+    # be 0_b4_b3b2_b1b0 (MSB is 0), where:
+    # - b4 specifies the type of size. When it is 0/1, `size` is a little-endian 1/4-byte
+    # unsigned integer.
+    # - b3b2/b1b0 specifies the integer type of id and offset. When the 2 bits are  0/1/2, the
+    # list contains 1/2/3-byte little-endian unsigned integers.
+    OBJECT = 2
+    # Array value. The content contains a size, a list of field offsets, and the actual element
+    # data. It is similar to an object without the id list. The length of the offset list
+    # is `size + 1`, where the last offset represent the total size of the element data.
+    # Its type info should be: 000_b2_b1b0:
+    # - b2 specifies the type of size.
+    # - b1b0 specifies the integer type of offset.
+    ARRAY = 3
+
+    # Below is all possible type info values for `PRIMITIVE`.
+    # JSON Null value. Empty content.
+    NULL = 0
+    # True value. Empty content.
+    TRUE = 1
+    # False value. Empty content.
+    FALSE = 2
+    # 1-byte little-endian signed integer.
+    INT1 = 3
+    # 2-byte little-endian signed integer.
+    INT2 = 4
+    # 4-byte little-endian signed integer.
+    INT4 = 5
+    # 4-byte little-endian signed integer.
+    INT8 = 6
+    # 8-byte IEEE double.
+    DOUBLE = 7
+    # 4-byte decimal. Content is 1-byte scale + 4-byte little-endian signed integer.
+    DECIMAL4 = 8
+    # 8-byte decimal. Content is 1-byte scale + 8-byte little-endian signed integer.
+    DECIMAL8 = 9
+    # 16-byte decimal. Content is 1-byte scale + 16-byte little-endian signed integer.
+    DECIMAL16 = 10
+    # Long string value. The content is (4-byte little-endian unsigned integer representing the
+    # string size) + (size bytes of string content).
+    LONG_STR = 16
+
+    U32_SIZE = 4
+
+    @classmethod
+    def to_json(cls, value: bytes, metadata: bytes) -> str:
+        """
+        Convert the VariantVal to a JSON string.
+        :return: JSON string
+        """
+        return cls._to_json(value, metadata, 0)
+
+
+    @classmethod
+    def to_python(cls, value: bytes, metadata: bytes) -> str:
+        """
+        Convert the VariantVal to a nested Python object of Python data types.
+        :return: Python representation of the Variant nested structure
+        """
+        return cls._to_python(value, metadata, 0)
+
+
+    @classmethod
+    def _read_long(cls, data: bytes, pos: int, num_bytes: int, signed: bool) -> int:
+        cls._check_index(pos, len(data))
+        cls._check_index(pos + num_bytes - 1, len(data))
+        return int.from_bytes(data[pos:pos + num_bytes], byteorder='little', signed=signed)
+
+
+    @classmethod
+    def _check_index(cls, pos: int, length: int) -> None:
+        if (pos < 0 or pos >= length):
+            raise Exception("Malformed Variant")
+
+
+    @classmethod
+    def _get_type_info(cls, value: bytes, pos: int):
+        """
+        Returns the (basic_type, type_info) pair from the given position in the value.
+        """
+        basic_type = value[pos] & VariantUtils.BASIC_TYPE_MASK
+        type_info = (value[pos] >> VariantUtils.BASIC_TYPE_BITS) & VariantUtils.TYPE_INFO_MASK
+        return (basic_type, type_info)
+
+
+    @classmethod
+    def _get_metadata_key(cls, metadata: bytes, id: int) -> str:
+        """
+        Returns the key string from the dictionary in the metadata, corresponding to `id`.
+        """
+        cls._check_index(0, len(metadata))
+        offset_size = ((metadata[0] >> 6) & 0x3) + 1
+        dict_size = cls._read_long(metadata, 1, offset_size, signed=False)
+        if id >= dict_size:
+            raise Exception("Malformed Variant")
+        string_start = 1 + (dict_size + 2) * offset_size
+        offset = cls._read_long(metadata, 1 + (id + 1) * offset_size, offset_size, signed=False)
+        next_offset = cls._read_long(
+            metadata, 1 + (id + 2) * offset_size, offset_size, signed=False)
+        if offset > next_offset:
+            raise Exception("Malformed Variant")
+        cls._check_index(string_start + next_offset - 1, len(metadata))
+        return metadata[string_start + offset:(string_start + next_offset)].decode("utf-8")
+
+
+    @classmethod
+    def _get_boolean(cls, value: bytes, pos: int) -> bool:
+        cls._check_index(pos, len(value))
+        basic_type, type_info = cls._get_type_info(value, pos)
+        if (basic_type != VariantUtils.PRIMITIVE or
+            (type_info != VariantUtils.TRUE and type_info != VariantUtils.FALSE)):
+            raise Exception("Unexpected Variant type: %s" % (str(bool)))
+        return type_info == VariantUtils.TRUE
+
+
+    @classmethod
+    def _get_long(cls, value: bytes, pos: int) -> int:
+        cls._check_index(pos, len(value))
+        basic_type, type_info = cls._get_type_info(value, pos)
+        if basic_type != VariantUtils.PRIMITIVE:
+            raise Exception("Unexpected Variant type: %s" % (str(int)))
+        if type_info == VariantUtils.INT1:
+            return cls._read_long(value, pos + 1, 1, signed=True)
+        elif type_info == VariantUtils.INT2:
+            return cls._read_long(value, pos + 1, 2, signed=True)
+        elif type_info == VariantUtils.INT4:
+            return cls._read_long(value, pos + 1, 4, signed=True)
+        elif type_info == VariantUtils.INT8:
+            return cls._read_long(value, pos + 1, 8, signed=True)
+        raise Exception("Unexpected Variant type: %s" % (str(int)))
+
+
+    @classmethod
+    def _get_string(cls, value: bytes, pos: int) -> str:
+        cls._check_index(pos, len(value))
+        basic_type, type_info = cls._get_type_info(value, pos)
+        if (basic_type == VariantUtils.SHORT_STR or
+            (basic_type == VariantUtils.PRIMITIVE and type_info == VariantUtils.LONG_STR)):
+            start = 0
+            length = 0
+            if basic_type == VariantUtils.SHORT_STR:
+                start = pos + 1
+                length = type_info
+            else:
+                start = pos + 1 + VariantUtils.U32_SIZE
+                length = cls._read_long(value, pos + 1, VariantUtils.U32_SIZE, signed=False)
+            cls._check_index(start + length - 1, len(value))
+            return value[start:start + length].decode("utf-8")
+        raise Exception("Unexpected Variant type: %s" % (str(str)))
+
+
+    @classmethod
+    def _get_double(cls, value: bytes, pos: int) -> float:
+        cls._check_index(pos, len(value))
+        basic_type, type_info = cls._get_type_info(value, pos)
+        if (basic_type != VariantUtils.PRIMITIVE or type_info != VariantUtils.DOUBLE):
+            raise Exception("Unexpected Variant type: %s" % (str(float)))
+        return struct.unpack('d', value[pos + 1:pos + 9])[0]
+
+
+    @classmethod
+    def _get_decimal(cls, value: bytes, pos: int) -> decimal.Decimal:
+        cls._check_index(pos, len(value))
+        basic_type, type_info = cls._get_type_info(value, pos)
+        if basic_type != VariantUtils.PRIMITIVE:
+            raise Exception("Unexpected Variant type: %s" % (str(Decimal)))
+        scale = value[pos + 1]
+        unscaled = 0
+        if type_info == VariantUtils.DECIMAL4:
+            unscaled = cls._read_long(value, pos + 2, 4, signed=True)
+        elif type_info == VariantUtils.DECIMAL8:
+            unscaled = cls._read_long(value, pos + 2, 8, signed=True)
+        elif type_info == VariantUtils.DECIMAL16:
+            cls._check_index(pos + 17, len(value))
+            unscaled = int.from_bytes(value[pos + 2:pos + 18], byteorder='little', signed=True)
+        else:
+            raise Exception("Unexpected Variant type: %s" % (str(Decimal)))
+        return decimal.Decimal(unscaled) * (decimal.Decimal(10) ** (-scale))
+
+
+    @classmethod
+    def _get_type(cls, value: bytes, pos: int):
+        """
+        Returns the Python type of the Variant at the given position.
+        """
+        cls._check_index(pos, len(value))
+        basic_type, type_info = cls._get_type_info(value, pos)
+        if basic_type == VariantUtils.SHORT_STR:
+           return str
+        elif basic_type == VariantUtils.OBJECT:
+            return dict
+        elif basic_type == VariantUtils.ARRAY:
+            return array
+        elif type_info == VariantUtils.NULL:
+            return type(None)
+        elif type_info == VariantUtils.TRUE or type_info == VariantUtils.FALSE:
+            return bool
+        elif (type_info == VariantUtils.INT1 or type_info == VariantUtils.INT2 or
+              type_info == VariantUtils.INT4 or type_info == VariantUtils.INT8):
+            return int
+        elif type_info == VariantUtils.DOUBLE:
+            return float
+        elif (type_info == VariantUtils.DECIMAL4 or type_info == VariantUtils.DECIMAL8 or
+            type_info == VariantUtils.DECIMAL16):
+            return decimal.Decimal
+        elif type_info == VariantUtils.LONG_STR:
+            return str
+        raise Exception("Malformed Variant")
+
+
+    @classmethod
+    def _to_json(cls, value: bytes, metadata: bytes, pos: int) -> Any:
+        variant_type = cls._get_type(value, pos)
+        if variant_type == dict:
+            def handle_object(key_value_pos_list):
+                key_value_list = [
+                    json.dumps(key) + ':' + cls._to_json(value, metadata, value_pos)
+                    for (key, value_pos) in key_value_pos_list]
+                return '{' + ','.join(key_value_list) + '}'
+            return cls._handle_object(value, metadata, pos, handle_object)
+        elif variant_type == array:
+            def handle_array(value_pos_list):
+                value_list = [cls._to_json(value, metadata, value_pos)
+                    for value_pos in value_pos_list]
+                return '[' + ','.join(value_list) + ']'
+            return cls._handle_array(value, pos, handle_array)
+        else:
+            value = cls._get_scalar(variant_type, value, metadata, pos)
+            if value == None:
+                return "null"
+            if type(value) == bool:
+                return "true" if value else "false"
+            if type(value) == str:
+                return json.dumps(value)
+            return str(value)
+
+
+    @classmethod
+    def _to_python(cls, value: bytes, metadata: bytes, pos: int) -> Any:
+        variant_type = cls._get_type(value, pos)
+        if variant_type == dict:
+            def handle_object(key_value_pos_list):
+                key_value_list = [
+                    (key, cls._to_python(value, metadata, value_pos))
+                    for (key, value_pos) in key_value_pos_list]
+                return dict(key_value_list)
+            return cls._handle_object(value, metadata, pos, handle_object)
+        elif variant_type == array:
+            def handle_array(value_pos_list):
+                value_list = [cls._to_python(value, metadata, value_pos)
+                    for value_pos in value_pos_list]
+                return value_list
+            return cls._handle_array(value, pos, handle_array)
+        else:
+            return cls._get_scalar(variant_type, value, metadata, pos)
+
+
+    @classmethod
+    def _get_scalar(cls, variant_type, value: bytes, metadata: bytes, pos: int) -> Any:
+        if variant_type == type(None):
+            return None
+        elif variant_type == bool:
+            return cls._get_boolean(value, pos)
+        elif variant_type == int:
+            return cls._get_long(value, pos)
+        elif variant_type == str:
+            return cls._get_string(value, pos)
+        elif variant_type == float:
+            return cls._get_double(value, pos)
+        elif variant_type == decimal.Decimal:
+            return cls._get_decimal(value, pos)
+        else:
+            raise Exception("Malformed Variant")
+
+
+    @classmethod
+    def _handle_object(cls, value: bytes, metadata: bytes, pos: int, func):
+        """
+        Parses the variant object at position `pos`.
+        Calls `func` with a list of (key, value position) pairs of the object.
+        """
+        cls._check_index(pos, len(value))
+        basic_type, type_info = cls._get_type_info(value, pos)
+        if basic_type != VariantUtils.OBJECT:
+            raise Exception("Malformed Variant")
+        large_size = ((type_info >> 4) & 0x1) != 0
+        size_bytes = VariantUtils.U32_SIZE if large_size else 1
+        num_fields = cls._read_long(value, pos + 1, size_bytes, signed=False)
+        id_size = ((type_info >> 2) & 0x3) + 1
+        offset_size = ((type_info) & 0x3) + 1
+        id_start = pos + 1 + size_bytes
+        offset_start = id_start + num_fields * id_size
+        data_start = offset_start + (num_fields + 1) * offset_size
+
+        key_value_pos_list = []
+        for i in range(num_fields):
+            id = cls._read_long(value, id_start + id_size * i, id_size, signed=False)
+            offset = cls._read_long(
+                value, offset_start + offset_size * i, offset_size, signed=False)
+            value_pos = data_start + offset
+            key_value_pos_list.append((cls._get_metadata_key(metadata, id), value_pos))
+        return func(key_value_pos_list)
+
+
+    @classmethod
+    def _handle_array(cls, value: bytes, pos: int, func):
+        """
+        Parses the variant array at position `pos`.
+        Calls `func` with a list of element positions of the array.
+        """
+        cls._check_index(pos, len(value))
+        basic_type, type_info = cls._get_type_info(value, pos)
+        if basic_type != VariantUtils.ARRAY:
+            raise Exception("Malformed Variant")
+        large_size = ((type_info >> 2) & 0x1) != 0
+        size_bytes = VariantUtils.U32_SIZE if large_size else 1
+        num_fields = cls._read_long(value, pos + 1, size_bytes, signed=False)
+        offset_size = (type_info & 0x3) + 1
+        offset_start = pos + 1 + size_bytes
+        data_start = offset_start + (num_fields + 1) * offset_size
+
+        value_pos_list = []
+        for i in range(num_fields):
+            offset = cls._read_long(
+                value, offset_start + offset_size * i, offset_size, signed=False)
+            element_pos = data_start + offset
+            value_pos_list.append(element_pos)
+        return func(value_pos_list)

--- a/python/pyspark/sql/variant_utils.py
+++ b/python/pyspark/sql/variant_utils.py
@@ -22,6 +22,7 @@ from array import array
 from typing import Any
 from pyspark.errors import PySparkValueError
 
+
 class VariantUtils:
     """
     A utility class for VariantVal.

--- a/python/pyspark/sql/variant_utils.py
+++ b/python/pyspark/sql/variant_utils.py
@@ -280,7 +280,7 @@ class VariantUtils:
             return cls._handle_array(value, pos, handle_array)
         else:
             value = cls._get_scalar(variant_type, value, metadata, pos)
-            if value == None:
+            if value is None:
                 return "null"
             if type(value) == bool:
                 return "true" if value else "false"
@@ -315,7 +315,7 @@ class VariantUtils:
 
     @classmethod
     def _get_scalar(cls, variant_type, value: bytes, metadata: bytes, pos: int) -> Any:
-        if variant_type == type(None):
+        if isinstance(None, variant_type):
             return None
         elif variant_type == bool:
             return cls._get_boolean(value, pos)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a `VariantVal` implementation for PySpark. It includes convenience methods to convert the Variant to a string, or to a Python object.

### Why are the changes needed?

Allows users to work with Variant data more conveniently.

### Does this PR introduce _any_ user-facing change?

This is new PySpark functionality to allow users to work with Variant data.

### How was this patch tested?

Added unit tests.

### Was this patch authored or co-authored using generative AI tooling?
No
