### PR TITLE
[SPARK-47748][BUILD] Upgrade `zstd-jni` to 1.5.6-2

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -277,4 +277,4 @@ xz/1.9//xz-1.9.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.9.2//zookeeper-jute-3.9.2.jar
 zookeeper/3.9.2//zookeeper-3.9.2.jar
-zstd-jni/1.5.6-1//zstd-jni-1.5.6-1.jar
+zstd-jni/1.5.6-2//zstd-jni-1.5.6-2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -797,7 +797,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.5.6-1</version>
+        <version>1.5.6-2</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `zstd-jni` from `1.5.6-1` to `1.5.6-2`.

### Why are the changes needed?
- v1.5.6-1 VS v1.5.6-2
https://github.com/luben/zstd-jni/compare/v1.5.6-1...v1.5.6-2

- compilation optimization
  [Use the M1 MacOS runner to compile the aarch64 binary](https://github.com/luben/zstd-jni/commit/ec1ddeb069f59727ecfcbeeb34ca3e6d8a481d49)
  [Use cross-compile for i386](https://github.com/luben/zstd-jni/commit/1ff89339eeee9707523b04ccd373ff6c3e659ec8)

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
