### PR TITLE
[SPARK-47934] [CORE]  Ensure trailing slashes in `HistoryServer` URL redirections

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -115,9 +115,9 @@ class HistoryServer(
       // requested, and the proper data should be served at that point.
       // Also, make sure that the redirect url contains the query string present in the request.
       val redirect = if (shouldAppendAttemptId) {
-        req.getRequestURI.stripSuffix("/") + "/" + attemptId.get
+        req.getRequestURI.stripSuffix("/") + "/" + attemptId.get + "/"
       } else {
-        req.getRequestURI
+        req.getRequestURI.stripSuffix("/") + "/"
       }
       val query = Option(req.getQueryString).map("?" + _).getOrElse("")
       res.sendRedirect(res.encodeRedirectURL(redirect + query))


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR addresses the issue outlined in JIRA ticket [SPARK-47934](https://issues.apache.org/jira/browse/SPARK-47934), where inconsistent application of trailing slashes in URL redirections within the Spark's history web UI was leading to unnecessary HTTP redirects by Jetty. This inefficiency caused increased load times and reduced the UI's performance.


### Why are the changes needed?
to fix  [SPARK-47934](https://issues.apache.org/jira/browse/SPARK-47934)



### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
This patch was tested with an added unit test method in the HistoryServerSuite that verifies correct redirection behavior for different attempt IDs.




### Was this patch authored or co-authored using generative AI tooling?
no
