### PR TITLE
[SPARK-47885][PYTHON][CONNECT] Make pyspark.resource compatible with pyspark-connect

### DIFF
--- a/python/pyspark/resource/profile.py
+++ b/python/pyspark/resource/profile.py
@@ -201,14 +201,15 @@ class ResourceProfileBuilder:
     """
 
     def __init__(self) -> None:
-        from pyspark.core.context import SparkContext
-
-        # TODO: ignore[attr-defined] will be removed, once SparkContext is inlined
-        _jvm = SparkContext._jvm
-
         from pyspark.sql import is_remote
 
-        if _jvm is not None and not is_remote():
+        _jvm = None
+        if not is_remote():
+            from pyspark.core.context import SparkContext
+
+            _jvm = SparkContext._jvm
+
+        if _jvm is not None:
             self._jvm = _jvm
             self._java_resource_profile_builder = (
                 _jvm.org.apache.spark.resource.ResourceProfileBuilder()

--- a/python/pyspark/resource/requests.py
+++ b/python/pyspark/resource/requests.py
@@ -164,14 +164,17 @@ class ExecutorResourceRequests:
         _jvm: Optional["JVMView"] = None,
         _requests: Optional[Dict[str, ExecutorResourceRequest]] = None,
     ):
-        from pyspark import SparkContext
         from pyspark.sql import is_remote
 
-        _jvm = _jvm or SparkContext._jvm
+        jvm = None
+        if not is_remote():
+            from pyspark.core.context import SparkContext
 
-        if _jvm is not None and not is_remote():
+            jvm = _jvm or SparkContext._jvm
+
+        if jvm is not None:
             self._java_executor_resource_requests = (
-                _jvm.org.apache.spark.resource.ExecutorResourceRequests()
+                jvm.org.apache.spark.resource.ExecutorResourceRequests()
             )
             if _requests is not None:
                 for k, v in _requests.items():
@@ -462,15 +465,18 @@ class TaskResourceRequests:
         _jvm: Optional["JVMView"] = None,
         _requests: Optional[Dict[str, TaskResourceRequest]] = None,
     ):
-        from pyspark import SparkContext
         from pyspark.sql import is_remote
 
-        _jvm = _jvm or SparkContext._jvm
+        jvm = None
+        if not is_remote():
+            from pyspark.core.context import SparkContext
 
-        if _jvm is not None and not is_remote():
+            jvm = _jvm or SparkContext._jvm
+
+        if jvm is not None:
             self._java_task_resource_requests: Optional[
                 "JavaObject"
-            ] = _jvm.org.apache.spark.resource.TaskResourceRequests()
+            ] = jvm.org.apache.spark.resource.TaskResourceRequests()
             if _requests is not None:
                 for k, v in _requests.items():
                     if k == self._CPUS:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to make `pyspark.resource` compatible with `pyspark-connect`.

### Why are the changes needed?

In order for `pyspark-connect` to work without classic PySpark packages and dependencies.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested in https://github.com/apache/spark/pull/46090

### Was this patch authored or co-authored using generative AI tooling?

No.
