### PR TITLE
[SPARK-47761][SQL] Oracle: Support reading AnsiIntervalTypes

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -19,11 +19,12 @@ package org.apache.spark.sql.jdbc
 
 import java.math.BigDecimal
 import java.sql.{Connection, Date, Timestamp}
+import java.time.{Duration, Period}
 import java.util.{Properties, TimeZone}
 
 import org.scalatest.time.SpanSugar._
 
-import org.apache.spark.sql.{Row, SaveMode}
+import org.apache.spark.sql.{DataFrame, Row, SaveMode}
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils._
 import org.apache.spark.sql.execution.{RowDataSourceScanExec, WholeStageCodegenExec}
 import org.apache.spark.sql.execution.datasources.LogicalRelation
@@ -539,5 +540,31 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSpark
     val df2 = reader.load()
     assert(df.count() === 2)
     assert(df2.collect().forall(_.getTimestamp(0) === row1))
+  }
+
+  test("SPARK-47761: Reading ANSI INTERVAL Types") {
+    val df: String => DataFrame = query => spark.read.format("jdbc")
+      .option("url", jdbcUrl)
+      .option("query", query)
+      .load()
+    checkAnswer(df("SELECT INTERVAL '1-2' YEAR(1) TO MONTH as i0 FROM dual"),
+      Row(Period.of(1, 2, 0)))
+    checkAnswer(df("SELECT INTERVAL '1-2' YEAR(2) TO MONTH as i1 FROM dual"),
+      Row(Period.of(1, 2, 0)))
+    checkAnswer(df("SELECT INTERVAL '12345-2' YEAR(9) TO MONTH as i2 FROM dual"),
+      Row(Period.of(12345, 2, 0)))
+    checkAnswer(df("SELECT INTERVAL '1 12:23:56' DAY(1) TO SECOND(0) as i3 FROM dual"),
+        Row(Duration.ofDays(1).plusHours(12).plusMinutes(23).plusSeconds(56)))
+    checkAnswer(df("SELECT INTERVAL '1 12:23:56.12' DAY TO SECOND(2) as i4 FROM dual"),
+        Row(Duration.ofDays(1).plusHours(12).plusMinutes(23).plusSeconds(56).plusMillis(120)))
+    checkAnswer(df("SELECT INTERVAL '1 12:23:56.1234' DAY TO SECOND(4) as i5 FROM dual"),
+        Row(Duration.ofDays(1).plusHours(12).plusMinutes(23).plusSeconds(56).plusMillis(123)
+          .plusNanos(400000)))
+    checkAnswer(df("SELECT INTERVAL '1 12:23:56.123456' DAY TO SECOND(6) as i6 FROM dual"),
+        Row(Duration.ofDays(1).plusHours(12).plusMinutes(23).plusSeconds(56).plusMillis(123)
+          .plusNanos(456000)))
+    checkAnswer(df("SELECT INTERVAL '1 12:23:56.12345678' DAY TO SECOND(8) as i7 FROM dual"),
+        Row(Duration.ofDays(1).plusHours(12).plusMinutes(23).plusSeconds(56).plusMillis(123)
+          .plusNanos(456000)))
   }
 }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/OracleIntegrationSuite.scala
