### PR TITLE
[SPARK-47713][SQL][CONNECT] Fix a self-join failure

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -940,11 +940,14 @@ class ClientE2ETestSuite extends RemoteSparkSession with SQLHelper with PrivateM
     }
     assert(e3.getMessage.contains("AMBIGUOUS_COLUMN_REFERENCE"))
 
-    val e4 = intercept[AnalysisException] {
-      // df1("i") is ambiguous as df1 appears in both join sides (df1_filter contains df1).
-      df1.join(df1_filter, df1("i") === 1).collect()
-    }
-    assert(e4.getMessage.contains("AMBIGUOUS_COLUMN_REFERENCE"))
+    //    val e4 = intercept[AnalysisException] {
+    //      // df1("i") is ambiguous as df1 appears in both join sides (df1_filter contains df1).
+    //      df1.join(df1_filter, df1("i") === 1).collect()
+    //    }
+    //    assert(e4.getMessage.contains("AMBIGUOUS_COLUMN_REFERENCE"))
+    //
+    //    "[AMBIGUOUS_COLUMN_OR_FIELD] Column or field `i` is ambiguous and has 2 matches.
+    //    SQLSTATE: 42702" did not contain "AMBIGUOUS_COLUMN_REFERENCE"
 
     checkSameResult(
       Seq(Row("a")),

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -940,14 +940,11 @@ class ClientE2ETestSuite extends RemoteSparkSession with SQLHelper with PrivateM
     }
     assert(e3.getMessage.contains("AMBIGUOUS_COLUMN_REFERENCE"))
 
-    //    val e4 = intercept[AnalysisException] {
-    //      // df1("i") is ambiguous as df1 appears in both join sides (df1_filter contains df1).
-    //      df1.join(df1_filter, df1("i") === 1).collect()
-    //    }
-    //    assert(e4.getMessage.contains("AMBIGUOUS_COLUMN_REFERENCE"))
-    //
-    //    "[AMBIGUOUS_COLUMN_OR_FIELD] Column or field `i` is ambiguous and has 2 matches.
-    //    SQLSTATE: 42702" did not contain "AMBIGUOUS_COLUMN_REFERENCE"
+    // df1.join(df1_filter, df1("i") === 1) fails in classic spark due to:
+    // org.apache.spark.sql.AnalysisException: Column i#24 are ambiguous
+    assert(
+      df1.join(df1_filter, df1("i") === 1).columns ===
+        Array("i", "j", "i", "j"))
 
     checkSameResult(
       Seq(Row("a")),

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -940,9 +940,10 @@ class ClientE2ETestSuite extends RemoteSparkSession with SQLHelper with PrivateM
     }
     assert(e3.getMessage.contains("AMBIGUOUS_COLUMN_REFERENCE"))
 
-    // df1.join(df1_filter, df1("i") === 1) fails in classic spark due to:
-    // org.apache.spark.sql.AnalysisException: Column i#24 are ambiguous
+    // TODO(SPARK-47749): Dataframe.collect should accept duplicated column names
     assert(
+      // df1.join(df1_filter, df1("i") === 1) fails in classic spark due to:
+      // org.apache.spark.sql.AnalysisException: Column i#24 are ambiguous
       df1.join(df1_filter, df1("i") === 1).columns ===
         Array("i", "j", "i", "j"))
 

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -1155,6 +1155,15 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             set(spark_df.select("id").crossJoin(other=spark_df.select("name")).toPandas()),
         )
 
+    def test_self_join(self):
+        # SPARK-47713: this query fails in classic spark
+        df1 = self.connect.createDataFrame([(1, "a")], schema=["i", "j"])
+        df1_filter = df1.filter(df1.i > 0)
+        df2 = df1.join(df1_filter, df1.i == 1)
+        self.assertEqual(df2.count(), 1)
+        self.assertEqual(df2.columns, ["i", "j", "i", "j"])
+        self.assertEqual(list(df2.first()), [1, "a", 1, "a"])
+
     def test_with_metadata(self):
         cdf = self.connect.createDataFrame(data=[(2, "Alice"), (5, "Bob")], schema=["age", "name"])
         self.assertEqual(cdf.schema["age"].metadata, {})

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -123,6 +123,13 @@ class DataFrameTestsMixin:
         df = df2.join(df1, df2["b"] == df1["a"])
         self.assertTrue(df.count() == 100)
 
+    def test_self_join_II(self):
+        df = self.spark.createDataFrame([(1, 2), (3, 4)], schema=["a", "b"])
+        df2 = df.select(df.a.alias("aa"), df.b)
+        df3 = df2.join(df, df2.b == df.b)
+        self.assertTrue(df3.columns, ["aa", "b", "a", "b"])
+        self.assertTrue(df3.count() == 2)
+
     def test_duplicated_column_names(self):
         df = self.spark.createDataFrame([(1, 2)], ["c", "c"])
         row = df.select("*").first()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -547,17 +547,11 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
       q: Seq[LogicalPlan],
       d: Int): Option[(NamedExpression, Int)] = {
     q.flatMap(resolveDataFrameColumnRecursively(u, id, isMetadataAccess, _, d))
-      .sortBy(_._2) // make sure 0-depth result is on the left side (avoid case like: 1, 2, 0)
+      .sortBy(_._2) // make sure 0-depth result is on the left side (avoid depths like: 1, 2, 0)
       .foldLeft(Option.empty[(NamedExpression, Int)]) {
-        case (Some((r1, d1)), (r2, d2)) =>
-          if (d1 == 0 && d2 != 0) {
-            Some((r1, d1))
-          } else if (d2 == 0 && d1 != 0) {
-            Some((r2, d2))
-          } else {
-            throw QueryCompilationErrors.ambiguousColumnReferences(u)
-          }
         case (None, (r2, d2)) => Some((r2, d2))
+        case (Some((r1, 0)), (r2, d2)) if d2 != 0 => Some((r1, 0))
+        case _ => throw QueryCompilationErrors.ambiguousColumnReferences(u)
       }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
update the logic to resolve column in spark connect


### Why are the changes needed?
```
        df = spark.createDataFrame([(1, 2), (3, 4)], schema=["a", "b"])
        df2 = df.select(df.a.alias("aa"), df.b)
        df3 = df2.join(df, df2.b == df.b)

AnalysisException: [AMBIGUOUS_COLUMN_REFERENCE] Column "b" is ambiguous. It's because you joined several DataFrame together, and some of these DataFrames are the same.
This column points to one of the DataFrames but Spark is unable to figure out which one.
Please alias the DataFrames with different names via `DataFrame.alias` before joining them,
and specify the column using qualified name, e.g. `df.alias("a").join(df.alias("b"), col("a.id") > col("b.id"))`. SQLSTATE: 42702

```


### Does this PR introduce _any_ user-facing change?
yes, above query can run successfully after this PR

This PR only affects Spark Connect, won't affect Classic Spark.


### How was this patch tested?
added tests


### Was this patch authored or co-authored using generative AI tooling?
no