### PR TITLE
[SPARK-47787][BUILD] Upgrade `commons-compress` to 1.26.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -40,7 +40,7 @@ commons-codec/1.16.1//commons-codec-1.16.1.jar
 commons-collections/3.2.2//commons-collections-3.2.2.jar
 commons-collections4/4.4//commons-collections4-4.4.jar
 commons-compiler/3.1.9//commons-compiler-3.1.9.jar
-commons-compress/1.26.0//commons-compress-1.26.0.jar
+commons-compress/1.26.1//commons-compress-1.26.1.jar
 commons-crypto/1.1.0//commons-crypto-1.1.0.jar
 commons-dbcp/1.4//commons-dbcp-1.4.jar
 commons-io/2.16.0//commons-io-2.16.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
     <snappy.version>1.1.10.5</snappy.version>
     <netlib.ludovic.dev.version>3.0.3</netlib.ludovic.dev.version>
     <commons-codec.version>1.16.1</commons-codec.version>
-    <commons-compress.version>1.26.0</commons-compress.version>
+    <commons-compress.version>1.26.1</commons-compress.version>
     <commons-io.version>2.16.0</commons-io.version>
     <!-- org.apache.commons/commons-lang/-->
     <commons-lang2.version>2.6</commons-lang2.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `commons-compress` to 1.26.1.

### Why are the changes needed?

`1.26.1` is a maintenance release of `1.26.1` with the following fixes.
- https://commons.apache.org/proper/commons-compress/changes-report.html#a1.26.1

### Does this PR introduce _any_ user-facing change?

`1.26.0` is not released yet.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.