### PR TITLE
[SPARK-47924][CORE] Add a DEBUG log to `DiskStore.moveFileToBlock`

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/DiskStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskStore.scala
@@ -148,6 +148,7 @@ private[spark] class DiskStore(
   def moveFileToBlock(sourceFile: File, blockSize: Long, targetBlockId: BlockId): Unit = {
     blockSizes.put(targetBlockId, blockSize)
     val targetFile = diskManager.getFile(targetBlockId.name)
+    logDebug(s"${sourceFile.getPath()} -> ${targetFile.getPath()}")
     FileUtils.moveFile(sourceFile, targetFile)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a DEBUG-level log to `DiskStore.moveFileToBlock` for traceability.

### Why are the changes needed?

This helps the Spark debugging.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and manual review because this is a LOG.

### Was this patch authored or co-authored using generative AI tooling?

No.