### PR TITLE
[WIP][SPARK-47758][BUILD] Upgrade commons-collections4 to 4.5.0-M1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -38,7 +38,7 @@ chill_2.13/0.10.0//chill_2.13-0.10.0.jar
 commons-cli/1.6.0//commons-cli-1.6.0.jar
 commons-codec/1.16.1//commons-codec-1.16.1.jar
 commons-collections/3.2.2//commons-collections-3.2.2.jar
-commons-collections4/4.4//commons-collections4-4.4.jar
+commons-collections4/4.5.0-M1//commons-collections4-4.5.0-M1.jar
 commons-compiler/3.1.9//commons-compiler-3.1.9.jar
 commons-compress/1.26.0//commons-compress-1.26.0.jar
 commons-crypto/1.1.0//commons-crypto-1.1.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
     <commons.math3.version>3.6.1</commons.math3.version>
     <!-- managed up from 3.2.1 for SPARK-11652 -->
     <commons.collections.version>3.2.2</commons.collections.version>
-    <commons.collections4.version>4.4</commons.collections4.version>
+    <commons.collections4.version>4.5.0-M1</commons.collections4.version>
     <scala.version>2.13.13</scala.version>
     <scala.binary.version>2.13</scala.binary.version>
     <scalatest-maven-plugin.version>2.2.0</scalatest-maven-plugin.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `commons-collections4` from `4.4` to `4.5.0-M1`.

### Why are the changes needed?
1.This milestone release requires Java 8 and adds the package `org.apache.commons.collections4.bloomfilter` for review.
It has been almost `5` years since the previous version:
<img width="824" alt="image" src="https://github.com/apache/spark/assets/15246973/a4f4bb18-ba9c-458f-8713-5690bbfcee54">

2.Full release notes:
https://commons.apache.org/proper/commons-collections/changes-report.html#a4.5.0-M1


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
