### PR TITLE
[SPARK-47724][PYTHON][TESTS][FOLLOW-UP] Make testing script to inherits SPARK_CONNECT_TESTING_REMOTE env

### DIFF
--- a/python/run-tests.py
+++ b/python/run-tests.py
@@ -98,6 +98,9 @@ def run_individual_python_test(target_dir, test_name, pyspark_python, keep_test_
         'PYARROW_IGNORE_TIMEZONE': '1',
     })
 
+    if "SPARK_CONNECT_TESTING_REMOTE" in os.environ:
+        env.update({"SPARK_CONNECT_TESTING_REMOTE": os.environ["SPARK_CONNECT_TESTING_REMOTE"]})
+
     # Create a unique temp directory under 'target/' for each run. The TMPDIR variable is
     # recognized by the tempfile module to override the default system temp directory.
     tmp_dir = os.path.join(target_dir, str(uuid.uuid4()))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/45868 that proposes to make testing script to inherits SPARK_CONNECT_TESTING_REMOTE environment variable.

### Why are the changes needed?

So the testing script can set `SPARK_CONNECT_TESTING_REMOTE`, and makes the env effective.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually tested at https://github.com/apache/spark/pull/45870

### Was this patch authored or co-authored using generative AI tooling?

No.