### PR TITLE
[MINOR][TESTS] Make `check_invalid_args` reusable in parity test

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_pandas_udf_window.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_udf_window.py
@@ -20,12 +20,11 @@ from pyspark.sql.tests.pandas.test_pandas_udf_window import WindowPandasUDFTests
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
-class PandasUDFWindowParityTests(WindowPandasUDFTestsMixin, ReusedConnectTestCase):
-    # TODO(SPARK-43734): Expression "<lambda>(v)" within a window function doesn't raise a
-    #  AnalysisException
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_invalid_args(self):
-        super().test_invalid_args()
+class PandasUDFWindowParityTests(
+    WindowPandasUDFTestsMixin,
+    ReusedConnectTestCase,
+):
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_window.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_window.py
@@ -292,7 +292,7 @@ class WindowPandasUDFTestsMixin:
 
         with self.assertRaisesRegex(AnalysisException, ".*not supported within a window function"):
             foo_udf = pandas_udf(lambda x: x, "v double", PandasUDFType.GROUPED_MAP)
-            df.withColumn("v2", foo_udf(df["v"]).over(w))
+            df.withColumn("v2", foo_udf(df["v"]).over(w)).schema
 
     def test_bounded_simple(self):
         from pyspark.sql.functions import mean, max, min, count


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `check_invalid_args` reusable in parity test


### Why are the changes needed?
test coverage


### Does this PR introduce _any_ user-facing change?
no, test only


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no
