### PR TITLE
[SPARK-47826][SQL][PYTHON][FOLLOW-UP] Do not use list[...] that is invalid type syntax for Python 3.8

### DIFF
--- a/python/pyspark/sql/variant_utils.py
+++ b/python/pyspark/sql/variant_utils.py
@@ -261,7 +261,7 @@ class VariantUtils:
         variant_type = cls._get_type(value, pos)
         if variant_type == dict:
 
-            def handle_object(key_value_pos_list: list[Tuple[str, int]]) -> str:
+            def handle_object(key_value_pos_list: List[Tuple[str, int]]) -> str:
                 key_value_list = [
                     json.dumps(key) + ":" + cls._to_json(value, metadata, value_pos)
                     for (key, value_pos) in key_value_pos_list
@@ -271,7 +271,7 @@ class VariantUtils:
             return cls._handle_object(value, metadata, pos, handle_object)
         elif variant_type == array:
 
-            def handle_array(value_pos_list: list[int]) -> str:
+            def handle_array(value_pos_list: List[int]) -> str:
                 value_list = [
                     cls._to_json(value, metadata, value_pos) for value_pos in value_pos_list
                 ]
@@ -293,7 +293,7 @@ class VariantUtils:
         variant_type = cls._get_type(value, pos)
         if variant_type == dict:
 
-            def handle_object(key_value_pos_list: list[Tuple[str, int]]) -> Dict[str, Any]:
+            def handle_object(key_value_pos_list: List[Tuple[str, int]]) -> Dict[str, Any]:
                 key_value_list = [
                     (key, cls._to_python(value, metadata, value_pos))
                     for (key, value_pos) in key_value_pos_list
@@ -303,7 +303,7 @@ class VariantUtils:
             return cls._handle_object(value, metadata, pos, handle_object)
         elif variant_type == array:
 
-            def handle_array(value_pos_list: list[int]) -> List[Any]:
+            def handle_array(value_pos_list: List[int]) -> List[Any]:
                 value_list = [
                     cls._to_python(value, metadata, value_pos) for value_pos in value_pos_list
                 ]
@@ -332,7 +332,7 @@ class VariantUtils:
 
     @classmethod
     def _handle_object(
-        cls, value: bytes, metadata: bytes, pos: int, func: Callable[[list[Tuple[str, int]]], Any]
+        cls, value: bytes, metadata: bytes, pos: int, func: Callable[[List[Tuple[str, int]]], Any]
     ) -> Any:
         """
         Parses the variant object at position `pos`.
@@ -362,7 +362,7 @@ class VariantUtils:
         return func(key_value_pos_list)
 
     @classmethod
-    def _handle_array(cls, value: bytes, pos: int, func: Callable[[list[int]], Any]) -> Any:
+    def _handle_array(cls, value: bytes, pos: int, func: Callable[[List[int]], Any]) -> Any:
         """
         Parses the variant array at position `pos`.
         Calls `func` with a list of element positions of the array.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/45826 that proposes to avoid using list[...] that is invalid type syntax for Python 3.8.

### Why are the changes needed?

Python 3.8 support is broken by this https://github.com/apache/spark/actions/runs/8648933358/job/23715458133

```
Starting test(pypy3): pyspark.sql.tests.pandas.test_converter (temp output: /__w/spark/spark/python/target/c6f14f2f-c85c-4336-8023-f5309338dbc5/pypy3__pyspark.sql.tests.pandas.test_converter__h_032d22.log)
Traceback (most recent call last):
  File "/usr/local/pypy/pypy3.8/lib/pypy3.8/runpy.py", line 188, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/local/pypy/pypy3.8/lib/pypy3.8/runpy.py", line 111, in _get_module_details
    __import__(pkg_name)
  File "/__w/spark/spark/python/pyspark/__init__.py", line 129, in <module>
    from pyspark.sql import SQLContext, HiveContext, Row  # noqa: F401
  File "/__w/spark/spark/python/pyspark/sql/__init__.py", line 42, in <module>
    from pyspark.sql.types import Row, VariantVal
  File "/__w/spark/spark/python/pyspark/sql/types.py", line 51, in <module>
    from pyspark.sql.variant_utils import VariantUtils
  File "/__w/spark/spark/python/pyspark/sql/variant_utils.py", line 26, in <module>
    class VariantUtils:
  File "/__w/spark/spark/python/pyspark/sql/variant_utils.py", line 335, in VariantUtils
    cls, value: bytes, metadata: bytes, pos: int, func: Callable[[list[Tuple[str, int]]], Any]
TypeError: 'type' object is not subscriptable (key typing.Tuple[str, int])
```

### Does this PR introduce _any_ user-facing change?


### How was this patch tested?

Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.