### PR TITLE
[SPARK-47705][INFRA] Sort LogKey alphabetically and build a test to ensure it

### DIFF
--- a/common/utils/src/test/scala/org/apache/spark/util/LogKeySuite.scala
+++ b/common/utils/src/test/scala/org/apache/spark/util/LogKeySuite.scala
@@ -17,10 +17,14 @@
 
 package org.apache.spark.util
 
-import org.apache.spark.SparkFunSuite
+import org.scalatest.funsuite.AnyFunSuite // scalastyle:ignore funsuite
+
 import org.apache.spark.internal.{Logging, LogKey}
 
-class LogKeySuite extends SparkFunSuite with Logging {
+class LogKeySuite
+    extends AnyFunSuite // scalastyle:ignore funsuite
+    with Logging {
+
   test("LogKey enumeration fields must be sorted alphabetically") {
     val keys = LogKey.values.toSeq
     assert(keys === keys.sorted, "LogKey enumeration fields must be sorted alphabetically")

--- a/core/src/test/scala/org/apache/spark/util/LogKeySuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/LogKeySuite.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.internal.{Logging, LogKey}
+
+class LogKeySuite extends SparkFunSuite with Logging {
+  test("LogKey enumeration fields must be sorted alphabetically") {
+    val keys = LogKey.values.toSeq
+    assert(keys === keys.sorted, "LogKey enumeration fields must be sorted alphabetically")
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a unit test to ensure that the fields of the `LogKey` enumeration are sorted alphabetically, as specified by https://issues.apache.org/jira/browse/SPARK-47705.

### Why are the changes needed?

This will make sure that the fields of the enumeration remain easy to read in the future as we add more cases.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This PR adds testing coverage only.

### Was this patch authored or co-authored using generative AI tooling?

GitHub copilot offered some suggestions, but I rejected them