### PR TITLE
[SPARK-47174][CONNECT][SS][1/2] Server side SparkConnectListenerBusListener for Client side streaming query listener

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -3073,9 +3073,10 @@ class SparkConnectPlanner(
       sessionHolder.streamingServersideListenerHolder.streamingQueryStartedEventCache.remove(
         query.runId.toString))
     queryStartedEvent.foreach {
-      logDebug(s"[SessionId: $sessionId][UserId: $userId][operationId: " +
-        s"${executeHolder.operationId}][query id: ${query.id}][query runId: ${query.runId}] " +
-        s"Adding QueryStartedEvent to response")
+      logDebug(
+        s"[SessionId: $sessionId][UserId: $userId][operationId: " +
+          s"${executeHolder.operationId}][query id: ${query.id}][query runId: ${query.runId}] " +
+          s"Adding QueryStartedEvent to response")
       e => resultBuilder.setQueryStartedEventJson(e.json)
     }
 

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -36,13 +36,6 @@ import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.{CreateResourceProfileCommand, ExecutePlanResponse, SqlCommand, StreamingForeachFunction, StreamingQueryCommand, StreamingQueryCommandResult, StreamingQueryInstanceId, StreamingQueryManagerCommand, StreamingQueryManagerCommandResult, WriteStreamOperationStart, WriteStreamOperationStartResult}
 import org.apache.spark.connect.proto.ExecutePlanResponse.SqlCommandResult
 import org.apache.spark.connect.proto.Parse.ParseFormat
-import org.apache.spark.connect.proto.StreamingForeachFunction
-import org.apache.spark.connect.proto.StreamingQueryCommand
-import org.apache.spark.connect.proto.StreamingQueryCommandResult
-import org.apache.spark.connect.proto.StreamingQueryInstanceId
-import org.apache.spark.connect.proto.StreamingQueryListenerBusCommand
-import org.apache.spark.connect.proto.StreamingQueryManagerCommand
-import org.apache.spark.connect.proto.StreamingQueryManagerCommandResult
 import org.apache.spark.connect.proto.StreamingQueryManagerCommandResult.StreamingQueryInstance
 import org.apache.spark.connect.proto.WriteStreamOperationStart.TriggerCase
 import org.apache.spark.internal.Logging

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -59,7 +59,7 @@ import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, CharVarcharUtils}
 import org.apache.spark.sql.connect.common.{DataTypeProtoConverter, ForeachWriterPacket, InvalidPlanInput, LiteralValueProtoConverter, StorageLevelProtoConverter, StreamingListenerPacket, UdfPacket}
 import org.apache.spark.sql.connect.config.Connect.CONNECT_GRPC_ARROW_MAX_BATCH_SIZE
 import org.apache.spark.sql.connect.plugin.SparkConnectPluginRegistry
-import org.apache.spark.sql.connect.service.{ExecuteHolder, SessionHolder, SparkConnectListenerBusListener, SparkConnectService}
+import org.apache.spark.sql.connect.service.{ExecuteHolder, SessionHolder, SparkConnectService}
 import org.apache.spark.sql.connect.utils.MetricGenerator
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.QueryExecution

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectStreamingQueryListenerHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectStreamingQueryListenerHandler.scala
@@ -21,14 +21,11 @@ import scala.util.control.NonFatal
 
 import io.grpc.stub.StreamObserver
 
-import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.ExecutePlanResponse
 import org.apache.spark.connect.proto.StreamingQueryListenerBusCommand
