### PR TITLE
[SPARK-47727][PYTHON] Make SparkConf to root level to for both SparkSession and SparkContext

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -430,9 +430,9 @@ pyspark_core = Module(
     source_file_regexes=["python/(?!pyspark/(ml|mllib|sql|streaming))"],
     python_test_goals=[
         # doctests
+        "pyspark.conf",
         "pyspark.core.rdd",
         "pyspark.core.context",
-        "pyspark.core.conf",
         "pyspark.core.broadcast",
         "pyspark.accumulators",
         "pyspark.core.files",

--- a/python/pyspark/__init__.py
+++ b/python/pyspark/__init__.py
@@ -53,20 +53,19 @@ from typing import cast, Any, Callable, TypeVar, Union
 from pyspark.util import is_remote_only
 
 if not is_remote_only():
-    from pyspark.core.conf import SparkConf
     from pyspark.core.rdd import RDD, RDDBarrier
     from pyspark.core.files import SparkFiles
     from pyspark.core.status import StatusTracker, SparkJobInfo, SparkStageInfo
     from pyspark.core.broadcast import Broadcast
-    from pyspark.core import conf, rdd, files, status, broadcast
+    from pyspark.core import rdd, files, status, broadcast
 
     # for backward compatibility references.
-    sys.modules["pyspark.conf"] = conf
     sys.modules["pyspark.rdd"] = rdd
     sys.modules["pyspark.files"] = files
     sys.modules["pyspark.status"] = status
     sys.modules["pyspark.broadcast"] = broadcast
 
+from pyspark.conf import SparkConf
 from pyspark.util import InheritableThread, inheritable_thread_target
 from pyspark.storagelevel import StorageLevel
 from pyspark.accumulators import Accumulator, AccumulatorParam

--- a/python/pyspark/conf.py
+++ b/python/pyspark/conf.py
@@ -62,8 +62,8 @@ class SparkConf:
 
     Examples
     --------
-    >>> from pyspark.conf import SparkConf
-    >>> from pyspark.context import SparkContext
+    >>> from pyspark import SparkConf
+    >>> from pyspark import SparkContext
     >>> conf = SparkConf()
     >>> conf.setMaster("local").setAppName("My app")
     <pyspark.conf.SparkConf object at ...>

--- a/python/pyspark/conf.py
+++ b/python/pyspark/conf.py
@@ -62,11 +62,11 @@ class SparkConf:
 
     Examples
     --------
-    >>> from pyspark.core.conf import SparkConf
-    >>> from pyspark.core.context import SparkContext
+    >>> from pyspark.conf import SparkConf
+    >>> from pyspark.context import SparkContext
     >>> conf = SparkConf()
     >>> conf.setMaster("local").setAppName("My app")
-    <pyspark.core.conf.SparkConf object at ...>
+    <pyspark.conf.SparkConf object at ...>
     >>> conf.get("spark.master")
     'local'
     >>> conf.get("spark.app.name")
@@ -81,13 +81,13 @@ class SparkConf:
 
     >>> conf = SparkConf(loadDefaults=False)
     >>> conf.setSparkHome("/path")
-    <pyspark.core.conf.SparkConf object at ...>
+    <pyspark.conf.SparkConf object at ...>
     >>> conf.get("spark.home")
     '/path'
     >>> conf.setExecutorEnv("VAR1", "value1")
-    <pyspark.core.conf.SparkConf object at ...>
+    <pyspark.conf.SparkConf object at ...>
     >>> conf.setExecutorEnv(pairs = [("VAR3", "value3"), ("VAR4", "value4")])
-    <pyspark.core.conf.SparkConf object at ...>
+    <pyspark.conf.SparkConf object at ...>
     >>> conf.get("spark.executorEnv.VAR1")
     'value1'
     >>> print(conf.toDebugString())

--- a/python/pyspark/conf.py
+++ b/python/pyspark/conf.py
@@ -62,8 +62,7 @@ class SparkConf:
 
     Examples
     --------
-    >>> from pyspark import SparkConf
-    >>> from pyspark import SparkContext
+    >>> from pyspark import SparkConf, SparkContext
     >>> conf = SparkConf()
     >>> conf.setMaster("local").setAppName("My app")
     <pyspark.conf.SparkConf object at ...>

--- a/python/pyspark/conf.py
+++ b/python/pyspark/conf.py
@@ -18,11 +18,13 @@
 __all__ = ["SparkConf"]
 
 import sys
-from typing import Dict, List, Optional, Tuple, cast, overload
+from typing import Dict, List, Optional, Tuple, cast, overload, TYPE_CHECKING
 
-from py4j.java_gateway import JVMView, JavaObject
-
+from pyspark.util import is_remote_only
 from pyspark.errors import PySparkRuntimeError
+
+if TYPE_CHECKING:
+    from py4j.java_gateway import JVMView, JavaObject
 
 
 class SparkConf:
@@ -109,14 +111,14 @@ class SparkConf:
     spark.home=/path
     """
 
-    _jconf: Optional[JavaObject]
+    _jconf: Optional["JavaObject"]
     _conf: Optional[Dict[str, str]]
 
     def __init__(
         self,
         loadDefaults: bool = True,
-        _jvm: Optional[JVMView] = None,
-        _jconf: Optional[JavaObject] = None,
+        _jvm: Optional["JVMView"] = None,
+        _jconf: Optional["JavaObject"] = None,
     ):
         """
         Create a new Spark configuration.
@@ -124,9 +126,11 @@ class SparkConf:
         if _jconf:
             self._jconf = _jconf
         else:
-            from pyspark.core.context import SparkContext
+            _jvm = None
+            if not is_remote_only():
+                from pyspark.core.context import SparkContext
 
-            _jvm = _jvm or SparkContext._jvm
+                _jvm = _jvm or SparkContext._jvm
 
             if _jvm is not None:
                 # JVM is created, so create self._jconf directly through JVM
@@ -240,6 +244,8 @@ class SparkConf:
     def getAll(self) -> List[Tuple[str, str]]:
         """Get all values as a list of key-value pairs."""
         if self._jconf is not None:
+            from py4j.java_gateway import JavaObject
+
             return [(elem._1(), elem._2()) for elem in cast(JavaObject, self._jconf).getAll()]
         else:
             assert self._conf is not None

--- a/python/pyspark/conf.py
+++ b/python/pyspark/conf.py
@@ -126,15 +126,15 @@ class SparkConf:
         if _jconf:
             self._jconf = _jconf
         else:
-            _jvm = None
+            jvm = None
             if not is_remote_only():
                 from pyspark.core.context import SparkContext
 
-                _jvm = _jvm or SparkContext._jvm
+                jvm = _jvm or SparkContext._jvm
 
-            if _jvm is not None:
+            if jvm is not None:
                 # JVM is created, so create self._jconf directly through JVM
-                self._jconf = _jvm.SparkConf(loadDefaults)
+                self._jconf = jvm.SparkConf(loadDefaults)
                 self._conf = None
             else:
                 # JVM is not created, so store data in self._conf first

--- a/python/pyspark/core/context.py
+++ b/python/pyspark/core/context.py
@@ -47,7 +47,6 @@ from py4j.java_collections import JavaMap
 from py4j.protocol import Py4JError
 
 from pyspark import accumulators
-from pyspark.conf import SparkConf
 from pyspark.accumulators import Accumulator
 from pyspark.core.broadcast import Broadcast, BroadcastPickleRegistry
 from pyspark.core.files import SparkFiles
@@ -74,6 +73,7 @@ from pyspark.errors import PySparkRuntimeError
 from py4j.java_gateway import is_instance_of, JavaGateway, JavaObject, JVMView
 
 if TYPE_CHECKING:
+    from pyspark.conf import SparkConf
     from pyspark.accumulators import AccumulatorParam
 
 __all__ = ["SparkContext"]
@@ -235,6 +235,8 @@ class SparkContext:
         udf_profiler_cls: Type[UDFBasicProfiler] = UDFBasicProfiler,
         memory_profiler_cls: Type[MemoryProfiler] = MemoryProfiler,
     ) -> None:
+        from pyspark.conf import SparkConf
+
         self.environment = environment or {}
         # java gateway must have been launched at this point.
         if conf is not None and conf._jconf is not None:
@@ -511,6 +513,8 @@ class SparkContext:
         >>> SparkContext.getOrCreate()
         <SparkContext ...>
         """
+        from pyspark.conf import SparkConf
+
         with SparkContext._lock:
             if SparkContext._active_spark_context is None:
                 SparkContext(conf=conf or SparkConf())
@@ -2561,6 +2565,8 @@ class SparkContext:
 
         .. versionadded:: 2.1.0
         """
+        from pyspark.conf import SparkConf
+
         conf = SparkConf()
         conf.setAll(self._conf.getAll())
         return conf
@@ -2598,7 +2604,7 @@ class SparkContext:
 
 def _test() -> None:
     import doctest
-    from pyspark import SparkConf
+    from pyspark.conf import SparkConf
 
     globs = globals().copy()
     conf = SparkConf().set("spark.ui.enabled", "True")

--- a/python/pyspark/core/context.py
+++ b/python/pyspark/core/context.py
@@ -175,7 +175,7 @@ class SparkContext:
         environment: Optional[Dict[str, Any]] = None,
         batchSize: int = 0,
         serializer: "Serializer" = CPickleSerializer(),
-        conf: Optional[SparkConf] = None,
+        conf: Optional["SparkConf"] = None,
         gateway: Optional[JavaGateway] = None,
         jsc: Optional[JavaObject] = None,
         profiler_cls: Type[BasicProfiler] = BasicProfiler,
@@ -229,7 +229,7 @@ class SparkContext:
         environment: Optional[Dict[str, Any]],
         batchSize: int,
         serializer: Serializer,
-        conf: Optional[SparkConf],
+        conf: Optional["SparkConf"],
         jsc: JavaObject,
         profiler_cls: Type[BasicProfiler] = BasicProfiler,
         udf_profiler_cls: Type[UDFBasicProfiler] = UDFBasicProfiler,
@@ -428,7 +428,7 @@ class SparkContext:
         cls,
         instance: Optional["SparkContext"] = None,
         gateway: Optional[JavaGateway] = None,
-        conf: Optional[SparkConf] = None,
+        conf: Optional["SparkConf"] = None,
     ) -> None:
         """
         Checks whether a SparkContext is initialized or not.
@@ -491,7 +491,7 @@ class SparkContext:
         self.stop()
 
     @classmethod
-    def getOrCreate(cls, conf: Optional[SparkConf] = None) -> "SparkContext":
+    def getOrCreate(cls, conf: Optional["SparkConf"] = None) -> "SparkContext":
         """
         Get or instantiate a :class:`SparkContext` and register it as a singleton object.
 
