### PR TITLE
[MINOR][DOCS] Make the link of spark properties with YARN more accurate

### DIFF
--- a/docs/job-scheduling.md
+++ b/docs/job-scheduling.md
@@ -53,7 +53,7 @@ Resource allocation can be configured as follows, based on the cluster type:
   on the cluster (`spark.executor.instances` as configuration property), while `--executor-memory`
   (`spark.executor.memory` configuration property) and `--executor-cores` (`spark.executor.cores` configuration
   property) control the resources per executor. For more information, see the
-  [YARN Spark Properties](running-on-yarn.html).
+  [YARN Spark Properties](running-on-yarn.html#spark-properties).
 
 Note that none of the modes currently provide memory sharing across applications. If you would like to share
 data this way, we recommend running a single server application that can serve multiple requests by querying


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR propose to make the link of spark properties with YARN more accurate.


### Why are the changes needed?
Currently, the link of `YARN Spark Properties` is just the page of `running-on-yarn.html`.
We should add the anchor point.


### Does this PR introduce _any_ user-facing change?
'Yes'.
More convenient for readers to read.


### How was this patch tested?
N/A


### Was this patch authored or co-authored using generative AI tooling?
'No'.
