### PR TITLE
[SPARK-47864][PYTHON][DOCS] Enhance "Installation" page to cover all installable options

### DIFF
--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -197,26 +197,26 @@ Spark SQL
 
 Installable with ``pip install "pyspark[sql]"``.
 
-========================== ========================= ======================================================================================
+========================== ========================= ======================================================
 Package                    Supported version         Note
-========================== ========================= ======================================================================================
-`pandas`                   >=1.4.4                   Provides integration with the Pandas library, enabling conversion between DataFrame formats and leveraging Pandas instances.
-`pyarrow`                  >=10.0.0                  Facilitates high-performance data transfers and conversion between PySpark and Pandas data structures.
-`numpy`                    >=1.21                    Enhances numerical operations in Spark, necessary for statistical functions and data manipulation within PySpark.
-========================== ========================= ======================================================================================
+========================== ========================= ======================================================
+`pandas`                   >=1.4.4                   Enables seamless DataFrame operations between Spark and Pandas.
+`pyarrow`                  >=10.0.0                  Optimizes data conversion and transfer between PySpark and Pandas.
+`numpy`                    >=1.21                    Essential for numerical data manipulation within PySpark.
+========================== ========================= ======================================================
 
 Pandas API on Spark
 ^^^^^^^^^^^^^^^^^^^
 
 Installable with ``pip install "pyspark[pandas_on_spark]"``.
 
-========================== ========================= ======================================================================================
+========================== ========================= ======================================================
 Package                    Supported version         Note
-========================== ========================= ======================================================================================
-`pandas`                   >=1.4.4                   Enables direct operations on Pandas DataFrames, essential for PySpark’s Pandas API.
-`pyarrow`                  >=10.0.0                  Required to ensure compatibility and performance improvements in DataFrame conversions.
-`numpy`                    >=1.21                    Supports numerical data operations, crucial for handling Pandas objects and MLlib functionalities.
-========================== ========================= ======================================================================================
+========================== ========================= ======================================================
+`pandas`                   >=1.4.4                   Required for utilizing the Pandas API features in Spark.
+`pyarrow`                  >=10.0.0                  Ensures efficient data handling and performance in Pandas operations.
+`numpy`                    >=1.21                    Facilitates complex numerical operations within Spark.
+========================== ========================= ======================================================
 
 Note: Run ``pip install "pyspark[pandas_on_spark] plotly"`` if you want to use visualization features.
 
@@ -228,7 +228,7 @@ Installable with ``pip install "pyspark[ml]"``.
 ========================== ========================= ======================================================================================
 Package                    Supported version         Note
 ========================== ========================= ======================================================================================
-`numpy`                    >=1.21                    Necessary for MLlib's advanced linear algebra operations, enhances machine learning algorithms.
+`numpy`                    >=1.21                    Supports advanced data manipulation and algorithm implementation in ML.
 ========================== ========================= ======================================================================================
 
 MLlib
@@ -247,14 +247,13 @@ Spark Connect
 
 Installable with ``pip install "pyspark[connect]"``.
 
-========================== ========================= ======================================================================================
+========================== ========================= ======================================================
 Package                    Supported version         Note
-========================== ========================= ======================================================================================
-`pandas`                   >=1.4.4                   Necessary for utilizing the Pandas API within Spark Connect, facilitates smooth data handling.
-`pyarrow`                  >=10.0.0                  Enhances serialization and conversion processes, important for efficient network communication.
-`numpy`                    >=1.21                    Integral for data manipulation in Spark Connect, improves computation capabilities.
-`grpcio`                   >=1.62.0                  Provides the RPC framework necessary for Spark Connect's distributed computing functionalities.
-`grpcio-status`            >=1.62.0                  Adds support for handling RPC statuses and messages within Spark Connect.
-`googleapis-common-protos` >=1.56.4                  Includes essential protocol buffers from Google APIs, crucial for communication protocols in Spark Connect.
-========================== ========================= ======================================================================================
-
+========================== ========================= ======================================================
+`pandas`                   >=1.4.4                   Facilitates DataFrame handling and manipulation.
+`pyarrow`                  >=10.0.0                  Crucial for data serialization and network communication efficiency.
+`numpy`                    >=1.21                    Enhances data processing capabilities.
+`grpcio`                   >=1.62.0                  Necessary for implementing RPC functionalities in Spark Connect.
+`grpcio-status`            >=1.62.0                  Supports detailed status handling in network communications.
+`googleapis-common-protos` >=1.56.4                  Provides essential Google API protocols for network interactions.
+========================== ========================= ======================================================

