### PR TITLE
[SPARK-47914][SQL] Do not display the splits parameter in Range

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1071,7 +1071,8 @@ case class Range(
   override def newInstance(): Range = copy(output = output.map(_.newInstance()))
 
   override def simpleString(maxFields: Int): String = {
-    s"Range ($start, $end, step=$step, splits=$numSlices)"
+    val splits = if (numSlices.isDefined) { s" splits=$numSlices" } else { "" }
+    s"Range ($start, $end, step=$step,$splits)"
   }
 
   override def maxRows: Option[Long] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1071,8 +1071,8 @@ case class Range(
   override def newInstance(): Range = copy(output = output.map(_.newInstance()))
 
   override def simpleString(maxFields: Int): String = {
-    val splits = if (numSlices.isDefined) { s" splits=$numSlices" } else { "" }
-    s"Range ($start, $end, step=$step,$splits)"
+    val splits = if (numSlices.isDefined) { s", splits=$numSlices" } else { "" }
+    s"Range ($start, $end, step=$step$splits)"
   }
 
   override def maxRows: Option[Long] = {

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/group-by.sql.out
@@ -395,7 +395,7 @@ SELECT 1 FROM range(10) HAVING true
 -- !query analysis
 Filter cast(true as boolean)
 +- Aggregate [1 AS 1#x]
-   +- Range (0, 10, step=1, splits=None)
+   +- Range (0, 10, step=1)
 
 
 -- !query
@@ -404,7 +404,7 @@ SELECT 1 FROM range(10) HAVING MAX(id) > 0
 Project [1#x]
 +- Filter (max(id#xL)#xL > cast(0 as bigint))
    +- Aggregate [1 AS 1#x, max(id#xL) AS max(id#xL)#xL]
-      +- Range (0, 10, step=1, splits=None)
+      +- Range (0, 10, step=1)
 
 
 -- !query
@@ -435,7 +435,7 @@ SELECT 1 FROM range(10) HAVING true
 -- !query analysis
 Filter cast(true as boolean)
 +- Project [1 AS 1#x]
-   +- Range (0, 10, step=1, splits=None)
+   +- Range (0, 10, step=1)
 
 
 -- !query
@@ -464,7 +464,7 @@ SELECT id FROM range(10) HAVING id > 0
 -- !query analysis
 Filter (id#xL > cast(0 as bigint))
 +- Project [id#xL]
-   +- Range (0, 10, step=1, splits=None)
+   +- Range (0, 10, step=1)
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/identifier-clause.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/identifier-clause.sql.out
@@ -198,7 +198,7 @@ Project [abs(c1#x) AS abs(c1)#x]
 SELECT * FROM IDENTIFIER('ra' || 'nge')(0, 1)
 -- !query analysis
 Project [id#xL]
-+- Range (0, 1, step=1, splits=None)
++- Range (0, 1, step=1)
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/join-lateral.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/join-lateral.sql.out
@@ -2315,7 +2315,7 @@ SELECT * FROM t1, LATERAL RANGE(3)
 -- !query analysis
 Project [c1#x, c2#x, id#xL]
 +- LateralJoin lateral-subquery#x [], Inner
-   :  +- Range (0, 3, step=1, splits=None)
+   :  +- Range (0, 3, step=1)
    +- SubqueryAlias spark_catalog.default.t1
       +- View (`spark_catalog`.`default`.`t1`, [c1#x, c2#x])
          +- Project [cast(col1#x as int) AS c1#x, cast(col2#x as int) AS c2#x]

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/limit.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/limit.sql.out
@@ -191,7 +191,7 @@ Project [id#xL]
       +- GlobalLimit 5
          +- LocalLimit 5
             +- Project [id#xL]
-               +- Range (0, 10, step=1, splits=None)
+               +- Range (0, 10, step=1)
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/named-function-arguments.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/named-function-arguments.sql.out
@@ -194,7 +194,7 @@ CREATE OR REPLACE TEMPORARY VIEW v AS SELECT id FROM range(0, 8)
 -- !query analysis
 CreateViewCommand `v`, SELECT id FROM range(0, 8), false, true, LocalTempView, true
    +- Project [id#xL]
-      +- Range (0, 8, step=1, splits=None)
+      +- Range (0, 8, step=1)
 
 
 -- !query
@@ -205,7 +205,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.UNSUPPORTED_TABLE_ARGUMENT",
   "sqlState" : "0A000",
   "messageParameters" : {
-    "treeNode" : "'Generate explode(table-argument#x []), false\n:  +- SubqueryAlias v\n:     +- View (`v`, [id#xL])\n:        +- Project [cast(id#xL as bigint) AS id#xL]\n:           +- Project [id#xL]\n:              +- Range (0, 8, step=1, splits=None)\n+- OneRowRelation\n"
+    "treeNode" : "'Generate explode(table-argument#x []), false\n:  +- SubqueryAlias v\n:     +- View (`v`, [id#xL])\n:        +- Project [cast(id#xL as bigint) AS id#xL]\n:           +- Project [id#xL]\n:              +- Range (0, 8, step=1)\n+- OneRowRelation\n"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/non-excludable-rule.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/non-excludable-rule.sql.out
@@ -13,11 +13,11 @@ SELECT
 -- !query analysis
 Project [scalar-subquery#x [] AS scalarsubquery()#xL, scalar-subquery#x [] AS scalarsubquery()#xL, scalar-subquery#x [] AS scalarsubquery()#xL]
 :  :- Aggregate [min(id#xL) AS min(id)#xL]
-:  :  +- Range (0, 10, step=1, splits=None)
+:  :  +- Range (0, 10, step=1)
 :  :- Aggregate [sum(id#xL) AS sum(id)#xL]
-:  :  +- Range (0, 10, step=1, splits=None)
+:  :  +- Range (0, 10, step=1)
 :  +- Aggregate [count(distinct id#xL) AS count(DISTINCT id)#xL]
-:     +- Range (0, 10, step=1, splits=None)
+:     +- Range (0, 10, step=1)
 +- OneRowRelation
 
 
@@ -40,15 +40,15 @@ WithCTE
 :  +- SubqueryAlias tmp
 :     +- Intersect false
 :        :- Project [id#xL]
-:        :  +- Range (0, 2, step=1, splits=None)
+:        :  +- Range (0, 2, step=1)
 :        +- Project [id#xL]
-:           +- Range (0, 4, step=1, splits=None)
+:           +- Range (0, 4, step=1)
 +- Project [id#xL]
    +- Filter (id#xL > scalar-subquery#x [])
       :  +- Aggregate [max(id#xL) AS max(id)#xL]
       :     +- SubqueryAlias tmp
       :        +- CTERelationRef xxxx, true, [id#xL], false
-      +- Range (0, 3, step=1, splits=None)
+      +- Range (0, 3, step=1)
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/aggregates_part1.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/aggregates_part1.sql.out
@@ -154,70 +154,70 @@ Aggregate [stddev_pop(cast(cast(3.0 as decimal(38,0)) as double)) AS stddev_pop(
 select sum(CAST(null AS int)) from range(1,4)
 -- !query analysis
 Aggregate [sum(cast(null as int)) AS sum(CAST(NULL AS INT))#xL]
-+- Range (1, 4, step=1, splits=None)
++- Range (1, 4, step=1)
 
 
 -- !query
 select sum(CAST(null AS long)) from range(1,4)
 -- !query analysis
 Aggregate [sum(cast(null as bigint)) AS sum(CAST(NULL AS BIGINT))#xL]
-+- Range (1, 4, step=1, splits=None)
++- Range (1, 4, step=1)
 
 
 -- !query
 select sum(CAST(null AS Decimal(38,0))) from range(1,4)
 -- !query analysis
 Aggregate [sum(cast(null as decimal(38,0))) AS sum(CAST(NULL AS DECIMAL(38,0)))#x]
-+- Range (1, 4, step=1, splits=None)
++- Range (1, 4, step=1)
 
 
 -- !query
 select sum(CAST(null AS DOUBLE)) from range(1,4)
 -- !query analysis
 Aggregate [sum(cast(null as double)) AS sum(CAST(NULL AS DOUBLE))#x]
-+- Range (1, 4, step=1, splits=None)
++- Range (1, 4, step=1)
 
 
 -- !query
 select avg(CAST(null AS int)) from range(1,4)
 -- !query analysis
 Aggregate [avg(cast(null as int)) AS avg(CAST(NULL AS INT))#x]
-+- Range (1, 4, step=1, splits=None)
++- Range (1, 4, step=1)
 
 
 -- !query
 select avg(CAST(null AS long)) from range(1,4)
 -- !query analysis
 Aggregate [avg(cast(null as bigint)) AS avg(CAST(NULL AS BIGINT))#x]
-+- Range (1, 4, step=1, splits=None)
++- Range (1, 4, step=1)
 
 
 -- !query
 select avg(CAST(null AS Decimal(38,0))) from range(1,4)
 -- !query analysis
 Aggregate [avg(cast(null as decimal(38,0))) AS avg(CAST(NULL AS DECIMAL(38,0)))#x]
-+- Range (1, 4, step=1, splits=None)
++- Range (1, 4, step=1)
 
 
 -- !query
 select avg(CAST(null AS DOUBLE)) from range(1,4)
 -- !query analysis
 Aggregate [avg(cast(null as double)) AS avg(CAST(NULL AS DOUBLE))#x]
-+- Range (1, 4, step=1, splits=None)
++- Range (1, 4, step=1)
 
 
 -- !query
 select sum(CAST('NaN' AS DOUBLE)) from range(1,4)
 -- !query analysis
 Aggregate [sum(cast(NaN as double)) AS sum(CAST(NaN AS DOUBLE))#x]
-+- Range (1, 4, step=1, splits=None)
++- Range (1, 4, step=1)
 
 
 -- !query
 select avg(CAST('NaN' AS DOUBLE)) from range(1,4)
 -- !query analysis
 Aggregate [avg(cast(NaN as double)) AS avg(CAST(NaN AS DOUBLE))#x]
-+- Range (1, 4, step=1, splits=None)
++- Range (1, 4, step=1)
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/int8.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/int8.sql.out
@@ -626,7 +626,7 @@ Project [q1#xL, q2#xL, (q1#xL & q2#xL) AS and#xL, (q1#xL | q2#xL) AS or#xL, ~q1#
 SELECT * FROM range(bigint('+4567890123456789'), bigint('+4567890123456799'))
 -- !query analysis
 Project [id#xL]
-+- Range (4567890123456789, 4567890123456799, step=1, splits=None)
++- Range (4567890123456789, 4567890123456799, step=1)
 
 
 -- !query
@@ -653,7 +653,7 @@ org.apache.spark.sql.AnalysisException
 SELECT * FROM range(bigint('+4567890123456789'), bigint('+4567890123456799'), 2)
 -- !query analysis
 Project [id#xL]
-+- Range (4567890123456789, 4567890123456799, step=2, splits=None)
++- Range (4567890123456789, 4567890123456799, step=2)
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/join.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/join.sql.out
@@ -1716,7 +1716,7 @@ CreateViewCommand `tt3`, select * from
          +- Project [id#x AS f1#x, repeat(xyzzy, 100)#x AS f2#x]
             +- Project [cast(id#xL as int) AS id#x, repeat(xyzzy, 100) AS repeat(xyzzy, 100)#x]
                +- SubqueryAlias x
-                  +- Range (1, 10001, step=1, splits=None)
+                  +- Range (1, 10001, step=1)
 
 
 -- !query
@@ -1767,7 +1767,7 @@ Project [f1#x]
                   :                 +- Project [id#x AS f1#x, repeat(xyzzy, 100)#x AS f2#x]
                   :                    +- Project [cast(id#xL as int) AS id#x, repeat(xyzzy, 100) AS repeat(xyzzy, 100)#x]
                   :                       +- SubqueryAlias x
-                  :                          +- Range (1, 10001, step=1, splits=None)
+                  :                          +- Range (1, 10001, step=1)
                   +- SubqueryAlias c
                      +- SubqueryAlias tt3
                         +- View (`tt3`, [f1#x, f2#x])
@@ -1777,7 +1777,7 @@ Project [f1#x]
                                     +- Project [id#x AS f1#x, repeat(xyzzy, 100)#x AS f2#x]
                                        +- Project [cast(id#xL as int) AS id#x, repeat(xyzzy, 100) AS repeat(xyzzy, 100)#x]
                                           +- SubqueryAlias x
-                                             +- Range (1, 10001, step=1, splits=None)
+                                             +- Range (1, 10001, step=1)
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/numeric.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/numeric.sql.out
@@ -4775,21 +4775,21 @@ Project [EXP(cast(1234.5678 as double)) AS EXP(1234.5678)#x]
 select * from range(cast(0.0 as decimal(38, 18)), cast(4.0 as decimal(38, 18)))
 -- !query analysis
 Project [id#xL]
-+- Range (0, 4, step=1, splits=None)
++- Range (0, 4, step=1)
 
 
 -- !query
 select * from range(cast(0.1 as decimal(38, 18)), cast(4.0 as decimal(38, 18)), cast(1.3 as decimal(38, 18)))
 -- !query analysis
 Project [id#xL]
-+- Range (0, 4, step=1, splits=None)
++- Range (0, 4, step=1)
 
 
 -- !query
 select * from range(cast(4.0 as decimal(38, 18)), cast(-1.5 as decimal(38, 18)), cast(-2.2 as decimal(38, 18)))
 -- !query analysis
 Project [id#xL]
-+- Range (4, -1, step=-2, splits=None)
++- Range (4, -1, step=-2)
 
 
 -- !query
@@ -4894,14 +4894,14 @@ Project [LOG(cast(1.000016 as double), 8.45201E18) AS LOG(1.000016, 8.45201E18)#
 SELECT SUM(decimal(9999)) FROM range(1, 100001)
 -- !query analysis
 Aggregate [sum(cast(9999 as decimal(10,0))) AS sum(9999)#x]
-+- Range (1, 100001, step=1, splits=None)
++- Range (1, 100001, step=1)
 
 
 -- !query
 SELECT SUM(decimal(-9999)) FROM range(1, 100001)
 -- !query analysis
 Aggregate [sum(cast(-9999 as decimal(10,0))) AS sum(-9999)#x]
-+- Range (1, 100001, step=1, splits=None)
++- Range (1, 100001, step=1)
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/text.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/text.sql.out
@@ -137,7 +137,7 @@ Sort [i#xL ASC NULLS FIRST], true
 +- Project [i#xL, left(ahoj, cast(i#xL as int)) AS left(ahoj, i)#x, right(ahoj, cast(i#xL as int)) AS right(ahoj, i)#x]
    +- SubqueryAlias t
       +- Project [id#xL AS i#xL]
-         +- Range (-5, 6, step=1, splits=None)
+         +- Range (-5, 6, step=1)
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/union.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/union.sql.out
@@ -1059,9 +1059,9 @@ select * from range(1,5) union select * from range(1,3)
 Distinct
 +- Union false, false
    :- Project [id#xL]
-   :  +- Range (1, 5, step=1, splits=None)
+   :  +- Range (1, 5, step=1)
    +- Project [id#xL]
-      +- Range (1, 3, step=1, splits=None)
+      +- Range (1, 3, step=1)
 
 
 -- !query
@@ -1069,9 +1069,9 @@ select * from range(1,6) union all select * from range(1,4)
 -- !query analysis
 Union false, false
 :- Project [id#xL]
-:  +- Range (1, 6, step=1, splits=None)
+:  +- Range (1, 6, step=1)
 +- Project [id#xL]
-   +- Range (1, 4, step=1, splits=None)
+   +- Range (1, 4, step=1)
 
 
 -- !query
@@ -1079,9 +1079,9 @@ select * from range(1,6) intersect select * from range(1,4)
 -- !query analysis
 Intersect false
 :- Project [id#xL]
-:  +- Range (1, 6, step=1, splits=None)
+:  +- Range (1, 6, step=1)
 +- Project [id#xL]
-   +- Range (1, 4, step=1, splits=None)
+   +- Range (1, 4, step=1)
 
 
 -- !query
@@ -1089,9 +1089,9 @@ select * from range(1,6) intersect all select * from range(1,4)
 -- !query analysis
 Intersect All true
 :- Project [id#xL]
-:  +- Range (1, 6, step=1, splits=None)
+:  +- Range (1, 6, step=1)
 +- Project [id#xL]
-   +- Range (1, 4, step=1, splits=None)
+   +- Range (1, 4, step=1)
 
 
 -- !query
@@ -1099,9 +1099,9 @@ select * from range(1,6) except select * from range(1,4)
 -- !query analysis
 Except false
 :- Project [id#xL]
-:  +- Range (1, 6, step=1, splits=None)
+:  +- Range (1, 6, step=1)
 +- Project [id#xL]
-   +- Range (1, 4, step=1, splits=None)
+   +- Range (1, 4, step=1)
 
 
 -- !query
@@ -1109,9 +1109,9 @@ select * from range(1,6) except all select * from range(1,4)
 -- !query analysis
 Except All true
 :- Project [id#xL]
-:  +- Range (1, 6, step=1, splits=None)
+:  +- Range (1, 6, step=1)
 +- Project [id#xL]
-   +- Range (1, 4, step=1, splits=None)
+   +- Range (1, 4, step=1)
 
 
 -- !query
@@ -1120,9 +1120,9 @@ select * from range(1,6) union select * from range(1,4)
 Distinct
 +- Union false, false
    :- Project [id#xL]
-   :  +- Range (1, 6, step=1, splits=None)
+   :  +- Range (1, 6, step=1)
    +- Project [id#xL]
-      +- Range (1, 4, step=1, splits=None)
+      +- Range (1, 4, step=1)
 
 
 -- !query
@@ -1130,9 +1130,9 @@ select * from range(1,6) union all select * from range(1,4)
 -- !query analysis
 Union false, false
 :- Project [id#xL]
-:  +- Range (1, 6, step=1, splits=None)
+:  +- Range (1, 6, step=1)
 +- Project [id#xL]
-   +- Range (1, 4, step=1, splits=None)
+   +- Range (1, 4, step=1)
 
 
 -- !query
@@ -1140,9 +1140,9 @@ select * from range(1,6) intersect select * from range(1,4)
 -- !query analysis
 Intersect false
 :- Project [id#xL]
-:  +- Range (1, 6, step=1, splits=None)
+:  +- Range (1, 6, step=1)
 +- Project [id#xL]
-   +- Range (1, 4, step=1, splits=None)
+   +- Range (1, 4, step=1)
 
 
 -- !query
@@ -1150,9 +1150,9 @@ select * from range(1,6) intersect all select * from range(1,4)
 -- !query analysis
 Intersect All true
 :- Project [id#xL]
-:  +- Range (1, 6, step=1, splits=None)
+:  +- Range (1, 6, step=1)
 +- Project [id#xL]
-   +- Range (1, 4, step=1, splits=None)
+   +- Range (1, 4, step=1)
 
 
 -- !query
@@ -1160,9 +1160,9 @@ select * from range(1,6) except select * from range(1,4)
 -- !query analysis
 Except false
 :- Project [id#xL]
-:  +- Range (1, 6, step=1, splits=None)
+:  +- Range (1, 6, step=1)
 +- Project [id#xL]
-   +- Range (1, 4, step=1, splits=None)
+   +- Range (1, 4, step=1)
 
 
 -- !query
@@ -1170,9 +1170,9 @@ select * from range(1,6) except all select * from range(1,4)
 -- !query analysis
 Except All true
 :- Project [id#xL]
-:  +- Range (1, 6, step=1, splits=None)
+:  +- Range (1, 6, step=1)
 +- Project [id#xL]
-   +- Range (1, 4, step=1, splits=None)
+   +- Range (1, 4, step=1)
 
 
 -- !query
@@ -1223,7 +1223,7 @@ Sort [x#xL ASC NULLS FIRST], true
          +- Distinct
             +- Union false, false
                :- Project [1 AS t#x, id#xL AS x#xL]
-               :  +- Range (1, 11, step=1, splits=None)
+               :  +- Range (1, 11, step=1)
                +- Project [t#x, cast(x#x as bigint) AS x#xL]
                   +- Project [2 AS t#x, 4 AS x#x]
                      +- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/window_part1.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/window_part1.sql.out
@@ -528,7 +528,7 @@ FROM range(1, 11) i, false, false, LocalTempView, true
          +- Window [sum(id#xL) windowspecdefinition(id#xL ASC NULLS FIRST, specifiedwindowframe(RowFrame, -1, 1)) AS sum_rows#xL], [id#xL ASC NULLS FIRST]
             +- Project [id#xL]
                +- SubqueryAlias i
-                  +- Range (1, 11, step=1, splits=None)
+                  +- Range (1, 11, step=1)
 
 
 -- !query
@@ -543,7 +543,7 @@ Project [id#xL, sum_rows#xL]
                +- Window [sum(id#xL) windowspecdefinition(id#xL ASC NULLS FIRST, specifiedwindowframe(RowFrame, -1, 1)) AS sum_rows#xL], [id#xL ASC NULLS FIRST]
                   +- Project [id#xL]
                      +- SubqueryAlias i
-                        +- Range (1, 11, step=1, splits=None)
+                        +- Range (1, 11, step=1)
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/window_part2.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/window_part2.sql.out
@@ -177,7 +177,7 @@ Project [id#xL, y#xL, first(y) OVER (ORDER BY id DESC NULLS LAST RANGE BETWEEN (
                :- Union false, false
                :  :- Project [id#xL, id#xL AS y#xL]
                :  :  +- SubqueryAlias x
-               :  :     +- Range (1, 6, step=1, )
+               :  :     +- Range (1, 6, step=1)
                :  +- Project [cast(NULL#x as bigint) AS NULL#xL, cast(42#x as bigint) AS 42#xL]
                :     +- Project [null AS NULL#x, 42 AS 42#x]
                :        +- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/window_part2.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/window_part2.sql.out
@@ -90,7 +90,7 @@ Project [id#xL, y#xL, first(y) OVER (ORDER BY id ASC NULLS FIRST RANGE BETWEEN (
                :- Union false, false
                :  :- Project [id#xL, id#xL AS y#xL]
                :  :  +- SubqueryAlias x
-               :  :     +- Range (1, 6, step=1, splits=None)
+               :  :     +- Range (1, 6, step=1)
                :  +- Project [cast(NULL#x as bigint) AS NULL#xL, cast(42#x as bigint) AS 42#xL]
                :     +- Project [null AS NULL#x, 42 AS 42#x]
                :        +- OneRowRelation
@@ -119,7 +119,7 @@ Project [id#xL, y#xL, first(y) OVER (ORDER BY id ASC NULLS LAST RANGE BETWEEN (-
                :- Union false, false
                :  :- Project [id#xL, id#xL AS y#xL]
                :  :  +- SubqueryAlias x
-               :  :     +- Range (1, 6, step=1, splits=None)
+               :  :     +- Range (1, 6, step=1)
                :  +- Project [cast(NULL#x as bigint) AS NULL#xL, cast(42#x as bigint) AS 42#xL]
                :     +- Project [null AS NULL#x, 42 AS 42#x]
                :        +- OneRowRelation
@@ -148,7 +148,7 @@ Project [id#xL, y#xL, first(y) OVER (ORDER BY id DESC NULLS FIRST RANGE BETWEEN 
                :- Union false, false
                :  :- Project [id#xL, id#xL AS y#xL]
                :  :  +- SubqueryAlias x
-               :  :     +- Range (1, 6, step=1, splits=None)
+               :  :     +- Range (1, 6, step=1)
                :  +- Project [cast(NULL#x as bigint) AS NULL#xL, cast(42#x as bigint) AS 42#xL]
                :     +- Project [null AS NULL#x, 42 AS 42#x]
                :        +- OneRowRelation
@@ -177,7 +177,7 @@ Project [id#xL, y#xL, first(y) OVER (ORDER BY id DESC NULLS LAST RANGE BETWEEN (
                :- Union false, false
                :  :- Project [id#xL, id#xL AS y#xL]
                :  :  +- SubqueryAlias x
-               :  :     +- Range (1, 6, step=1, splits=None)
+               :  :     +- Range (1, 6, step=1, )
                :  +- Project [cast(NULL#x as bigint) AS NULL#xL, cast(42#x as bigint) AS 42#xL]
                :     +- Project [null AS NULL#x, 42 AS 42#x]
                :        +- OneRowRelation
@@ -195,7 +195,7 @@ Project [id#xL, last(id) OVER (ORDER BY id ASC NULLS FIRST RANGE BETWEEN CURRENT
    +- Window [last(id#xL, false) windowspecdefinition(id#xL ASC NULLS FIRST, specifiedwindowframe(RangeFrame, currentrow$(), cast(2147450884 as bigint))) AS last(id) OVER (ORDER BY id ASC NULLS FIRST RANGE BETWEEN CURRENT ROW AND 2147450884 FOLLOWING)#xL], [id#xL ASC NULLS FIRST]
       +- Project [id#xL]
          +- SubqueryAlias x
-            +- Range (32764, 32767, step=1, splits=None)
+            +- Range (32764, 32767, step=1)
 
 
 -- !query
@@ -207,7 +207,7 @@ Project [id#xL, last(id) OVER (ORDER BY id DESC NULLS LAST RANGE BETWEEN CURRENT
    +- Window [last(id#xL, false) windowspecdefinition(id#xL DESC NULLS LAST, specifiedwindowframe(RangeFrame, currentrow$(), cast(2147450885 as bigint))) AS last(id) OVER (ORDER BY id DESC NULLS LAST RANGE BETWEEN CURRENT ROW AND 2147450885 FOLLOWING)#xL], [id#xL DESC NULLS LAST]
       +- Project [id#xL]
          +- SubqueryAlias x
-            +- Range (-32766, -32765, step=1, splits=None)
+            +- Range (-32766, -32765, step=1)
 
 
 -- !query
@@ -219,7 +219,7 @@ Project [id#xL, last(id) OVER (ORDER BY id ASC NULLS FIRST RANGE BETWEEN CURRENT
    +- Window [last(id#xL, false) windowspecdefinition(id#xL ASC NULLS FIRST, specifiedwindowframe(RangeFrame, currentrow$(), cast(4 as bigint))) AS last(id) OVER (ORDER BY id ASC NULLS FIRST RANGE BETWEEN CURRENT ROW AND 4 FOLLOWING)#xL], [id#xL ASC NULLS FIRST]
       +- Project [id#xL]
          +- SubqueryAlias x
-            +- Range (2147483644, 2147483647, step=1, splits=None)
+            +- Range (2147483644, 2147483647, step=1)
 
 
 -- !query
@@ -231,7 +231,7 @@ Project [id#xL, last(id) OVER (ORDER BY id DESC NULLS LAST RANGE BETWEEN CURRENT
    +- Window [last(id#xL, false) windowspecdefinition(id#xL DESC NULLS LAST, specifiedwindowframe(RangeFrame, currentrow$(), cast(5 as bigint))) AS last(id) OVER (ORDER BY id DESC NULLS LAST RANGE BETWEEN CURRENT ROW AND 5 FOLLOWING)#xL], [id#xL DESC NULLS LAST]
       +- Project [id#xL]
          +- SubqueryAlias x
-            +- Range (-2147483646, -2147483645, step=1, splits=None)
+            +- Range (-2147483646, -2147483645, step=1)
 
 
 -- !query
@@ -243,7 +243,7 @@ Project [id#xL, last(id) OVER (ORDER BY id ASC NULLS FIRST RANGE BETWEEN CURRENT
    +- Window [last(id#xL, false) windowspecdefinition(id#xL ASC NULLS FIRST, specifiedwindowframe(RangeFrame, currentrow$(), cast(4 as bigint))) AS last(id) OVER (ORDER BY id ASC NULLS FIRST RANGE BETWEEN CURRENT ROW AND 4 FOLLOWING)#xL], [id#xL ASC NULLS FIRST]
       +- Project [id#xL]
          +- SubqueryAlias x
-            +- Range (9223372036854775804, 9223372036854775807, step=1, splits=None)
+            +- Range (9223372036854775804, 9223372036854775807, step=1)
 
 
 -- !query
@@ -255,7 +255,7 @@ Project [id#xL, last(id) OVER (ORDER BY id DESC NULLS LAST RANGE BETWEEN CURRENT
    +- Window [last(id#xL, false) windowspecdefinition(id#xL DESC NULLS LAST, specifiedwindowframe(RangeFrame, currentrow$(), cast(5 as bigint))) AS last(id) OVER (ORDER BY id DESC NULLS LAST RANGE BETWEEN CURRENT ROW AND 5 FOLLOWING)#xL], [id#xL DESC NULLS LAST]
       +- Project [id#xL]
          +- SubqueryAlias x
-            +- Range (-9223372036854775806, -9223372036854775805, step=1, splits=None)
+            +- Range (-9223372036854775806, -9223372036854775805, step=1)
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/window_part3.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/window_part3.sql.out
@@ -93,7 +93,7 @@ WithCTE
 :  +- SubqueryAlias cte
 :     +- Project [id#xL AS x#xL]
 :        +- Project [id#xL]
-:           +- Range (1, 36, step=2, splits=None)
+:           +- Range (1, 36, step=2)
 +- Project [x#xL, sum(x) OVER (ORDER BY x ASC NULLS FIRST ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)#xL]
    +- Project [x#xL, sum(x) OVER (ORDER BY x ASC NULLS FIRST ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)#xL, sum(x) OVER (ORDER BY x ASC NULLS FIRST ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)#xL]
       +- Window [sum(x#xL) windowspecdefinition(x#xL ASC NULLS FIRST, specifiedwindowframe(RowFrame, -1, 1)) AS sum(x) OVER (ORDER BY x ASC NULLS FIRST ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)#xL], [x#xL ASC NULLS FIRST]
@@ -115,7 +115,7 @@ WithCTE
 :  +- SubqueryAlias cte
 :     +- Project [id#xL AS x#xL]
 :        +- Project [id#xL]
-:           +- Range (1, 36, step=2, splits=None)
+:           +- Range (1, 36, step=2)
 +- Project [x#xL, sum(x) OVER (ORDER BY x ASC NULLS FIRST RANGE BETWEEN (- 1) FOLLOWING AND 1 FOLLOWING)#xL]
    +- Project [x#xL, sum(x) OVER (ORDER BY x ASC NULLS FIRST RANGE BETWEEN (- 1) FOLLOWING AND 1 FOLLOWING)#xL, sum(x) OVER (ORDER BY x ASC NULLS FIRST RANGE BETWEEN (- 1) FOLLOWING AND 1 FOLLOWING)#xL]
       +- Window [sum(x#xL) windowspecdefinition(x#xL ASC NULLS FIRST, specifiedwindowframe(RangeFrame, cast(-1 as bigint), cast(1 as bigint))) AS sum(x) OVER (ORDER BY x ASC NULLS FIRST RANGE BETWEEN (- 1) FOLLOWING AND 1 FOLLOWING)#xL], [x#xL ASC NULLS FIRST]
@@ -148,7 +148,7 @@ WithCTE
 :           :     +- Project [1 AS 1#x]
 :           :        +- OneRowRelation
 :           +- Project [id#xL]
-:              +- Range (5, 50, step=2, splits=None)
+:              +- Range (5, 50, step=2)
 +- Project [x#xL, sum(x) OVER (ORDER BY x ASC NULLS FIRST ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)#xL]
    +- Project [x#xL, sum(x) OVER (ORDER BY x ASC NULLS FIRST ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)#xL, sum(x) OVER (ORDER BY x ASC NULLS FIRST ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)#xL]
       +- Window [sum(x#xL) windowspecdefinition(x#xL ASC NULLS FIRST, specifiedwindowframe(RowFrame, -1, 1)) AS sum(x) OVER (ORDER BY x ASC NULLS FIRST ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)#xL], [x#xL ASC NULLS FIRST]
@@ -181,7 +181,7 @@ WithCTE
 :           :     +- Project [1 AS 1#x]
 :           :        +- OneRowRelation
 :           +- Project [id#xL]
-:              +- Range (5, 50, step=2, splits=None)
+:              +- Range (5, 50, step=2)
 +- Project [x#xL, sum(x) OVER (ORDER BY x ASC NULLS FIRST RANGE BETWEEN (- 1) FOLLOWING AND 1 FOLLOWING)#xL]
    +- Project [x#xL, sum(x) OVER (ORDER BY x ASC NULLS FIRST RANGE BETWEEN (- 1) FOLLOWING AND 1 FOLLOWING)#xL, sum(x) OVER (ORDER BY x ASC NULLS FIRST RANGE BETWEEN (- 1) FOLLOWING AND 1 FOLLOWING)#xL]
       +- Window [sum(x#xL) windowspecdefinition(x#xL ASC NULLS FIRST, specifiedwindowframe(RangeFrame, cast(-1 as bigint), cast(1 as bigint))) AS sum(x) OVER (ORDER BY x ASC NULLS FIRST RANGE BETWEEN (- 1) FOLLOWING AND 1 FOLLOWING)#xL], [x#xL ASC NULLS FIRST]

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/sql-compatibility-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/sql-compatibility-functions.sql.out
@@ -122,4 +122,4 @@ Aggregate [nvl(st#x.col1, value)], [nvl(st#x.col1, value) AS nvl(st.col1, value)
 SELECT nullif(SUM(id), 0) from range(5)
 -- !query analysis
 Aggregate [nullif(sum(id#xL), 0) AS nullif(sum(id), 0)#xL]
-+- Range (0, 5, step=1, splits=None)
++- Range (0, 5, step=1)

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/sql-session-variables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/sql-session-variables.sql.out
@@ -498,7 +498,7 @@ SELECT (SELECT MAX(id) FROM RANGE(10) WHERE id < title) FROM VALUES 1, 2 AS t(ti
 Project [scalar-subquery#x [title#x] AS scalarsubquery(title)#xL]
 :  +- Aggregate [max(id#xL) AS max(id)#xL]
 :     +- Filter (id#xL < cast(outer(title#x) as bigint))
-:        +- Range (0, 10, step=1, splits=None)
+:        +- Range (0, 10, step=1)
 +- SubqueryAlias t
    +- LocalRelation [title#x]
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/scalar-subquery/scalar-subquery-predicate.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/scalar-subquery/scalar-subquery-predicate.sql.out
@@ -1626,9 +1626,9 @@ Project [id#xL]
    :  +- Project [id#xL AS c#xL]
    :     +- Filter (outer(id#xL) = id#xL)
    :        +- SubqueryAlias t2
-   :           +- Range (1, 2, step=1, splits=None)
+   :           +- Range (1, 2, step=1)
    +- SubqueryAlias t1
-      +- Range (1, 3, step=1, splits=None)
+      +- Range (1, 3, step=1)
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/scalar-subquery/scalar-subquery-select.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/scalar-subquery/scalar-subquery-select.sql.out
@@ -1054,9 +1054,9 @@ Project [c1#xL, c2#xL]
          :  +- Project [id#xL AS c#xL]
          :     +- Filter (outer(id#xL) = id#xL)
          :        +- SubqueryAlias t2
-         :           +- Range (1, 2, step=1, splits=None)
+         :           +- Range (1, 2, step=1)
          +- SubqueryAlias t1
-            +- Range (1, 3, step=1, splits=None)
+            +- Range (1, 3, step=1)
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/table-valued-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/table-valued-functions.sql.out
@@ -23,21 +23,21 @@ org.apache.spark.sql.AnalysisException
 select * from range(6 + cos(3))
 -- !query analysis
 Project [id#xL]
-+- Range (0, 5, step=1, splits=None)
++- Range (0, 5, step=1)
 
 
 -- !query
 select * from range(5, 10)
 -- !query analysis
 Project [id#xL]
-+- Range (5, 10, step=1, splits=None)
++- Range (5, 10, step=1)
 
 
 -- !query
 select * from range(0, 10, 2)
 -- !query analysis
 Project [id#xL]
-+- Range (0, 10, step=2, splits=None)
++- Range (0, 10, step=2)
 
 
 -- !query
@@ -142,7 +142,7 @@ org.apache.spark.sql.AnalysisException
 select * from RaNgE(2)
 -- !query analysis
 Project [id#xL]
-+- Range (0, 2, step=1, splits=None)
++- Range (0, 2, step=1)
 
 
 -- !query
@@ -151,7 +151,7 @@ select i from range(0, 2) t(i)
 Project [i#xL]
 +- SubqueryAlias t
    +- Project [id#xL AS i#xL]
-      +- Range (0, 2, step=1, splits=None)
+      +- Range (0, 2, step=1)
 
 
 -- !query
@@ -430,7 +430,7 @@ select * from range(2) join explode(array(1, 2))
 -- !query analysis
 Project [id#xL, col#x]
 +- Join Inner
-   :- Range (0, 2, step=1, splits=None)
+   :- Range (0, 2, step=1)
    +- Generate explode(array(1, 2)), false, [col#x]
       +- OneRowRelation
 
@@ -440,7 +440,7 @@ select * from range(2) join explode_outer(array())
 -- !query analysis
 Project [id#xL, col#x]
 +- Join Inner
-   :- Range (0, 2, step=1, splits=None)
+   :- Range (0, 2, step=1)
    +- Generate explode(array()), true, [col#x]
       +- OneRowRelation
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/typeCoercion/native/concat.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/typeCoercion/native/concat.sql.out
@@ -12,7 +12,7 @@ FROM (
 Project [concat(concat(cast(col1#xL as string), col2#x), cast(col3#x as string)) AS col#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [id#xL AS col1#xL, cast((id#xL + cast(1 as bigint)) as string) AS col2#x, encode(cast((id#xL + cast(2 as bigint)) as string), utf-8, false) AS col3#x]
-      +- Range (0, 10, step=1, splits=None)
+      +- Range (0, 10, step=1)
 
 
 -- !query
@@ -30,7 +30,7 @@ FROM (
 Project [concat(concat(concat(col1#x, cast(col2#xL as string)), concat(col3#x, cast(col4#x as string))), cast(col5#x as string)) AS col#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [prefix_ AS col1#x, id#xL AS col2#xL, cast((id#xL + cast(1 as bigint)) as string) AS col3#x, encode(cast((id#xL + cast(2 as bigint)) as string), utf-8, false) AS col4#x, cast(id#xL as double) AS col5#x]
-      +- Range (0, 10, step=1, splits=None)
+      +- Range (0, 10, step=1, )
 
 
 -- !query
@@ -47,7 +47,7 @@ FROM (
 Project [concat(concat(col1#x, col2#x), cast(concat(col3#x, col4#x) as string)) AS col#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [cast(id#xL as string) AS col1#x, cast((id#xL + cast(1 as bigint)) as string) AS col2#x, encode(cast((id#xL + cast(2 as bigint)) as string), utf-8, false) AS col3#x, encode(cast((id#xL + cast(3 as bigint)) as string), utf-8, false) AS col4#x]
-      +- Range (0, 10, step=1, splits=None)
+      +- Range (0, 10, step=1, )
 
 
 -- !query
@@ -68,7 +68,7 @@ FROM (
 Project [concat(cast(col1#x as string), cast(col2#x as string)) AS col#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [encode(cast(id#xL as string), utf-8, false) AS col1#x, encode(cast((id#xL + cast(1 as bigint)) as string), utf-8, false) AS col2#x]
-      +- Range (0, 10, step=1, splits=None)
+      +- Range (0, 10, step=1, )
 
 
 -- !query
@@ -85,7 +85,7 @@ FROM (
 Project [concat(concat(concat(cast(col1#x as string), cast(col2#x as string)), cast(col3#x as string)), cast(col4#x as string)) AS col#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [encode(cast(id#xL as string), utf-8, false) AS col1#x, encode(cast((id#xL + cast(1 as bigint)) as string), utf-8, false) AS col2#x, encode(cast((id#xL + cast(2 as bigint)) as string), utf-8, false) AS col3#x, encode(cast((id#xL + cast(3 as bigint)) as string), utf-8, false) AS col4#x]
-      +- Range (0, 10, step=1, splits=None)
+      +- Range (0, 10, step=1, )
 
 
 -- !query
@@ -102,7 +102,7 @@ FROM (
 Project [concat(concat(cast(col1#x as string), cast(col2#x as string)), concat(cast(col3#x as string), cast(col4#x as string))) AS col#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [encode(cast(id#xL as string), utf-8, false) AS col1#x, encode(cast((id#xL + cast(1 as bigint)) as string), utf-8, false) AS col2#x, encode(cast((id#xL + cast(2 as bigint)) as string), utf-8, false) AS col3#x, encode(cast((id#xL + cast(3 as bigint)) as string), utf-8, false) AS col4#x]
-      +- Range (0, 10, step=1, splits=None)
+      +- Range (0, 10, step=1, )
 
 
 -- !query
@@ -123,7 +123,7 @@ FROM (
 Project [concat(col1#x, col2#x) AS col#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [encode(cast(id#xL as string), utf-8, false) AS col1#x, encode(cast((id#xL + cast(1 as bigint)) as string), utf-8, false) AS col2#x]
-      +- Range (0, 10, step=1, splits=None)
+      +- Range (0, 10, step=1, )
 
 
 -- !query
@@ -140,7 +140,7 @@ FROM (
 Project [concat(concat(concat(col1#x, col2#x), col3#x), col4#x) AS col#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [encode(cast(id#xL as string), utf-8, false) AS col1#x, encode(cast((id#xL + cast(1 as bigint)) as string), utf-8, false) AS col2#x, encode(cast((id#xL + cast(2 as bigint)) as string), utf-8, false) AS col3#x, encode(cast((id#xL + cast(3 as bigint)) as string), utf-8, false) AS col4#x]
-      +- Range (0, 10, step=1, splits=None)
+      +- Range (0, 10, step=1, )
 
 
 -- !query
@@ -157,7 +157,7 @@ FROM (
 Project [concat(concat(col1#x, col2#x), concat(col3#x, col4#x)) AS col#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [encode(cast(id#xL as string), utf-8, false) AS col1#x, encode(cast((id#xL + cast(1 as bigint)) as string), utf-8, false) AS col2#x, encode(cast((id#xL + cast(2 as bigint)) as string), utf-8, false) AS col3#x, encode(cast((id#xL + cast(3 as bigint)) as string), utf-8, false) AS col4#x]
-      +- Range (0, 10, step=1, splits=None)
+      +- Range (0, 10, step=1, )
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/typeCoercion/native/concat.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/typeCoercion/native/concat.sql.out
@@ -30,7 +30,7 @@ FROM (
 Project [concat(concat(concat(col1#x, cast(col2#xL as string)), concat(col3#x, cast(col4#x as string))), cast(col5#x as string)) AS col#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [prefix_ AS col1#x, id#xL AS col2#xL, cast((id#xL + cast(1 as bigint)) as string) AS col3#x, encode(cast((id#xL + cast(2 as bigint)) as string), utf-8, false) AS col4#x, cast(id#xL as double) AS col5#x]
-      +- Range (0, 10, step=1, )
+      +- Range (0, 10, step=1)
 
 
 -- !query
@@ -47,7 +47,7 @@ FROM (
 Project [concat(concat(col1#x, col2#x), cast(concat(col3#x, col4#x) as string)) AS col#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [cast(id#xL as string) AS col1#x, cast((id#xL + cast(1 as bigint)) as string) AS col2#x, encode(cast((id#xL + cast(2 as bigint)) as string), utf-8, false) AS col3#x, encode(cast((id#xL + cast(3 as bigint)) as string), utf-8, false) AS col4#x]
-      +- Range (0, 10, step=1, )
+      +- Range (0, 10, step=1)
 
 
 -- !query
@@ -68,7 +68,7 @@ FROM (
 Project [concat(cast(col1#x as string), cast(col2#x as string)) AS col#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [encode(cast(id#xL as string), utf-8, false) AS col1#x, encode(cast((id#xL + cast(1 as bigint)) as string), utf-8, false) AS col2#x]
-      +- Range (0, 10, step=1, )
+      +- Range (0, 10, step=1)
 
 
 -- !query
@@ -85,7 +85,7 @@ FROM (
 Project [concat(concat(concat(cast(col1#x as string), cast(col2#x as string)), cast(col3#x as string)), cast(col4#x as string)) AS col#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [encode(cast(id#xL as string), utf-8, false) AS col1#x, encode(cast((id#xL + cast(1 as bigint)) as string), utf-8, false) AS col2#x, encode(cast((id#xL + cast(2 as bigint)) as string), utf-8, false) AS col3#x, encode(cast((id#xL + cast(3 as bigint)) as string), utf-8, false) AS col4#x]
-      +- Range (0, 10, step=1, )
+      +- Range (0, 10, step=1)
 
 
 -- !query
@@ -102,7 +102,7 @@ FROM (
 Project [concat(concat(cast(col1#x as string), cast(col2#x as string)), concat(cast(col3#x as string), cast(col4#x as string))) AS col#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [encode(cast(id#xL as string), utf-8, false) AS col1#x, encode(cast((id#xL + cast(1 as bigint)) as string), utf-8, false) AS col2#x, encode(cast((id#xL + cast(2 as bigint)) as string), utf-8, false) AS col3#x, encode(cast((id#xL + cast(3 as bigint)) as string), utf-8, false) AS col4#x]
-      +- Range (0, 10, step=1, )
+      +- Range (0, 10, step=1)
 
 
 -- !query
@@ -123,7 +123,7 @@ FROM (
 Project [concat(col1#x, col2#x) AS col#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [encode(cast(id#xL as string), utf-8, false) AS col1#x, encode(cast((id#xL + cast(1 as bigint)) as string), utf-8, false) AS col2#x]
-      +- Range (0, 10, step=1, )
+      +- Range (0, 10, step=1)
 
 
 -- !query
@@ -140,7 +140,7 @@ FROM (
 Project [concat(concat(concat(col1#x, col2#x), col3#x), col4#x) AS col#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [encode(cast(id#xL as string), utf-8, false) AS col1#x, encode(cast((id#xL + cast(1 as bigint)) as string), utf-8, false) AS col2#x, encode(cast((id#xL + cast(2 as bigint)) as string), utf-8, false) AS col3#x, encode(cast((id#xL + cast(3 as bigint)) as string), utf-8, false) AS col4#x]
-      +- Range (0, 10, step=1, )
+      +- Range (0, 10, step=1)
 
 
 -- !query
@@ -157,7 +157,7 @@ FROM (
 Project [concat(concat(col1#x, col2#x), concat(col3#x, col4#x)) AS col#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [encode(cast(id#xL as string), utf-8, false) AS col1#x, encode(cast((id#xL + cast(1 as bigint)) as string), utf-8, false) AS col2#x, encode(cast((id#xL + cast(2 as bigint)) as string), utf-8, false) AS col3#x, encode(cast((id#xL + cast(3 as bigint)) as string), utf-8, false) AS col4#x]
-      +- Range (0, 10, step=1, )
+      +- Range (0, 10, step=1)
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/typeCoercion/native/elt.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/typeCoercion/native/elt.sql.out
@@ -14,7 +14,7 @@ FROM (
 Project [elt(2, col1#x, cast(col2#xL as string), col3#x, cast(col4#x as string), cast(col5#x as string), false) AS col#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [prefix_ AS col1#x, id#xL AS col2#xL, cast((id#xL + cast(1 as bigint)) as string) AS col3#x, encode(cast((id#xL + cast(2 as bigint)) as string), utf-8, false) AS col4#x, cast(id#xL as double) AS col5#x]
-      +- Range (0, 10, step=1, splits=None)
+      +- Range (0, 10, step=1)
 
 
 -- !query
@@ -31,7 +31,7 @@ FROM (
 Project [elt(3, col1#x, col2#x, cast(col3#x as string), cast(col4#x as string), false) AS col#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [cast(id#xL as string) AS col1#x, cast((id#xL + cast(1 as bigint)) as string) AS col2#x, encode(cast((id#xL + cast(2 as bigint)) as string), utf-8, false) AS col3#x, encode(cast((id#xL + cast(3 as bigint)) as string), utf-8, false) AS col4#x]
-      +- Range (0, 10, step=1, splits=None)
+      +- Range (0, 10, step=1)
 
 
 -- !query
@@ -52,7 +52,7 @@ FROM (
 Project [elt(1, cast(col1#x as string), cast(col2#x as string), false) AS col#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [encode(cast(id#xL as string), utf-8, false) AS col1#x, encode(cast((id#xL + cast(1 as bigint)) as string), utf-8, false) AS col2#x]
-      +- Range (0, 10, step=1, splits=None)
+      +- Range (0, 10, step=1)
 
 
 -- !query
@@ -73,4 +73,4 @@ FROM (
 Project [elt(2, col1#x, col2#x, false) AS col#x]
 +- SubqueryAlias __auto_generated_subquery_name
    +- Project [encode(cast(id#xL as string), utf-8, false) AS col1#x, encode(cast((id#xL + cast(1 as bigint)) as string), utf-8, false) AS col2#x]
-      +- Range (0, 10, step=1, splits=None)
+      +- Range (0, 10, step=1)

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/udf/postgreSQL/udf-aggregates_part1.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/udf/postgreSQL/udf-aggregates_part1.sql.out
@@ -154,70 +154,70 @@ Aggregate [stddev_pop(cast(cast(udf(cast(cast(3.0 as decimal(38,0)) as string)) 
 select sum(udf(CAST(null AS int))) from range(1,4)
 -- !query analysis
 Aggregate [sum(cast(udf(cast(cast(null as int) as string)) as int)) AS sum(udf(CAST(NULL AS INT)))#xL]
-+- Range (1, 4, step=1, splits=None)
++- Range (1, 4, step=1)
 
 
 -- !query
 select sum(udf(CAST(null AS long))) from range(1,4)
 -- !query analysis
 Aggregate [sum(cast(udf(cast(cast(null as bigint) as string)) as bigint)) AS sum(udf(CAST(NULL AS BIGINT)))#xL]
-+- Range (1, 4, step=1, splits=None)
++- Range (1, 4, step=1)
 
 
 -- !query
 select sum(udf(CAST(null AS Decimal(38,0)))) from range(1,4)
 -- !query analysis
 Aggregate [sum(cast(udf(cast(cast(null as decimal(38,0)) as string)) as decimal(38,0))) AS sum(udf(CAST(NULL AS DECIMAL(38,0))))#x]
-+- Range (1, 4, step=1, splits=None)
++- Range (1, 4, step=1)
 
 
 -- !query
 select sum(udf(CAST(null AS DOUBLE))) from range(1,4)
 -- !query analysis
 Aggregate [sum(cast(udf(cast(cast(null as double) as string)) as double)) AS sum(udf(CAST(NULL AS DOUBLE)))#x]
-+- Range (1, 4, step=1, splits=None)
++- Range (1, 4, step=1)
 
 
 -- !query
 select avg(udf(CAST(null AS int))) from range(1,4)
 -- !query analysis
 Aggregate [avg(cast(udf(cast(cast(null as int) as string)) as int)) AS avg(udf(CAST(NULL AS INT)))#x]
-+- Range (1, 4, step=1, splits=None)
++- Range (1, 4, step=1)
 
 
 -- !query
 select avg(udf(CAST(null AS long))) from range(1,4)
 -- !query analysis
 Aggregate [avg(cast(udf(cast(cast(null as bigint) as string)) as bigint)) AS avg(udf(CAST(NULL AS BIGINT)))#x]
-+- Range (1, 4, step=1, splits=None)
++- Range (1, 4, step=1)
 
 
 -- !query
 select avg(udf(CAST(null AS Decimal(38,0)))) from range(1,4)
 -- !query analysis
 Aggregate [avg(cast(udf(cast(cast(null as decimal(38,0)) as string)) as decimal(38,0))) AS avg(udf(CAST(NULL AS DECIMAL(38,0))))#x]
-+- Range (1, 4, step=1, splits=None)
++- Range (1, 4, step=1)
 
 
 -- !query
 select avg(udf(CAST(null AS DOUBLE))) from range(1,4)
 -- !query analysis
 Aggregate [avg(cast(udf(cast(cast(null as double) as string)) as double)) AS avg(udf(CAST(NULL AS DOUBLE)))#x]
-+- Range (1, 4, step=1, splits=None)
++- Range (1, 4, step=1)
 
 
 -- !query
 select sum(CAST(udf('NaN') AS DOUBLE)) from range(1,4)
 -- !query analysis
 Aggregate [sum(cast(cast(udf(cast(NaN as string)) as string) as double)) AS sum(CAST(udf(NaN) AS DOUBLE))#x]
-+- Range (1, 4, step=1, splits=None)
++- Range (1, 4, step=1)
 
 
 -- !query
 select avg(CAST(udf('NaN') AS DOUBLE)) from range(1,4)
 -- !query analysis
 Aggregate [avg(cast(cast(udf(cast(NaN as string)) as string) as double)) AS avg(CAST(udf(NaN) AS DOUBLE))#x]
-+- Range (1, 4, step=1, splits=None)
++- Range (1, 4, step=1)
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/udf/postgreSQL/udf-join.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/udf/postgreSQL/udf-join.sql.out
@@ -1727,7 +1727,7 @@ InsertIntoHadoopFsRelationCommand file:[not included in comparison]/{warehouse_d
 +- Project [cast(id#xL as int) AS f1#x, cast(repeat(xyzzy, 100)#x as string) AS f2#x]
    +- Project [id#xL, repeat(xyzzy, 100) AS repeat(xyzzy, 100)#x]
       +- SubqueryAlias x
-         +- Range (1, 10001, step=1, splits=None)
+         +- Range (1, 10001, step=1)
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/udf/udf-group-by.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/udf/udf-group-by.sql.out
@@ -362,7 +362,7 @@ SELECT udf(1) FROM range(10) HAVING true
 -- !query analysis
 Filter cast(true as boolean)
 +- Aggregate [cast(udf(cast(1 as string)) as int) AS udf(1)#x]
-   +- Range (0, 10, step=1, splits=None)
+   +- Range (0, 10, step=1)
 
 
 -- !query
@@ -371,7 +371,7 @@ SELECT udf(udf(1)) FROM range(10) HAVING MAX(id) > 0
 Project [udf(udf(1))#x]
 +- Filter (max(id#xL)#xL > cast(0 as bigint))
    +- Aggregate [cast(udf(cast(cast(udf(cast(1 as string)) as int) as string)) as int) AS udf(udf(1))#x, max(id#xL) AS max(id#xL)#xL]
-      +- Range (0, 10, step=1, splits=None)
+      +- Range (0, 10, step=1)
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/named-function-arguments.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/named-function-arguments.sql.out
@@ -188,7 +188,7 @@ org.apache.spark.sql.catalyst.ExtendedAnalysisException
   "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.UNSUPPORTED_TABLE_ARGUMENT",
   "sqlState" : "0A000",
   "messageParameters" : {
-    "treeNode" : "'Generate explode(table-argument#x []), false\n:  +- SubqueryAlias v\n:     +- View (`v`, [id#xL])\n:        +- Project [cast(id#xL as bigint) AS id#xL]\n:           +- Project [id#xL]\n:              +- Range (0, 8, step=1, splits=None)\n+- OneRowRelation\n"
+    "treeNode" : "'Generate explode(table-argument#x []), false\n:  +- SubqueryAlias v\n:     +- View (`v`, [id#xL])\n:        +- Project [cast(id#xL as bigint) AS id#xL]\n:           +- Project [id#xL]\n:              +- Range (0, 8, step=1)\n+- OneRowRelation\n"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ExplainSuite.scala
@@ -151,11 +151,11 @@ class ExplainSuite extends ExplainSuiteHelper with DisableAdaptiveExecutionSuite
   }
 
   test("explain table valued functions") {
-    checkKeywordsExistsInExplain(sql("select * from RaNgE(2)"), "Range (0, 2, step=1, splits=None)")
+    checkKeywordsExistsInExplain(sql("select * from RaNgE(2)"), "Range (0, 2, step=1)")
     checkKeywordsExistsInExplain(sql("SELECT * FROM range(3) CROSS JOIN range(3)"),
       "Join Cross",
-      ":- Range (0, 3, step=1, splits=None)",
-      "+- Range (0, 3, step=1, splits=None)")
+      ":- Range (0, 3, step=1)",
+      "+- Range (0, 3, step=1)")
   }
 
   test("explain lateral joins") {


### PR DESCRIPTION


### What changes were proposed in this pull request?
[SQL]

explain extended select * from range(0, 4);

Before this pr, the split is also displayed in the logical execution phase as None, if it is not be set. 
`

plan

== Parsed Logical Plan ==

'Project [*]

+- 'UnresolvedTableValuedFunction [range], [0, 4]

 

== Analyzed Logical Plan ==

id: bigint

Project [id#11L](https://issues.apache.org/jira/projects/SPARK/issues/SPARK-47914?filter=allissues#11L)

+- Range (0, 4, step=1, splits=None)

 

== Optimized Logical Plan ==

Range (0, 4, step=1, splits=None)

 

== Physical Plan ==

*(1) Range (0, 4, step=1, splits=1)`



After this pr, the split will not be displayed in the logical execution phase , if it is not set. At the same time,  it will be  be displayed when it is be set.

`

plan

== Parsed Logical Plan ==

'Project [*]

+- 'UnresolvedTableValuedFunction [range], [0, 4]

 

== Analyzed Logical Plan ==

id: bigint

Project [id#11L](https://issues.apache.org/jira/projects/SPARK/issues/SPARK-47914?filter=allissues#11L)

+- Range (0, 4, step=1)

 

== Optimized Logical Plan ==

Range (0, 4, step=1)

 

== Physical Plan ==

*(1) Range (0, 4, step=1, splits=1)`



### Why are the changes needed?
If the split is not be set.  it is also displayed in the logical execution phase as None, which is not very user-friendly.


### Does this PR introduce _any_ user-facing change?



### How was this patch tested?



### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
