### PR TITLE
[SPARK-47418][SQL] Add hand-crafted implementations for lowercase unicode-aware contains, startsWith and endsWith and optimize UTF8_BINARY_LCASE

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationSupport.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationSupport.java
@@ -57,7 +57,7 @@ public final class CollationSupport {
       return l.contains(r);
     }
     public static boolean execLowercase(final UTF8String l, final UTF8String r) {
-      return l.toLowerCase().contains(r.toLowerCase());
+      return l.containsInLowerCase(r);
     }
     public static boolean execICU(final UTF8String l, final UTF8String r,
         final int collationId) {
@@ -95,7 +95,7 @@ public final class CollationSupport {
       return l.startsWith(r);
     }
     public static boolean execLowercase(final UTF8String l, final UTF8String r) {
-      return l.toLowerCase().startsWith(r.toLowerCase());
+      return l.startsWithInLowerCase(r);
     }
     public static boolean execICU(final UTF8String l, final UTF8String r,
         final int collationId) {
@@ -132,7 +132,7 @@ public final class CollationSupport {
       return l.endsWith(r);
     }
     public static boolean execLowercase(final UTF8String l, final UTF8String r) {
-      return l.toLowerCase().endsWith(r.toLowerCase());
+      return l.endsWithInLowerCase(r);
     }
     public static boolean execICU(final UTF8String l, final UTF8String r,
         final int collationId) {

--- a/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/unsafe/types/UTF8String.java
@@ -342,6 +342,61 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
   }
 
   /**
+   * Returns whether `this` contains `substring` in a lowercase unicode-aware manner
+   *
+   * This function is written in a way which avoids excessive allocations in case if we work with
+   * bare ASCII-character strings.
+   */
+  public boolean containsInLowerCase(final UTF8String substring) {
+    if (substring.numBytes == 0) {
+      return true;
+    }
+
+    // Both `this` and the `substring` are checked for non-ASCII characters, otherwise we would
+    // have to use `startsWithLowerCase(...)` in a loop, and it would frequently allocate
+    // (e.g. in case of `containsInLowerCase("1大1大1大...", "11")`)
+    if (!substring.isFullAscii()) {
+      return toLowerCase().contains(substring.toLowerCaseSlow());
+    }
+    if (!isFullAscii()) {
+      return toLowerCaseSlow().contains(substring.toLowerCaseAscii());
+    }
+
+    if (numBytes < substring.numBytes) {
+      return false;
+    }
+
+    final var firstLower = Character.toLowerCase(substring.getByte(0));
+    for (var i = 0; i <= (numBytes - substring.numBytes); i++) {
+      if (Character.toLowerCase(getByte(i)) == firstLower) {
+        final var rest = UTF8String.fromAddress(base, offset + i, numBytes - i);
+        if (rest.startsWithInLowerCaseASCII(substring)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  private boolean startsWithInLowerCaseASCII(final UTF8String prefix) {
+    if (prefix.numBytes == 0) {
+      return true;
+    }
+    if (numBytes < prefix.numBytes) {
+      return false;
+    }
+
+    for (var i = 0; i < prefix.numBytes; i++) {
+      if (Character.toLowerCase(getByte(i)) != Character.toLowerCase(prefix.getByte(i))) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
    * Returns the byte at position `i`.
    */
   private byte getByte(int i) {
@@ -359,8 +414,95 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     return matchAt(prefix, 0);
   }
 
+  /**
+   * Checks whether `prefix` is a prefix of `this` in a lowercase unicode-aware manner
+   *
+   * This function is written in a way which avoids excessive allocations in case if we work with
+   * bare ASCII-character strings.
+   */
+  public boolean startsWithInLowerCase(final UTF8String prefix) {
+    // No way to match sizes of strings for early return, since single grapheme can be expanded
+    // into several independent ones in lowercase
+    if (prefix.numBytes == 0) {
+      return true;
+    }
+    if (numBytes == 0) {
+      return false;
+    }
+
+    for (var i = 0; i < prefix.numBytes; i++) {
+      final var lhsByte = getByte(i);
+      final var rhsByte = prefix.getByte(i);
+      if (lhsByte < 0 || rhsByte < 0) {
+        final var lhsRest = UTF8String.fromAddress(base, offset + i, numBytes - i);
+        final var rhsRest = UTF8String
+          .fromAddress(prefix.base, prefix.offset + i, prefix.numBytes - i);
+
+        final var lhsRestLowerCase = lhsByte < 0 ?
+          lhsRest.toLowerCaseSlow() : lhsRest.toLowerCase();
+        final var rhsRestLowerCase = rhsByte < 0 ?
+          rhsRest.toLowerCaseSlow() : rhsRest.toLowerCase();
+
+        return UTF8String
+          .fromAddress(lhsRestLowerCase.base, lhsRestLowerCase.offset, rhsRestLowerCase.numBytes)
+          .binaryCompare(rhsRestLowerCase) == 0;
+      }
+
+      if (Character.toLowerCase(lhsByte) != Character.toLowerCase(rhsByte)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   public boolean endsWith(final UTF8String suffix) {
     return matchAt(suffix, numBytes - suffix.numBytes);
+  }
+
+  /**
+   * Checks whether `suffix` is a suffix of `this` in a lowercase unicode-aware manner
+   *
+   * This function is written in a way which avoids excessive allocations in case if we work with
+   * bare ASCII-character strings.
+   */
+  public boolean endsWithInLowerCase(final UTF8String suffix) {
+    // No way to match sizes of strings for early return, since single grapheme can be expanded
+    // into several independent ones in lowercase
+    if (suffix.numBytes == 0) {
+      return true;
+    }
+    if (numBytes == 0) {
+      return false;
+    }
+
+    for (var i = 0; i < suffix.numBytes; i++) {
+      final var lhsByte = getByte(numBytes - i - 1);
+      final var rhsByte = suffix.getByte(suffix.numBytes - i - 1);
+      if (lhsByte < 0 || rhsByte < 0) {
+        final var lhsRest = UTF8String.fromAddress(base, offset, numBytes - i);
+        final var rhsRest = UTF8String
+          .fromAddress(suffix.base, suffix.offset, suffix.numBytes - i);
+
+        final var lhsRestLowerCase = lhsByte < 0 ?
+          lhsRest.toLowerCaseSlow() : lhsRest.toLowerCase();
+        final var rhsRestLowerCase = rhsByte < 0 ?
+          rhsRest.toLowerCaseSlow() : rhsRest.toLowerCase();
+
+        return UTF8String
+          .fromAddress(
+            lhsRestLowerCase.base,
+            lhsRestLowerCase.offset + lhsRestLowerCase.numBytes - rhsRestLowerCase.numBytes,
+            rhsRestLowerCase.numBytes)
+          .binaryCompare(rhsRestLowerCase) == 0;
+      }
+
+      if (Character.toLowerCase(lhsByte) != Character.toLowerCase(rhsByte)) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   /**
@@ -423,22 +565,29 @@ public final class UTF8String implements Comparable<UTF8String>, Externalizable,
     if (numBytes == 0) {
       return EMPTY_UTF8;
     }
-    // Optimization - do char level lowercase conversion in case of chars in ASCII range
-    for (int i = 0; i < numBytes; i++) {
+
+    return isFullAscii() ? toLowerCaseAscii() : toLowerCaseSlow();
+  }
+
+  private boolean isFullAscii() {
+    for (var i = 0; i < numBytes; i++) {
       if (getByte(i) < 0) {
-        // non-ASCII
-        return toLowerCaseSlow();
+        return false;
       }
     }
-    byte[] bytes = new byte[numBytes];
-    for (int i = 0; i < numBytes; i++) {
-      bytes[i] = (byte) Character.toLowerCase(getByte(i));
-    }
-    return fromBytes(bytes);
+    return true;
   }
 
   private UTF8String toLowerCaseSlow() {
     return fromString(toString().toLowerCase());
+  }
+
+  private UTF8String toLowerCaseAscii() {
+    final var bytes = new byte[numBytes];
+    for (var i = 0; i < numBytes; i++) {
+      bytes[i] = (byte) Character.toLowerCase(getByte(i));
+    }
+    return fromBytes(bytes);
   }
 
   /**

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
@@ -104,6 +104,18 @@ public class CollationSupportSuite {
     // Case-variable character length
     assertContains("abİo12", "i̇o", "UNICODE_CI", true);
     assertContains("abi̇o12", "İo", "UNICODE_CI", true);
+    assertContains("the İodine", "the i̇odine", "UTF8_BINARY_LCASE", true);
+    assertContains("the i̇odine", "the İodine", "UTF8_BINARY_LCASE", true);
+    assertContains("The İodiNe", " i̇oDin", "UTF8_BINARY_LCASE", true);
+    assertContains("İodiNe", "i̇oDine", "UTF8_BINARY_LCASE", true);
+    assertContains("İodiNe", " i̇oDin", "UTF8_BINARY_LCASE", false);
+    // Characters with the same binary lowercase representation
+    assertContains("The Kelvin.", "Kelvin", "UTF8_BINARY_LCASE", true);
+    assertContains("The Kelvin.", "Kelvin", "UTF8_BINARY_LCASE", true);
+    assertContains("The KKelvin.", "KKelvin", "UTF8_BINARY_LCASE", true);
+    assertContains("2 Kelvin.", "2 Kelvin", "UTF8_BINARY_LCASE", true);
+    assertContains("2 Kelvin.", "2 Kelvin", "UTF8_BINARY_LCASE", true);
+    assertContains("The KKelvin.", "KKelvin,", "UTF8_BINARY_LCASE", false);
   }
 
   private void assertStartsWith(
@@ -182,6 +194,17 @@ public class CollationSupportSuite {
     // Case-variable character length
     assertStartsWith("İonic", "i̇o", "UNICODE_CI", true);
     assertStartsWith("i̇onic", "İo", "UNICODE_CI", true);
+    assertStartsWith("the İodine", "the i̇odine", "UTF8_BINARY_LCASE", true);
+    assertStartsWith("the i̇odine", "the İodine", "UTF8_BINARY_LCASE", true);
+    assertStartsWith("İodiNe", "i̇oDin", "UTF8_BINARY_LCASE", true);
+    assertStartsWith("The İodiNe", "i̇oDin", "UTF8_BINARY_LCASE", false);
+    // Characters with the same binary lowercase representation
+    assertStartsWith("Kelvin.", "Kelvin", "UTF8_BINARY_LCASE", true);
+    assertStartsWith("Kelvin.", "Kelvin", "UTF8_BINARY_LCASE", true);
+    assertStartsWith("KKelvin.", "KKelvin", "UTF8_BINARY_LCASE", true);
+    assertStartsWith("2 Kelvin.", "2 Kelvin", "UTF8_BINARY_LCASE", true);
+    assertStartsWith("2 Kelvin.", "2 Kelvin", "UTF8_BINARY_LCASE", true);
+    assertStartsWith("KKelvin.", "KKelvin,", "UTF8_BINARY_LCASE", false);
   }
 
   private void assertEndsWith(String pattern, String suffix, String collationName, boolean expected)
@@ -259,6 +282,17 @@ public class CollationSupportSuite {
     // Case-variable character length
     assertEndsWith("The İo", "i̇o", "UNICODE_CI", true);
     assertEndsWith("The i̇o", "İo", "UNICODE_CI", true);
+    assertEndsWith("the İodine", "the i̇odine", "UTF8_BINARY_LCASE", true);
+    assertEndsWith("the i̇odine", "the İodine", "UTF8_BINARY_LCASE", true);
+    assertEndsWith("The İodiNe", "i̇oDine", "UTF8_BINARY_LCASE", true);
+    assertEndsWith("The İodiNe", "i̇oDin", "UTF8_BINARY_LCASE", false);
+    // Characters with the same binary lowercase representation
+    assertEndsWith("The Kelvin", "Kelvin", "UTF8_BINARY_LCASE", true);
+    assertEndsWith("The Kelvin", "Kelvin", "UTF8_BINARY_LCASE", true);
+    assertEndsWith("The KKelvin", "KKelvin", "UTF8_BINARY_LCASE", true);
+    assertEndsWith("The 2 Kelvin", "2 Kelvin", "UTF8_BINARY_LCASE", true);
+    assertEndsWith("The 2 Kelvin", "2 Kelvin", "UTF8_BINARY_LCASE", true);
+    assertEndsWith("The KKelvin", "KKelvin,", "UTF8_BINARY_LCASE", false);
   }
 
   // TODO: Test more collation-aware string expressions.

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java
@@ -216,6 +216,43 @@ public class UTF8StringSuite {
   }
 
   @Test
+  public void containsInLowerCase() {
+    // Corner cases
+    assertTrue(EMPTY_UTF8.containsInLowerCase(EMPTY_UTF8));
+    assertTrue(fromString("a").containsInLowerCase(EMPTY_UTF8));
+    assertTrue(fromString("A").containsInLowerCase(fromString("a")));
+    assertTrue(fromString("a").containsInLowerCase(fromString("A")));
+    assertFalse(EMPTY_UTF8.containsInLowerCase(fromString("a")));
+    // ASCII
+    assertTrue(fromString("hello").containsInLowerCase(fromString("ello")));
+    assertFalse(fromString("hello").containsInLowerCase(fromString("vello")));
+    assertFalse(fromString("hello").containsInLowerCase(fromString("hellooo")));
+    // Unicode
+    assertTrue(fromString("大千世界").containsInLowerCase(fromString("千世界")));
+    assertFalse(fromString("大千世界").containsInLowerCase(fromString("世千")));
+    assertFalse(fromString("大千世界").containsInLowerCase(fromString("大千世界好")));
+    // ASCII lowercase
+    assertTrue(fromString("HeLlO").containsInLowerCase(fromString("ElL")));
+    assertFalse(fromString("HeLlO").containsInLowerCase(fromString("ElLoO")));
+    // Unicode lowercase
+    assertTrue(fromString("ЯбЛоКо").containsInLowerCase(fromString("БлОк")));
+    assertFalse(fromString("ЯбЛоКо").containsInLowerCase(fromString("лОкБ")));
+    // Characters with the same binary lowercase representation
+    assertTrue(fromString("The Kelvin.").containsInLowerCase(fromString("Kelvin")));
+    assertTrue(fromString("The Kelvin.").containsInLowerCase(fromString("Kelvin")));
+    assertTrue(fromString("The KKelvin.").containsInLowerCase(fromString("KKelvin")));
+    assertTrue(fromString("2 Kelvin.").containsInLowerCase(fromString("2 Kelvin")));
+    assertTrue(fromString("2 Kelvin.").containsInLowerCase(fromString("2 Kelvin")));
+    assertFalse(fromString("The KKelvin.").containsInLowerCase(fromString("KKelvin,")));
+    // Characters with longer binary lowercase representation
+    assertTrue(fromString("the İodine").containsInLowerCase(fromString("the i̇odine")));
+    assertTrue(fromString("the i̇odine").containsInLowerCase(fromString("the İodine")));
+    assertTrue(fromString("The İodiNe").containsInLowerCase(fromString(" i̇oDin")));
+    assertTrue(fromString("İodiNe").containsInLowerCase(fromString("i̇oDin")));
+    assertFalse(fromString("İodiNe").containsInLowerCase(fromString(" i̇oDin")));
+  }
+
+  @Test
   public void startsWith() {
     assertTrue(EMPTY_UTF8.startsWith(EMPTY_UTF8));
     assertTrue(fromString("hello").startsWith(fromString("hell")));
@@ -227,6 +264,40 @@ public class UTF8StringSuite {
   }
 
   @Test
+  public void startsWithInLowerCase() {
+    // Corner cases
+    assertTrue(EMPTY_UTF8.startsWithInLowerCase(EMPTY_UTF8));
+    assertTrue(fromString("a").startsWithInLowerCase(EMPTY_UTF8));
+    assertTrue(fromString("A").startsWithInLowerCase(fromString("a")));
+    assertTrue(fromString("a").startsWithInLowerCase(fromString("A")));
+    assertFalse(EMPTY_UTF8.startsWithInLowerCase(fromString("a")));
+    // ASCII
+    assertTrue(fromString("hello").startsWithInLowerCase(fromString("hell")));
+    assertFalse(fromString("hello").startsWithInLowerCase(fromString("ell")));
+    // Unicode
+    assertTrue(fromString("大千世界").startsWithInLowerCase(fromString("大千")));
+    assertFalse(fromString("大千世界").startsWithInLowerCase(fromString("世千")));
+    // ASCII lowercase
+    assertTrue(fromString("HeLlO").startsWithInLowerCase(fromString("hElL")));
+    assertFalse(fromString("HeLlO").startsWithInLowerCase(fromString("ElL")));
+    // Unicode lowercase
+    assertTrue(fromString("ЯбЛоКо").startsWithInLowerCase(fromString("яБлОк")));
+    assertFalse(fromString("ЯбЛоКо").startsWithInLowerCase(fromString("БлОк")));
+    // Characters with the same binary lowercase representation
+    assertTrue(fromString("Kelvin.").startsWithInLowerCase(fromString("Kelvin")));
+    assertTrue(fromString("Kelvin.").startsWithInLowerCase(fromString("Kelvin")));
+    assertTrue(fromString("KKelvin.").startsWithInLowerCase(fromString("KKelvin")));
+    assertTrue(fromString("2 Kelvin.").startsWithInLowerCase(fromString("2 Kelvin")));
+    assertTrue(fromString("2 Kelvin.").startsWithInLowerCase(fromString("2 Kelvin")));
+    assertFalse(fromString("KKelvin.").startsWithInLowerCase(fromString("KKelvin,")));
+    // Characters with longer binary lowercase representation
+    assertTrue(fromString("the İodine").startsWithInLowerCase(fromString("the i̇odine")));
+    assertTrue(fromString("the i̇odine").startsWithInLowerCase(fromString("the İodine")));
+    assertTrue(fromString("İodiNe").startsWithInLowerCase(fromString("i̇oDin")));
+    assertFalse(fromString("The İodiNe").startsWithInLowerCase(fromString("i̇oDin")));
+  }
+
+  @Test
   public void endsWith() {
     assertTrue(EMPTY_UTF8.endsWith(EMPTY_UTF8));
     assertTrue(fromString("hello").endsWith(fromString("ello")));
@@ -235,6 +306,40 @@ public class UTF8StringSuite {
     assertTrue(fromString("大千世界").endsWith(fromString("世界")));
     assertFalse(fromString("大千世界").endsWith(fromString("世")));
     assertFalse(fromString("数据砖头").endsWith(fromString("我的数据砖头")));
+  }
+
+  @Test
+  public void endsWithInLowerCase() {
+    // Corner cases
+    assertTrue(EMPTY_UTF8.endsWithInLowerCase(EMPTY_UTF8));
+    assertTrue(fromString("a").endsWithInLowerCase(EMPTY_UTF8));
+    assertTrue(fromString("A").endsWithInLowerCase(fromString("a")));
+    assertTrue(fromString("a").endsWithInLowerCase(fromString("A")));
+    assertFalse(EMPTY_UTF8.endsWithInLowerCase(fromString("a")));
+    // ASCII
+    assertTrue(fromString("hello").endsWithInLowerCase(fromString("ello")));
+    assertFalse(fromString("hello").endsWithInLowerCase(fromString("hell")));
+    // Unicode
+    assertTrue(fromString("大千世界").endsWithInLowerCase(fromString("世界")));
+    assertFalse(fromString("大千世界").endsWithInLowerCase(fromString("大千")));
+    // ASCII lowercase
+    assertTrue(fromString("HeLlO").endsWithInLowerCase(fromString("ElLo")));
+    assertFalse(fromString("HeLlO").endsWithInLowerCase(fromString("hElL")));
+    // Unicode lowercase
+    assertTrue(fromString("ЯбЛоКо").endsWithInLowerCase(fromString("БлОкО")));
+    assertFalse(fromString("ЯбЛоКо").endsWithInLowerCase(fromString("яБлОк")));
+    // Characters with the same binary lowercase representation
+    assertTrue(fromString("The Kelvin").endsWithInLowerCase(fromString("Kelvin")));
+    assertTrue(fromString("The Kelvin").endsWithInLowerCase(fromString("Kelvin")));
+    assertTrue(fromString("The KKelvin").endsWithInLowerCase(fromString("KKelvin")));
+    assertTrue(fromString("The 2 Kelvin").endsWithInLowerCase(fromString("2 Kelvin")));
+    assertTrue(fromString("The 2 Kelvin").endsWithInLowerCase(fromString("2 Kelvin")));
+    assertFalse(fromString("The KKelvin").endsWithInLowerCase(fromString("KKelvin,")));
+    // Characters with longer binary lowercase representation
+    assertTrue(fromString("the İodine").endsWithInLowerCase(fromString("the i̇odine")));
+    assertTrue(fromString("the i̇odine").endsWithInLowerCase(fromString("the İodine")));
+    assertTrue(fromString("The İodiNe").endsWithInLowerCase(fromString("i̇oDine")));
+    assertFalse(fromString("The İodiNe").endsWithInLowerCase(fromString("i̇oDin")));
   }
 
   @Test

--- a/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
@@ -1,54 +1,54 @@
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                    6910           6912           3          0.0       69099.7       1.0X
-UNICODE                                              4367           4368           1          0.0       43669.6       1.6X
-UTF8_BINARY                                          4361           4364           4          0.0       43606.5       1.6X
-UNICODE_CI                                          46480          46526          66          0.0      464795.7       0.1X
+UTF8_BINARY_LCASE                                    6933           6936           5          0.0       69332.1       1.0X
+UNICODE                                              4332           4344          16          0.0       43324.4       1.6X
+UTF8_BINARY                                          4320           4326          10          0.0       43195.1       1.6X
+UNICODE_CI                                          44571          44577           8          0.0      445711.8       0.2X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                     6522           6526           4          0.0       65223.9       1.0X
-UNICODE                                              45792          45797           7          0.0      457922.3       0.1X
-UTF8_BINARY                                           7092           7112          29          0.0       70921.7       0.9X
-UNICODE_CI                                           47548          47564          22          0.0      475476.7       0.1X
+UTF8_BINARY_LCASE                                     6823           6836          19          0.0       68230.1       1.0X
+UNICODE                                              45981          45989          12          0.0      459807.8       0.1X
+UTF8_BINARY                                           7421           7422           1          0.0       74212.5       0.9X
+UNICODE_CI                                           48587          48616          41          0.0      485866.3       0.1X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                 11716          11716           1          0.0      117157.9       1.0X
-UNICODE                                          180133         180137           5          0.0     1801332.1       0.1X
-UTF8_BINARY                                       10476          10477           1          0.0      104757.4       1.1X
-UNICODE_CI                                       148171         148190          28          0.0     1481705.6       0.1X
+UTF8_BINARY_LCASE                                 11430          11437          10          0.0      114298.7       1.0X
+UNICODE                                          176891         176904          18          0.0     1768912.1       0.1X
+UTF8_BINARY                                        9898           9900           3          0.0       98977.9       1.2X
+UNICODE_CI                                       156862         156869          11          0.0     1568616.3       0.1X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - contains:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                 49257          49280          32          0.0      492574.0       1.0X
-UNICODE                                           18253          18293          57          0.0      182530.8       2.7X
-UTF8_BINARY                                       20199          20247          68          0.0      201987.8       2.4X
-UNICODE_CI                                       882302         882576         387          0.0     8823023.9       0.1X
+UTF8_BINARY_LCASE                                 33962          33969          10          0.0      339620.0       1.0X
+UNICODE                                           18991          18993           3          0.0      189909.3       1.8X
+UTF8_BINARY                                       20454          20465          15          0.0      204539.7       1.7X
+UNICODE_CI                                       903059         903559         707          0.0     9030585.1       0.0X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - startsWith:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                 45015          45024          13          0.0      450153.7       1.0X
-UNICODE                                           17425          17455          43          0.0      174247.1       2.6X
-UTF8_BINARY                                       19237          19268          44          0.0      192371.4       2.3X
-UNICODE_CI                                       954993         955680         971          0.0     9549930.3       0.0X
+UTF8_BINARY_LCASE                                 30916          30925          12          0.0      309163.5       1.0X
+UNICODE                                           15069          15074           7          0.0      150694.4       2.1X
+UTF8_BINARY                                       16748          16765          23          0.0      167484.3       1.8X
+UNICODE_CI                                       893058         893931        1234          0.0     8930578.7       0.0X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - endsWith:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                 45919          45966          67          0.0      459187.0       1.0X
-UNICODE                                           17697          17713          23          0.0      176970.4       2.6X
-UTF8_BINARY                                       19448          19449           2          0.0      194479.6       2.4X
-UNICODE_CI                                       962916         963010         133          0.0     9629158.5       0.0X
+UTF8_BINARY_LCASE                                 31785          31793          11          0.0      317847.5       1.0X
+UNICODE                                           15118          15126          11          0.0      151179.0       2.1X
+UTF8_BINARY                                       16786          16791           7          0.0      167855.7       1.9X
+UNICODE_CI                                       895325         895832         717          0.0     8953249.9       0.0X
 

--- a/sql/core/benchmarks/CollationBenchmark-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-results.txt
@@ -1,54 +1,54 @@
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                    7692           7731          55          0.0       76919.2       1.0X
-UNICODE                                              4378           4379           0          0.0       43784.6       1.8X
-UTF8_BINARY                                          4382           4396          19          0.0       43821.6       1.8X
-UNICODE_CI                                          48344          48360          23          0.0      483436.5       0.2X
+UTF8_BINARY_LCASE                                    7731           7744          19          0.0       77307.7       1.0X
+UNICODE                                              4361           4363           3          0.0       43610.6       1.8X
+UTF8_BINARY                                          4365           4369           7          0.0       43645.9       1.8X
+UNICODE_CI                                          48650          48651           1          0.0      486504.4       0.2X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                     9819           9820           0          0.0       98194.9       1.0X
-UNICODE                                              49507          49518          17          0.0      495066.2       0.2X
-UTF8_BINARY                                           7354           7365          17          0.0       73536.3       1.3X
-UNICODE_CI                                           52149          52163          20          0.0      521489.4       0.2X
+UTF8_BINARY_LCASE                                    10419          10421           3          0.0      104191.5       1.0X
+UNICODE                                              51409          51418          13          0.0      514090.1       0.2X
+UTF8_BINARY                                           7808           7816          10          0.0       78084.4       1.3X
+UNICODE_CI                                           51597          51665          96          0.0      515966.1       0.2X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                 18110          18127          24          0.0      181103.9       1.0X
-UNICODE                                          171375         171435          85          0.0     1713752.3       0.1X
-UTF8_BINARY                                       14012          14030          26          0.0      140116.7       1.3X
-UNICODE_CI                                       153847         153901          76          0.0     1538471.1       0.1X
+UTF8_BINARY_LCASE                                 17963          17976          18          0.0      179630.9       1.0X
+UNICODE                                          171257         171257           1          0.0     1712565.3       0.1X
+UTF8_BINARY                                       10569          10574           7          0.0      105687.7       1.7X
+UNICODE_CI                                       149242         149281          55          0.0     1492422.8       0.1X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - contains:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                 48528          48534           8          0.0      485281.3       1.0X
-UNICODE                                           17612          17628          23          0.0      176119.4       2.8X
-UTF8_BINARY                                       19664          19671          11          0.0      196636.4       2.5X
-UNICODE_CI                                       860919         862936        2853          0.0     8609190.8       0.1X
+UTF8_BINARY_LCASE                                 33192          33214          32          0.0      331919.3       1.0X
+UNICODE                                           19068          19077          13          0.0      190676.4       1.7X
+UTF8_BINARY                                       21136          21138           3          0.0      211360.4       1.6X
+UNICODE_CI                                       884378         884484         149          0.0     8843780.9       0.0X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - startsWith:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                 49520          49524           7          0.0      495195.4       1.0X
-UNICODE                                           18346          18346           0          0.0      183457.7       2.7X
-UTF8_BINARY                                       20483          20488           7          0.0      204828.7       2.4X
-UNICODE_CI                                       928756         930065        1851          0.0     9287564.4       0.1X
+UTF8_BINARY_LCASE                                 25579          25594          22          0.0      255786.4       1.0X
+UNICODE                                           16631          16647          23          0.0      166307.0       1.5X
+UTF8_BINARY                                       18689          18697          11          0.0      186889.8       1.4X
+UNICODE_CI                                       872172         872296         175          0.0     8721724.1       0.0X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - endsWith:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                 49501          49504           5          0.0      495006.9       1.0X
-UNICODE                                           18052          18095          61          0.0      180523.7       2.7X
-UTF8_BINARY                                       20187          20197          15          0.0      201867.1       2.5X
-UNICODE_CI                                       934011         938842        6833          0.0     9340109.8       0.1X
+UTF8_BINARY_LCASE                                 26268          26278          14          0.0      262679.5       1.0X
+UNICODE                                           16882          16899          23          0.0      168822.9       1.6X
+UTF8_BINARY                                       18958          18967          12          0.0      189583.5       1.4X
+UNICODE_CI                                       897433         897549         165          0.0     8974329.6       0.0X
 

--- a/sql/core/benchmarks/CollationNonASCIIBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/CollationNonASCIIBenchmark-jdk21-results.txt
@@ -1,54 +1,54 @@
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                   18244          18258          20          0.0      456096.4       1.0X
-UNICODE                                               498            498           0          0.1       12440.3      36.7X
-UTF8_BINARY                                           499            500           1          0.1       12467.7      36.6X
-UNICODE_CI                                          13429          13443          19          0.0      335725.4       1.4X
+UTF8_BINARY_LCASE                                   18412          18491         113          0.0      460288.0       1.0X
+UNICODE                                               500            501           3          0.1       12489.2      36.9X
+UTF8_BINARY                                           500            502           3          0.1       12511.4      36.8X
+UNICODE_CI                                          13663          13673          14          0.0      341564.3       1.3X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                    18377          18399          31          0.0      459430.5       1.0X
-UNICODE                                              14238          14240           3          0.0      355957.4       1.3X
-UTF8_BINARY                                            975            976           1          0.0       24371.3      18.9X
-UNICODE_CI                                           13819          13826          10          0.0      345482.6       1.3X
+UTF8_BINARY_LCASE                                    18578          18582           6          0.0      464453.0       1.0X
+UNICODE                                              13870          13904          47          0.0      346759.1       1.3X
+UTF8_BINARY                                           1029           1030           2          0.0       25714.2      18.1X
+UNICODE_CI                                           14092          14103          16          0.0      352289.2       1.3X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                  9183           9230          67          0.0      229564.0       1.0X
-UNICODE                                           38937          38952          22          0.0      973421.3       0.2X
-UTF8_BINARY                                        1376           1376           0          0.0       34397.5       6.7X
-UNICODE_CI                                        32881          32882           1          0.0      822027.4       0.3X
+UTF8_BINARY_LCASE                                  9410           9413           5          0.0      235238.0       1.0X
+UNICODE                                           41038          41047          12          0.0     1025949.7       0.2X
+UTF8_BINARY                                        1406           1408           3          0.0       35151.5       6.7X
+UNICODE_CI                                        31829          31829           1          0.0      795717.5       0.3X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - contains:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                 22429          22438          13          0.0      560735.1       1.0X
-UNICODE                                            2900           2901           2          0.0       72503.2       7.7X
-UTF8_BINARY                                        3190           3198          11          0.0       79740.5       7.0X
-UNICODE_CI                                       166847         167278         609          0.0     4171180.3       0.1X
+UTF8_BINARY_LCASE                                 22537          22546          13          0.0      563430.8       1.0X
+UNICODE                                            3064           3066           3          0.0       76600.5       7.4X
+UTF8_BINARY                                        3346           3351           7          0.0       83652.0       6.7X
+UNICODE_CI                                       165867         165948         115          0.0     4146664.2       0.1X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - startsWith:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                 22865          22875          13          0.0      571636.3       1.0X
-UNICODE                                            3137           3137           0          0.0       78422.3       7.3X
-UTF8_BINARY                                        3448           3450           3          0.0       86188.5       6.6X
-UNICODE_CI                                       190473         190894         595          0.0     4761831.2       0.1X
+UTF8_BINARY_LCASE                                 23191          23196           8          0.0      579764.3       1.0X
+UNICODE                                            2728           2729           2          0.0       68206.0       8.5X
+UTF8_BINARY                                        3009           3013           6          0.0       75213.4       7.7X
+UNICODE_CI                                       164341         164423         115          0.0     4108531.1       0.1X
 
-OpenJDK 64-Bit Server VM 21.0.2+13-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - endsWith:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                 23693          23695           3          0.0      592333.2       1.0X
-UNICODE                                            3170           3172           3          0.0       79243.5       7.5X
-UTF8_BINARY                                        3472           3473           2          0.0       86788.8       6.8X
-UNICODE_CI                                        63331          63603         384          0.0     1583274.3       0.4X
+UTF8_BINARY_LCASE                                 23384          23411          38          0.0      584606.2       1.0X
+UNICODE                                            2602           2603           0          0.0       65061.3       9.0X
+UTF8_BINARY                                        2901           2903           2          0.0       72536.6       8.1X
+UNICODE_CI                                       179352         179427         106          0.0     4483798.1       0.1X
 

--- a/sql/core/benchmarks/CollationNonASCIIBenchmark-results.txt
+++ b/sql/core/benchmarks/CollationNonASCIIBenchmark-results.txt
@@ -1,54 +1,54 @@
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                   17881          17885           6          0.0      447017.7       1.0X
-UNICODE                                               493            495           2          0.1       12328.9      36.3X
-UTF8_BINARY                                           493            494           1          0.1       12331.4      36.3X
-UNICODE_CI                                          13731          13737           8          0.0      343284.6       1.3X
+UTF8_BINARY_LCASE                                   18682          18687           8          0.0      467053.4       1.0X
+UNICODE                                               397            397           0          0.1        9921.3      47.1X
+UTF8_BINARY                                           397            397           0          0.1        9916.3      47.1X
+UNICODE_CI                                          14407          14424          23          0.0      360176.3       1.3X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                    18041          18047           8          0.0      451030.2       1.0X
-UNICODE                                              14023          14047          34          0.0      350573.9       1.3X
-UTF8_BINARY                                           1387           1397          14          0.0       34680.4      13.0X
-UNICODE_CI                                           14232          14242          14          0.0      355808.4       1.3X
+UTF8_BINARY_LCASE                                    18426          18443          24          0.0      460649.2       1.0X
+UNICODE                                              14073          14077           5          0.0      351833.2       1.3X
+UTF8_BINARY                                            978            980           2          0.0       24443.0      18.8X
+UNICODE_CI                                           14166          14176          14          0.0      354140.4       1.3X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                 10494          10499           6          0.0      262360.0       1.0X
-UNICODE                                           40410          40422          17          0.0     1010261.8       0.3X
-UTF8_BINARY                                        2035           2035           1          0.0       50877.8       5.2X
-UNICODE_CI                                        31470          31493          32          0.0      786752.4       0.3X
+UTF8_BINARY_LCASE                                 10939          10941           3          0.0      273478.2       1.0X
+UNICODE                                           39469          39472           4          0.0      986720.2       0.3X
+UTF8_BINARY                                        2043           2044           1          0.0       51083.5       5.4X
+UNICODE_CI                                        33820          33861          57          0.0      845507.0       0.3X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - contains:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                 22342          22352          13          0.0      558560.4       1.0X
-UNICODE                                            3073           3074           0          0.0       76829.5       7.3X
-UTF8_BINARY                                        3486           3487           2          0.0       87147.6       6.4X
-UNICODE_CI                                       162838         164378        2177          0.0     4070960.3       0.1X
+UTF8_BINARY_LCASE                                 22880          22885           7          0.0      571997.6       1.0X
+UNICODE                                            3098           3117          28          0.0       77438.8       7.4X
+UTF8_BINARY                                        3405           3409           5          0.0       85131.8       6.7X
+UNICODE_CI                                       157964         158054         127          0.0     3949109.8       0.1X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - startsWith:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                 21882          21890          11          0.0      547051.8       1.0X
-UNICODE                                            2672           2676           6          0.0       66799.0       8.2X
-UTF8_BINARY                                        3069           3071           2          0.0       76732.2       7.1X
-UNICODE_CI                                       187853         188724        1232          0.0     4696336.1       0.1X
+UTF8_BINARY_LCASE                                 23690          23696           8          0.0      592259.8       1.0X
+UNICODE                                            2893           2901          11          0.0       72324.5       8.2X
+UTF8_BINARY                                        3242           3256          19          0.0       81060.0       7.3X
+UNICODE_CI                                       157881         158103         313          0.0     3947026.5       0.2X
 
-OpenJDK 64-Bit Server VM 17.0.10+7-LTS on Linux 6.5.0-1017-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1018-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - endsWith:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY_LCASE                                 21818          21866          68          0.0      545439.9       1.0X
-UNICODE                                            2637           2643           9          0.0       65913.3       8.3X
-UTF8_BINARY                                        3037           3039           2          0.0       75934.6       7.2X
-UNICODE_CI                                        61372          61510         195          0.0     1534307.9       0.4X
+UTF8_BINARY_LCASE                                 24720          24763          62          0.0      617991.5       1.0X
+UNICODE                                            2722           2727           6          0.0       68057.1       9.1X
+UTF8_BINARY                                        3041           3042           1          0.0       76026.5       8.1X
+UNICODE_CI                                       172247         172312          92          0.0     4306178.0       0.1X
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added hand-crafted implementations of unicode-aware lower-case `contains`, `startsWith`, `endsWith` to optimize UTF8_BINARY_LCASE for ASCII-only strings.


### Why are the changes needed?
`UTF8String.toLowerCase()`, which is used for the aforementioned collation-aware functions, has an optimization for full-ascii strings, but still always allocates a new object. In this PR I introduced loop-based implementations, which fall-back to `toLowerCase()` in case they meet a non-asci character.


### Does this PR introduce _any_ user-facing change?
No, these functions should behave exactly as:
- `lhs.containsInLowerCase(rhs)` == `lhs.toLowerCase().contains(rhs.toLowerCase())`
- `lhs.startsWithInLowerCase(rhs)` == `lhs.toLowerCase().startsWith(rhs.toLowerCase())`
- `lhs.endsWithInLowerCase(rhs)` == `lhs.toLowerCase().endsWith(rhs.toLowerCase())`


### How was this patch tested?
Added new test cases to `org.apache.spark.unsafe.types.CollationSupportSuite` and `org.apache.spark.unsafe.types.UTF8StringSuite`, including several unicode lowercase specific. Also I've run `CollationBenchmark` on GHA for JDK 17 and JDK 21 and have updated the data.


### Was this patch authored or co-authored using generative AI tooling?
No
