### PR TITLE
[SPARK-47790][BUILD][3.5] Upgrade `commons-io` to 2.16.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -43,7 +43,7 @@ commons-compiler/3.1.9//commons-compiler-3.1.9.jar
 commons-compress/1.23.0//commons-compress-1.23.0.jar
 commons-crypto/1.1.0//commons-crypto-1.1.0.jar
 commons-dbcp/1.4//commons-dbcp-1.4.jar
-commons-io/2.13.0//commons-io-2.13.0.jar
+commons-io/2.16.1//commons-io-2.16.1.jar
 commons-lang/2.6//commons-lang-2.6.jar
 commons-lang3/3.12.0//commons-lang3-3.12.0.jar
 commons-logging/1.1.3//commons-logging-1.1.3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
     <netlib.ludovic.dev.version>3.0.3</netlib.ludovic.dev.version>
     <commons-codec.version>1.16.1</commons-codec.version>
     <commons-compress.version>1.23.0</commons-compress.version>
-    <commons-io.version>2.13.0</commons-io.version>
+    <commons-io.version>2.16.1</commons-io.version>
     <!-- org.apache.commons/commons-lang/-->
     <commons-lang2.version>2.6</commons-lang2.version>
     <!-- org.apache.commons/commons-lang3/-->


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `commons-io` to 2.16.1.

### Why are the changes needed?

To bring the latest bug fixes
- https://commons.apache.org/proper/commons-io/changes-report.html#a2.16.1 (2024-04-04)
- https://commons.apache.org/proper/commons-io/changes-report.html#a2.16.0 (2024-03-25)
- https://commons.apache.org/proper/commons-io/changes-report.html#a2.15.1 (2023-11-24)
- https://commons.apache.org/proper/commons-io/changes-report.html#a2.15.0 (2023-10-21)
- https://commons.apache.org/proper/commons-io/changes-report.html#a2.14.0 (2023-09-24)

### Does this PR introduce _any_ user-facing change?

Yes, this is a dependency change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.