### PR TITLE
[SPARK-47454][PYTHON][TESTS][FOLLOWUP] Skip `test_create_dataframe_from_pandas_with_day_time_interval` if pandas is not avaiable

### DIFF
--- a/python/pyspark/sql/tests/test_creation.py
+++ b/python/pyspark/sql/tests/test_creation.py
@@ -113,7 +113,7 @@ class DataFrameCreationTestsMixin:
 
     # TODO(SPARK-43354): Re-enable test_create_dataframe_from_pandas_with_day_time_interval
     @unittest.skipIf(
-        "pypy" in platform.python_implementation().lower(),
+        "pypy" in platform.python_implementation().lower() or not have_pandas,
         "Fails in PyPy Python 3.8, should enable.",
     )
     def test_create_dataframe_from_pandas_with_day_time_interval(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #45591 to skip `test_create_dataframe_from_pandas_with_day_time_interval` if `pandas` is not available.

### Why are the changes needed?

The test requires `pandas` due to `import pandas as pd`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and manual test.

### Was this patch authored or co-authored using generative AI tooling?

No.