### PR TITLE
[SPARK-47735][PYTHON][TESTS] Make pyspark.testing.connectutils compatible with pyspark-connect

### DIFF
--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -45,6 +45,7 @@ except ImportError as e:
 have_googleapis_common_protos = googleapis_common_protos_requirement_message is None
 
 from pyspark import Row, SparkConf
+from pyspark.util import is_remote_only
 from pyspark.testing.utils import PySparkErrorTestUtils
 from pyspark.testing.sqlutils import (
     have_pandas,
@@ -184,7 +185,9 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
             .remote(cls.master())
             .getOrCreate()
         )
-        cls._legacy_sc = PySparkSession._instantiatedSession._sc
+        cls._legacy_sc = None
+        if not is_remote_only():
+            cls._legacy_sc = PySparkSession._instantiatedSession._sc
         cls.tempdir = tempfile.NamedTemporaryFile(delete=False)
         os.unlink(cls.tempdir.name)
         cls.testData = [Row(key=i, value=str(i)) for i in range(100)]
@@ -203,4 +206,5 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
     def quiet(self):
         from pyspark.testing.utils import QuietTest
 
-        return QuietTest(self._legacy_sc)
+        if self._legacy_sc is not None:
+            return QuietTest(self._legacy_sc)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to make `pyspark.testing.connectutils` compatible with `pyspark-connect`.

### Why are the changes needed?

This is the base work to set up the CI for pyspark-connect.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Tested in https://github.com/apache/spark/pull/45870.

### Was this patch authored or co-authored using generative AI tooling?

No.