### PR TITLE
[SPARK-47725][INFRA][FOLLOW-UP] Do not run scheduled job in forked repository

### DIFF
--- a/.github/workflows/build_python_connect.yml
+++ b/.github/workflows/build_python_connect.yml
@@ -29,6 +29,7 @@ jobs:
     name: "Build modules: pyspark-connect"
     runs-on: ubuntu-latest
     timeout-minutes: 300
+    if: github.repository == 'apache/spark'
     steps:
       - name: Checkout Spark repository
         uses: actions/checkout@v4


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a followup of https://github.com/apache/spark/pull/45870 that skips the run in forked repository.

### Why are the changes needed?

For consistency, and to save resources in forked repository by default.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Should be tested in individual forked repository.

### Was this patch authored or co-authored using generative AI tooling?

No.
