### PR TITLE
[SPARK-47762][PYTHON][CONNECT] Add pyspark.sql.connect.protobuf into setup.py

### DIFF
--- a/python/packaging/classic/setup.py
+++ b/python/packaging/classic/setup.py
@@ -275,6 +275,7 @@ try:
             "pyspark.sql.connect.client",
             "pyspark.sql.connect.functions",
             "pyspark.sql.connect.proto",
+            "pyspark.sql.connect.protobuf",
             "pyspark.sql.connect.shell",
             "pyspark.sql.connect.streaming",
             "pyspark.sql.connect.streaming.worker",

--- a/python/packaging/connect/setup.py
+++ b/python/packaging/connect/setup.py
@@ -103,6 +103,7 @@ try:
         "pyspark.sql.connect.client",
         "pyspark.sql.connect.functions",
         "pyspark.sql.connect.proto",
+        "pyspark.sql.connect.protobuf",
         "pyspark.sql.connect.shell",
         "pyspark.sql.connect.streaming",
         "pyspark.sql.connect.streaming.worker",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/42563 (but using new JIRA as it's already released), which adds `pyspark.sql.connect.protobuf` into `setup.py`.

### Why are the changes needed?

So PyPI packaged PySpark can support protobuf function with Spark Connect on.

### Does this PR introduce _any_ user-facing change?

Yes. The new feature is now available with Spark Connect on if users install Spark Connect by `pip`.

### How was this patch tested?

Being tested in https://github.com/apache/spark/pull/45870

### Was this patch authored or co-authored using generative AI tooling?

No.