### PR TITLE
[SPARK-47694][CONNECT] Make max message size configurable on the client side

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/SparkConnectClientSuite.scala
@@ -310,7 +310,14 @@ class SparkConnectClientSuite extends ConnectFunSuite with BeforeAndAfterEach {
         assert(client.userAgent.contains("scala/"))
         assert(client.userAgent.contains("jvm/"))
         assert(client.userAgent.contains("os/"))
-      }))
+      }),
+    TestPackURI(
+      "sc://SPARK-47694:123/;grpc_max_message_size=1860",
+      isCorrect = true,
+      client => {
+        assert(client.configuration.grpcMaxMessageSize == 1860)
+      }),
+    TestPackURI("sc://SPARK-47694:123/;grpc_max_message_size=abc", isCorrect = false))
 
   private def checkTestPack(testPack: TestPackURI): Unit = {
     val client = SparkConnectClient.builder().connectionString(testPack.connectionString).build()

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
@@ -510,6 +510,7 @@ object SparkConnectClient {
       val PARAM_TOKEN = "token"
       val PARAM_USER_AGENT = "user_agent"
       val PARAM_SESSION_ID = "session_id"
+      val PARAM_GRPC_MAX_MESSAGE_SIZE = "grpc_max_message_size"
     }
 
     private def verifyURI(uri: URI): Unit = {
@@ -558,6 +559,13 @@ object SparkConnectClient {
 
     def userAgent: String = _configuration.userAgent
 
+    def grpcMaxMessageSize(messageSize: Int): Builder = {
+      _configuration = _configuration.copy(grpcMaxMessageSize = messageSize)
+      this
+    }
+
+    def grpcMaxMessageSize: Int = _configuration.grpcMaxMessageSize
+
     def option(key: String, value: String): Builder = {
       _configuration = _configuration.copy(metadata = _configuration.metadata + ((key, value)))
       this
@@ -584,6 +592,7 @@ object SparkConnectClient {
           case URIParams.PARAM_USE_SSL =>
             if (java.lang.Boolean.valueOf(value)) enableSsl() else disableSsl()
           case URIParams.PARAM_SESSION_ID => sessionId(value)
+          case URIParams.PARAM_GRPC_MAX_MESSAGE_SIZE => grpcMaxMessageSize(value.toInt)
           case _ => option(key, value)
         }
       }
@@ -693,7 +702,8 @@ object SparkConnectClient {
       retryPolicies: Seq[RetryPolicy] = RetryPolicy.defaultPolicies(),
       useReattachableExecute: Boolean = true,
       interceptors: List[ClientInterceptor] = List.empty,
-      sessionId: Option[String] = None) {
+      sessionId: Option[String] = None,
+      grpcMaxMessageSize: Int = ConnectCommon.CONNECT_GRPC_MAX_MESSAGE_SIZE) {
 
     def userContext: proto.UserContext = {
       val builder = proto.UserContext.newBuilder()
@@ -731,7 +741,7 @@ object SparkConnectClient {
 
       interceptors.foreach(channelBuilder.intercept(_))
 
-      channelBuilder.maxInboundMessageSize(ConnectCommon.CONNECT_GRPC_MAX_MESSAGE_SIZE)
+      channelBuilder.maxInboundMessageSize(grpcMaxMessageSize)
       channelBuilder.build()
     }
 

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClientParser.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClientParser.scala
@@ -32,16 +32,17 @@ private[sql] object SparkConnectClientParser {
   def usage(): String =
     s"""
        |Options:
-       |   --remote REMOTE          URI of the Spark Connect Server to connect to.
-       |   --host HOST              Host where the Spark Connect Server is running.
-       |   --port PORT              Port where the Spark Connect Server is running.
-       |   --use_ssl                Connect to the server using SSL.
-       |   --token TOKEN            Token to use for authentication.
-       |   --user_id USER_ID        Id of the user connecting.
-       |   --user_name USER_NAME    Name of the user connecting.
-       |   --user_agent USER_AGENT  The User-Agent Client information (only intended for logging purposes by the server).
-       |   --session_id SESSION_ID  Session Id of the user connecting.
-       |   --option KEY=VALUE       Key-value pair that is used to further configure the session.
+       |   --remote REMOTE              URI of the Spark Connect Server to connect to.
+       |   --host HOST                  Host where the Spark Connect Server is running.
+       |   --port PORT                  Port where the Spark Connect Server is running.
+       |   --use_ssl                    Connect to the server using SSL.
+       |   --token TOKEN                Token to use for authentication.
+       |   --user_id USER_ID            Id of the user connecting.
+       |   --user_name USER_NAME        Name of the user connecting.
+       |   --user_agent USER_AGENT      The User-Agent Client information (only intended for logging purposes by the server).
+       |   --session_id SESSION_ID      Session Id of the user connecting.
+       |   --grpc_max_message_size SIZE Maximum message size allowed for gRPC messages in bytes.
+       |   --option KEY=VALUE           Key-value pair that is used to further configure the session.
      """.stripMargin
   // scalastyle:on line.size.limit
 
@@ -88,6 +89,9 @@ private[sql] object SparkConnectClientParser {
             s"--option should contain key=value, found ${tail.head} instead")
         }
         parse(tail.tail, builder.option(key, value))
+      case "--grpc_max_message_size" :: tail =>
+        val (value, remainder) = extract("--grpc_max_message_size", tail)
+        parse(remainder, builder.grpcMaxMessageSize(value.toInt))
       case unsupported :: _ =>
         throw new IllegalArgumentException(s"$unsupported is an unsupported argument.")
     }

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -130,7 +130,7 @@ class ChannelBuilder:
     ):
         self._interceptors: List[grpc.UnaryStreamClientInterceptor] = []
         self._params: Dict[str, str] = params or dict()
-        self._channel_options: List[Tuple[str, Any]] = ChannelBuilder.GRPC_DEFAULT_OPTIONS
+        self._channel_options: List[Tuple[str, Any]] = ChannelBuilder.GRPC_DEFAULT_OPTIONS.copy()
 
         if channelOptions is not None:
             for key, value in channelOptions:

--- a/python/pyspark/sql/tests/connect/test_connect_session.py
+++ b/python/pyspark/sql/tests/connect/test_connect_session.py
@@ -495,6 +495,26 @@ class ChannelBuilderTests(unittest.TestCase):
         chan = DefaultChannelBuilder("sc://host/")
         self.assertIsNone(chan.session_id)
 
+    def test_channel_options(self):
+        # SPARK-47694
+        chan = DefaultChannelBuilder(
+            "sc://host", [("grpc.max_send_message_length", 1860000), ("test", "robert")]
+        )
+        options = chan._channel_options
+        self.assertEqual(
+            [k for k, _ in options].count("grpc.max_send_message_length"),
+            1,
+            "only one occurrence for defaults",
+        )
+        self.assertEqual(
+            next(v for k, v in options if k == "grpc.max_send_message_length"),
+            1860000,
+            "overwrites defaults",
+        )
+        self.assertEqual(
+            next(v for k, v in options if k == "test"), "robert", "new values are picked up"
+        )
+
 
 if __name__ == "__main__":
     from pyspark.sql.tests.connect.test_connect_session import *  # noqa: F401

--- a/python/pyspark/sql/tests/connect/test_connect_session.py
+++ b/python/pyspark/sql/tests/connect/test_connect_session.py
@@ -498,7 +498,7 @@ class ChannelBuilderTests(unittest.TestCase):
     def test_channel_options(self):
         # SPARK-47694
         chan = DefaultChannelBuilder(
-            "sc://host", [("grpc.max_send_message_length", 1860000), ("test", "robert")]
+            "sc://host", [("grpc.max_send_message_length", 1860), ("test", "robert")]
         )
         options = chan._channel_options
         self.assertEqual(
@@ -508,7 +508,7 @@ class ChannelBuilderTests(unittest.TestCase):
         )
         self.assertEqual(
             next(v for k, v in options if k == "grpc.max_send_message_length"),
-            1860000,
+            1860,
             "overwrites defaults",
         )
         self.assertEqual(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Follow up to https://github.com/apache/spark/pull/40447.
Allows to configure the currently hardcoded max message of 128MB on the client side for both the Scala and Python clients.
Adds the option to the Scala client and improves the way we handle `channelOptions` in Python's `ChannelBuiler`.

### Why are the changes needed?
Usability - I am aware of two different cases where these limits are hit:

1. The user is trying to create a large dataframe from local data. We either hit the` grpc.max_send_message_length` in the Python client ([currently hardcoded](https://github.com/apache/spark/pull/40447/files)) or the `maxInboundMessageSize`  on the cluster side ([now configurable](https://github.com/apache/spark/pull/40447/files)).
2. The result from the cluster has a single row that is larger than 128MB, causing an `ExecutePlanResponse` that is larger than the client's `grpc.max_receive_message_length` (Python) or `channel.maxInboundMessageSize`  (Scala) ([both hardcoded](https://github.com/apache/spark/pull/40447/files)).

This gives the option to increase these limits on the client side.


### Does this PR introduce _any_ user-facing change?
Scala: Adds option to set `grpcMaxMessageSize` to `SparkConnectClient.Builder`
Python: No.


### How was this patch tested?
Tests added.


### Was this patch authored or co-authored using generative AI tooling?
No.
