### PR TITLE
[SPARK-47866][SQL][TESTS] Use explicit GC in `PythonForeachWriterSuite`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonForeachWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonForeachWriterSuite.scala
@@ -72,6 +72,7 @@ class PythonForeachWriterSuite extends SparkFunSuite with Eventually with Mockit
       sleepPerRowReadMs: Int = 0
     )(f: BufferTester => Unit): Unit = {
 
+    System.gc()
     test(name) {
       var tester: BufferTester = null
       try {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to reduce the flakiness of `PythonForeachWriterSuite` in CIs by invoking `System.gc` explicitly before each test.

### Why are the changes needed?

Currently, the flakiness happens in Apple Silicon CI environment.
- https://github.com/apache/spark/actions/workflows/build_maven_java21_macos14.yml
    - https://github.com/apache/spark/actions/runs/8637092571
```
- UnsafeRowBuffer: handles more data than memory *** FAILED ***
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.
```
$ build/sbt "sql/testOnly *.PythonForeachWriterSuite"
...
[info] All tests passed.
[success] Total time: 143 s (02:23), completed Apr 15, 2024, 8:04:20 PM
```

### Was this patch authored or co-authored using generative AI tooling?

No.