@@ -2560,7 +2560,7 @@ class SparkContext:
                 message_parameters={},
             )
 
-    def getConf(self) -> SparkConf:
+    def getConf(self) -> "SparkConf":
         """Return a copy of this SparkContext's configuration :class:`SparkConf`.
 
         .. versionadded:: 2.1.0

--- a/python/pyspark/core/context.py
+++ b/python/pyspark/core/context.py
@@ -145,7 +145,7 @@ class SparkContext:
 
     Examples
     --------
-    >>> from pyspark.core.context import SparkContext
+    >>> from pyspark.context import SparkContext
     >>> sc = SparkContext('local', 'test')
     >>> sc2 = SparkContext('local', 'test2') # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):

--- a/python/pyspark/core/context.py
+++ b/python/pyspark/core/context.py
@@ -47,9 +47,9 @@ from py4j.java_collections import JavaMap
 from py4j.protocol import Py4JError
 
 from pyspark import accumulators
+from pyspark.conf import SparkConf
 from pyspark.accumulators import Accumulator
 from pyspark.core.broadcast import Broadcast, BroadcastPickleRegistry
-from pyspark.core.conf import SparkConf
 from pyspark.core.files import SparkFiles
 from pyspark.java_gateway import launch_gateway
 from pyspark.serializers import (

--- a/python/pyspark/core/context.py
+++ b/python/pyspark/core/context.py
@@ -47,6 +47,7 @@ from py4j.java_collections import JavaMap
 from py4j.protocol import Py4JError
 
 from pyspark import accumulators
+from pyspark.conf import SparkConf
 from pyspark.accumulators import Accumulator
 from pyspark.core.broadcast import Broadcast, BroadcastPickleRegistry
 from pyspark.core.files import SparkFiles
@@ -73,7 +74,6 @@ from pyspark.errors import PySparkRuntimeError
 from py4j.java_gateway import is_instance_of, JavaGateway, JavaObject, JVMView
 
 if TYPE_CHECKING:
-    from pyspark.conf import SparkConf
     from pyspark.accumulators import AccumulatorParam
 
 __all__ = ["SparkContext"]
@@ -145,7 +145,7 @@ class SparkContext:
 
     Examples
     --------
-    >>> from pyspark.context import SparkContext
+    >>> from pyspark.core.context import SparkContext
     >>> sc = SparkContext('local', 'test')
     >>> sc2 = SparkContext('local', 'test2') # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
@@ -175,7 +175,7 @@ class SparkContext:
         environment: Optional[Dict[str, Any]] = None,
         batchSize: int = 0,
         serializer: "Serializer" = CPickleSerializer(),
-        conf: Optional["SparkConf"] = None,
+        conf: Optional[SparkConf] = None,
         gateway: Optional[JavaGateway] = None,
         jsc: Optional[JavaObject] = None,
         profiler_cls: Type[BasicProfiler] = BasicProfiler,
@@ -229,14 +229,12 @@ class SparkContext:
         environment: Optional[Dict[str, Any]],
         batchSize: int,
         serializer: Serializer,
-        conf: Optional["SparkConf"],
+        conf: Optional[SparkConf],
         jsc: JavaObject,
         profiler_cls: Type[BasicProfiler] = BasicProfiler,
         udf_profiler_cls: Type[UDFBasicProfiler] = UDFBasicProfiler,
         memory_profiler_cls: Type[MemoryProfiler] = MemoryProfiler,
     ) -> None:
-        from pyspark.conf import SparkConf
-
         self.environment = environment or {}
         # java gateway must have been launched at this point.
         if conf is not None and conf._jconf is not None:
@@ -428,7 +426,7 @@ class SparkContext:
         cls,
         instance: Optional["SparkContext"] = None,
         gateway: Optional[JavaGateway] = None,
-        conf: Optional["SparkConf"] = None,
+        conf: Optional[SparkConf] = None,
     ) -> None:
         """
         Checks whether a SparkContext is initialized or not.
