### PR TITLE
[SPARK-47825][DSTREAMS][3.5] Make `KinesisTestUtils` & `WriteInputFormatTestDataGenerator` deprecated

### DIFF
--- a/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisTestUtils.scala
+++ b/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisTestUtils.scala
@@ -40,6 +40,7 @@ import org.apache.spark.internal.Logging
  *
  * PLEASE KEEP THIS FILE UNDER src/main AS PYTHON TESTS NEED ACCESS TO THIS FILE!
  */
+@deprecated("This class will be move to `test`.", "3.5.2")
 private[kinesis] class KinesisTestUtils(streamShardCount: Int = 2) extends Logging {
 
   val endpointUrl = KinesisTestUtils.endpointUrl
@@ -198,6 +199,7 @@ private[kinesis] class KinesisTestUtils(streamShardCount: Int = 2) extends Loggi
   }
 }
 
+@deprecated("This class will be move to `test`.", "3.5.2")
 private[kinesis] object KinesisTestUtils {
 
   val envVarNameForEnablingTests = "ENABLE_KINESIS_TESTS"
@@ -265,11 +267,13 @@ private[kinesis] object KinesisTestUtils {
 }
 
 /** A wrapper interface that will allow us to consolidate the code for synthetic data generation. */
+@deprecated("This class will be move to `test`.", "3.5.2")
 private[kinesis] trait KinesisDataGenerator {
   /** Sends the data to Kinesis and returns the metadata for everything that has been sent. */
   def sendData(streamName: String, data: Seq[Int]): Map[String, Seq[(Int, String)]]
 }
 
+@deprecated("This class will be move to `test`.", "3.5.2")
 private[kinesis] class SimpleDataGenerator(
     client: AmazonKinesisClient) extends KinesisDataGenerator {
   override def sendData(streamName: String, data: Seq[Int]): Map[String, Seq[(Int, String)]] = {

--- a/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisTestUtils.scala
+++ b/connector/kinesis-asl/src/main/scala/org/apache/spark/streaming/kinesis/KinesisTestUtils.scala
@@ -40,7 +40,6 @@ import org.apache.spark.internal.Logging
  *
  * PLEASE KEEP THIS FILE UNDER src/main AS PYTHON TESTS NEED ACCESS TO THIS FILE!
  */
-@deprecated("This class will be move to `test`.", "3.5.2")
 private[kinesis] class KinesisTestUtils(streamShardCount: Int = 2) extends Logging {
 
   val endpointUrl = KinesisTestUtils.endpointUrl
@@ -199,7 +198,6 @@ private[kinesis] class KinesisTestUtils(streamShardCount: Int = 2) extends Loggi
   }
 }
 
-@deprecated("This class will be move to `test`.", "3.5.2")
 private[kinesis] object KinesisTestUtils {
 
   val envVarNameForEnablingTests = "ENABLE_KINESIS_TESTS"
@@ -267,13 +265,11 @@ private[kinesis] object KinesisTestUtils {
 }
 
 /** A wrapper interface that will allow us to consolidate the code for synthetic data generation. */
-@deprecated("This class will be move to `test`.", "3.5.2")
 private[kinesis] trait KinesisDataGenerator {
   /** Sends the data to Kinesis and returns the metadata for everything that has been sent. */
   def sendData(streamName: String, data: Seq[Int]): Map[String, Seq[(Int, String)]]
 }
 
-@deprecated("This class will be move to `test`.", "3.5.2")
 private[kinesis] class SimpleDataGenerator(
     client: AmazonKinesisClient) extends KinesisDataGenerator {
   override def sendData(streamName: String, data: Seq[Int]): Map[String, Seq[(Int, String)]] = {

--- a/core/src/main/scala/org/apache/spark/api/python/WriteInputFormatTestDataGenerator.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/WriteInputFormatTestDataGenerator.scala
@@ -57,14 +57,12 @@ case class TestWritable(var str: String, var int: Int, var double: Double) exten
   }
 }
 
-@deprecated("This class will be move to `test`.", "3.5.2")
 private[python] class TestInputKeyConverter extends Converter[Any, Any] {
   override def convert(obj: Any): Char = {
     obj.asInstanceOf[IntWritable].get().toChar
   }
 }
 
-@deprecated("This class will be move to `test`.", "3.5.2")
 private[python] class TestInputValueConverter extends Converter[Any, Any] {
   override def convert(obj: Any): ju.List[Double] = {
     val m = obj.asInstanceOf[MapWritable]
@@ -72,24 +70,20 @@ private[python] class TestInputValueConverter extends Converter[Any, Any] {
   }
 }
 
-@deprecated("This class will be move to `test`.", "3.5.2")
 private[python] class TestOutputKeyConverter extends Converter[Any, Any] {
   override def convert(obj: Any): Text = {
     new Text(obj.asInstanceOf[Int].toString)
   }
 }
 
-@deprecated("This class will be move to `test`.", "3.5.2")
 private[python] class TestOutputValueConverter extends Converter[Any, Any] {
   override def convert(obj: Any): DoubleWritable = {
     new DoubleWritable(obj.asInstanceOf[java.util.Map[Double, _]].keySet().iterator().next())
   }
 }
 
-@deprecated("This class will be move to `test`.", "3.5.2")
 private[python] class DoubleArrayWritable extends ArrayWritable(classOf[DoubleWritable])
 
-@deprecated("This class will be move to `test`.", "3.5.2")
 private[python] class DoubleArrayToWritableConverter extends Converter[Any, Writable] {
   override def convert(obj: Any): DoubleArrayWritable = obj match {
     case arr if arr.getClass.isArray && arr.getClass.getComponentType == classOf[Double] =>
@@ -100,7 +94,6 @@ private[python] class DoubleArrayToWritableConverter extends Converter[Any, Writ
   }
 }
 
-@deprecated("This class will be move to `test`.", "3.5.2")
 private[python] class WritableToDoubleArrayConverter extends Converter[Any, Array[Double]] {
   override def convert(obj: Any): Array[Double] = obj match {
     case daw : DoubleArrayWritable => daw.get().map(_.asInstanceOf[DoubleWritable].get())

--- a/core/src/main/scala/org/apache/spark/api/python/WriteInputFormatTestDataGenerator.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/WriteInputFormatTestDataGenerator.scala
@@ -33,6 +33,7 @@ import org.apache.spark.errors.SparkCoreErrors
  * A class to test Pickle serialization on the Scala side, that will be deserialized
  * in Python
  */
+@deprecated("This class will be move to `test`.", "3.5.2")
 case class TestWritable(var str: String, var int: Int, var double: Double) extends Writable {
   def this() = this("", 0, 0.0)
 
@@ -56,12 +57,14 @@ case class TestWritable(var str: String, var int: Int, var double: Double) exten
   }
 }
 
+@deprecated("This class will be move to `test`.", "3.5.2")
 private[python] class TestInputKeyConverter extends Converter[Any, Any] {
   override def convert(obj: Any): Char = {
     obj.asInstanceOf[IntWritable].get().toChar
   }
 }
 
+@deprecated("This class will be move to `test`.", "3.5.2")
 private[python] class TestInputValueConverter extends Converter[Any, Any] {
   override def convert(obj: Any): ju.List[Double] = {
     val m = obj.asInstanceOf[MapWritable]
@@ -69,20 +72,24 @@ private[python] class TestInputValueConverter extends Converter[Any, Any] {
   }
 }
 
+@deprecated("This class will be move to `test`.", "3.5.2")
 private[python] class TestOutputKeyConverter extends Converter[Any, Any] {
   override def convert(obj: Any): Text = {
     new Text(obj.asInstanceOf[Int].toString)
   }
 }
 
+@deprecated("This class will be move to `test`.", "3.5.2")
 private[python] class TestOutputValueConverter extends Converter[Any, Any] {
   override def convert(obj: Any): DoubleWritable = {
     new DoubleWritable(obj.asInstanceOf[java.util.Map[Double, _]].keySet().iterator().next())
   }
 }
 
+@deprecated("This class will be move to `test`.", "3.5.2")
 private[python] class DoubleArrayWritable extends ArrayWritable(classOf[DoubleWritable])
 
+@deprecated("This class will be move to `test`.", "3.5.2")
 private[python] class DoubleArrayToWritableConverter extends Converter[Any, Writable] {
   override def convert(obj: Any): DoubleArrayWritable = obj match {
     case arr if arr.getClass.isArray && arr.getClass.getComponentType == classOf[Double] =>
@@ -93,6 +100,7 @@ private[python] class DoubleArrayToWritableConverter extends Converter[Any, Writ
   }
 }
 
+@deprecated("This class will be move to `test`.", "3.5.2")
 private[python] class WritableToDoubleArrayConverter extends Converter[Any, Array[Double]] {
   override def convert(obj: Any): Array[Double] = obj match {
     case daw : DoubleArrayWritable => daw.get().map(_.asInstanceOf[DoubleWritable].get())
@@ -104,6 +112,7 @@ private[python] class WritableToDoubleArrayConverter extends Converter[Any, Arra
  * This object contains method to generate SequenceFile test data and write it to a
  * given directory (probably a temp directory)
  */
+@deprecated("This class will be move to `test`.", "3.5.2")
 object WriteInputFormatTestDataGenerator {
 
   def main(args: Array[String]): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to make `KinesisTestUtils` & `WriteInputFormatTestDataGenerator` deprecated
Master pr: https://github.com/apache/spark/pull/46000


### Why are the changes needed?
Because these two classes will be moved from `main` to` test` in version `4.0`, we need to first `deprecate` them in version `3.5` to make them exit more naturally.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
