### PR TITLE
[SPARK-47838][BUILD] Upgrade `rocksdbjni` to 8.11.4

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -247,7 +247,7 @@ parquet-jackson/1.13.1//parquet-jackson-1.13.1.jar
 pickle/1.3//pickle-1.3.jar
 py4j/0.10.9.7//py4j-0.10.9.7.jar
 remotetea-oncrpc/1.1.2//remotetea-oncrpc-1.1.2.jar
-rocksdbjni/8.11.3//rocksdbjni-8.11.3.jar
+rocksdbjni/8.11.4//rocksdbjni-8.11.4.jar
 scala-collection-compat_2.13/2.7.0//scala-collection-compat_2.13-2.7.0.jar
 scala-compiler/2.13.13//scala-compiler-2.13.13.jar
 scala-library/2.13.13//scala-library-2.13.13.jar

--- a/pom.xml
+++ b/pom.xml
@@ -687,7 +687,7 @@
       <dependency>
         <groupId>org.rocksdb</groupId>
         <artifactId>rocksdbjni</artifactId>
-        <version>8.11.3</version>
+        <version>8.11.4</version>
       </dependency>
       <dependency>
         <groupId>${leveldbjni.group}</groupId>

--- a/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-jdk21-results.txt
@@ -2,110 +2,143 @@
 put rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                            6              7           1          1.7         580.7       1.0X
