### PR TITLE
[MINOR][PYTHON][CONNECT][TESTS] Enable `MapInPandasParityTests.test_dataframes_with_incompatible_types`

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_pandas_map.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_map.py
@@ -14,17 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import unittest
-
 
 from pyspark.sql.tests.pandas.test_pandas_map import MapInPandasTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
-class MapInPandasParityTests(MapInPandasTestsMixin, ReusedConnectTestCase):
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_dataframes_with_incompatible_types(self):
-        super().test_dataframes_with_incompatible_types()
+class MapInPandasParityTests(
+    MapInPandasTestsMixin,
+    ReusedConnectTestCase,
+):
+    pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable `MapInPandasParityTests.test_dataframes_with_incompatible_types`

### Why are the changes needed?
for test coverage


### Does this PR introduce _any_ user-facing change?
no, test only


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no