### PR TITLE
[SPARK-47709][BUILD] Upgrade tink to 1.13.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -266,7 +266,7 @@ stax-api/1.0.1//stax-api-1.0.1.jar
 stream/2.9.6//stream-2.9.6.jar
 super-csv/2.2.0//super-csv-2.2.0.jar
 threeten-extra/1.7.1//threeten-extra-1.7.1.jar
-tink/1.12.0//tink-1.12.0.jar
+tink/1.13.0//tink-1.13.0.jar
 transaction-api/1.1//transaction-api-1.1.jar
 txw2/3.0.2//txw2-3.0.2.jar
 univocity-parsers/2.9.1//univocity-parsers-2.9.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <commons-cli.version>1.6.0</commons-cli.version>
     <bouncycastle.version>1.77</bouncycastle.version>
-    <tink.version>1.12.0</tink.version>
+    <tink.version>1.13.0</tink.version>
     <datasketches.version>5.0.1</datasketches.version>
     <netty.version>4.1.108.Final</netty.version>
     <netty-tcnative.version>2.0.65.Final</netty-tcnative.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade tink from 1.12.0 to 1.13.0.

### Why are the changes needed?
According to the release notes, the new version is 20% faster than the previous one in terms of `AES-GCM`
- AES-GCM is now about 20% faster.

The full release notes as follows:
- https://github.com/tink-crypto/tink-java/releases/tag/v1.13.0

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No