### PR TITLE
[SPARK-47743][Core] Use milliseconds as the time unit in logging

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
@@ -41,6 +41,7 @@ object LogKey extends Enumeration {
   val CONTAINER_ID = Value
   val COUNT = Value
   val DRIVER_ID = Value
+  val EFFECTIVE_TIME = Value
   val END_POINT = Value
   val ERROR = Value
   val EVENT_LOOP = Value
@@ -102,7 +103,7 @@ object LogKey extends Enumeration {
   val THREAD_NAME = Value
   val TID = Value
   val TIMEOUT = Value
-  val TIME_UNITS = Value
+  val TOTAL_TIME = Value
   val URI = Value
   val USER_NAME = Value
   val WATERMARK_CONSTRAINT = Value

--- a/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
@@ -41,7 +41,6 @@ object LogKey extends Enumeration {
   val CONTAINER_ID = Value
   val COUNT = Value
   val DRIVER_ID = Value
-  val EFFECTIVE_TIME = Value
   val END_POINT = Value
   val ERROR = Value
   val EVENT_LOOP = Value
@@ -103,6 +102,7 @@ object LogKey extends Enumeration {
   val THREAD_NAME = Value
   val TID = Value
   val TIMEOUT = Value
+  val TOTAL_EFFECTIVE_TIME = Value
   val TOTAL_TIME = Value
   val URI = Value
   val USER_NAME = Value

--- a/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
@@ -83,7 +83,7 @@ object LogKey extends Enumeration {
   val SHUFFLE_ID = Value
   val SHUFFLE_MERGE_ID = Value
   val SIZE = Value
-  val SLEEP_TIME_SECONDS = Value
+  val SLEEP_TIME = Value
   val STAGE_ID = Value
   val SUBMISSION_ID = Value
   val SUBSAMPLING_RATE = Value

--- a/common/utils/src/main/scala/org/apache/spark/internal/README.md
+++ b/common/utils/src/main/scala/org/apache/spark/internal/README.md
@@ -7,6 +7,7 @@ LogKeys serve as identifiers for mapped diagnostic contexts (MDC) within logs. F
 * Use `UPPER_SNAKE_CASE` for key names.
 * Key names should be both simple and broad, yet include specific identifiers like `STAGE_ID`, `TASK_ID`, and `JOB_ID` when needed for clarity. For instance, use `MAX_ATTEMPTS` as a general key instead of creating separate keys for each scenario such as `EXECUTOR_STATE_SYNC_MAX_ATTEMPTS` and `MAX_TASK_FAILURES`. This balances simplicity with the detail needed for effective logging.
 * Use abbreviations in names if they are widely understood, such as `APP_ID` for APPLICATION_ID, and `K8S` for KUBERNETES.
+* For time-related keys, use milliseconds as the unit of time.
 
 ## Exceptions
 

--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -42,7 +42,7 @@ import org.apache.spark._
 import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.executor.DataReadMethod
 import org.apache.spark.internal.{config, Logging, MDC}
-import org.apache.spark.internal.LogKey.{BLOCK_ID, COUNT, SLEEP_TIME_SECONDS}
+import org.apache.spark.internal.LogKey.{BLOCK_ID, COUNT, SLEEP_TIME}
 import org.apache.spark.internal.config.{Network, RDD_CACHE_VISIBILITY_TRACKING_ENABLED, Tests}
 import org.apache.spark.memory.{MemoryManager, MemoryMode}
 import org.apache.spark.metrics.source.Source
@@ -616,7 +616,7 @@ private[spark] class BlockManager(
       shuffleManagerMeta)
 
     val MAX_ATTEMPTS = conf.get(config.SHUFFLE_REGISTRATION_MAX_ATTEMPTS)
-    val SLEEP_TIME_SECS = 5
+    val SLEEP_TIME_MS = 5000
 
     for (i <- 1 to MAX_ATTEMPTS) {
       try {
@@ -628,8 +628,8 @@ private[spark] class BlockManager(
         case e: Exception if i < MAX_ATTEMPTS =>
           logError(log"Failed to connect to external shuffle server, will retry " +
             log"${MDC(COUNT, MAX_ATTEMPTS - i)} more times after waiting " +
-            log"${MDC(SLEEP_TIME_SECONDS, SLEEP_TIME_SECS)} seconds...", e)
-          Thread.sleep(SLEEP_TIME_SECS * 1000L)
+            log"${MDC(SLEEP_TIME, SLEEP_TIME_MS)} ms...", e)
+          Thread.sleep(SLEEP_TIME_MS)
         case NonFatal(e) => throw SparkCoreErrors.unableToRegisterWithExternalShuffleServerError(e)
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1641,7 +1641,7 @@ object CodeGenerator extends Logging {
         val timeMs: Double = duration.toDouble / NANOS_PER_MILLIS
         CodegenMetrics.METRIC_SOURCE_CODE_SIZE.update(code.body.length)
         CodegenMetrics.METRIC_COMPILATION_TIME.update(timeMs.toLong)
-        logInfo(log"Code generated in ${MDC(TIME_UNITS, timeMs)} ms")
+        logInfo(log"Code generated in ${MDC(TOTAL_TIME, timeMs)} ms")
         _compileTime.add(duration)
         result
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
@@ -23,7 +23,7 @@ import org.apache.spark.internal.LogKey._
 import org.apache.spark.internal.MDC
 import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.trees.TreeNode
-import org.apache.spark.sql.catalyst.util.DateTimeConstants.NANOS_PER_SECOND
+import org.apache.spark.sql.catalyst.util.DateTimeConstants.NANOS_PER_MILLIS
 import org.apache.spark.sql.catalyst.util.sideBySide
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.SQLConf
@@ -88,15 +88,15 @@ class PlanChangeLogger[TreeType <: TreeNode[_]] extends Logging {
   }
 
   def logMetrics(metrics: QueryExecutionMetrics): Unit = {
-    val totalTime = metrics.time / NANOS_PER_SECOND.toDouble
-    val totalTimeEffective = metrics.timeEffective / NANOS_PER_SECOND.toDouble
+    val totalTime = metrics.time / NANOS_PER_MILLIS.toDouble
+    val totalTimeEffective = metrics.timeEffective / NANOS_PER_MILLIS.toDouble
     val message: MessageWithContext =
       log"""
          |=== Metrics of Executed Rules ===
          |Total number of runs: ${MDC(RULE_NUMBER_OF_RUNS, metrics.numRuns)}
-         |Total time: ${MDC(TIME_UNITS, totalTime)} seconds
+         |Total time: ${MDC(EFFECTIVE_TIME, totalTime)} ms
          |Total number of effective runs: ${MDC(RULE_NUMBER_OF_RUNS, metrics.numEffectiveRuns)}
-         |Total time of effective runs: ${MDC(TIME_UNITS, totalTimeEffective)} seconds
+         |Total time of effective runs: ${MDC(TOTAL_TIME, totalTimeEffective)} ms
       """.stripMargin
 
     logBasedOnLevel(message)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleExecutor.scala
@@ -94,9 +94,9 @@ class PlanChangeLogger[TreeType <: TreeNode[_]] extends Logging {
       log"""
          |=== Metrics of Executed Rules ===
          |Total number of runs: ${MDC(RULE_NUMBER_OF_RUNS, metrics.numRuns)}
-         |Total time: ${MDC(EFFECTIVE_TIME, totalTime)} ms
+         |Total time: ${MDC(TOTAL_TIME, totalTime)} ms
          |Total number of effective runs: ${MDC(RULE_NUMBER_OF_RUNS, metrics.numEffectiveRuns)}
-         |Total time of effective runs: ${MDC(TOTAL_TIME, totalTimeEffective)} ms
+         |Total time of effective runs: ${MDC(TOTAL_EFFECTIVE_TIME, totalTimeEffective)} ms
       """.stripMargin
 
     logBasedOnLevel(message)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Use milliseconds as the time unit in logging

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
During migrations, for the same log key `TIMEOUT` there are [log entry using seconds](https://github.com/apache/spark/blob/master/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/SparkExecuteStatementOperation.scala#L145) and [another entry using ms](https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/executor/Executor.scala#L1017).
I suggest unify them and use milliseconds for all time related loggings.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Exising UT

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No