### PR TITLE
[MINOR][PYTHON] Enable parity test `test_different_group_key_cardinality`

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_cogrouped_map.py
@@ -22,10 +22,6 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 class CogroupedApplyInPandasTests(CogroupedApplyInPandasTestsMixin, ReusedConnectTestCase):
     @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_different_group_key_cardinality(self):
-        self.check_different_group_key_cardinality()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_wrong_args(self):
         self.check_wrong_args()
 

--- a/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
@@ -154,7 +154,7 @@ class CogroupedApplyInPandasTestsMixin:
         ):
             (left.groupby("id", "k").cogroup(right.groupby("id"))).applyInPandas(
                 merge_pandas, "id long, k int, v int"
-            )
+            ).schema
 
     def test_apply_in_pandas_not_returning_pandas_dataframe(self):
         with self.quiet():


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable parity test `test_different_group_key_cardinality`, by trigger the analysis

### Why are the changes needed?
for test coverage


### Does this PR introduce _any_ user-facing change?
no, test only

### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no