### PR TITLE
[SQL] Add collations support to split regex expression

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationSupport.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationSupport.java
@@ -150,6 +150,7 @@ public final class CollationSupport {
       if (collation.supportsBinaryEquality) {
         return execBinary(string, regex, limit);
       } else {
+        assert(collation.supportsLowercaseEquality);
         return execLowercase(string, regex, limit);
       }
     }

--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationSupport.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationSupport.java
@@ -172,8 +172,7 @@ public final class CollationSupport {
       if (string.numBytes() != 0 && regex.numBytes() == 0) {
         return string.split(regex, limit);
       } else {
-        // ui flags toggle unicode case-insensitive matching
-        return string.split(UTF8String.fromString("(?ui)" + regex.toString()), limit);
+        return string.split(CollationAwareUTF8String.getLowercaseRegex(regex), limit);
       }
     }
   }
@@ -202,6 +201,13 @@ public final class CollationSupport {
       }
       return CollationFactory.getStringSearch(target.substring(
         pos, pos + pattern.numChars()), pattern, collationId).last() == 0;
+    }
+
+    // ui flags toggle unicode case-insensitive matching
+    private static final UTF8String lowercaseRegexPrefix = UTF8String.fromString("(?ui)");
+
+    private static UTF8String getLowercaseRegex(UTF8String regex) {
+      return UTF8String.concat(lowercaseRegexPrefix, regex);
     }
 
   }

--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationSupport.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationSupport.java
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.sql.catalyst.util;
 
+import java.util.regex.Pattern;
+
 import com.ibm.icu.text.StringSearch;
 
 import org.apache.spark.unsafe.types.UTF8String;
@@ -142,6 +144,36 @@ public final class CollationSupport {
   /**
    * Collation-aware regexp expressions.
    */
+
+  public static class StringSplit {
+    public static UTF8String[] exec(final UTF8String l, final UTF8String r, final int limit,
+        final int collationId) {
+      CollationFactory.Collation collation = CollationFactory.fetchCollation(collationId);
+      if (collation.supportsBinaryEquality) {
+        return execBinary(l, r, limit);
+      } else {
+        return execLowercase(l, r, limit);
+      }
+    }
+    public static String genCode(final String l, final String r, final String limit,
+        final int collationId) {
+      CollationFactory.Collation collation = CollationFactory.fetchCollation(collationId);
+      String expr = "CollationSupport.StringSplit.exec";
+      if (collation.supportsBinaryEquality) {
+        return String.format(expr + "Binary(%s, %s, %s)", l, r, limit);
+      } else {
+        return String.format(expr + "Lowercase(%s, %s, %s)", l, r, limit);
+      }
+    }
+    public static UTF8String[] execBinary(final UTF8String l, final UTF8String r,
+        final int limit) {
+      return l.split(r, limit);
+    }
+    public static UTF8String[] execLowercase(final UTF8String l, final UTF8String r,
+        final int limit) {
+      return l.split(r, limit, Pattern.UNICODE_CASE | Pattern.CASE_INSENSITIVE);
+    }
+  }
 
   // TODO: Add more collation-aware regexp expressions.
 

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -1028,7 +1028,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     return fromBytes(result);
   }
 
-  public UTF8String[] split(UTF8String pattern, int limit) {
+  public UTF8String[] split(UTF8String pattern, int limit, int regexFlags) {
     // For the empty `pattern` a `split` function ignores trailing empty strings unless original
     // string is empty.
     if (numBytes() != 0 && pattern.numBytes() == 0) {
@@ -1044,7 +1044,11 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
       }
       return result;
     }
-    return split(pattern.toString(), limit);
+    return split(pattern.toString(), limit, regexFlags);
+  }
+
+  public UTF8String[] split(UTF8String pattern, int limit) {
+    return split(pattern, limit, 0); // Pattern without regex flags
   }
 
   public UTF8String[] splitSQL(UTF8String delimiter, int limit) {
@@ -1061,19 +1065,29 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     }
   }
 
