### PR TITLE
[SPARK-44444][SQL] Use ANSI SQL mode by default

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -24,6 +24,7 @@ license: |
 
 ## Upgrading from Spark SQL 3.5 to 4.0
 
+- Since Spark 4.0, `spark.sql.ansi.enabled` is on by default. To restore the previous behavior, set `spark.sql.ansi.enabled` to `false` or `SPARK_ANSI_SQL_MODE` to `false`.
 - Since Spark 4.0, the default behaviour when inserting elements in a map is changed to first normalize keys -0.0 to 0.0. The affected SQL functions are `create_map`, `map_from_arrays`, `map_from_entries`, and `map_concat`. To restore the previous behaviour, set `spark.sql.legacy.disableMapKeyNormalization` to `true`.
 - Since Spark 4.0, the default value of `spark.sql.maxSinglePartitionBytes` is changed from `Long.MaxValue` to `128m`. To restore the previous behavior, set `spark.sql.maxSinglePartitionBytes` to `9223372036854775807`(`Long.MaxValue`).
 - Since Spark 4.0, any read of SQL tables takes into consideration the SQL configs `spark.sql.files.ignoreCorruptFiles`/`spark.sql.files.ignoreMissingFiles` instead of the core config `spark.files.ignoreCorruptFiles`/`spark.files.ignoreMissingFiles`.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3351,7 +3351,7 @@ object SQLConf {
       "standard directly, but their behaviors align with ANSI SQL's style")
     .version("3.0.0")
     .booleanConf
-    .createWithDefault(sys.env.get("SPARK_ANSI_SQL_MODE").contains("true"))
+    .createWithDefault(!sys.env.get("SPARK_ANSI_SQL_MODE").contains("false"))
 
   val ENFORCE_RESERVED_KEYWORDS = buildConf("spark.sql.ansi.enforceReservedKeywords")
     .doc(s"When true and '${ANSI_ENABLED.key}' is true, the Spark SQL parser enforces the ANSI " +


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable `spark.sql.ansi.enabled` by default for Apache Spark 4.0.0.

### Why are the changes needed?

- `spark.sql.ansi.enabled` is added at Apache Spark 3.0.0 and has been serving well to provide a way of ANSI SQL Standard. To improve Apache Spark SQL compatibility in an official way, we had better enable it by default from Apache Spark 4.0.0 while keeping the legacy way actively at the same time.
- Apache Spark 4.0.0 is a new major version change to fit the above goal. After 4.0.0 release, it's difficult for Apache Spark community to make this kind of move in the feature releases for next 4 years.

Note that the following `Spark Connector` issues should be addressed before Apache Spark 4.0.0.
- SPARK-41794 Reenable ANSI mode in pyspark.sql.tests.connect.test_connect_column
- SPARK-41547 Reenable ANSI mode in pyspark.sql.tests.connect.test_connect_functions

### Does this PR introduce _any_ user-facing change?

Yes, the default behavior change is documented.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.