### PR TITLE
[SPARK-47877][SS][CONNECT] Speed up test_parity_listener

### DIFF
--- a/python/pyspark/sql/tests/streaming/test_streaming_listener.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_listener.py
@@ -39,16 +39,16 @@ class StreamingListenerTestsMixin:
         self.assertTrue(isinstance(event, QueryStartedEvent))
         self.assertTrue(isinstance(event.id, uuid.UUID))
         self.assertTrue(isinstance(event.runId, uuid.UUID))
-        self.assertTrue(event.name is None or event.name == "test")
+        self.assertTrue(event.name is None or event.name.startswith("test"))
         try:
             datetime.strptime(event.timestamp, "%Y-%m-%dT%H:%M:%S.%fZ")
         except ValueError:
             self.fail("'%s' is not in ISO 8601 format.")
 
-    def check_progress_event(self, event):
+    def check_progress_event(self, event, is_stateful):
         """Check QueryProgressEvent"""
         self.assertTrue(isinstance(event, QueryProgressEvent))
-        self.check_streaming_query_progress(event.progress)
+        self.check_streaming_query_progress(event.progress, is_stateful)
 
     def check_terminated_event(self, event, exception=None, error_class=None):
         """Check QueryTerminatedEvent"""
@@ -65,12 +65,12 @@ class StreamingListenerTestsMixin:
         else:
             self.assertEqual(event.errorClassOnException, None)
 
-    def check_streaming_query_progress(self, progress):
+    def check_streaming_query_progress(self, progress, is_stateful):
         """Check StreamingQueryProgress"""
         self.assertTrue(isinstance(progress, StreamingQueryProgress))
         self.assertTrue(isinstance(progress.id, uuid.UUID))
         self.assertTrue(isinstance(progress.runId, uuid.UUID))
-        self.assertEqual(progress.name, "test")
+        self.assertTrue(progress.name.startswith("test"))
         try:
             json.loads(progress.json)
         except Exception:
@@ -108,9 +108,10 @@ class StreamingListenerTestsMixin:
         self.assertTrue(all(map(lambda v: isinstance(v, str), progress.eventTime.values())))
 
         self.assertTrue(isinstance(progress.stateOperators, list))
-        self.assertTrue(len(progress.stateOperators) >= 1)
-        for so in progress.stateOperators:
-            self.check_state_operator_progress(so)
+        if is_stateful:
+            self.assertTrue(len(progress.stateOperators) >= 1)
+            for so in progress.stateOperators:
+                self.check_state_operator_progress(so)
 
         self.assertTrue(isinstance(progress.sources, list))
         self.assertTrue(len(progress.sources) >= 1)
@@ -313,7 +314,7 @@ class StreamingListenerTests(StreamingListenerTestsMixin, ReusedSQLTestCase):
                 self.spark.sparkContext._jsc.sc().listenerBus().waitUntilEmpty()
 
                 self.check_start_event(start_event)
-                self.check_progress_event(progress_event)
+                self.check_progress_event(progress_event, True)
                 self.check_terminated_event(terminated_event)
 
                 # Check query terminated with exception
@@ -470,7 +471,7 @@ class StreamingListenerTests(StreamingListenerTestsMixin, ReusedSQLTestCase):
         """
         progress = StreamingQueryProgress.fromJson(json.loads(progress_json))
 
-        self.check_streaming_query_progress(progress)
+        self.check_streaming_query_progress(progress, True)
 
         # checks for progress
         self.assertEqual(progress.id, uuid.UUID("00000000-0000-0001-0000-000000000001"))


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR makes test_parity_listener run faster.

The test was slow because of `TestListenerSparkV1` and `TestListenerSparkV2` makes server calls and has long wait time, and the test runs on both listeners. They were created to verify the listener function with and without the new `onQueryIdle` callback.

This PR fixes the slowness by removing the V1 and V2 of that listener (now only a `TestListenerSpark`), and create lightweight `TestListenerLocalV1` and `TestListenerLocalV2` for the `onQueryIdle` verification.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Faster and more stable ci

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
test only change

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no