### PR TITLE
[SPARK-47820][INFRA] Run `ANSI` SQL CI twice per day

### DIFF
--- a/.github/workflows/build_ansi.yml
+++ b/.github/workflows/build_ansi.yml
@@ -21,7 +21,7 @@ name: "Build / ANSI (master, Hadoop 3, JDK 17, Scala 2.13)"
 
 on:
   schedule:
-    - cron: '0 1 * * *'
+    - cron: '0 1,13 * * *'
 
 jobs:
   run-build:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to run `ANSI` SQL CI twice per day for Apache Spark 4.0.0.
- https://github.com/apache/spark/actions/workflows/build_ansi.yml

### Why are the changes needed?

To detect ANSI failure more easily.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Since this is a daily CI, this should be tested after merging.

### Was this patch authored or co-authored using generative AI tooling?

No.