### PR TITLE
[SPARK-47673][SS] Implementing TTL for ListState

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
@@ -73,6 +73,26 @@ private[sql] trait StatefulProcessorHandle extends Serializable {
   def getListState[T](stateName: String, valEncoder: Encoder[T]): ListState[T]
 
   /**
+   * Function to create new or return existing list state variable of given type
+   * with ttl. State values will not be returned past ttlDuration, and will be eventually removed
+   * from the state store. Any values in listState which have expired after ttlDuration will not
+   * be returned on get() and will be eventually removed from the state.
+   *
+   * The user must ensure to call this function only within the `init()` method of the
+   * StatefulProcessor.
+   *
+   * @param stateName  - name of the state variable
+   * @param valEncoder - SQL encoder for state variable
+   * @param ttlConfig  - the ttl configuration (time to live duration etc.)
+   * @tparam T - type of state variable
+   * @return - instance of ListState of type T that can be used to store state persistently
+   */
+  def getListState[T](
+     stateName: String,
+     valEncoder: Encoder[T],
+     ttlConfig: TTLConfig): ListState[T]
+
+  /**
    * Creates new or returns existing map state associated with stateName.
    * The MapState persists Key-Value pairs of type [K, V].
    *

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
@@ -88,9 +88,9 @@ private[sql] trait StatefulProcessorHandle extends Serializable {
    * @return - instance of ListState of type T that can be used to store state persistently
    */
   def getListState[T](
-     stateName: String,
-     valEncoder: Encoder[T],
-     ttlConfig: TTLConfig): ListState[T]
+      stateName: String,
+      valEncoder: Encoder[T],
+      ttlConfig: TTLConfig): ListState[T]
 
   /**
    * Creates new or returns existing map state associated with stateName.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ListStateImplWithTTL.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ListStateImplWithTTL.scala
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.streaming
+
+import org.apache.spark.sql.Encoder
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.execution.streaming.TransformWithStateKeyValueRowSchema.{KEY_ROW_SCHEMA, VALUE_ROW_SCHEMA_WITH_TTL}
+import org.apache.spark.sql.execution.streaming.state.{NoPrefixKeyStateEncoderSpec, StateStore, StateStoreErrors}
+import org.apache.spark.sql.streaming.{ListState, TTLConfig}
+import org.apache.spark.util.NextIterator
+
+/**
+ * Provides concrete implementation for list of values associated with a state variable
+ * used in the streaming transformWithState operator.
+ *
+ * @param store - reference to the StateStore instance to be used for storing state
+ * @param stateName - name of logical state partition
+ * @param keyEnc - Spark SQL encoder for key
+ * @param valEncoder - Spark SQL encoder for value
+ * @tparam S - data type of object that will be stored in the list
+ */
+class ListStateImplWithTTL[S](
+  store: StateStore,
+  stateName: String,
+  keyExprEnc: ExpressionEncoder[Any],
+  valEncoder: Encoder[S],
+  ttlConfig: TTLConfig,
+  batchTimestampMs: Long)
+  extends SingleKeyTTLStateImpl(stateName, store, batchTimestampMs) with ListState[S] {
+
+  private lazy val keySerializer = keyExprEnc.createSerializer()
+
+  private lazy val stateTypesEncoder = StateTypesEncoder(
+    keySerializer, valEncoder, stateName, hasTtl = true)
+
+  private lazy val ttlExpirationMs =
+    StateTTL.calculateExpirationTimeForDuration(ttlConfig.ttlDuration, batchTimestampMs)
+
+  initialize()
+
+  private def initialize(): Unit = {
+    store.createColFamilyIfAbsent(stateName, KEY_ROW_SCHEMA, VALUE_ROW_SCHEMA_WITH_TTL,
+      NoPrefixKeyStateEncoderSpec(KEY_ROW_SCHEMA), useMultipleValuesPerKey = true)
+  }
+
+  /** Whether state exists or not. */
+  override def exists(): Boolean = {
+    get().nonEmpty
+  }
+
+  /**
+   * Get the state value if it exists. If the state does not exist in state store, an
+   * empty iterator is returned.
+   */
+  override def get(): Iterator[S] = {
+    val encodedKey = stateTypesEncoder.encodeGroupingKey()
+    val unsafeRowValuesIterator = store.valuesIterator(encodedKey, stateName)
+
+    new NextIterator[S] {
+
+      override protected def getNext(): S = {
+        val iter = unsafeRowValuesIterator.dropWhile { row =>
+          stateTypesEncoder.isExpired(row, batchTimestampMs)
+        }
+
+        if (iter.hasNext) {
+          val currentRow = iter.next()
+          stateTypesEncoder.decodeValue(currentRow)
+        } else {
+          finished = true
+          null.asInstanceOf[S]
+        }
+      }
+
+      override protected def close(): Unit = {}
+    }
+  }
+
+  /** Update the value of the list. */
+  override def put(newState: Array[S]): Unit = {
+    validateNewState(newState)
+
+    val serializedGroupingKey = stateTypesEncoder.serializeGroupingKey()
+    val encodedKey = stateTypesEncoder.encodeSerializedGroupingKey(serializedGroupingKey)
+    var isFirst = true
+
+    newState.foreach { v =>
+      val encodedValue = stateTypesEncoder.encodeValue(v, ttlExpirationMs)
+      if (isFirst) {
+        store.put(encodedKey, encodedValue, stateName)
+        isFirst = false
+      } else {
+        store.merge(encodedKey, encodedValue, stateName)
+      }
+    }
+    upsertTTLForStateKey(serializedGroupingKey)
+  }
+
+  /** Append an entry to the list. */
+  override def appendValue(newState: S): Unit = {
+    StateStoreErrors.requireNonNullStateValue(newState, stateName)
+    val serializedGroupingKey = stateTypesEncoder.serializeGroupingKey()
+    store.merge(stateTypesEncoder.encodeSerializedGroupingKey(serializedGroupingKey),
+      stateTypesEncoder.encodeValue(newState, ttlExpirationMs), stateName)
+    upsertTTLForStateKey(serializedGroupingKey)
+  }
+
+  /** Append an entire list to the existing value. */
+  override def appendList(newState: Array[S]): Unit = {
+    validateNewState(newState)
+
+    val serializedGroupingKey = stateTypesEncoder.serializeGroupingKey()
+    val encodedKey = stateTypesEncoder.encodeSerializedGroupingKey(serializedGroupingKey)
+    newState.foreach { v =>
+      val encodedValue = stateTypesEncoder.encodeValue(v, ttlExpirationMs)
+      store.merge(encodedKey, encodedValue, stateName)
+    }
+    upsertTTLForStateKey(serializedGroupingKey)
+  }
+
+  /** Remove this state. */
+  override def clear(): Unit = {
+    store.remove(stateTypesEncoder.encodeGroupingKey(), stateName)
+  }
+
+  private def validateNewState(newState: Array[S]): Unit = {
+    StateStoreErrors.requireNonNullStateValue(newState, stateName)
+    StateStoreErrors.requireNonEmptyListStateValue(newState, stateName)
+
+    newState.foreach { v =>
+      StateStoreErrors.requireNonNullStateValue(v, stateName)
+    }
+  }
+
+  /**
+   *
+   * Loops through all the values associated with the grouping key, and removes
+   * the expired elements from the list.
+   * @param groupingKey grouping key for which cleanup should be performed.
+   */
+  override def clearIfExpired(groupingKey: Array[Byte]): Long = {
+    var numValuesExpired = 0L
+    val encodedGroupingKey = stateTypesEncoder.encodeSerializedGroupingKey(groupingKey)
+    val unsafeRowValuesIterator = store.valuesIterator(encodedGroupingKey, stateName)
+    // We clear the list, and use the iterator to put back all of the non-expired values
+    store.remove(encodedGroupingKey, stateName)
+    var isFirst = true
+    unsafeRowValuesIterator.foreach { encodedValue =>
+      if (!stateTypesEncoder.isExpired(encodedValue, batchTimestampMs)) {
+        if (isFirst) {
+          store.put(encodedGroupingKey, encodedValue, stateName)
+          isFirst = false
+        } else {
+          store.merge(encodedGroupingKey, encodedValue, stateName)
+        }
+      } else {
+        numValuesExpired += 1
+      }
+    }
+    numValuesExpired
+  }
+
+  private def upsertTTLForStateKey(serializedGroupingKey: Array[Byte]): Unit = {
+    upsertTTLForStateKey(ttlExpirationMs, serializedGroupingKey)
+  }
+
+  /*
+    * Internal methods to probe state for testing. The below methods exist for unit tests
+    * to read the state ttl values, and ensure that values are persisted correctly in
+    * the underlying state store.
+    */
+
+  /**
+   * Retrieves the value from State even if its expired. This method is used
+   * in tests to read the state store value, and ensure if its cleaned up at the
+   * end of the micro-batch.
+   */
+  private[sql] def getWithoutEnforcingTTL(): Iterator[S] = {
+    val encodedGroupingKey = stateTypesEncoder.encodeGroupingKey()
+    val unsafeRowValuesIterator = store.valuesIterator(encodedGroupingKey, stateName)
+    unsafeRowValuesIterator.map{
+      valueUnsafeRow =>
+        stateTypesEncoder.decodeValue(valueUnsafeRow)
+    }
+  }
+
+  /**
+   * Read the ttl value associated with the grouping key.
+   */
+  private[sql] def getTTLValues(): Iterator[(S, Long)] = {
+    val encodedGroupingKey = stateTypesEncoder.encodeGroupingKey()
+    val unsafeRowValuesIterator = store.valuesIterator(encodedGroupingKey, stateName)
+    unsafeRowValuesIterator.map{
+      valueUnsafeRow =>
+        (stateTypesEncoder.decodeValue(valueUnsafeRow),
+          stateTypesEncoder.decodeTtlExpirationMs(valueUnsafeRow).get)
+    }
+  }
+  /**
+   * Get all ttl values stored in ttl state for current implicit
+   * grouping key.
+   */
+  private[sql] def getValuesInTTLState(): Iterator[Long] = {
+    getValuesInTTLState(stateTypesEncoder.serializeGroupingKey())
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ListStateImplWithTTL.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ListStateImplWithTTL.scala
@@ -24,14 +24,16 @@ import org.apache.spark.sql.streaming.{ListState, TTLConfig}
 import org.apache.spark.util.NextIterator
 
 /**
- * Provides concrete implementation for list of values associated with a state variable
- * used in the streaming transformWithState operator.
+ * Class that provides a concrete implementation for a list state state associated with state
+ * variables (with ttl expiration support) used in the streaming transformWithState operator.
  *
  * @param store - reference to the StateStore instance to be used for storing state
  * @param stateName - name of logical state partition
- * @param keyEnc - Spark SQL encoder for key
+ * @param keyExprEnc - Spark SQL encoder for key
  * @param valEncoder - Spark SQL encoder for value
- * @tparam S - data type of object that will be stored in the list
+ * @param ttlConfig  - TTL configuration for values  stored in this state
+ * @param batchTimestampMs - current batch processing timestamp.
+ * @tparam S - data type of object that will be stored
  */
 class ListStateImplWithTTL[S](
   store: StateStore,
@@ -147,7 +149,6 @@ class ListStateImplWithTTL[S](
   }
 
   /**
-   *
    * Loops through all the values associated with the grouping key, and removes
    * the expired elements from the list.
    * @param groupingKey grouping key for which cleanup should be performed.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ListStateImplWithTTL.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ListStateImplWithTTL.scala
@@ -36,12 +36,12 @@ import org.apache.spark.util.NextIterator
  * @tparam S - data type of object that will be stored
  */
 class ListStateImplWithTTL[S](
-  store: StateStore,
-  stateName: String,
-  keyExprEnc: ExpressionEncoder[Any],
-  valEncoder: Encoder[S],
-  ttlConfig: TTLConfig,
-  batchTimestampMs: Long)
+    store: StateStore,
+    stateName: String,
+    keyExprEnc: ExpressionEncoder[Any],
+    valEncoder: Encoder[S],
+    ttlConfig: TTLConfig,
+    batchTimestampMs: Long)
   extends SingleKeyTTLStateImpl(stateName, store, batchTimestampMs) with ListState[S] {
 
   private lazy val keySerializer = keyExprEnc.createSerializer()
@@ -193,9 +193,8 @@ class ListStateImplWithTTL[S](
   private[sql] def getWithoutEnforcingTTL(): Iterator[S] = {
     val encodedGroupingKey = stateTypesEncoder.encodeGroupingKey()
     val unsafeRowValuesIterator = store.valuesIterator(encodedGroupingKey, stateName)
-    unsafeRowValuesIterator.map{
-      valueUnsafeRow =>
-        stateTypesEncoder.decodeValue(valueUnsafeRow)
+    unsafeRowValuesIterator.map { valueUnsafeRow =>
+      stateTypesEncoder.decodeValue(valueUnsafeRow)
     }
   }
 
@@ -205,12 +204,12 @@ class ListStateImplWithTTL[S](
   private[sql] def getTTLValues(): Iterator[(S, Long)] = {
     val encodedGroupingKey = stateTypesEncoder.encodeGroupingKey()
     val unsafeRowValuesIterator = store.valuesIterator(encodedGroupingKey, stateName)
-    unsafeRowValuesIterator.map{
-      valueUnsafeRow =>
-        (stateTypesEncoder.decodeValue(valueUnsafeRow),
-          stateTypesEncoder.decodeTtlExpirationMs(valueUnsafeRow).get)
+    unsafeRowValuesIterator.map { valueUnsafeRow =>
+      (stateTypesEncoder.decodeValue(valueUnsafeRow),
+        stateTypesEncoder.decodeTtlExpirationMs(valueUnsafeRow).get)
     }
   }
+
   /**
    * Get all ttl values stored in ttl state for current implicit
    * grouping key.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StateTypesEncoderUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StateTypesEncoderUtils.scala
@@ -139,6 +139,11 @@ class StateTypesEncoder[GK, V](
       Some(expirationMs)
     }
   }
+
+  def isExpired(row: UnsafeRow, batchTimestampMs: Long): Boolean = {
+    val expirationMs = decodeTtlExpirationMs(row)
+    expirationMs.exists(StateTTL.isExpired(_, batchTimestampMs))
+  }
 }
 
 object StateTypesEncoder {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
@@ -271,7 +271,7 @@ class StatefulProcessorHandleImpl(
     assert(batchTimestampMs.isDefined)
     val listStateWithTTL = new ListStateImplWithTTL[T](store, stateName,
       keyEncoder, valEncoder, ttlConfig, batchTimestampMs.get)
-    incrementMetric("numValueStateWithTTLVars")
+    incrementMetric("numListStateWithTTLVars")
     ttlStates.add(listStateWithTTL)
 
     listStateWithTTL

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
@@ -245,6 +245,38 @@ class StatefulProcessorHandleImpl(
     resultState
   }
 
+  /**
+   * Function to create new or return existing list state variable of given type
+   * with ttl. State values will not be returned past ttlDuration, and will be eventually removed
+   * from the state store. Any values in listState which have expired after ttlDuration will not
+   * returned on get() and will be eventually removed from the state.
+   *
+   * The user must ensure to call this function only within the `init()` method of the
+   * StatefulProcessor.
+   *
+   * @param stateName  - name of the state variable
+   * @param valEncoder - SQL encoder for state variable
+   * @param ttlConfig  - the ttl configuration (time to live duration etc.)
+   * @tparam T - type of state variable
+   * @return - instance of ListState of type T that can be used to store state persistently
+   */
+  override def getListState[T](
+    stateName: String,
+    valEncoder: Encoder[T],
+    ttlConfig: TTLConfig): ListState[T] = {
+
+    verifyStateVarOperations("get_list_state")
+    validateTTLConfig(ttlConfig, stateName)
+
+    assert(batchTimestampMs.isDefined)
+    val listStateWithTTL = new ListStateImplWithTTL[T](store, stateName,
+      keyEncoder, valEncoder, ttlConfig, batchTimestampMs.get)
+    incrementMetric("numValueStateWithTTLVars")
+    ttlStates.add(listStateWithTTL)
+
+    listStateWithTTL
+  }
+
   override def getMapState[K, V](
       stateName: String,
       userKeyEnc: Encoder[K],

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
@@ -261,9 +261,9 @@ class StatefulProcessorHandleImpl(
    * @return - instance of ListState of type T that can be used to store state persistently
    */
   override def getListState[T](
-    stateName: String,
-    valEncoder: Encoder[T],
-    ttlConfig: TTLConfig): ListState[T] = {
+      stateName: String,
+      valEncoder: Encoder[T],
+      ttlConfig: TTLConfig): ListState[T] = {
 
     verifyStateVarOperations("get_list_state")
     validateTTLConfig(ttlConfig, stateName)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TTLState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TTLState.scala
@@ -73,7 +73,7 @@ trait TTLState {
    *
    * @param groupingKey grouping key for which cleanup should be performed.
    *
-   * @return true if the state was cleared, false otherwise.
+   * @return how many state objects were cleaned up.
    */
   def clearIfExpired(groupingKey: Array[Byte]): Long
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TTLState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TTLState.scala
@@ -75,7 +75,7 @@ trait TTLState {
    *
    * @return true if the state was cleared, false otherwise.
    */
-  def clearIfExpired(groupingKey: Array[Byte]): Boolean
+  def clearIfExpired(groupingKey: Array[Byte]): Long
 }
 
 /**
@@ -118,9 +118,7 @@ abstract class SingleKeyTTLStateImpl(
       StateTTL.isExpired(expirationMs, ttlExpirationMs)
     }.foreach { kv =>
       val groupingKey = kv.key.getBinary(1)
-      if (clearIfExpired(groupingKey)) {
-        numValuesExpired += 1
-      }
+      numValuesExpired += clearIfExpired(groupingKey)
       store.remove(kv.key, ttlColumnFamilyName)
     }
     numValuesExpired
@@ -138,6 +136,30 @@ abstract class SingleKeyTTLStateImpl(
           expirationMs = kv.key.getLong(0),
           groupingKey = kv.key.getBinary(1)
         )
+      }
+    }
+  }
+
+  private[sql] def getValuesInTTLState(groupingKey: Array[Byte]): Iterator[Long] = {
+    val ttlIterator = ttlIndexIterator()
+    var nextValue: Option[Long] = None
+
+    new Iterator[Long] {
+      override def hasNext: Boolean = {
+        while (nextValue.isEmpty && ttlIterator.hasNext) {
+          val nextTtlValue = ttlIterator.next()
+          val valueGroupingKey = nextTtlValue.groupingKey
+          if (valueGroupingKey sameElements groupingKey) {
+            nextValue = Some(nextTtlValue.expirationMs)
+          }
+        }
+        nextValue.isDefined
+      }
+
+      override def next(): Long = {
+        val result = nextValue.get
+        nextValue = None
+        result
       }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -311,6 +311,8 @@ case class TransformWithStateExec(
       // metrics around TTL
       StatefulOperatorCustomSumMetric("numValueStateWithTTLVars",
         "Number of value state variables with TTL"),
+      StatefulOperatorCustomSumMetric("numListStateWithTTLVars",
+        "Number of list state variables with TTL"),
       StatefulOperatorCustomSumMetric("numValuesRemovedDueToTTLExpiry",
         "Number of values removed due to TTL expiry")
     )

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ValueStateImplWithTTL.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ValueStateImplWithTTL.scala
@@ -18,7 +18,6 @@ package org.apache.spark.sql.execution.streaming
 
 import org.apache.spark.sql.Encoder
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
-import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.execution.streaming.TransformWithStateKeyValueRowSchema.{KEY_ROW_SCHEMA, VALUE_ROW_SCHEMA_WITH_TTL}
 import org.apache.spark.sql.execution.streaming.state.{NoPrefixKeyStateEncoderSpec, StateStore}
 import org.apache.spark.sql.streaming.{TTLConfig, ValueState}
@@ -75,7 +74,7 @@ class ValueStateImplWithTTL[S](
     if (retRow != null) {
       val resState = stateTypesEncoder.decodeValue(retRow)
 
-      if (!isExpired(retRow)) {
+      if (!stateTypesEncoder.isExpired(retRow, batchTimestampMs)) {
         resState
       } else {
         null.asInstanceOf[S]
@@ -99,23 +98,18 @@ class ValueStateImplWithTTL[S](
     store.remove(stateTypesEncoder.encodeGroupingKey(), stateName)
   }
 
-  def clearIfExpired(groupingKey: Array[Byte]): Boolean = {
+  def clearIfExpired(groupingKey: Array[Byte]): Long = {
     val encodedGroupingKey = stateTypesEncoder.encodeSerializedGroupingKey(groupingKey)
     val retRow = store.get(encodedGroupingKey, stateName)
 
-    var result = false
+    var result = 0L
     if (retRow != null) {
-      if (isExpired(retRow)) {
+      if (stateTypesEncoder.isExpired(retRow, batchTimestampMs)) {
         store.remove(encodedGroupingKey, stateName)
-        result = true
+        result = 1L
       }
     }
     result
-  }
-
-  private def isExpired(valueRow: UnsafeRow): Boolean = {
-    val expirationMs = stateTypesEncoder.decodeTtlExpirationMs(valueRow)
-    expirationMs.exists(StateTTL.isExpired(_, batchTimestampMs))
   }
 
   /*
@@ -144,12 +138,15 @@ class ValueStateImplWithTTL[S](
   /**
    * Read the ttl value associated with the grouping key.
    */
-  private[sql] def getTTLValue(): Option[Long] = {
+  private[sql] def getTTLValue(): Option[(S, Long)] = {
     val encodedGroupingKey = stateTypesEncoder.encodeGroupingKey()
     val retRow = store.get(encodedGroupingKey, stateName)
 
+    // if the returned row is not null, we want to return the value associated with the
+    // ttlExpiration
     if (retRow != null) {
-      stateTypesEncoder.decodeTtlExpirationMs(retRow)
+      val ttlExpiration = stateTypesEncoder.decodeTtlExpirationMs(retRow)
+      ttlExpiration.map(expiration => (stateTypesEncoder.decodeValue(retRow), expiration))
     } else {
       None
     }
@@ -160,28 +157,7 @@ class ValueStateImplWithTTL[S](
    * grouping key.
    */
   private[sql] def getValuesInTTLState(): Iterator[Long] = {
-    val ttlIterator = ttlIndexIterator()
-    val implicitGroupingKey = stateTypesEncoder.serializeGroupingKey()
-    var nextValue: Option[Long] = None
-
-    new Iterator[Long] {
-      override def hasNext: Boolean = {
-        while (nextValue.isEmpty && ttlIterator.hasNext) {
-          val nextTtlValue = ttlIterator.next()
-          val groupingKey = nextTtlValue.groupingKey
-          if (groupingKey sameElements implicitGroupingKey) {
-            nextValue = Some(nextTtlValue.expirationMs)
-          }
-        }
-        nextValue.isDefined
-      }
-
-      override def next(): Long = {
-        val result = nextValue.get
-        nextValue = None
-        result
-      }
-    }
+    getValuesInTTLState(stateTypesEncoder.serializeGroupingKey())
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/ListStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/ListStateSuite.scala
@@ -17,13 +17,14 @@
 
 package org.apache.spark.sql.execution.streaming.state
 
+import java.time.Duration
 import java.util.UUID
 
 import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.sql.Encoders
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
-import org.apache.spark.sql.execution.streaming.{ImplicitGroupingKeyTracker, StatefulProcessorHandleImpl}
-import org.apache.spark.sql.streaming.{ListState, TimeMode, ValueState}
+import org.apache.spark.sql.execution.streaming.{ImplicitGroupingKeyTracker, ListStateImplWithTTL, StatefulProcessorHandleImpl}
+import org.apache.spark.sql.streaming.{ListState, TimeMode, TTLConfig, ValueState}
 
 /**
  * Class that adds unit tests for ListState types used in arbitrary stateful
@@ -158,6 +159,62 @@ class ListStateSuite extends StateVariableSuiteBase {
       assert(listState2.exists())
       assert(!valueState.exists())
       assert(listState1.get().toSeq === Seq.empty[Long])
+    }
+  }
+
+  test(s"test List state TTL") {
+    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+      val store = provider.getStore(0)
+      val timestampMs = 10
+      val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
+        Encoders.STRING.asInstanceOf[ExpressionEncoder[Any]],
+        TimeMode.ProcessingTime(), batchTimestampMs = Some(timestampMs))
+
+      val ttlConfig = TTLConfig(ttlDuration = Duration.ofMinutes(1))
+      val testState: ListStateImplWithTTL[String] = handle.getListState[String]("testState",
+        Encoders.STRING, ttlConfig).asInstanceOf[ListStateImplWithTTL[String]]
+      ImplicitGroupingKeyTracker.setImplicitKey("test_key")
+      testState.put(Array("v1", "v2", "v3"))
+      assert(testState.get().toSeq === Seq("v1", "v2", "v3"))
+      assert(testState.getWithoutEnforcingTTL().toSeq === Seq("v1", "v2", "v3"))
+
+      val ttlExpirationMs = timestampMs + 60000
+      var ttlValues = testState.getTTLValues()
+      assert(ttlValues.nonEmpty)
+      assert(ttlValues.forall(_._2 === ttlExpirationMs))
+      var ttlStateValueIterator = testState.getValuesInTTLState()
+      assert(ttlStateValueIterator.hasNext)
+
+      // increment batchProcessingTime, or watermark and ensure expired value is not returned
+      val nextBatchHandle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
+        Encoders.STRING.asInstanceOf[ExpressionEncoder[Any]],
+        TimeMode.ProcessingTime(), batchTimestampMs = Some(ttlExpirationMs))
+
+      val nextBatchTestState: ListStateImplWithTTL[String] =
+        nextBatchHandle.getListState[String]("testState", Encoders.STRING, ttlConfig)
+          .asInstanceOf[ListStateImplWithTTL[String]]
+
+      ImplicitGroupingKeyTracker.setImplicitKey("test_key")
+
+      // ensure get does not return the expired value
+      assert(!nextBatchTestState.exists())
+      assert(nextBatchTestState.get().isEmpty)
+
+      // ttl value should still exist in state
+      ttlValues = nextBatchTestState.getTTLValues()
+      assert(ttlValues.nonEmpty)
+      assert(ttlValues.forall(_._2 === ttlExpirationMs))
+      ttlStateValueIterator = nextBatchTestState.getValuesInTTLState()
+      assert(ttlStateValueIterator.hasNext)
+      assert(ttlStateValueIterator.next() === ttlExpirationMs)
+      assert(ttlStateValueIterator.isEmpty)
+
+      // getWithoutTTL should still return the expired value
+      assert(nextBatchTestState.getWithoutEnforcingTTL().toSeq === Seq("v1", "v2", "v3"))
+
+      nextBatchTestState.clear()
+      assert(!nextBatchTestState.exists())
+      assert(nextBatchTestState.get().isEmpty)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StatefulProcessorHandleSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StatefulProcessorHandleSuite.scala
@@ -219,7 +219,7 @@ class StatefulProcessorHandleSuite extends StateVariableSuiteBase {
     }
   }
 
-  test(s"ttl States are populated for valueState and timeMode=ProcessingTime") {
+  test("ttl States are populated for valueState and timeMode=ProcessingTime") {
     tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
       val store = provider.getStore(0)
       val handle = new StatefulProcessorHandleImpl(store,
@@ -237,7 +237,7 @@ class StatefulProcessorHandleSuite extends StateVariableSuiteBase {
     }
   }
 
-  test(s"ttl States are populated for listState and timeMode=ProcessingTime") {
+  test("ttl States are populated for listState and timeMode=ProcessingTime") {
     tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
       val store = provider.getStore(0)
       val handle = new StatefulProcessorHandleImpl(store,
@@ -255,7 +255,7 @@ class StatefulProcessorHandleSuite extends StateVariableSuiteBase {
     }
   }
 
-  test(s"ttl States are not populated for timeMode=None") {
+  test("ttl States are not populated for timeMode=None") {
     tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
       val store = provider.getStore(0)
       val handle = new StatefulProcessorHandleImpl(store,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StatefulProcessorHandleSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StatefulProcessorHandleSuite.scala
@@ -255,15 +255,14 @@ class StatefulProcessorHandleSuite extends StateVariableSuiteBase {
     }
   }
 
-
   test(s"ttl States are not populated for timeMode=None") {
     tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
       val store = provider.getStore(0)
       val handle = new StatefulProcessorHandleImpl(store,
         UUID.randomUUID(), keyExprEncoder, TimeMode.None())
 
-      handle.getValueState("testState", Encoders.STRING)
-      handle.getListState("testState", Encoders.STRING)
+      handle.getValueState("testValueState", Encoders.STRING)
+      handle.getListState("testListState", Encoders.STRING)
 
       assert(handle.ttlStates.isEmpty)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/ValueStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/ValueStateSuite.scala
@@ -324,7 +324,7 @@ class ValueStateSuite extends StateVariableSuiteBase {
       val ttlExpirationMs = timestampMs + 60000
       var ttlValue = testState.getTTLValue()
       assert(ttlValue.isDefined)
-      assert(ttlValue.get === ttlExpirationMs)
+      assert(ttlValue.get._2 === ttlExpirationMs)
       var ttlStateValueIterator = testState.getValuesInTTLState()
       assert(ttlStateValueIterator.hasNext)
 
@@ -346,7 +346,7 @@ class ValueStateSuite extends StateVariableSuiteBase {
       // ttl value should still exist in state
       ttlValue = nextBatchTestState.getTTLValue()
       assert(ttlValue.isDefined)
-      assert(ttlValue.get === ttlExpirationMs)
+      assert(ttlValue.get._2 === ttlExpirationMs)
       ttlStateValueIterator = nextBatchTestState.getValuesInTTLState()
       assert(ttlStateValueIterator.hasNext)
       assert(ttlStateValueIterator.next() === ttlExpirationMs)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithListStateTTLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithListStateTTLSuite.scala
@@ -98,9 +98,10 @@ class ListStateTTLProcessor(ttlConfig: TTLConfig)
 class TransformWithListStateTTLSuite extends TransformWithStateTTLTest {
 
   import testImplicits._
+
   override def getProcessor(ttlConfig: TTLConfig):
-  StatefulProcessor[String, InputEvent, OutputEvent] = {
-    new ListStateTTLProcessor(ttlConfig)
+    StatefulProcessor[String, InputEvent, OutputEvent] = {
+      new ListStateTTLProcessor(ttlConfig)
   }
 
   override def getStateTTLMetricName: String = "numListStateWithTTLVars"

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithListStateTTLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithListStateTTLSuite.scala
@@ -103,6 +103,8 @@ class TransformWithListStateTTLSuite extends TransformWithStateTTLTest {
     new ListStateTTLProcessor(ttlConfig)
   }
 
+  override def getStateTTLMetricName: String = "numListStateWithTTLVars"
+
   test("verify iterator works with expired values in middle of list") {
     withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
       classOf[RocksDBStateStoreProvider].getName,

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithListStateTTLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithListStateTTLSuite.scala
@@ -1,0 +1,347 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.streaming
+
+import java.time.Duration
+
+import org.apache.spark.sql.Encoders
+import org.apache.spark.sql.execution.streaming.{ListStateImplWithTTL, MemoryStream}
+import org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreProvider
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.streaming.util.StreamManualClock
+
+class ListStateTTLProcessor(ttlConfig: TTLConfig)
+  extends StatefulProcessor[String, InputEvent, OutputEvent] {
+
+  @transient private var _listState: ListStateImplWithTTL[Int] = _
+
+  override def init(
+   outputMode: OutputMode,
+   timeMode: TimeMode): Unit = {
+    _listState = getHandle
+      .getListState("listState", Encoders.scalaInt, ttlConfig)
+      .asInstanceOf[ListStateImplWithTTL[Int]]
+  }
+
+  override def handleInputRows(
+    key: String,
+    inputRows: Iterator[InputEvent],
+    timerValues: TimerValues,
+    expiredTimerInfo: ExpiredTimerInfo): Iterator[OutputEvent] = {
+    var results = List[OutputEvent]()
+
+    inputRows.foreach { row =>
+      val resultIter = processRow(row, _listState)
+      resultIter.foreach { r =>
+        results = r :: results
+      }
+    }
+
+    results.iterator
+  }
+
+  def processRow(
+    row: InputEvent,
+    listState: ListStateImplWithTTL[Int]): Iterator[OutputEvent] = {
+
+    var results = List[OutputEvent]()
+    val key = row.key
+    if (row.action == "get") {
+      val currState = listState.get()
+      currState.foreach { v =>
+        results = OutputEvent(key, v, isTTLValue = false, -1) :: results
+      }
+    } else if (row.action == "get_without_enforcing_ttl") {
+      val currState = listState.getWithoutEnforcingTTL()
+      currState.foreach { v =>
+        results = OutputEvent(key, v, isTTLValue = false, -1) :: results
+      }
+    } else if (row.action == "get_ttl_value_from_state") {
+      val ttlValues = listState.getTTLValues()
+      ttlValues.foreach { ttlValue =>
+        results = OutputEvent(key, ttlValue._1, isTTLValue = true, ttlValue._2) :: results
+      }
+    } else if (row.action == "put") {
+      listState.put(Array(row.value))
+    } else if (row.action == "append") {
+      listState.appendValue(row.value)
+    } else if (row.action == "get_values_in_ttl_state") {
+      val ttlValues = listState.getValuesInTTLState()
+      ttlValues.foreach { v =>
+        results = OutputEvent(key, -1, isTTLValue = true, ttlValue = v) :: results
+      }
+    }
+
+    results.iterator
+  }
+}
+
+/**
+ * Test suite for testing list state with TTL.
+ * We use the base TTL suite with a list state processor.
+ */
+class TransformWithListStateTTLSuite extends TransformWithStateTTLTest {
+
+  import testImplicits._
+  override def getProcessor(ttlConfig: TTLConfig):
+  StatefulProcessor[String, InputEvent, OutputEvent] = {
+    new ListStateTTLProcessor(ttlConfig)
+  }
+
+  test("verify iterator works with expired values in middle of list") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName,
+      SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
+      withTempDir { checkpointLocation =>
+        val ttlConfig1 = TTLConfig(ttlDuration = Duration.ofMinutes(3))
+        val inputStream = MemoryStream[InputEvent]
+        val result1 = inputStream.toDS()
+          .groupByKey(x => x.key)
+          .transformWithState(
+            getProcessor(ttlConfig1),
+            TimeMode.ProcessingTime(),
+            OutputMode.Append())
+
+        val clock = new StreamManualClock
+        // add 3 elements with a duration of a minute
+        testStream(result1)(
+          StartStream(Trigger.ProcessingTime("1 second"), triggerClock = clock,
+            checkpointLocation = checkpointLocation.getAbsolutePath),
+          AddData(inputStream, InputEvent("k1", "put", 1)),
+          AdvanceManualClock(1 * 1000),
+          AddData(inputStream, InputEvent("k1", "append", 2)),
+          AddData(inputStream, InputEvent("k1", "append", 3)),
+          // advance clock to trigger processing
+          AdvanceManualClock(1 * 1000),
+          CheckNewAnswer(),
+          // get ttl values
+          AddData(inputStream, InputEvent("k1", "get_ttl_value_from_state", -1, null)),
+          AdvanceManualClock(1 * 1000),
+          CheckNewAnswer(
+            OutputEvent("k1", 1, isTTLValue = true, 181000),
+            OutputEvent("k1", 2, isTTLValue = true, 182000),
+            OutputEvent("k1", 3, isTTLValue = true, 182000)
+          ),
+          AddData(inputStream, InputEvent("k1", "get", -1, null)),
+          AdvanceManualClock(1 * 1000),
+          CheckNewAnswer(
+            OutputEvent("k1", 1, isTTLValue = false, -1),
+            OutputEvent("k1", 2, isTTLValue = false, -1),
+            OutputEvent("k1", 3, isTTLValue = false, -1)
+          ),
+          StopStream
+        )
+
+        val ttlConfig2 = TTLConfig(ttlDuration = Duration.ofSeconds(15))
+        val result2 = inputStream.toDS()
+          .groupByKey(x => x.key)
+          .transformWithState(
+            getProcessor(ttlConfig2),
+            TimeMode.ProcessingTime(),
+            OutputMode.Append())
+        // add 3 elements with a duration of 15 seconds
+        testStream(result2)(
+          StartStream(Trigger.ProcessingTime("1 second"), triggerClock = clock,
+            checkpointLocation = checkpointLocation.getAbsolutePath),
+          AddData(inputStream, InputEvent("k1", "append", 4)),
+          AddData(inputStream, InputEvent("k1", "append", 5)),
+          AddData(inputStream, InputEvent("k1", "append", 6)),
+          // advance clock to trigger processing
+          AdvanceManualClock(1 * 1000),
+          CheckNewAnswer(),
+          // get all elements without enforcing ttl
+          AddData(inputStream, InputEvent("k1", "get_without_enforcing_ttl", -1, null)),
+          AdvanceManualClock(1 * 1000),
+          CheckNewAnswer(
+            OutputEvent("k1", 1, isTTLValue = false, -1),
+            OutputEvent("k1", 2, isTTLValue = false, -1),
+            OutputEvent("k1", 3, isTTLValue = false, -1),
+            OutputEvent("k1", 4, isTTLValue = false, -1),
+            OutputEvent("k1", 5, isTTLValue = false, -1),
+            OutputEvent("k1", 6, isTTLValue = false, -1)
+          ),
+          StopStream
+        )
+        // add 3 more elements with a duration of a minute
+        testStream(result1)(
+          StartStream(Trigger.ProcessingTime("1 second"), triggerClock = clock,
+            checkpointLocation = checkpointLocation.getAbsolutePath),
+          AddData(inputStream, InputEvent("k1", "append", 7)),
+          AddData(inputStream, InputEvent("k1", "append", 8)),
+          AddData(inputStream, InputEvent("k1", "append", 9)),
+          // advance clock to trigger processing
+          AdvanceManualClock(1 * 1000),
+          CheckNewAnswer(),
+          // advance clock to expire the middle three elements
+          AddData(inputStream, InputEvent("k1", "get_values_in_ttl_state", -1, null)),
+          AdvanceManualClock(1 * 1000),
+          // validate that the expired elements are not returned
+          CheckNewAnswer(
+            OutputEvent("k1", -1, isTTLValue = true, 20000),
+            OutputEvent("k1", -1, isTTLValue = true, 181000),
+            OutputEvent("k1", -1, isTTLValue = true, 182000),
+            OutputEvent("k1", -1, isTTLValue = true, 187000)
+          ),
+          AdvanceManualClock(45 * 1000),
+          // Get all elements in the list
+          AddData(inputStream, InputEvent("k1", "get", -1, null)),
+          AdvanceManualClock(1 * 1000),
+          // validate that the expired elements are not returned
+          CheckNewAnswer(
+            OutputEvent("k1", 1, isTTLValue = false, -1),
+            OutputEvent("k1", 2, isTTLValue = false, -1),
+            OutputEvent("k1", 3, isTTLValue = false, -1),
+            OutputEvent("k1", 7, isTTLValue = false, -1),
+            OutputEvent("k1", 8, isTTLValue = false, -1),
+            OutputEvent("k1", 9, isTTLValue = false, -1)
+          ),
+          AddData(inputStream, InputEvent("k1", "get_without_enforcing_ttl", -1, null)),
+          AdvanceManualClock(1 * 1000),
+          // validate that the expired elements are not returned
+          CheckNewAnswer(
+            OutputEvent("k1", 1, isTTLValue = false, -1),
+            OutputEvent("k1", 2, isTTLValue = false, -1),
+            OutputEvent("k1", 3, isTTLValue = false, -1),
+            OutputEvent("k1", 7, isTTLValue = false, -1),
+            OutputEvent("k1", 8, isTTLValue = false, -1),
+            OutputEvent("k1", 9, isTTLValue = false, -1)
+          ),
+          AddData(inputStream, InputEvent("k1", "get_values_in_ttl_state", -1, null)),
+          AdvanceManualClock(1 * 1000),
+          // validate that the expired elements are not returned
+          CheckNewAnswer(
+            OutputEvent("k1", -1, isTTLValue = true, 181000),
+            OutputEvent("k1", -1, isTTLValue = true, 182000),
+            OutputEvent("k1", -1, isTTLValue = true, 187000)
+          ),
+          StopStream
+        )
+      }
+    }
+  }
+
+  test("verify iterator works with expired values in beginning of list") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName,
+      SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
+      withTempDir { checkpointLocation =>
+        val inputStream = MemoryStream[InputEvent]
+        val ttlConfig1 = TTLConfig(ttlDuration = Duration.ofMinutes(1))
+        val result1 = inputStream.toDS()
+          .groupByKey(x => x.key)
+          .transformWithState(
+            getProcessor(ttlConfig1),
+            TimeMode.ProcessingTime(),
+            OutputMode.Append())
+
+        val ttlConfig2 = TTLConfig(ttlDuration = Duration.ofMinutes(2))
+        val result2 = inputStream.toDS()
+          .groupByKey(x => x.key)
+          .transformWithState(
+            getProcessor(ttlConfig2),
+            TimeMode.ProcessingTime(),
+            OutputMode.Append())
+
+        val clock = new StreamManualClock
+        // add 3 elements with a duration of a minute
+        testStream(result1)(
+          StartStream(Trigger.ProcessingTime("1 second"), triggerClock = clock,
+            checkpointLocation = checkpointLocation.getAbsolutePath),
+          AddData(inputStream, InputEvent("k1", "put", 1)),
+          AdvanceManualClock(1 * 1000),
+          AddData(inputStream, InputEvent("k1", "append", 2)),
+          AddData(inputStream, InputEvent("k1", "append", 3)),
+          // advance clock to trigger processing
+          AdvanceManualClock(1 * 1000),
+          CheckNewAnswer(),
+          // get ttl values
+          AddData(inputStream, InputEvent("k1", "get_ttl_value_from_state", -1, null)),
+          AdvanceManualClock(1 * 1000),
+          CheckNewAnswer(
+            OutputEvent("k1", 1, isTTLValue = true, 61000),
+            OutputEvent("k1", 2, isTTLValue = true, 62000),
+            OutputEvent("k1", 3, isTTLValue = true, 62000)
+          ),
+          AddData(inputStream, InputEvent("k1", "get", -1, null)),
+          AdvanceManualClock(1 * 1000),
+          CheckNewAnswer(
+            OutputEvent("k1", 1, isTTLValue = false, -1),
+            OutputEvent("k1", 2, isTTLValue = false, -1),
+            OutputEvent("k1", 3, isTTLValue = false, -1)
+          ),
+          StopStream
+        )
+
+        // add 3 elements with a duration of two minutes
+        testStream(result2)(
+          StartStream(Trigger.ProcessingTime("1 second"), triggerClock = clock,
+            checkpointLocation = checkpointLocation.getAbsolutePath),
+          AddData(inputStream, InputEvent("k1", "append", 4)),
+          AddData(inputStream, InputEvent("k1", "append", 5)),
+          AddData(inputStream, InputEvent("k1", "append", 6)),
+          // advance clock to trigger processing
+          AdvanceManualClock(1 * 1000),
+          CheckNewAnswer(),
+          // get ttl values
+          AddData(inputStream, InputEvent("k1", "get_ttl_value_from_state", -1, null)),
+          AdvanceManualClock(1 * 1000),
+          CheckNewAnswer(
+            OutputEvent("k1", 1, isTTLValue = true, 61000),
+            OutputEvent("k1", 2, isTTLValue = true, 62000),
+            OutputEvent("k1", 3, isTTLValue = true, 62000),
+            OutputEvent("k1", 4, isTTLValue = true, 125000),
+            OutputEvent("k1", 5, isTTLValue = true, 125000),
+            OutputEvent("k1", 6, isTTLValue = true, 125000)
+          ),
+          AddData(inputStream, InputEvent("k1", "get_values_in_ttl_state", -1, null)),
+          AdvanceManualClock(1 * 1000),
+          // validate that the expired elements are not returned
+          CheckNewAnswer(
+            OutputEvent("k1", -1, isTTLValue = true, 61000),
+            OutputEvent("k1", -1, isTTLValue = true, 62000),
+            OutputEvent("k1", -1, isTTLValue = true, 125000)
+          ),
+          // expire beginning values
+          AdvanceManualClock(60 * 1000),
+          AddData(inputStream, InputEvent("k1", "get", -1, null)),
+          AdvanceManualClock(1 * 1000),
+          CheckNewAnswer(
+            OutputEvent("k1", 4, isTTLValue = false, -1),
+            OutputEvent("k1", 5, isTTLValue = false, -1),
+            OutputEvent("k1", 6, isTTLValue = false, -1)
+          ),
+          AddData(inputStream, InputEvent("k1", "get_without_enforcing_ttl", -1, null)),
+          AdvanceManualClock(1 * 1000),
+          // validate that the expired elements are not returned
+          CheckNewAnswer(
+            OutputEvent("k1", 4, isTTLValue = false, -1),
+            OutputEvent("k1", 5, isTTLValue = false, -1),
+            OutputEvent("k1", 6, isTTLValue = false, -1)
+          ),
+          AddData(inputStream, InputEvent("k1", "get_values_in_ttl_state", -1, null)),
+          AdvanceManualClock(1 * 1000),
+          // validate that the expired elements are not returned
+          CheckNewAnswer(
+            OutputEvent("k1", -1, isTTLValue = true, 125000)
+          ),
+          StopStream
+        )
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateTTLTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateTTLTest.scala
@@ -46,6 +46,8 @@ abstract class TransformWithStateTTLTest
 
   def getProcessor(ttlConfig: TTLConfig): StatefulProcessor[String, InputEvent, OutputEvent]
 
+  def getStateTTLMetricName: String
+
   test("validate state is evicted at ttl expiry") {
     withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
       classOf[RocksDBStateStoreProvider].getName) {
@@ -113,7 +115,7 @@ abstract class TransformWithStateTTLTest
             // for stateful operator
             val progData = q.recentProgress.filter(prog => prog.stateOperators.size > 0)
             assert(progData.filter(prog =>
-              prog.stateOperators(0).customMetrics.get("numValueStateWithTTLVars") > 0).size > 0)
+              prog.stateOperators(0).customMetrics.get(getStateTTLMetricName) > 0).size > 0)
             assert(progData.filter(prog =>
               prog.stateOperators(0).customMetrics
                 .get("numValuesRemovedDueToTTLExpiry") > 0).size > 0)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateTTLTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateTTLTest.scala
@@ -36,9 +36,9 @@ case class OutputEvent(
     value: Int,
     isTTLValue: Boolean,
     ttlValue: Long)
+
 /**
- * Tests that ttl works as expected for Value State for
- * processing time and event time based ttl.
+ * Test suite base for TransformWithState with TTL support.
  */
 abstract class TransformWithStateTTLTest
   extends StreamTest {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateTTLTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateTTLTest.scala
@@ -1,0 +1,286 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.streaming
+
+import java.sql.Timestamp
+import java.time.Duration
+
+import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreProvider
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.streaming.util.StreamManualClock
+
+case class InputEvent(
+    key: String,
+    action: String,
+    value: Int,
+    eventTime: Timestamp = null)
+
+case class OutputEvent(
+    key: String,
+    value: Int,
+    isTTLValue: Boolean,
+    ttlValue: Long)
+/**
+ * Tests that ttl works as expected for Value State for
+ * processing time and event time based ttl.
+ */
+abstract class TransformWithStateTTLTest
+  extends StreamTest {
+  import testImplicits._
+
+  def getProcessor(ttlConfig: TTLConfig): StatefulProcessor[String, InputEvent, OutputEvent]
+
+  test("validate state is evicted at ttl expiry") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName) {
+      withTempDir { dir =>
+        val inputStream = MemoryStream[InputEvent]
+        val ttlConfig = TTLConfig(ttlDuration = Duration.ofMinutes(1))
+        val result = inputStream.toDS()
+          .groupByKey(x => x.key)
+          .transformWithState(
+            getProcessor(ttlConfig),
+            TimeMode.ProcessingTime(),
+            OutputMode.Append())
+
+        val clock = new StreamManualClock
+        testStream(result)(
+          StartStream(
+            Trigger.ProcessingTime("1 second"),
+            triggerClock = clock,
+            checkpointLocation = dir.getAbsolutePath),
+          AddData(inputStream, InputEvent("k1", "put", 1)),
+          // advance clock to trigger processing
+          AdvanceManualClock(1 * 1000),
+          CheckNewAnswer(),
+          StopStream,
+          StartStream(
+            Trigger.ProcessingTime("1 second"),
+            triggerClock = clock,
+            checkpointLocation = dir.getAbsolutePath),
+          // get this state, and make sure we get unexpired value
+          AddData(inputStream, InputEvent("k1", "get", -1)),
+          AdvanceManualClock(1 * 1000),
+          CheckNewAnswer(OutputEvent("k1", 1, isTTLValue = false, -1)),
+          StopStream,
+          StartStream(
+            Trigger.ProcessingTime("1 second"),
+            triggerClock = clock,
+            checkpointLocation = dir.getAbsolutePath),
+          // ensure ttl values were added correctly
+          AddData(inputStream, InputEvent("k1", "get_ttl_value_from_state", -1)),
+          AdvanceManualClock(1 * 1000),
+          CheckNewAnswer(OutputEvent("k1", 1, isTTLValue = true, 61000)),
+          AddData(inputStream, InputEvent("k1", "get_values_in_ttl_state", -1)),
+          AdvanceManualClock(1 * 1000),
+          CheckNewAnswer(OutputEvent("k1", -1, isTTLValue = true, 61000)),
+          StopStream,
+          StartStream(
+            Trigger.ProcessingTime("1 second"),
+            triggerClock = clock,
+            checkpointLocation = dir.getAbsolutePath),
+          // advance clock so that state expires
+          AdvanceManualClock(60 * 1000),
+          AddData(inputStream, InputEvent("k1", "get", -1, null)),
+          AdvanceManualClock(1 * 1000),
+          // validate expired value is not returned
+          CheckNewAnswer(),
+          // ensure this state does not exist any longer in State
+          AddData(inputStream, InputEvent("k1", "get_without_enforcing_ttl", -1)),
+          AdvanceManualClock(1 * 1000),
+          CheckNewAnswer(),
+          AddData(inputStream, InputEvent("k1", "get_values_in_ttl_state", -1)),
+          AdvanceManualClock(1 * 1000),
+          CheckNewAnswer(),
+          Execute { q =>
+            // Filter for idle progress events and then verify the custom metrics
+            // for stateful operator
+            val progData = q.recentProgress.filter(prog => prog.stateOperators.size > 0)
+            assert(progData.filter(prog =>
+              prog.stateOperators(0).customMetrics.get("numValueStateWithTTLVars") > 0).size > 0)
+            assert(progData.filter(prog =>
+              prog.stateOperators(0).customMetrics
+                .get("numValuesRemovedDueToTTLExpiry") > 0).size > 0)
+          }
+        )
+      }
+    }
+  }
+
+  test("validate state update updates the expiration timestamp") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName) {
+      val inputStream = MemoryStream[InputEvent]
+      val ttlConfig = TTLConfig(ttlDuration = Duration.ofMinutes(1))
+      val result = inputStream.toDS()
+        .groupByKey(x => x.key)
+        .transformWithState(
+          getProcessor(ttlConfig),
+          TimeMode.ProcessingTime(),
+          OutputMode.Append())
+
+      val clock = new StreamManualClock
+      testStream(result)(
+        StartStream(Trigger.ProcessingTime("1 second"), triggerClock = clock),
+        AddData(inputStream, InputEvent("k1", "put", 1)),
+        // advance clock to trigger processing
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(),
+        // get this state, and make sure we get unexpired value
+        AddData(inputStream, InputEvent("k1", "get", -1)),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(OutputEvent("k1", 1, isTTLValue = false, -1)),
+        // ensure ttl values were added correctly
+        AddData(inputStream, InputEvent("k1", "get_ttl_value_from_state", -1)),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(OutputEvent("k1", 1, isTTLValue = true, 61000)),
+        AddData(inputStream, InputEvent("k1", "get_values_in_ttl_state", -1)),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(OutputEvent("k1", -1, isTTLValue = true, 61000)),
+        // advance clock and update expiration time
+        AdvanceManualClock(30 * 1000),
+        AddData(inputStream, InputEvent("k1", "put", 1)),
+        AddData(inputStream, InputEvent("k1", "get", -1)),
+        // advance clock to trigger processing
+        AdvanceManualClock(1 * 1000),
+        // validate value is not expired
+        CheckNewAnswer(OutputEvent("k1", 1, isTTLValue = false, -1)),
+        // validate ttl value is updated in the state
+        AddData(inputStream, InputEvent("k1", "get_ttl_value_from_state", -1)),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(OutputEvent("k1", 1, isTTLValue = true, 95000)),
+        // validate ttl state has both ttl values present
+        AddData(inputStream, InputEvent("k1", "get_values_in_ttl_state", -1)),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(OutputEvent("k1", -1, isTTLValue = true, 61000),
+          OutputEvent("k1", -1, isTTLValue = true, 95000)
+        ),
+        // advance clock after older expiration value
+        AdvanceManualClock(30 * 1000),
+        // ensure unexpired value is still present in the state
+        AddData(inputStream, InputEvent("k1", "get", -1)),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(OutputEvent("k1", 1, isTTLValue = false, -1)),
+        // validate that the older expiration value is removed from ttl state
+        AddData(inputStream, InputEvent("k1", "get_values_in_ttl_state", -1)),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(OutputEvent("k1", -1, isTTLValue = true, 95000))
+      )
+    }
+  }
+
+  test("validate state is evicted at ttl expiry for no data batch") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+    classOf[RocksDBStateStoreProvider].getName) {
+      val inputStream = MemoryStream[InputEvent]
+      val ttlConfig = TTLConfig(ttlDuration = Duration.ofMinutes(1))
+      val result = inputStream.toDS()
+        .groupByKey(x => x.key)
+        .transformWithState(
+          getProcessor(ttlConfig),
+          TimeMode.ProcessingTime(),
+          OutputMode.Append())
+
+      val clock = new StreamManualClock
+      testStream(result)(
+        StartStream(
+          Trigger.ProcessingTime("1 second"),
+          triggerClock = clock),
+        AddData(inputStream, InputEvent("k1", "put", 1)),
+        // advance clock to trigger processing
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(),
+        // get this state, and make sure we get unexpired value
+        AddData(inputStream, InputEvent("k1", "get", -1)),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(OutputEvent("k1", 1, isTTLValue = false, -1)),
+        // ensure ttl values were added correctly
+        AddData(inputStream, InputEvent("k1", "get_ttl_value_from_state", -1)),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(OutputEvent("k1", 1, isTTLValue = true, 61000)),
+        AddData(inputStream, InputEvent("k1", "get_values_in_ttl_state", -1)),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(OutputEvent("k1", -1, isTTLValue = true, 61000)),
+        // advance clock so that state expires
+        AdvanceManualClock(60 * 1000),
+        // run a no data batch
+        CheckNewAnswer(),
+        AddData(inputStream, InputEvent("k1", "get", -1)),
+        AdvanceManualClock(1 * 1000),
+        // validate expired value is not returned
+        CheckNewAnswer(),
+        // ensure this state does not exist any longer in State
+        AddData(inputStream, InputEvent("k1", "get_without_enforcing_ttl", -1)),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(),
+        AddData(inputStream, InputEvent("k1", "get_values_in_ttl_state", -1)),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer()
+      )
+    }
+  }
+
+  test("validate only expired keys are removed from the state") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName,
+      SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
+      val inputStream = MemoryStream[InputEvent]
+      val ttlConfig = TTLConfig(ttlDuration = Duration.ofMinutes(1))
+      val result = inputStream.toDS()
+        .groupByKey(x => x.key)
+        .transformWithState(
+          getProcessor(ttlConfig),
+          TimeMode.ProcessingTime(),
+          OutputMode.Append())
+
+      val clock = new StreamManualClock
+      testStream(result)(
+        StartStream(Trigger.ProcessingTime("1 second"), triggerClock = clock),
+        AddData(inputStream, InputEvent("k1", "put", 1)),
+        // advance clock to trigger processing
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(),
+        // advance clock halfway to expiration ttl, and add another key
+        AdvanceManualClock(30 * 1000),
+        AddData(inputStream, InputEvent("k2", "put", 2)),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(),
+        // advance clock so that key k1 is expired
+        AdvanceManualClock(30 * 1000),
+        AddData(inputStream, InputEvent("k1", "get", 1)),
+        AddData(inputStream, InputEvent("k2", "get", -1)),
+        AdvanceManualClock(1 * 1000),
+        // validate k1 is expired and k2 is not
+        CheckNewAnswer(OutputEvent("k2", 2, isTTLValue = false, -1)),
+        // validate k1 is deleted from state
+        AddData(inputStream, InputEvent("k1", "get_ttl_value_from_state", -1)),
+        AddData(inputStream, InputEvent("k1", "get_values_in_ttl_state", -1)),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(),
+        // validate k2 exists in state
+        AddData(inputStream, InputEvent("k2", "get_ttl_value_from_state", -1)),
+        AddData(inputStream, InputEvent("k2", "get_values_in_ttl_state", -1)),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(
+          OutputEvent("k2", 2, isTTLValue = true, 92000),
+          OutputEvent("k2", -1, isTTLValue = true, 92000))
+      )
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithValueStateTTLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithValueStateTTLSuite.scala
@@ -168,6 +168,7 @@ class TransformWithValueStateTTLSuite extends TransformWithStateTTLTest {
     new ValueStateTTLProcessor(ttlConfig)
   }
 
+  override def getStateTTLMetricName: String = "numValueStateWithTTLVars"
 
   test("validate multiple value states") {
     withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithValueStateTTLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithValueStateTTLSuite.scala
@@ -163,9 +163,10 @@ case class MultipleValueStatesTTLProcessor(
 class TransformWithValueStateTTLSuite extends TransformWithStateTTLTest {
 
   import testImplicits._
+
   override def getProcessor(ttlConfig: TTLConfig):
     StatefulProcessor[String, InputEvent, OutputEvent] = {
-    new ValueStateTTLProcessor(ttlConfig)
+      new ValueStateTTLProcessor(ttlConfig)
   }
 
   override def getStateTTLMetricName: String = "numValueStateWithTTLVars"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds support for expiring state based on TTL for ListState. Using this functionality, Spark users can specify a TTL Mode for transformWithState operator, and provide a ttlDuration for each value in ListState. TTL support for Map State will be added in future PRs. Once the ttlDuration has expired, the value will not be returned as part of get() and would be cleaned up at the end of the micro-batch.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
These changes are needed to support TTL for ListState. The PR supports specifying ttl for processing time.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, modifies the ListState interface for specifying ttlDuration

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added the TransformWithListStateTTLSuite, ListStateSuite, StatefulProcessorHandleSuite
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No