@@ -491,7 +489,7 @@ class SparkContext:
         self.stop()
 
     @classmethod
-    def getOrCreate(cls, conf: Optional["SparkConf"] = None) -> "SparkContext":
+    def getOrCreate(cls, conf: Optional[SparkConf] = None) -> "SparkContext":
         """
         Get or instantiate a :class:`SparkContext` and register it as a singleton object.
 
@@ -513,8 +511,6 @@ class SparkContext:
         >>> SparkContext.getOrCreate()
         <SparkContext ...>
         """
-        from pyspark.conf import SparkConf
-
         with SparkContext._lock:
             if SparkContext._active_spark_context is None:
                 SparkContext(conf=conf or SparkConf())
@@ -2560,13 +2556,11 @@ class SparkContext:
                 message_parameters={},
             )
 
-    def getConf(self) -> "SparkConf":
+    def getConf(self) -> SparkConf:
         """Return a copy of this SparkContext's configuration :class:`SparkConf`.
 
         .. versionadded:: 2.1.0
         """
-        from pyspark.conf import SparkConf
-
         conf = SparkConf()
         conf.setAll(self._conf.getAll())
         return conf
@@ -2604,7 +2598,6 @@ class SparkContext:
 
 def _test() -> None:
     import doctest
-    from pyspark.conf import SparkConf
 
     globs = globals().copy()
     conf = SparkConf().set("spark.ui.enabled", "True")

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -38,6 +38,7 @@ from typing import (
     TYPE_CHECKING,
 )
 
