### PR TITLE
[SPARK-47923][R] Upgrade the minimum version of `arrow` R package to 10.0.0

### DIFF
--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -21,7 +21,7 @@ Suggests:
     testthat,
     e1071,
     survival,
-    arrow (>= 1.0.0)
+    arrow (>= 10.0.0)
 Collate:
     'schema.R'
     'generics.R'


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade the minimum version of `arrow` R package to 10.0.0 like PySpark.

### Why are the changes needed?

Apache Spark `master` branch tests only with the latest R package which is `15.0.1` as of now. To avoid any incompatibility issues across R and Python, we had better use the same minimum policy.
```
$ docker run -it --rm ghcr.io/apache/apache-spark-ci-image:master-8755911327 R -e 'installed.packages()' | grep arrow | head -n1
arrow        "arrow"        "/usr/local/lib/R/site-library" "15.0.1"
```

### Does this PR introduce _any_ user-facing change?

Yes, but most SparkR users has been using the latest one which is higher than 10.0.0 because `Arrow R package 10.0.0` was released 2022-10-26 and has been used over one and half years.
- https://cran.r-project.org/src/contrib/Archive/arrow/

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.