### PR TITLE
[SPARK-47901][BUILD] Upgrade common-text 1.12.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -48,7 +48,7 @@ commons-lang/2.6//commons-lang-2.6.jar
 commons-lang3/3.14.0//commons-lang3-3.14.0.jar
 commons-math3/3.6.1//commons-math3-3.6.1.jar
 commons-pool/1.5.4//commons-pool-1.5.4.jar
-commons-text/1.11.0//commons-text-1.11.0.jar
+commons-text/1.12.0//commons-text-1.12.0.jar
 compress-lzf/1.1.2//compress-lzf-1.1.2.jar
 curator-client/5.6.0//curator-client-5.6.0.jar
 curator-framework/5.6.0//curator-framework-5.6.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -606,7 +606,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
-        <version>1.11.0</version>
+        <version>1.12.0</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade Apache common-text from 1.11.0 to 1.12.0

### Why are the changes needed?
The new version bring 2 bug fix:

- [TEXT-232](https://issues.apache.org/jira/browse/TEXT-232):  WordUtils.containsAllWords?() may throw PatternSyntaxException
- [TEXT-175](https://issues.apache.org/jira/browse/TEXT-175):  Fix regression for determining whitespace in WordUtils

The full release notes as follows:

- https://github.com/apache/commons-text/blob/rel/commons-text-1.12.0/RELEASE-NOTES.txt

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
