### PR TITLE
[SPARK-47230] [SQL] Push projection through Filter-> Generate

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -325,7 +325,7 @@ case class Generate(
       copy(child = newChild)
     } else {
       val newOut = AttributeMap[Int](newChild.output.zipWithIndex.map(x => x._1 -> x._2))
-      val unRequired = unrequiredChildOutput.map(x => newOut.getOrElse(x, -1)).filter(x => x > 0)
+      val unRequired = unrequiredChildOutput.flatMap(x => newOut.get(x))
       copy(child = newChild, unrequiredChildIndex = unRequired)
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -309,9 +309,8 @@ case class Generate(
 
   def output: Seq[Attribute] = requiredChildOutput ++ qualifiedGeneratorOutput
 
-  override protected def withNewChildInternal(newChild: LogicalPlan): Generate = {
+  override protected def withNewChildInternal(newChild: LogicalPlan): Generate =
     copy(child = newChild)
-  }
 }
 
 case class Filter(condition: Expression, child: LogicalPlan)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -285,11 +285,6 @@ case class Generate(
     child.output.zipWithIndex.filterNot(t => unrequiredSet.contains(t._2)).map(_._1)
   }
 
-  lazy val unrequiredChildOutput: Seq[Attribute] = {
-    val unrequiredSet = unrequiredChildIndex.toSet
-    child.output.zipWithIndex.filter(t => unrequiredSet.contains(t._2)).map(_._1)
-  }
-
   override lazy val resolved: Boolean = {
     generator.resolved &&
       childrenResolved &&
@@ -314,20 +309,8 @@ case class Generate(
 
   def output: Seq[Attribute] = requiredChildOutput ++ qualifiedGeneratorOutput
 
-  /**
-   * Need to recalculate the unrequiredChildIndex as the output of the newChild may not
-   * be the same as the original child, which makes the unrequiredChildIndex incorrect
-   * @param newChild
-   * @return
-   */
   override protected def withNewChildInternal(newChild: LogicalPlan): Generate = {
-    if (!child.resolved || unrequiredChildIndex.isEmpty) {
-      copy(child = newChild)
-    } else {
-      val newOut = AttributeMap[Int](newChild.output.zipWithIndex.map(x => x._1 -> x._2))
-      val unRequired = unrequiredChildOutput.flatMap(x => newOut.get(x))
-      copy(child = newChild, unrequiredChildIndex = unRequired)
-    }
+    copy(child = newChild)
   }
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3295,6 +3295,17 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val NESTED_SCHEMA_PRUNING_THROUGH_FILTER_GENERATE =
+    buildConf("spark.sql.optimizer.nestedSchemaPruningThroughFilterGenerate.enabled")
+      .internal()
+      .doc("This optimization is an enhance for spark.sql.optimizer.nestedSchemaPruning.enabled " +
+        "where it solved the problem that the pruning could be pushed down if there was a filter " +
+        "on one of the nested fields of the exploded field."
+      )
+      .version("3.5.2")
+      .booleanConf
+      .createWithDefault(false)
+
   val DISABLE_HINTS =
     buildConf("spark.sql.optimizer.disableHints")
       .internal()
@@ -5098,6 +5109,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   }
 
   def nestedSchemaPruningEnabled: Boolean = getConf(NESTED_SCHEMA_PRUNING_ENABLED)
+
+  def nestedSchemaPruningThroughFilterGenerate: Boolean =
+    getConf(NESTED_SCHEMA_PRUNING_THROUGH_FILTER_GENERATE)
 
   def serializerNestedSchemaPruningEnabled: Boolean =
     getConf(SERIALIZER_NESTED_SCHEMA_PRUNING_ENABLED)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ColumnPruningSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ColumnPruningSuite.scala
@@ -118,7 +118,7 @@ class ColumnPruningSuite extends PlanTest {
           .where($"explode".isNotNull)
           .analyze
       val optimized = Optimize.execute(query)
-      val aliases = NestedColumnAliasingSuite.collectGeneratedAliases(optimized)
+      val aliases = NestedColumnAliasingSuite.collectGeneratedAliases(optimized).toSeq
       val aliasedExprs: Seq[String] => Seq[Expression] =
         aliases => Seq($"c".getField("d").as(aliases(0)), $"c".getField("e").as(aliases(1)))
       val replacedGenerator: Seq[String] => Generator =
@@ -153,7 +153,7 @@ class ColumnPruningSuite extends PlanTest {
           .where($"explode".getField("h1").isNotNull)
           .analyze
       val optimized = Optimize.execute(query)
-      val aliases = NestedColumnAliasingSuite.collectGeneratedAliases(optimized)
+      val aliases = NestedColumnAliasingSuite.collectGeneratedAliases(optimized).toSeq
       val aliasedExprs: Seq[String] => Seq[Expression] =
         aliases => Seq($"c".getField("d").as(aliases(0)), $"c.h.h1".as(aliases(1)))
       val replacedGenerator: Seq[String] => Generator =

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ColumnPruningSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ColumnPruningSuite.scala
@@ -174,6 +174,34 @@ class ColumnPruningSuite extends PlanTest {
     }
   }
 
+  test("Nested column pruning for Generate with Filter 3") {
+    withSQLConf(SQLConf.NESTED_SCHEMA_PRUNING_THROUGH_FILTER_GENERATE.key -> "true") {
+      val structType = StructType.fromDDL("d double, e array<string>, f double, g double, " +
+        "h array<struct<h1: int, h2: double, h3 int>>")
+      val input = LocalRelation($"a".int, $"b".int, $"c".struct(structType))
+      val selectedExprs = Seq(UnresolvedAttribute("a"), $"c".getField("d")) ++ Seq($"explode.h2")
+      val query =
+        input
+          .generate(Explode($"c".getField("h")), outputNames = Seq("explode"))
+          .select(selectedExprs: _*)
+          .where($"explode".getField("h1").isNotNull)
+          .analyze
+      val optimized = Optimize.execute(query)
+      val finalSelectedExprs = Seq(UnresolvedAttribute("a"), $"c.d".as("c.d")) ++
+        Seq($"explode.h2".as("h2"))
+      val correctAnswer =
+        input
+          .select($"a", $"c")
+          .generate(Explode($"c.h".as("c.h")),
+            unrequiredChildIndex = Seq(),
+            outputNames = Seq("explode"))
+          .where($"explode.h1".isNotNull)
+          .select(finalSelectedExprs: _*)
+          .analyze
+      comparePlans(optimized, correctAnswer)
+    }
+  }
+
   test("Nested column pruning for Generate") {
     def runTest(
         origGenerator: Generator,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Pushed nested schema pruning through Filter->Generate in certain cases to improve performance of [SPARK-47230](https://issues.apache.org/jira/browse/SPARK-47230)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The performance is extremely bad for the case in [SPARK-47230](https://issues.apache.org/jira/browse/SPARK-47230)


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
It added a config that could disable this feature

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
I added some unit-tests in the code

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No