### PR TITLE
[SPARK-47752][PS][CONNECT] Make pyspark.pandas compatible with pyspark-connect

### DIFF
--- a/python/pyspark/pandas/plot/core.py
+++ b/python/pyspark/pandas/plot/core.py
@@ -22,8 +22,6 @@ import numpy as np
 from pandas.core.base import PandasObject
 from pandas.core.dtypes.inference import is_integer
 
-from pyspark.ml.feature import Bucketizer
-from pyspark.mllib.stat import KernelDensity
 from pyspark.sql import functions as F
 from pyspark.pandas.missing import unsupported_function
 from pyspark.pandas.config import get_option
@@ -147,6 +145,8 @@ class HistogramPlotBase(NumericPlotBase):
 
     @staticmethod
     def compute_hist(psdf, bins):
+        from pyspark.ml.feature import Bucketizer
+
         # 'data' is a Spark DataFrame that selects one column.
         assert isinstance(bins, (np.ndarray, np.generic))
 
@@ -463,6 +463,8 @@ class KdePlotBase(NumericPlotBase):
 
     @staticmethod
     def compute_kde(sdf, bw_method=None, ind=None):
+        from pyspark.mllib.stat import KernelDensity
+
         # 'sdf' is a Spark DataFrame that selects one column.
 
         # Using RDD is slow so we might have to change it to Dataset based implementation

--- a/python/pyspark/pandas/spark/functions.py
+++ b/python/pyspark/pandas/spark/functions.py
@@ -17,7 +17,6 @@
 """
 Additional Spark functions used in pandas-on-Spark.
 """
-from pyspark import SparkContext
 from pyspark.sql.column import Column
 from pyspark.sql.utils import is_remote
 
@@ -33,6 +32,8 @@ def product(col: Column, dropna: bool) -> Column:
         )
 
     else:
+        from pyspark import SparkContext
+
         sc = SparkContext._active_spark_context
         return Column(sc._jvm.PythonSQLUtils.pandasProduct(col._jc, dropna))
 
@@ -48,6 +49,8 @@ def stddev(col: Column, ddof: int) -> Column:
         )
 
     else:
+        from pyspark import SparkContext
+
         sc = SparkContext._active_spark_context
         return Column(sc._jvm.PythonSQLUtils.pandasStddev(col._jc, ddof))
 
@@ -63,6 +66,8 @@ def var(col: Column, ddof: int) -> Column:
         )
 
     else:
+        from pyspark import SparkContext
+
         sc = SparkContext._active_spark_context
         return Column(sc._jvm.PythonSQLUtils.pandasVariance(col._jc, ddof))
 
@@ -77,6 +82,8 @@ def skew(col: Column) -> Column:
         )
 
     else:
+        from pyspark import SparkContext
+
         sc = SparkContext._active_spark_context
         return Column(sc._jvm.PythonSQLUtils.pandasSkewness(col._jc))
 
@@ -91,6 +98,8 @@ def kurt(col: Column) -> Column:
         )
 
     else:
+        from pyspark import SparkContext
+
         sc = SparkContext._active_spark_context
         return Column(sc._jvm.PythonSQLUtils.pandasKurtosis(col._jc))
 
@@ -106,6 +115,8 @@ def mode(col: Column, dropna: bool) -> Column:
         )
 
     else:
+        from pyspark import SparkContext
+
         sc = SparkContext._active_spark_context
         return Column(sc._jvm.PythonSQLUtils.pandasMode(col._jc, dropna))
 
@@ -122,6 +133,8 @@ def covar(col1: Column, col2: Column, ddof: int) -> Column:
         )
 
     else:
+        from pyspark import SparkContext
+
         sc = SparkContext._active_spark_context
         return Column(sc._jvm.PythonSQLUtils.pandasCovar(col1._jc, col2._jc, ddof))
 
@@ -138,6 +151,8 @@ def ewm(col: Column, alpha: float, ignore_na: bool) -> Column:
         )
 
     else:
+        from pyspark import SparkContext
+
         sc = SparkContext._active_spark_context
         return Column(sc._jvm.PythonSQLUtils.ewm(col._jc, alpha, ignore_na))
 
@@ -152,6 +167,8 @@ def null_index(col: Column) -> Column:
         )
 
     else:
+        from pyspark import SparkContext
+
         sc = SparkContext._active_spark_context
         return Column(sc._jvm.PythonSQLUtils.nullIndex(col._jc))
 
@@ -168,5 +185,7 @@ def timestampdiff(unit: str, start: Column, end: Column) -> Column:
         )
 
     else:
+        from pyspark import SparkContext
+
         sc = SparkContext._active_spark_context
         return Column(sc._jvm.PythonSQLUtils.timestampDiff(unit, start._jc, end._jc))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to make `pyspark.pandas` compatible with `pyspark-connect`.

### Why are the changes needed?

In order for `pyspark-connect` to work without classic PySpark packages and dependencies.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Yes, at https://github.com/apache/spark/pull/45870. Once CI is setup there, it will be tested there properly.

### Was this patch authored or co-authored using generative AI tooling?

No.