--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -182,6 +182,10 @@ Package                    Supported version         Note
                                                      interaction between Python and JVM.
 ========================== ========================= ============================================
 
+Additional libraries that enhance functionality but are not included in the installation packages:
+
+- **memory-profiler**: Useful for diagnosing and analyzing memory usage in PySpark applications.
+
 Note that PySpark requires Java 17 or later with ``JAVA_HOME`` properly set and refer to |downloading|_.
 
 
@@ -190,70 +194,91 @@ Note that PySpark requires Java 17 or later with ``JAVA_HOME`` properly set and 
 Optional dependencies
 ~~~~~~~~~~~~~~~~~~~~~
 
-PySpark has several optional dependencies that enhance its functionality for specific modules. These dependencies are only required for certain features and are not necessary for the basic functionality of PySpark. If these optional dependencies are not installed, PySpark will function correctly for basic operations but will raise an ``ImportError`` when you try to use features that require these dependencies.
+PySpark has several optional dependencies that enhance its functionality for specific modules.
+These dependencies are only required for certain features and are not necessary for the basic functionality of PySpark.
+If these optional dependencies are not installed, PySpark will function correctly for basic operations but will raise an ``ImportError``
+when you try to use features that require these dependencies.
 
 Spark SQL
 ^^^^^^^^^
 
 Installable with ``pip install "pyspark[sql]"``.
 
-========================== ========================= ======================================================
-Package                    Supported version         Note
-========================== ========================= ======================================================
-`pandas`                   >=1.4.4                   Enables seamless DataFrame operations between Spark and Pandas.
-`pyarrow`                  >=10.0.0                  Optimizes data conversion and transfer between PySpark and Pandas.
-`numpy`                    >=1.21                    Essential for numerical data manipulation within PySpark.
-========================== ========================= ======================================================
+========= ================= ==================================================================
+Package   Supported version Note
+========= ================= ==================================================================
+`pandas`  >=1.4.4           Enables seamless DataFrame operations between Spark and Pandas.
+`pyarrow` >=10.0.0          Optimizes data conversion and transfer between PySpark and Pandas.
+`numpy`   >=1.21            Essential for numerical data manipulation within PySpark.
+========= ================= ==================================================================
+
 
 Pandas API on Spark
 ^^^^^^^^^^^^^^^^^^^
 
 Installable with ``pip install "pyspark[pandas_on_spark]"``.
 
-========================== ========================= ======================================================
-Package                    Supported version         Note
-========================== ========================= ======================================================
-`pandas`                   >=1.4.4                   Required for utilizing the Pandas API features in Spark.
-`pyarrow`                  >=10.0.0                  Ensures efficient data handling and performance in Pandas operations.
-`numpy`                    >=1.21                    Facilitates complex numerical operations within Spark.
-========================== ========================= ======================================================
+========= ================= =====================================================================
+Package   Supported version Note
+========= ================= =====================================================================
+`pandas`  >=1.4.4           Required for utilizing the Pandas API features in Spark.
+`pyarrow` >=10.0.0          Ensures efficient data handling and performance in Pandas operations.
+`numpy`   >=1.21            Facilitates complex numerical operations within Spark.
+========= ================= =====================================================================
 
-Note: Run ``pip install "pyspark[pandas_on_spark] plotly"`` if you want to use visualization features.
+Additional libraries that enhance functionality but are not included in the installation packages:
+
+- **mlflow**: Enhances machine learning lifecycle management, including experiment tracking and model deployment.
+- **plotly, matplotlib**: Provide advanced plotting capabilities for visualization.
+
 
 ML
 ^^
 
 Installable with ``pip install "pyspark[ml]"``.
 
-========================== ========================= ======================================================================================
-Package                    Supported version         Note
-========================== ========================= ======================================================================================
-`numpy`                    >=1.21                    Supports advanced data manipulation and algorithm implementation in ML.
-========================== ========================= ======================================================================================
+======= ================= =======================================================================
+Package Supported version Note
+======= ================= =======================================================================
+`numpy` >=1.21            Supports advanced data manipulation and algorithm implementation in ML.
+======= ================= =======================================================================
+
+Additional libraries that enhance functionality but are not included in the installation packages:
+
+- **scipy**: Essential for scientific computing and statistical functions in ML.
+- **scikit-learn**: Required for implementing machine learning algorithms.
 
 MLlib
 ^^^^^
 
 Installable with ``pip install "pyspark[mllib]"``.
 