+from pyspark.conf import SparkConf
 from pyspark.util import is_remote_only
 from pyspark.sql.column import _to_java_column
 from pyspark.sql.conf import RuntimeConfig
@@ -67,7 +68,6 @@ from pyspark.errors import PySparkValueError, PySparkTypeError, PySparkRuntimeEr
 
 if TYPE_CHECKING:
     from py4j.java_gateway import JavaObject
-    from pyspark.core.conf import SparkConf
     from pyspark.core.context import SparkContext
     from pyspark.core.rdd import RDD
     from pyspark.sql._typing import AtomicValue, RowLike, OptionalPrimitiveType
@@ -220,7 +220,7 @@ class SparkSession(SparkConversionMixin):
             self._options: Dict[str, Any] = {}
 
         @overload
-        def config(self, *, conf: "SparkConf") -> "SparkSession.Builder":
+        def config(self, *, conf: SparkConf) -> "SparkSession.Builder":
             ...
 
         @overload
@@ -235,7 +235,7 @@ class SparkSession(SparkConversionMixin):
             self,
             key: Optional[str] = None,
             value: Optional[Any] = None,
-            conf: Optional["SparkConf"] = None,
+            conf: Optional[SparkConf] = None,
             *,
             map: Optional[Dict[str, "OptionalPrimitiveType"]] = None,
         ) -> "SparkSession.Builder":
