### PR TITLE
[SPARK-47779][PS][TESTS] Add a helper function to sort PS Frame/Series

### DIFF
--- a/python/pyspark/pandas/tests/diff_frames_ops/test_arithmetic_chain.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_arithmetic_chain.py
@@ -84,24 +84,29 @@ class ArithmeticChainTestingFuncMixin:
 
         # MultiIndex Series
         self.assert_eq(
-            (psser1 + psser2 - psser3).sort_index(), (pser1 + pser2 - pser3).sort_index()
+            self.sort_index_with_values(psser1 + psser2 - psser3),
+            self.sort_index_with_values(pser1 + pser2 - pser3),
         )
 
         self.assert_eq(
-            (psser1 * psser2 * psser3).sort_index(), (pser1 * pser2 * pser3).sort_index()
+            self.sort_index_with_values(psser1 * psser2 * psser3),
+            self.sort_index_with_values(pser1 * pser2 * pser3),
         )
 
         if check_extension and not extension_float_dtypes_available:
             self.assert_eq(
-                (psser1 - psser2 / psser3).sort_index(), (pser1 - pser2 / pser3).sort_index()
+                self.sort_index_with_values(psser1 - psser2 / psser3),
+                self.sort_index_with_values(pser1 - pser2 / pser3),
             )
         else:
             self.assert_eq(
-                (psser1 - psser2 / psser3).sort_index(), (pser1 - pser2 / pser3).sort_index()
+                self.sort_index_with_values(psser1 - psser2 / psser3),
+                self.sort_index_with_values(pser1 - pser2 / pser3),
             )
 
         self.assert_eq(
-            (psser1 + psser2 * psser3).sort_index(), (pser1 + pser2 * pser3).sort_index()
+            self.sort_index_with_values(psser1 + psser2 * psser3),
+            self.sort_index_with_values(pser1 + pser2 * pser3),
         )
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a helper function to sort PS Frame/Series
Use it in `pyspark.pandas.tests.diff_frames_ops.test_arithmetic_*` and their parity tests



### Why are the changes needed?
normally, `sort_index` or `sort_value` is enough to make test result deterministic. However, there are some edge cases like `MultiIndex` with duplicated indices and the sorted result is non-deterministic. for example, test `pyspark.pandas.tests.connect.diff_frames_ops.test_parity_arithmetic_chain.ArithmeticChainParityTests.test_arithmetic_chain` fail in some testing envs even with `sort_index`:
```
Left:
cow     length    250.0
        power       NaN
        speed    -218.8
        speed       1.2
        weight      NaN
...
float64
Right:
cow     length    250.0
        power       NaN
        speed       1.2
        speed    -218.8
        weight      NaN
...
float64
```

This PR introduce a new helper function to sort indices and values together.


### Does this PR introduce _any_ user-facing change?
no, test only


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no