-  private UTF8String[] split(String delimiter, int limit) {
+  private UTF8String[] split(String delimiter, int limit, int regexFlags) {
     // Java String's split method supports "ignore empty string" behavior when the limit is 0
     // whereas other languages do not. To avoid this java specific behavior, we fall back to
     // -1 when the limit is 0.
     if (limit == 0) {
       limit = -1;
     }
-    String[] splits = toString().split(delimiter, limit);
+    String[] splits;
+    if (regexFlags == 0) {
+      // Pattern without regex flags
+      splits = toString().split(delimiter, limit);
+    } else {
+      splits = Pattern.compile(delimiter, regexFlags).split(toString(), limit);
+    }
     UTF8String[] res = new UTF8String[splits.length];
     for (int i = 0; i < res.length; i++) {
       res[i] = fromString(splits[i]);
     }
     return res;
+  }
+
+  private UTF8String[] split(String delimiter, int limit) {
+    return split(delimiter, limit, 0);
   }
 
   public UTF8String replace(UTF8String search, UTF8String replace) {

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -1028,7 +1028,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     return fromBytes(result);
   }
 
-  public UTF8String[] split(UTF8String pattern, int limit, int regexFlags) {
+  public UTF8String[] split(UTF8String pattern, int limit) {
     // For the empty `pattern` a `split` function ignores trailing empty strings unless original
     // string is empty.
     if (numBytes() != 0 && pattern.numBytes() == 0) {
@@ -1044,11 +1044,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
       }
       return result;
     }
-    return split(pattern.toString(), limit, regexFlags);
-  }
-
-  public UTF8String[] split(UTF8String pattern, int limit) {
-    return split(pattern, limit, 0); // Pattern without regex flags
+    return split(pattern.toString(), limit);
   }
 
   public UTF8String[] splitSQL(UTF8String delimiter, int limit) {
@@ -1065,29 +1061,19 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     }
   }
 
