### PR TITLE
[SPARK-47941] [SS] [Connect] Propagate ForeachBatch worker initialization errors to users for PySpark

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3779,6 +3779,12 @@
     ],
     "sqlState" : "42601"
   },
+  "STREAMING_PYTHON_RUNNER_DID_NOT_INITIALIZE" : {
+    "message" : [
+      "Streaming Runner initialization failed, returned <resFromPython>. Cause: <msg>"
+    ],
+    "sqlState" : "XXKST"
+  },
   "STREAMING_STATEFUL_OPERATOR_NOT_MATCH_IN_STATE_METADATA" : {
     "message" : [
       "Streaming stateful operator name does not match with the operator in state metadata. This likely to happen when user adds/removes/changes stateful operator of existing streaming query.",

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3779,7 +3779,7 @@
     ],
     "sqlState" : "42601"
   },
-  "STREAMING_PYTHON_RUNNER_DID_NOT_INITIALIZE" : {
+  "STREAMING_PYTHON_RUNNER_INITIALIZATION_FAILURE" : {
     "message" : [
       "Streaming Runner initialization failed, returned <resFromPython>. Cause: <msg>"
     ],

--- a/common/utils/src/main/scala/org/apache/spark/SparkException.scala
+++ b/common/utils/src/main/scala/org/apache/spark/SparkException.scala
@@ -464,6 +464,35 @@ private[spark] class SparkRuntimeException private(
   override def getQueryContext: Array[QueryContext] = context
 }
 
+private[spark] class SparkPythonException private(
+    message: String,
+    cause: Option[Throwable],
+    errorClass: Option[String],
+    messageParameters: Map[String, String],
+    context: Array[QueryContext])
+  extends RuntimeException(message, cause.orNull) with SparkThrowable {
+
+  def this(
+      errorClass: String,
+      messageParameters: Map[String, String],
+      cause: Throwable = null,
+      context: Array[QueryContext] = Array.empty,
+      summary: String = "") = {
+    this(
+      SparkThrowableHelper.getMessage(errorClass, messageParameters, summary),
+      Option(cause),
+      Option(errorClass),
+      messageParameters,
+      context
+    )
+  }
+
+  override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
+
+  override def getErrorClass: String = errorClass.orNull
+  override def getQueryContext: Array[QueryContext] = context
+}
+
 /**
  * No such element exception thrown from Spark with an error class.
  */

--- a/core/src/main/scala/org/apache/spark/api/python/StreamingPythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/StreamingPythonRunner.scala
@@ -91,6 +91,11 @@ private[spark] class StreamingPythonRunner(
       new BufferedInputStream(pythonWorker.get.channel.socket().getInputStream, bufferSize))
 
     val resFromPython = dataIn.readInt()
+    if (resFromPython != 0) {
+      val errMessage = PythonWorkerUtils.readUTF(dataIn)
+      throw new RuntimeException(s"Runner initialization failed (returned $resFromPython). " +
+        s"Error message: $errMessage")
+    }
     logInfo(s"Runner initialization succeeded (returned $resFromPython).")
 
     (dataOut, dataIn)

--- a/core/src/main/scala/org/apache/spark/api/python/StreamingPythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/StreamingPythonRunner.scala
@@ -18,9 +18,10 @@
 package org.apache.spark.api.python
 
 import java.io.{BufferedInputStream, BufferedOutputStream, DataInputStream, DataOutputStream}
+
 import scala.jdk.CollectionConverters._
 
-import org.apache.spark.{SparkEnv, SparkPythonException, SparkUnsupportedOperationException}
+import org.apache.spark.{SparkEnv, SparkPythonException}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.BUFFER_SIZE
 import org.apache.spark.internal.config.Python.PYTHON_AUTH_SOCKET_TIMEOUT

--- a/core/src/main/scala/org/apache/spark/api/python/StreamingPythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/StreamingPythonRunner.scala
@@ -93,21 +93,21 @@ private[spark] class StreamingPythonRunner(
     val resFromPython = dataIn.readInt()
     if (resFromPython != 0) {
       val errMessage = PythonWorkerUtils.readUTF(dataIn)
-      throw streamingPythonRunnerDidNotInitialize(resFromPython, errMessage)
+      throw streamingPythonRunnerInitializationFailure(resFromPython, errMessage)
     }
     logInfo(s"Runner initialization succeeded (returned $resFromPython).")
 
     (dataOut, dataIn)
   }
 
-  def streamingPythonRunnerDidNotInitialize(resFromPython: Int, errMessage: String):
+  def streamingPythonRunnerInitializationFailure(resFromPython: Int, errMessage: String):
     StreamingPythonRunnerInitializationException = {
     new StreamingPythonRunnerInitializationException(resFromPython, errMessage)
   }
 
   class StreamingPythonRunnerInitializationException(resFromPython: Int, errMessage: String)
     extends SparkPythonException(
-      errorClass = "STREAMING_PYTHON_RUNNER_DID_NOT_INITIALIZE",
+      errorClass = "STREAMING_PYTHON_RUNNER_INITIALIZATION_FAILURE",
       messageParameters = Map(
         "resFromPython" -> resFromPython.toString,
         "msg" -> errMessage))

--- a/core/src/main/scala/org/apache/spark/api/python/StreamingPythonRunner.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/StreamingPythonRunner.scala
@@ -93,8 +93,9 @@ private[spark] class StreamingPythonRunner(
     val resFromPython = dataIn.readInt()
     if (resFromPython != 0) {
       val errMessage = PythonWorkerUtils.readUTF(dataIn)
-      throw new RuntimeException(s"Runner initialization failed (returned $resFromPython). " +
-        s"Error message: $errMessage")
+      throw new PythonException(s"Streaming Runner initialization failed" +
+        s" (returned $resFromPython). " +
+        s"Error message: $errMessage", null)
     }
     logInfo(s"Runner initialization succeeded (returned $resFromPython).")
 

--- a/python/pyspark/sql/connect/streaming/worker/foreach_batch_worker.py
+++ b/python/pyspark/sql/connect/streaming/worker/foreach_batch_worker.py
@@ -64,10 +64,6 @@ def main(infile: IO, outfile: IO) -> None:
 
     # TODO(SPARK-44461): Enable Process Isolation
 
-    write_int(0, outfile)  # Indicate successful initialization
-
-    outfile.flush()
-
     log_name = "Streaming ForeachBatch worker"
 
     def process(df_id, batch_id):  # type: ignore[no-untyped-def]
@@ -79,6 +75,8 @@ def main(infile: IO, outfile: IO) -> None:
 
     try:
         func = worker.read_command(pickle_ser, infile)
+        write_int(0, outfile)
+        outfile.flush()
         while True:
             df_ref_id = utf8_deserializer.loads(infile)
             batch_id = read_long(infile)

--- a/python/pyspark/sql/connect/streaming/worker/foreach_batch_worker.py
+++ b/python/pyspark/sql/connect/streaming/worker/foreach_batch_worker.py
@@ -68,6 +68,7 @@ def main(infile: IO, outfile: IO) -> None:
     except Exception as e:
         handle_worker_exception(e, outfile)
         outfile.flush()
+        return
 
     write_int(0, outfile)  # Indicate successful initialization
 

--- a/python/pyspark/sql/connect/streaming/worker/foreach_batch_worker.py
+++ b/python/pyspark/sql/connect/streaming/worker/foreach_batch_worker.py
@@ -77,6 +77,7 @@ def main(infile: IO, outfile: IO) -> None:
         func = worker.read_command(pickle_ser, infile)
         write_int(0, outfile)
         outfile.flush()
+
         while True:
             df_ref_id = utf8_deserializer.loads(infile)
             batch_id = read_long(infile)

--- a/python/pyspark/sql/connect/streaming/worker/foreach_batch_worker.py
+++ b/python/pyspark/sql/connect/streaming/worker/foreach_batch_worker.py
@@ -62,7 +62,12 @@ def main(infile: IO, outfile: IO) -> None:
     assert spark_connect_session.session_id == session_id
     spark = spark_connect_session
 
-    func = worker.read_command(pickle_ser, infile)
+    # TODO(SPARK-44461): Enable Process Isolation
+    read_command_exception = None
+    try:
+        func = worker.read_command(pickle_ser, infile)
+    except Exception as e:
+        read_command_exception = e
     write_int(0, outfile)  # Indicate successful initialization
 
     outfile.flush()
@@ -77,6 +82,10 @@ def main(infile: IO, outfile: IO) -> None:
         print(f"{log_name} Completed batch {batch_id} with DF id {df_id}")
 
     while True:
+        if read_command_exception is not None:
+            handle_worker_exception(read_command_exception, outfile)
+            outfile.flush()
+            break
         df_ref_id = utf8_deserializer.loads(infile)
         batch_id = read_long(infile)
         # Handle errors inside Python worker. Write 0 to outfile if no errors and write -2 with

--- a/python/pyspark/sql/connect/streaming/worker/foreach_batch_worker.py
+++ b/python/pyspark/sql/connect/streaming/worker/foreach_batch_worker.py
@@ -62,8 +62,6 @@ def main(infile: IO, outfile: IO) -> None:
     assert spark_connect_session.session_id == session_id
     spark = spark_connect_session
 
-    # TODO(SPARK-44461): Enable Process Isolation
-
     log_name = "Streaming ForeachBatch worker"
 
     def process(df_id, batch_id):  # type: ignore[no-untyped-def]
@@ -86,7 +84,7 @@ def main(infile: IO, outfile: IO) -> None:
             process(df_ref_id, int(batch_id))
             write_int(0, outfile)
             outfile.flush()
-    except BaseException as e:
+    except Exception as e:
         handle_worker_exception(e, outfile)
         outfile.flush()
 

--- a/python/pyspark/sql/tests/connect/streaming/test_parity_foreach_batch.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_foreach_batch.py
@@ -98,7 +98,7 @@ class StreamingForeachBatchParityTests(StreamingTestsForeachBatchMixin, ReusedCo
 
         # Assert that the error message contains the expected string
         self.assertIn(
-            "(java.lang.PythonException) Streaming Runner initialization failed",
+            "Streaming Runner initialization failed",
             str(error.exception),
         )
 

--- a/python/pyspark/sql/tests/connect/streaming/test_parity_foreach_batch.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_foreach_batch.py
@@ -74,16 +74,18 @@ class StreamingForeachBatchParityTests(StreamingTestsForeachBatchMixin, ReusedCo
             def __reduce__(self):
                 # Serialize only the data attribute
                 return (self.__class__, (self.data,))
+
             def __reduce_ex__(self, proto):
                 # Raise an error upon unpickling
-                raise ValueError("NoUnpickle objects cannot be unpickled")
+                raise ValueError("Cannot unpickle instance of NoUnpickle")
 
-        no_unpickle = NoUnpickle()
+        no_unpickle = NoUnpickle("object-1")
+
         def func(df, _):
             print(no_unpickle)
             df.count()
 
-        with self.assertRaises(Exception, "Cannot unpickle instance of NoUnpickle"):
+        with self.assertRaises(Exception, msg="Cannot unpickle instance of NoUnpickle"):
             df = self.spark.readStream.format("text").load("python/test_support/sql/streaming")
             q = df.writeStream.foreachBatch(func).start()
             q.processAllAvailable()

--- a/python/pyspark/sql/tests/connect/streaming/test_parity_foreach_batch.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_foreach_batch.py
@@ -80,11 +80,12 @@ class StreamingForeachBatchParityTests(StreamingTestsForeachBatchMixin, ReusedCo
         # Create an instance of the class
         obj = SerializableButNotDeserializable()
 
-        df = (self.spark.readStream
-              .format("rate")
-              .option("rowsPerSecond", "10")
-              .option("numPartitions", "1")
-              .load())
+        df = (
+            self.spark.readStream.format("rate")
+            .option("rowsPerSecond", "10")
+            .option("numPartitions", "1")
+            .load()
+        )
 
         obj = SerializableButNotDeserializable()
 
@@ -93,15 +94,13 @@ class StreamingForeachBatchParityTests(StreamingTestsForeachBatchMixin, ReusedCo
 
         # Assert that an exception occurs during the initialization
         with self.assertRaises(SparkConnectGrpcException) as error:
-            q = (df.select("value")
-                 .writeStream
-                 .foreachBatch(fcn)
-                 .start())
+            q = df.select("value").writeStream.foreachBatch(fcn).start()
 
         # Assert that the error message contains the expected string
         self.assertIn(
             "(java.lang.PythonException) Streaming Runner initialization failed",
-            str(error.exception))
+            str(error.exception),
+        )
 
     def test_accessing_spark_session(self):
         spark = self.spark

--- a/python/pyspark/sql/tests/connect/streaming/test_parity_foreach_batch.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_foreach_batch.py
@@ -68,13 +68,15 @@ class StreamingForeachBatchParityTests(StreamingTestsForeachBatchMixin, ReusedCo
 
     def test_pickling_deserialization_error(self):
         class NoUnpickle:
-            def __reduce__(self):
-                if isinstance(self, type(None)):
-                    raise TypeError("Cannot unpickle instance of NoUnpickle")
-                return type(self), ()
+            def __init__(self, data):
+                self.data = data
 
-            def __repr__(self):
-                return "NoUnpickle()"
+            def __reduce__(self):
+                # Serialize only the data attribute
+                return (self.__class__, (self.data,))
+            def __reduce_ex__(self, proto):
+                # Raise an error upon unpickling
+                raise ValueError("NoUnpickle objects cannot be unpickled")
 
         no_unpickle = NoUnpickle()
         def func(df, _):

--- a/python/pyspark/sql/tests/connect/streaming/test_parity_foreach_batch.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_foreach_batch.py
@@ -68,18 +68,15 @@ class StreamingForeachBatchParityTests(StreamingTestsForeachBatchMixin, ReusedCo
 
     def test_pickling_deserialization_error(self):
         class NoUnpickle:
-            def __init__(self, data):
-                self.data = data
 
             def __reduce__(self):
                 # Serialize only the data attribute
-                return (self.__class__, (self.data,))
+                return self.throw_exception(), ()
 
-            def __reduce_ex__(self, proto):
-                # Raise an error upon unpickling
-                raise ValueError("Cannot unpickle instance of NoUnpickle")
+            def throw_exception(self):
+                raise RuntimeError("Cannot unpickle instance of NoUnpickle")
 
-        no_unpickle = NoUnpickle("object-1")
+        no_unpickle = NoUnpickle()
 
         def func(df, _):
             print(no_unpickle)

--- a/python/pyspark/sql/tests/connect/streaming/test_parity_foreach_batch.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_foreach_batch.py
@@ -89,12 +89,12 @@ class StreamingForeachBatchParityTests(StreamingTestsForeachBatchMixin, ReusedCo
 
         obj = SerializableButNotDeserializable()
 
-        def fcn(batch, id):
+        def fcn(df, _):
             print(obj)
 
         # Assert that an exception occurs during the initialization
         with self.assertRaises(SparkConnectGrpcException) as error:
-            q = df.select("value").writeStream.foreachBatch(fcn).start()
+            df.select("value").writeStream.foreachBatch(fcn).start()
 
         # Assert that the error message contains the expected string
         self.assertIn(

--- a/python/pyspark/sql/tests/connect/streaming/test_parity_foreach_batch.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_foreach_batch.py
@@ -100,7 +100,7 @@ class StreamingForeachBatchParityTests(StreamingTestsForeachBatchMixin, ReusedCo
 
         # Assert that the error message contains the expected string
         self.assertIn(
-            "(java.lang.RuntimeException) Runner initialization failed",
+            "(java.lang.PythonException) Streaming Runner initialization failed",
             str(error.exception))
 
     def test_accessing_spark_session(self):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This change was made to propagate errors in PySpark foreachBatch worker initialization to the user, which can happen if the UDF isn't serializable or deserializable. 
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When the foreachBatch function isn't serializable, previously we were not propagating this error to the user, and instead were failing with an ambiguous SparkConnectGrpcException (while the real error was being written to stderr). With this change, we will send the error message to the user with a more specific error message about worker initialization failure. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, we are simply propagating the error to the user instead of just writing the error to stderr.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Using unit tests and a notebook with the change. 
Stack trace before change:
```
SparkConnectGrpcException: (java.io.EOFException) 
File <command-41186175708098>, line 27
      def fcn(batch, id):
          print(obj)
       q = (df.select("value")
          .writeStream
          .foreachBatch(fcn)
--->       .start())
```

Stack trace after change:
```
SparkConnectGrpcException: (java.lang.RuntimeException) Runner initialization failed (returned -2). Error message: Traceback (most recent call last):
  File "/databricks/spark/python/pyspark/serializers.py", line 192, in _read_with_length
    return self.loads(obj)
           ^^^^^^^^^^^^^^^
  File "/databricks/spark/python/pyspark/serializers.py", line 572, in loads
    return cloudpickle.loads(obj, encoding=encoding)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/spark-f94b69d4-fdb2-409f-89cf-1a/.ipykernel/13276/command-41186175708098-95633136", line 4, in _reduce_function
ValueError: Cannot unpickle this object
```
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No