### PR TITLE
[SPARK-46722][CONNECT][SS][TESTS][FOLLOW-UP] Drop the tables after tests finished

### DIFF
--- a/python/pyspark/sql/tests/connect/streaming/test_parity_listener.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_listener.py
@@ -122,8 +122,16 @@ class StreamingListenerParityTests(StreamingListenerTestsMixin, ReusedConnectTes
                 # Remove again to verify this won't throw any error
                 self.spark.streams.removeListener(test_listener)
 
-        verify(TestListenerV1(), "_v1")
-        verify(TestListenerV2(), "_v2")
+        with self.table(
+            "listener_start_events_v1",
+            "listener_progress_events_v1",
+            "listener_terminated_events_v1",
+            "listener_start_events_v2",
+            "listener_progress_events_v2",
+            "listener_terminated_events_v2",
+        ):
+            verify(TestListenerV1(), "_v1")
+            verify(TestListenerV2(), "_v2")
 
     def test_accessing_spark_session(self):
         spark = self.spark


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to drop the tables after tests finished.

### Why are the changes needed?

- To clean up resources properly.
- It can affect other test cases when only one session is being used across other tests.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Tested in https://github.com/apache/spark/pull/45870.

### Was this patch authored or co-authored using generative AI tooling?

No.
