### PR TITLE
[SPARK-46812][PYTHON][TESTS][FOLLOWUP] Skip `pandas`-required tests if pandas is not available

### DIFF
--- a/python/pyspark/resource/tests/test_connect_resources.py
+++ b/python/pyspark/resource/tests/test_connect_resources.py
@@ -18,8 +18,10 @@ import unittest
 
 from pyspark.resource import ResourceProfileBuilder, TaskResourceRequests, ExecutorResourceRequests
 from pyspark.sql import SparkSession
+from pyspark.testing.sqlutils import have_pandas, pandas_requirement_message
 
 
+@unittest.skipIf(not have_pandas, pandas_requirement_message)
 class ResourceProfileTests(unittest.TestCase):
     def test_profile_before_sc_for_connect(self):
         rpb = ResourceProfileBuilder()

--- a/python/pyspark/resource/tests/test_resources.py
+++ b/python/pyspark/resource/tests/test_resources.py
@@ -18,6 +18,7 @@ import unittest
 
 from pyspark.resource import ExecutorResourceRequests, ResourceProfileBuilder, TaskResourceRequests
 from pyspark.sql import SparkSession
+from pyspark.testing.sqlutils import have_pandas, pandas_requirement_message
 
 
 class ResourceProfileTests(unittest.TestCase):
@@ -71,6 +72,7 @@ class ResourceProfileTests(unittest.TestCase):
         assert_request_contents(rp3.executorResources, rp3.taskResources)
         sc.stop()
 
+    @unittest.skipIf(not have_pandas, pandas_requirement_message)
     def test_profile_before_sc_for_sql(self):
         rpb = ResourceProfileBuilder()
         treqs = TaskResourceRequests().cpus(2)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of the followings to skip `pandas`-related tests if pandas is not available.
- #44852
- #45232

### Why are the changes needed?

`pandas` is an optional dependency. We had better skip it without causing failures.

To recover the PyPy 3.8 CI,
- https://github.com/apache/spark/actions/runs/8541011879/job/23421483071

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually test.
```
$ python/run-tests --modules=pyspark-resource --parallelism=1 --python-executables=python3.10
Running PySpark tests. Output is in /Users/dongjoon/APACHE/spark-merge/python/unit-tests.log
Will test against the following Python executables: ['python3.10']
Will test the following Python modules: ['pyspark-resource']
python3.10 python_implementation is CPython
python3.10 version is: Python 3.10.13
Starting test(python3.10): pyspark.resource.profile (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/021bc7bb-242f-4cb4-8584-11ed6e711f78/python3.10__pyspark.resource.profile__jn89f1hh.log)
Finished test(python3.10): pyspark.resource.profile (1s)
Starting test(python3.10): pyspark.resource.tests.test_connect_resources (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/244d6c6f-8799-4a2a-b7a7-20d7c50d643d/python3.10__pyspark.resource.tests.test_connect_resources__5ta1tf6e.log)
Finished test(python3.10): pyspark.resource.tests.test_connect_resources (0s) ... 1 tests were skipped
Starting test(python3.10): pyspark.resource.tests.test_resources (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/671e7afa-e764-443f-bc40-7e940d7342ea/python3.10__pyspark.resource.tests.test_resources__lhbp6y5f.log)
Finished test(python3.10): pyspark.resource.tests.test_resources (2s) ... 1 tests were skipped
Tests passed in 4 seconds

Skipped tests in pyspark.resource.tests.test_connect_resources with python3.10:
      test_profile_before_sc_for_connect (pyspark.resource.tests.test_connect_resources.ResourceProfileTests) ... skip (0.005s)

Skipped tests in pyspark.resource.tests.test_resources with python3.10:
      test_profile_before_sc_for_sql (pyspark.resource.tests.test_resources.ResourceProfileTests) ... skip (0.001s)
```

### Was this patch authored or co-authored using generative AI tooling?

No.