### PR TITLE
[SPARK-47802][SQL] Revert (*) from meaning struct(*) back to meaning *

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -38,7 +38,6 @@ license: |
   - `spark.sql.avro.datetimeRebaseModeInWrite` instead of `spark.sql.legacy.avro.datetimeRebaseModeInWrite`
   - `spark.sql.avro.datetimeRebaseModeInRead` instead of `spark.sql.legacy.avro.datetimeRebaseModeInRead`
 - Since Spark 4.0, the default value of `spark.sql.orc.compression.codec` is changed from `snappy` to `zstd`. To restore the previous behavior, set `spark.sql.orc.compression.codec` to `snappy`.
-- Since Spark 4.0, `SELECT (*)` is equivalent to `SELECT struct(*)` instead of `SELECT *`. To restore the previous behavior, set `spark.sql.legacy.ignoreParenthesesAroundStar` to `true`.
 - Since Spark 4.0, the SQL config `spark.sql.legacy.allowZeroIndexInFormatString` is deprecated. Consider to change `strfmt` of the `format_string` function to use 1-based indexes. The first argument must be referenced by "1$", the second by "2$", etc.
 - Since Spark 4.0, JDBC read option `preferTimestampNTZ=true` will not convert Postgres TIMESTAMP WITH TIME ZONE and TIME WITH TIME ZONE data types to TimestampNTZType, which is available in Spark 3.5. 
 - Since Spark 4.0, JDBC read option `preferTimestampNTZ=true` will not convert MySQL TIMESTAMP to TimestampNTZType, which is available in Spark 3.5. MySQL DATETIME is not affected.

--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -575,13 +575,8 @@ transformClause
       (RECORDREADER recordReader=stringLit)?
     ;
 
-parenthesizedStar
-    : LEFT_PAREN ASTERISK RIGHT_PAREN
-    ;
-
 selectClause
