### PR TITLE
[SPARK-47912][SQL] Infer serde class from format classes

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -681,9 +681,9 @@ class SparkSqlAstBuilder extends AstBuilder {
     } else {
       val serdeInfo = maybeSerdeInfo.get
       if (serdeInfo.storedAs.isEmpty) {
-        val serde = serdeInfo.formatClasses
-          .flatMap(f => HiveSerDe.getSerDeFromFormatClasses(f.input, f.output))
-          .orElse(serdeInfo.serde)
+        val serde = serdeInfo.serde
+          .orElse(serdeInfo.formatClasses
+            .flatMap(f => HiveSerDe.getSerDeFromFormatClasses(f.input, f.output)))
         CatalogStorageFormat.empty.copy(
           locationUri = location.map(CatalogUtils.stringToURI),
           inputFormat = serdeInfo.formatClasses.map(_.input),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -681,11 +681,14 @@ class SparkSqlAstBuilder extends AstBuilder {
     } else {
       val serdeInfo = maybeSerdeInfo.get
       if (serdeInfo.storedAs.isEmpty) {
+        val serde = serdeInfo.formatClasses
+          .flatMap(f => HiveSerDe.getSerDeFromFormatClasses(f.input, f.output))
+          .orElse(serdeInfo.serde)
         CatalogStorageFormat.empty.copy(
           locationUri = location.map(CatalogUtils.stringToURI),
           inputFormat = serdeInfo.formatClasses.map(_.input),
           outputFormat = serdeInfo.formatClasses.map(_.output),
-          serde = serdeInfo.serde,
+          serde = serde,
           properties = serdeInfo.serdeProperties)
       } else {
         HiveSerDe.sourceToSerDe(serdeInfo.storedAs.get) match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/HiveSerDe.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/HiveSerDe.scala
@@ -97,6 +97,20 @@ object HiveSerDe {
   }
 
   /**
+   * Get serde class from format classes
+   */
+  def getSerDeFromFormatClasses(inputFormat: String, outputFormat: String): Option[String] = {
+    if (inputFormat.isEmpty || outputFormat.isEmpty) {
+      None
+    } else {
+      serdeMap.find {
+        case (_, serDe) => serDe.inputFormat.get.equalsIgnoreCase(inputFormat) &&
+          serDe.outputFormat.get.equalsIgnoreCase(outputFormat)
+      }.flatMap(_._2.serde).orElse(Some("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"))
+    }
+  }
+
+  /**
    * Get the Spark data source name from the Hive SerDe information.
    *
    * @param serde Hive SerDe information.

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/HiveSerDe.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/HiveSerDe.scala
@@ -103,7 +103,7 @@ object HiveSerDe {
     serdeMap.find {
       case (_, serDe) => serDe.inputFormat.get.equalsIgnoreCase(inputFormat) &&
         serDe.outputFormat.get.equalsIgnoreCase(outputFormat)
-    }.flatMap(_._2.serde).orElse(Some("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"))
+    }.flatMap(_._2.serde)
   }
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/HiveSerDe.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/HiveSerDe.scala
@@ -100,14 +100,10 @@ object HiveSerDe {
    * Get serde class from format classes
    */
   def getSerDeFromFormatClasses(inputFormat: String, outputFormat: String): Option[String] = {
-    if (inputFormat.isEmpty || outputFormat.isEmpty) {
-      None
-    } else {
-      serdeMap.find {
-        case (_, serDe) => serDe.inputFormat.get.equalsIgnoreCase(inputFormat) &&
-          serDe.outputFormat.get.equalsIgnoreCase(outputFormat)
-      }.flatMap(_._2.serde).orElse(Some("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"))
-    }
+    serdeMap.find {
+      case (_, serDe) => serDe.inputFormat.get.equalsIgnoreCase(inputFormat) &&
+        serDe.outputFormat.get.equalsIgnoreCase(outputFormat)
+    }.flatMap(_._2.serde).orElse(Some("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe"))
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Infer serde class from format classes.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
File format of insert overwrite dir does not take effect.

Reproduce:
```
set hive.default.fileformat=parquet;

-- Not as expected, I want an orc file but generated a parquet file.
INSERT OVERWRITE DIRECTORY '$tablePath'
STORED AS
  INPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat'
  OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
select 1;

-- Failed
select * from `orc`.`$tablePath`; 
```

When we use stored as fileformat to insert directory, `InsertIntoDir.storage.serde` will be set to `parquet` which is default fileformat serde class we set, and then `RelationConversions` optimizer will convert `InsertIntoDir` to `InsertIntoDataSourceDirCommand` causing the fileformat classes we specified to be ignored.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

added new unit test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No