### PR TITLE
[SPARK-47703][SQL] Modify the simpleString of DataSourceV2ScanRelation to distinguish it from DataSourceV2Relation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Relation.scala
@@ -152,7 +152,7 @@ case class DataSourceV2ScanRelation(
   override def name: String = relation.name
 
   override def simpleString(maxFields: Int): String = {
-    s"RelationV2${truncatedString(output, "[", ", ", "]", maxFields)} $name"
+    s"ScanRelationV2${truncatedString(output, "[", ", ", "]", maxFields)} $name"
   }
 
   override def computeStats(): Statistics = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Modify the simpleString of DataSourceV2ScanRelation to distinguish it from DataSourceV2Relation

### Why are the changes needed?
At present, the simpleString of DataSourveV2ScanRelation and DataSourveV2Relation are the same, it is difficult to distinguish them.

before:
```
=== Applying Rule org.apache.spark.sql.execution.datasources.v2.V2ScanRelationPushDown ===
 Subquery true                                                                                                                                 Subquery true
!+- RelationV2[cs_sold_date_sk#116L, cs_sold_time_sk#117L, cs_ship_date_sk#118L, cs_bill_customer_sk#119L, ... 30 more fields] catalog_sales   +- RelationV2[cs_sold_date_sk#116L, cs_sold_time_sk#117L, cs_ship_date_sk#118L, cs_bill_customer_sk#119L, ... 30 more fields] catalog_sales
 
```

after:
```
=== Applying Rule org.apache.spark.sql.execution.datasources.v2.V2ScanRelationPushDown ===
 Subquery true                                                                                                                                 Subquery true
!+- RelationV2[cs_sold_date_sk#116L, cs_sold_time_sk#117L, cs_ship_date_sk#118L, cs_bill_customer_sk#119L, ... 30 more fields] catalog_sales   +- ScanRelationV2[cs_sold_date_sk#116L, cs_sold_time_sk#117L, cs_ship_date_sk#118L, cs_bill_customer_sk#119L, ... 30 more fields] catalog_sales
 
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
