### PR TITLE
[SPARK-47816][CONNECT][DOCS] Document the lazy evaluation of views in `spark.{sql, table}`

### DIFF
--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1633,8 +1633,9 @@ class SparkSession(SparkConversionMixin):
         Notes
         -----
         In Classic Spark, a referenced temporary view is resolved immediately, while in Spark
-        Connect it is lazy evaluated. So if a view is dropped, modified or replaced after
-        `spark.sql`, the execution may fail or generate incorrect results.
+        Connect it is lazy evaluated.
+        So in Spark Connect if a view is dropped, modified or replaced after `spark.sql`, the
+        execution may fail or generate different results.
 
         Examples
         --------
@@ -1765,8 +1766,9 @@ class SparkSession(SparkConversionMixin):
         Notes
         -----
         In Classic Spark, a referenced temporary view is resolved immediately, while in Spark
-        Connect it is lazy evaluated. So if a view is dropped, modified or replaced after
-        `spark.table`, the execution may fail or generate incorrect results.
+        Connect it is lazy evaluated.
+        So in Spark Connect if a view is dropped, modified or replaced after `spark.table`, the
+        execution may fail or generate different results.
 
         Examples
         --------

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1630,6 +1630,12 @@ class SparkSession(SparkConversionMixin):
         -------
         :class:`DataFrame`
 
+        Notes
+        -----
+        In Classic Spark, a referenced temporary view is resolved immediately, while in Spark
+        Connect it is lazy evaluated. So if a view is dropped, modified or replaced after
+        `spark.sql`, the execution may fail or generate incorrect results.
+
         Examples
         --------
         Executing a SQL query.
@@ -1755,6 +1761,12 @@ class SparkSession(SparkConversionMixin):
         Returns
         -------
         :class:`DataFrame`
+
+        Notes
+        -----
+        In Classic Spark, a referenced temporary view is resolved immediately, while in Spark
+        Connect it is lazy evaluated. So if a view is dropped, modified or replaced after
+        `spark.table`, the execution may fail or generate incorrect results.
 
         Examples
         --------

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1632,8 +1632,8 @@ class SparkSession(SparkConversionMixin):
 
         Notes
         -----
-        In Classic Spark, a temporary view referenced in `spark.sql` is resolved immediately,
-        while in Spark Connect it is lazy evaluated.
+        In Spark Classic, a temporary view referenced in `spark.sql` is resolved immediately,
+        while in Spark Connect it is lazily evaluated.
         So in Spark Connect if a view is dropped, modified or replaced after `spark.sql`, the
         execution may fail or generate different results.
 
@@ -1765,8 +1765,8 @@ class SparkSession(SparkConversionMixin):
 
         Notes
         -----
-        In Classic Spark, a temporary view referenced in `spark.table` is resolved immediately,
-        while in Spark Connect it is lazy evaluated.
+        In Spark Classic, a temporary view referenced in `spark.table` is resolved immediately,
+        while in Spark Connect it is lazily evaluated.
         So in Spark Connect if a view is dropped, modified or replaced after `spark.table`, the
         execution may fail or generate different results.
 

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1632,8 +1632,8 @@ class SparkSession(SparkConversionMixin):
 
         Notes
         -----
-        In Classic Spark, a referenced temporary view is resolved immediately, while in Spark
-        Connect it is lazy evaluated.
+        In Classic Spark, a temporary view referenced in `spark.sql` is resolved immediately,
+        while in Spark Connect it is lazy evaluated.
         So in Spark Connect if a view is dropped, modified or replaced after `spark.sql`, the
         execution may fail or generate different results.
 
@@ -1765,8 +1765,8 @@ class SparkSession(SparkConversionMixin):
 
         Notes
         -----
-        In Classic Spark, a referenced temporary view is resolved immediately, while in Spark
-        Connect it is lazy evaluated.
+        In Classic Spark, a temporary view referenced in `spark.table` is resolved immediately,
+        while in Spark Connect it is lazy evaluated.
         So in Spark Connect if a view is dropped, modified or replaced after `spark.table`, the
         execution may fail or generate different results.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Document the lazy evaluation of views in `spark.{sql, table}`


### Why are the changes needed?
it is by design in Spark Connect, so we need to document it


### Does this PR introduce _any_ user-facing change?
doc change

### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no