-import org.apache.spark.connect.proto.StreamingQueryListenerEvent
 import org.apache.spark.connect.proto.StreamingQueryListenerEventsResult
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.connect.service.{ExecuteHolder, SessionHolder, SparkConnectListenerBusListener}
+import org.apache.spark.sql.connect.service.ExecuteHolder
 
 
 /**
@@ -108,6 +105,8 @@ class SparkConnectStreamingQueryListenerHandler(executeHolder: ExecuteHolder) ex
               s"but received remove listener call. Exiting.")
             return
         }
+      case StreamingQueryListenerBusCommand.CommandCase.COMMAND_NOT_SET =>
+        throw new IllegalArgumentException("Missing command in StreamingQueryListenerBusCommand")
     }
     // If this thread is the handling thread of the original ADD_LISTENER_BUS_LISTENER command,
     // this will be sent when the latch is counted down (either through

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectStreamingQueryListenerHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectStreamingQueryListenerHandler.scala
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.planner
+
+import scala.util.control.NonFatal
+
+import io.grpc.stub.StreamObserver
+
+import org.apache.spark.connect.proto
+import org.apache.spark.connect.proto.ExecutePlanResponse
+import org.apache.spark.connect.proto.StreamingQueryListenerBusCommand
+import org.apache.spark.connect.proto.StreamingQueryListenerEvent
+import org.apache.spark.connect.proto.StreamingQueryListenerEventsResult
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connect.service.{ExecuteHolder, SessionHolder, SparkConnectListenerBusListener}
+
+
+/**
+ * Handle long-running streaming query listener events.
+ */
+class SparkConnectStreamingQueryListenerHandler(executeHolder: ExecuteHolder) extends Logging {
+
+  val sessionHolder = executeHolder.sessionHolder
+
+  private[connect] def userId: String = sessionHolder.userId
+
+  private[connect] def sessionId: String = sessionHolder.sessionId
+
+  /**
+   * The handler logic.
+   * The handler of ADD_LISTENER_BUS_LISTENER uses the streamingQueryListenerLatch to block
+   * the handling thread, preventing it from sending back the final ResultComplete response.
+   *
+   * The handler of REMOVE_LISTENER_BUS_LISTENER cleans up the server side listener resources
+   * and count down the latch, allowing the handling thread of the original
+   * ADD_LISTENER_BUS_LISTENER to proceed to send back the final ResultComplete response.
+   */
+  def handleListenerCommand(
+      command: StreamingQueryListenerBusCommand,
+      responseObserver: StreamObserver[ExecutePlanResponse]): Unit = {
+
+    val listenerHolder = sessionHolder.streamingServersideListenerHolder
+
+    command.getCommandCase match {
+      case StreamingQueryListenerBusCommand.CommandCase.ADD_LISTENER_BUS_LISTENER =>
+        listenerHolder.isServerSideListenerRegistered match {
+          case true =>
+            logWarning(s"[SessionId: $sessionId][UserId: $userId][operationId: " +
+              s"${executeHolder.operationId}] Redundant server side listener added. Exiting.")
+            return
+          case false =>
+            // This transfers sending back the response to the client until
+            // the long running command is terminated, either by
+            // errors in streamingQueryServerSideListener.send,
+            // or client issues a REMOVE_LISTENER_BUS_LISTENER call.
+            listenerHolder.init(responseObserver)
+            // Send back listener added response
+            val respBuilder = StreamingQueryListenerEventsResult.newBuilder()
+            val listenerAddedResult = respBuilder
+              .setListenerBusListenerAdded(true)
+              .build()
+            try {
+              responseObserver.onNext(
+                ExecutePlanResponse
+                  .newBuilder()
+                  .setSessionId(sessionHolder.sessionId)
+                  .setServerSideSessionId(sessionHolder.serverSessionId)
+                  .setStreamingQueryListenerEventsResult(listenerAddedResult)
+                  .build())
+            } catch {
+              case NonFatal(e) =>
+                logError(s"[SessionId: $sessionId][UserId: $userId][operationId: " +
+                  s"${executeHolder.operationId}] Error sending listener added response.", e)
+                listenerHolder.cleanUp()
+                return
+            }
+        }
+        logInfo(s"[SessionId: $sessionId][UserId: $userId][operationId: " +
+          s"${executeHolder.operationId}] Server side listener added. Now blocking until " +
+          "all client side listeners are removed or there is error transmitting the event back.")
+        // Block the handling thread, and have serverListener continuously send back new events
+        listenerHolder.streamingQueryListenerLatch.await()
+        logInfo(s"[SessionId: $sessionId][UserId: $userId][operationId: " +
+          s"${executeHolder.operationId}] Server side listener long-running handling thread ended.")
+      case StreamingQueryListenerBusCommand.CommandCase.REMOVE_LISTENER_BUS_LISTENER =>
+        listenerHolder.isServerSideListenerRegistered match {
+          case true =>
+            sessionHolder.streamingServersideListenerHolder.cleanUp()
+          case false =>
+            logWarning(s"[SessionId: $sessionId][UserId: $userId][operationId: " +
+              s"${executeHolder.operationId}] No active server side listener bus listener " +
+              s"but received remove listener call. Exiting.")
+            return
+        }
+    }
+    // If this thread is the handling thread of the original ADD_LISTENER_BUS_LISTENER command,
+    // this will be sent when the latch is counted down (either through
+    // a REMOVE_LISTENER_BUS_LISTENER command, or long-lived gRPC throws.
+    // If this thread is the handling thread of the REMOVE_LISTENER_BUS_LISTENER command,
+    // this is hit right away.
+    executeHolder.eventsManager.postFinished()
+  }
+}

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectStreamingQueryListenerHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectStreamingQueryListenerHandler.scala
@@ -27,7 +27,6 @@ import org.apache.spark.connect.proto.StreamingQueryListenerEventsResult
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.connect.service.ExecuteHolder
 