@@ -272,7 +272,7 @@ class SparkSession(SparkConversionMixin):
             --------
             For an existing :class:`SparkConf`, use `conf` parameter.
 
-            >>> from pyspark.core.conf import SparkConf
+            >>> from pyspark.conf import SparkConf
             >>> conf = SparkConf().setAppName("example").setMaster("local")
             >>> SparkSession.builder.config(conf=conf)
             <pyspark.sql.session.SparkSession.Builder...
@@ -488,7 +488,6 @@ class SparkSession(SparkConversionMixin):
                 return RemoteSparkSession.builder.config(map=opts).getOrCreate()  # type: ignore
 
             from pyspark.core.context import SparkContext
-            from pyspark.core.conf import SparkConf
 
             with self._lock:
                 if (
@@ -1212,7 +1211,6 @@ class SparkSession(SparkConversionMixin):
         that script, which would expose those to users.
         """
         import py4j
-        from pyspark.core.conf import SparkConf
         from pyspark.core.context import SparkContext
 
         try:

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -193,9 +193,6 @@ class SparkSessionTests3(unittest.TestCase, PySparkErrorTestUtils):
             session.range(5).collect()
 
     def test_active_session_with_None_and_not_None_context(self):
-        from pyspark.core.context import SparkContext
-        from pyspark.core.conf import SparkConf
-
         sc = None
         session = None
         try:

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -52,7 +52,7 @@ except ImportError:
     # No NumPy, but that's okay, we'll skip those tests
     pass
 
-from pyspark import SparkContext, SparkConf
+from pyspark import SparkConf
 from pyspark.errors import PySparkAssertionError, PySparkException
 from pyspark.find_spark_home import _find_spark_home
 from pyspark.sql.dataframe import DataFrame
@@ -154,6 +154,8 @@ class QuietTest:
 
 class PySparkTestCase(unittest.TestCase):
     def setUp(self):
+        from pyspark import SparkContext
+
         self._old_sys_path = list(sys.path)
         class_name = self.__class__.__name__
         self.sc = SparkContext("local[4]", class_name)
@@ -173,6 +175,8 @@ class ReusedPySparkTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        from pyspark import SparkContext
+
         cls.sc = SparkContext("local[4]", cls.__name__, conf=cls.conf())
 
     @classmethod


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to make SparkConf to root level to for both `SparkSession` and `SparkContext`.

### Why are the changes needed?

`SparkConf` is special. `SparkSession.builder.options` can take it as an option, and this instance can be created without JVM access. So it can be shared with pure Python `pysaprk-connect` package.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

CI in this PR should verify them.

### Was this patch authored or co-authored using generative AI tooling?

No.
