### PR TITLE
[SPARK-47815][CONNECT] Unify the user agent with json

### DIFF
--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
@@ -27,6 +27,8 @@ import scala.util.Properties
 
 import com.google.protobuf.ByteString
 import io.grpc._
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods._
 
 import org.apache.spark.SparkBuildInfo.{spark_version => SPARK_VERSION}
 import org.apache.spark.connect.proto
@@ -669,12 +671,14 @@ object SparkConnectClient {
       else if (os.contains("win")) "windows"
       else "unknown"
     }
-    List(
-      value,
-      s"spark/$SPARK_VERSION",
-      s"scala/$scalaVersion",
-      s"jvm/$jvmVersion",
-      s"os/$osName").mkString(" ")
+
+    compact(
+      render(
+        ("agent" -> value) ~
+          ("spark" -> SPARK_VERSION) ~
+          ("os" -> osName) ~
+          ("scala" -> scalaVersion) ~
+          ("jvm" -> jvmVersion)))
   }
 
   /**

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -30,6 +30,7 @@ import platform
 import urllib.parse
 import uuid
 import sys
+import json
 from typing import (
     Iterable,
     Iterator,
@@ -263,13 +264,15 @@ class ChannelBuilder:
             raise SparkConnectException(
                 f"'user_agent' parameter should not exceed 2048 characters, found {len} characters."
             )
-        return " ".join(
-            [
-                user_agent,
-                f"spark/{__version__}",
-                f"os/{platform.uname().system.lower()}",
-                f"python/{platform.python_version()}",
-            ]
+
+        return json.dumps(
+            obj={
+                "agent": user_agent,
+                "spark": __version__,
+                "os": platform.uname().system.lower(),
+                "python": platform.python_version(),
+            },
+            separators=(",", ":"),
         )
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Unify the user agent with json


### Why are the changes needed?
to make them more easier to analyze:

before:
```
_SPARK_CONNECT_PYTHON spark/4.0.0.dev0 os/linux python/3.11.0rc1
_SPARK_CONNECT_SCALA spark/4.0.0-SNAPSHOT scala/2.13.12 jvm/17.0.8.1 os/darwin
```

after:
```
{"agent":"_SPARK_CONNECT_PYTHON","spark":"4.0.0-SNAPSHOT","os":"darwin","python":"3.12.2"}
{"agent":"_SPARK_CONNECT_SCALA","spark":"4.0.0-SNAPSHOT","os":"darwin","scala":"2.13.13","jvm":"17.0.10"}
```


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no