-
 /**
  * Handle long-running streaming query listener events.
  */
@@ -40,13 +39,13 @@ class SparkConnectStreamingQueryListenerHandler(executeHolder: ExecuteHolder) ex
   private[connect] def sessionId: String = sessionHolder.sessionId
 
   /**
-   * The handler logic.
-   * The handler of ADD_LISTENER_BUS_LISTENER uses the streamingQueryListenerLatch to block
-   * the handling thread, preventing it from sending back the final ResultComplete response.
+   * The handler logic. The handler of ADD_LISTENER_BUS_LISTENER uses the
+   * streamingQueryListenerLatch to block the handling thread, preventing it from sending back the
+   * final ResultComplete response.
    *
-   * The handler of REMOVE_LISTENER_BUS_LISTENER cleans up the server side listener resources
-   * and count down the latch, allowing the handling thread of the original
-   * ADD_LISTENER_BUS_LISTENER to proceed to send back the final ResultComplete response.
+   * The handler of REMOVE_LISTENER_BUS_LISTENER cleans up the server side listener resources and
+   * count down the latch, allowing the handling thread of the original ADD_LISTENER_BUS_LISTENER
+   * to proceed to send back the final ResultComplete response.
    */
   def handleListenerCommand(
       command: StreamingQueryListenerBusCommand,
@@ -58,8 +57,9 @@ class SparkConnectStreamingQueryListenerHandler(executeHolder: ExecuteHolder) ex
       case StreamingQueryListenerBusCommand.CommandCase.ADD_LISTENER_BUS_LISTENER =>
         listenerHolder.isServerSideListenerRegistered match {
           case true =>
-            logWarning(s"[SessionId: $sessionId][UserId: $userId][operationId: " +
-              s"${executeHolder.operationId}] Redundant server side listener added. Exiting.")
+            logWarning(
+              s"[SessionId: $sessionId][UserId: $userId][operationId: " +
+                s"${executeHolder.operationId}] Redundant server side listener added. Exiting.")
             return
           case false =>
             // This transfers sending back the response to the client until
@@ -82,8 +82,10 @@ class SparkConnectStreamingQueryListenerHandler(executeHolder: ExecuteHolder) ex
                   .build())
             } catch {
               case NonFatal(e) =>
-                logError(s"[SessionId: $sessionId][UserId: $userId][operationId: " +
-                  s"${executeHolder.operationId}] Error sending listener added response.", e)
+                logError(
+                  s"[SessionId: $sessionId][UserId: $userId][operationId: " +
+                    s"${executeHolder.operationId}] Error sending listener added response.",
+                  e)
                 listenerHolder.cleanUp()
                 return
             }
@@ -100,9 +102,10 @@ class SparkConnectStreamingQueryListenerHandler(executeHolder: ExecuteHolder) ex
           case true =>
             sessionHolder.streamingServersideListenerHolder.cleanUp()
           case false =>
-            logWarning(s"[SessionId: $sessionId][UserId: $userId][operationId: " +
-              s"${executeHolder.operationId}] No active server side listener bus listener " +
-              s"but received remove listener call. Exiting.")
+            logWarning(
+              s"[SessionId: $sessionId][UserId: $userId][operationId: " +
+                s"${executeHolder.operationId}] No active server side listener bus listener " +
+                s"but received remove listener call. Exiting.")
             return
         }
       case StreamingQueryListenerBusCommand.CommandCase.COMMAND_NOT_SET =>

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.connect.service
 
 import java.nio.file.Path
 import java.util.UUID
