### PR TITLE
[SPARK-47830][CONNECT][TESTS] Enable local-cluster tests with pyspark-connect package

### DIFF
--- a/.github/workflows/build_python_connect.yml
+++ b/.github/workflows/build_python_connect.yml
@@ -29,6 +29,7 @@ jobs:
     name: "Build modules: pyspark-connect"
     runs-on: ubuntu-latest
     timeout-minutes: 300
+    if: github.repository == 'apache/spark'
     steps:
       - name: Checkout Spark repository
         uses: actions/checkout@v4
@@ -80,19 +81,43 @@ jobs:
           # Make less noisy
           cp conf/log4j2.properties.template conf/log4j2.properties
           sed -i 's/rootLogger.level = info/rootLogger.level = warn/g' conf/log4j2.properties
-          # Start a Spark Connect server
+
+          # Start a Spark Connect server for local
           PYTHONPATH="python/lib/pyspark.zip:python/lib/py4j-0.10.9.7-src.zip:$PYTHONPATH" ./sbin/start-connect-server.sh \
             --driver-java-options "-Dlog4j.configurationFile=file:$GITHUB_WORKSPACE/conf/log4j2.properties" \
             --jars "`find connector/connect/server/target -name spark-connect-*SNAPSHOT.jar`,`find connector/protobuf/target -name spark-protobuf-*SNAPSHOT.jar`,`find connector/avro/target -name spark-avro*SNAPSHOT.jar`"
+
           # Make sure running Python workers that contains pyspark.core once. They will be reused.
           python -c "from pyspark.sql import SparkSession; _ = SparkSession.builder.remote('sc://localhost').getOrCreate().range(100).repartition(100).mapInPandas(lambda x: x, 'id INT').collect()"
+
           # Remove Py4J and PySpark zipped library to make sure there is no JVM connection
