### PR TITLE
[SPARK-47371][SQL][FOLLOWUP] XML: Stop ignoring CDATA within row tags

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
@@ -802,19 +802,6 @@ class XmlTokenizer(
         commentIdx = 0
       }
 
-      if (c == cdataStart(cdataIdx)) {
-        if (cdataIdx >= cdataStart.length - 1) {
-          //  If a CDATA beigns we must ignore everything until its end
-          buffer.setLength(buffer.length - cdataStart.length)
-          cdataIdx = 0
-          readUntilMatch(cdataEnd)
-        } else {
-          cdataIdx += 1
-        }
-      } else {
-        cdataIdx = 0
-      }
-
       if (c == '>' && prevC != '/') {
         canSelfClose = false
       }

--- a/sql/core/src/test/resources/test-data/xml-resources/cdata-ending-eof.xml
+++ b/sql/core/src/test/resources/test-data/xml-resources/cdata-ending-eof.xml
@@ -23,10 +23,11 @@
     <ROW><a>10</a></ROW>
     <!-- <ROW><a>0</a></ROW> -->
     <![CDATA[<!-- <ROW><a>0</a></ROW>]]>
-    <ROW> <![CDATA[<ROW><a>0</a></ROW>]]> <a>11</a> <![CDATA[<ROW><a>0</a></ROW>]]> </ROW>
-    <![CDATA[<ROW><a>0</a> <!-- --> </ROW>]]><ROW> <![CDATA[a>0</a>]]> <a>12</a> </ROW> <![CDATA[<ROW><a>0</a></ROW>]]>
+    <!-- CDATA within row should not be ignored -->
+    <ROW>  <a> <![CDATA[ 11 ]]> </a> </ROW>
+    <![CDATA[<ROW><a>0</a> <!-- --> </ROW>]]><ROW> <a> <![CDATA[ 12 ]]> </a> </ROW> <![CDATA[<ROW><a>0</a></ROW>]]>
     <ROW> <a>13</a> </ROW>