-========================== ========================= ======================================================================================
-Package                    Supported version         Note
-========================== ========================= ======================================================================================
-`numpy`                    >=1.21                    Essential for mathematical operations within MLlib, improves performance and accuracy of algorithms.
-========================== ========================= ======================================================================================
+======= ================= ====================================================================================================
+Package Supported version Note
+======= ================= ====================================================================================================
+`numpy` >=1.21            Essential for mathematical operations within MLlib, improves performance and accuracy of algorithms.
+======= ================= ====================================================================================================
+
+Additional libraries that enhance functionality but are not included in the installation packages:
+
+- **torch**: Utilized for machine learning model training on PySpark.
+- **torchvision**: Supports image and video processing within PySpark models.
+- **torcheval**: Facilitates model evaluation metrics in PySpark.
+- **deepspeed; sys_platform != 'darwin'**: Provides high-performance model training optimizations. Installable on non-Darwin systems.
+
 
 Spark Connect
 ^^^^^^^^^^^^^
 
 Installable with ``pip install "pyspark[connect]"``.
 
-========================== ========================= ======================================================
-Package                    Supported version         Note
-========================== ========================= ======================================================
-`pandas`                   >=1.4.4                   Facilitates DataFrame handling and manipulation.
-`pyarrow`                  >=10.0.0                  Crucial for data serialization and network communication efficiency.
-`numpy`                    >=1.21                    Enhances data processing capabilities.
-`grpcio`                   >=1.62.0                  Necessary for implementing RPC functionalities in Spark Connect.
-`grpcio-status`            >=1.62.0                  Supports detailed status handling in network communications.
-`googleapis-common-protos` >=1.56.4                  Provides essential Google API protocols for network interactions.
-========================== ========================= ======================================================
+========================== ================= ====================================================================
+Package                    Supported version Note
+========================== ================= ====================================================================
+`pandas`                   >=1.4.4           Facilitates DataFrame handling and manipulation.
+`pyarrow`                  >=10.0.0          Crucial for data serialization and network communication efficiency.
+`numpy`                    >=1.21            Enhances data processing capabilities.
+`grpcio`                   >=1.62.0          Necessary for implementing RPC functionalities in Spark Connect.
+`grpcio-status`            >=1.62.0          Supports detailed status handling in network communications.
+`googleapis-common-protos` >=1.56.4          Provides essential Google API protocols for network interactions.
+========================== ================= ====================================================================

--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -53,6 +53,9 @@ If you want to install extra dependencies for a specific component, you can inst
     # Spark Connect
     pip install pyspark[connect]
 
+
+See :ref:`optional-dependencies` for more detail about extra dependencies.
+
 For PySpark with/without a specific Hadoop version, you can install it by using ``PYSPARK_HADOOP_VERSION`` environment variables as below:
 
 .. code-block:: bash
@@ -165,16 +168,93 @@ To install PySpark from source, refer to |building_spark|_.
 
 Dependencies
 ------------
-========================== ========================= ======================================================================================
-Package                    Supported version Note
-========================== ========================= ======================================================================================
-`py4j`                     >=0.10.9.7                Required
-`pandas`                   >=1.4.4                   Required for pandas API on Spark and Spark Connect; Optional for Spark SQL
-`pyarrow`                  >=10.0.0                  Required for pandas API on Spark and Spark Connect; Optional for Spark SQL
-`numpy`                    >=1.21                    Required for pandas API on Spark and MLLib DataFrame-based API; Optional for Spark SQL
-`grpcio`                   >=1.62.0                  Required for Spark Connect
-`grpcio-status`            >=1.62.0                  Required for Spark Connect
-`googleapis-common-protos` >=1.56.4                  Required for Spark Connect
-========================== ========================= ======================================================================================
+
+Required dependencies
+~~~~~~~~~~~~~~~~~~~~~
+
+PySpark requires the following dependencies.
+
+========================== ========================= ============================================
+Package                    Supported version         Note
+========================== ========================= ============================================
+`py4j`                     >=0.10.9.7                Essential for Python to interface with the
+                                                     Java objects in Spark; ensures seamless
+                                                     interaction between Python and JVM.
+========================== ========================= ============================================
 
 Note that PySpark requires Java 17 or later with ``JAVA_HOME`` properly set and refer to |downloading|_.
