### PR TITLE
[SPARK-47760][SPARK-47763][CONNECT][TESTS] Reeanble Avro and Protobuf function doctests

### DIFF
--- a/.github/workflows/build_python_connect.yml
+++ b/.github/workflows/build_python_connect.yml
@@ -29,7 +29,6 @@ jobs:
     name: "Build modules: pyspark-connect"
     runs-on: ubuntu-latest
     timeout-minutes: 300
-    if: github.repository == 'apache/spark'
     steps:
       - name: Checkout Spark repository
         uses: actions/checkout@v4
@@ -63,7 +62,7 @@ jobs:
           architecture: x64
       - name: Build Spark
         run: |
-          ./build/sbt -Phive test:package
+          ./build/sbt -Phive Test/package
       - name: Install pure Python package (pyspark-connect)
         env:
           SPARK_TESTING: 1
@@ -82,7 +81,9 @@ jobs:
           cp conf/log4j2.properties.template conf/log4j2.properties
           sed -i 's/rootLogger.level = info/rootLogger.level = warn/g' conf/log4j2.properties
           # Start a Spark Connect server
-          PYTHONPATH="python/lib/pyspark.zip:python/lib/py4j-0.10.9.7-src.zip:$PYTHONPATH" ./sbin/start-connect-server.sh --driver-java-options "-Dlog4j.configurationFile=file:$GITHUB_WORKSPACE/conf/log4j2.properties" --jars `find connector/connect/server/target -name spark-connect*SNAPSHOT.jar`
+          PYTHONPATH="python/lib/pyspark.zip:python/lib/py4j-0.10.9.7-src.zip:$PYTHONPATH" ./sbin/start-connect-server.sh \
+            --driver-java-options "-Dlog4j.configurationFile=file:$GITHUB_WORKSPACE/conf/log4j2.properties" \
+            --jars "`find connector/connect/server/target -name spark-connect-*SNAPSHOT.jar`,`find connector/protobuf/target -name spark-protobuf-*SNAPSHOT.jar`,`find connector/avro/target -name spark-avro*SNAPSHOT.jar`"
           # Make sure running Python workers that contains pyspark.core once. They will be reused.
           python -c "from pyspark.sql import SparkSession; _ = SparkSession.builder.remote('sc://localhost').getOrCreate().range(100).repartition(100).mapInPandas(lambda x: x, 'id INT').collect()"
           # Remove Py4J and PySpark zipped library to make sure there is no JVM connection
@@ -98,9 +99,9 @@ jobs:
         with:
           name: test-results-spark-connect-python-only
           path: "**/target/test-reports/*.xml"
-      - name: Upload unit tests log files
+      - name: Upload Spark Connect server log file
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: unit-tests-log-spark-connect-python-only
-          path: "**/target/unit-tests.log"
+          path: logs/*.out

--- a/python/pyspark/sql/connect/avro/functions.py
+++ b/python/pyspark/sql/connect/avro/functions.py
@@ -80,15 +80,8 @@ def _test() -> None:
     import doctest
     from pyspark.sql import SparkSession as PySparkSession
     import pyspark.sql.connect.avro.functions
-    from pyspark.util import is_remote_only
 
     globs = pyspark.sql.connect.avro.functions.__dict__.copy()
-
-    # TODO(SPARK-47760): Reeanble Avro function doctests
-    if is_remote_only():
-        del pyspark.sql.connect.avro.functions.from_avro
-        del pyspark.sql.connect.avro.functions.to_avro
-
     globs["spark"] = (
         PySparkSession.builder.appName("sql.connect.avro.functions tests")
         .remote(os.environ.get("SPARK_CONNECT_TESTING_REMOTE", "local[4]"))

--- a/python/pyspark/sql/connect/protobuf/functions.py
+++ b/python/pyspark/sql/connect/protobuf/functions.py
@@ -120,7 +120,6 @@ def _read_descriptor_set_file(filePath: str) -> bytes:
 def _test() -> None:
     import os
     import sys
-    from pyspark.util import is_remote_only
     from pyspark.testing.utils import search_jar
 
     protobuf_jar = search_jar("connector/protobuf", "spark-protobuf-assembly-", "spark-protobuf")
@@ -142,12 +141,6 @@ def _test() -> None:
     import pyspark.sql.connect.protobuf.functions
 
     globs = pyspark.sql.connect.protobuf.functions.__dict__.copy()
-
-    # TODO(SPARK-47763): Reeanble Protobuf function doctests
-    if is_remote_only():
-        del pyspark.sql.connect.protobuf.functions.from_protobuf
-        del pyspark.sql.connect.protobuf.functions.to_protobuf
-
     globs["spark"] = (
         PySparkSession.builder.appName("sql.protobuf.functions tests")
         .remote(os.environ.get("SPARK_CONNECT_TESTING_REMOTE", "local[2]"))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to reeanble Avro and Protobuf function doctests by providing the required jars into Spark Connect server.

### Why are the changes needed?

For test coverages of Avro and Protobuf functions.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Tested in my fork: https://github.com/HyukjinKwon/spark/actions/runs/8704014674/job/23871383802

### Was this patch authored or co-authored using generative AI tooling?

No.
