### PR TITLE
[SPARK-47705][INFRA][FOLLOWUP] Sort LogKey alphabetically and build a test to ensure it

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
@@ -30,8 +30,8 @@ object LogKey extends Enumeration {
   val MAX_EXECUTOR_FAILURES = Value
   val MAX_SIZE = Value
   val MIN_SIZE = Value
-  val REMOTE_ADDRESS = Value
   val POD_ID = Value
+  val REMOTE_ADDRESS = Value
 
   type LogKey = Value
 }

--- a/common/utils/src/test/scala/org/apache/spark/util/LogKeySuite.scala
+++ b/common/utils/src/test/scala/org/apache/spark/util/LogKeySuite.scala
@@ -27,6 +27,6 @@ class LogKeySuite
 
   test("LogKey enumeration fields must be sorted alphabetically") {
     val keys = LogKey.values.toSeq
-    assert(keys === keys.sorted, "LogKey enumeration fields must be sorted alphabetically")
+    assert(keys === keys.sortBy(_.toString), "LogKey enumeration fields must be sorted alphabetically")
   }
 }

--- a/common/utils/src/test/scala/org/apache/spark/util/LogKeySuite.scala
+++ b/common/utils/src/test/scala/org/apache/spark/util/LogKeySuite.scala
@@ -27,6 +27,7 @@ class LogKeySuite
 
   test("LogKey enumeration fields must be sorted alphabetically") {
     val keys = LogKey.values.toSeq
-    assert(keys === keys.sortBy(_.toString), "LogKey enumeration fields must be sorted alphabetically")
+    assert(keys === keys.sortBy(_.toString),
+      "LogKey enumeration fields must be sorted alphabetically")
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix bug about https://github.com/apache/spark/pull/45857


### Why are the changes needed?
In fact, `LogKey.values.toSeq.sorted` did not sort alphabetically as expected.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Pass GA.
- Manually test.


### Was this patch authored or co-authored using generative AI tooling?
No.