@@ -554,17 +554,17 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationSuite with SharedSpark
     checkAnswer(df("SELECT INTERVAL '12345-2' YEAR(9) TO MONTH as i2 FROM dual"),
       Row(Period.of(12345, 2, 0)))
     checkAnswer(df("SELECT INTERVAL '1 12:23:56' DAY(1) TO SECOND(0) as i3 FROM dual"),
-        Row(Duration.ofDays(1).plusHours(12).plusMinutes(23).plusSeconds(56)))
+      Row(Duration.ofDays(1).plusHours(12).plusMinutes(23).plusSeconds(56)))
     checkAnswer(df("SELECT INTERVAL '1 12:23:56.12' DAY TO SECOND(2) as i4 FROM dual"),
-        Row(Duration.ofDays(1).plusHours(12).plusMinutes(23).plusSeconds(56).plusMillis(120)))
+      Row(Duration.ofDays(1).plusHours(12).plusMinutes(23).plusSeconds(56).plusMillis(120)))
     checkAnswer(df("SELECT INTERVAL '1 12:23:56.1234' DAY TO SECOND(4) as i5 FROM dual"),
-        Row(Duration.ofDays(1).plusHours(12).plusMinutes(23).plusSeconds(56).plusMillis(123)
-          .plusNanos(400000)))
+      Row(Duration.ofDays(1).plusHours(12).plusMinutes(23).plusSeconds(56).plusMillis(123)
+        .plusNanos(400000)))
     checkAnswer(df("SELECT INTERVAL '1 12:23:56.123456' DAY TO SECOND(6) as i6 FROM dual"),
-        Row(Duration.ofDays(1).plusHours(12).plusMinutes(23).plusSeconds(56).plusMillis(123)
-          .plusNanos(456000)))
+      Row(Duration.ofDays(1).plusHours(12).plusMinutes(23).plusSeconds(56).plusMillis(123)
+        .plusNanos(456000)))
     checkAnswer(df("SELECT INTERVAL '1 12:23:56.12345678' DAY TO SECOND(8) as i7 FROM dual"),
-        Row(Duration.ofDays(1).plusHours(12).plusMinutes(23).plusSeconds(56).plusMillis(123)
-          .plusNanos(456000)))
+      Row(Duration.ofDays(1).plusHours(12).plusMinutes(23).plusSeconds(56).plusMillis(123)
+        .plusNanos(456000)))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -526,6 +526,16 @@ object JdbcUtils extends Logging with SQLConfHelper {
       (rs: ResultSet, row: InternalRow, pos: Int) =>
         row.update(pos, rs.getBytes(pos + 1))
 
+    case _: YearMonthIntervalType =>
+      (rs: ResultSet, row: InternalRow, pos: Int) =>
+        row.update(pos,
+          nullSafeConvert(rs.getString(pos + 1), dialect.getYearMonthIntervalAsMonths))
+
+    case _: DayTimeIntervalType =>
+      (rs: ResultSet, row: InternalRow, pos: Int) =>
+        row.update(pos,
+          nullSafeConvert(rs.getString(pos + 1), dialect.getDayTimeIntervalAsMicros))
+
     case _: ArrayType if metadata.contains("pg_bit_array_type") =>
       // SPARK-47628: Handle PostgreSQL bit(n>1) array type ahead. As in the pgjdbc driver,
       // bit(n>1)[] is not distinguishable from bit(1)[], and they are all recognized as boolen[].

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -21,6 +21,7 @@ import java.sql.{Connection, Date, Driver, Statement, Timestamp}
 import java.time.{Instant, LocalDate, LocalDateTime}
 import java.util
 import java.util.ServiceLoader
+import java.util.concurrent.TimeUnit
 
 import scala.collection.mutable.ArrayBuilder
 import scala.util.control.NonFatal
@@ -34,6 +35,7 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.CatalystTypeConverters
 import org.apache.spark.sql.catalyst.util.{DateFormatter, DateTimeUtils, TimestampFormatter}
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.{localDateTimeToMicros, toJavaTimestampNoRebase}
+import org.apache.spark.sql.catalyst.util.IntervalUtils.{fromDayTimeString, fromYearMonthString, getDuration}
 import org.apache.spark.sql.connector.catalog.{Identifier, TableChange}
 import org.apache.spark.sql.connector.catalog.TableChange._
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction
@@ -163,6 +165,17 @@ abstract class JdbcDialect extends Serializable with Logging {
    */
   @Since("4.0.0")
   def convertJavaDateToDate(d: Date): Date = d
+
+  @Since("4.0.0")
+  def getYearMonthIntervalAsMonths(yearmonthStr: String): Int = {
+    fromYearMonthString(yearmonthStr).months
+  }
+
+  @Since("4.0.0")
+  def getDayTimeIntervalAsMicros(daytimeStr: String): Long = {
+    getDuration(fromDayTimeString(daytimeStr), TimeUnit.MICROSECONDS)
+  }
+
 
   /**
    * Convert java.sql.Timestamp to a LocalDateTime representing the same wall-clock time as the

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -28,7 +28,7 @@ import scala.util.control.NonFatal
 
 import org.apache.commons.lang3.StringUtils
 
-import org.apache.spark.{SparkIllegalArgumentException, SparkUnsupportedOperationException}
+import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.annotation.{DeveloperApi, Since}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
@@ -171,7 +171,7 @@ abstract class JdbcDialect extends Serializable with Logging {
    *
    * @param yearmonthStr the year-month interval string
    * @return the number of total months in the interval
-   * @throws SparkIllegalArgumentException if the input string is invalid
+   * @throws IllegalArgumentException if the input string is invalid
    */
   @Since("4.0.0")
   def getYearMonthIntervalAsMonths(yearmonthStr: String): Int = {
@@ -183,7 +183,7 @@ abstract class JdbcDialect extends Serializable with Logging {
    *
    * @param daytimeStr the day-time interval string
    * @return the number of total microseconds in the interval
-   * @throws SparkIllegalArgumentException if the input string is invalid
+   * @throws IllegalArgumentException if the input string is invalid
    */
   @Since("4.0.0")
   def getDayTimeIntervalAsMicros(daytimeStr: String): Long = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/JdbcDialects.scala
@@ -28,7 +28,7 @@ import scala.util.control.NonFatal
 
 import org.apache.commons.lang3.StringUtils
 
-import org.apache.spark.SparkUnsupportedOperationException
+import org.apache.spark.{SparkIllegalArgumentException, SparkUnsupportedOperationException}
 import org.apache.spark.annotation.{DeveloperApi, Since}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
@@ -166,16 +166,29 @@ abstract class JdbcDialect extends Serializable with Logging {
   @Since("4.0.0")
   def convertJavaDateToDate(d: Date): Date = d
 
+  /**
+   * Converts an year-month interval string to an int value `months`.
+   *
+   * @param yearmonthStr the year-month interval string
+   * @return the number of total months in the interval
+   * @throws SparkIllegalArgumentException if the input string is invalid
+   */
   @Since("4.0.0")
   def getYearMonthIntervalAsMonths(yearmonthStr: String): Int = {
     fromYearMonthString(yearmonthStr).months
   }
 
+  /**
+   * Converts a day-time interval string to a long value `micros`.
+   *
+   * @param daytimeStr the day-time interval string
+   * @return the number of total microseconds in the interval
+   * @throws SparkIllegalArgumentException if the input string is invalid
+   */
   @Since("4.0.0")
   def getDayTimeIntervalAsMicros(daytimeStr: String): Long = {
     getDuration(fromDayTimeString(daytimeStr), TimeUnit.MICROSECONDS)
   }
-
 
   /**
    * Convert java.sql.Timestamp to a LocalDateTime representing the same wall-clock time as the

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/OracleDialect.scala
@@ -103,6 +103,8 @@ private case class OracleDialect() extends JdbcDialect {
         Some(TimestampType)
       case BINARY_FLOAT => Some(FloatType) // Value for OracleTypes.BINARY_FLOAT
       case BINARY_DOUBLE => Some(DoubleType) // Value for OracleTypes.BINARY_DOUBLE
+      case INTERVAL_YM => Some(YearMonthIntervalType())
+      case INTERVAL_DS => Some(DayTimeIntervalType())
       case _ => None
     }
   }
@@ -231,4 +233,16 @@ private[jdbc] object OracleDialect {
   final val TIMESTAMP_TZ = -101
   // oracle.jdbc.OracleType.TIMESTAMP_WITH_LOCAL_TIME_ZONE
   final val TIMESTAMP_LTZ = -102
+  // INTERVAL YEAR [(year_precision)] TO MONTH
+  // Stores a period of time in years and months, where year_precision is the number of digits in
+  // the YEAR datetime field. Accepted values are 0 to 9. The default is 2.
+  // The size is fixed at 5 bytes.
+  final val INTERVAL_YM = -103
+  // INTERVAL DAY [(day_precision)] TO SECOND [(fractional_seconds_precision)]
+  // Stores a period of time in days, hours, minutes, and seconds, where
+  // - day_precision is the maximum number of digits in the DAY datetime field.
+  //   Accepted values are 0 to 9. The default is 2.
+  // - fractional_seconds_precision is the number of digits in the fractional part
+  //   of the SECOND field. Accepted values are 0 to 9. The default is 6.
+  final val INTERVAL_DS = -104
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

In this PR, I proposed to add support for reading well-defined ANSI interval types from Oracle databases.

- NTERVAL YEAR [(year_precision)] TO MONTH
  - Stores a period of time in years and months, where year_precision is the number of digits in the YEAR datetime field. Accepted values are 0 to 9. The default is 2. The size is fixed at 5 bytes.
- INTERVAL DAY [(day_precision)] TO SECOND [(fractional_seconds_precision)]
  - Stores a period of time in days, hours, minutes, and seconds, where
    - day_precision is the maximum number of digits in the DAY datetime field. Accepted values are 0 to 9. The default is 2.
    - fractional_seconds_precision is the number of digits in the fractional part of the SECOND field. Accepted values are 0 to 9. The default is 6. The size is fixed at 11 bytes.

Both of them are mapped to the defaults of AnsiIntervalTypes.

We also add two developer APIs that convert interval strings to underlying representations of YearMonthIntervalType and DaytimeIntervalType. The default implementations assume that the inputs are compatible with the ANSI style, incompatible values will fail to be parsed. However, it shall fail much earlier at the data type mapping step because of undefined mapping rules

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Improve the Oracle accessibility, as tt's safe to read Oracle external intervals 


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes, reading Oracle intervals are available now
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->new tests


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->no
