### PR TITLE
[SPARK-47863][SQL] Fix startsWith & endsWith collation-aware implementation for ICU

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationSupport.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationSupport.java
@@ -99,7 +99,10 @@ public final class CollationSupport {
     }
     public static boolean execICU(final UTF8String l, final UTF8String r,
         final int collationId) {
-      return CollationAwareUTF8String.matchAt(l, r, 0, collationId);
+      if (r.numBytes() == 0) return true;
+      if (l.numBytes() == 0) return false;
+      StringSearch stringSearch = CollationFactory.getStringSearch(l, r, collationId);
+      return stringSearch.first() == 0;
     }
   }
 
@@ -133,7 +136,11 @@ public final class CollationSupport {
     }
     public static boolean execICU(final UTF8String l, final UTF8String r,
         final int collationId) {
-      return CollationAwareUTF8String.matchAt(l, r, l.numBytes() - r.numBytes(), collationId);
+      if (r.numBytes() == 0) return true;
+      if (l.numBytes() == 0) return false;
+      StringSearch stringSearch = CollationFactory.getStringSearch(l, r, collationId);
+      int endIndex = stringSearch.getTarget().getEndIndex();
+      return stringSearch.last() == endIndex - stringSearch.getMatchLength();
     }
   }
 
@@ -156,18 +163,6 @@ public final class CollationSupport {
    */
 
   private static class CollationAwareUTF8String {
-
-    private static boolean matchAt(final UTF8String target, final UTF8String pattern,
-        final int pos, final int collationId) {
-      if (pattern.numChars() + pos > target.numChars() || pos < 0) {
-        return false;
-      }
-      if (pattern.numBytes() == 0 || target.numBytes() == 0) {
-        return pattern.numBytes() == 0;
-      }
-      return CollationFactory.getStringSearch(target.substring(
-        pos, pos + pattern.numChars()), pattern, collationId).last() == 0;
-    }
 
   }
 

--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
@@ -101,6 +101,9 @@ public class CollationSupportSuite {
     assertContains("ab世De", "AB世dE", "UNICODE_CI", true);
     assertContains("äbćδe", "ÄbćδE", "UNICODE_CI", true);
     assertContains("äbćδe", "ÄBcΔÉ", "UNICODE_CI", false);
+    // Case-variable character length
+    assertContains("abİo12", "i̇o", "UNICODE_CI", true);
+    assertContains("abi̇o12", "İo", "UNICODE_CI", true);
   }
 
   private void assertStartsWith(
@@ -139,6 +142,7 @@ public class CollationSupportSuite {
     assertStartsWith("abcde", "X", "UTF8_BINARY_LCASE", false);
     assertStartsWith("abcde", "a", "UNICODE_CI", true);
     assertStartsWith("abcde", "aBC", "UNICODE_CI", true);
+    assertStartsWith("abcde", "bcd", "UNICODE_CI", false);
     assertStartsWith("abcde", "123", "UNICODE_CI", false);
     // Case variation
     assertStartsWith("aBcDe", "abc", "UTF8_BINARY", false);
@@ -175,6 +179,9 @@ public class CollationSupportSuite {
     assertStartsWith("ab世De", "AB世dE", "UNICODE_CI", true);
     assertStartsWith("äbćδe", "ÄbćδE", "UNICODE_CI", true);
     assertStartsWith("äbćδe", "ÄBcΔÉ", "UNICODE_CI", false);
+    // Case-variable character length
+    assertStartsWith("İonic", "i̇o", "UNICODE_CI", true);
+    assertStartsWith("i̇onic", "İo", "UNICODE_CI", true);
   }
 
   private void assertEndsWith(String pattern, String suffix, String collationName, boolean expected)
@@ -212,6 +219,7 @@ public class CollationSupportSuite {
     assertEndsWith("abcde", "X", "UTF8_BINARY_LCASE", false);
     assertEndsWith("abcde", "e", "UNICODE_CI", true);
     assertEndsWith("abcde", "CDe", "UNICODE_CI", true);
+    assertEndsWith("abcde", "bcd", "UNICODE_CI", false);
     assertEndsWith("abcde", "123", "UNICODE_CI", false);
     // Case variation
     assertEndsWith("aBcDe", "cde", "UTF8_BINARY", false);
@@ -248,6 +256,9 @@ public class CollationSupportSuite {
     assertEndsWith("ab世De", "AB世dE", "UNICODE_CI", true);
     assertEndsWith("äbćδe", "ÄbćδE", "UNICODE_CI", true);
     assertEndsWith("äbćδe", "ÄBcΔÉ", "UNICODE_CI", false);
+    // Case-variable character length
+    assertEndsWith("The İo", "i̇o", "UNICODE_CI", true);
+    assertEndsWith("The i̇o", "İo", "UNICODE_CI", true);
   }
 
   // TODO: Test more collation-aware string expressions.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix startsWith/endsWith ICU collation-aware implementation to cover edge cases in UNICODE.


### Why are the changes needed?
Offsets used to compare strings in the previous implementation were wrong in some special cases where lowercase and uppercase have different length (for example: uppercase İ is 1 char, lowercase i̇ is 2 chars)


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
New unit tests in `CollationSupport`.


### Was this patch authored or co-authored using generative AI tooling?
No.
