### PR TITLE
[SPARK-47759][CORE] Make the critical path like RpcUtils$.askRpcTimeout less fragile

### DIFF
--- a/core/src/main/scala/org/apache/spark/rpc/RpcTimeout.scala
+++ b/core/src/main/scala/org/apache/spark/rpc/RpcTimeout.scala
@@ -128,7 +128,7 @@ private[spark] object RpcTimeout {
       conf.getOption(propKey).foreach { prop => foundProp = Some((propKey, prop)) }
     }
     val finalProp = foundProp.getOrElse((timeoutPropList.head, defaultValue))
-    val timeout = { Utils.timeStringAsSeconds(finalProp._2).seconds }
+    val timeout = Utils.timeStringAsSecondsWithSafeFallback(finalProp._2)
     new RpcTimeout(timeout, finalProp._1)
   }
 }

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -36,6 +36,7 @@ import java.util.zip.{GZIPInputStream, ZipInputStream}
 import scala.annotation.tailrec
 import scala.collection.Map
 import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.duration._
 import scala.io.Source
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
@@ -1079,6 +1080,30 @@ private[spark] object Utils
    */
   def timeStringAsSeconds(str: String): Long = {
     JavaUtils.timeStringAsSec(str)
+  }
+
+  /**
+   * In case that timeStringAsMs in the Try block gives us a runtime exception, we'll go with
+   * a safe fallback by deriving a duration based on the leading numeric chars of the given input.
+   */
+  def timeStringAsMsWithSafeFallback(str: String): FiniteDuration = {
+    Try {
+      JavaUtils.timeStringAsMs(str).milliseconds
+    }.getOrElse(
+      JavaUtils.numericsFrom(str).milliseconds
+    )
+  }
+
+  /**
+   * In case that timeStringAsSec in the Try block gives us a runtime exception, we'll go with
+   * a safe fallback by deriving a duration based on the leading numeric chars of the given input.
+   */
+  def timeStringAsSecondsWithSafeFallback(str: String): FiniteDuration = {
+    Try {
+      JavaUtils.timeStringAsSec(str).seconds
+    }.getOrElse(
+      JavaUtils.numericsFrom(str).seconds
+    )
   }
 
   /**

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit
 import java.util.zip.GZIPOutputStream
 
 import scala.collection.mutable.ListBuffer
+import scala.concurrent.duration._
 import scala.util.Random
 
 import com.google.common.io.Files
@@ -93,6 +94,35 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
 
     intercept[NumberFormatException] {
       Utils.timeStringAsMs("This 123s breaks")
+    }
+  }
+
+  test("timeConversion with the safe fallback") {
+    assert(Utils.timeStringAsSecondsWithSafeFallback("3s") === 3.seconds)
+    assert(Utils.timeStringAsSecondsWithSafeFallback("4") === 4.seconds)
+    assert(Utils.timeStringAsSecondsWithSafeFallback(" 5 xyz ") === 5.seconds)
+
+    intercept[NullPointerException] {
+      Utils.timeStringAsSecondsWithSafeFallback(null)
+    }
+    intercept[NumberFormatException] {
+      Utils.timeStringAsSecondsWithSafeFallback(" ")
+    }
+    intercept[NumberFormatException] {
+      Utils.timeStringAsSecondsWithSafeFallback("This 123s breaks")
+    }
+
+    assert(Utils.timeStringAsMsWithSafeFallback("60ms") === 60.milliseconds)
+    assert(Utils.timeStringAsMsWithSafeFallback("70") === 70.milliseconds)
+    assert(Utils.timeStringAsMsWithSafeFallback(" 80 whatever ") === 80.milliseconds)
+    intercept[NullPointerException] {
+      Utils.timeStringAsMsWithSafeFallback(null)
+    }
+    intercept[NumberFormatException] {
+      Utils.timeStringAsMsWithSafeFallback(" ")
+    }
+    intercept[NumberFormatException] {
+      Utils.timeStringAsMsWithSafeFallback("This 123ms breaks")
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make the critical path like RpcUtils$.askRpcTimeout less fragile

### Why are the changes needed?

It's observed that our Spark apps occasionally got stuck with an unexpected stack trace when reading/parsing a legitimate time string. Note that we manually killed the stuck app instances and the retry goes thru on the same cluster (without requiring any app code change). For detailed stack traces, please refer to [SPARK-47759](https://issues.apache.org/jira/browse/SPARK-47759). 

Under the circumstance where a caller can fall back to a default value of a given time unit (e.g., second, ms), we should swallow runtime exceptions triggered by the regex logic and unit conversion, especially for the critical path like RpcUtils$.askRpcTimeout where it might result in a hanging app.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

```
$build/mvn package -DskipTests -Djava.version=17 -pl common/network-common
$build/mvn package -DskipTests -Djava.version=17 -pl core

$build/mvn test -DwildcardSuites=none -Dtest=org.apache.spark.api.java.JavaUtilsSuite test
$build/mvn -Dtest=none -DwildcardSuites=org.apache.spark.util.UtilsSuite test
```

### Was this patch authored or co-authored using generative AI tooling?
No
