### PR TITLE
[SPARK-47848][SS] Fix thread safety issue around access to loadedMaps in close function for hdfs store provider

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -346,7 +346,7 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
   }
 
   override def close(): Unit = {
-    loadedMaps.values.asScala.foreach(_.clear())
+    synchronized { loadedMaps.values.asScala.foreach(_.clear()) }
   }
 
   override def supportedCustomMetrics: Seq[StateStoreCustomMetric] = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix thread safety issue around access to loadedMaps in close function for hdfs store provider

### Why are the changes needed?
To ensure thread safe access to `loadedMaps` which is the critical section for the hdfs backed state store provider in structured streaming


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing unit tests

```
[info] Run completed in 2 minutes, 51 seconds.
[info] Total number of tests run: 152
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 152, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```


### Was this patch authored or co-authored using generative AI tooling?
No