-    <![CDATA[<ROW><a>0</a></ROW> <!-- open comment]]> <ROW> <![CDATA[<a>0</a>]]> <a>14</a> <![CDATA[<a>0</a>]]> </ROW> <![CDATA[<a>0</a>]]>
+    <![CDATA[<ROW><a>0</a></ROW> <!-- open comment]]> <ROW> <a> <![CDATA[ 14 ]]> </a> </ROW> <![CDATA[<a>0</a>]]>
     <![CDATA[
         <ROW><a>0</a></ROW>
         <a>0</a> <!-- <a>0</a> -->

--- a/sql/core/src/test/resources/test-data/xml-resources/cdata-no-close.xml
+++ b/sql/core/src/test/resources/test-data/xml-resources/cdata-no-close.xml
@@ -23,10 +23,11 @@
     <ROW><a>10</a></ROW>
     <!-- <ROW><a>0</a></ROW> -->
     <![CDATA[<!-- <ROW><a>0</a></ROW>]]>
-    <ROW> <![CDATA[<ROW><a>0</a></ROW>]]> <a>11</a> <![CDATA[<ROW><a>0</a></ROW>]]> </ROW>
-    <![CDATA[<ROW><a>0</a> <!-- --> </ROW>]]><ROW> <![CDATA[a>0</a>]]> <a>12</a> </ROW> <![CDATA[<ROW><a>0</a></ROW>]]>
+    <!-- CDATA within row should not be ignored -->
+    <ROW>  <a> <![CDATA[ 11 ]]> </a> </ROW>
+    <![CDATA[<ROW><a>0</a> <!-- --> </ROW>]]><ROW> <a> <![CDATA[ 12 ]]> </a> </ROW> <![CDATA[<ROW><a>0</a></ROW>]]>
     <ROW> <a>13</a> </ROW>
-    <![CDATA[<ROW><a>0</a></ROW> <!-- open comment]]> <ROW> <![CDATA[<a>0</a>]]> <a>14</a> <![CDATA[<a>0</a>]]> </ROW> <![CDATA[<a>0</a>]]>
+    <![CDATA[<ROW><a>0</a></ROW> <!-- open comment]]> <ROW> <a> <![CDATA[ 14 ]]> </a> </ROW> <![CDATA[<a>0</a>]]>
     <![CDATA[
         <ROW><a>0</a></ROW>
         <a>0</a> <!-- <a>0</a> -->
@@ -44,5 +45,4 @@
     <ROW> <a>17</a> </ROW>
 </ROWSET>
 <![CDATA[
-        CDATA no close tag
-
+        CDATA ending at eof

--- a/sql/core/src/test/resources/test-data/xml-resources/cdata-no-ignore.xml
+++ b/sql/core/src/test/resources/test-data/xml-resources/cdata-no-ignore.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<!-- Should read CDATA as raw string -->
+<ROWSET>
+    <![CDATA[ <ROW> ignored row </ROW> ]]>
+    <ROW><![CDATA[ <a>1</a> ]]></ROW>
+    <ROW><![CDATA[ 2 ]]></ROW>
+    <ROW><![CDATA[ <ROW>3</ROW> ]]></ROW>
+    <ROW><![CDATA[ 4 ]]></ROW>
+    <ROW><![CDATA[ <ROW>5</ROW> ]]></ROW>
+    <![CDATA[ <ROW> ignored row </ROW> ]]>
+</ROWSET>

--- a/sql/core/src/test/resources/test-data/xml-resources/ignored-rows.xml
+++ b/sql/core/src/test/resources/test-data/xml-resources/ignored-rows.xml
@@ -23,10 +23,11 @@
     <ROW><a>10</a></ROW>
     <!-- <ROW><a>0</a></ROW> -->
     <![CDATA[<!-- <ROW><a>0</a></ROW>]]>
-    <ROW> <![CDATA[<ROW><a>0</a></ROW>]]> <a>11</a> <![CDATA[<ROW><a>0</a></ROW>]]> </ROW>
-    <![CDATA[<ROW><a>0</a> <!-- --> </ROW>]]><ROW> <![CDATA[a>0</a>]]> <a>12</a> </ROW> <![CDATA[<ROW><a>0</a></ROW>]]>
+    <!-- CDATA within row should not be ignored -->
+    <ROW>  <a> <![CDATA[ 11 ]]> </a> </ROW>
+    <![CDATA[<ROW><a>0</a> <!-- --> </ROW>]]><ROW> <a> <![CDATA[ 12 ]]> </a> </ROW> <![CDATA[<ROW><a>0</a></ROW>]]>
     <ROW> <a>13</a> </ROW>
-    <![CDATA[<ROW><a>0</a></ROW> <!-- open comment]]> <ROW> <![CDATA[<a>0</a>]]> <a>14</a> <![CDATA[<a>0</a>]]> </ROW> <![CDATA[<a>0</a>]]>
+    <![CDATA[<ROW><a>0</a></ROW> <!-- open comment]]> <ROW> <a> <![CDATA[ 14 ]]> </a> </ROW> <![CDATA[<a>0</a>]]>
     <![CDATA[
         <ROW><a>0</a></ROW>
         <a>0</a> <!-- <a>0</a> -->

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
@@ -2625,6 +2625,18 @@ class XmlSuite
 
     val expectedResults3 = Seq.range(1, 18).map(Row(_))
     checkAnswer(results3, expectedResults3)
+
+    val results4 = spark.read.format("xml")
+      .option("rowTag", "ROW")
+      .load(getTestResourcePath(resDir + "cdata-no-ignore.xml"))
+
+    val expectedResults4 = Seq(
+      Row("<a>1</a>"),
+      Row("2"),
+      Row("<ROW>3</ROW>"),
+      Row("4"),
+      Row("<ROW>5</ROW>"))
+    checkAnswer(results4, expectedResults4)
   }
 
   test("capture values interspersed between elements - nested struct") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
The previous PR: https://github.com/apache/spark/pull/45487 
The previous PR modified the parser to ignore CDATA within rowTag elements which results in missed data during parsing. 

These changes add the following:
1. Changed to not ignore CDATA within row tags (only CDATA outside of a row is ignored).
2. Changed the existing tests to reflect that CDATA within row tags is not ignored.
3. Added one more test to test CDATA within a row.

The new test case includes this:

`<ROW><![CDATA[ <ROW>3</ROW> ]]></ROW>`

This actually parses correctly because both start and end tag are within the CDATA, but if one of them was missing it would break. For example, the following would break:

`<ROW><![CDATA[ 3</ROW> ]]></ROW>`

Future work should allow the case above to pass by not matching to row tags within CDATA.
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Correct XML parsing behaviour.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
CDATA outside of a row is now ignored, CDATA within a row is not ignored.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.