### PR TITLE
[MINOR][PS] Use expression instead of a string column in Series.asof

### DIFF
--- a/python/pyspark/pandas/series.py
+++ b/python/pyspark/pandas/series.py
@@ -5870,7 +5870,7 @@ class Series(Frame, IndexOpsMixin, Generic[T]):
                     # then return monotonically_increasing_id. This will let max by
                     # to return last index value, which is the behaviour of pandas
                     else spark_column.isNotNull(),
-                    monotonically_increasing_id_column,
+                    F.col(monotonically_increasing_id_column),
                 ),
             )
             for index in where


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to use expression instead of a string column in Series.asof

### Why are the changes needed?

It's better to use an expression over a string, and this particular case is a preparation of adding a DataFrame.asof in PySpark itself.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

It is a code cleanup

### Was this patch authored or co-authored using generative AI tooling?

No.
