### PR TITLE
[SPARK-47754][SQL] Postgres: Support reading multidimensional arrays

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCRDD.scala
@@ -67,7 +67,7 @@ object JDBCRDD extends Logging {
       Using.resource(conn.prepareStatement(query)) { statement =>
         statement.setQueryTimeout(options.queryTimeout)
         Using.resource(statement.executeQuery()) { rs =>
-          JdbcUtils.getSchema(rs, dialect, alwaysNullable = true,
+          JdbcUtils.getSchema(conn, rs, dialect, alwaysNullable = true,
             isTimestampNTZ = options.preferTimestampNTZ)
         }
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -799,6 +799,19 @@ abstract class JdbcDialect extends Serializable with Logging {
     JdbcUtils.getTimestampType(md.getBoolean("isTimestampNTZ"))
   }
 
+  /**
+   * Return the array dimension of the column. The array dimension will be carried in the
+   * metadata of the column and used by `getCatalystType` to determine the dimension of the
+   * ArrayType.
+   *
+   * @param conn The connection currently connection being used.
+   * @param tableName The name of the table which the column belongs to.
+   * @param columnName The name of the column.
+   * @return An Option[Int] which contains the number of array dimension.
+   *         If Some(n), the column is an array with n dimensions.
+   *         If the method is un-implemented, or some error encountered, return None.
+   *         Then, `getCatalystType` will try use 1 dimension as default for arrays.
+   */
   @Since("4.0.0")
   def getArrayDimension(conn: Connection, tableName: String, columnName: String): Option[Int] = None
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -798,6 +798,9 @@ abstract class JdbcDialect extends Serializable with Logging {
   protected final def getTimestampType(md: Metadata): DataType = {
     JdbcUtils.getTimestampType(md.getBoolean("isTimestampNTZ"))
   }
+
+  @Since("4.0.0")
+  def getArrayDimension(conn: Connection, tableName: String, columnName: String): Option[Int] = None
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -22,6 +22,8 @@ import java.time.{LocalDateTime, ZoneOffset}
 import java.util
 import java.util.Locale
 
+import scala.util.Using
+
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.SQLConfHelper
 import org.apache.spark.sql.catalyst.analysis.{IndexAlreadyExistsException, NonEmptyNamespaceException, NoSuchIndexException}
@@ -74,7 +76,16 @@ private case class PostgresDialect() extends JdbcDialect with SQLConfHelper {
       case _ if "text".equalsIgnoreCase(typeName) => Some(StringType) // sqlType is Types.VARCHAR
       case Types.ARRAY =>
         // postgres array type names start with underscore
-        toCatalystType(typeName.drop(1), size, md).map(ArrayType(_))
+        val elementType = toCatalystType(typeName.drop(1), size, md)
+        elementType.map { et =>
+          val metadata = md.build()
+          val dim = if (metadata.contains("arrayDimension")) {
+            metadata.getLong("arrayDimension").toInt
+          } else {
+            1
+          }
+          (0 until dim).foldLeft(et)((acc, _) => ArrayType(acc))
+        }
       case _ => None
     }
   }
@@ -329,6 +340,29 @@ private case class PostgresDialect() extends JdbcDialect with SQLConfHelper {
       case -9223372036832400000L =>
         new Date(LocalDateTime.of(1, 1, 1, 0, 0, 0).toInstant(ZoneOffset.UTC).toEpochMilli)
       case _ => d
+    }
+  }
+
+  override def getArrayDimension(
+      conn: Connection,
+      tableName: String,
+      columnName: String): Option[Int] = {
+    val query =
+      s"""
+         |SELECT pg_attribute.attndims
+         |FROM pg_attribute
+         |  JOIN pg_class ON pg_attribute.attrelid = pg_class.oid
+         |  JOIN pg_namespace ON pg_class.relnamespace = pg_namespace.oid
+         |WHERE pg_class.relname = '$tableName' and pg_attribute.attname = '$columnName'
+         |""".stripMargin
+    try {
+      Using.resource(conn.createStatement()) { stmt =>
+        Using.resource(stmt.executeQuery(query)) { rs =>
+          if (rs.next()) Some(rs.getInt(1)) else None
+        }
+      }
+    } catch {
+      case _: SQLException => None
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -2012,6 +2012,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     when(mockRsmd.isSigned(anyInt())).thenReturn(false)
     when(mockRsmd.isNullable(anyInt())).thenReturn(java.sql.ResultSetMetaData.columnNoNulls)
 
+    val mockConn = mock(classOf[java.sql.Connection])
     val mockRs = mock(classOf[java.sql.ResultSet])
     when(mockRs.getMetaData).thenReturn(mockRsmd)
 
@@ -2019,7 +2020,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     when(mockDialect.getCatalystType(anyInt(), anyString(), anyInt(), any[MetadataBuilder]))
       .thenReturn(None)
 
-    val schema = JdbcUtils.getSchema(mockRs, mockDialect)
+    val schema = JdbcUtils.getSchema(mockConn, mockRs, mockDialect)
     val fields = schema.fields
     assert(fields.length === 1)
     assert(fields(0).dataType === StringType)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Because the ResultSetMetadata cannot distinguish a single-dimensional array from multidimensional arrays. Thus, we always read multidimensional arrays as single-dimensional ones, For example, `text[][]` is mapping to `ArrayType(StringType)` and `int[][][]` is `ArrayType(IntegerType)`, this result in errors when converting a ResultSet with multidimensional arrays to InternalRows.

This PR supports reading multidimensional arrays from PostgreSQL data sources. To achieve this, the simplest way is to add a new developer API to retrieve it from the information schema of Postgres.

https://www.postgresql.org/docs/16/catalog-pg-attribute.html#CATALOG-PG-ATTRIBUTE

It is possible to use functions like `array_dims` to retrieve the dimension of an array column, but it is not easy to inject without causing breaking changes or to determine the dimension based on the actual data.
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
We have supported writing multidimensional arrays to Postgres, so we shall improve postgres reading abilities too.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no