+
+
+.. _optional-dependencies:
+
+Optional dependencies
+~~~~~~~~~~~~~~~~~~~~~
+
+PySpark has several optional dependencies that enhance its functionality for specific modules. These dependencies are only required for certain features and are not necessary for the basic functionality of PySpark. If these optional dependencies are not installed, PySpark will function correctly for basic operations but will raise an ``ImportError`` when you try to use features that require these dependencies.
+
+Spark SQL
+^^^^^^^^^
+
+Installable with ``pip install "pyspark[sql]"``.
+
+========================== ========================= ======================================================================================
+Package                    Supported version         Note
+========================== ========================= ======================================================================================
+`pandas`                   >=1.4.4                   Provides integration with the Pandas library, enabling conversion between DataFrame formats and leveraging Pandas instances.
+`pyarrow`                  >=10.0.0                  Facilitates high-performance data transfers and conversion between PySpark and Pandas data structures.
+`numpy`                    >=1.21                    Enhances numerical operations in Spark, necessary for statistical functions and data manipulation within PySpark.
+========================== ========================= ======================================================================================
+
+Pandas API on Spark
+^^^^^^^^^^^^^^^^^^^
+
+Installable with ``pip install "pyspark[pandas_on_spark]"``.
+
+========================== ========================= ======================================================================================
+Package                    Supported version         Note
+========================== ========================= ======================================================================================
+`pandas`                   >=1.4.4                   Enables direct operations on Pandas DataFrames, essential for PySpark’s Pandas API.
+`pyarrow`                  >=10.0.0                  Required to ensure compatibility and performance improvements in DataFrame conversions.
+`numpy`                    >=1.21                    Supports numerical data operations, crucial for handling Pandas objects and MLlib functionalities.
+========================== ========================= ======================================================================================
+
+Note: Run ``pip install "pyspark[pandas_on_spark] plotly"`` if you want to use visualization features.
+
+ML
+^^
+
+Installable with ``pip install "pyspark[ml]"``.
+
+========================== ========================= ======================================================================================
+Package                    Supported version         Note
+========================== ========================= ======================================================================================
+`numpy`                    >=1.21                    Necessary for MLlib's advanced linear algebra operations, enhances machine learning algorithms.
+========================== ========================= ======================================================================================
+
+MLlib
+^^^^^
+
+Installable with ``pip install "pyspark[mllib]"``.
+
+========================== ========================= ======================================================================================
+Package                    Supported version         Note
+========================== ========================= ======================================================================================
+`numpy`                    >=1.21                    Essential for mathematical operations within MLlib, improves performance and accuracy of algorithms.
+========================== ========================= ======================================================================================
+
+Spark Connect
+^^^^^^^^^^^^^
+
+Installable with ``pip install "pyspark[connect]"``.
+
+========================== ========================= ======================================================================================
+Package                    Supported version         Note
+========================== ========================= ======================================================================================
+`pandas`                   >=1.4.4                   Necessary for utilizing the Pandas API within Spark Connect, facilitates smooth data handling.
+`pyarrow`                  >=10.0.0                  Enhances serialization and conversion processes, important for efficient network communication.
+`numpy`                    >=1.21                    Integral for data manipulation in Spark Connect, improves computation capabilities.
+`grpcio`                   >=1.62.0                  Provides the RPC framework necessary for Spark Connect's distributed computing functionalities.
+`grpcio-status`            >=1.62.0                  Adds support for handling RPC statuses and messages within Spark Connect.
+`googleapis-common-protos` >=1.56.4                  Includes essential protocol buffers from Google APIs, crucial for communication protocols in Spark Connect.
+========================== ========================= ======================================================================================
+

--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -174,11 +174,11 @@ Required dependencies
 
 PySpark requires the following dependencies.
 
-========================== ========================= =======================
+========================== ========================= =============================
 Package                    Supported version         Note
-========================== ========================= =======================
-`py4j`                     >=0.10.9.7                Used to interact to JVM
-========================== ========================= =======================
+========================== ========================= =============================
+`py4j`                     >=0.10.9.7                Required to interact with JVM
+========================== ========================= =============================
 
 Additional libraries that enhance functionality but are not included in the installation packages:
 
