### PR TITLE
[SPARK-47870][SQL] Optimize predicate after push extra predicate through join

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -146,7 +146,10 @@ abstract class Optimizer(catalogManager: CatalogManager)
         operatorOptimizationRuleSet: _*) ::
       Batch("Push extra predicate through join", fixedPoint,
         PushExtraPredicateThroughJoin,
-        PushDownPredicates) :: Nil
+        PushDownPredicates,
+        ConstantFolding,
+        BooleanSimplification,
+        PruneFilters) :: Nil
     }
 
     val batches = (


### PR DESCRIPTION

### What changes were proposed in this pull request?
Add rules `ConstantFolding`、`BooleanSimplification` and `PruneFilters` at last of push extra predicate through join batch to optimize predicate.
For example:
```
    spark.sql("select 1 as a, 2 as b").write.mode("overwrite").parquet("tmp/t1")
    spark.sql("select 1 as a").write.mode("overwrite").parquet("tmp/t2")
    spark.sql("select 1 as a, 1 as c").write.mode("overwrite").parquet("tmp/t3")
    spark.read.parquet("tmp/t1").createOrReplaceTempView("t1")
    spark.read.parquet("tmp/t2").createOrReplaceTempView("t2")
    spark.read.parquet("tmp/t3").createOrReplaceTempView("t3")
    spark.sql(
      """
        |select t.*,t3.a as c from
        |(
        |select * from t1
        |union all
        |select *,1 as b from t2
        |) t, t3
        |where t.a=t3.a
        |and (t.a > 1 or (t.b = 1 and t3.c=1))
        |""".stripMargin)
```
before PR:
```
== Optimized Logical Plan ==
Project [a#0, b#1, a#6 AS c#11]
+- Join Inner, ((a#0 = a#6) AND ((a#0 > 1) OR ((b#1 = 1) AND (c#7 = 1))))
   :- Union false, false
   :  :- Filter (isnotnull(a#0) AND ((a#0 > 1) OR (b#1 = 1)))
   :  :  +- Relation [a#0,b#1] parquet
   :  +- Project [a#4, 1 AS b#10]
   :     +- Filter (isnotnull(a#4) AND ((a#4 > 1) OR (1 = 1)))
   :        +- Relation [a#4] parquet
   +- Filter isnotnull(a#6)
      +- Relation [a#6,c#7] parquet
```
after PR:
```
== Optimized Logical Plan ==
Project [a#15, b#16, a#21 AS c#26]
+- Join Inner, ((a#15 = a#21) AND ((a#15 > 1) OR ((b#16 = 1) AND (c#22 = 1))))
   :- Union false, false
   :  :- Filter (isnotnull(a#15) AND ((a#15 > 1) OR (b#16 = 1)))
   :  :  +- Relation [a#15,b#16] parquet
   :  +- Project [a#19, 1 AS b#25]
   :     +- Filter isnotnull(a#19)
   :        +- Relation [a#19] parquet
   +- Filter isnotnull(a#21)
      +- Relation [a#21,c#22] parquet
```

### Why are the changes needed?
Simplify plan and improve perfermance.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Unit test.


### Was this patch authored or co-authored using generative AI tooling?
No.
