### PR TITLE
[MINOR][PS][TESTS] Make `test_compare` deterministic

### DIFF
--- a/python/pyspark/pandas/tests/diff_frames_ops/test_compare_series.py
+++ b/python/pyspark/pandas/tests/diff_frames_ops/test_compare_series.py
@@ -131,7 +131,7 @@ class CompareSeriesMixin:
         )
 
         with ps.option_context("compute.eager_check", False):
-            self.assert_eq(expected, psser1.compare(psser2))
+            self.assert_eq(expected, psser1.compare(psser2).sort_index())
 
 
 class CompareSeriesTests(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `test_compare` deterministic

### Why are the changes needed?
it fails in some env:
```
AssertionError: DataFrame.index are different
DataFrame.index values are different (80.0 %)
[left]:  Int64Index([3, 4, 5, 6, 7], dtype='int64')
[right]: Int64Index([4, 3, 7, 6, 5], dtype='int64')
```


### Does this PR introduce _any_ user-facing change?
no, test only


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no