### PR TITLE
[SPARK-47799][BUILD] Add `-g` to javac compile parameters when using SBT package jar

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -311,6 +311,7 @@ object SparkBuild extends PomBuild {
 
     (Compile / javacOptions) ++= Seq(
       "-encoding", UTF_8.name(),
+      "-g",
       "--release", javaVersion.value
     ),
     // This -target and Xlint:unchecked options cannot be set in the Compile configuration scope since


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to add `-g` to javac compile parameters when using SBT package jar.

> -g
Generates all debugging information, including local variables. By default, only line number and source file information is generated.

https://docs.oracle.com/en/java/javase/17/docs/specs/man/javac.html

### Why are the changes needed?
`maven-compiler-plugin` defaults to debug=true, `plexus-compiler-javac` will add the parameter `-g`.

SBT does not have this behavior by default, which leads to some differences between the jars of maven and sbt builds, although the code logic is the same.

https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#debug

https://github.com/apache/maven-compiler-plugin/blob/736da68adf543cf56cd82a68e5ad28d397ace2f4/src/main/java/org/apache/maven/plugin/compiler/AbstractCompilerMojo.java#L734

https://github.com/codehaus-plexus/plexus-compiler/blob/6ae79d7f2feca3a02e75f7661468abac6a9a0a11/plexus-compilers/plexus-compiler-javac/src/main/java/org/codehaus/plexus/compiler/javac/JavacCompiler.java#L279-L285


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
GA

```bash
./build/sbt common-utils/package
```

local test

### Current

<img width="1005" alt="image" src="https://github.com/apache/spark/assets/3898450/6233068c-b15b-46e4-a070-d3d36db540a4">


### PR
<img width="1395" alt="image" src="https://github.com/apache/spark/assets/3898450/a5c156b1-d1a2-4847-9265-0c608a129091">



### Was this patch authored or co-authored using generative AI tooling?
No