@@ -202,27 +202,27 @@ Spark Connect
 
 Installable with ``pip install "pyspark[connect]"``.
 
-========================== ================= ====================================================================
+========================== ================= ==========================
 Package                    Supported version Note
-========================== ================= ====================================================================
-`pandas`                   >=1.4.4           Required for Spark Connect.
-`pyarrow`                  >=10.0.0          Crucial for data serialization and network communication efficiency.
-`grpcio`                   >=1.62.0          Necessary for implementing RPC functionalities in Spark Connect.
-`grpcio-status`            >=1.62.0          Supports detailed status handling in network communications.
-`googleapis-common-protos` >=1.56.4          Provides essential Google API protocols for network interactions.
-========================== ================= ====================================================================
+========================== ================= ==========================
+`pandas`                   >=1.4.4           Required for Spark Connect
+`pyarrow`                  >=10.0.0          Required for Spark Connect
+`grpcio`                   >=1.62.0          Required for Spark Connect
+`grpcio-status`            >=1.62.0          Required for Spark Connect
+`googleapis-common-protos` >=1.56.4          Required for Spark Connect
+========================== ================= ==========================
 
 Spark SQL
 ^^^^^^^^^
 
 Installable with ``pip install "pyspark[sql]"``.
 
-========= ================= ===============================================================
+========= ================= ======================
 Package   Supported version Note
-========= ================= ===============================================================
-`pandas`  >=1.4.4           Used for pandas UDFs and ``DataFrame.toPandas``.
-`pyarrow` >=10.0.0          For faster data conversion/transfer between PySpark and Pandas.
-========= ================= ===============================================================
+========= ================= ======================
+`pandas`  >=1.4.4           Required for Spark SQL
+`pyarrow` >=10.0.0          Required for Spark SQL
+========= ================= ======================
 
 
 Pandas API on Spark
@@ -230,18 +230,18 @@ Pandas API on Spark
 
 Installable with ``pip install "pyspark[pandas_on_spark]"``.
 
-========= ================= ===============================================================
+========= ================= ================================
 Package   Supported version Note
-========= ================= ===============================================================
-`pandas`  >=1.4.4           Required for Pandas API on Spark.
-`pyarrow` >=10.0.0          For faster data conversion/transfer between PySpark and pandas.
-========= ================= ===============================================================
+========= ================= ================================
+`pandas`  >=1.4.4           Required for Pandas API on Spark
+`pyarrow` >=10.0.0          Required for Pandas API on Spark
+========= ================= ================================
 
 Additional libraries that enhance functionality but are not included in the installation packages:
 
-- **mlflow**: Enhances machine learning lifecycle management. Used for ``pyspark.pandas.mlflow``.
-- **plotly**: Provide advanced plotting capabilities for visualization.
-- **matplotlib**: Provide plotting, but **plotly** is recommended. The default is **plotly**.
+- **mlflow**: Required for ``pyspark.pandas.mlflow``.
+- **plotly**: Provide plotting for visualization. It is recommended using **plotly** over **matplotlib**.
+- **matplotlib**: Provide plotting for visualization. The default is **plotly**.
 
 
 MLLib DataFrame-based API
@@ -249,28 +249,28 @@ MLLib DataFrame-based API
 
 Installable with ``pip install "pyspark[ml]"``.
 
-======= ================= =======================================
+======= ================= ======================================
 Package Supported version Note
-======= ================= =======================================
-`numpy` >=1.21            Required for MLLib DataFrame-based API.
-======= ================= =======================================
+======= ================= ======================================
+`numpy` >=1.21            Required for MLLib DataFrame-based API
+======= ================= ======================================
 
 Additional libraries that enhance functionality but are not included in the installation packages:
 
-- **scipy**: Essential for scientific computing and statistical functions in ML.
+- **scipy**: Required for SciPy integration.
 - **scikit-learn**: Required for implementing machine learning algorithms.
-- **torch**: Utilized for machine learning model training on PySpark.
-- **torchvision**: Supports image and video processing within PySpark models.
-- **torcheval**: Facilitates model evaluation metrics in PySpark.
-- **deepspeed**: Provides high-performance model training optimizations. Installable on non-Darwin systems.
+- **torch**: Required for machine learning model training.
+- **torchvision**: Required for supporting image and video processing.
+- **torcheval**: Required for facilitating model evaluation metrics.
+- **deepspeed**: Required for providing high-performance model training optimizations. Installable on non-Darwin systems.
 
 MLlib
 ^^^^^
 
 Installable with ``pip install "pyspark[mllib]"``.
 