-import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap, CountDownLatch, TimeUnit}
+import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap, TimeUnit}
 import javax.annotation.concurrent.GuardedBy
 
 import scala.collection.mutable

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListener.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListener.scala
@@ -145,7 +145,7 @@ private[sql] class SparkConnectListenerBusListener(
   }
 
   override def onQueryTerminated(
-    event: StreamingQueryListener.QueryTerminatedEvent): Unit = {
+      event: StreamingQueryListener.QueryTerminatedEvent): Unit = {
     send(event.json, StreamingQueryEventType.QUERY_TERMINATED_EVENT)
   }
 

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListener.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListener.scala
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.service
+
+import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap, CountDownLatch}
+
+import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
+
+import io.grpc.stub.StreamObserver
+
+import org.apache.spark.connect.proto.ExecutePlanResponse
+import org.apache.spark.connect.proto.StreamingQueryEventType
+import org.apache.spark.connect.proto.StreamingQueryListenerEvent
+import org.apache.spark.connect.proto.StreamingQueryListenerEventsResult
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.streaming.StreamingQueryListener
+import org.apache.spark.util.ArrayImplicits._
+
+/**
+ * A holder for the server side listener and related resources. There should be only one
+ * such holder for each sessionHolder.
+ */
+private[sql] class ServerSideListenerHolder(val sessionHolder: SessionHolder) {
+  // The server side listener that is responsible to stream streaming query events back to client.
+  // There is only one listener per sessionHolder, but each listener is responsible for all events
+  // of all streaming queries in the SparkSession.
+  var streamingQueryServerSideListener: Option[SparkConnectListenerBusListener] = None
+  // The count down latch to hold the long-running listener thread before sending ResultComplete.
+  var streamingQueryListenerLatch = new CountDownLatch(1)
+  // The cache for QueryStartedEvent, key is query runId and value is the actual QueryStartedEvent.
+  // Events for corresponding query will be sent back to client with
+  // the WriteStreamOperationStart response, so that the client can handle the event before
+  // DataStreamWriter.start() returns. This special handling is to satisfy the contract of
+  // onQueryStarted in StreamingQueryListener.
+  val streamingQueryStartedEventCache:
+  ConcurrentMap[String, StreamingQueryListener.QueryStartedEvent] = new ConcurrentHashMap()
+
+  def isServerSideListenerRegistered: Boolean = streamingQueryServerSideListener.isDefined
+
+  /**
+   * The initialization of the server side listener and related resources.
+   * This method is called when the first ADD_LISTENER_BUS_LISTENER command is received.
+   * It is attached to a responseObserver, from the first executeThread (long running thread),
+   * so the lifecycle of the responseObserver is the same as the life cycle of the listener.
+   *
+   * @param responseObserver the responseObserver created from the first long running executeThread.
+   */
+  def init(responseObserver: StreamObserver[ExecutePlanResponse]): Unit = {
+    val serverListener = new SparkConnectListenerBusListener(
+      this, responseObserver)
+    sessionHolder.session.streams.addListener(serverListener)
+    streamingQueryServerSideListener = Some(serverListener)
+    streamingQueryListenerLatch = new CountDownLatch(1)
+  }
+
+  /**
+   * The cleanup of the server side listener and related resources.
+   * This method is called when the REMOVE_LISTENER_BUS_LISTENER command is received or when
+   * responseObserver.onNext throws an exception.
+   * It removes the listener from the session, clears the cache. Also it counts down the latch,
+   * so the long-running thread can proceed to send back the final ResultComplete response.
+   */
+  def cleanUp(): Unit = {
+    streamingQueryServerSideListener.foreach { listener =>
+        sessionHolder.session.streams.removeListener(listener)
+    }
+    streamingQueryStartedEventCache.clear()
+    streamingQueryServerSideListener = None
+    streamingQueryListenerLatch.countDown()
+  }
+}
+
+/**
+ * A customized StreamingQueryListener used in Spark Connect for the client-side listeners.
+ * Upon the invocation of each callback function, it serializes the event to json and
+ * sent it to the client.
+ */
+private[sql] class SparkConnectListenerBusListener(
+    serverSideListenerHolder: ServerSideListenerHolder,
+    responseObserver: StreamObserver[ExecutePlanResponse]
+) extends StreamingQueryListener with Logging {
+
+  val sessionHolder = serverSideListenerHolder.sessionHolder
+  // The method used to stream back the events to the client.
+  // The event is serialized to json and sent to the client.
+  // The responseObserver is what of the first executeThread (long running thread),
+  // which is held still by the streamingQueryListenerLatch.
+  // If any exception is thrown while transmitting back the event, the listener is removed,
+  // all related sources are cleaned up, and the long-running thread will proceed to send
+  // the final ResultComplete response.
+  private def send(eventJson: String, eventType: StreamingQueryEventType): Unit = {
+    val event = StreamingQueryListenerEvent
+      .newBuilder()
+      .setEventJson(eventJson)
+      .setEventType(eventType)
+      .build()
+
+    val respBuilder = StreamingQueryListenerEventsResult.newBuilder()
+    val eventResult = respBuilder
+      .addAllEvents(Array[StreamingQueryListenerEvent](event).toImmutableArraySeq.asJava)
+      .build()
+
+    try {
+      responseObserver.onNext(
+        ExecutePlanResponse
+          .newBuilder()
+          .setSessionId(sessionHolder.sessionId)
+          .setServerSideSessionId(sessionHolder.serverSessionId)
+          .setStreamingQueryListenerEventsResult(eventResult)
+          .build())
+    } catch {
+      case NonFatal(e) =>
+        logError(s"[SessionId: ${sessionHolder.sessionId}][UserId: ${sessionHolder.userId}] " +
+          s"Removing SparkConnectListenerBusListener and terminating the long-running thread " +
+          s"because of exception: $e")
+        // This likely means that the client is not responsive even with retry, we should
+        // remove this listener and cleanup resources.
+        serverSideListenerHolder.cleanUp()
+    }
+  }
+
+  // QueryStartedEvent is sent to client along with WriteStreamOperationStartResult
+  override def onQueryStarted(event: StreamingQueryListener.QueryStartedEvent): Unit = {
+    serverSideListenerHolder.streamingQueryStartedEventCache.put(event.runId.toString, event)
+  }
+
+  override def onQueryProgress(event: StreamingQueryListener.QueryProgressEvent): Unit = {
+    send(event.json, StreamingQueryEventType.QUERY_PROGRESS_EVENT)
+  }
+
+  override def onQueryTerminated(
+    event: StreamingQueryListener.QueryTerminatedEvent): Unit = {
+    send(event.json, StreamingQueryEventType.QUERY_TERMINATED_EVENT)
+  }
+
+  override def onQueryIdle(event: StreamingQueryListener.QueryIdleEvent): Unit = {
+    send(event.json, StreamingQueryEventType.QUERY_IDLE_EVENT)
+  }
+}

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListenerSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListenerSuite.scala
@@ -25,12 +25,12 @@ import scala.jdk.CollectionConverters._
 
 import io.grpc.stub.StreamObserver
 import org.mockito.ArgumentMatchers.any
