### PR TITLE
[SPARK-46411][BUILD][3.4] Change to use `bcprov/bcpkix-jdk18on` for UT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
     <maven-antrun.version>1.8</maven-antrun.version>
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <commons-cli.version>1.5.0</commons-cli.version>
-    <bouncycastle.version>1.70</bouncycastle.version>
+    <bouncycastle.version>1.77</bouncycastle.version>
     <tink.version>1.7.0</tink.version>
     <netty.version>4.1.87.Final</netty.version>
     <!--
@@ -1440,13 +1440,13 @@
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk15on</artifactId>
+        <artifactId>bcprov-jdk18on</artifactId>
         <version>${bouncycastle.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcpkix-jdk15on</artifactId>
+        <artifactId>bcpkix-jdk18on</artifactId>
         <version>${bouncycastle.version}</version>
         <scope>test</scope>
       </dependency>

--- a/resource-managers/yarn/pom.xml
+++ b/resource-managers/yarn/pom.xml
@@ -90,12 +90,12 @@
         <!-- Used by MiniYARNCluster -->
         <dependency>
           <groupId>org.bouncycastle</groupId>
-          <artifactId>bcprov-jdk15on</artifactId>
+          <artifactId>bcprov-jdk18on</artifactId>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.bouncycastle</groupId>
-          <artifactId>bcpkix-jdk15on</artifactId>
+          <artifactId>bcpkix-jdk18on</artifactId>
           <scope>test</scope>
         </dependency>
       </dependencies>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This is a backport of https://github.com/apache/spark/pull/44359 .

This PR migrates the test dependency `bcprov/bcpkix` from `jdk15on` to `jdk18on`, and upgrades the version from 1.70 to 1.77, the `jdk18on` jars are compiled to work with anything from Java 1.8 up.

### Why are the changes needed?
The full release notes as follows:
- https://www.bouncycastle.org/releasenotes.html#r1rv77


### Does this PR introduce _any_ user-facing change?
No, just for test.


### How was this patch tested?
Pass GitHub Actions.


### Was this patch authored or co-authored using generative AI tooling?
No
