### PR TITLE
[SPARK-47883][SQL] Make `CollectTailExec.doExecute` lazy

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/collection/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/Utils.scala
@@ -51,7 +51,7 @@ private[spark] object Utils extends SparkCollectionUtils {
       Iterator.empty[T]
     } else {
       var last = Seq.empty[T]
-      val grouped = input.grouped(num)
+      val grouped = input.sliding(num)
       while (grouped.hasNext) {
         last = grouped.next()
       }

--- a/core/src/main/scala/org/apache/spark/util/collection/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/collection/Utils.scala
@@ -43,6 +43,23 @@ private[spark] object Utils extends SparkCollectionUtils {
   }
 
   /**
+   * Returns the last K elements from the input.
+   */
+  def takeLast[T](input: Iterator[T], num: Int): Iterator[T] = {
+    assert(num >= 0)
+    if (input.isEmpty || num == 0) {
+      Iterator.empty[T]
+    } else {
+      var last = Seq.empty[T]
+      val grouped = input.grouped(num)
+      while (grouped.hasNext) {
+        last = grouped.next()
+      }
+      last.iterator
+    }
+  }
+
+  /**
    * Returns an iterator over the merged contents of all given input iterators,
    * traversing every element of the input iterators.
    * Equivalent entries will not be de-duplicated.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/limit.scala
@@ -26,7 +26,6 @@ import org.apache.spark.sql.catalyst.plans.physical._
 import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
 import org.apache.spark.sql.execution.metric.{SQLShuffleReadMetricsReporter, SQLShuffleWriteMetricsReporter}
-import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.collection.Utils
 
 /**
@@ -68,13 +67,13 @@ case class CollectLimitExec(limit: Int = -1, child: SparkPlan, offset: Int = 0) 
   override lazy val metrics = readMetrics ++ writeMetrics
   protected override def doExecute(): RDD[InternalRow] = {
     val childRDD = child.execute()
-    if (childRDD.getNumPartitions == 0) {
+    if (childRDD.getNumPartitions == 0 || limit == 0) {
       new ParallelCollectionRDD(sparkContext, Seq.empty[InternalRow], 1, Map.empty)
     } else {
       val singlePartitionRDD = if (childRDD.getNumPartitions == 1) {
         childRDD
       } else {
-        val locallyLimited = if (limit >= 0) {
+        val locallyLimited = if (limit > 0) {
           childRDD.mapPartitionsInternal(_.take(limit))
         } else {
           childRDD
@@ -118,18 +117,39 @@ case class CollectLimitExec(limit: Int = -1, child: SparkPlan, offset: Int = 0) 
  * logical plan, which happens when the user is collecting results back to the driver.
  */
 case class CollectTailExec(limit: Int, child: SparkPlan) extends LimitExec {
+  assert(limit >= 0)
+
   override def output: Seq[Attribute] = child.output
   override def outputPartitioning: Partitioning = SinglePartition
   override def executeCollect(): Array[InternalRow] = child.executeTail(limit)
+  private val serializer: Serializer = new UnsafeRowSerializer(child.output.size)
+  private lazy val writeMetrics =
+    SQLShuffleWriteMetricsReporter.createShuffleWriteMetrics(sparkContext)
+  private lazy val readMetrics =
+    SQLShuffleReadMetricsReporter.createShuffleReadMetrics(sparkContext)
+  override lazy val metrics = readMetrics ++ writeMetrics
   protected override def doExecute(): RDD[InternalRow] = {
-    // This is a bit hacky way to avoid a shuffle and scanning all data when it performs
-    // at `Dataset.tail`.
-    // Since this execution plan and `execute` are currently called only when
-    // `Dataset.tail` is invoked, the jobs are always executed when they are supposed to be.
-
-    // If we use this execution plan separately like `Dataset.limit` without an actual
-    // job launch, we might just have to mimic the implementation of `CollectLimitExec`.
-    sparkContext.parallelize(executeCollect().toImmutableArraySeq, numSlices = 1)
+    val childRDD = child.execute()
+    if (childRDD.getNumPartitions == 0 || limit == 0) {
+      new ParallelCollectionRDD(sparkContext, Seq.empty[InternalRow], 1, Map.empty)
+    } else {
+      val singlePartitionRDD = if (childRDD.getNumPartitions == 1) {
+        childRDD
+      } else {
+        val locallyLimited = childRDD
+          .mapPartitionsInternal(iter => Utils.takeLast(iter.map(_.copy()), limit))
+        new ShuffledRowRDD(
+          ShuffleExchangeExec.prepareShuffleDependency(
+            locallyLimited,
+            child.output,
+            SinglePartition,
+            serializer,
+            writeMetrics),
+          readMetrics)
+      }
+      singlePartitionRDD
+        .mapPartitionsInternal(iter => Utils.takeLast(iter.map(_.copy()), limit))
+    }
   }
 
   override protected def withNewChildInternal(newChild: SparkPlan): SparkPlan =


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make CollectTailExec execute lazily


### Why are the changes needed?
In Spark Connect, `dataframe.tail` is based on `Tail(...).collect()`

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
existing unit tests


### Was this patch authored or co-authored using generative AI tooling?
no