### PR TITLE
[SQL] Add new functions to CollationBenchmark (obsolete)

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.benchmark
 import scala.concurrent.duration._
 
 import org.apache.spark.benchmark.{Benchmark, BenchmarkBase}
-import org.apache.spark.sql.catalyst.util.CollationFactory
+import org.apache.spark.sql.catalyst.util.{CollationFactory, CollationSupport}
 import org.apache.spark.unsafe.types.UTF8String
 
 abstract class CollationBenchmarkBase extends BenchmarkBase {
@@ -100,6 +100,90 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
     )
     benchmark.run()
   }
+
+  def benchmarkUTFStringContains(
+      collationTypes: Seq[String],
+      utf8Strings: Seq[UTF8String]): Unit = {
+    val sublistStrings = utf8Strings
+
+    val benchmark = new Benchmark(
+      "collation unit benchmarks - contains",
+      utf8Strings.size * 10,
+      warmupTime = 10.seconds,
+      output = output)
+    collationTypes.foreach(collationType => {
+      val collation = CollationFactory.fetchCollation(collationType)
+      benchmark.addCase(s"$collationType") { _ =>
+        sublistStrings.foreach(s1 =>
+          utf8Strings.foreach(s =>
+            (0 to 10).foreach(_ =>
+              CollationSupport.Contains.exec(
+                s, s1, CollationFactory.collationNameToId(collation.collationName)
+              )
+            )
+          )
+        )
+      }
+    }
+    )
+    benchmark.run()
+  }
+
+  def benchmarkUTFStringStartsWith(
+      collationTypes: Seq[String],
+      utf8Strings: Seq[UTF8String]): Unit = {
+    val sublistStrings = utf8Strings
+
+    val benchmark = new Benchmark(
+      "collation unit benchmarks - startsWith",
+      utf8Strings.size * 10,
+      warmupTime = 10.seconds,
+      output = output)
+    collationTypes.foreach(collationType => {
+      val collation = CollationFactory.fetchCollation(collationType)
+      benchmark.addCase(s"$collationType") { _ =>
+        sublistStrings.foreach(s1 =>
+          utf8Strings.foreach(s =>
+            (0 to 10).foreach(_ =>
+              CollationSupport.StartsWith.exec(
+                s, s1, CollationFactory.collationNameToId(collation.collationName)
+              )
+            )
+          )
+        )
+      }
+    }
+    )
+    benchmark.run()
+  }
+
+  def benchmarkUTFStringEndsWith(
+      collationTypes: Seq[String],
+      utf8Strings: Seq[UTF8String]): Unit = {
+    val sublistStrings = utf8Strings
+
+    val benchmark = new Benchmark(
+      "collation unit benchmarks - endsWith",
+      utf8Strings.size * 10,
+      warmupTime = 10.seconds,
+      output = output)
+    collationTypes.foreach(collationType => {
+      val collation = CollationFactory.fetchCollation(collationType)
+      benchmark.addCase(s"$collationType") { _ =>
+        sublistStrings.foreach(s1 =>
+          utf8Strings.foreach(s =>
+            (0 to 10).foreach(_ =>
+              CollationSupport.EndsWith.exec(
+                s, s1, CollationFactory.collationNameToId(collation.collationName)
+              )
+            )
+          )
+        )
+      }
+    }
+    )
+    benchmark.run()
+  }
 }
 
 /**
@@ -130,6 +214,9 @@ object CollationBenchmark extends CollationBenchmarkBase {
     benchmarkUTFStringEquals(collationTypes, generateSeqInput(10000L))
     benchmarkUTFStringCompare(collationTypes, generateSeqInput(10000L))
     benchmarkUTFStringHashFunction(collationTypes, generateSeqInput(10000L))
+    benchmarkUTFStringContains(collationTypes, generateSeqInput(10000L))
+    benchmarkUTFStringStartsWith(collationTypes, generateSeqInput(10000L))
+    benchmarkUTFStringEndsWith(collationTypes, generateSeqInput(10000L))
   }
 }
 
@@ -155,5 +242,8 @@ object CollationNonASCIIBenchmark extends CollationBenchmarkBase {
     benchmarkUTFStringEquals(collationTypes, generateSeqInput(4000L))
     benchmarkUTFStringCompare(collationTypes, generateSeqInput(4000L))
     benchmarkUTFStringHashFunction(collationTypes, generateSeqInput(4000L))
+    benchmarkUTFStringContains(collationTypes, generateSeqInput(4000L))
+    benchmarkUTFStringStartsWith(collationTypes, generateSeqInput(4000L))
+    benchmarkUTFStringEndsWith(collationTypes, generateSeqInput(4000L))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added new benchmarks for contains, startsWith, endsWith prior to improving the implementation for the UTF8_BINARY_LCASE collation.


### Why are the changes needed?
To see exact improvements after the implementation of https://issues.apache.org/jira/browse/SPARK-47418


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
GHA 'Run Benchmarks' ran on this, for both JDK 17 and JDK 21


### Was this patch authored or co-authored using generative AI tooling?
No
