### PR TITLE
[SPARK-47803][SQL] Support cast to variant.

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -4708,6 +4708,12 @@
     ],
     "sqlState" : "22023"
   },
+  "VARIANT_DUPLICATE_KEY" : {
+    "message" : [
+      "Failed to build variant because of a duplicate object key `<key>`."
+    ],
+    "sqlState" : "22023"
+  },
   "VARIANT_SIZE_LIMIT" : {
     "message" : [
       "Cannot build variant bigger than <sizeLimit> in <functionName>.",

--- a/common/variant/src/main/java/org/apache/spark/types/variant/Variant.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/Variant.java
@@ -41,12 +41,12 @@ import static org.apache.spark.types.variant.VariantUtil.*;
  * define a new class to avoid depending on or modifying Spark.
  */
 public final class Variant {
-  private final byte[] value;
-  private final byte[] metadata;
+  final byte[] value;
+  final byte[] metadata;
   // The variant value doesn't use the whole `value` binary, but starts from its `pos` index and
   // spans a size of `valueSize(value, pos)`. This design avoids frequent copies of the value binary
   // when reading a sub-variant in the array/object element.
-  private final int pos;
+  final int pos;
 
   public Variant(byte[] value, byte[] metadata) {
     this(value, metadata, 0);

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -2825,7 +2825,7 @@ Cannot construct a Variant larger than 16 MiB. The maximum allowed size of a Var
 
 [SQLSTATE: 22023](sql-error-conditions-sqlstates.html#class-22-data-exception)
 
-Failed to build variant bigger because of a duplicate object key ``<key>``.
+Failed to build variant because of a duplicate object key ``<key>``.
 
 ### VARIANT_SIZE_LIMIT
 

--- a/docs/sql-error-conditions.md
+++ b/docs/sql-error-conditions.md
@@ -2821,6 +2821,12 @@ To tolerate the error on drop use DROP VARIABLE IF EXISTS.
 
 Cannot construct a Variant larger than 16 MiB. The maximum allowed size of a Variant value is 16 MiB.
 
+### VARIANT_DUPLICATE_KEY
+
+[SQLSTATE: 22023](sql-error-conditions-sqlstates.html#class-22-data-exception)
+
+Failed to build variant bigger because of a duplicate object key ``<key>``.
+
 ### VARIANT_SIZE_LIMIT
 
 [SQLSTATE: 22023](sql-error-conditions-sqlstates.html#class-22-data-exception)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionEvalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionEvalUtils.scala
@@ -19,9 +19,11 @@ package org.apache.spark.sql.catalyst.expressions.variant
 
 import scala.util.control.NonFatal
 
-import org.apache.spark.sql.catalyst.util.BadRecordException
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.util.{ArrayData, BadRecordException, MapData}
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.types.variant.{VariantBuilder, VariantSizeLimitException, VariantUtil}
+import org.apache.spark.sql.types._
+import org.apache.spark.types.variant.{Variant, VariantBuilder, VariantSizeLimitException, VariantUtil}
 import org.apache.spark.unsafe.types.{UTF8String, VariantVal}
 
 /**
@@ -39,6 +41,71 @@ object VariantExpressionEvalUtils {
       case NonFatal(e) =>
         throw QueryExecutionErrors.malformedRecordsDetectedInRecordParsingError(
           input.toString, BadRecordException(() => input, cause = e))
+    }
+  }
+
+  /** Cast a Spark value from `dataType` into the variant type. */
+  def castToVariant(input: Any, dataType: DataType): VariantVal = {
+    val builder = new VariantBuilder
+    buildVariant(builder, input, dataType)
+    val v = builder.result()
+    new VariantVal(v.getValue, v.getMetadata)
+  }
+
+  private def buildVariant(builder: VariantBuilder, input: Any, dataType: DataType): Unit = {
+    if (input == null) {
+      builder.appendNull()
+      return
+    }
+    dataType match {
+      case BooleanType => builder.appendBoolean(input.asInstanceOf[Boolean])
+      case ByteType => builder.appendLong(input.asInstanceOf[Byte])
+      case ShortType => builder.appendLong(input.asInstanceOf[Short])
+      case IntegerType => builder.appendLong(input.asInstanceOf[Int])
+      case LongType => builder.appendLong(input.asInstanceOf[Long])
+      case FloatType => builder.appendFloat(input.asInstanceOf[Float])
+      case DoubleType => builder.appendDouble(input.asInstanceOf[Double])
+      case StringType => builder.appendString(input.asInstanceOf[UTF8String].toString)
+      case BinaryType => builder.appendBinary(input.asInstanceOf[Array[Byte]])
+      case DateType => builder.appendDate(input.asInstanceOf[Int])
+      case TimestampType => builder.appendTimestamp(input.asInstanceOf[Long])
+      case TimestampNTZType => builder.appendTimestampNtz(input.asInstanceOf[Long])
+      case VariantType =>
+        val v = input.asInstanceOf[VariantVal]
+        builder.appendVariant(new Variant(v.getValue, v.getMetadata))
+      case ArrayType(elementType, _) =>
+        val data = input.asInstanceOf[ArrayData]
+        val start = builder.getWritePos
+        val offsets = new java.util.ArrayList[java.lang.Integer](data.numElements())
+        for (i <- 0 until data.numElements()) {
+          offsets.add(builder.getWritePos - start)
+          buildVariant(builder, data.get(i, elementType), elementType)
+        }
+        builder.finishWritingArray(start, offsets)
+      case MapType(StringType, valueType, _) =>
+        val data = input.asInstanceOf[MapData]
+        val keys = data.keyArray()
+        val values = data.valueArray()
+        val start = builder.getWritePos
+        val fields = new java.util.ArrayList[VariantBuilder.FieldEntry](data.numElements())
+        for (i <- 0 until data.numElements()) {
+          val key = keys.getUTF8String(i).toString
+          val id = builder.addKey(key)
+          fields.add(new VariantBuilder.FieldEntry(key, id, builder.getWritePos - start))
+          buildVariant(builder, values.get(i, valueType), valueType)
+        }
+        builder.finishWritingObject(start, fields)
+      case StructType(structFields) =>
+        val data = input.asInstanceOf[InternalRow]
+        val start = builder.getWritePos
+        val fields = new java.util.ArrayList[VariantBuilder.FieldEntry](structFields.length)
+        for (i <- 0 until structFields.length) {
+          val key = structFields(i).name
+          val id = builder.addKey(key)
+          fields.add(new VariantBuilder.FieldEntry(key, id, builder.getWritePos - start))
+          buildVariant(builder, data.get(i, structFields(i).dataType), structFields(i).dataType)
+        }
+        builder.finishWritingObject(start, fields)
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionSuite.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.catalyst.expressions.variant
 
 import java.time.{LocalDateTime, ZoneId, ZoneOffset}
 
+import scala.reflect.runtime.universe.TypeTag
+
 import org.apache.spark.{SparkFunSuite, SparkRuntimeException}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.analysis.ResolveTimeZone
@@ -796,5 +798,29 @@ class VariantExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
       "\u0001\u0002\u0003")
     checkCast(Array(primitiveHeader(BINARY), 5, 0, 0, 0, 72, 101, 108, 108, 111), StringType,
       "Hello")
+  }
+
+  test("cast to variant") {
+    def check[T : TypeTag](input: T, expectedJson: String): Unit = {
+      val cast = Cast(Literal.create(input), VariantType, evalMode = EvalMode.ANSI)
+      checkEvaluation(StructsToJson(Map.empty, cast), expectedJson)
+    }
+
+    check(null.asInstanceOf[String], null)
+    for (input <- Seq[Any](false, true, 0.toByte, 1.toShort, 2, 3L, 4.0F, 5.0D)) {
+      check(input, input.toString)
+    }
+    check(Array(null, "a", "b", "c"), """[null,"a","b","c"]""")
+    check(Map("z" -> 1, "y" -> 2, "x" -> 3), """{"x":3,"y":2,"z":1}""")
+    check(Array(parseJson("""{"a": 1,"b": [1, 2, 3]}"""),
+      parseJson("""{"c": true,"d": {"e": "str"}}""")),
+      """[{"a":1,"b":[1,2,3]},{"c":true,"d":{"e":"str"}}]""")
+    val struct = Literal.create(
+      Row(
+        Seq("123", "true", "f"),
+        Map("a" -> "123", "b" -> "true", "c" -> "f"),
+        Row(0)),
+      StructType.fromDDL("c ARRAY<STRING>,b MAP<STRING, STRING>,a STRUCT<i: INT>"))
+    check(struct, """{"a":{"i":0},"b":{"a":"123","b":"true","c":"f"},"c":["123","true","f"]}""")
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR allows casting another type into the variant type. The changes can be divided into two major parts:
- The `VariantBuilder` class is greatly refactored. Many of its APIs are exposed so that Spark can use them to build a variant value without JSON parsing.
- The actual implementation of the cast.

### Why are the changes needed?

It provides a convenient way to build variant values from other Spark values. Before this PR, `parse_json` is the only SQL function that can produce variant values. If users want to do so, they may have to use `parse_json(to_json(input))`, which is inefficient and disallowed if the input has a scalar type.

### Does this PR introduce _any_ user-facing change?

Yes. Casting to variant was previously not allowed but now allowd.

### How was this patch tested?

Unit tests.

### Was this patch authored or co-authored using generative AI tooling?

No.