### PR TITLE
[MINOR] Remove unnecessary `imports`

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Distribution.scala
+++ b/core/src/main/scala/org/apache/spark/util/Distribution.scala
@@ -19,8 +19,6 @@ package org.apache.spark.util
 
 import java.io.PrintStream
 
-import scala.collection.immutable.IndexedSeq
-
 /**
  * Util for getting some stats from a small sample of numeric values, with some handy
  * summary functions.

--- a/core/src/test/scala/org/apache/spark/input/WholeTextFileInputFormatSuite.scala
+++ b/core/src/test/scala/org/apache/spark/input/WholeTextFileInputFormatSuite.scala
@@ -19,8 +19,6 @@ package org.apache.spark.input
 
 import java.io.{DataOutputStream, File, FileOutputStream}
 
-import scala.collection.immutable.IndexedSeq
-
 import org.apache.spark.{SparkConf, SparkContext, SparkFunSuite}
 
 /**

--- a/core/src/test/scala/org/apache/spark/input/WholeTextFileRecordReaderSuite.scala
+++ b/core/src/test/scala/org/apache/spark/input/WholeTextFileRecordReaderSuite.scala
@@ -21,8 +21,6 @@ import java.io.DataOutputStream
 import java.io.File
 import java.io.FileOutputStream
 
-import scala.collection.immutable.IndexedSeq
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.io.Text
 import org.apache.hadoop.io.compress.{CompressionCodecFactory, GzipCodec}

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/UpCastRule.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/UpCastRule.scala
@@ -16,8 +16,6 @@
  */
 package org.apache.spark.sql.types
 
-import scala.collection.immutable.IndexedSeq
-
 /**
  * Rule that defines which upcasts are allow in Spark.
  */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CacheManager.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.execution
 
-import scala.collection.immutable.IndexedSeq
-
 import org.apache.hadoop.fs.{FileSystem, Path}
 
 import org.apache.spark.internal.{LogEntry, Logging, MDC}

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationRegexpExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationRegexpExpressionsSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql
 
-import scala.collection.immutable.Seq
-
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.internal.SQLConf

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql
 
-import scala.collection.immutable.Seq
-
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql
 
-import scala.collection.immutable.Seq
 import scala.jdk.CollectionConverters.MapHasAsJava
 
 import org.apache.spark.SparkException

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuites.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientSuites.scala
@@ -19,8 +19,6 @@ package org.apache.spark.sql.hive.client
 
 import java.net.URI
 
-import scala.collection.immutable.IndexedSeq
-
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.Suite
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientUserNameSuites.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientUserNameSuites.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.hive.client
 
-import scala.collection.immutable.IndexedSeq
-
 import org.scalatest.Suite
 
 class HiveClientUserNameSuites extends Suite with HiveClientVersions {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientVersions.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HiveClientVersions.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.hive.client
 
-import scala.collection.immutable.IndexedSeq
-
 private[client] trait HiveClientVersions {
   private val testVersions = sys.env.get("SPARK_TEST_HIVE_CLIENT_VERSIONS")
   protected val versions = if (testVersions.nonEmpty) {

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuites.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/client/HivePartitionFilteringSuites.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.hive.client
 
-import scala.collection.immutable.IndexedSeq
-
 import org.scalatest.Suite
 
 class HivePartitionFilteringSuites extends Suite with HiveClientVersions {


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to remove unnecessary imports, include:
- `import scala.collection.immutable.Seq`
- `import scala.collection.immutable.IndexedSeq`

### Why are the changes needed?
Keep the code tidy.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
