### PR TITLE
[SPARK-47884][INFRA] Switch ANSI SQL CI job to NON-ANSI SQL CI job

### DIFF
--- a/.github/workflows/build_non_ansi.yml
+++ b/.github/workflows/build_non_ansi.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / ANSI (master, Hadoop 3, JDK 17, Scala 2.13)"
+name: "Build / NON-ANSI (master, Hadoop 3, JDK 17, Scala 2.13)"
 
 on:
   schedule:
@@ -36,7 +36,7 @@ jobs:
       hadoop: hadoop3
       envs: >-
         {
-          "SPARK_ANSI_SQL_MODE": "true",
+          "SPARK_ANSI_SQL_MODE": "false",
         }
       jobs: >-
         {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to switch `ANSI SQL` GitHub Action job to `NON-ANSI SQL` GitHub Action job.
- Rename `build_ansi.yml` to `build_non_ansi.yml`
- Change job name from `ANSI` to `NON-ANSI`
- Change `SPARK_ANSI_SQL_MODE` to `false`.

### Why are the changes needed?

Since SPARK-44111, Apache Spark uses ANSI mode by default. So, we need to switch this to keep `NON-ANSI SQL` mode test coverage.
- https://github.com/apache/spark/pull/46013

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review. This should be tested after merging.

### Was this patch authored or co-authored using generative AI tooling?

No.