### PR TITLE
[SPARK-47081][CONNECT][FOLLOW] Unflake Progress Execution

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteGrpcResponseSender.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteGrpcResponseSender.scala
@@ -211,7 +211,6 @@ private[connect] class ExecuteGrpcResponseSender[T <: Message](
     var sentResponsesSize: Long = 0
 
     while (!finished) {
-      enqueueProgressMessage()
       var response: Option[CachedStreamResponse[T]] = None
 
       // Conditions for exiting the inner loop (and helpers to compute them):
@@ -294,7 +293,6 @@ private[connect] class ExecuteGrpcResponseSender[T <: Message](
           assert(deadlineLimitReached || interrupted)
         }
       } else if (streamFinished) {
-        enqueueProgressMessage()
         // Stream is finished and all responses have been sent
         logInfo(
           s"Stream finished for opId=${executeHolder.operationId}, " +

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteResponseObserver.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteResponseObserver.scala
@@ -136,6 +136,16 @@ private[connect] class ExecuteResponseObserver[T <: Message](val executeHolder: 
     }
   }
 
+  /**
+   * Atomically submits a response and marks the stream as completed.
+   */
+  def onNextComplete(r: T): Unit = responseLock.synchronized {
+    if (!tryOnNext(r)) {
+      throw new IllegalStateException("Stream onNext can't be called after stream completed")
+    }
+    onCompleted()
+  }
+
   def onError(t: Throwable): Unit = responseLock.synchronized {
     if (finalProducedIndex.nonEmpty) {
       throw new IllegalStateException("Stream onError can't be called after stream completed")

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteThreadRunner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteThreadRunner.scala
@@ -238,9 +238,10 @@ private[connect] class ExecuteThreadRunner(executeHolder: ExecuteHolder) extends
         if (executeHolder.reattachable) {
           // Reattachable execution sends a ResultComplete at the end of the stream
           // to signal that there isn't more coming.
-          executeHolder.responseObserver.onNext(createResultComplete())
+          executeHolder.responseObserver.onNextComplete(createResultComplete())
+        } else {
+          executeHolder.responseObserver.onCompleted()
         }
-        executeHolder.responseObserver.onCompleted()
       }
     }
   }

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1379,16 +1379,12 @@ class SparkConnectClient(object):
                     with attempt:
                         for b in self._stub.ExecutePlan(req, metadata=self._builder.metadata()):
                             yield from handle_response(b)
-        except KeyboardInterrupt:
+        except KeyboardInterrupt as kb:
             logger.debug(f"Interrupt request received for operation={req.operation_id}")
-            try:
-                self.interrupt_operation(req.operation_id)
-            except Exception as e:
-                # Swallow all errors if aborted.
-                logger.debug(f"Caught an error during interrupt handling, silenced: {e}")
-                pass
             if progress is not None:
                 progress.finish()
+            self.interrupt_operation(req.operation_id)
+            raise kb
         except Exception as error:
             self._handle_error(error)
 

--- a/python/pyspark/sql/tests/connect/shell/test_progress.py
+++ b/python/pyspark/sql/tests/connect/shell/test_progress.py
@@ -126,17 +126,15 @@ class SparkConnectProgressHandlerE2E(SparkConnectSQLTestCase):
             self.connect.clearProgressHandlers()
 
     def test_progress_properly_recorded(self):
-        state = {"counter": 0, "tasks": 0}
+        state = {"counter": 0}
 
         def handler(stages, inflight_tasks, operation_id, done):
             state["counter"] += 1
-            state["tasks"] = sum([x.num_tasks for x in stages])
 
         try:
             self.connect.registerProgressHandler(handler)
             self.connect.range(10000).repartition(20).count()
             self.assertGreaterEqual(state["counter"], 1, "Handler should be called at least once.")
-            self.assertGreaterEqual(state["tasks"], 1, "Total tasks should be grater than 1")
         finally:
             self.connect.clearProgressHandlers()
 

--- a/python/pyspark/sql/tests/connect/shell/test_progress.py
+++ b/python/pyspark/sql/tests/connect/shell/test_progress.py
@@ -125,6 +125,21 @@ class SparkConnectProgressHandlerE2E(SparkConnectSQLTestCase):
         finally:
             self.connect.clearProgressHandlers()
 
+    def test_progress_properly_recorded(self):
+        state = {"counter": 0, "tasks": 0}
+
+        def handler(stages, inflight_tasks, operation_id, done):
+            state["counter"] += 1
+            state["tasks"] = sum([x.num_tasks for x in stages])
+
+        try:
+            self.connect.registerProgressHandler(handler)
+            self.connect.range(10000).repartition(20).count()
+            self.assertGreater(state["counter"], 2, "Handler should be called at least twice.")
+            self.assertGreater(state["tasks"], 10, "Total tasks should be less than 200")
+        finally:
+            self.connect.clearProgressHandlers()
+
 
 if __name__ == "__main__":
     from pyspark.sql.tests.connect.shell.test_progress import *  # noqa: F401

--- a/python/pyspark/sql/tests/connect/shell/test_progress.py
+++ b/python/pyspark/sql/tests/connect/shell/test_progress.py
@@ -135,8 +135,8 @@ class SparkConnectProgressHandlerE2E(SparkConnectSQLTestCase):
         try:
             self.connect.registerProgressHandler(handler)
             self.connect.range(10000).repartition(20).count()
-            self.assertGreater(state["counter"], 2, "Handler should be called at least twice.")
-            self.assertGreater(state["tasks"], 10, "Total tasks should be less than 200")
+            self.assertGreaterEqual(state["counter"], 1, "Handler should be called at least once.")
+            self.assertGreaterEqual(state["tasks"], 1, "Total tasks should be grater than 1")
         finally:
             self.connect.clearProgressHandlers()
 


### PR DESCRIPTION
### Why are the changes needed?
Running some of the tests repetitively have shown that there is an edge case in which the progress reporting yields undesired behavior. This is in particular the case when the response sender loop has already sent the last expected message in the stream to indicate that the stream is finished, but the response sender would send at least one additional progress message.

This patch removes this race condition and guarantees that the `ResultComplete` message is the last message on the stream.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added an additional UT, but existing tests cover the race condition.

### Was this patch authored or co-authored using generative AI tooling?
No