### PR TITLE
[MINOR][BUILD] Remove duplicate configuration of maven-compiler-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3110,7 +3110,6 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.12.1</version>
           <configuration>
-            <release>${java.version}</release>
             <skipMain>true</skipMain> <!-- skip compile -->
             <skip>true</skip> <!-- skip testCompile -->
           </configuration>


### PR DESCRIPTION
### What changes were proposed in this pull request?
`<release>${java.version}</release>` and `<maven.compiler.release>${java.version}</maven.compiler.release>` (https://github.com/apache/spark/pull/46024/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R117)
are equivalent duplicate configuration, so remove `<release>${java.version}</release>`.
https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html


### Why are the changes needed?
Simplify the code and facilitates subsequent configuration iterations.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass the CIs.


### Was this patch authored or co-authored using generative AI tooling?
No.
