### PR TITLE
[SPARK-47755][CONNECT] Pivot should fail when the number of distinct values is too large

### DIFF
--- a/python/pyspark/sql/tests/test_group.py
+++ b/python/pyspark/sql/tests/test_group.py
@@ -18,6 +18,7 @@ import unittest
 
 from pyspark.sql import Row
 from pyspark.sql import functions as sf
+from pyspark.errors import AnalysisException
 from pyspark.testing.sqlutils import (
     ReusedSQLTestCase,
     have_pandas,
@@ -184,6 +185,10 @@ class GroupTestsMixin:
 
             with self.assertRaises(IndexError):
                 df.orderBy(-3)
+
+        def test_pivot_exceed_max_values(self):
+            with self.assertRaises(AnalysisException):
+                spark.range(100001).groupBy(sf.lit(1)).pivot("id").count().show()
 
 
 class GroupTests(GroupTestsMixin, ReusedSQLTestCase):


### PR DESCRIPTION
### What changes were proposed in this pull request?
`Pivot` should fail when the number of distinct values is too large


### Why are the changes needed?
Following check is missing in Spark Connect
```
    if (values.length > maxValues) {
      throw QueryCompilationErrors.aggregationFunctionAppliedOnNonNumericColumnError(
        pivotColumn.toString, maxValues)
    }
```



### Does this PR introduce _any_ user-facing change?
pivot will fail when the number of distinct values exceed `DATAFRAME_PIVOT_MAX_VALUES`

and so will be consistent with classic spark.


### How was this patch tested?
added test


### Was this patch authored or co-authored using generative AI tooling?
no