-  private UTF8String[] split(String delimiter, int limit, int regexFlags) {
+  private UTF8String[] split(String delimiter, int limit) {
     // Java String's split method supports "ignore empty string" behavior when the limit is 0
     // whereas other languages do not. To avoid this java specific behavior, we fall back to
     // -1 when the limit is 0.
     if (limit == 0) {
       limit = -1;
     }
-    String[] splits;
-    if (regexFlags == 0) {
-      // Pattern without regex flags
-      splits = toString().split(delimiter, limit);
-    } else {
-      splits = Pattern.compile(delimiter, regexFlags).split(toString(), limit);
-    }
+    String[] splits = toString().split(delimiter, limit);
     UTF8String[] res = new UTF8String[splits.length];
     for (int i = 0; i < res.length; i++) {
       res[i] = fromString(splits[i]);
     }
     return res;
-  }
-
-  private UTF8String[] split(String delimiter, int limit) {
-    return split(delimiter, limit, 0); // Pattern without regex flags
   }
 
   public UTF8String replace(UTF8String search, UTF8String replace) {

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -1087,7 +1087,7 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
   }
 
   private UTF8String[] split(String delimiter, int limit) {
-    return split(delimiter, limit, 0);
+    return split(delimiter, limit, 0); // Pattern without regex flags
   }
 
   public UTF8String replace(UTF8String search, UTF8String replace) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -563,10 +563,9 @@ case class StringSplit(str: Expression, regex: Expression, limit: Expression)
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     val arrayClass = classOf[GenericArrayData].getName
-    nullSafeCodeGen(ctx, ev, (str, regex, limit) => {
+    defineCodeGen(ctx, ev, (str, regex, limit) => {
       // Array in java is covariant, so we don't need to cast UTF8String[] to Object[].
-      val genCode = CollationSupport.StringSplit.genCode(str, regex, limit, collationId)
-      s"""${ev.value} = new $arrayClass($genCode);""".stripMargin
+      s"new $arrayClass(${CollationSupport.StringSplit.genCode(str, regex, limit, collationId)})"
     })
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/regexpExpressions.scala
@@ -547,7 +547,6 @@ case class StringSplit(str: Expression, regex: Expression, limit: Expression)
   override def dataType: DataType = ArrayType(str.dataType, containsNull = false)
   override def inputTypes: Seq[AbstractDataType] =
     Seq(StringTypeBinaryLcase, StringTypeAnyCollation, IntegerType)
-
   override def first: Expression = str
   override def second: Expression = regex
   override def third: Expression = limit

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationRegexpExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationRegexpExpressionsSuite.scala
@@ -122,18 +122,10 @@ class CollationRegexpExpressionsSuite
       StringSplitTestCase("ABC", "[b]", "UTF8_BINARY", Seq("ABC")),
       StringSplitTestCase("ABC", "[b]", "UTF8_BINARY_LCASE", Seq("A", "C")),
       StringSplitTestCase("AAA", "[a]", "UTF8_BINARY_LCASE", Seq("", "", "", "")),
-      StringSplitTestCase("AAA", "[b]", "UTF8_BINARY_LCASE", Seq("AAA")),
-      StringSplitTestCase("aAbB", "[ab]", "UTF8_BINARY_LCASE", Seq("", "", "", "", "")),
-      StringSplitTestCase("", "", "UTF8_BINARY_LCASE", Seq("")),
-      StringSplitTestCase("", "[a]", "UTF8_BINARY_LCASE", Seq("")),
-      StringSplitTestCase("xAxBxaxbx", "[AB]", "UTF8_BINARY_LCASE", Seq("x", "x", "x", "x", "x")),
-      StringSplitTestCase("ABC", "", "UTF8_BINARY_LCASE", Seq("A", "B", "C")),
-      // test split with limit
-      StringSplitTestCase("ABC", "[b]", "UTF8_BINARY_LCASE", Seq("ABC"), 1),
-      StringSplitTestCase("ABC", "[b]", "UTF8_BINARY_LCASE", Seq("A", "C"), 2),
-      StringSplitTestCase("ABC", "[b]", "UTF8_BINARY_LCASE", Seq("A", "C"), 3),
       StringSplitTestCase("ABC", "[B]", "UNICODE", Seq("A", "C")),
-      StringSplitTestCase("ABC", "[b]", "UNICODE", Seq("ABC"))
+      StringSplitTestCase("ABC", "[b]", "UTF8_BINARY", Seq("ABC"), 1),
+      StringSplitTestCase("ABC", "[b]", "UTF8_BINARY_LCASE", Seq("ABC"), 1),
+      StringSplitTestCase("ABC", "[b]", "UTF8_BINARY_LCASE", Seq("A", "C"), 2)
     )
     testCases.foreach(t => {
       val query = s"SELECT split(collate('${t.l}', '${t.c}'), '${t.r}', ${t.limit})"

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationRegexpExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationRegexpExpressionsSuite.scala
@@ -138,7 +138,7 @@ class CollationRegexpExpressionsSuite
     testCases.foreach(t => {
       val query = s"SELECT split(collate('${t.l}', '${t.c}'), '${t.r}', ${t.limit})"
       // Result & data type
-      checkAnswer(sql(query), Seq(Row(t.result)))
+      checkAnswer(sql(query), Row(t.result))
       assert(sql(query).schema.fields.head.dataType.sameType(ArrayType(StringType(t.c))))
       // TODO: Implicit casting (not currently supported)
     })

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationRegexpExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationRegexpExpressionsSuite.scala
@@ -115,6 +115,7 @@ class CollationRegexpExpressionsSuite
   }
 
   test("Support StringSplit string expression with collation") {
+    // Supported collations
     case class StringSplitTestCase[R](l: String, r: String, c: String, result: R, limit: Int = -1)
     val testCases = Seq(
       StringSplitTestCase("ABC", "[B]", "UTF8_BINARY", Seq("A", "C")),
@@ -136,11 +137,14 @@ class CollationRegexpExpressionsSuite
     )
     testCases.foreach(t => {
       val query = s"SELECT split(collate('${t.l}', '${t.c}'), '${t.r}', ${t.limit})"
+      // Result & data type
       checkAnswer(sql(query), Seq(Row(t.result)))
       assert(sql(query).schema.fields.head.dataType.sameType(ArrayType(StringType(t.c))))
+      // TODO: Implicit casting (not currently supported)
     })
-    case class StringSplitFail(l: String, r: String, c: String)
-    val failCases = Seq(StringSplitFail("ABC", "[b]", "UNICODE_CI"))
+    // Unsupported collations
+    case class StringSplitTestFail(l: String, r: String, c: String)
+    val failCases = Seq(StringSplitTestFail("ABC", "[b]", "UNICODE_CI"))
     failCases.foreach(t => {
       val query = s"SELECT split(collate('${t.l}', '${t.c}'), '${t.r}')"
       val unsupportedCollation = intercept[AnalysisException] { sql(query) }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationRegexpExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationRegexpExpressionsSuite.scala
@@ -140,7 +140,6 @@ class CollationRegexpExpressionsSuite
       // Result & data type
       checkAnswer(sql(query), Row(t.result))
       assert(sql(query).schema.fields.head.dataType.sameType(ArrayType(StringType(t.c))))
-      // TODO: Implicit casting (not currently supported)
     })
     // Unsupported collations
     case class StringSplitTestFail(l: String, r: String, c: String)
@@ -150,7 +149,6 @@ class CollationRegexpExpressionsSuite
       val unsupportedCollation = intercept[AnalysisException] { sql(query) }
       assert(unsupportedCollation.getErrorClass === "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE")
     })
-    // TODO: Collation mismatch (not currently supported)
   }
 
   test("Support RegExpReplace string expression with collation") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

With these changes, split expression should support any collation with binary equality and `UTF8_BINARY_LCASE`. Other collations are derived from external ICU implementation and do not support split operation with regex splitters, for these we'll throw `TypeCheckFailure`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To introduce collations support for split expression.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, user should now successfully split collated strings.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Modified existing test in `CollationRegexpExpressionsSuite`.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.
