### PR TITLE
[SPARK-47810][SQL] Replace equivalent expression to <=> in join condition

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeJoinCondition.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeJoinCondition.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.expressions.{And, EqualNullSafe, EqualTo, IsNull, Or, PredicateHelper}
+import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.JOIN
+
+/**
+ * Replaces `t1.id is null and t2.id is null or t1.id = t2.id` to `t1.id <=> t2.id`
+ * in join condition for better performance.
+ */
+object OptimizeJoinCondition extends Rule[LogicalPlan] with PredicateHelper {
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.transformWithPruning(
+    _.containsPattern(JOIN), ruleId) {
+    case join @ Join(left, right, joinType, condition, hint) if condition.nonEmpty =>
+      val predicates = condition.map(splitConjunctivePredicates).get
+      var replace = false
+      val newPredicates = predicates.map {
+        case Or(EqualTo(l, r), And(IsNull(c1), IsNull(c2)))
+          if (l.semanticEquals(c1) && r.semanticEquals(c2))
+            || (l.semanticEquals(c2) && r.semanticEquals(c1)) =>
+          replace = true
+          EqualNullSafe(l, r)
+        case Or(And(IsNull(c1), IsNull(c2)), EqualTo(l, r))
+          if (l.semanticEquals(c1) && r.semanticEquals(c2))
+            || (l.semanticEquals(c2) && r.semanticEquals(c1)) =>
+          replace = true
+          EqualNullSafe(l, r)
+        case e => e
+      }
+      if (replace) {
+        val newCondition = Option(newPredicates.reduce(And))
+        Join(left, right, joinType, newCondition, hint)
+      } else {
+        join
+      }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -84,6 +84,7 @@ abstract class Optimizer(catalogManager: CatalogManager)
         PushDownPredicates,
         PushDownLeftSemiAntiJoin,
         PushLeftSemiLeftAntiThroughJoin,
+        OptimizeJoinCondition,
         LimitPushDown,
         LimitPushDownThroughWindow,
         ColumnPruning,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/rules/RuleIdCollection.scala
@@ -135,6 +135,7 @@ object RuleIdCollection {
       "org.apache.spark.sql.catalyst.optimizer.ObjectSerializerPruning" ::
       "org.apache.spark.sql.catalyst.optimizer.OptimizeCsvJsonExprs" ::
       "org.apache.spark.sql.catalyst.optimizer.OptimizeIn" ::
+      "org.apache.spark.sql.catalyst.optimizer.OptimizeJoinCondition" ::
       "org.apache.spark.sql.catalyst.optimizer.OptimizeRand" ::
       "org.apache.spark.sql.catalyst.optimizer.OptimizeOneRowPlan" ::
       "org.apache.spark.sql.catalyst.optimizer.Optimizer$OptimizeSubqueries" ::

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeJoinConditionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeJoinConditionSuite.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.dsl.plans._
+import org.apache.spark.sql.catalyst.plans._
+import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.rules._
+
+class OptimizeJoinConditionSuite extends PlanTest {
+
+  private object Optimize extends RuleExecutor[LogicalPlan] {
+    val batches =
+      Batch("Optimize join condition", FixedPoint(1),
+        OptimizeJoinCondition) :: Nil
+  }
+
+  val testRelation = LocalRelation($"a".int, $"b".int)
+  val testRelation1 = LocalRelation($"c".int, $"d".int)
+
+  test("Replace equivalent expression to <=> in join condition") {
+    val x = testRelation.subquery("x")
+    val y = testRelation1.subquery("y")
+    val joinTypes = Seq(Inner, FullOuter, LeftOuter, RightOuter, LeftSemi, LeftSemi, Cross)
+    joinTypes.foreach(joinType => {
+      val originalQuery =
+        x.join(y, joinType, Option($"a" === $"c" || ($"a".isNull && $"c".isNull)))
+      val correctAnswer =
+        x.join(y, joinType, Option($"a" <=> $"c"))
+      comparePlans(Optimize.execute(originalQuery.analyze), correctAnswer.analyze)
+    })
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameJoinSuite.scala
@@ -621,4 +621,14 @@ class DataFrameJoinSuite extends QueryTest
     checkAnswer(joined, Row("x", null, null))
     checkAnswer(joined.filter($"new".isNull), Row("x", null, null))
   }
+
+  test("SPARK-47810: replace equivalent expression to <=> in join condition") {
+    val joinTypes = Seq("inner", "outer", "left", "right", "semi", "anti", "cross")
+    joinTypes.foreach(joinType => {
+      val df1 = testData3.as("x").join(testData3.as("y"),
+        ($"x.a" <=> $"y.b").or($"x.a".isNull.and($"y.b".isNull)), joinType)
+      val df2 = testData3.as("x").join(testData3.as("y"), $"x.a" <=> $"y.b", joinType)
+      checkAnswer(df1, df2)
+    })
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Replaces `t1.id = t2.id or (t1.id is null and t2.id is null)` to `t1.id <=> t2.id` in join condition.


### Why are the changes needed?
Improve performance.
`t1.id = t2.id or (t1.id is null and t2.id is null)` and `t1.id <=> t2.id` are equivalent in join condition, but the plan will be different and the performance during execution will be completely different. Id is join key in `t1.id <=> t2.id`, in `t1.id = t2.id or (t1.id is null and t2.id is null)` id cannot be used as join key, this will affect join selection and subsequent matching logic.
For example:
```
sql(
      """
        |CREATE OR REPLACE TEMPORARY VIEW t1 AS SELECT * FROM VALUES
        |(1, 1),
        |(null, 2)
        |AS t1(a, b);
        |""".stripMargin)
    sql(
      """
        |CREATE OR REPLACE TEMPORARY VIEW t2 AS SELECT * FROM VALUES
        |(1, 10),
        |(null, 20)
        |AS t2(a, b);
        |""".stripMargin)
    sql("select t1.a,t2.b from t1 left join t2 on t1.a=t2.a or (t1.a is null and t2.a is null)")
```
before PR is `BroadcastNestedLoopJoin`:
```
== Optimized Logical Plan ==
Project [a#6, b#11]
+- Join LeftOuter, ((a#6 = a#10) OR (isnull(a#6) AND isnull(a#10)))
   :- Project [a#6]
   :  +- LocalRelation [a#6, b#7]
   +- LocalRelation [a#10, b#11]
== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- Project [a#6, b#11]
   +- BroadcastNestedLoopJoin BuildRight, LeftOuter, ((a#6 = a#10) OR (isnull(a#6) AND isnull(a#10)))
      :- Project [a#6]
      :  +- LocalTableScan [a#6, b#7]
      +- BroadcastExchange IdentityBroadcastMode, [plan_id=26]
         +- LocalTableScan [a#10, b#11]
```
after PR is BroadcastHashJoin:
```
== Optimized Logical Plan ==
Project [a#6, b#11]
+- Join LeftOuter, (a#6 <=> a#10)
   :- Project [a#6]
   :  +- LocalRelation [a#6, b#7]
   +- LocalRelation [a#10, b#11]

== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- Project [a#6, b#11]
   +- BroadcastHashJoin [coalesce(a#6, 0), isnull(a#6)], [coalesce(a#10, 0), isnull(a#10)], LeftOuter, BuildRight, false
      :- Project [a#6]
      :  +- LocalTableScan [a#6, b#7]
      +- BroadcastExchange HashedRelationBroadcastMode(List(coalesce(input[0, int, true], 0), isnull(input[0, int, true])),false), [plan_id=26]
         +- LocalTableScan [a#10, b#11]
```

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Unit test.


### Was this patch authored or co-authored using generative AI tooling?
No.
