### PR TITLE
[SPARK-47805][SS] Implementing TTL for MapState

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
@@ -108,6 +108,28 @@ private[sql] trait StatefulProcessorHandle extends Serializable {
       userKeyEnc: Encoder[K],
       valEncoder: Encoder[V]): MapState[K, V]
 
+  /**
+   * Function to create new or return existing map state variable of given type
+   * with ttl. State values will not be returned past ttlDuration, and will be eventually removed
+   * from the state store. Any values in mapState which have expired after ttlDuration will not
+   * returned on get() and will be eventually removed from the state.
+   *
+   * The user must ensure to call this function only within the `init()` method of the
+   * StatefulProcessor.
+   *
+   * @param stateName  - name of the state variable
+   * @param valEncoder - SQL encoder for state variable
+   * @param ttlConfig  - the ttl configuration (time to live duration etc.)
+   * @tparam K - type of key for map state variable
+   * @tparam V - type of value for map state variable
+   * @return - instance of MapState of type [K,V] that can be used to store state persistently
+   */
+  def getMapState[K, V](
+     stateName: String,
+     userKeyEnc: Encoder[K],
+     valEncoder: Encoder[V],
+     ttlConfig: TTLConfig): MapState[K, V]
+
   /** Function to return queryInfo for currently running task */
   def getQueryInfo(): QueryInfo
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
@@ -118,6 +118,7 @@ private[sql] trait StatefulProcessorHandle extends Serializable {
    * StatefulProcessor.
    *
    * @param stateName  - name of the state variable
+   * @param userKeyEnc  - spark sql encoder for the map key
    * @param valEncoder - SQL encoder for state variable
    * @param ttlConfig  - the ttl configuration (time to live duration etc.)
    * @tparam K - type of key for map state variable

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ListStateImplWithTTL.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ListStateImplWithTTL.scala
@@ -137,6 +137,7 @@ class ListStateImplWithTTL[S](
   /** Remove this state. */
   override def clear(): Unit = {
     store.remove(stateTypesEncoder.encodeGroupingKey(), stateName)
+    clearTTLState()
   }
 
   private def validateNewState(newState: Array[S]): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MapStateImplWithTTL.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MapStateImplWithTTL.scala
@@ -134,9 +134,9 @@ class MapStateImplWithTTL[K, V](
 
   /** Remove this state. */
   override def clear(): Unit = {
-    keys().foreach { itr =>
-      removeKey(itr)
-    }
+    store.removeColFamilyIfExists(stateName)
+    initialize()
+    clearTTLState()
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MapStateImplWithTTL.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MapStateImplWithTTL.scala
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.streaming
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.Encoder
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.execution.streaming.TransformWithStateKeyValueRowSchema.{COMPOSITE_KEY_ROW_SCHEMA, VALUE_ROW_SCHEMA_WITH_TTL}
+import org.apache.spark.sql.execution.streaming.state.{PrefixKeyScanStateEncoderSpec, StateStore, StateStoreErrors}
+import org.apache.spark.sql.streaming.{MapState, TTLConfig}
+import org.apache.spark.util.NextIterator
+
+
+class MapStateImplWithTTL[K, V](
+  store: StateStore,
+  stateName: String,
+  keyExprEnc: ExpressionEncoder[Any],
+  userKeyEnc: Encoder[K],
+  valEncoder: Encoder[V],
+  ttlConfig: TTLConfig,
+  batchTimestampMs: Long) extends CompositeKeyTTLStateImpl(stateName, store, batchTimestampMs)
+  with MapState[K, V] with Logging {
+
+  private val keySerializer = keyExprEnc.createSerializer()
+  private val stateTypesEncoder = new CompositeKeyStateEncoder(
+    keySerializer, userKeyEnc, valEncoder, COMPOSITE_KEY_ROW_SCHEMA, stateName, hasTtl = true)
+
+  private val ttlExpirationMs =
+    StateTTL.calculateExpirationTimeForDuration(ttlConfig.ttlDuration, batchTimestampMs)
+
+  initialize()
+
+  private def initialize(): Unit = {
+    store.createColFamilyIfAbsent(stateName, COMPOSITE_KEY_ROW_SCHEMA, VALUE_ROW_SCHEMA_WITH_TTL,
+      PrefixKeyScanStateEncoderSpec(COMPOSITE_KEY_ROW_SCHEMA, 1))
+  }
+
+  /** Whether state exists or not. */
+  override def exists(): Boolean = {
+    iterator().nonEmpty
+  }
+
+  /** Get the state value if it exists */
+  override def getValue(key: K): V = {
+    StateStoreErrors.requireNonNullStateValue(key, stateName)
+    val encodedCompositeKey = stateTypesEncoder.encodeCompositeKey(key)
+    val retRow = store.get(encodedCompositeKey, stateName)
+
+    if (retRow != null) {
+      val resState = stateTypesEncoder.decodeValue(retRow)
+
+      if (!stateTypesEncoder.isExpired(retRow, batchTimestampMs)) {
+        resState
+      } else {
+        null.asInstanceOf[V]
+      }
+    } else {
+      null.asInstanceOf[V]
+    }
+  }
+
+  /** Check if the user key is contained in the map */
+  override def containsKey(key: K): Boolean = {
+    StateStoreErrors.requireNonNullStateValue(key, stateName)
+    getValue(key) != null
+  }
+
+  /** Update value for given user key */
+  override def updateValue(key: K, value: V): Unit = {
+    StateStoreErrors.requireNonNullStateValue(key, stateName)
+    StateStoreErrors.requireNonNullStateValue(value, stateName)
+    val encodedValue = stateTypesEncoder.encodeValue(value, ttlExpirationMs)
+    val encodedCompositeKey = stateTypesEncoder.encodeCompositeKey(key)
+    store.put(encodedCompositeKey, encodedValue, stateName)
+    val serializedGroupingKey = stateTypesEncoder.serializeGroupingKey()
+    val serializedUserKey = stateTypesEncoder.serializeUserKey(key)
+    upsertTTLForStateKey(ttlExpirationMs, serializedGroupingKey, serializedUserKey)
+  }
+
+  /** Get the map associated with grouping key */
+  override def iterator(): Iterator[(K, V)] = {
+    val encodedGroupingKey = stateTypesEncoder.encodeGroupingKey()
+    val unsafeRowPairIterator = store.prefixScan(encodedGroupingKey, stateName)
+    new NextIterator[(K, V)] {
+      override protected def getNext(): (K, V) = {
+        val iter = unsafeRowPairIterator.dropWhile { rowPair =>
+          stateTypesEncoder.isExpired(rowPair.value, batchTimestampMs)
+        }
+        if (iter.hasNext) {
+          val currentRowPair = iter.next()
+          val key = stateTypesEncoder.decodeCompositeKey(currentRowPair.key)
+          val value = stateTypesEncoder.decodeValue(currentRowPair.value)
+          (key, value)
+        } else {
+          finished = true
+          null.asInstanceOf[(K, V)]
+        }
+      }
+
+      override protected def close(): Unit = {}
+    }
+  }
+
+  /** Get the list of keys present in map associated with grouping key */
+  override def keys(): Iterator[K] = {
+    iterator().map(_._1)
+  }
+
+  /** Get the list of values present in map associated with grouping key */
+  override def values(): Iterator[V] = {
+    iterator().map(_._2)
+  }
+
+  /** Remove user key from map state */
+  override def removeKey(key: K): Unit = {
+    StateStoreErrors.requireNonNullStateValue(key, stateName)
+    val compositeKey = stateTypesEncoder.encodeCompositeKey(key)
+    store.remove(compositeKey, stateName)
+  }
+
+  /** Remove this state. */
+  override def clear(): Unit = {
+    keys().foreach { itr =>
+      removeKey(itr)
+    }
+  }
+
+  /**
+   * Clears the user state associated with this grouping key
+   * if it has expired. This function is called by Spark to perform
+   * cleanup at the end of transformWithState processing.
+   *
+   * Spark uses a secondary index to determine if the user state for
+   * this grouping key has expired. However, its possible that the user
+   * has updated the TTL and secondary index is out of date. Implementations
+   * must validate that the user State has actually expired before cleanup based
+   * on their own State data.
+   *
+   * @param groupingKey grouping key for which cleanup should be performed.
+   * @param userKey     user key for which cleanup should be performed.
+   */
+  override def clearIfExpired(groupingKey: Array[Byte], userKey: Array[Byte]): Long = {
+    val encodedCompositeKey = stateTypesEncoder.encodeCompositeKey(groupingKey, userKey)
+    val retRow = store.get(encodedCompositeKey, stateName)
+    var numRemovedElements = 0L
+    if (retRow != null) {
+      if (stateTypesEncoder.isExpired(retRow, batchTimestampMs)) {
+        store.remove(encodedCompositeKey, stateName)
+        numRemovedElements += 1
+      }
+    }
+    numRemovedElements
+  }
+
+  /*
+   * Internal methods to probe state for testing. The below methods exist for unit tests
+   * to read the state ttl values, and ensure that values are persisted correctly in
+   * the underlying state store.
+   */
+
+  /**
+   * Retrieves the value from State even if its expired. This method is used
+   * in tests to read the state store value, and ensure if its cleaned up at the
+   * end of the micro-batch.
+   */
+  private[sql] def getWithoutEnforcingTTL(userKey: K): Option[V] = {
+    val encodedCompositeKey = stateTypesEncoder.encodeCompositeKey(userKey)
+    val retRow = store.get(encodedCompositeKey, stateName)
+
+    if (retRow != null) {
+      val resState = stateTypesEncoder.decodeValue(retRow)
+      Some(resState)
+    } else {
+      None
+    }
+  }
+
+  /**
+   * Read the ttl value associated with the grouping and user key.
+   */
+  private[sql] def getTTLValue(userKey: K): Option[(V, Long)] = {
+    val encodedCompositeKey = stateTypesEncoder.encodeCompositeKey(userKey)
+    val retRow = store.get(encodedCompositeKey, stateName)
+
+    // if the returned row is not null, we want to return the value associated with the
+    // ttlExpiration
+    Option(retRow).flatMap { row =>
+      val ttlExpiration = stateTypesEncoder.decodeTtlExpirationMs(row)
+      ttlExpiration.map(expiration => (stateTypesEncoder.decodeValue(row), expiration))
+    }
+  }
+
+  /**
+   * Get all ttl values stored in ttl state for current implicit
+   * grouping key.
+   */
+  private[sql] def getValuesInTTLState(): Iterator[Long] = {
+    val ttlIterator = ttlIndexIterator()
+    val implicitGroupingKey = stateTypesEncoder.serializeGroupingKey()
+    var nextValue: Option[Long] = None
+
+    new Iterator[Long] {
+      override def hasNext: Boolean = {
+        while (nextValue.isEmpty && ttlIterator.hasNext) {
+          val nextTtlValue = ttlIterator.next()
+          val groupingKey = nextTtlValue.groupingKey
+          if (groupingKey sameElements implicitGroupingKey) {
+            nextValue = Some(nextTtlValue.expirationMs)
+          }
+        }
+        nextValue.isDefined
+      }
+
+      override def next(): Long = {
+        val result = nextValue.get
+        nextValue = None
+        result
+      }
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MapStateImplWithTTL.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MapStateImplWithTTL.scala
@@ -24,15 +24,27 @@ import org.apache.spark.sql.execution.streaming.state.{PrefixKeyScanStateEncoder
 import org.apache.spark.sql.streaming.{MapState, TTLConfig}
 import org.apache.spark.util.NextIterator
 
-
+/**
+ * Class that provides a concrete implementation for map state associated with state
+ * variables (with ttl expiration support) used in the streaming transformWithState operator.
+ * @param store - reference to the StateStore instance to be used for storing state
+ * @param stateName  - name of the state variable
+ * @param keyExprEnc - Spark SQL encoder for key
+ * @param userKeyEnc  - Spark SQL encoder for the map key
+ * @param valEncoder - SQL encoder for state variable
+ * @param ttlConfig  - the ttl configuration (time to live duration etc.)
+ * @tparam K - type of key for map state variable
+ * @tparam V - type of value for map state variable
+ * @return - instance of MapState of type [K,V] that can be used to store state persistently
+ */
 class MapStateImplWithTTL[K, V](
-  store: StateStore,
-  stateName: String,
-  keyExprEnc: ExpressionEncoder[Any],
-  userKeyEnc: Encoder[K],
-  valEncoder: Encoder[V],
-  ttlConfig: TTLConfig,
-  batchTimestampMs: Long) extends CompositeKeyTTLStateImpl(stateName, store, batchTimestampMs)
+    store: StateStore,
+    stateName: String,
+    keyExprEnc: ExpressionEncoder[Any],
+    userKeyEnc: Encoder[K],
+    valEncoder: Encoder[V],
+    ttlConfig: TTLConfig,
+    batchTimestampMs: Long) extends CompositeKeyTTLStateImpl(stateName, store, batchTimestampMs)
   with MapState[K, V] with Logging {
 
   private val keySerializer = keyExprEnc.createSerializer()

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StateTypesEncoderUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StateTypesEncoderUtils.scala
@@ -195,6 +195,12 @@ class CompositeKeyStateEncoder[GK, K, V](
     compositeKeyRow
   }
 
+  def decodeUserKeyFromTTLRow(row: CompositeKeyTTLRow): K = {
+    val bytes = row.userKey
+    reusedKeyRow.pointTo(bytes, bytes.length)
+    val userKey = userKeyRowToObjDeserializer.apply(reusedKeyRow)
+    userKey
+  }
 
   /**
    * Grouping key and user key are encoded as a row of `schemaForCompositeKeyRow` schema.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StateTypesEncoderUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StateTypesEncoderUtils.scala
@@ -207,8 +207,8 @@ class CompositeKeyStateEncoder[GK, K, V](
    * Grouping key will be encoded in `RocksDBStateEncoder` as the prefix column.
    */
   def encodeCompositeKey(
-    groupingKeyByteArr: Array[Byte],
-    userKeyByteArr: Array[Byte]): UnsafeRow = {
+      groupingKeyByteArr: Array[Byte],
+      userKeyByteArr: Array[Byte]): UnsafeRow = {
     val compositeKeyRow = compositeKeyProjection(InternalRow(groupingKeyByteArr, userKeyByteArr))
     compositeKeyRow
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StateTypesEncoderUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StateTypesEncoderUtils.scala
@@ -27,6 +27,9 @@ import org.apache.spark.sql.types.{BinaryType, LongType, StructType}
 
 object TransformWithStateKeyValueRowSchema {
   val KEY_ROW_SCHEMA: StructType = new StructType().add("key", BinaryType)
+  val COMPOSITE_KEY_ROW_SCHEMA: StructType = new StructType()
+    .add("key", BinaryType)
+    .add("userKey", BinaryType)
   val VALUE_ROW_SCHEMA: StructType = new StructType()
     .add("value", BinaryType)
   val VALUE_ROW_SCHEMA_WITH_TTL: StructType = new StructType()
@@ -190,6 +193,22 @@ class CompositeKeyStateEncoder[GK, K, V](
 
     val compositeKeyRow = compositeKeyProjection(InternalRow(groupingKeyByteArr, userKeyBytesArr))
     compositeKeyRow
+  }
+
+
+  /**
+   * Grouping key and user key are encoded as a row of `schemaForCompositeKeyRow` schema.
+   * Grouping key will be encoded in `RocksDBStateEncoder` as the prefix column.
+   */
+  def encodeCompositeKey(
+    groupingKeyByteArr: Array[Byte],
+    userKeyByteArr: Array[Byte]): UnsafeRow = {
+    val compositeKeyRow = compositeKeyProjection(InternalRow(groupingKeyByteArr, userKeyByteArr))
+    compositeKeyRow
+  }
+
+  def serializeUserKey(userKey: K): Array[Byte] = {
+    userKeySerializer.apply(userKey).asInstanceOf[UnsafeRow].getBytes
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
@@ -287,6 +287,23 @@ class StatefulProcessorHandleImpl(
     resultState
   }
 
+  override def getMapState[K, V](
+      stateName: String,
+      userKeyEnc: Encoder[K],
+      valEncoder: Encoder[V],
+      ttlConfig: TTLConfig): MapState[K, V] = {
+    verifyStateVarOperations("get_map_state")
+    validateTTLConfig(ttlConfig, stateName)
+
+    assert(batchTimestampMs.isDefined)
+    val mapStateWithTTL = new MapStateImplWithTTL[K, V](store, stateName, keyEncoder, userKeyEnc,
+      valEncoder, ttlConfig, batchTimestampMs.get)
+    incrementMetric("numMapStateWithTTLVars")
+    ttlStates.add(mapStateWithTTL)
+
+    mapStateWithTTL
+  }
+
   private def validateTTLConfig(ttlConfig: TTLConfig, stateName: String): Unit = {
     val ttlDuration = ttlConfig.ttlDuration
     if (timeMode != TimeMode.ProcessingTime()) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TTLState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TTLState.scala
@@ -98,6 +98,16 @@ abstract class SingleKeyTTLStateImpl(
   store.createColFamilyIfAbsent(ttlColumnFamilyName, TTL_KEY_ROW_SCHEMA, TTL_VALUE_ROW_SCHEMA,
     RangeKeyScanStateEncoderSpec(TTL_KEY_ROW_SCHEMA, Seq(0)), isInternal = true)
 
+  def clearTTLState(): Unit = {
+    val iterator = store.iterator(ttlColumnFamilyName)
+    iterator.takeWhile { kv =>
+      val expirationMs = kv.key.getLong(0)
+      StateTTL.isExpired(expirationMs, ttlExpirationMs)
+    }.foreach { kv =>
+      store.remove(kv.key, ttlColumnFamilyName)
+    }
+  }
+
   def upsertTTLForStateKey(
       expirationMs: Long,
       groupingKey: Array[Byte]): Unit = {
@@ -202,6 +212,16 @@ abstract class CompositeKeyTTLStateImpl(
   store.createColFamilyIfAbsent(ttlColumnFamilyName, TTL_COMPOSITE_KEY_ROW_SCHEMA,
     TTL_VALUE_ROW_SCHEMA, RangeKeyScanStateEncoderSpec(TTL_COMPOSITE_KEY_ROW_SCHEMA,
       Seq(0)), isInternal = true)
+
+  def clearTTLState(): Unit = {
+    val iterator = store.iterator(ttlColumnFamilyName)
+    iterator.takeWhile { kv =>
+      val expirationMs = kv.key.getLong(0)
+      StateTTL.isExpired(expirationMs, ttlExpirationMs)
+    }.foreach { kv =>
+      store.remove(kv.key, ttlColumnFamilyName)
+    }
+  }
 
   def upsertTTLForStateKey(
     expirationMs: Long,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TTLState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TTLState.scala
@@ -195,9 +195,9 @@ abstract class SingleKeyTTLStateImpl(
  * Manages the ttl information for user state keyed with a single key (grouping key).
  */
 abstract class CompositeKeyTTLStateImpl(
-  stateName: String,
-  store: StateStore,
-  ttlExpirationMs: Long)
+    stateName: String,
+    store: StateStore,
+    ttlExpirationMs: Long)
   extends TTLState {
 
   import org.apache.spark.sql.execution.streaming.StateTTLSchema._

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TTLState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TTLState.scala
@@ -98,6 +98,11 @@ abstract class SingleKeyTTLStateImpl(
   store.createColFamilyIfAbsent(ttlColumnFamilyName, TTL_KEY_ROW_SCHEMA, TTL_VALUE_ROW_SCHEMA,
     RangeKeyScanStateEncoderSpec(TTL_KEY_ROW_SCHEMA, Seq(0)), isInternal = true)
 
+  /**
+   * This function will be called when clear() on State Variables
+   * with ttl enabled is called. This function should clear any
+   * associated ttlState, since we are clearing the user state.
+   */
   def clearTTLState(): Unit = {
     val iterator = store.iterator(ttlColumnFamilyName)
     iterator.takeWhile { kv =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TTLState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TTLState.scala
@@ -27,6 +27,10 @@ object StateTTLSchema {
   val TTL_KEY_ROW_SCHEMA: StructType = new StructType()
     .add("expirationMs", LongType)
     .add("groupingKey", BinaryType)
+  val TTL_COMPOSITE_KEY_ROW_SCHEMA: StructType = new StructType()
+    .add("expirationMs", LongType)
+    .add("groupingKey", BinaryType)
+    .add("userKey", BinaryType)
   val TTL_VALUE_ROW_SCHEMA: StructType =
     StructType(Array(StructField("__dummy__", NullType)))
 }
@@ -40,6 +44,18 @@ object StateTTLSchema {
 case class SingleKeyTTLRow(
     groupingKey: Array[Byte],
     expirationMs: Long)
+
+/**
+ * Encapsulates the ttl row information stored in [[CompositeKeyTTLStateImpl]].
+ *
+ * @param groupingKey grouping key for which ttl is set
+ * @param userKey user key for which ttl is set
+ * @param expirationMs expiration time for the grouping key
+ */
+case class CompositeKeyTTLRow(
+   groupingKey: Array[Byte],
+   userKey: Array[Byte],
+   expirationMs: Long)
 
 /**
  * Represents the underlying state for secondary TTL Index for a user defined
@@ -59,23 +75,6 @@ trait TTLState {
    * @return number of values cleaned up.
    */
   def clearExpiredState(): Long
-
-  /**
-   * Clears the user state associated with this grouping key
-   * if it has expired. This function is called by Spark to perform
-   * cleanup at the end of transformWithState processing.
-   *
-   * Spark uses a secondary index to determine if the user state for
-   * this grouping key has expired. However, its possible that the user
-   * has updated the TTL and secondary index is out of date. Implementations
-   * must validate that the user State has actually expired before cleanup based
-   * on their own State data.
-   *
-   * @param groupingKey grouping key for which cleanup should be performed.
-   *
-   * @return how many state objects were cleaned up.
-   */
-  def clearIfExpired(groupingKey: Array[Byte]): Long
 }
 
 /**
@@ -163,6 +162,105 @@ abstract class SingleKeyTTLStateImpl(
       }
     }
   }
+
+  /**
+   * Clears the user state associated with this grouping key
+   * if it has expired. This function is called by Spark to perform
+   * cleanup at the end of transformWithState processing.
+   *
+   * Spark uses a secondary index to determine if the user state for
+   * this grouping key has expired. However, its possible that the user
+   * has updated the TTL and secondary index is out of date. Implementations
+   * must validate that the user State has actually expired before cleanup based
+   * on their own State data.
+   *
+   * @param groupingKey grouping key for which cleanup should be performed.
+   *
+   * @return true if the state was cleared, false otherwise.
+   */
+  def clearIfExpired(groupingKey: Array[Byte]): Long
+}
+
+/**
+ * Manages the ttl information for user state keyed with a single key (grouping key).
+ */
+abstract class CompositeKeyTTLStateImpl(
+  stateName: String,
+  store: StateStore,
+  ttlExpirationMs: Long)
+  extends TTLState {
+
+  import org.apache.spark.sql.execution.streaming.StateTTLSchema._
+
+  private val ttlColumnFamilyName = s"_ttl_$stateName"
+  private val ttlKeyEncoder = UnsafeProjection.create(TTL_COMPOSITE_KEY_ROW_SCHEMA)
+
+  // empty row used for values
+  private val EMPTY_ROW =
+    UnsafeProjection.create(Array[DataType](NullType)).apply(InternalRow.apply(null))
+
+  store.createColFamilyIfAbsent(ttlColumnFamilyName, TTL_COMPOSITE_KEY_ROW_SCHEMA,
+    TTL_VALUE_ROW_SCHEMA, RangeKeyScanStateEncoderSpec(TTL_COMPOSITE_KEY_ROW_SCHEMA,
+      Seq(0)), isInternal = true)
+
+  def upsertTTLForStateKey(
+    expirationMs: Long,
+    groupingKey: Array[Byte],
+    userKey: Array[Byte]): Unit = {
+    val encodedTtlKey = ttlKeyEncoder(InternalRow(expirationMs, groupingKey, userKey))
+    store.put(encodedTtlKey, EMPTY_ROW, ttlColumnFamilyName)
+  }
+
+  /**
+   * Clears any state which has ttl older than [[ttlExpirationMs]].
+   */
+  override def clearExpiredState(): Long = {
+    val iterator = store.iterator(ttlColumnFamilyName)
+    var numRemovedElements = 0L
+    iterator.takeWhile { kv =>
+      val expirationMs = kv.key.getLong(0)
+      StateTTL.isExpired(expirationMs, ttlExpirationMs)
+    }.foreach { kv =>
+      val groupingKey = kv.key.getBinary(1)
+      val userKey = kv.key.getBinary(2)
+      numRemovedElements += clearIfExpired(groupingKey, userKey)
+      store.remove(kv.key, ttlColumnFamilyName)
+    }
+    numRemovedElements
+  }
+
+  private[sql] def ttlIndexIterator(): Iterator[CompositeKeyTTLRow] = {
+    val ttlIterator = store.iterator(ttlColumnFamilyName)
+
+    new Iterator[CompositeKeyTTLRow] {
+      override def hasNext: Boolean = ttlIterator.hasNext
+
+      override def next(): CompositeKeyTTLRow = {
+        val kv = ttlIterator.next()
+        CompositeKeyTTLRow(
+          expirationMs = kv.key.getLong(0),
+          groupingKey = kv.key.getBinary(1),
+          userKey = kv.key.getBinary(2)
+        )
+      }
+    }
+  }
+
+  /**
+   * Clears the user state associated with this grouping key
+   * if it has expired. This function is called by Spark to perform
+   * cleanup at the end of transformWithState processing.
+   *
+   * Spark uses a secondary index to determine if the user state for
+   * this grouping key has expired. However, its possible that the user
+   * has updated the TTL and secondary index is out of date. Implementations
+   * must validate that the user State has actually expired before cleanup based
+   * on their own State data.
+   *
+   * @param groupingKey grouping key for which cleanup should be performed.
+   * @param userKey user key for which cleanup should be performed.
+   */
+  def clearIfExpired(groupingKey: Array[Byte], userKey: Array[Byte]): Long
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TTLState.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TTLState.scala
@@ -105,10 +105,7 @@ abstract class SingleKeyTTLStateImpl(
    */
   def clearTTLState(): Unit = {
     val iterator = store.iterator(ttlColumnFamilyName)
-    iterator.takeWhile { kv =>
-      val expirationMs = kv.key.getLong(0)
-      StateTTL.isExpired(expirationMs, ttlExpirationMs)
-    }.foreach { kv =>
+    iterator.foreach { kv =>
       store.remove(kv.key, ttlColumnFamilyName)
     }
   }
@@ -220,18 +217,15 @@ abstract class CompositeKeyTTLStateImpl(
 
   def clearTTLState(): Unit = {
     val iterator = store.iterator(ttlColumnFamilyName)
-    iterator.takeWhile { kv =>
-      val expirationMs = kv.key.getLong(0)
-      StateTTL.isExpired(expirationMs, ttlExpirationMs)
-    }.foreach { kv =>
+    iterator.foreach { kv =>
       store.remove(kv.key, ttlColumnFamilyName)
     }
   }
 
   def upsertTTLForStateKey(
-    expirationMs: Long,
-    groupingKey: Array[Byte],
-    userKey: Array[Byte]): Unit = {
+      expirationMs: Long,
+      groupingKey: Array[Byte],
+      userKey: Array[Byte]): Unit = {
     val encodedTtlKey = ttlKeyEncoder(InternalRow(expirationMs, groupingKey, userKey))
     store.put(encodedTtlKey, EMPTY_ROW, ttlColumnFamilyName)
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -313,6 +313,8 @@ case class TransformWithStateExec(
         "Number of value state variables with TTL"),
       StatefulOperatorCustomSumMetric("numListStateWithTTLVars",
         "Number of list state variables with TTL"),
+      StatefulOperatorCustomSumMetric("numMapStateWithTTLVars",
+        "Number of map state variables with TTL"),
       StatefulOperatorCustomSumMetric("numValuesRemovedDueToTTLExpiry",
         "Number of values removed due to TTL expiry")
     )

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ValueStateImplWithTTL.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ValueStateImplWithTTL.scala
@@ -96,6 +96,7 @@ class ValueStateImplWithTTL[S](
   /** Function to remove state for given key */
   override def clear(): Unit = {
     store.remove(stateTypesEncoder.encodeGroupingKey(), stateName)
+    clearTTLState()
   }
 
   def clearIfExpired(groupingKey: Array[Byte]): Long = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MapStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MapStateSuite.scala
@@ -191,7 +191,7 @@ class MapStateSuite extends StateVariableSuiteBase {
       var ttlValue = testState.getTTLValue("k1")
       assert(ttlValue.isDefined)
       assert(ttlValue.get._2 === ttlExpirationMs)
-      var ttlStateValueIterator = testState.getValuesInTTLState()
+      var ttlStateValueIterator = testState.getKeyValuesInTTLState().map(_._2)
       assert(ttlStateValueIterator.hasNext)
 
       // increment batchProcessingTime, or watermark and ensure expired value is not returned
@@ -214,7 +214,7 @@ class MapStateSuite extends StateVariableSuiteBase {
       ttlValue = nextBatchTestState.getTTLValue("k1")
       assert(ttlValue.isDefined)
       assert(ttlValue.get._2 === ttlExpirationMs)
-      ttlStateValueIterator = nextBatchTestState.getValuesInTTLState()
+      ttlStateValueIterator = nextBatchTestState.getKeyValuesInTTLState().map(_._2)
       assert(ttlStateValueIterator.hasNext)
       assert(ttlStateValueIterator.next() === ttlExpirationMs)
       assert(ttlStateValueIterator.isEmpty)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MapStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MapStateSuite.scala
@@ -17,12 +17,14 @@
 
 package org.apache.spark.sql.execution.streaming.state
 
+import java.time.Duration
 import java.util.UUID
 
+import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.sql.Encoders
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
-import org.apache.spark.sql.execution.streaming.{ImplicitGroupingKeyTracker, StatefulProcessorHandleImpl}
-import org.apache.spark.sql.streaming.{ListState, MapState, TimeMode, ValueState}
+import org.apache.spark.sql.execution.streaming.{ImplicitGroupingKeyTracker, MapStateImplWithTTL, StatefulProcessorHandleImpl}
+import org.apache.spark.sql.streaming.{ListState, MapState, TTLConfig, TimeMode, ValueState}
 import org.apache.spark.sql.types.{BinaryType, StructType}
 
 /**
@@ -165,6 +167,92 @@ class MapStateSuite extends StateVariableSuiteBase {
       assert(!mapTestState1.exists())
       assert(mapTestState2.exists())
       assert(mapTestState2.iterator().toList === List(("k2", 4)))
+    }
+  }
+
+  test("test Map state TTL") {
+    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+      val store = provider.getStore(0)
+      val timestampMs = 10
+      val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
+        Encoders.STRING.asInstanceOf[ExpressionEncoder[Any]], TimeMode.ProcessingTime(),
+        batchTimestampMs = Some(timestampMs))
+
+      val ttlConfig = TTLConfig(ttlDuration = Duration.ofMinutes(1))
+      val testState: MapStateImplWithTTL[String, String] =
+        handle.getMapState[String, String]("testState", Encoders.STRING,
+          Encoders.STRING, ttlConfig).asInstanceOf[MapStateImplWithTTL[String, String]]
+      ImplicitGroupingKeyTracker.setImplicitKey("test_key")
+      testState.updateValue("k1", "v1")
+      assert(testState.getValue("k1") === "v1")
+      assert(testState.getWithoutEnforcingTTL("k1").get === "v1")
+
+      val ttlExpirationMs = timestampMs + 60000
+      var ttlValue = testState.getTTLValue("k1")
+      assert(ttlValue.isDefined)
+      assert(ttlValue.get._2 === ttlExpirationMs)
+      var ttlStateValueIterator = testState.getValuesInTTLState()
+      assert(ttlStateValueIterator.hasNext)
+
+      // increment batchProcessingTime, or watermark and ensure expired value is not returned
+      val nextBatchHandle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
+        Encoders.STRING.asInstanceOf[ExpressionEncoder[Any]],
+        TimeMode.ProcessingTime(), batchTimestampMs = Some(ttlExpirationMs))
+
+      val nextBatchTestState: MapStateImplWithTTL[String, String] =
+        nextBatchHandle.getMapState[String, String](
+            "testState", Encoders.STRING, Encoders.STRING, ttlConfig)
+            .asInstanceOf[MapStateImplWithTTL[String, String]]
+
+      ImplicitGroupingKeyTracker.setImplicitKey("test_key")
+
+      // ensure get does not return the expired value
+      assert(!nextBatchTestState.exists())
+      assert(nextBatchTestState.getValue("k1") === null)
+
+      // ttl value should still exist in state
+      ttlValue = nextBatchTestState.getTTLValue("k1")
+      assert(ttlValue.isDefined)
+      assert(ttlValue.get._2 === ttlExpirationMs)
+      ttlStateValueIterator = nextBatchTestState.getValuesInTTLState()
+      assert(ttlStateValueIterator.hasNext)
+      assert(ttlStateValueIterator.next() === ttlExpirationMs)
+      assert(ttlStateValueIterator.isEmpty)
+
+      // getWithoutTTL should still return the expired value
+      assert(nextBatchTestState.getWithoutEnforcingTTL("k1").get === "v1")
+
+      nextBatchTestState.clear()
+      assert(!nextBatchTestState.exists())
+      assert(nextBatchTestState.getValue("k1") === null)
+    }
+  }
+
+  test("test negative or zero TTL duration throws error") {
+    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+      val store = provider.getStore(0)
+      val batchTimestampMs = 10
+      val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
+        Encoders.STRING.asInstanceOf[ExpressionEncoder[Any]],
+        TimeMode.ProcessingTime(), batchTimestampMs = Some(batchTimestampMs))
+
+      Seq(null, Duration.ZERO, Duration.ofMinutes(-1)).foreach { ttlDuration =>
+        val ttlConfig = TTLConfig(ttlDuration)
+        val ex = intercept[SparkUnsupportedOperationException] {
+          handle.getMapState[String, String](
+            "testState", Encoders.STRING, Encoders.STRING, ttlConfig)
+        }
+
+        checkError(
+          ex,
+          errorClass = "STATEFUL_PROCESSOR_TTL_DURATION_MUST_BE_POSITIVE",
+          parameters = Map(
+            "operationType" -> "update",
+            "stateName" -> "testState"
+          ),
+          matchPVals = true
+        )
+      }
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MapStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MapStateSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.sql.Encoders
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.execution.streaming.{ImplicitGroupingKeyTracker, MapStateImplWithTTL, StatefulProcessorHandleImpl}
-import org.apache.spark.sql.streaming.{ListState, MapState, TTLConfig, TimeMode, ValueState}
+import org.apache.spark.sql.streaming.{ListState, MapState, TimeMode, TTLConfig, ValueState}
 import org.apache.spark.sql.types.{BinaryType, StructType}
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithMapStateTTLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithMapStateTTLSuite.scala
@@ -180,7 +180,7 @@ class TransformWithMapStateTTLSuite extends TransformWithStateTTLTest {
 
   import testImplicits._
   override def getProcessor(ttlConfig: TTLConfig):
-  StatefulProcessor[String, InputEvent, OutputEvent] = {
+      StatefulProcessor[String, InputEvent, OutputEvent] = {
     new MapStateSingleKeyTTLProcessor(ttlConfig)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithMapStateTTLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithMapStateTTLSuite.scala
@@ -1,0 +1,274 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.streaming
+
+import java.time.Duration
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.Encoders
+import org.apache.spark.sql.execution.streaming.{MapStateImplWithTTL, MemoryStream}
+import org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreProvider
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.streaming.util.StreamManualClock
+
+class MapStateSingleKeyTTLProcessor(ttlConfig: TTLConfig)
+  extends StatefulProcessor[String, InputEvent, OutputEvent]
+    with Logging {
+
+  @transient private var _mapState: MapStateImplWithTTL[String, Int] = _
+
+  override def init(
+   outputMode: OutputMode,
+   timeMode: TimeMode
+  ): Unit = {
+    _mapState = getHandle
+      .getMapState("mapState", Encoders.STRING, Encoders.scalaInt, ttlConfig)
+      .asInstanceOf[MapStateImplWithTTL[String, Int]]
+  }
+  override def handleInputRows(
+    key: String,
+    inputRows: Iterator[InputEvent],
+    timerValues: TimerValues,
+    expiredTimerInfo: ExpiredTimerInfo): Iterator[OutputEvent] = {
+    var results = List[OutputEvent]()
+
+    for (row <- inputRows) {
+      val resultIter = processRow(row, _mapState)
+      resultIter.foreach { r =>
+        results = r :: results
+      }
+    }
+
+    results.iterator
+  }
+
+  def processRow(
+    row: InputEvent,
+    mapState: MapStateImplWithTTL[String, Int]): Iterator[OutputEvent] = {
+    var results = List[OutputEvent]()
+    val key = row.key
+    val userKey = "key"
+    if (row.action == "get") {
+      if (mapState.containsKey(userKey)) {
+        results = OutputEvent(key, mapState.getValue(userKey), isTTLValue = false, -1) :: results
+      }
+    } else if (row.action == "get_without_enforcing_ttl") {
+      val currState = mapState.getWithoutEnforcingTTL(userKey)
+      if (currState.isDefined) {
+        results = OutputEvent(key, currState.get, isTTLValue = false, -1) :: results
+      }
+    } else if (row.action == "get_ttl_value_from_state") {
+      val ttlValue = mapState.getTTLValue(userKey)
+      if (ttlValue.isDefined) {
+        val value = ttlValue.get._1
+        val ttlExpiration = ttlValue.get._2
+        results = OutputEvent(key, value, isTTLValue = true, ttlExpiration) :: results
+      }
+    } else if (row.action == "put") {
+      mapState.updateValue(userKey, row.value)
+    } else if (row.action == "get_values_in_ttl_state") {
+      val ttlValues = mapState.getValuesInTTLState()
+      ttlValues.foreach { v =>
+        results = OutputEvent(key, -1, isTTLValue = true, ttlValue = v) :: results
+      }
+    }
+
+    results.iterator
+  }
+}
+
+
+case class MapInputEvent(
+  key: String,
+  userKey: String,
+  action: String,
+  value: Int)
+
+case class MapOutputEvent(
+  key: String,
+  userKey: String,
+  value: Int,
+  isTTLValue: Boolean,
+  ttlValue: Long)
+
+
+class MapStateTTLProcessor(ttlConfig: TTLConfig)
+  extends StatefulProcessor[String, MapInputEvent, MapOutputEvent]
+    with Logging {
+
+  @transient private var _mapState: MapStateImplWithTTL[String, Int] = _
+
+  override def init(
+    outputMode: OutputMode,
+    timeMode: TimeMode): Unit = {
+    _mapState = getHandle
+      .getMapState("mapState", Encoders.STRING, Encoders.scalaInt, ttlConfig)
+      .asInstanceOf[MapStateImplWithTTL[String, Int]]
+  }
+
+  override def handleInputRows(
+    key: String,
+    inputRows: Iterator[MapInputEvent],
+    timerValues: TimerValues,
+    expiredTimerInfo: ExpiredTimerInfo): Iterator[MapOutputEvent] = {
+    var results = List[MapOutputEvent]()
+
+    for (row <- inputRows) {
+      val resultIter = processRow(row, _mapState)
+      resultIter.foreach { r =>
+        results = r :: results
+      }
+    }
+
+    results.iterator
+  }
+
+  def processRow(
+    row: MapInputEvent,
+    mapState: MapStateImplWithTTL[String, Int]): Iterator[MapOutputEvent] = {
+    var results = List[MapOutputEvent]()
+    val key = row.key
+    val userKey = row.userKey
+    if (row.action == "get") {
+      if (mapState.containsKey(userKey)) {
+        results = MapOutputEvent(key, userKey, mapState.getValue(userKey),
+          isTTLValue = false, -1) :: results
+      }
+    } else if (row.action == "get_without_enforcing_ttl") {
+      val currState = mapState.getWithoutEnforcingTTL(userKey)
+      if (currState.isDefined) {
+        results = MapOutputEvent(key, userKey, currState.get, isTTLValue = false, -1) :: results
+      }
+    } else if (row.action == "get_ttl_value_from_state") {
+      val ttlValue = mapState.getTTLValue(userKey)
+      if (ttlValue.isDefined) {
+        val value = ttlValue.get._1
+        val ttlExpiration = ttlValue.get._2
+        results = MapOutputEvent(key, userKey, value, isTTLValue = true, ttlExpiration) :: results
+      }
+    } else if (row.action == "put") {
+      mapState.updateValue(userKey, row.value)
+    } else if (row.action == "get_values_in_ttl_state") {
+      val ttlValues = mapState.getValuesInTTLState()
+      ttlValues.foreach { v =>
+        results = MapOutputEvent(key, userKey, -1, isTTLValue = true, ttlValue = v) :: results
+      }
+    } else if (row.action == "iterator") {
+      val iter = mapState.iterator()
+      iter.foreach { elem =>
+        results = MapOutputEvent(key, elem._1, elem._2, isTTLValue = false, -1) :: results
+      }
+    }
+
+    results.iterator
+  }
+}
+
+class TransformWithMapStateTTLSuite extends TransformWithStateTTLTest {
+
+  import testImplicits._
+  override def getProcessor(ttlConfig: TTLConfig):
+  StatefulProcessor[String, InputEvent, OutputEvent] = {
+    new MapStateSingleKeyTTLProcessor(ttlConfig)
+  }
+
+  def getStateTTLMetricName: String = "numMapStateWithTTLVars"
+
+  test("validate state is evicted with multiple user keys") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName,
+      SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
+
+      val inputStream = MemoryStream[MapInputEvent]
+      val ttlConfig = TTLConfig(ttlDuration = Duration.ofMinutes(1))
+      val result = inputStream.toDS()
+        .groupByKey(x => x.key)
+        .transformWithState(
+          new MapStateTTLProcessor(ttlConfig),
+          TimeMode.ProcessingTime(),
+          OutputMode.Append())
+
+      val clock = new StreamManualClock
+      testStream(result)(
+        StartStream(Trigger.ProcessingTime("1 second"), triggerClock = clock),
+        AddData(inputStream, MapInputEvent("k1", "key1", "put", 1)),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(),
+        AddData(inputStream, MapInputEvent("k1", "key1", "get", -1)),
+        AdvanceManualClock(30 * 1000),
+        CheckNewAnswer(MapOutputEvent("k1", "key1", 1, isTTLValue = false, -1)),
+        AddData(inputStream, MapInputEvent("k1", "key2", "put", 2)),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(),
+        // advance clock to expire first key
+        AdvanceManualClock(30 * 1000),
+        AddData(inputStream, MapInputEvent("k1", "key1", "get", -1),
+          MapInputEvent("k1", "key2", "get", -1)),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(MapOutputEvent("k1", "key2", 2, isTTLValue = false, -1)),
+        StopStream
+      )
+    }
+  }
+
+  test("verify iterator doesn't return expired keys") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName,
+      SQLConf.SHUFFLE_PARTITIONS.key -> "1") {
+
+      val inputStream = MemoryStream[MapInputEvent]
+      val ttlConfig = TTLConfig(ttlDuration = Duration.ofMinutes(1))
+      val result = inputStream.toDS()
+        .groupByKey(x => x.key)
+        .transformWithState(
+          new MapStateTTLProcessor(ttlConfig),
+          TimeMode.ProcessingTime(),
+          OutputMode.Append())
+
+      val clock = new StreamManualClock
+      testStream(result)(
+        StartStream(Trigger.ProcessingTime("1 second"), triggerClock = clock),
+        AddData(inputStream,
+          MapInputEvent("k1", "key1", "put", 1),
+          MapInputEvent("k1", "key2", "put", 2)),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(),
+        AddData(inputStream,
+          MapInputEvent("k1", "key1", "get", -1),
+          MapInputEvent("k1", "key2", "get", -1)),
+        AdvanceManualClock(30 * 1000),
+        CheckNewAnswer(
+          MapOutputEvent("k1", "key1", 1, isTTLValue = false, -1),
+          MapOutputEvent("k1", "key2", 2, isTTLValue = false, -1)),
+        // advance clock to expire first two values
+        AdvanceManualClock(30 * 1000),
+        AddData(inputStream,
+          MapInputEvent("k1", "key3", "put", 3),
+          MapInputEvent("k1", "key4", "put", 4),
+          MapInputEvent("k1", "key5", "put", 5),
+          MapInputEvent("k1", "", "iterator", -1)),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(
+          MapOutputEvent("k1", "key3", 3, isTTLValue = false, -1),
+          MapOutputEvent("k1", "key4", 4, isTTLValue = false, -1),
+          MapOutputEvent("k1", "key5", 5, isTTLValue = false, -1)),
+        StopStream
+      )
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithMapStateTTLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithMapStateTTLSuite.scala
@@ -184,7 +184,7 @@ class TransformWithMapStateTTLSuite extends TransformWithStateTTLTest {
     new MapStateSingleKeyTTLProcessor(ttlConfig)
   }
 
-  def getStateTTLMetricName: String = "numMapStateWithTTLVars"
+  override def getStateTTLMetricName: String = "numMapStateWithTTLVars"
 
   test("validate state is evicted with multiple user keys") {
     withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithMapStateTTLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithMapStateTTLSuite.scala
@@ -81,9 +81,9 @@ class MapStateSingleKeyTTLProcessor(ttlConfig: TTLConfig)
     } else if (row.action == "put") {
       mapState.updateValue(userKey, row.value)
     } else if (row.action == "get_values_in_ttl_state") {
-      val ttlValues = mapState.getValuesInTTLState()
+      val ttlValues = mapState.getKeyValuesInTTLState()
       ttlValues.foreach { v =>
-        results = OutputEvent(key, -1, isTTLValue = true, ttlValue = v) :: results
+        results = OutputEvent(key, -1, isTTLValue = true, ttlValue = v._2) :: results
       }
     }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithMapStateTTLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithMapStateTTLSuite.scala
@@ -91,7 +91,6 @@ class MapStateSingleKeyTTLProcessor(ttlConfig: TTLConfig)
   }
 }
 
-
 case class MapInputEvent(
     key: String,
     userKey: String,
@@ -104,7 +103,6 @@ case class MapOutputEvent(
     value: Int,
     isTTLValue: Boolean,
     ttlValue: Long)
-
 
 class MapStateTTLProcessor(ttlConfig: TTLConfig)
   extends StatefulProcessor[String, MapInputEvent, MapOutputEvent]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds support for expiring state based on TTL for MapState. Using this functionality, Spark users can specify a TTL Mode for transformWithState operator, and provide a ttlDuration for each value in MapState. Once the ttlDuration has expired, the value will not be returned as part of get() and would be cleaned up at the end of the micro-batch.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
These changes are needed to support TTL for MapState. The PR supports specifying ttl for processing time.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, modifies the MapState interface for specifying ttlDuration

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added the TransformWithMapStateTTLSuite, MapStateSuite, StatefulProcessorHandleSuite
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No