-    : SELECT (hints+=hint)* setQuantifier parenthesizedStar
-    | SELECT (hints+=hint)* setQuantifier? namedExpressionSeq
+    : SELECT (hints+=hint)* setQuantifier? namedExpressionSeq
     ;
 
 setClause

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2599,23 +2599,9 @@ class AstBuilder extends DataTypeAstBuilder with SQLConfHelper with Logging {
    * Create an expression for an expression between parentheses. This is need because the ANTLR
    * visitor cannot automatically convert the nested context into an expression.
    */
-  override def visitParenthesizedStar(
-     ctx: ParenthesizedStarContext): Seq[Expression] = withOrigin(ctx) {
-    Seq(UnresolvedStar(None))
- }
-
-  /**
-   * Create an expression for an expression between parentheses. This is need because the ANTLR
-   * visitor cannot automatically convert the nested context into an expression.
-   */
   override def visitParenthesizedExpression(
      ctx: ParenthesizedExpressionContext): Expression = withOrigin(ctx) {
-    val res = expression(ctx.expression())
-    res match {
-      case s: UnresolvedStar if (!conf.getConf(SQLConf.LEGACY_IGNORE_PARENTHESES_AROUND_STAR)) =>
-        CreateStruct(Seq(s))
-      case o => o
-    }
+    expression(ctx.expression)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4779,16 +4779,6 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
-  val LEGACY_IGNORE_PARENTHESES_AROUND_STAR =
-    buildConf("spark.sql.legacy.ignoreParenthesesAroundStar")
-    .internal()
-    .doc("When set to true, SELECT (*) equals SELECT * FROM T instead of SELECT struct(*)." +
-      "SELECT (*) was never documented as defined behavior."
-    )
-    .version("4.0.0")
-    .booleanConf
-    .createWithDefault(false)
-
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -5713,9 +5703,6 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def legacyJavaCharsets: Boolean = getConf(SQLConf.LEGACY_JAVA_CHARSETS)
 
   def legacyEvalCurrentTime: Boolean = getConf(SQLConf.LEGACY_EVAL_CURRENT_TIME)
-
-  def legacyIgnoreParenthesesAroundStar: Boolean =
-    getConf(SQLConf.LEGACY_IGNORE_PARENTHESES_AROUND_STAR)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/selectExcept.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/selectExcept.sql.out
@@ -414,7 +414,7 @@ Project [concat_ws(,, cast(c1#x as string), cast(c2#x as string), cast(c3#x as a
 -- !query
 SELECT (*) FROM v1
 -- !query analysis
-Project [named_struct(c1, c1#x, c2, c2#x, c3, c3#x, c4, c4#x, c5, c5#x) AS named_struct(c1, c1, c2, c2, c3, c3, c4, c4, c5, c5)#x]
+Project [c1#x, c2#x, c3#x, c4#x, c5#x]
 +- SubqueryAlias v1
    +- View (`v1`, [c1#x, c2#x, c3#x, c4#x, c5#x])
       +- Project [cast(c1#x as int) AS c1#x, cast(c2#x as int) AS c2#x, cast(c3#x as void) AS c3#x, cast(c4#x as int) AS c4#x, cast(c5#x as int) AS c5#x]
@@ -529,73 +529,3 @@ Project [x#x]
          +- Project [cast(c1#x as int) AS c1#x, cast(c2#x as int) AS c2#x, cast(c3#x as void) AS c3#x, cast(c4#x as int) AS c4#x, cast(c5#x as int) AS c5#x]
             +- SubqueryAlias T
                +- LocalRelation [c1#x, c2#x, c3#x, c4#x, c5#x]
-
-
--- !query
-SET spark.sql.legacy.ignoreParenthesesAroundStar = true
--- !query analysis
-SetCommand (spark.sql.legacy.ignoreParenthesesAroundStar,Some(true))
-
-
--- !query
-SELECT (*) FROM v1
--- !query analysis
-Project [c1#x, c2#x, c3#x, c4#x, c5#x]
-+- SubqueryAlias v1
-   +- View (`v1`, [c1#x, c2#x, c3#x, c4#x, c5#x])
-      +- Project [cast(c1#x as int) AS c1#x, cast(c2#x as int) AS c2#x, cast(c3#x as void) AS c3#x, cast(c4#x as int) AS c4#x, cast(c5#x as int) AS c5#x]
-         +- SubqueryAlias T
-            +- LocalRelation [c1#x, c2#x, c3#x, c4#x, c5#x]
-
-
--- !query
-SELECT DISTINCT * FROM v1
--- !query analysis
-Distinct
-+- Project [c1#x, c2#x, c3#x, c4#x, c5#x]
-   +- SubqueryAlias v1
-      +- View (`v1`, [c1#x, c2#x, c3#x, c4#x, c5#x])
-         +- Project [cast(c1#x as int) AS c1#x, cast(c2#x as int) AS c2#x, cast(c3#x as void) AS c3#x, cast(c4#x as int) AS c4#x, cast(c5#x as int) AS c5#x]
-            +- SubqueryAlias T
-               +- LocalRelation [c1#x, c2#x, c3#x, c4#x, c5#x]
-
-
--- !query
-SELECT DISTINCT(*) FROM v1
--- !query analysis
-Distinct
-+- SubqueryAlias v1
-   +- View (`v1`, [c1#x, c2#x, c3#x, c4#x, c5#x])
-      +- Project [cast(c1#x as int) AS c1#x, cast(c2#x as int) AS c2#x, cast(c3#x as void) AS c3#x, cast(c4#x as int) AS c4#x, cast(c5#x as int) AS c5#x]
-         +- SubqueryAlias T
-            +- LocalRelation [c1#x, c2#x, c3#x, c4#x, c5#x]
-
-
--- !query
-SET spark.sql.legacy.ignoreParenthesesAroundStar = false
--- !query analysis
-SetCommand (spark.sql.legacy.ignoreParenthesesAroundStar,Some(false))
-
-
--- !query
-SELECT DISTINCT(*) FROM v1
--- !query analysis
-Distinct
-+- SubqueryAlias v1
-   +- View (`v1`, [c1#x, c2#x, c3#x, c4#x, c5#x])
-      +- Project [cast(c1#x as int) AS c1#x, cast(c2#x as int) AS c2#x, cast(c3#x as void) AS c3#x, cast(c4#x as int) AS c4#x, cast(c5#x as int) AS c5#x]
-         +- SubqueryAlias T
-            +- LocalRelation [c1#x, c2#x, c3#x, c4#x, c5#x]
-
-
--- !query
-DROP VIEW v1
--- !query analysis
-DropTempViewCommand v1
-
-
--- !query
-SELECT DISTINCT(*)
--- !query analysis
-Distinct
-+- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/inputs/selectExcept.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/selectExcept.sql
@@ -60,7 +60,10 @@ SELECT coalesce(* EXCEPT(c1, c2)) FROM v1;
 SELECT array(*) FROM v1;
 SELECT array(v1.*) FROM v1;
 SELECT concat_ws(',', *) FROM v1;
+
+-- This is just SELECT *
 SELECT (*) FROM v1;
+
 SELECT struct(*) FROM v1;
 SELECT greatest(*) FROM v1;
 SELECT 5 IN (*) FROM v1;
@@ -72,22 +75,4 @@ SELECT 1 FROM v1 WHERE array(*) = array(1, 2, NULL, 4, 5);
 SELECT 1 FROM v1 WHERE 4 IN (*);
 SELECT T.* FROM v1, LATERAL (SELECT  v1.*) AS T(c1, c2, c3, c4, c5);
 SELECT T.* FROM v1, LATERAL (SELECT  COALESCE(v1.*)) AS T(x);
-
-
--- We used to ignore () around * in the past, but now we don't
-SET spark.sql.legacy.ignoreParenthesesAroundStar = true;
-SELECT (*) FROM v1;
-
-SELECT DISTINCT * FROM v1;
-
-SELECT DISTINCT(*) FROM v1;
-
-SET spark.sql.legacy.ignoreParenthesesAroundStar = false;
-
-SELECT DISTINCT(*) FROM v1;
-
-DROP VIEW v1;
-
--- Except for DISTINCT, where we still ignore ()
-SELECT DISTINCT(*)
 

--- a/sql/core/src/test/resources/sql-tests/results/selectExcept.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/selectExcept.sql.out
@@ -419,9 +419,9 @@ struct<concat_ws(,, c1, c2, c3, c4, c5):string>
 -- !query
 SELECT (*) FROM v1
 -- !query schema
-struct<named_struct(c1, c1, c2, c2, c3, c3, c4, c4, c5, c5):struct<c1:int,c2:int,c3:void,c4:int,c5:int>>
+struct<c1:int,c2:int,c3:void,c4:int,c5:int>
 -- !query output
-{"c1":1,"c2":2,"c3":null,"c4":4,"c5":5}
+1	2	NULL	4	5
 
 
 -- !query
@@ -494,67 +494,3 @@ SELECT T.* FROM v1, LATERAL (SELECT  COALESCE(v1.*)) AS T(x)
 struct<x:int>
 -- !query output
 1
-
-
--- !query
-SET spark.sql.legacy.ignoreParenthesesAroundStar = true
--- !query schema
-struct<key:string,value:string>
--- !query output
-spark.sql.legacy.ignoreParenthesesAroundStar	true
-
-
--- !query
-SELECT (*) FROM v1
--- !query schema
-struct<c1:int,c2:int,c3:void,c4:int,c5:int>
--- !query output
-1	2	NULL	4	5
-
-
--- !query
-SELECT DISTINCT * FROM v1
--- !query schema
-struct<c1:int,c2:int,c3:void,c4:int,c5:int>
--- !query output
-1	2	NULL	4	5
-
-
--- !query
-SELECT DISTINCT(*) FROM v1
--- !query schema
-struct<c1:int,c2:int,c3:void,c4:int,c5:int>
--- !query output
-1	2	NULL	4	5
-
-
--- !query
-SET spark.sql.legacy.ignoreParenthesesAroundStar = false
--- !query schema
-struct<key:string,value:string>
--- !query output
-spark.sql.legacy.ignoreParenthesesAroundStar	false
-
-
--- !query
-SELECT DISTINCT(*) FROM v1
--- !query schema
-struct<c1:int,c2:int,c3:void,c4:int,c5:int>
--- !query output
-1	2	NULL	4	5
-
-
--- !query
-DROP VIEW v1
--- !query schema
-struct<>
--- !query output
-
-
-
--- !query
-SELECT DISTINCT(*)
--- !query schema
-struct<>
--- !query output
-


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
We will revert the meaning of `(*)` back (https://github.com/apache/spark/pull/44938) to its original Spark 3.x behavior.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
There are too many usages of `(*)` in the wild to justify the change

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No (post revert)

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
changed selectExcept.sql to reflect the original behavior.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No