### PR TITLE
[SPARK-47840][SS] Disable foldable propagation across Streaming Aggregate/Join nodes

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryOptimizationCorrectnessSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryOptimizationCorrectnessSuite.scala
@@ -1,0 +1,419 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.streaming
+
+import java.sql.Timestamp
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.apache.spark.sql.functions.{lit, window}
+
+/**
+ * This test ensures that any optimizations done by Spark SQL optimizer are
+ * correct for Streaming queries.
+ */
+class StreamingQueryOptimizationCorrectnessSuite extends StreamTest {
+  import testImplicits._
+
+  test("streaming Union with literal produces correct results") {
+    val inputStream1 = MemoryStream[Int]
+    val ds1 = inputStream1
+      .toDS()
+      .withColumn("name", lit("ds1"))
+      .withColumn("count", $"value")
+      .select("name", "count")
+
+    val inputStream2 = MemoryStream[Int]
+    val ds2 = inputStream2
+      .toDS()
+      .withColumn("name", lit("ds2"))
+      .withColumn("count", $"value")
+      .select("name", "count")
+
+    val result =
+      ds1.union(ds2)
+        .groupBy("name")
+        .count()
+
+    testStream(result, OutputMode.Complete())(
+      AddData(inputStream1, 1),
+      ProcessAllAvailable(),
+      AddData(inputStream2, 1),
+      ProcessAllAvailable(),
+      CheckNewAnswer(Row("ds1", 1), Row("ds2", 1))
+    )
+  }
+
+  test("streaming aggregate with literal and watermark after literal column" +
+    " produces correct results on query change") {
+    withTempDir { dir =>
+      val inputStream1 = MemoryStream[Timestamp]
+      val ds1 = inputStream1
+        .toDS()
+        .withColumn("name", lit("ds1"))
+        .withColumn("ts", $"value")
+        .withWatermark("ts", "1 minutes")
+        .select("name", "ts")
+
+      val result =
+        ds1.groupBy("name").count()
+
+      testStream(result, OutputMode.Complete())(
+        StartStream(checkpointLocation = dir.getAbsolutePath),
+        AddData(inputStream1, Timestamp.valueOf("2023-01-02 00:00:00")),
+        ProcessAllAvailable()
+      )
+
+      val ds2 = inputStream1
+        .toDS()
+        .withColumn("name", lit("ds2"))
+        .withColumn("ts", $"value")
+        .withWatermark("ts", "1 minutes")
+        .select("name", "ts")
+
+      val result2 =
+        ds2.groupBy("name").count()
+
+      testStream(result2, OutputMode.Complete())(
+        StartStream(checkpointLocation = dir.getAbsolutePath),
+        AddData(inputStream1, Timestamp.valueOf("2023-01-03 00:00:00")),
+        ProcessAllAvailable(),
+        CheckNewAnswer(Row("ds1", 1), Row("ds2", 1)),
+        AddData(inputStream1, Timestamp.valueOf("2023-01-04 00:00:00")),
+        ProcessAllAvailable(),
+        CheckNewAnswer(Row("ds1", 1), Row("ds2", 2))
+      )
+    }
+  }
+
+  test("streaming aggregate with literal and watermark before literal column" +
+    " produces correct results on query change") {
+    withTempDir { dir =>
+      val inputStream1 = MemoryStream[Timestamp]
+      val ds1 = inputStream1
+        .toDS()
+        .withColumn("ts", $"value")
+        .withWatermark("ts", "1 minutes")
+        .withColumn("name", lit("ds1"))
+        .select("name", "ts")
+
+      val result =
+        ds1.groupBy("name").count()
+
+      testStream(result, OutputMode.Complete())(
+        StartStream(checkpointLocation = dir.getAbsolutePath),
+        AddData(inputStream1, Timestamp.valueOf("2023-01-02 00:00:00")),
+        ProcessAllAvailable()
+      )
+
+      val ds2 = inputStream1
+        .toDS()
+        .withColumn("ts", $"value")
+        .withWatermark("ts", "1 minutes")
+        .withColumn("name", lit("ds2"))
+        .select("name", "ts")
+
+      val result2 =
+        ds2.groupBy("name").count()
+
+      testStream(result2, OutputMode.Complete())(
+        StartStream(checkpointLocation = dir.getAbsolutePath),
+        AddData(inputStream1, Timestamp.valueOf("2023-01-03 00:00:00")),
+        ProcessAllAvailable(),
+        CheckNewAnswer(Row("ds1", 1), Row("ds2", 1)),
+        AddData(inputStream1, Timestamp.valueOf("2023-01-04 00:00:00")),
+        ProcessAllAvailable(),
+        CheckNewAnswer(Row("ds1", 1), Row("ds2", 2))
+      )
+    }
+  }
+
+  test("streaming aggregate with literal" +
+    " produces correct results on query change") {
+    withTempDir { dir =>
+      val inputStream1 = MemoryStream[Int]
+      val ds1 = inputStream1
+        .toDS()
+        .withColumn("name", lit("ds1"))
+        .withColumn("count", $"value")
+        .select("name", "count")
+
+      val result =
+        ds1.groupBy("name").count()
+
+      testStream(result, OutputMode.Complete())(
+        StartStream(checkpointLocation = dir.getAbsolutePath),
+        AddData(inputStream1, 1),
+        ProcessAllAvailable()
+      )
+
+      val ds2 = inputStream1
+        .toDS()
+        .withColumn("name", lit("ds2"))
+        .withColumn("count", $"value")
+        .select("name", "count")
+
+      val result2 =
+        ds2.groupBy("name").count()
+
+      testStream(result2, OutputMode.Complete())(
+        StartStream(checkpointLocation = dir.getAbsolutePath),
+        AddData(inputStream1, 1),
+        ProcessAllAvailable(),
+        CheckNewAnswer(Row("ds1", 1), Row("ds2", 1))
+      )
+    }
+  }
+
+  test("stream stream join with literal" +
+    " produces correct results") {
+    withTempDir { dir =>
+      import java.sql.Timestamp
+      val inputStream1 = MemoryStream[Int]
+      val inputStream2 = MemoryStream[Int]
+
+      val ds1 = inputStream1
+        .toDS()
+        .withColumn("name", lit(Timestamp.valueOf("2023-01-01 00:00:00")))
+        .withWatermark("name", "1 minutes")
+        .withColumn("count1", lit(1))
+
+      val ds2 = inputStream2
+        .toDS()
+        .withColumn("name", lit(Timestamp.valueOf("2023-01-02 00:00:00")))
+        .withWatermark("name", "1 minutes")
+        .withColumn("count2", lit(2))
+
+
+      val result =
+        ds1.join(ds2, "name", "full")
+          .select("name", "count1", "count2")
+
+      testStream(result, OutputMode.Append())(
+        StartStream(checkpointLocation = dir.getAbsolutePath),
+        AddData(inputStream1, 1),
+        ProcessAllAvailable(),
+        AddData(inputStream2, 1),
+        ProcessAllAvailable(),
+        AddData(inputStream1, 2),
+        ProcessAllAvailable(),
+        AddData(inputStream2, 2),
+        ProcessAllAvailable(),
+        CheckNewAnswer()
+      )
+
+      // modify the query and update literal values for name
+      val ds3 = inputStream1
+        .toDS()
+        .withColumn("name", lit(Timestamp.valueOf("2023-02-01 00:00:00")))
+        .withWatermark("name", "1 minutes")
+        .withColumn("count1", lit(3))
+
+      val ds4 = inputStream2
+        .toDS()
+        .withColumn("name", lit(Timestamp.valueOf("2023-02-02 00:00:00")))
+        .withWatermark("name", "1 minutes")
+        .withColumn("count2", lit(4))
+
+      val result2 =
+        ds3.join(ds4, "name", "full")
+          .select("name", "count1", "count2")
+
+      testStream(result2, OutputMode.Append())(
+        StartStream(checkpointLocation = dir.getAbsolutePath),
+        AddData(inputStream1, 1),
+        ProcessAllAvailable(),
+        AddData(inputStream2, 1),
+        ProcessAllAvailable(),
+        AddData(inputStream1, 2),
+        ProcessAllAvailable(),
+        AddData(inputStream2, 2),
+        ProcessAllAvailable(),
+        CheckNewAnswer(
+          Row(Timestamp.valueOf("2023-01-01 00:00:00"),
+            1, null.asInstanceOf[java.lang.Integer]),
+          Row(Timestamp.valueOf("2023-01-01 00:00:00"),
+            1, null.asInstanceOf[java.lang.Integer]),
+          Row(Timestamp.valueOf("2023-01-02 00:00:00"),
+            null.asInstanceOf[java.lang.Integer], 2),
+          Row(Timestamp.valueOf("2023-01-02 00:00:00"),
+            null.asInstanceOf[java.lang.Integer], 2)
+        )
+      )
+    }
+  }
+
+  test("streaming SQL distinct usage with literal grouping" +
+    " key produces correct results") {
+    val inputStream1 = MemoryStream[Int]
+    val ds1 = inputStream1
+      .toDS()
+      .withColumn("name", lit("ds1"))
+      .withColumn("count", $"value")
+      .select("name", "count")
+
+    val inputStream2 = MemoryStream[Int]
+    val ds2 = inputStream2
+      .toDS()
+      .withColumn("name", lit("ds2"))
+      .withColumn("count", $"value")
+      .select("name", "count")
+
+    val result =
+      ds1.union(ds2)
+        .groupBy("name")
+        .as[String, (String, Int, Int)]
+        .keys
+
+    testStream(result, OutputMode.Complete())(
+      AddData(inputStream1, 1),
+      ProcessAllAvailable(),
+      AddData(inputStream2, 1),
+      ProcessAllAvailable(),
+      CheckNewAnswer(Row("ds1"), Row("ds2"))
+    )
+  }
+
+  test("streaming window aggregation with literal time column" +
+    " key produces correct results") {
+    val inputStream1 = MemoryStream[Int]
+    val ds1 = inputStream1
+      .toDS()
+      .withColumn("name", lit(Timestamp.valueOf("2023-01-01 00:00:00")))
+      .withColumn("count", $"value")
+      .select("name", "count")
+
+    val inputStream2 = MemoryStream[Int]
+    val ds2 = inputStream2
+      .toDS()
+      .withColumn("name", lit(Timestamp.valueOf("2023-01-02 00:00:00")))
+      .withColumn("count", $"value")
+      .select("name", "count")
+
+    val result =
+      ds1.union(ds2)
+        .groupBy(
+          window($"name", "1 second", "1 second")
+        )
+        .count()
+
+    testStream(result, OutputMode.Complete())(
+      AddData(inputStream1, 1),
+      ProcessAllAvailable(),
+      AddData(inputStream2, 1),
+      ProcessAllAvailable(),
+      CheckNewAnswer(
+        Row(
+          Row(Timestamp.valueOf("2023-01-01 00:00:00"), Timestamp.valueOf("2023-01-01 00:00:01")),
+          1),
+        Row(
+          Row(Timestamp.valueOf("2023-01-02 00:00:00"), Timestamp.valueOf("2023-01-02 00:00:01")),
+          1))
+    )
+  }
+
+  test("stream stream join with literals produces correct value") {
+    withTempDir { dir =>
+      val input1 = MemoryStream[Int]
+      val input2 = MemoryStream[Int]
+
+      val df1 = input1
+        .toDF()
+        .withColumn("key", $"value")
+        .withColumn("leftValue", lit(1))
+        .select("key", "leftValue")
+
+      val df2 = input2
+        .toDF()
+        .withColumn("key", $"value")
+        .withColumn("rightValue", lit(2))
+        .select("key", "rightValue")
+
+      val result = df1
+        .join(df2, "key")
+        .select("key", "leftValue", "rightValue")
+
+      testStream(result, OutputMode.Append())(
+        StartStream(checkpointLocation = dir.getAbsolutePath),
+        AddData(input1, 1),
+        ProcessAllAvailable(),
+        AddData(input2, 1),
+        ProcessAllAvailable(),
+        CheckAnswer(Row(1, 1, 2))
+      )
+    }
+  }
+
+  test("stream stream join with literals produces correct value on query change") {
+    withTempDir { dir =>
+      val input1 = MemoryStream[Int]
+      val input2 = MemoryStream[Int]
+
+      val df1 = input1
+        .toDF()
+        .withColumn("key", lit("key1"))
+        .withColumn("leftValue", lit(1))
+        .select("key", "leftValue")
+
+      val df2 = input2
+        .toDF()
+        .withColumn("key", lit("key2"))
+        .withColumn("rightValue", lit(2))
+        .select("key", "rightValue")
+
+      val result = df1
+        .join(df2, "key")
+        .select("key", "leftValue", "rightValue")
+
+      testStream(result, OutputMode.Append())(
+        StartStream(checkpointLocation = dir.getAbsolutePath),
+        AddData(input1, 1),
+        ProcessAllAvailable(),
+        AddData(input2, 1),
+        ProcessAllAvailable()
+      )
+
+      val df3 = input1
+        .toDF()
+        .withColumn("key", lit("key2"))
+        .withColumn("leftValue", lit(3))
+        .select("key", "leftValue")
+
+      val df4 = input2
+        .toDF()
+        .withColumn("key", lit("key1"))
+        .withColumn("rightValue", lit(4))
+        .select("key", "rightValue")
+
+      val result2 = df3
+        .join(df4, "key")
+        .select("key", "leftValue", "rightValue")
+
+      testStream(result2, OutputMode.Append())(
+        StartStream(checkpointLocation = dir.getAbsolutePath),
+        AddData(input1, 1),
+        ProcessAllAvailable(),
+        AddData(input2, 1),
+        ProcessAllAvailable(),
+        CheckAnswer(
+          Row("key1", 1, 4),
+          Row("key2", 3, 2))
+      )
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Streaming queries with Union of 2 data streams followed by an Aggregate (groupBy) can produce incorrect results if the grouping key is a constant literal for micro-batch duration.

The query produces incorrect results because the query optimizer recognizes the literal value in the grouping key as foldable and replaces the grouping key expression with the actual literal value. This optimization is correct for batch queries. However Streaming queries also read information from StateStore, and the output contains both the results from StateStore (computed in previous microbatches) and data from input sources (computed in this microbatch). The HashAggregate node after StateStore always reads grouping key value as the optimized literal (as the grouping key expression is optimized into a literal by the optimizer). This ends up replacing keys in StateStore with the literal value resulting in incorrect output. 

See an example logical and physical plan below for a query performing a union on 2 data streams, followed by a groupBy. Note that the name#4 expression has been optimized to ds1. The Streaming query Aggregate adds StateStoreSave node as child of HashAggregate, however any grouping key read from StateStore will still be read as ds1 due to the optimization. 


### Optimized Logical Plan

```
=== Applying Rule org.apache.spark.sql.catalyst.optimizer.FoldablePropagation ===

=== Old Plan ===

WriteToMicroBatchDataSource MemorySink, eb67645e-30fc-41a8-8006-35bb7649c202, Complete, 0
+- Aggregate [name#4], [name#4, count(1) AS count#31L]
   +- Project [ds1 AS name#4]
  	+- StreamingDataSourceV2ScanRelation[value#1] MemoryStreamDataSource


=== New Plan ===

WriteToMicroBatchDataSource MemorySink, eb67645e-30fc-41a8-8006-35bb7649c202, Complete, 0
+- Aggregate [ds1], [ds1 AS name#4, count(1) AS count#31L]
   +- Project [ds1 AS name#4]
  	+- StreamingDataSourceV2ScanRelation[value#1] MemoryStreamDataSource


====
```


### Corresponding Physical Plan

```
WriteToDataSourceV2 MicroBatchWrite[epoch: 0, writer: org.apache.spark.sql.execution.streaming.sources.MemoryStreamingWrite@2b4c6242], org.apache.spark.sql.execution.datasources.v2.DataSourceV2Strategy$$Lambda$3143/1859075634@35709d26
+- HashAggregate(keys=[ds1#39], functions=[finalmerge_count(merge count#38L) AS count(1)#30L], output=[name#4, count#31L])
   +- StateStoreSave [ds1#39], state info [ checkpoint = file:/tmp/streaming.metadata-e470782a-18a3-463c-9e61-3a10d0bdf180/state, runId = 4dedecca-910c-4518-855e-456702617414, opId = 0, ver = 0, numPartitions = 5], Complete, 0, 0, 2
  	+- HashAggregate(keys=[ds1#39], functions=[merge_count(merge count#38L) AS count#38L], output=[ds1#39, count#38L])
     	+- StateStoreRestore [ds1#39], state info [ checkpoint = file:/tmp/streaming.metadata-e470782a-18a3-463c-9e61-3a10d0bdf180/state, runId = 4dedecca-910c-4518-855e-456702617414, opId = 0, ver = 0, numPartitions = 5], 2
        	+- HashAggregate(keys=[ds1#39], functions=[merge_count(merge count#38L) AS count#38L], output=[ds1#39, count#38L])
           	+- HashAggregate(keys=[ds1 AS ds1#39], functions=[partial_count(1) AS count#38L], output=[ds1#39, count#38L])
              	+- Project
                 	+- MicroBatchScan[value#1] MemoryStreamDataSource

```

This PR disables foldable propagation across Streaming Aggregate/Join nodes in the logical plan. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Changes are needed to ensure that Streaming queries with literal value for grouping key/join key produce correct results. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added `sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryOptimizationCorrectnessSuite.scala` testcase.

```

[info] Run completed in 54 seconds, 150 milliseconds.
[info] Total number of tests run: 9
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 9, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.

```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No