### PR TITLE
[SPARK-47780][SQL] Make catalyst-generated classes stable and uniquely named

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDF.scala
@@ -1192,7 +1192,13 @@ case class ScalaUDF(
 
   private def functionName = udfName.map { uName => s"$uName ($funcCls)" }.getOrElse(funcCls)
 
-  lazy val funcCls = Utils.getSimpleName(function.getClass)
+  lazy val funcCls = {
+    val clsName = Utils.getSimpleName(function.getClass)
+    // remove the random lambda-proxy hash to make generated code stable
+    if (clsName.contains("$$Lambda")) clsName.split("/0x")(0)
+    else clsName
+  }
+
   lazy val inputTypesString = children.map(_.dataType.catalogString).mkString(", ")
   lazy val outputType = dataType.catalogString
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/codegen/CodeGenerator.scala
@@ -1512,8 +1512,9 @@ object CodeGenerator extends Logging {
     // https://issues.apache.org/jira/browse/SPARK-11636.
     val parentClassLoader = new ParentClassLoader(Utils.getContextOrSparkClassLoader)
     evaluator.setParentClassLoader(parentClassLoader)
+    val codeHash = code.hashCode.abs
     // Cannot be under package codegen, or fail with java.lang.InstantiationException
-    evaluator.setClassName("org.apache.spark.sql.catalyst.expressions.GeneratedClass")
+    evaluator.setClassName(s"org.apache.spark.sql.catalyst.expressions.GeneratedClass$$$codeHash")
     evaluator.setDefaultImports(
       classOf[Platform].getName,
       classOf[InternalRow].getName,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGeneratorWithInterpretedFallbackSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CodeGeneratorWithInterpretedFallbackSuite.scala
@@ -51,7 +51,7 @@ class CodeGeneratorWithInterpretedFallbackSuite extends SparkFunSuite with PlanT
     val input = Seq(BoundReference(0, IntegerType, nullable = true))
     withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key -> codegenOnly) {
       val obj = UnsafeProjection.createObject(input)
-      assert(obj.getClass.getName.contains("GeneratedClass$SpecificUnsafeProjection"))
+      assert(obj.getClass.getName.matches(".*GeneratedClass\\$\\d*\\$SpecificUnsafeProjection"))
     }
 
     withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key -> noCodegen) {
@@ -64,7 +64,7 @@ class CodeGeneratorWithInterpretedFallbackSuite extends SparkFunSuite with PlanT
     val input = Seq(BoundReference(0, IntegerType, nullable = true))
     withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key -> codegenOnly) {
       val obj = MutableProjection.createObject(input)
-      assert(obj.getClass.getName.contains("GeneratedClass$SpecificMutableProjection"))
+      assert(obj.getClass.getName.matches(".*GeneratedClass\\$\\d*\\$SpecificMutableProjection"))
     }
 
     withSQLConf(SQLConf.CODEGEN_FACTORY_MODE.key -> noCodegen) {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/OrderingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/OrderingSuite.scala
@@ -129,7 +129,7 @@ class OrderingSuite extends SparkFunSuite with ExpressionEvalHelper {
     }
   }
 
-  test("SPARK-16845: GeneratedClass$SpecificOrdering grows beyond 64 KiB") {
+  test("SPARK-16845: GeneratedClass$<hash>$SpecificOrdering grows beyond 64 KiB") {
     val sortOrder = Literal("abc").asc
 
     // this is passing prior to SPARK-16845, and it should also be passing after SPARK-16845

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -412,9 +412,9 @@ class QueryExecutionErrorsSuite
     spark.udf.register("luckyCharOfWord", luckyCharOfWord)
 
     val functionNameRegex = if (Utils.isJavaVersionAtLeast21) {
-      "`luckyCharOfWord \\(QueryExecutionErrorsSuite\\$\\$Lambda/\\w+\\)`"
+      "`luckyCharOfWord \\(QueryExecutionErrorsSuite\\$\\$Lambda\\)`"
     } else {
-      "`luckyCharOfWord \\(QueryExecutionErrorsSuite\\$\\$Lambda\\$\\d+/\\w+\\)`"
+      "`luckyCharOfWord \\(QueryExecutionErrorsSuite\\$\\$Lambda\\$\\d+\\)`"
     }
     val reason = if (Utils.isJavaVersionAtLeast21) {
       "java.lang.StringIndexOutOfBoundsException: Range \\[5, 6\\) out of bounds for length 5"
@@ -443,9 +443,9 @@ class QueryExecutionErrorsSuite
       word.substring(index, index + 1)
     }}
     val functionNameRegex = if (Utils.isJavaVersionAtLeast21) {
-      "`QueryExecutionErrorsSuite\\$\\$Lambda/\\w+`"
+      "`QueryExecutionErrorsSuite\\$\\$Lambda`"
     } else {
-      "`QueryExecutionErrorsSuite\\$\\$Lambda\\$\\d+/\\w+`"
+      "`QueryExecutionErrorsSuite\\$\\$Lambda\\$\\d+`"
     }
     val reason = if (Utils.isJavaVersionAtLeast21) {
       "java.lang.StringIndexOutOfBoundsException: Range \\[5, 6\\) out of bounds for length 5"


### PR DESCRIPTION
### What changes were proposed in this pull request?
This change make the classes generated by catalyst:
1. Stable across different runs. The generated code does not contain random numbers that come from lambda-proxy names (`0x<address>`).
2. Uniquely named. The name uniqueness is achieved by adding the hash code of the generated code to the class name. The generated classes are now named `org.apache.spark.sql.catalyst.expressions.GeneratedClass$<codeHash>` instead of `org.apache.spark.sql.catalyst.expressions.GeneratedClass`.
  
### Why are the changes needed?
The changes were needed to allow running Spark SQL workloads on [GraalVM Native Image](https://www.graalvm.org/).

### Does this PR introduce _any_ user-facing change?
Yes, it removes the random number from the lambda-proxy name in the UDF failure error message. Before this change:
```
[FAILED_EXECUTE_UDF] Failed to execute user defined function (QueryExecutionErrorsSuite$$Lambda$970/0x181260145: (string, int) => string).
```
After this change:
```
[FAILED_EXECUTE_UDF] Failed to execute user defined function (nextChar in QueryExecutionErrorsSuite$$Lambda$970: (string, int) => string).
```
### How was this patch tested?
The test cases for this code path were already introduced in the following [PR](https://github.com/apache/spark/pull/41599). This PR modifies these tests to check for the new format.

### Was this patch authored or co-authored using generative AI tooling?
No!