### PR TITLE
[SPARK-47867][FOLLOWUP] Fix variant parsing in JacksonParser.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -116,6 +116,12 @@ class JacksonParser(
   }
 
   protected final def parseVariant(parser: JsonParser): VariantVal = {
+    // Skips `FIELD_NAME` at the beginning. This check is adapted from `parseJsonToken`, but we
+    // cannot directly use the function here because it also handles the `VALUE_NULL` token and
+    // returns null (representing a SQL NULL). Instead, we want to return a variant null.
+    if (parser.getCurrentToken == FIELD_NAME) {
+      parser.nextToken()
+    }
     try {
       val v = VariantBuilder.parseJson(parser)
       new VariantVal(v.getValue, v.getMetadata)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes an issue introduced in https://github.com/apache/spark/pull/46071. When parsing a JSON object as a map or struct, the `JacksonParser` only peeks the `FIELD_NAME` token without consuming it. `VariantBuilder.parseJson` will then fail because the current token is `FIELD_NAME` rather than the starting token of the value. Previous tests with struct schemas didn't fail because the parsing error was caught and the parser would then consume the field name, and the field value would be read in the next iteration. However, a map schema with variant value would fail.

### Why are the changes needed?

It is a bug fix and allows Spark to read a map schema with variant value (for example, `map<string, variant>`) correctly.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

A new unit test. It would fail without the changes.

### Was this patch authored or co-authored using generative AI tooling?

No.
