### PR TITLE
[SPARK-47511][SQL][FOLLOWUP] Rename the config REPLACE_NULLIF_USING_WITH_EXPR to be more general

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Between.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Between.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
+import org.apache.spark.sql.internal.SQLConf
+
 // scalastyle:off line.size.limit
 @ExpressionDescription(
   usage = "Usage: input [NOT] BETWEEN lower AND upper - evaluate if `input` is [not] in between `lower` and `upper`",
@@ -36,13 +38,17 @@ package org.apache.spark.sql.catalyst.expressions
 case class Between private(input: Expression, lower: Expression, upper: Expression, replacement: Expression)
   extends RuntimeReplaceable with InheritAnalysisRules  {
   def this(input: Expression, lower: Expression, upper: Expression) = {
-    this(input, lower, upper, {
-      val commonExpr = CommonExpressionDef(input)
-      val ref = new CommonExpressionRef(commonExpr)
-      val replacement = And(GreaterThanOrEqual(ref, lower), LessThanOrEqual(ref, upper))
-      With(replacement, Seq(commonExpr))
-    })
-  };
+    this(input, lower, upper,
+      if (!SQLConf.get.getConf(SQLConf.ALWAYS_INLINE_COMMON_EXPR_IN_WITH)) {
+        val commonExpr = CommonExpressionDef(input)
+        val ref = new CommonExpressionRef(commonExpr)
+        val replacement = And(GreaterThanOrEqual(ref, lower), LessThanOrEqual(ref, upper))
+        With(replacement, Seq(commonExpr))
+      } else {
+        And(GreaterThanOrEqual(input, lower), LessThanOrEqual(input, upper))
+      }
+    )
+  }
 
   override def parameters: Seq[Expression] = Seq(input, lower, upper)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Between.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Between.scala
@@ -39,11 +39,10 @@ case class Between private(input: Expression, lower: Expression, upper: Expressi
   extends RuntimeReplaceable with InheritAnalysisRules  {
   def this(input: Expression, lower: Expression, upper: Expression) = {
     this(input, lower, upper,
-      if (!SQLConf.get.getConf(SQLConf.ALWAYS_INLINE_COMMON_EXPR_IN_WITH)) {
-        val commonExpr = CommonExpressionDef(input)
-        val ref = new CommonExpressionRef(commonExpr)
-        val replacement = And(GreaterThanOrEqual(ref, lower), LessThanOrEqual(ref, upper))
-        With(replacement, Seq(commonExpr))
+      if (!SQLConf.get.getConf(SQLConf.ALWAYS_INLINE_COMMON_EXPR)) {
+        With(input) { case Seq(ref) =>
+          And(GreaterThanOrEqual(ref, lower), LessThanOrEqual(ref, upper))
+        }
       } else {
         And(GreaterThanOrEqual(input, lower), LessThanOrEqual(input, upper))
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -160,7 +160,7 @@ case class NullIf(left: Expression, right: Expression, replacement: Expression)
 
   def this(left: Expression, right: Expression) = {
     this(left, right,
-      if (SQLConf.get.getConf(SQLConf.REPLACE_NULLIF_USING_WITH_EXPR)) {
+      if (!SQLConf.get.getConf(SQLConf.ALWAYS_INLINE_COMMON_EXPR_IN_WITH)) {
         With(left) { case Seq(ref) =>
           If(EqualTo(ref, right), Literal.create(null, left.dataType), ref)
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -160,7 +160,7 @@ case class NullIf(left: Expression, right: Expression, replacement: Expression)
 
   def this(left: Expression, right: Expression) = {
     this(left, right,
-      if (!SQLConf.get.getConf(SQLConf.ALWAYS_INLINE_COMMON_EXPR_IN_WITH)) {
+      if (!SQLConf.get.getConf(SQLConf.ALWAYS_INLINE_COMMON_EXPR)) {
         With(left) { case Seq(ref) =>
           If(EqualTo(ref, right), Literal.create(null, left.dataType), ref)
         }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3396,6 +3396,7 @@ object SQLConf {
       .doc("When true, always inline common expressions instead of using the WITH expression. " +
         "This may lead to duplicated expressions and the config should only be enabled if you " +
         "hit bugs caused by the WITH expression.")
+      .version("4.0.0")
       .booleanConf
       .createWithDefault(false)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3390,13 +3390,13 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
-  val REPLACE_NULLIF_USING_WITH_EXPR =
-    buildConf("spark.databricks.sql.replaceNullIfUsingWithExpr")
+  val ALWAYS_INLINE_COMMON_EXPR_IN_WITH =
+    buildConf("spark.sql.alwaysInlineCommonExprInWith")
       .internal()
-      .doc("When true, NullIf expressions are rewritten using With expressions to avoid " +
-        "expression duplication.")
+      .doc("When true, always inline common expressions inside WITH expression which may lead " +
+        "to duplicated expressions.")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   val USE_NULLS_FOR_MISSING_DEFAULT_COLUMN_VALUES =
     buildConf("spark.sql.defaultColumn.useNullsForMissingDefaultValues")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3390,11 +3390,12 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
-  val ALWAYS_INLINE_COMMON_EXPR_IN_WITH =
-    buildConf("spark.sql.alwaysInlineCommonExprInWith")
+  val ALWAYS_INLINE_COMMON_EXPR =
+    buildConf("spark.sql.alwaysInlineCommonExpr")
       .internal()
-      .doc("When true, always inline common expressions inside WITH expression which may lead " +
-        "to duplicated expressions.")
+      .doc("When true, always inline common expressions instead of using the WITH expression. " +
+        "This may lead to duplicated expressions and the config should only be enabled if you " +
+        "hit bugs caused by the WITH expression.")
       .booleanConf
       .createWithDefault(false)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This is a follow-up of
- #45649

`With` is not only used by `NullIf`, but also `Between`. This PR renames the config `REPLACE_NULLIF_USING_WITH_EXPR` to be more general, and use it to control `Between` as well.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
have a conf to control all the usages of `With`.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no, not released yet

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
existing tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no