### PR TITLE
[SPARK-47775][SQL] Support remaining scalar types in the variant spec.

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/VariantVal.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/VariantVal.java
@@ -21,6 +21,8 @@ import org.apache.spark.unsafe.Platform;
 import org.apache.spark.types.variant.Variant;
 
 import java.io.Serializable;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 
 /**
@@ -99,13 +101,17 @@ public class VariantVal implements Serializable {
         '}';
   }
 
+  public String toJson(ZoneId zoneId) {
+    return new Variant(value, metadata).toJson(zoneId);
+  }
+
   /**
    * @return A human-readable representation of the Variant value. It is always a JSON string at
    * this moment.
    */
   @Override
   public String toString() {
-    return new Variant(value, metadata).toJson();
+    return toJson(ZoneOffset.UTC);
   }
 
   /**

--- a/common/variant/src/main/java/org/apache/spark/types/variant/Variant.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/Variant.java
@@ -23,7 +23,15 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import java.io.CharArrayWriter;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.util.Arrays;
+import java.util.Base64;
+import java.util.Locale;
 
 import static org.apache.spark.types.variant.VariantUtil.*;
 
@@ -87,6 +95,37 @@ public final class Variant {
   // Get a decimal value from the variant.
   public BigDecimal getDecimal() {
     return VariantUtil.getDecimal(value, pos);
+  }
+
+  // Get a raw date value (number of days from the Unix epoch) from the variant.
+  public int getRawDate() {
+    return VariantUtil.getRawDate(value, pos);
+  }
+
+  // Get a date value from the variant.
+  public LocalDate getDate() {
+    return VariantUtil.getDate(value, pos);
+  }
+
+  // Get a raw timestamp/timestamp_ntz value (number of microseconds from the Unix epoch) from the
+  // variant
+  public long getRawTimestamp() {
+    return VariantUtil.getRawTimestamp(value, pos);
+  }
+
+  // Get a timestamp/timestamp_ntz value from the variant.
+  public Instant getTimestamp() {
+    return VariantUtil.getTimestamp(value, pos);
+  }
+
+  // Get a float value from the variant.
+  public float getFloat() {
+    return VariantUtil.getFloat(value, pos);
+  }
+
+  // Get a binary value from the variant.
+  public byte[] getBinary() {
+    return VariantUtil.getBinary(value, pos);
   }
 
   // Get a string value from the variant.
@@ -188,9 +227,9 @@ public final class Variant {
 
   // Stringify the variant in JSON format.
   // Throw `MALFORMED_VARIANT` if the variant is malformed.
-  public String toJson() {
+  public String toJson(ZoneId zoneId) {
     StringBuilder sb = new StringBuilder();
-    toJsonImpl(value, metadata, pos, sb);
+    toJsonImpl(value, metadata, pos, sb, zoneId);
     return sb.toString();
   }
 
@@ -208,7 +247,26 @@ public final class Variant {
     }
   }
 
-  static void toJsonImpl(byte[] value, byte[] metadata, int pos, StringBuilder sb) {
+  // A simplified and more performant version of `sb.append(escapeJson(str))`. It is used when we
+  // know `str` doesn't contain any special character that needs escaping.
+  static void appendQuoted(StringBuilder sb, String str) {
+    sb.append('"');
+    sb.append(str);
+    sb.append('"');
+  }
+
+  private static final DateTimeFormatter TIMESTAMP_NTZ_FORMATTER = new DateTimeFormatterBuilder()
+      .append(DateTimeFormatter.ISO_LOCAL_DATE)
+      .appendLiteral(' ')
+      .append(DateTimeFormatter.ISO_LOCAL_TIME)
+      .toFormatter(Locale.US);
+
+  private static final DateTimeFormatter TIMESTAMP_FORMATTER = new DateTimeFormatterBuilder()
+      .append(TIMESTAMP_NTZ_FORMATTER)
+      .appendOffset("+HH:MM", "+00:00")
+      .toFormatter(Locale.US);
+
+  static void toJsonImpl(byte[] value, byte[] metadata, int pos, StringBuilder sb, ZoneId zoneId) {
     switch (VariantUtil.getType(value, pos)) {
       case OBJECT:
         handleObject(value, pos, (size, idSize, offsetSize, idStart, offsetStart, dataStart) -> {
@@ -220,7 +278,7 @@ public final class Variant {
             if (i != 0) sb.append(',');
             sb.append(escapeJson(getMetadataKey(metadata, id)));
             sb.append(':');
-            toJsonImpl(value, metadata, elementPos, sb);
+            toJsonImpl(value, metadata, elementPos, sb, zoneId);
           }
           sb.append('}');
           return null;
@@ -233,7 +291,7 @@ public final class Variant {
             int offset = readUnsigned(value, offsetStart + offsetSize * i, offsetSize);
             int elementPos = dataStart + offset;
             if (i != 0) sb.append(',');
-            toJsonImpl(value, metadata, elementPos, sb);
+            toJsonImpl(value, metadata, elementPos, sb, zoneId);
           }
           sb.append(']');
           return null;
@@ -256,6 +314,23 @@ public final class Variant {
         break;
       case DECIMAL:
         sb.append(VariantUtil.getDecimal(value, pos).toPlainString());
+        break;
+      case DATE:
+        appendQuoted(sb, VariantUtil.getDate(value, pos).toString());
+        break;
+      case TIMESTAMP:
+        appendQuoted(sb, TIMESTAMP_FORMATTER.format(
+            VariantUtil.getTimestamp(value, pos).atZone(zoneId)));
+        break;
+      case TIMESTAMP_NTZ:
+        appendQuoted(sb, TIMESTAMP_NTZ_FORMATTER.format(
+            VariantUtil.getTimestamp(value, pos).atZone(ZoneOffset.UTC)));
+        break;
+      case FLOAT:
+        sb.append(VariantUtil.getFloat(value, pos));
+        break;
+      case BINARY:
+        appendQuoted(sb, Base64.getEncoder().encodeToString(VariantUtil.getBinary(value, pos)));
         break;
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala
@@ -1114,7 +1114,7 @@ case class Cast(
       _ => throw QueryExecutionErrors.cannotCastFromNullTypeError(to)
     } else if (from.isInstanceOf[VariantType]) {
       buildCast[VariantVal](_, v => {
-        variant.VariantGet.cast(v, to, evalMode != EvalMode.TRY, timeZoneId)
+        variant.VariantGet.cast(v, to, evalMode != EvalMode.TRY, timeZoneId, zoneId)
       })
     } else {
       to match {
@@ -1211,11 +1211,12 @@ case class Cast(
     case _ if from.isInstanceOf[VariantType] => (c, evPrim, evNull) =>
       val tmp = ctx.freshVariable("tmp", classOf[Object])
       val dataTypeArg = ctx.addReferenceObj("dataType", to)
-      val zoneIdArg = ctx.addReferenceObj("zoneId", timeZoneId)
+      val zoneStrArg = ctx.addReferenceObj("zoneStr", timeZoneId)
+      val zoneIdArg = ctx.addReferenceObj("zoneId", zoneId, classOf[ZoneId].getName)
       val failOnError = evalMode != EvalMode.TRY
       val cls = classOf[variant.VariantGet].getName
       code"""
-        Object $tmp = $cls.cast($c, $dataTypeArg, $failOnError, $zoneIdArg);
+        Object $tmp = $cls.cast($c, $dataTypeArg, $failOnError, $zoneStrArg, $zoneIdArg);
         if ($tmp == null) {
           $evNull = true;
         } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/variantExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/variantExpressions.scala
@@ -299,9 +299,9 @@ case object VariantGet {
           case Type.DECIMAL =>
             val d = Decimal(v.getDecimal)
             Literal(Decimal(v.getDecimal), DecimalType(d.precision, d.scale))
-          case Type.DATE => Literal(v.getRawDate, DateType)
-          case Type.TIMESTAMP => Literal(v.getRawTimestamp, TimestampType)
-          case Type.TIMESTAMP_NTZ => Literal(v.getRawTimestamp, TimestampNTZType)
+          case Type.DATE => Literal(v.getLong.toInt, DateType)
+          case Type.TIMESTAMP => Literal(v.getLong, TimestampType)
+          case Type.TIMESTAMP_NTZ => Literal(v.getLong, TimestampNTZType)
           case Type.FLOAT => Literal(v.getFloat, FloatType)
           case Type.BINARY => Literal(v.getBinary, BinaryType)
           // We have handled other cases and should never reach here. This case is only intended

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonGenerator.scala
@@ -317,7 +317,7 @@ class JacksonGenerator(
   }
 
   def write(v: VariantVal): Unit = {
-    gen.writeRawValue(v.toString)
+    gen.writeRawValue(v.toJson(options.zoneId))
   }
 
   def writeLineEnding(): Unit = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionSuite.scala
@@ -23,6 +23,7 @@ import org.apache.spark.{SparkFunSuite, SparkRuntimeException}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.analysis.ResolveTimeZone
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.util.DateTimeConstants._
 import org.apache.spark.sql.catalyst.util.DateTimeTestUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
@@ -684,5 +685,116 @@ class VariantExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
       ArrayType(IntegerType),
       Array(null, null, 1)
     )
+  }
+
+  test("atomic types that are not produced by parse_json") {
+    // Dictionary size is `0` for value 0. An empty dictionary contains one offset `0` for the
+    // one-past-the-end position (i.e. the sum of all string lengths).
+    val emptyMetadata = Array[Byte](VERSION, 0, 0)
+
+    def checkToJson(value: Array[Byte], expected: String): Unit = {
+      val input = Literal(new VariantVal(value, emptyMetadata))
+      checkEvaluation(StructsToJson(Map.empty, input), expected)
+    }
+
+    def checkCast(value: Array[Byte], dataType: DataType, expected: Any): Unit = {
+      val input = Literal(new VariantVal(value, emptyMetadata))
+      checkEvaluation(Cast(input, dataType, evalMode = EvalMode.ANSI), expected)
+    }
+
+    checkToJson(Array(primitiveHeader(DATE), 0, 0, 0, 0), "\"1970-01-01\"")
+    checkToJson(Array(primitiveHeader(DATE), -1, -1, -1, 127), "\"+5881580-07-11\"")
+    checkToJson(Array(primitiveHeader(DATE), 0, 0, 0, -128), "\"-5877641-06-23\"")
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      checkCast(Array(primitiveHeader(DATE), 0, 0, 0, 0), TimestampType, 0L)
+      checkCast(Array(primitiveHeader(DATE), 1, 0, 0, 0), TimestampType, MICROS_PER_DAY)
+    }
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "America/Los_Angeles") {
+      checkCast(Array(primitiveHeader(DATE), 0, 0, 0, 0), TimestampType, 8 * MICROS_PER_HOUR)
+      checkCast(Array(primitiveHeader(DATE), 1, 0, 0, 0), TimestampType,
+        MICROS_PER_DAY + 8 * MICROS_PER_HOUR)
+    }
+
+    def littleEndianLong(value: Long): Array[Byte] =
+      BigInt(value).toByteArray.reverse.padTo(8, 0.toByte)
+
+    val time1 = littleEndianLong(0)
+    // In America/Los_Angeles timezone, timestamp value `skippedTime` is 2011-03-13 03:00:00.
+    // The next second of 2011-03-13 01:59:59 jumps to 2011-03-13 03:00:00.
+    val skippedTime = 1300010400000000L
+    val time2 = littleEndianLong(skippedTime)
+    val time3 = littleEndianLong(skippedTime - 1)
+    val time4 = littleEndianLong(Long.MinValue)
+    val time5 = littleEndianLong(Long.MaxValue)
+    val time6 = littleEndianLong(-62198755200000000L)
+    val timestampHeader = Array(primitiveHeader(TIMESTAMP))
+    val timestampNtzHeader = Array(primitiveHeader(TIMESTAMP_NTZ))
+
+    for (timeZone <- Seq("UTC", "America/Los_Angeles")) {
+      withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> timeZone) {
+        checkToJson(timestampNtzHeader ++ time1, "\"1970-01-01 00:00:00\"")
+        checkToJson(timestampNtzHeader ++ time2, "\"2011-03-13 10:00:00\"")
+        checkToJson(timestampNtzHeader ++ time3, "\"2011-03-13 09:59:59.999999\"")
+        checkToJson(timestampNtzHeader ++ time4, "\"-290308-12-21 19:59:05.224192\"")
+        checkToJson(timestampNtzHeader ++ time5, "\"+294247-01-10 04:00:54.775807\"")
+        checkToJson(timestampNtzHeader ++ time6, "\"-0001-01-01 00:00:00\"")
+
+        checkCast(timestampNtzHeader ++ time1, DateType, 0)
+        checkCast(timestampNtzHeader ++ time2, DateType, 15046)
+        checkCast(timestampNtzHeader ++ time3, DateType, 15046)
+        checkCast(timestampNtzHeader ++ time4, DateType, -106751992)
+        checkCast(timestampNtzHeader ++ time5, DateType, 106751991)
+        checkCast(timestampNtzHeader ++ time6, DateType, -719893)
+      }
+    }
+
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "UTC") {
+      checkToJson(timestampHeader ++ time1, "\"1970-01-01 00:00:00+00:00\"")
+      checkToJson(timestampHeader ++ time2, "\"2011-03-13 10:00:00+00:00\"")
+      checkToJson(timestampHeader ++ time3, "\"2011-03-13 09:59:59.999999+00:00\"")
+      checkToJson(timestampHeader ++ time4, "\"-290308-12-21 19:59:05.224192+00:00\"")
+      checkToJson(timestampHeader ++ time5, "\"+294247-01-10 04:00:54.775807+00:00\"")
+      checkToJson(timestampHeader ++ time6, "\"-0001-01-01 00:00:00+00:00\"")
+
+      checkCast(timestampHeader ++ time1, DateType, 0)
+      checkCast(timestampHeader ++ time2, DateType, 15046)
+      checkCast(timestampHeader ++ time3, DateType, 15046)
+      checkCast(timestampHeader ++ time4, DateType, -106751992)
+      checkCast(timestampHeader ++ time5, DateType, 106751991)
+      checkCast(timestampHeader ++ time6, DateType, -719893)
+    }
+
+    withSQLConf(SQLConf.SESSION_LOCAL_TIMEZONE.key -> "America/Los_Angeles") {
+      checkToJson(timestampHeader ++ time1, "\"1969-12-31 16:00:00-08:00\"")
+      checkToJson(timestampHeader ++ time2, "\"2011-03-13 03:00:00-07:00\"")
+      checkToJson(timestampHeader ++ time3, "\"2011-03-13 01:59:59.999999-08:00\"")
+      checkToJson(timestampHeader ++ time4, "\"-290308-12-21 12:06:07.224192-07:52\"")
+      checkToJson(timestampHeader ++ time5, "\"+294247-01-09 20:00:54.775807-08:00\"")
+      checkToJson(timestampHeader ++ time6, "\"-0002-12-31 16:07:02-07:52\"")
+
+      checkCast(timestampHeader ++ time1, DateType, -1)
+      checkCast(timestampHeader ++ time2, DateType, 15046)
+      checkCast(timestampHeader ++ time3, DateType, 15046)
+      checkCast(timestampHeader ++ time4, DateType, -106751992)
+      checkCast(timestampHeader ++ time5, DateType, 106751990)
+      checkCast(timestampHeader ++ time6, DateType, -719894)
+    }
+
+    checkToJson(Array(primitiveHeader(FLOAT)) ++
+      BigInt(java.lang.Float.floatToIntBits(1.23F)).toByteArray.reverse, "1.23")
+    checkToJson(Array(primitiveHeader(FLOAT)) ++
+      BigInt(java.lang.Float.floatToIntBits(-0.0F)).toByteArray.reverse, "-0.0")
+    // Note: 1.23F.toDouble != 1.23.
+    checkCast(Array(primitiveHeader(FLOAT)) ++
+      BigInt(java.lang.Float.floatToIntBits(1.23F)).toByteArray.reverse, DoubleType, 1.23F.toDouble)
+
+    checkToJson(Array(primitiveHeader(BINARY), 0, 0, 0, 0), "\"\"")
+    checkToJson(Array(primitiveHeader(BINARY), 1, 0, 0, 0, 1), "\"AQ==\"")
+    checkToJson(Array(primitiveHeader(BINARY), 2, 0, 0, 0, 1, 2), "\"AQI=\"")
+    checkToJson(Array(primitiveHeader(BINARY), 3, 0, 0, 0, 1, 2, 3), "\"AQID\"")
+    checkCast(Array(primitiveHeader(BINARY), 3, 0, 0, 0, 1, 2, 3), StringType,
+      "\u0001\u0002\u0003")
+    checkCast(Array(primitiveHeader(BINARY), 5, 0, 0, 0, 72, 101, 108, 108, 111), StringType,
+      "Hello")
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds support for the remaining scalar types defined in the variant spec (DATE, TIMESTAMP, TIMESTAMP_NTZ, FLOAT, BINARY). The current `parse_json` expression doesn't produce these types, but we need them when we support casting a corresponding Spark type into the variant type.

### Why are the changes needed?

This PR can be considered as a preparation for the cast-to-variant feature and will make the latter PR smaller.

### Does this PR introduce _any_ user-facing change?

Yes.  Existing variant expressions can decode more variant scalar types.

### How was this patch tested?

Unit tests. We manually construct variant values with these new scalar types and test the existing variant expressions on them.

### Was this patch authored or co-authored using generative AI tooling?

No.