-RocksDB (trackTotalNumberOfRows: true)                              42             43           2          0.2        4191.6       0.1X
-RocksDB (trackTotalNumberOfRows: false)                             15             16           1          0.7        1497.2       0.4X
+In-memory                                                           10             12           1          1.0        1004.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                              42             48           3          0.2        4200.6       0.2X
+RocksDB (trackTotalNumberOfRows: false)                             15             18           2          0.7        1529.7       0.7X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          6              7           1          1.7         574.6       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            35             36           1          0.3        3473.9       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           15             16           1          0.7        1505.4       0.4X
+In-memory                                                         11             15           2          0.9        1064.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            42             46           2          0.2        4200.2       0.3X
+RocksDB (trackTotalNumberOfRows: false)                           16             19           1          0.6        1590.7       0.7X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          5              6           1          1.8         542.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            29             30           1          0.3        2863.2       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           15             16           1          0.7        1517.5       0.4X
+In-memory                                                         11             15           2          0.9        1082.8       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            43             47           1          0.2        4309.4       0.3X
+RocksDB (trackTotalNumberOfRows: false)                           17             20           1          0.6        1720.4       0.6X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                      5              6           1          1.8         542.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                        27             28           1          0.4        2689.8       0.2X
-RocksDB (trackTotalNumberOfRows: false)                       15             16           1          0.7        1497.0       0.4X
+In-memory                                                     13             17           1          0.8        1301.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                        42             46           2          0.2        4170.9       0.3X
+RocksDB (trackTotalNumberOfRows: false)                       16             19           1          0.6        1583.9       0.8X
+
+
+================================================================================================
+merge rows
+================================================================================================
+
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
+AMD EPYC 7763 64-Core Processor
+merging 10000 rows with 10 values per key (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------------------------------------
+RocksDB (trackTotalNumberOfRows: true)                                                    556            584          11          0.0       55626.9       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                                   179            201           7          0.1       17921.3       3.1X
+
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
+AMD EPYC 7763 64-Core Processor
+merging 10000 rows with 10 values per key (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+RocksDB (trackTotalNumberOfRows: true)                                                  534            563          10          0.0       53394.1       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                                 184            202           5          0.1       18411.3       2.9X
+
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
+AMD EPYC 7763 64-Core Processor
+merging 10000 rows with 10 values per key (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+RocksDB (trackTotalNumberOfRows: true)                                                  520            552          10          0.0       52036.0       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                                 175            196           5          0.1       17528.3       3.0X
+
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
+AMD EPYC 7763 64-Core Processor
+merging 10000 rows with 10 values per key (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+--------------------------------------------------------------------------------------------------------------------------------------------------------
+RocksDB (trackTotalNumberOfRows: true)                                              525            551          10          0.0       52517.7       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                             171            202           6          0.1       17065.0       3.1X
 
 
 ================================================================================================
 delete rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(10000 rows are non-existing - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                        0              1           0         27.9          35.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                          27             28           1          0.4        2721.0       0.0X
-RocksDB (trackTotalNumberOfRows: false)                                                         15             16           1          0.7        1503.3       0.0X
+In-memory                                                                                        1              2           1         11.1          90.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                          42             45           1          0.2        4154.5       0.0X
+RocksDB (trackTotalNumberOfRows: false)                                                         17             20           1          0.6        1745.8       0.1X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(5000 rows are non-existing - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      4              5           1          2.3         425.7       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        34             35           1          0.3        3412.4       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       15             16           1          0.7        1524.0       0.3X
+In-memory                                                                                     10             14           1          1.0        1036.8       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        42             46           1          0.2        4214.0       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                       16             19           1          0.6        1635.9       0.6X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(1000 rows are non-existing - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      5              6           1          2.1         480.1       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        40             41           1          0.2        4003.6       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                       15             16           1          0.7        1469.5       0.3X
+In-memory                                                                                     12             16           2          0.8        1186.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        42             47           2          0.2        4244.3       0.3X
+RocksDB (trackTotalNumberOfRows: false)                                                       17             19           1          0.6        1687.3       0.7X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(0 rows are non-existing - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                  5              6           1          2.1         479.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                    41             42           1          0.2        4101.5       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                                   15             15           0          0.7        1458.3       0.3X
+In-memory                                                                                 10             15           1          1.0        1003.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                    43             47           1          0.2        4299.2       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                   17             19           1          0.6        1696.5       0.6X
 
 
 ================================================================================================
 evict rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 evicting 10000 rows (maxTimestampToEvictInMillis: 9999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                            5              5           1          2.1         477.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                              40             41           1          0.2        4023.8       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                             15             16           1          0.6        1542.2       0.3X
+In-memory                                                                            9             12           1          1.1         948.4       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                              40             42           1          0.3        3986.5       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                             17             18           1          0.6        1652.7       0.6X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 evicting 5000 rows (maxTimestampToEvictInMillis: 4999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           4              5           1          2.3         427.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             22             22           1          0.5        2172.1       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                             9             10           0          1.1         932.8       0.5X
+In-memory                                                                           9             10           1          1.2         855.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             22             23           1          0.5        2163.3       0.4X
+RocksDB (trackTotalNumberOfRows: false)                                             9             10           1          1.1         943.9       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 evicting 1000 rows (maxTimestampToEvictInMillis: 999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                          4              4           1          2.7         369.7       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             7              7           0          1.5         689.3       0.5X
-RocksDB (trackTotalNumberOfRows: false)                                            4              5           0          2.2         444.6       0.8X
+In-memory                                                                          7              9           1          1.3         749.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             7              8           0          1.4         694.5       1.1X
+RocksDB (trackTotalNumberOfRows: false)                                            5              5           0          2.1         466.9       1.6X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 evicting 0 rows (maxTimestampToEvictInMillis: -1) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                      0              0           0         25.1          39.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                         3              3           0          3.2         308.3       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                        3              3           0          3.2         308.6       0.1X
+In-memory                                                                      0              1           0         22.5          44.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                         3              4           0          3.1         318.3       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                        3              4           0          3.1         322.8       0.1X
 
 

--- a/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-jdk21-results.txt
@@ -6,33 +6,33 @@ OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                           10             12           1          1.0        1004.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                              42             48           3          0.2        4200.6       0.2X
-RocksDB (trackTotalNumberOfRows: false)                             15             18           2          0.7        1529.7       0.7X
+In-memory                                                            9             10           1          1.1         938.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                              42             44           2          0.2        4215.2       0.2X
+RocksDB (trackTotalNumberOfRows: false)                             15             16           1          0.7        1535.3       0.6X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                         11             15           2          0.9        1064.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            42             46           2          0.2        4200.2       0.3X
-RocksDB (trackTotalNumberOfRows: false)                           16             19           1          0.6        1590.7       0.7X
+In-memory                                                          9             11           1          1.1         943.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            41             43           2          0.2        4083.3       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           15             16           1          0.7        1534.4       0.6X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                         11             15           2          0.9        1082.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            43             47           1          0.2        4309.4       0.3X
-RocksDB (trackTotalNumberOfRows: false)                           17             20           1          0.6        1720.4       0.6X
+In-memory                                                          9             10           1          1.1         909.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            40             41           1          0.2        4017.6       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           15             16           1          0.7        1533.0       0.6X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                     13             17           1          0.8        1301.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                        42             46           2          0.2        4170.9       0.3X
-RocksDB (trackTotalNumberOfRows: false)                       16             19           1          0.6        1583.9       0.8X
+In-memory                                                      9             10           0          1.1         900.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                        40             42           1          0.3        3993.3       0.2X
+RocksDB (trackTotalNumberOfRows: false)                       15             16           1          0.6        1547.1       0.6X
 
 
 ================================================================================================
@@ -43,29 +43,29 @@ OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                                    556            584          11          0.0       55626.9       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                                   179            201           7          0.1       17921.3       3.1X
+RocksDB (trackTotalNumberOfRows: true)                                                    544            561           6          0.0       54379.3       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                                   178            184           3          0.1       17764.5       3.1X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                                  534            563          10          0.0       53394.1       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                                 184            202           5          0.1       18411.3       2.9X
+RocksDB (trackTotalNumberOfRows: true)                                                  528            543           6          0.0       52813.5       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                                 179            184           3          0.1       17896.3       3.0X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                                  520            552          10          0.0       52036.0       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                                 175            196           5          0.1       17528.3       3.0X
+RocksDB (trackTotalNumberOfRows: true)                                                  515            530           6          0.0       51526.1       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                                 178            183           3          0.1       17774.8       2.9X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                              525            551          10          0.0       52517.7       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                             171            202           6          0.1       17065.0       3.1X
+RocksDB (trackTotalNumberOfRows: true)                                              513            529           6          0.0       51333.1       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                             177            183           3          0.1       17713.4       2.9X
 
 
 ================================================================================================
@@ -76,33 +76,33 @@ OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(10000 rows are non-existing - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                        1              2           1         11.1          90.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                          42             45           1          0.2        4154.5       0.0X
-RocksDB (trackTotalNumberOfRows: false)                                                         17             20           1          0.6        1745.8       0.1X
+In-memory                                                                                        0              1           0         22.0          45.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                          40             42           1          0.2        4030.3       0.0X
+RocksDB (trackTotalNumberOfRows: false)                                                         16             17           1          0.6        1576.1       0.0X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(5000 rows are non-existing - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                     10             14           1          1.0        1036.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        42             46           1          0.2        4214.0       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                       16             19           1          0.6        1635.9       0.6X
+In-memory                                                                                      8              9           0          1.3         797.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        42             43           1          0.2        4184.7       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                       16             16           0          0.6        1579.2       0.5X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(1000 rows are non-existing - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                     12             16           2          0.8        1186.6       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        42             47           2          0.2        4244.3       0.3X
-RocksDB (trackTotalNumberOfRows: false)                                                       17             19           1          0.6        1687.3       0.7X
+In-memory                                                                                      8              9           0          1.2         848.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        43             44           1          0.2        4268.3       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                       16             17           0          0.6        1582.7       0.5X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(0 rows are non-existing - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                 10             15           1          1.0        1003.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                    43             47           1          0.2        4299.2       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                   17             19           1          0.6        1696.5       0.6X
+In-memory                                                                                  9              9           0          1.2         856.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                    42             44           1          0.2        4244.3       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                   16             16           0          0.6        1570.4       0.5X
 
 
 ================================================================================================
@@ -113,32 +113,32 @@ OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 evicting 10000 rows (maxTimestampToEvictInMillis: 9999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                            9             12           1          1.1         948.4       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                              40             42           1          0.3        3986.5       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                             17             18           1          0.6        1652.7       0.6X
+In-memory                                                                            8              9           0          1.2         829.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                              41             42           1          0.2        4110.7       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                             17             17           0          0.6        1652.2       0.5X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 evicting 5000 rows (maxTimestampToEvictInMillis: 4999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           9             10           1          1.2         855.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             22             23           1          0.5        2163.3       0.4X
-RocksDB (trackTotalNumberOfRows: false)                                             9             10           1          1.1         943.9       0.9X
+In-memory                                                                           8              8           0          1.3         782.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             22             23           0          0.5        2207.2       0.4X
+RocksDB (trackTotalNumberOfRows: false)                                            10             10           0          1.0         955.0       0.8X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 evicting 1000 rows (maxTimestampToEvictInMillis: 999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                          7              9           1          1.3         749.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             7              8           0          1.4         694.5       1.1X
-RocksDB (trackTotalNumberOfRows: false)                                            5              5           0          2.1         466.9       1.6X
+In-memory                                                                          7              8           0          1.4         729.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             7              7           0          1.4         710.1       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                            5              5           0          2.2         465.1       1.6X
 
 OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 evicting 0 rows (maxTimestampToEvictInMillis: -1) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                      0              1           0         22.5          44.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                         3              4           0          3.1         318.3       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                        3              4           0          3.1         322.8       0.1X
+In-memory                                                                      0              0           0         24.0          41.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                         3              3           0          3.0         329.6       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                        3              3           0          3.0         330.2       0.1X
 
 

--- a/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-jdk21-results.txt
@@ -2,141 +2,110 @@
 put rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                            9             10           1          1.1         936.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                              41             42           1          0.2        4068.9       0.2X
-RocksDB (trackTotalNumberOfRows: false)                             15             16           1          0.7        1500.4       0.6X
+In-memory                                                            6              7           1          1.7         580.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                              42             43           2          0.2        4191.6       0.1X
+RocksDB (trackTotalNumberOfRows: false)                             15             16           1          0.7        1497.2       0.4X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          9             11           1          1.1         929.8       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            40             41           1          0.3        3955.7       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           15             16           1          0.7        1497.3       0.6X
+In-memory                                                          6              7           1          1.7         574.6       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            35             36           1          0.3        3473.9       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           15             16           1          0.7        1505.4       0.4X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          9             10           1          1.1         907.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            39             40           1          0.3        3886.5       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           15             16           1          0.7        1497.2       0.6X
+In-memory                                                          5              6           1          1.8         542.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            29             30           1          0.3        2863.2       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           15             16           1          0.7        1517.5       0.4X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                      9             10           1          1.1         904.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                        39             40           1          0.3        3859.8       0.2X
-RocksDB (trackTotalNumberOfRows: false)                       15             16           0          0.7        1497.2       0.6X
-
-
-================================================================================================
-merge rows
-================================================================================================
-
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
-AMD EPYC 7763 64-Core Processor
-merging 10000 rows with 10 values per key (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
---------------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                                    519            533           7          0.0       51916.6       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                                   171            177           3          0.1       17083.9       3.0X
-
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
-AMD EPYC 7763 64-Core Processor
-merging 10000 rows with 10 values per key (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                                  506            521           7          0.0       50644.0       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                                 170            176           3          0.1       17022.0       3.0X
-
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
-AMD EPYC 7763 64-Core Processor
-merging 10000 rows with 10 values per key (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
-------------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                                  493            508           6          0.0       49319.3       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                                 169            175           3          0.1       16897.6       2.9X
-
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
-AMD EPYC 7763 64-Core Processor
-merging 10000 rows with 10 values per key (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
---------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                              495            508           6          0.0       49462.5       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                             169            175           3          0.1       16896.6       2.9X
+In-memory                                                      5              6           1          1.8         542.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                        27             28           1          0.4        2689.8       0.2X
+RocksDB (trackTotalNumberOfRows: false)                       15             16           1          0.7        1497.0       0.4X
 
 
 ================================================================================================
 delete rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(10000 rows are non-existing - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                        0              1           0         26.3          38.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                          39             41           1          0.3        3942.0       0.0X
-RocksDB (trackTotalNumberOfRows: false)                                                         15             16           1          0.7        1529.2       0.0X
+In-memory                                                                                        0              1           0         27.9          35.8       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                          27             28           1          0.4        2721.0       0.0X
+RocksDB (trackTotalNumberOfRows: false)                                                         15             16           1          0.7        1503.3       0.0X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(5000 rows are non-existing - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      8              9           1          1.3         790.4       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        40             41           1          0.2        4036.7       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                       15             16           0          0.7        1536.9       0.5X
+In-memory                                                                                      4              5           1          2.3         425.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        34             35           1          0.3        3412.4       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       15             16           1          0.7        1524.0       0.3X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(1000 rows are non-existing - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      8             10           1          1.2         847.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        41             42           1          0.2        4099.8       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                       16             16           0          0.6        1563.3       0.5X
+In-memory                                                                                      5              6           1          2.1         480.1       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        40             41           1          0.2        4003.6       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                       15             16           1          0.7        1469.5       0.3X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(0 rows are non-existing - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                  9             10           1          1.2         859.4       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                    41             42           1          0.2        4118.9       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                   15             16           1          0.7        1507.8       0.6X
+In-memory                                                                                  5              6           1          2.1         479.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                    41             42           1          0.2        4101.5       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                                   15             15           0          0.7        1458.3       0.3X
 
 
 ================================================================================================
 evict rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
 AMD EPYC 7763 64-Core Processor
 evicting 10000 rows (maxTimestampToEvictInMillis: 9999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                            8              9           1          1.2         831.0       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                              40             40           1          0.3        3956.6       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                             16             16           0          0.6        1571.3       0.5X
+In-memory                                                                            5              5           1          2.1         477.5       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                              40             41           1          0.2        4023.8       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                             15             16           1          0.6        1542.2       0.3X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
 AMD EPYC 7763 64-Core Processor
 evicting 5000 rows (maxTimestampToEvictInMillis: 4999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           8              8           1          1.3         787.6       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             21             22           0          0.5        2112.6       0.4X
-RocksDB (trackTotalNumberOfRows: false)                                             9              9           0          1.1         932.9       0.8X
+In-memory                                                                           4              5           1          2.3         427.8       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             22             22           1          0.5        2172.1       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                             9             10           0          1.1         932.8       0.5X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
 AMD EPYC 7763 64-Core Processor
 evicting 1000 rows (maxTimestampToEvictInMillis: 999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                          7              8           0          1.4         715.7       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             7              7           0          1.5         676.3       1.1X
-RocksDB (trackTotalNumberOfRows: false)                                            4              5           0          2.3         442.3       1.6X
+In-memory                                                                          4              4           1          2.7         369.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             7              7           0          1.5         689.3       0.5X
+RocksDB (trackTotalNumberOfRows: false)                                            4              5           0          2.2         444.6       0.8X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 5.15.0-1059-azure
 AMD EPYC 7763 64-Core Processor
 evicting 0 rows (maxTimestampToEvictInMillis: -1) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                      0              0           0         23.8          41.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                         3              3           0          3.2         309.5       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                        3              3           0          3.2         309.9       0.1X
+In-memory                                                                      0              0           0         25.1          39.8       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                         3              3           0          3.2         308.3       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                        3              3           0          3.2         308.6       0.1X
+
+

--- a/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-results.txt
+++ b/sql/core/benchmarks/StateStoreBasicOperationsBenchmark-results.txt
@@ -2,141 +2,143 @@
 put rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                           10             12           1          1.0         960.1       1.0X
-RocksDB (trackTotalNumberOfRows: true)                              42             43           2          0.2        4173.9       0.2X
-RocksDB (trackTotalNumberOfRows: false)                             16             16           1          0.6        1551.6       0.6X
+In-memory                                                            9             10           0          1.1         934.9       1.0X
+RocksDB (trackTotalNumberOfRows: true)                              40             41           2          0.2        4018.6       0.2X
+RocksDB (trackTotalNumberOfRows: false)                             15             16           1          0.7        1499.5       0.6X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                         10             12           1          1.0         970.1       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            41             42           1          0.2        4095.8       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           15             17           1          0.6        1544.6       0.6X
+In-memory                                                          9             10           1          1.1         922.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            39             40           1          0.3        3924.1       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           15             15           1          0.7        1504.0       0.6X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                          9             11           1          1.1         933.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                            40             41           1          0.3        3966.2       0.2X
-RocksDB (trackTotalNumberOfRows: false)                           15             16           1          0.6        1540.2       0.6X
+In-memory                                                          9             10           1          1.1         902.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                            38             39           1          0.3        3846.6       0.2X
+RocksDB (trackTotalNumberOfRows: false)                           15             15           1          0.7        1501.3       0.6X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 putting 10000 rows (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                      9             11           1          1.1         936.1       1.0X
-RocksDB (trackTotalNumberOfRows: true)                        39             41           1          0.3        3942.4       0.2X
-RocksDB (trackTotalNumberOfRows: false)                       15             16           0          0.7        1530.1       0.6X
+In-memory                                                      9             10           0          1.1         896.1       1.0X
+RocksDB (trackTotalNumberOfRows: true)                        38             39           1          0.3        3816.6       0.2X
+RocksDB (trackTotalNumberOfRows: false)                       15             15           0          0.7        1496.4       0.6X
 
 
 ================================================================================================
 merge rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (10000 rows to overwrite - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                                    525            538           6          0.0       52516.4       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                                   170            177           4          0.1       16960.4       3.1X
+RocksDB (trackTotalNumberOfRows: true)                                                    508            519           5          0.0       50831.2       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                                   169            175           3          0.1       16943.3       3.0X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (5000 rows to overwrite - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                                  514            528           6          0.0       51351.9       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                                 168            174           4          0.1       16794.0       3.1X
+RocksDB (trackTotalNumberOfRows: true)                                                  495            505           6          0.0       49515.8       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                                 166            171           3          0.1       16606.9       3.0X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (1000 rows to overwrite - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                                  500            513           6          0.0       49955.1       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                                 169            174           2          0.1       16867.1       3.0X
+RocksDB (trackTotalNumberOfRows: true)                                                  487            501           7          0.0       48742.3       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                                 167            174           3          0.1       16654.6       2.9X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 merging 10000 rows with 10 values per key (0 rows to overwrite - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------------------------------------
-RocksDB (trackTotalNumberOfRows: true)                                              492            508           8          0.0       49225.8       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                             168            173           3          0.1       16757.2       2.9X
+RocksDB (trackTotalNumberOfRows: true)                                              480            496           6          0.0       48046.7       1.0X
+RocksDB (trackTotalNumberOfRows: false)                                             166            173           3          0.1       16591.0       2.9X
 
 
 ================================================================================================
 delete rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(10000 rows are non-existing - rate 100):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                        0              1           0         26.1          38.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                          38             40           1          0.3        3835.6       0.0X
-RocksDB (trackTotalNumberOfRows: false)                                                         15             16           1          0.7        1455.7       0.0X
+In-memory                                                                                        0              0           0         25.8          38.8       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                          38             39           1          0.3        3772.3       0.0X
+RocksDB (trackTotalNumberOfRows: false)                                                         15             15           0          0.7        1466.1       0.0X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(5000 rows are non-existing - rate 50):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      8              9           1          1.3         793.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        40             41           1          0.2        4018.1       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                       15             16           0          0.7        1505.6       0.5X
+In-memory                                                                                      8              8           1          1.3         777.7       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        39             40           1          0.3        3898.8       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                       15             15           1          0.7        1482.2       0.5X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(1000 rows are non-existing - rate 10):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                      8             10           1          1.2         837.2       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                        41             42           1          0.2        4073.9       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                       15             16           1          0.7        1470.6       0.6X
+In-memory                                                                                      8              9           0          1.2         823.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                        40             41           1          0.3        3960.8       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                       15             15           0          0.7        1489.0       0.6X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 trying to delete 10000 rows from 10000 rows(0 rows are non-existing - rate 0):  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                                  8              9           0          1.2         843.6       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                                    41             42           1          0.2        4088.7       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                                   15             15           0          0.7        1466.1       0.6X
+In-memory                                                                                  8              9           0          1.2         832.0       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                                    40             41           1          0.3        3986.7       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                                   15             16           0          0.7        1480.5       0.6X
 
 
 ================================================================================================
 evict rows
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 evicting 10000 rows (maxTimestampToEvictInMillis: 9999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                            8              9           0          1.2         833.5       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                              40             41           0          0.3        3976.5       0.2X
-RocksDB (trackTotalNumberOfRows: false)                                             16             16           0          0.6        1588.1       0.5X
+In-memory                                                                            8              9           0          1.2         838.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                              39             39           1          0.3        3867.4       0.2X
+RocksDB (trackTotalNumberOfRows: false)                                             16             16           1          0.6        1564.6       0.5X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 evicting 5000 rows (maxTimestampToEvictInMillis: 4999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                           8              8           0          1.3         784.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             22             22           0          0.5        2155.1       0.4X
-RocksDB (trackTotalNumberOfRows: false)                                            10             10           0          1.0         986.9       0.8X
+In-memory                                                                           8              8           0          1.3         785.3       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             21             22           1          0.5        2098.1       0.4X
+RocksDB (trackTotalNumberOfRows: false)                                            10             10           0          1.0         957.2       0.8X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 evicting 1000 rows (maxTimestampToEvictInMillis: 999) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -----------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                          7              8           0          1.4         722.3       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                             7              7           0          1.4         718.8       1.0X
-RocksDB (trackTotalNumberOfRows: false)                                            5              5           0          2.0         488.7       1.5X
+In-memory                                                                          7              8           0          1.4         725.4       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                             7              7           0          1.5         682.3       1.1X
+RocksDB (trackTotalNumberOfRows: false)                                            5              5           0          2.2         458.3       1.6X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1016-azure
+OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
 AMD EPYC 7763 64-Core Processor
 evicting 0 rows (maxTimestampToEvictInMillis: -1) from 10000 rows:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------------
-In-memory                                                                      0              1           0         21.3          46.9       1.0X
-RocksDB (trackTotalNumberOfRows: true)                                         4              4           0          2.8         358.9       0.1X
-RocksDB (trackTotalNumberOfRows: false)                                        4              4           0          2.8         358.7       0.1X
+In-memory                                                                      0              1           0         21.2          47.2       1.0X
+RocksDB (trackTotalNumberOfRows: true)                                         3              3           0          3.1         326.5       0.1X
+RocksDB (trackTotalNumberOfRows: false)                                        3              3           0          3.1         326.6       0.1X
+
+


### PR DESCRIPTION
### What changes were proposed in this pull request?

Upgrades `rocksdbjni` dependency to 8.11.4. 

### Why are the changes needed?

8.11.4 has Java-related RocksDB fixes:

https://github.com/facebook/rocksdb/releases/tag/v8.11.4

- Fixed CMake Javadoc build
- Fixed Java SstFileMetaData to prevent throwing java.lang.NoSuchMethodError

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- All existing UTs should pass
- [In progress] Performance benchmarks

### Was this patch authored or co-authored using generative AI tooling?

No.
