### PR TITLE
[SPARK-47808][PYTHON][ML][TESTS] Make pyspark.ml.connect tests running without optional dependencies

### DIFF
--- a/python/pyspark/ml/connect/classification.py
+++ b/python/pyspark/ml/connect/classification.py
@@ -321,6 +321,8 @@ class LogisticRegressionModel(
     def _get_transform_fn(self) -> Callable[["pd.Series"], Any]:
         import torch
 
+        import torch.nn as torch_nn
+
         model_state_dict = self.torch_model.state_dict()
         num_features = self.num_features
         num_classes = self.num_classes
@@ -363,6 +365,7 @@ class LogisticRegressionModel(
 
     def _save_core_model(self, path: str) -> None:
         import torch
+        import torch.nn as torch_nn
 
         lor_torch_model = torch_nn.Sequential(
             self.torch_model,

--- a/python/pyspark/ml/connect/classification.py
+++ b/python/pyspark/ml/connect/classification.py
@@ -17,8 +17,6 @@
 from typing import Any, Dict, Union, List, Tuple, Callable, Optional
 import math
 
-import torch
-import torch.nn as torch_nn
 import numpy as np
 import pandas as pd
 
@@ -87,6 +85,8 @@ def _train_logistic_regression_model_worker_fn(
     seed: int,
 ) -> Any:
     from pyspark.ml.torch.distributor import _get_spark_partition_data_loader
+    import torch
+    import torch.nn as torch_nn
     from torch.nn.parallel import DistributedDataParallel as DDP
     import torch.distributed
     import torch.optim as optim
@@ -216,6 +216,9 @@ class LogisticRegression(
         self._set(**kwargs)
 
     def _fit(self, dataset: Union[DataFrame, pd.DataFrame]) -> "LogisticRegressionModel":
+        import torch
+        import torch.nn as torch_nn
+
         if isinstance(dataset, pd.DataFrame):
             # TODO: support pandas dataframe fitting
             raise NotImplementedError("Fitting pandas dataframe is not supported yet.")
@@ -316,6 +319,8 @@ class LogisticRegressionModel(
         return output_cols
 
     def _get_transform_fn(self) -> Callable[["pd.Series"], Any]:
+        import torch
+
         model_state_dict = self.torch_model.state_dict()
         num_features = self.num_features
         num_classes = self.num_classes
@@ -357,6 +362,8 @@ class LogisticRegressionModel(
         return self.__class__.__name__ + ".torch"
 
     def _save_core_model(self, path: str) -> None:
+        import torch
+
         lor_torch_model = torch_nn.Sequential(
             self.torch_model,
             torch_nn.Softmax(dim=1),

--- a/python/pyspark/ml/connect/classification.py
+++ b/python/pyspark/ml/connect/classification.py
@@ -374,6 +374,8 @@ class LogisticRegressionModel(
         torch.save(lor_torch_model, path)
 
     def _load_core_model(self, path: str) -> None:
+        import torch
+
         lor_torch_model = torch.load(path)
         self.torch_model = lor_torch_model[0]
 

--- a/python/pyspark/ml/tests/connect/test_connect_classification.py
+++ b/python/pyspark/ml/tests/connect/test_connect_classification.py
@@ -21,6 +21,7 @@ import unittest
 from pyspark.sql import SparkSession
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 
+torch_requirement_message = "torch is required"
 have_torch = True
 try:
     import torch  # noqa: F401
@@ -32,7 +33,8 @@ if should_test_connect:
 
 
 @unittest.skipIf(
-    not should_test_connect or not have_torch, connect_requirement_message or "torch is required"
+    not should_test_connect or not have_torch,
+    connect_requirement_message or torch_requirement_message,
 )
 class ClassificationTestsOnConnect(ClassificationTestsMixin, unittest.TestCase):
     def setUp(self) -> None:

--- a/python/pyspark/ml/tests/connect/test_connect_feature.py
+++ b/python/pyspark/ml/tests/connect/test_connect_feature.py
@@ -20,11 +20,22 @@ import unittest
 from pyspark.sql import SparkSession
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 
+have_sklearn = True
+sklearn_requirement_message = None
+try:
+    from sklearn.datasets import load_breast_cancer  # noqa: F401
+except ImportError:
+    have_sklearn = False
+    sklearn_requirement_message = "No sklearn found"
+
 if should_test_connect:
     from pyspark.ml.tests.connect.test_legacy_mode_feature import FeatureTestsMixin
 
 
-@unittest.skipIf(not should_test_connect, connect_requirement_message)
+@unittest.skipIf(
+    not should_test_connect or not have_sklearn,
+    connect_requirement_message or sklearn_requirement_message,
+)
 class FeatureTestsOnConnect(FeatureTestsMixin, unittest.TestCase):
     def setUp(self) -> None:
         self.spark = SparkSession.builder.remote("local[2]").getOrCreate()

--- a/python/pyspark/ml/tests/connect/test_connect_pipeline.py
+++ b/python/pyspark/ml/tests/connect/test_connect_pipeline.py
@@ -18,7 +18,6 @@
 
 import unittest
 
-from pyspark.util import is_remote_only
 from pyspark.sql import SparkSession
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 

--- a/python/pyspark/ml/tests/connect/test_connect_pipeline.py
+++ b/python/pyspark/ml/tests/connect/test_connect_pipeline.py
@@ -18,14 +18,26 @@
 
 import unittest
 
+from pyspark.util import is_remote_only
 from pyspark.sql import SparkSession
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 
 if should_test_connect:
     from pyspark.ml.tests.connect.test_legacy_mode_pipeline import PipelineTestsMixin
 
+torch_requirement_message = None
+have_torch = True
+try:
+    import torch  # noqa: F401
+except ImportError:
+    have_torch = False
+    torch_requirement_message = "torch is required"
 
-@unittest.skipIf(not should_test_connect, connect_requirement_message)
+
+@unittest.skipIf(
+    not should_test_connect or not have_torch,
+    connect_requirement_message or torch_requirement_message,
+)
 class PipelineTestsOnConnect(PipelineTestsMixin, unittest.TestCase):
     def setUp(self) -> None:
         self.spark = (


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes `pyspark.ml.connect` tests running without optional dependencies.

### Why are the changes needed?

Optional dependencies should not stop the tests.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Will be tested together in https://github.com/apache/spark/pull/45941

### Was this patch authored or co-authored using generative AI tooling?

No.