### PR TITLE
[SPARK-47081][CONNECT][TESTS][FOLLOW-UP] Skip the flaky doctests for now

### DIFF
--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -2048,7 +2048,7 @@ class SparkSession(SparkConversionMixin):
         >>> def progress_handler(stages, inflight_tasks, done):
         ...     print(f"{len(stages)} Stages known, Done: {done}")
         >>> spark.registerProgressHandler(progress_handler)
-        >>> res = spark.range(10).repartition(1).collect()
+        >>> res = spark.range(10).repartition(1).collect()  # doctest: +SKIP
         3 Stages known, Done: False
         3 Stages known, Done: True
         >>> spark.clearProgressHandlers()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/45150 that skips flaky doctests.

### Why are the changes needed?

In order to make the build stable.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

CI in this PR should verify it.

### Was this patch authored or co-authored using generative AI tooling?

No.