-          rm python/lib/*
-          rm -r python/pyspark
+          mv python/lib lib.back
+          mv python/pyspark pyspark.back
+
           # Several tests related to catalog requires to run them sequencially, e.g., writing a table in a listener.
           ./python/run-tests --parallelism=1 --python-executables=python3 --modules pyspark-connect,pyspark-ml-connect
           # None of tests are dependent on each other in Pandas API on Spark so run them in parallel
           ./python/run-tests --parallelism=4 --python-executables=python3 --modules pyspark-pandas-connect-part0,pyspark-pandas-connect-part1,pyspark-pandas-connect-part2,pyspark-pandas-connect-part3
+
+          # Stop Spark Connect server.
+          ./sbin/stop-connect-server.sh
+          mv lib.back python/lib
+          mv pyspark.back python/pyspark
+
+          # Start a Spark Connect server for local-cluster
+          PYTHONPATH="python/lib/pyspark.zip:python/lib/py4j-0.10.9.7-src.zip:$PYTHONPATH" ./sbin/start-connect-server.sh \
+            --master "local-cluster[2, 4, 1024]" \
+            --driver-java-options "-Dlog4j.configurationFile=file:$GITHUB_WORKSPACE/conf/log4j2.properties" \
+            --jars "`find connector/connect/server/target -name spark-connect-*SNAPSHOT.jar`,`find connector/protobuf/target -name spark-protobuf-*SNAPSHOT.jar`,`find connector/avro/target -name spark-avro*SNAPSHOT.jar`"
+
+          # Make sure running Python workers that contains pyspark.core once. They will be reused.
+          python -c "from pyspark.sql import SparkSession; _ = SparkSession.builder.remote('sc://localhost').getOrCreate().range(100).repartition(100).mapInPandas(lambda x: x, 'id INT').show(n=100)" > /dev/null
+
+          # Remove Py4J and PySpark zipped library to make sure there is no JVM connection
+          mv python/lib lib.back
+          mv python/pyspark lib.back
+
+          ./python/run-tests --parallelism=1 --python-executables=python3 --testnames "pyspark.resource.tests.test_connect_resources,pyspark.sql.tests.connect.client.test_artifact,pyspark.sql.tests.connect.test_resources"
       - name: Upload test results to report
         if: always()
         uses: actions/upload-artifact@v4

--- a/python/packaging/connect/setup.py
+++ b/python/packaging/connect/setup.py
@@ -70,6 +70,7 @@ if "SPARK_TESTING" in os.environ:
     test_packages = [
         "pyspark.tests",  # for Memory profiler parity tests
         "pyspark.testing",
+        "pyspark.resource.tests",
         "pyspark.sql.tests",
         "pyspark.sql.tests.connect",
         "pyspark.sql.tests.connect.streaming",

--- a/python/pyspark/sql/tests/connect/test_resources.py
+++ b/python/pyspark/sql/tests/connect/test_resources.py
@@ -15,19 +15,16 @@
 # limitations under the License.
 #
 import unittest
+import os
 
-from pyspark.util import is_remote_only
 from pyspark.testing.connectutils import ReusedConnectTestCase
+from pyspark.sql.tests.test_resources import ResourceProfileTestsMixin
 
 
-# TODO(SPARK-47757): Reeanble ResourceProfileTests for pyspark-connect
-if not is_remote_only():
-    from pyspark.sql.tests.test_resources import ResourceProfileTestsMixin
-
-    class ResourceProfileTests(ResourceProfileTestsMixin, ReusedConnectTestCase):
-        @classmethod
-        def master(cls):
-            return "local-cluster[1, 4, 1024]"
+class ResourceProfileTests(ResourceProfileTestsMixin, ReusedConnectTestCase):
+    @classmethod
+    def master(cls):
+        return os.environ.get("SPARK_CONNECT_TESTING_REMOTE", "local-cluster[1, 4, 1024]")
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/test_resources.py
+++ b/python/pyspark/sql/tests/test_resources.py
@@ -16,7 +16,7 @@
 #
 import unittest
 
-from pyspark import SparkContext, TaskContext
+from pyspark import TaskContext
 from pyspark.resource import TaskResourceRequests, ResourceProfileBuilder
 from pyspark.sql import SparkSession
 from pyspark.testing.sqlutils import (
@@ -41,7 +41,7 @@ class ResourceProfileTestsMixin(object):
                 yield batch
 
         df = self.spark.range(10)
-        df.mapInArrow(func, "id long").collect()
+        df.mapInArrow(func, "id long").show(n=10)
 
     def test_map_in_arrow_with_profile(self):
         def func(iterator):
@@ -54,7 +54,7 @@ class ResourceProfileTestsMixin(object):
 
         treqs = TaskResourceRequests().cpus(3)
         rp = ResourceProfileBuilder().require(treqs).build
-        df.mapInArrow(func, "id long", False, rp).collect()
+        df.mapInArrow(func, "id long", False, rp).show(n=10)
 
     def test_map_in_pandas_without_profile(self):
         def func(iterator):
@@ -64,7 +64,7 @@ class ResourceProfileTestsMixin(object):
                 yield batch
 
         df = self.spark.range(10)
-        df.mapInPandas(func, "id long").collect()
+        df.mapInPandas(func, "id long").show(n=10)
 
     def test_map_in_pandas_with_profile(self):
         def func(iterator):
@@ -77,12 +77,14 @@ class ResourceProfileTestsMixin(object):
 
         treqs = TaskResourceRequests().cpus(3)
         rp = ResourceProfileBuilder().require(treqs).build
-        df.mapInPandas(func, "id long", False, rp).collect()
+        df.mapInPandas(func, "id long", False, rp).show(n=10)
 
 
 class ResourceProfileTests(ResourceProfileTestsMixin, ReusedPySparkTestCase):
     @classmethod
     def setUpClass(cls):
+        from pyspark.core.context import SparkContext
+
         cls.sc = SparkContext("local-cluster[1, 4, 1024]", cls.__name__, conf=cls.conf())
         cls.spark = SparkSession(cls.sc)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to extends `pyspark-connect` scheduled job to run `pyspark.resource` tests as well.

### Why are the changes needed?

In order to make sure pure Python library works with `pyspark.resource`.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Tested in my own fork: https://github.com/HyukjinKwon/spark/actions/runs/8718980385/job/23917348664

### Was this patch authored or co-authored using generative AI tooling?

No.