### PR TITLE
[SPARK-47807][PYTHON][ML] Make pyspark.ml compatible with pyspark-connect

### DIFF
--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -37,7 +37,7 @@ from typing import (
     TYPE_CHECKING,
 )
 
-from pyspark import keyword_only, since, SparkContext, inheritable_thread_target
+from pyspark import keyword_only, since, inheritable_thread_target
 from pyspark.ml import Estimator, Predictor, PredictionModel, Model
 from pyspark.ml.param.shared import (
     HasRawPredictionCol,
@@ -97,6 +97,7 @@ from pyspark.storagelevel import StorageLevel
 if TYPE_CHECKING:
     from pyspark.ml._typing import P, ParamMap
     from py4j.java_gateway import JavaObject
+    from pyspark.core import SparkContext
 
 
 T = TypeVar("T")
@@ -3677,7 +3678,7 @@ class _OneVsRestSharedReadWrite:
     @staticmethod
     def saveImpl(
         instance: Union[OneVsRest, "OneVsRestModel"],
-        sc: SparkContext,
+        sc: "SparkContext",
         path: str,
         extraMetadata: Optional[Dict[str, Any]] = None,
     ) -> None:
@@ -3690,7 +3691,7 @@ class _OneVsRestSharedReadWrite:
         cast(MLWritable, instance.getClassifier()).save(classifierPath)
 
     @staticmethod
-    def loadClassifier(path: str, sc: SparkContext) -> Union[OneVsRest, "OneVsRestModel"]:
+    def loadClassifier(path: str, sc: "SparkContext") -> Union[OneVsRest, "OneVsRestModel"]:
         classifierPath = os.path.join(path, "classifier")
         return DefaultParamsReader.loadParamsInstance(classifierPath, sc)
 
@@ -3771,6 +3772,8 @@ class OneVsRestModel(
 
     def __init__(self, models: List[ClassificationModel]):
         super(OneVsRestModel, self).__init__()
+        from pyspark.core import SparkContext
+
         self.models = models
         if not isinstance(models[0], JavaMLWritable):
             return
@@ -3913,6 +3916,8 @@ class OneVsRestModel(
         py4j.java_gateway.JavaObject
             Java object equivalent to this instance.
         """
+        from pyspark.core import SparkContext
+
         sc = SparkContext._active_spark_context
         assert sc is not None and sc._gateway is not None
 

--- a/python/pyspark/ml/classification.py
+++ b/python/pyspark/ml/classification.py
@@ -97,7 +97,7 @@ from pyspark.storagelevel import StorageLevel
 if TYPE_CHECKING:
     from pyspark.ml._typing import P, ParamMap
     from py4j.java_gateway import JavaObject
-    from pyspark.core import SparkContext
+    from pyspark.core.context import SparkContext
 
 
 T = TypeVar("T")
@@ -3772,7 +3772,7 @@ class OneVsRestModel(
 
     def __init__(self, models: List[ClassificationModel]):
         super(OneVsRestModel, self).__init__()
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         self.models = models
         if not isinstance(models[0], JavaMLWritable):
@@ -3916,7 +3916,7 @@ class OneVsRestModel(
         py4j.java_gateway.JavaObject
             Java object equivalent to this instance.
         """
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         sc = SparkContext._active_spark_context
         assert sc is not None and sc._gateway is not None

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -225,7 +225,7 @@ class GaussianMixtureModel(
         Array of :py:class:`MultivariateGaussian` where gaussians[i] represents
         the Multivariate Gaussian (Normal) Distribution for Gaussian i
         """
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         sc = SparkContext._active_spark_context
         assert sc is not None and self._java_obj is not None

--- a/python/pyspark/ml/clustering.py
+++ b/python/pyspark/ml/clustering.py
@@ -44,7 +44,6 @@ from pyspark.ml.util import (
     JavaMLReadable,
     GeneralJavaMLWritable,
     HasTrainingSummary,
-    SparkContext,
 )
 from pyspark.ml.wrapper import JavaEstimator, JavaModel, JavaParams, JavaWrapper
 from pyspark.ml.common import inherit_doc, _java2py
@@ -226,6 +225,8 @@ class GaussianMixtureModel(
         Array of :py:class:`MultivariateGaussian` where gaussians[i] represents
         the Multivariate Gaussian (Normal) Distribution for Gaussian i
         """
+        from pyspark.core import SparkContext
+
         sc = SparkContext._active_spark_context
         assert sc is not None and self._java_obj is not None
 

--- a/python/pyspark/ml/common.py
+++ b/python/pyspark/ml/common.py
@@ -23,7 +23,6 @@ from pyspark.sql import DataFrame, SparkSession
 
 if TYPE_CHECKING:
     import py4j.protocol
-    from py4j.protocol import Py4JJavaError
     from py4j.java_gateway import JavaObject
 
     import pyspark.core.context

--- a/python/pyspark/ml/common.py
+++ b/python/pyspark/ml/common.py
@@ -26,7 +26,8 @@ if TYPE_CHECKING:
     from py4j.java_gateway import JavaObject
 
     import pyspark.core.context
-    from pyspark.core import RDD, SparkContext
+    from pyspark.core.rdd import RDD
+    from pyspark.core.context import SparkContext
     from pyspark.ml._typing import C, JavaObjectOrPickleDump
 
 
@@ -79,7 +80,8 @@ def _to_java_object_rdd(rdd: "RDD") -> "JavaObject":
 def _py2java(sc: "SparkContext", obj: Any) -> "JavaObject":
     """Convert Python object into Java"""
     from py4j.java_gateway import JavaObject
-    from pyspark.core import RDD, SparkContext
+    from pyspark.core.rdd import RDD
+    from pyspark.core.context import SparkContext
 
     if isinstance(obj, RDD):
         obj = _to_java_object_rdd(obj)

--- a/python/pyspark/ml/common.py
+++ b/python/pyspark/ml/common.py
@@ -17,21 +17,25 @@
 
 from typing import Any, Callable, TYPE_CHECKING
 
-import py4j.protocol
-from py4j.protocol import Py4JJavaError
-from py4j.java_gateway import JavaObject
-from py4j.java_collections import JavaArray, JavaList
-
-import pyspark.core.context
-from pyspark import RDD, SparkContext
+from pyspark.util import is_remote_only
 from pyspark.serializers import CPickleSerializer, AutoBatchedSerializer
 from pyspark.sql import DataFrame, SparkSession
 
 if TYPE_CHECKING:
+    import py4j.protocol
+    from py4j.protocol import Py4JJavaError
+    from py4j.java_gateway import JavaObject
+
+    import pyspark.core.context
+    from pyspark.core import RDD, SparkContext
     from pyspark.ml._typing import C, JavaObjectOrPickleDump
 
-# Hack for support float('inf') in Py4j
-_old_smart_decode = py4j.protocol.smart_decode
+
+if not is_remote_only():
+    import py4j
+
+    # Hack for support float('inf') in Py4j
+    _old_smart_decode = py4j.protocol.smart_decode
 
 _float_str_mapping = {
     "nan": "NaN",
@@ -47,7 +51,10 @@ def _new_smart_decode(obj: Any) -> str:
     return _old_smart_decode(obj)
 
 
-py4j.protocol.smart_decode = _new_smart_decode
+if not is_remote_only():
+    import py4j
+
+    py4j.protocol.smart_decode = _new_smart_decode
 
 
 _picklable_classes = [
@@ -59,7 +66,7 @@ _picklable_classes = [
 
 
 # this will call the ML version of pythonToJava()
-def _to_java_object_rdd(rdd: RDD) -> JavaObject:
+def _to_java_object_rdd(rdd: "RDD") -> "JavaObject":
     """Return an JavaRDD of Object by unpickling
 
     It will convert each Python object into Java object by Pickle, whenever the
@@ -70,8 +77,11 @@ def _to_java_object_rdd(rdd: RDD) -> JavaObject:
     return rdd.ctx._jvm.org.apache.spark.ml.python.MLSerDe.pythonToJava(rdd._jrdd, True)
 
 
-def _py2java(sc: SparkContext, obj: Any) -> JavaObject:
+def _py2java(sc: "SparkContext", obj: Any) -> "JavaObject":
     """Convert Python object into Java"""
+    from py4j.java_gateway import JavaObject
+    from pyspark.core import RDD, SparkContext
+
     if isinstance(obj, RDD):
         obj = _to_java_object_rdd(obj)
     elif isinstance(obj, DataFrame):
@@ -91,7 +101,11 @@ def _py2java(sc: SparkContext, obj: Any) -> JavaObject:
     return obj
 
 
-def _java2py(sc: SparkContext, r: "JavaObjectOrPickleDump", encoding: str = "bytes") -> Any:
+def _java2py(sc: "SparkContext", r: "JavaObjectOrPickleDump", encoding: str = "bytes") -> Any:
+    from py4j.protocol import Py4JJavaError
+    from py4j.java_gateway import JavaObject
+    from py4j.java_collections import JavaArray, JavaList
+
     if isinstance(r, JavaObject):
         clsName = r.getClass().getSimpleName()
         # convert RDD into JavaRDD
@@ -122,7 +136,9 @@ def _java2py(sc: SparkContext, r: "JavaObjectOrPickleDump", encoding: str = "byt
 
 
 def callJavaFunc(
-    sc: pyspark.core.context.SparkContext, func: Callable[..., "JavaObjectOrPickleDump"], *args: Any
+    sc: "pyspark.core.context.SparkContext",
+    func: Callable[..., "JavaObjectOrPickleDump"],
+    *args: Any,
 ) -> "JavaObjectOrPickleDump":
     """Call Java Function"""
     java_args = [_py2java(sc, a) for a in args]

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -28,7 +28,7 @@ from typing import (
     TYPE_CHECKING,
 )
 
-from pyspark import keyword_only, since, SparkContext
+from pyspark import keyword_only, since
 from pyspark.ml.linalg import _convert_to_vector, DenseMatrix, DenseVector, Vector
 from pyspark.sql.dataframe import DataFrame
 from pyspark.ml.param.shared import (
@@ -1202,6 +1202,8 @@ class CountVectorizerModel(
         Construct the model directly from a vocabulary list of strings,
         requires an active SparkContext.
         """
+        from pyspark.core import SparkContext
+
         sc = SparkContext._active_spark_context
         assert sc is not None and sc._gateway is not None
         java_class = sc._gateway.jvm.java.lang.String
@@ -4791,6 +4793,8 @@ class StringIndexerModel(
         Construct the model directly from an array of label strings,
         requires an active SparkContext.
         """
+        from pyspark.core import SparkContext
+
         sc = SparkContext._active_spark_context
         assert sc is not None and sc._gateway is not None
         java_class = sc._gateway.jvm.java.lang.String
@@ -4818,6 +4822,8 @@ class StringIndexerModel(
         Construct the model directly from an array of array of label strings,
         requires an active SparkContext.
         """
+        from pyspark.core import SparkContext
+
         sc = SparkContext._active_spark_context
         assert sc is not None and sc._gateway is not None
         java_class = sc._gateway.jvm.java.lang.String

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -1202,7 +1202,7 @@ class CountVectorizerModel(
         Construct the model directly from a vocabulary list of strings,
         requires an active SparkContext.
         """
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         sc = SparkContext._active_spark_context
         assert sc is not None and sc._gateway is not None
@@ -4793,7 +4793,7 @@ class StringIndexerModel(
         Construct the model directly from an array of label strings,
         requires an active SparkContext.
         """
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         sc = SparkContext._active_spark_context
         assert sc is not None and sc._gateway is not None
@@ -4822,7 +4822,7 @@ class StringIndexerModel(
         Construct the model directly from an array of array of label strings,
         requires an active SparkContext.
         """
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         sc = SparkContext._active_spark_context
         assert sc is not None and sc._gateway is not None

--- a/python/pyspark/ml/functions.py
+++ b/python/pyspark/ml/functions.py
@@ -27,7 +27,6 @@ try:
 except ImportError:
     pass  # Let it throw a better error message later when the API is invoked.
 
-from pyspark import SparkContext
 from pyspark.sql.functions import pandas_udf
 from pyspark.sql.column import Column, _to_java_column
 from pyspark.sql.types import (
@@ -116,6 +115,8 @@ def vector_to_array(col: Column, dtype: str = "float64") -> Column:
     [StructField('vec', ArrayType(FloatType(), False), False),
      StructField('oldVec', ArrayType(FloatType(), False), False)]
     """
+    from pyspark.core import SparkContext
+
     sc = SparkContext._active_spark_context
     assert sc is not None and sc._jvm is not None
     return Column(
@@ -157,6 +158,8 @@ def array_to_vector(col: Column) -> Column:
     >>> df3.select(array_to_vector('v1').alias('vec1')).collect()
     [Row(vec1=DenseVector([1.0, 3.0]))]
     """
+    from pyspark.core import SparkContext
+
     sc = SparkContext._active_spark_context
     assert sc is not None and sc._jvm is not None
     return Column(sc._jvm.org.apache.spark.ml.functions.array_to_vector(_to_java_column(col)))

--- a/python/pyspark/ml/functions.py
+++ b/python/pyspark/ml/functions.py
@@ -115,7 +115,7 @@ def vector_to_array(col: Column, dtype: str = "float64") -> Column:
     [StructField('vec', ArrayType(FloatType(), False), False),
      StructField('oldVec', ArrayType(FloatType(), False), False)]
     """
-    from pyspark.core import SparkContext
+    from pyspark.core.context import SparkContext
 
     sc = SparkContext._active_spark_context
     assert sc is not None and sc._jvm is not None
@@ -158,7 +158,7 @@ def array_to_vector(col: Column) -> Column:
     >>> df3.select(array_to_vector('v1').alias('vec1')).collect()
     [Row(vec1=DenseVector([1.0, 3.0]))]
     """
-    from pyspark.core import SparkContext
+    from pyspark.core.context import SparkContext
 
     sc = SparkContext._active_spark_context
     assert sc is not None and sc._jvm is not None

--- a/python/pyspark/ml/image.py
+++ b/python/pyspark/ml/image.py
@@ -62,7 +62,7 @@ class _ImageSchema:
 
         .. versionadded:: 2.3.0
         """
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         if self._imageSchema is None:
             ctx = SparkContext._active_spark_context
@@ -83,7 +83,7 @@ class _ImageSchema:
 
         .. versionadded:: 2.3.0
         """
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         if self._ocvTypes is None:
             ctx = SparkContext._active_spark_context
@@ -104,7 +104,7 @@ class _ImageSchema:
 
         .. versionadded:: 2.4.0
         """
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         if self._columnSchema is None:
             ctx = SparkContext._active_spark_context
@@ -125,7 +125,7 @@ class _ImageSchema:
 
         .. versionadded:: 2.3.0
         """
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         if self._imageFields is None:
             ctx = SparkContext._active_spark_context
@@ -140,7 +140,7 @@ class _ImageSchema:
 
         .. versionadded:: 2.3.0
         """
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         if self._undefinedImageType is None:
             ctx = SparkContext._active_spark_context

--- a/python/pyspark/ml/image.py
+++ b/python/pyspark/ml/image.py
@@ -29,7 +29,6 @@ from typing import Any, Dict, List, NoReturn, Optional, cast
 
 import numpy as np
 
-from pyspark import SparkContext
 from pyspark.sql.types import Row, StructType, _create_row, _parse_datatype_json_string
 from pyspark.sql import SparkSession
 
@@ -63,6 +62,7 @@ class _ImageSchema:
 
         .. versionadded:: 2.3.0
         """
+        from pyspark.core import SparkContext
 
         if self._imageSchema is None:
             ctx = SparkContext._active_spark_context
@@ -83,6 +83,7 @@ class _ImageSchema:
 
         .. versionadded:: 2.3.0
         """
+        from pyspark.core import SparkContext
 
         if self._ocvTypes is None:
             ctx = SparkContext._active_spark_context
@@ -103,6 +104,7 @@ class _ImageSchema:
 
         .. versionadded:: 2.4.0
         """
+        from pyspark.core import SparkContext
 
         if self._columnSchema is None:
             ctx = SparkContext._active_spark_context
@@ -123,6 +125,7 @@ class _ImageSchema:
 
         .. versionadded:: 2.3.0
         """
+        from pyspark.core import SparkContext
 
         if self._imageFields is None:
             ctx = SparkContext._active_spark_context
@@ -137,6 +140,7 @@ class _ImageSchema:
 
         .. versionadded:: 2.3.0
         """
+        from pyspark.core import SparkContext
 
         if self._undefinedImageType is None:
             ctx = SparkContext._active_spark_context

--- a/python/pyspark/ml/pipeline.py
+++ b/python/pyspark/ml/pipeline.py
@@ -18,7 +18,7 @@ import os
 
 from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast, TYPE_CHECKING
 
-from pyspark import keyword_only, since, SparkContext
+from pyspark import keyword_only, since
 from pyspark.ml.base import Estimator, Model, Transformer
 from pyspark.ml.param import Param, Params
 from pyspark.ml.util import (
@@ -40,6 +40,7 @@ from pyspark.sql.dataframe import DataFrame
 if TYPE_CHECKING:
     from pyspark.ml._typing import ParamMap, PipelineStage
     from py4j.java_gateway import JavaObject
+    from pyspark.core import SparkContext
 
 
 @inherit_doc
@@ -200,6 +201,7 @@ class Pipeline(Estimator["PipelineModel"], MLReadable["Pipeline"], MLWritable):
         py4j.java_gateway.JavaObject
             Java object equivalent to this instance.
         """
+        from pyspark.core import SparkContext
 
         gateway = SparkContext._gateway
         assert gateway is not None and SparkContext._jvm is not None
@@ -353,6 +355,7 @@ class PipelineModel(Model, MLReadable["PipelineModel"], MLWritable):
 
         :return: Java object equivalent to this instance.
         """
+        from pyspark.core import SparkContext
 
         gateway = SparkContext._gateway
         assert gateway is not None and SparkContext._jvm is not None
@@ -400,7 +403,7 @@ class PipelineSharedReadWrite:
     def saveImpl(
         instance: Union[Pipeline, PipelineModel],
         stages: List["PipelineStage"],
-        sc: SparkContext,
+        sc: "SparkContext",
         path: str,
     ) -> None:
         """
@@ -419,7 +422,7 @@ class PipelineSharedReadWrite:
 
     @staticmethod
     def load(
-        metadata: Dict[str, Any], sc: SparkContext, path: str
+        metadata: Dict[str, Any], sc: "SparkContext", path: str
     ) -> Tuple[str, List["PipelineStage"]]:
         """
         Load metadata and stages for a :py:class:`Pipeline` or :py:class:`PipelineModel`

--- a/python/pyspark/ml/pipeline.py
+++ b/python/pyspark/ml/pipeline.py
@@ -40,7 +40,7 @@ from pyspark.sql.dataframe import DataFrame
 if TYPE_CHECKING:
     from pyspark.ml._typing import ParamMap, PipelineStage
     from py4j.java_gateway import JavaObject
-    from pyspark.core import SparkContext
+    from pyspark.core.context import SparkContext
 
 
 @inherit_doc
@@ -201,7 +201,7 @@ class Pipeline(Estimator["PipelineModel"], MLReadable["Pipeline"], MLWritable):
         py4j.java_gateway.JavaObject
             Java object equivalent to this instance.
         """
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         gateway = SparkContext._gateway
         assert gateway is not None and SparkContext._jvm is not None
@@ -355,7 +355,7 @@ class PipelineModel(Model, MLReadable["PipelineModel"], MLWritable):
 
         :return: Java object equivalent to this instance.
         """
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         gateway = SparkContext._gateway
         assert gateway is not None and SparkContext._jvm is not None

--- a/python/pyspark/ml/stat.py
+++ b/python/pyspark/ml/stat.py
@@ -18,7 +18,7 @@
 import sys
 from typing import Optional, Tuple, TYPE_CHECKING
 
-from pyspark import since, SparkContext
+from pyspark import since
 from pyspark.ml.common import _java2py, _py2java
 from pyspark.ml.linalg import Matrix, Vector
 from pyspark.ml.wrapper import JavaWrapper, _jvm
@@ -102,6 +102,8 @@ class ChiSquareTest:
         >>> row[0].statistic
         4.0
         """
+        from pyspark.core import SparkContext
+
         sc = SparkContext._active_spark_context
         assert sc is not None
 
@@ -171,6 +173,8 @@ class Correlation:
                      [        NaN,         NaN,  1.        ,         NaN],
                      [ 0.4       ,  0.9486... ,         NaN,  1.        ]])
         """
+        from pyspark.core import SparkContext
+
         sc = SparkContext._active_spark_context
         assert sc is not None
 
@@ -239,6 +243,8 @@ class KolmogorovSmirnovTest:
         >>> round(ksResult.statistic, 3)
         0.175
         """
+        from pyspark.core import SparkContext
+
         sc = SparkContext._active_spark_context
         assert sc is not None
 
@@ -424,6 +430,8 @@ class Summarizer:
         -------
         :py:class:`pyspark.ml.stat.SummaryBuilder`
         """
+        from pyspark.core import SparkContext
+
         sc = SparkContext._active_spark_context
         assert sc is not None
 

--- a/python/pyspark/ml/stat.py
+++ b/python/pyspark/ml/stat.py
@@ -102,7 +102,7 @@ class ChiSquareTest:
         >>> row[0].statistic
         4.0
         """
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         sc = SparkContext._active_spark_context
         assert sc is not None
@@ -173,7 +173,7 @@ class Correlation:
                      [        NaN,         NaN,  1.        ,         NaN],
                      [ 0.4       ,  0.9486... ,         NaN,  1.        ]])
         """
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         sc = SparkContext._active_spark_context
         assert sc is not None
@@ -243,7 +243,7 @@ class KolmogorovSmirnovTest:
         >>> round(ksResult.statistic, 3)
         0.175
         """
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         sc = SparkContext._active_spark_context
         assert sc is not None
@@ -430,7 +430,7 @@ class Summarizer:
         -------
         :py:class:`pyspark.ml.stat.SummaryBuilder`
         """
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         sc = SparkContext._active_spark_context
         assert sc is not None

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -37,7 +37,7 @@ from typing import (
 
 import numpy as np
 
-from pyspark import keyword_only, since, SparkContext, inheritable_thread_target
+from pyspark import keyword_only, since, inheritable_thread_target
 from pyspark.ml import Estimator, Transformer, Model
 from pyspark.ml.common import inherit_doc, _py2java, _java2py
 from pyspark.ml.evaluation import Evaluator, JavaEvaluator
@@ -63,6 +63,7 @@ if TYPE_CHECKING:
     from pyspark.ml._typing import ParamMap
     from py4j.java_gateway import JavaObject
     from py4j.java_collections import JavaArray
+    from pyspark.core import SparkContext
 
 __all__ = [
     "ParamGridBuilder",
@@ -272,6 +273,7 @@ class _ValidatorParams(HasSeed):
         """
         Return Java estimator, estimatorParamMaps, and evaluator from this Python instance.
         """
+        from pyspark.core import SparkContext
 
         gateway = SparkContext._gateway
         assert gateway is not None and SparkContext._jvm is not None
@@ -301,6 +303,8 @@ class _ValidatorSharedReadWrite:
     def meta_estimator_transfer_param_maps_to_java(
         pyEstimator: Estimator, pyParamMaps: Sequence["ParamMap"]
     ) -> "JavaArray":
+        from pyspark.core import SparkContext
+
         pyStages = MetaAlgorithmReadWrite.getAllNestedStages(pyEstimator)
         stagePairs = list(map(lambda stage: (stage, cast(JavaParams, stage)._to_java()), pyStages))
         sc = SparkContext._active_spark_context
@@ -335,6 +339,8 @@ class _ValidatorSharedReadWrite:
     def meta_estimator_transfer_param_maps_from_java(
         pyEstimator: Estimator, javaParamMaps: "JavaArray"
     ) -> List["ParamMap"]:
+        from pyspark.core import SparkContext
+
         pyStages = MetaAlgorithmReadWrite.getAllNestedStages(pyEstimator)
         stagePairs = list(map(lambda stage: (stage, cast(JavaParams, stage)._to_java()), pyStages))
         sc = SparkContext._active_spark_context
@@ -380,7 +386,7 @@ class _ValidatorSharedReadWrite:
     def saveImpl(
         path: str,
         instance: _ValidatorParams,
-        sc: SparkContext,
+        sc: "SparkContext",
         extraMetadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         numParamsNotJson = 0
@@ -424,7 +430,7 @@ class _ValidatorSharedReadWrite:
 
     @staticmethod
     def load(
-        path: str, sc: SparkContext, metadata: Dict[str, Any]
+        path: str, sc: "SparkContext", metadata: Dict[str, Any]
     ) -> Tuple[Dict[str, Any], Estimator, Evaluator, List["ParamMap"]]:
         evaluatorPath = os.path.join(path, "evaluator")
         evaluator: Evaluator = DefaultParamsReader.loadParamsInstance(evaluatorPath, sc)
@@ -1089,6 +1095,8 @@ class CrossValidatorModel(
         Given a Java CrossValidatorModel, create and return a Python wrapper of it.
         Used for ML persistence.
         """
+        from pyspark.core import SparkContext
+
         sc = SparkContext._active_spark_context
         assert sc is not None
 
@@ -1126,6 +1134,7 @@ class CrossValidatorModel(
         py4j.java_gateway.JavaObject
             Java object equivalent to this instance.
         """
+        from pyspark.core import SparkContext
 
         sc = SparkContext._active_spark_context
         assert sc is not None
@@ -1648,6 +1657,7 @@ class TrainValidationSplitModel(
         Given a Java TrainValidationSplitModel, create and return a Python wrapper of it.
         Used for ML persistence.
         """
+        from pyspark.core import SparkContext
 
         # Load information from java_stage to the instance.
         sc = SparkContext._active_spark_context
@@ -1687,6 +1697,7 @@ class TrainValidationSplitModel(
         py4j.java_gateway.JavaObject
             Java object equivalent to this instance.
         """
+        from pyspark.core import SparkContext
 
         sc = SparkContext._active_spark_context
         assert sc is not None

--- a/python/pyspark/ml/tuning.py
+++ b/python/pyspark/ml/tuning.py
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
     from pyspark.ml._typing import ParamMap
     from py4j.java_gateway import JavaObject
     from py4j.java_collections import JavaArray
-    from pyspark.core import SparkContext
+    from pyspark.core.context import SparkContext
 
 __all__ = [
     "ParamGridBuilder",
@@ -273,7 +273,7 @@ class _ValidatorParams(HasSeed):
         """
         Return Java estimator, estimatorParamMaps, and evaluator from this Python instance.
         """
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         gateway = SparkContext._gateway
         assert gateway is not None and SparkContext._jvm is not None
@@ -303,7 +303,7 @@ class _ValidatorSharedReadWrite:
     def meta_estimator_transfer_param_maps_to_java(
         pyEstimator: Estimator, pyParamMaps: Sequence["ParamMap"]
     ) -> "JavaArray":
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         pyStages = MetaAlgorithmReadWrite.getAllNestedStages(pyEstimator)
         stagePairs = list(map(lambda stage: (stage, cast(JavaParams, stage)._to_java()), pyStages))
@@ -339,7 +339,7 @@ class _ValidatorSharedReadWrite:
     def meta_estimator_transfer_param_maps_from_java(
         pyEstimator: Estimator, javaParamMaps: "JavaArray"
     ) -> List["ParamMap"]:
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         pyStages = MetaAlgorithmReadWrite.getAllNestedStages(pyEstimator)
         stagePairs = list(map(lambda stage: (stage, cast(JavaParams, stage)._to_java()), pyStages))
@@ -1095,7 +1095,7 @@ class CrossValidatorModel(
         Given a Java CrossValidatorModel, create and return a Python wrapper of it.
         Used for ML persistence.
         """
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         sc = SparkContext._active_spark_context
         assert sc is not None
@@ -1134,7 +1134,7 @@ class CrossValidatorModel(
         py4j.java_gateway.JavaObject
             Java object equivalent to this instance.
         """
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         sc = SparkContext._active_spark_context
         assert sc is not None
@@ -1657,7 +1657,7 @@ class TrainValidationSplitModel(
         Given a Java TrainValidationSplitModel, create and return a Python wrapper of it.
         Used for ML persistence.
         """
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         # Load information from java_stage to the instance.
         sc = SparkContext._active_spark_context
@@ -1697,7 +1697,7 @@ class TrainValidationSplitModel(
         py4j.java_gateway.JavaObject
             Java object equivalent to this instance.
         """
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         sc = SparkContext._active_spark_context
         assert sc is not None

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
     from pyspark.ml._typing import PipelineStage
     from pyspark.ml.base import Params
     from pyspark.ml.wrapper import JavaWrapper
-    from pyspark.core import SparkContext
+    from pyspark.core.context import SparkContext
 
 T = TypeVar("T")
 RW = TypeVar("RW", bound="BaseReadWrite")
@@ -62,7 +62,7 @@ def _jvm() -> "JavaGateway":
     Returns the JVM view associated with SparkContext. Must be called
     after SparkContext is initialized.
     """
-    from pyspark.core import SparkContext
+    from pyspark.core.context import SparkContext
 
     jvm = SparkContext._jvm
     if jvm:

--- a/python/pyspark/ml/util.py
+++ b/python/pyspark/ml/util.py
@@ -34,7 +34,7 @@ from typing import (
     TYPE_CHECKING,
 )
 
-from pyspark import SparkContext, since
+from pyspark import since
 from pyspark.ml.common import inherit_doc
 from pyspark.sql import SparkSession
 from pyspark.sql.utils import is_remote
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     from pyspark.ml._typing import PipelineStage
     from pyspark.ml.base import Params
     from pyspark.ml.wrapper import JavaWrapper
+    from pyspark.core import SparkContext
 
 T = TypeVar("T")
 RW = TypeVar("RW", bound="BaseReadWrite")
@@ -61,6 +62,8 @@ def _jvm() -> "JavaGateway":
     Returns the JVM view associated with SparkContext. Must be called
     after SparkContext is initialized.
     """
+    from pyspark.core import SparkContext
+
     jvm = SparkContext._jvm
     if jvm:
         return jvm
@@ -119,7 +122,7 @@ class BaseReadWrite:
         return self._sparkSession
 
     @property
-    def sc(self) -> SparkContext:
+    def sc(self) -> "SparkContext":
         """
         Returns the underlying `SparkContext`.
         """
@@ -435,7 +438,7 @@ class DefaultParamsWriter(MLWriter):
     def saveMetadata(
         instance: "Params",
         path: str,
-        sc: SparkContext,
+        sc: "SparkContext",
         extraMetadata: Optional[Dict[str, Any]] = None,
         paramMap: Optional[Dict[str, Any]] = None,
     ) -> None:
@@ -466,7 +469,7 @@ class DefaultParamsWriter(MLWriter):
     @staticmethod
     def _get_metadata_to_save(
         instance: "Params",
-        sc: SparkContext,
+        sc: "SparkContext",
         extraMetadata: Optional[Dict[str, Any]] = None,
         paramMap: Optional[Dict[str, Any]] = None,
     ) -> str:
@@ -562,7 +565,7 @@ class DefaultParamsReader(MLReader[RL]):
         return instance
 
     @staticmethod
-    def loadMetadata(path: str, sc: SparkContext, expectedClassName: str = "") -> Dict[str, Any]:
+    def loadMetadata(path: str, sc: "SparkContext", expectedClassName: str = "") -> Dict[str, Any]:
         """
         Load metadata saved using :py:meth:`DefaultParamsWriter.saveMetadata`
 
@@ -634,7 +637,7 @@ class DefaultParamsReader(MLReader[RL]):
         return metadata["class"].startswith("pyspark.ml.")
 
     @staticmethod
-    def loadParamsInstance(path: str, sc: SparkContext) -> RL:
+    def loadParamsInstance(path: str, sc: "SparkContext") -> RL:
         """
         Load a :py:class:`Params` instance from the given path, and return it.
         This assumes the instance inherits from :py:class:`MLReadable`.

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -48,7 +48,7 @@ class JavaWrapper:
         self._java_obj = java_obj
 
     def __del__(self) -> None:
-        from pyspark.core import SparkContext
+        from pyspark.core.context import SparkContext
 
         if SparkContext._active_spark_context and self._java_obj is not None:
             SparkContext._active_spark_context._gateway.detach(  # type: ignore[union-attr]

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -64,7 +64,7 @@ class JavaWrapper:
         return cls(java_obj)
 
     def _call_java(self, name: str, *args: Any) -> Any:
-        from pyspark import SparkContext
+        from pyspark.core.context import SparkContext
 
         m = getattr(self._java_obj, name)
         sc = SparkContext._active_spark_context
@@ -78,7 +78,7 @@ class JavaWrapper:
         """
         Returns a new Java object.
         """
-        from pyspark import SparkContext
+        from pyspark.core.context import SparkContext
 
         sc = SparkContext._active_spark_context
         assert sc is not None
@@ -119,7 +119,7 @@ class JavaWrapper:
         :py:class:`py4j.java_collections.JavaArray`
           Java Array of converted pylist.
         """
-        from pyspark import SparkContext
+        from pyspark.core.context import SparkContext
 
         sc = SparkContext._active_spark_context
         assert sc is not None
@@ -157,7 +157,7 @@ class JavaParams(JavaWrapper, Params, metaclass=ABCMeta):
         """
         Makes a Java param pair.
         """
-        from pyspark import SparkContext
+        from pyspark.core.context import SparkContext
 
         sc = SparkContext._active_spark_context
         assert sc is not None and self._java_obj is not None
@@ -171,7 +171,7 @@ class JavaParams(JavaWrapper, Params, metaclass=ABCMeta):
         """
         Transforms the embedded params to the companion Java object.
         """
-        from pyspark import SparkContext
+        from pyspark.core.context import SparkContext
 
         assert self._java_obj is not None
 
@@ -222,7 +222,7 @@ class JavaParams(JavaWrapper, Params, metaclass=ABCMeta):
         """
         Transforms the embedded params from the companion Java object.
         """
-        from pyspark import SparkContext
+        from pyspark.core.context import SparkContext
 
         sc = SparkContext._active_spark_context
         assert sc is not None and self._java_obj is not None
@@ -247,7 +247,7 @@ class JavaParams(JavaWrapper, Params, metaclass=ABCMeta):
         """
         Transforms a Java ParamMap into a Python ParamMap.
         """
-        from pyspark import SparkContext
+        from pyspark.core.context import SparkContext
 
         sc = SparkContext._active_spark_context
         assert sc is not None

--- a/python/pyspark/ml/wrapper.py
+++ b/python/pyspark/ml/wrapper.py
@@ -19,7 +19,6 @@ from abc import ABCMeta, abstractmethod
 from typing import Any, Generic, Optional, List, Type, TypeVar, TYPE_CHECKING
 
 from pyspark import since
-from pyspark import SparkContext
 from pyspark.sql import DataFrame
 from pyspark.ml import Estimator, Predictor, PredictionModel, Transformer, Model
 from pyspark.ml.base import _PredictorParams
@@ -49,6 +48,8 @@ class JavaWrapper:
         self._java_obj = java_obj
 
     def __del__(self) -> None:
+        from pyspark.core import SparkContext
+
         if SparkContext._active_spark_context and self._java_obj is not None:
             SparkContext._active_spark_context._gateway.detach(  # type: ignore[union-attr]
                 self._java_obj
@@ -63,6 +64,8 @@ class JavaWrapper:
         return cls(java_obj)
 
     def _call_java(self, name: str, *args: Any) -> Any:
+        from pyspark import SparkContext
+
         m = getattr(self._java_obj, name)
         sc = SparkContext._active_spark_context
         assert sc is not None
@@ -75,6 +78,8 @@ class JavaWrapper:
         """
         Returns a new Java object.
         """
+        from pyspark import SparkContext
+
         sc = SparkContext._active_spark_context
         assert sc is not None
 
@@ -114,6 +119,8 @@ class JavaWrapper:
         :py:class:`py4j.java_collections.JavaArray`
           Java Array of converted pylist.
         """
+        from pyspark import SparkContext
+
         sc = SparkContext._active_spark_context
         assert sc is not None
         assert sc._gateway is not None
@@ -150,6 +157,8 @@ class JavaParams(JavaWrapper, Params, metaclass=ABCMeta):
         """
         Makes a Java param pair.
         """
+        from pyspark import SparkContext
+
         sc = SparkContext._active_spark_context
         assert sc is not None and self._java_obj is not None
 
@@ -162,6 +171,8 @@ class JavaParams(JavaWrapper, Params, metaclass=ABCMeta):
         """
         Transforms the embedded params to the companion Java object.
         """
+        from pyspark import SparkContext
+
         assert self._java_obj is not None
 
         pair_defaults = []
@@ -211,6 +222,8 @@ class JavaParams(JavaWrapper, Params, metaclass=ABCMeta):
         """
         Transforms the embedded params from the companion Java object.
         """
+        from pyspark import SparkContext
+
         sc = SparkContext._active_spark_context
         assert sc is not None and self._java_obj is not None
 
@@ -234,6 +247,8 @@ class JavaParams(JavaWrapper, Params, metaclass=ABCMeta):
         """
         Transforms a Java ParamMap into a Python ParamMap.
         """
+        from pyspark import SparkContext
+
         sc = SparkContext._active_spark_context
         assert sc is not None
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to make `pyspark.ml` compatible with `pyspark-connect`.

### Why are the changes needed?

In order for `pyspark-connect` to work without classic PySpark packages and dependencies.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Yes, at https://github.com/apache/spark/pull/45941. Once CI is setup there, it will be tested there properly.

### Was this patch authored or co-authored using generative AI tooling?

No.