### PR TITLE
[SPARK-45387][SQL]Optimize hive patition filter when the comparision dataType not match

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -352,6 +352,13 @@ object LiteralTreeBits {
  */
 case class Literal (value: Any, dataType: DataType) extends LeafExpression {
 
+  var text: String = ""
+
+  def setText(text: String): Literal = {
+    this.text = text
+    this
+  }
+
   Literal.validateLiteralValue(value, dataType)
 
   override def foldable: Boolean = true

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2636,10 +2636,10 @@ class AstBuilder extends DataTypeAstBuilder with SQLConfHelper with Logging {
   override def visitIntegerLiteral(ctx: IntegerLiteralContext): Literal = withOrigin(ctx) {
     BigDecimal(ctx.getText) match {
       case v if v.isValidInt =>
-        Literal(v.intValue)
+        Literal(v.intValue).setText(ctx.getText)
       case v if v.isValidLong =>
-        Literal(v.longValue)
-      case v => Literal(v.underlying())
+        Literal(v.longValue).setText(ctx.getText)
+      case v => Literal(v.underlying()).setText(ctx.getText)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
During the PruneFileSourcePartitions process, we can optimize by casting the dataType of the constant to match the dataType of the corresponding partition key.


### Why are the changes needed?
Suppose we have a partitioned table `table_pt` with partition colum `dt` which is StringType and the table metadata is managed by Hive Metastore, if we filter partition by dt = '123', this filter can be pushed down to data source directly, but if the filter condition is number, e.g. dt = 123, Spark will not known which partition should be pushed down. Thus in the process of physical plan optimization, Spark will pull all of that table's partition meta data to client side, to decide which partition filter should be push down to the data source. This is poor of performance if the table has thousands of partitions and increasing the risk of hive metastore oom. In our production env, we encounter this problem.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
in our production env, this fix is OK


### Was this patch authored or co-authored using generative AI tooling?
No