### PR TITLE
[SPARK-47774][INFRA] Remove redundant rules from `MimaExcludes`

### DIFF
--- a/project/MimaExcludes.scala
+++ b/project/MimaExcludes.scala
@@ -38,17 +38,11 @@ object MimaExcludes {
     // [SPARK-44863][UI] Add a button to download thread dump as a txt in Spark UI
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.status.api.v1.ThreadStackTrace.*"),
     ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.status.api.v1.ThreadStackTrace$"),
-    // [SPARK-44705][PYTHON] Make PythonRunner single-threaded
-    ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.spark.api.python.BasePythonRunner#ReaderIterator.this"),
-    // [SPARK-44198][CORE] Support propagation of the log level to the executors
-    ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages$SparkAppConfig$"),
     //[SPARK-46399][Core] Add exit status to the Application End event for the use of Spark Listener
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.scheduler.SparkListenerApplicationEnd.*"),
     ProblemFilters.exclude[MissingTypesProblem]("org.apache.spark.scheduler.SparkListenerApplicationEnd$"),
     // [SPARK-45427][CORE] Add RPC SSL settings to SSLOptions and SparkTransportConf
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.spark.network.netty.SparkTransportConf.fromSparkConf"),
-    // [SPARK-45136][CONNECT] Enhance ClosureCleaner with Ammonite support
-    ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.util.MethodIdentifier$"),
     // [SPARK-45022][SQL] Provide context for dataset API errors
     ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.QueryContext.contextType"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.spark.QueryContext.code"),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove redundant rules from `MimaExcludes` for Apache Spark 4.0.0.

Previously, these rules were required due to the `dev/mima` limitation which is fixed at
- https://github.com/apache/spark/pull/45938 

### Why are the changes needed?

To minimize the exclusion rules for Apache Spark 4.0.0 by removing the following `private class` rules.

- `BasePythonRunner`
https://github.com/apache/spark/blob/319edfdc5cd6731d1d630a8beeea5b23a2326f07/core/src/main/scala/org/apache/spark/api/python/PythonRunner.scala#L102

- `CoarseGrainedClusterMessage`
https://github.com/apache/spark/blob/319edfdc5cd6731d1d630a8beeea5b23a2326f07/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedClusterMessage.scala#L30

- `MethodIdentifier` 
https://github.com/apache/spark/blob/319edfdc5cd6731d1d630a8beeea5b23a2326f07/common/utils/src/main/scala/org/apache/spark/util/ClosureCleaner.scala#L1002

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No