-======= ================= ===================
+======= ================= ==================
 Package Supported version Note
-======= ================= ===================
-`numpy` >=1.21            Required for MLLib.
-======= ================= ===================
+======= ================= ==================
+`numpy` >=1.21            Required for MLLib
+======= ================= ==================

--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -174,17 +174,15 @@ Required dependencies
 
 PySpark requires the following dependencies.
 
-========================== ========================= ============================================
+========================== ========================= =======================
 Package                    Supported version         Note
-========================== ========================= ============================================
-`py4j`                     >=0.10.9.7                Essential for Python to interface with the
-                                                     Java objects in Spark; ensures seamless
-                                                     interaction between Python and JVM.
-========================== ========================= ============================================
+========================== ========================= =======================
+`py4j`                     >=0.10.9.7                Used to interact to JVM
+========================== ========================= =======================
 
 Additional libraries that enhance functionality but are not included in the installation packages:
 
-- **memory-profiler**: Useful for diagnosing and analyzing memory usage in PySpark applications.
+- **memory-profiler**: Used for PySpark UDF memory profiling, ``spark.profile.show(...)`` and ``spark.sql.pyspark.udf.profiler``.
 
 Note that PySpark requires Java 17 or later with ``JAVA_HOME`` properly set and refer to |downloading|_.
 
@@ -199,74 +197,6 @@ These dependencies are only required for certain features and are not necessary 
 If these optional dependencies are not installed, PySpark will function correctly for basic operations but will raise an ``ImportError``
 when you try to use features that require these dependencies.
 
-Spark SQL
-^^^^^^^^^
-
-Installable with ``pip install "pyspark[sql]"``.
-
-========= ================= ==================================================================
-Package   Supported version Note
-========= ================= ==================================================================
-`pandas`  >=1.4.4           Enables seamless DataFrame operations between Spark and Pandas.
-`pyarrow` >=10.0.0          Optimizes data conversion and transfer between PySpark and Pandas.
-`numpy`   >=1.21            Essential for numerical data manipulation within PySpark.
-========= ================= ==================================================================
-
-
-Pandas API on Spark
-^^^^^^^^^^^^^^^^^^^
-
-Installable with ``pip install "pyspark[pandas_on_spark]"``.
-
-========= ================= =====================================================================
-Package   Supported version Note
-========= ================= =====================================================================
-`pandas`  >=1.4.4           Required for utilizing the Pandas API features in Spark.
-`pyarrow` >=10.0.0          Ensures efficient data handling and performance in Pandas operations.
-`numpy`   >=1.21            Facilitates complex numerical operations within Spark.
-========= ================= =====================================================================
-
-Additional libraries that enhance functionality but are not included in the installation packages:
-
-- **mlflow**: Enhances machine learning lifecycle management, including experiment tracking and model deployment.
-- **plotly, matplotlib**: Provide advanced plotting capabilities for visualization.
-
-
-ML
-^^
-
-Installable with ``pip install "pyspark[ml]"``.
-
-======= ================= =======================================================================
-Package Supported version Note
-======= ================= =======================================================================
-`numpy` >=1.21            Supports advanced data manipulation and algorithm implementation in ML.
-======= ================= =======================================================================
-
-Additional libraries that enhance functionality but are not included in the installation packages:
-
-- **scipy**: Essential for scientific computing and statistical functions in ML.
-- **scikit-learn**: Required for implementing machine learning algorithms.
-
-MLlib
-^^^^^
-
-Installable with ``pip install "pyspark[mllib]"``.
-
-======= ================= ====================================================================================================
-Package Supported version Note
-======= ================= ====================================================================================================
-`numpy` >=1.21            Essential for mathematical operations within MLlib, improves performance and accuracy of algorithms.
-======= ================= ====================================================================================================
-
-Additional libraries that enhance functionality but are not included in the installation packages:
-
-- **torch**: Utilized for machine learning model training on PySpark.
-- **torchvision**: Supports image and video processing within PySpark models.
-- **torcheval**: Facilitates model evaluation metrics in PySpark.
-- **deepspeed; sys_platform != 'darwin'**: Provides high-performance model training optimizations. Installable on non-Darwin systems.
-
-
 Spark Connect
 ^^^^^^^^^^^^^
 
