### PR TITLE
[SPARK-47729][PYTHON][TESTS] Get the proper default port for pyspark-connect testcases

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -56,6 +56,7 @@ import grpc
 from google.protobuf import text_format, any_pb2
 from google.rpc import error_details_pb2
 
+from pyspark.util import is_remote_only
 from pyspark.accumulators import SpecialAccumulatorIds
 from pyspark.loose_version import LooseVersion
 from pyspark.version import __version__
@@ -291,7 +292,7 @@ class DefaultChannelBuilder(ChannelBuilder):
 
     @staticmethod
     def default_port() -> int:
-        if "SPARK_TESTING" in os.environ:
+        if "SPARK_TESTING" in os.environ and not is_remote_only():
             from pyspark.sql.session import SparkSession as PySparkSession
 
             # In the case when Spark Connect uses the local mode, it starts the regular Spark


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to get the proper default port for `pyspark-connect` testcases.

### Why are the changes needed?

`pyspark-connect` cannot access to the JVM, so cannot get the randomized port assigned from JVM.

### Does this PR introduce _any_ user-facing change?

No, `pyspark-connect` is not published yet, and this is a test-only change.

### How was this patch tested?

Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.