### PR TITLE
[SPARK-47942][K8S][DOCS] Drop K8s v1.26 Support

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -44,7 +44,7 @@ Cluster administrators should use [Pod Security Policies](https://kubernetes.io/
 
 # Prerequisites
 
-* A running Kubernetes cluster at version >= 1.26 with access configured to it using
+* A running Kubernetes cluster at version >= 1.27 with access configured to it using
 [kubectl](https://kubernetes.io/docs/reference/kubectl/).  If you do not already have a working Kubernetes cluster,
 you may set up a test cluster on your local machine using
 [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/).


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update K8s docs to recommend K8s v1.27+ for Apache Spark 4.0.0.

This is a kind of follow-up of the following previous PR because Apache Spark 4.0.0 schedule is delayed slightly.
- #43069

### Why are the changes needed?

**1. K8s community starts to release v1.30.0 from 2024-04-17.**
- https://kubernetes.io/releases/#release-v1-30

**2. Default K8s Version in Public Cloud environments**

The default K8s versions of public cloud providers are already K8s 1.27+.

- EKS: v1.29 (Default)
- GKE: v1.29 (Rapid),  v1.28 (Regular), v1.27 (Stable)
- AKS: v1.27

**3. End Of Support**

In addition, K8s 1.26 is going to reach EOL when Apache Spark 4.0.0 arrives because K8s 1.26 is also going to reach EOL on June.

| K8s  |   AKS   |   GKE   |   EKS   |
| ---- | ------- | ------- | ------- |
| 1.26 | 2024-03 | 2024-06 | 2024-06 |

- [AKS EOL Schedule](https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar)
- [GKE EOL Schedule](https://cloud.google.com/kubernetes-engine/docs/release-schedule)
- [EKS EOL Schedule](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar)

### Does this PR introduce _any_ user-facing change?

- No, this is a documentation-only change about K8s versions.
- Apache Spark K8s Integration Test is currently using K8s v1.30.0 on Minikube already.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.