### PR TITLE
[SPARK-47855][CONNECT] Add `spark.sql.execution.arrow.pyspark.fallback.enabled` in the unsupported list

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectConfigHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectConfigHandler.scala
@@ -168,7 +168,8 @@ class SparkConnectConfigHandler(responseObserver: StreamObserver[proto.ConfigRes
 
 object SparkConnectConfigHandler {
 
-  private[connect] val unsupportedConfigurations = Set("spark.sql.execution.arrow.enabled")
+  private[connect] val unsupportedConfigurations =
+    Set("spark.sql.execution.arrow.enabled", "spark.sql.execution.arrow.pyspark.fallback.enabled")
 
   def toKeyValue(pair: proto.KeyValue): (String, Option[String]) = {
     val key = pair.getKey


### PR DESCRIPTION
### What changes were proposed in this pull request?
Warn `spark.sql.execution.arrow.pyspark.fallback.enabled` in Connect


### Why are the changes needed?
it doesn't take effect in Spark Connect


### Does this PR introduce _any_ user-facing change?
before:
```
In [2]: spark.conf.set("spark.sql.execution.arrow.pyspark.fallback.enabled", True)

In [3]:
```


after:
```
In [1]: spark.conf.set("spark.sql.execution.arrow.pyspark.fallback.enabled", True)
/Users/ruifeng.zheng/Dev/spark/python/pyspark/sql/connect/conf.py:48: UserWarning: The SQL config 'spark.sql.execution.arrow.pyspark.fallback.enabled' is NOT supported in Spark Connect
  warnings.warn(warn)

In [2]:
```


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no