-import org.mockito.MockitoSugar.{doAnswer, doThrow, when}
+import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.scalatestplus.mockito.MockitoSugar
 
 import org.apache.spark.SparkFunSuite
-import org.apache.spark.connect.proto.{Command, ExecutePlanResponse, StreamingQueryListenerBusCommand}
+import org.apache.spark.connect.proto.{Command, ExecutePlanResponse}
 import org.apache.spark.sql.connect.planner.SparkConnectStreamingQueryListenerHandler
 import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryListener}
 import org.apache.spark.sql.streaming.Trigger.ProcessingTime

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListenerSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectListenerBusListenerSuite.scala
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.service
+
+import java.util.UUID
+
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.duration.DurationInt
+import scala.jdk.CollectionConverters._
+
+import io.grpc.stub.StreamObserver
+import org.mockito.ArgumentMatchers.any
+import org.mockito.MockitoSugar.{doAnswer, doThrow, when}
+import org.mockito.invocation.InvocationOnMock
+import org.scalatestplus.mockito.MockitoSugar
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.connect.proto.{Command, ExecutePlanResponse, StreamingQueryListenerBusCommand}
+import org.apache.spark.sql.connect.planner.SparkConnectStreamingQueryListenerHandler
+import org.apache.spark.sql.streaming.{StreamingQuery, StreamingQueryListener}
+import org.apache.spark.sql.streaming.Trigger.ProcessingTime
+import org.apache.spark.sql.test.SharedSparkSession
+
+class SparkConnectListenerBusListenerSuite extends SparkFunSuite
+  with SharedSparkSession with MockitoSugar {
+
+  override def afterEach(): Unit = {
+    try {
+      spark.streams.active.foreach(_.stop())
+      spark.streams.listListeners().foreach(spark.streams.removeListener)
+    } finally {
+      super.afterEach()
+    }
+  }
+
+
+  // A test listener that caches all events
+  private class CacheEventsStreamingQueryListener(
+      startEvents: ArrayBuffer[StreamingQueryListener.QueryStartedEvent],
+      otherEvents: ArrayBuffer[StreamingQueryListener.Event]
+  ) extends StreamingQueryListener {
+
+    override def onQueryStarted(event: StreamingQueryListener.QueryStartedEvent): Unit = {
+      startEvents += event
+    }
+
+    override def onQueryProgress(event: StreamingQueryListener.QueryProgressEvent): Unit = {
+      otherEvents += event
+    }
+
+    override def onQueryTerminated(event: StreamingQueryListener.QueryTerminatedEvent): Unit = {
+      otherEvents += event
+    }
+
+    override def onQueryIdle(event: StreamingQueryListener.QueryIdleEvent): Unit = {
+      otherEvents += event
+    }
+  }
+
+  private def verifyEventsSent(
+      fromCachedEventsListener: ArrayBuffer[StreamingQueryListener.Event],
+      fromListenerBusListener: ArrayBuffer[String]): Unit = {
+    assert(fromListenerBusListener.toSet === fromCachedEventsListener.map {
+      case e: StreamingQueryListener.QueryStartedEvent => e.json
+      case e: StreamingQueryListener.QueryProgressEvent => e.json
+      case e: StreamingQueryListener.QueryTerminatedEvent => e.json
+      case e: StreamingQueryListener.QueryIdleEvent => e.json
+    }.toSet)
+  }
+
+  private def startQuery(slow: Boolean = false): StreamingQuery = {
+    val dsw = spark.readStream.format("rate").load().writeStream.format("noop")
+    if (slow) {
+      dsw.trigger(ProcessingTime("20 seconds"))
+    }
+    dsw.start()
+  }
+
+  Seq(1, 5, 20).foreach {
+    queryNum =>
+      test("Basic functionalities - onQueryStart, onQueryProgress, onQueryTerminated" +
+          s" - $queryNum queries") {
+        val sessionHolder = SessionHolder.forTesting(spark)
+        val responseObserver = mock[StreamObserver[ExecutePlanResponse]]
+        val eventJsonBuffer = ArrayBuffer.empty[String]
+        val startEventsBuffer = ArrayBuffer.empty[StreamingQueryListener.QueryStartedEvent]
+        val otherEventsBuffer = ArrayBuffer.empty[StreamingQueryListener.Event]
+
+        doAnswer((invocation: InvocationOnMock) => {
+          val argument = invocation.getArgument[ExecutePlanResponse](0)
+          val eventJson = argument.getStreamingQueryListenerEventsResult().getEvents(0).getEventJson
+          eventJsonBuffer += eventJson
+        }).when(responseObserver).onNext(any[ExecutePlanResponse]())
+
+        val listenerHolder = sessionHolder.streamingServersideListenerHolder
+        listenerHolder.init(responseObserver)
+        val cachedEventsListener =
+          new CacheEventsStreamingQueryListener(startEventsBuffer, otherEventsBuffer)
+
+        spark.streams.addListener(cachedEventsListener)
+
+        for (_ <- 1 to queryNum) startQuery()
+
+        // after all queries made some progresses
+        eventually(timeout(60.seconds), interval(2.seconds)) {
+          spark.streams.active.foreach {
+            q => assert(q.lastProgress.batchId > 5)
+          }
+        }
+
+        // stops all queries
+        spark.streams.active.foreach(_.stop())
+
+        eventually(timeout(60.seconds), interval(500.milliseconds)) {
+          assert(eventJsonBuffer.nonEmpty)
+          assert(!listenerHolder.streamingQueryStartedEventCache.isEmpty)
+          verifyEventsSent(otherEventsBuffer, eventJsonBuffer)
+          assert(startEventsBuffer.map(_.json).toSet ===
+            listenerHolder.streamingQueryStartedEventCache.asScala.map(_._2.json).toSet)
+        }
+      }
+  }
+
+  test("Basic functionalities - Slow query") {
+    val sessionHolder = SessionHolder.forTesting(spark)
+    val responseObserver = mock[StreamObserver[ExecutePlanResponse]]
+    val eventJsonBuffer = ArrayBuffer.empty[String]
+    val startEventsBuffer = ArrayBuffer.empty[StreamingQueryListener.QueryStartedEvent]
+    val otherEventsBuffer = ArrayBuffer.empty[StreamingQueryListener.Event]
+
+    doAnswer((invocation: InvocationOnMock) => {
+      val argument = invocation.getArgument[ExecutePlanResponse](0)
+      val eventJson = argument.getStreamingQueryListenerEventsResult().getEvents(0).getEventJson
+      eventJsonBuffer += eventJson
+    }).when(responseObserver).onNext(any[ExecutePlanResponse]())
+
+    val listenerHolder = sessionHolder.streamingServersideListenerHolder
+    listenerHolder.init(responseObserver)
+
+    val cachedEventsListener =
+      new CacheEventsStreamingQueryListener(startEventsBuffer, otherEventsBuffer)
+    spark.streams.addListener(cachedEventsListener)
+
+    // Slow query
+    val q = startQuery(true)
+
+    // after the slow query made some progresses
+    eventually(timeout(100.seconds), interval(7.seconds)) {
+      assert(q.lastProgress.batchId > 2)
+    }
+
+    q.stop()
+
+    eventually(timeout(60.seconds), interval(1.second)) {
+      assert(eventJsonBuffer.nonEmpty)
+      assert(!listenerHolder.streamingQueryStartedEventCache.isEmpty)
+      verifyEventsSent(otherEventsBuffer, eventJsonBuffer)
+      assert(startEventsBuffer.map(_.json).toSet ===
+        listenerHolder.streamingQueryStartedEventCache.asScala.map(_._2.json).toSet)
+    }
+  }
+
+  test("Proper handling on onNext throw - initial response") {
+    val sessionHolder = SessionHolder.forTesting(spark)
+
+    val executeHolder = mock[ExecuteHolder]
+    when(executeHolder.sessionHolder).thenReturn(sessionHolder)
+    when(executeHolder.operationId).thenReturn("operationId")
+
+    val responseObserver = mock[StreamObserver[ExecutePlanResponse]]
+    doThrow(new RuntimeException("I'm dead"))
+      .when(responseObserver).onNext(any[ExecutePlanResponse]())
+
+    val listenerCntBeforeThrow = spark.streams.listListeners().size
+
+    val handler = new SparkConnectStreamingQueryListenerHandler(executeHolder)
+    val listenerBusCmdBuilder = Command.newBuilder().getStreamingQueryListenerBusCommandBuilder
+    val addListenerCommand = listenerBusCmdBuilder.setAddListenerBusListener(true).build()
+    handler.handleListenerCommand(addListenerCommand, responseObserver)
+
+    val listenerHolder = sessionHolder.streamingServersideListenerHolder
+    eventually(timeout(5.seconds), interval(500.milliseconds)) {
+      assert(sessionHolder.streamingServersideListenerHolder
+        .streamingQueryServerSideListener.isEmpty)
+      assert(spark.streams.listListeners().size === listenerCntBeforeThrow)
+      assert(listenerHolder.streamingQueryStartedEventCache.isEmpty)
+      assert(listenerHolder.streamingQueryListenerLatch.getCount === 0)
+    }
+
+  }
+
+  test("Proper handling on onNext throw - query progress") {
+    val sessionHolder = SessionHolder.forTesting(spark)
+    val responseObserver = mock[StreamObserver[ExecutePlanResponse]]
+    doThrow(new RuntimeException("I'm dead"))
+      .when(responseObserver).onNext(any[ExecutePlanResponse]())
+
+    val listenerHolder = sessionHolder.streamingServersideListenerHolder
+    listenerHolder.init(responseObserver)
+    val listenerBusListener = listenerHolder.streamingQueryServerSideListener.get
+
+    // mock a QueryStartedEvent for cleanup test
+    val queryStartedEvent = new StreamingQueryListener.QueryStartedEvent(
+      UUID.randomUUID, UUID.randomUUID, "name", "timestamp")
+    listenerHolder.streamingQueryStartedEventCache.put(
+      queryStartedEvent.runId.toString, queryStartedEvent)
+
+    startQuery()
+
+    eventually(timeout(5.seconds), interval(500.milliseconds)) {
+      assert(!spark.streams.listListeners().contains(listenerBusListener))
+      assert(listenerHolder.streamingQueryStartedEventCache.isEmpty)
+      assert(listenerHolder.streamingQueryListenerLatch.getCount === 0)
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Server side `SparkConnectListenerBusListener` implementation for the client side listener. There would only be one such listener for each `SessionHolder`. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Move streaming query listener to client side 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added unit test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No