### PR TITLE
[SPARK-46812][CONNECT][PYTHON][FOLLOW-UP] Add pyspark.pyspark.sql.connect.resource into PyPi packaging

### DIFF
--- a/python/packaging/classic/setup.py
+++ b/python/packaging/classic/setup.py
@@ -276,6 +276,7 @@ try:
             "pyspark.sql.connect.functions",
             "pyspark.sql.connect.proto",
             "pyspark.sql.connect.protobuf",
+            "pyspark.sql.connect.resource",
             "pyspark.sql.connect.shell",
             "pyspark.sql.connect.streaming",
             "pyspark.sql.connect.streaming.worker",

--- a/python/packaging/connect/setup.py
+++ b/python/packaging/connect/setup.py
@@ -145,6 +145,7 @@ try:
         "pyspark.sql.connect.functions",
         "pyspark.sql.connect.proto",
         "pyspark.sql.connect.protobuf",
+        "pyspark.sql.connect.resource",
         "pyspark.sql.connect.shell",
         "pyspark.sql.connect.streaming",
         "pyspark.sql.connect.streaming.worker",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add `pyspark.pyspark.sql.connect.resource` into PyPi packaging.

### Why are the changes needed?

In order for PyPI end users to download PySpark and leverage this feature.

### Does this PR introduce _any_ user-facing change?

No, the main change has not been released.

### How was this patch tested?

Being tested at https://github.com/apache/spark/pull/46090

### Was this patch authored or co-authored using generative AI tooling?

No.