### PR TITLE
[SPARK-47841][BUILD] Upgrade `postgresql` to 42.7.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,7 @@
     </extraJavaTestArgs>
     <mariadb.java.client.version>2.7.12</mariadb.java.client.version>
     <mysql.connector.version>8.3.0</mysql.connector.version>
-    <postgresql.version>42.7.2</postgresql.version>
+    <postgresql.version>42.7.3</postgresql.version>
     <db2.jcc.version>11.5.9.0</db2.jcc.version>
     <mssql.jdbc.version>9.4.1.jre8</mssql.jdbc.version>
     <ojdbc11.version>23.3.0.23.09</ojdbc11.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `postgresql` from `42.7.2` to `42.7.3`.

### Why are the changes needed?
The version `42.7.3` full release notes:
https://jdbc.postgresql.org/changelogs/2024-03-14-42.7.3-release/
- fix: boolean types not handled in SimpleQuery mode [PR #3146](https://github.com/pgjdbc/pgjdbc/pull/3146) *make sure we handle boolean types in simple query mode
support uuid as well
handle all well known types in text mode and change else if to switch
- fix: released new versions of 42.2.29, 42.3.10, 42.4.5, 42.5.6, 42.6.2 to deal with NoSuchMethodError on ByteBuffer#position when running on Java 8

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