@@ -275,10 +205,72 @@ Installable with ``pip install "pyspark[connect]"``.
 ========================== ================= ====================================================================
 Package                    Supported version Note
 ========================== ================= ====================================================================
-`pandas`                   >=1.4.4           Facilitates DataFrame handling and manipulation.
+`pandas`                   >=1.4.4           Required for Spark Connect.
 `pyarrow`                  >=10.0.0          Crucial for data serialization and network communication efficiency.
-`numpy`                    >=1.21            Enhances data processing capabilities.
 `grpcio`                   >=1.62.0          Necessary for implementing RPC functionalities in Spark Connect.
 `grpcio-status`            >=1.62.0          Supports detailed status handling in network communications.
 `googleapis-common-protos` >=1.56.4          Provides essential Google API protocols for network interactions.
 ========================== ================= ====================================================================
+
+Spark SQL
+^^^^^^^^^
+
+Installable with ``pip install "pyspark[sql]"``.
+
+========= ================= ===============================================================
+Package   Supported version Note
+========= ================= ===============================================================
+`pandas`  >=1.4.4           Used for pandas UDFs and ``DataFrame.toPandas``.
+`pyarrow` >=10.0.0          For faster data conversion/transfer between PySpark and Pandas.
+========= ================= ===============================================================
+
+
+Pandas API on Spark
+^^^^^^^^^^^^^^^^^^^
+
+Installable with ``pip install "pyspark[pandas_on_spark]"``.
+
+========= ================= ===============================================================
+Package   Supported version Note
+========= ================= ===============================================================
+`pandas`  >=1.4.4           Required for Pandas API on Spark.
+`pyarrow` >=10.0.0          For faster data conversion/transfer between PySpark and pandas.
+========= ================= ===============================================================
+
+Additional libraries that enhance functionality but are not included in the installation packages:
+
+- **mlflow**: Enhances machine learning lifecycle management. Used for ``pyspark.pandas.mlflow``.
+- **plotly**: Provide advanced plotting capabilities for visualization.
+- **matplotlib**: Provide plotting, but **plotly** is recommended. The default is **plotly**.
+
+
+MLLib DataFrame-based API
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Installable with ``pip install "pyspark[ml]"``.
+
+======= ================= =======================================
+Package Supported version Note
+======= ================= =======================================
+`numpy` >=1.21            Required for MLLib DataFrame-based API.
+======= ================= =======================================
+
+Additional libraries that enhance functionality but are not included in the installation packages:
+
+- **scipy**: Essential for scientific computing and statistical functions in ML.
+- **scikit-learn**: Required for implementing machine learning algorithms.
+- **torch**: Utilized for machine learning model training on PySpark.
+- **torchvision**: Supports image and video processing within PySpark models.
+- **torcheval**: Facilitates model evaluation metrics in PySpark.
+- **deepspeed**: Provides high-performance model training optimizations. Installable on non-Darwin systems.
+
+MLlib
+^^^^^
+
+Installable with ``pip install "pyspark[mllib]"``.
+
+======= ================= ===================
+Package Supported version Note
+======= ================= ===================
+`numpy` >=1.21            Required for MLLib.
+======= ================= ===================


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to enhance "Installation" page to cover all installable options for PySpark pip installation.

### Why are the changes needed?

To provide more detailed options for user-facing documentation.


### Does this PR introduce _any_ user-facing change?

No API changes, but the user-facing documentation will be improved as below:

## Before

<img width="748" alt="Screenshot 2024-04-17 at 4 13 39 PM" src="https://github.com/apache/spark/assets/44108233/3b5567de-ba04-4b6b-8ae8-92dd3901142a">


## After
<img width="501" alt="Screenshot 2024-04-18 at 1 54 54 PM" src="https://github.com/apache/spark/assets/44108233/06584a84-822b-4c98-9513-20210e9b6467">
<img width="494" alt="Screenshot 2024-04-18 at 1 55 04 PM" src="https://github.com/apache/spark/assets/44108233/c85b439a-8786-417d-9575-7d38b3420d8d">



### How was this patch tested?

Manually built docs and check visually.

### Was this patch authored or co-authored using generative AI tooling?

No.