### PR TITLE
[SPARK-47944][BUILD] Upgrade icu4j to 75.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -100,7 +100,7 @@ hk2-locator/3.0.3//hk2-locator-3.0.3.jar
 hk2-utils/3.0.3//hk2-utils-3.0.3.jar
 httpclient/4.5.14//httpclient-4.5.14.jar
 httpcore/4.4.16//httpcore-4.4.16.jar
-icu4j/72.1//icu4j-72.1.jar
+icu4j/75.1//icu4j-75.1.jar
 ini4j/0.5.4//ini4j-0.5.4.jar
 istack-commons-runtime/3.0.8//istack-commons-runtime-3.0.8.jar
 ivy/2.5.2//ivy-2.5.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
     <datasketches.version>5.0.1</datasketches.version>
     <netty.version>4.1.109.Final</netty.version>
     <netty-tcnative.version>2.0.65.Final</netty-tcnative.version>
-    <icu4j.version>72.1</icu4j.version>
+    <icu4j.version>75.1</icu4j.version>
     <!--
     If you are changing Arrow version specification, please check
     ./python/pyspark/sql/pandas/utils.py, ./python/packaging/classic/setup.py


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `icu4j` from `72.1` to `75.1`.

### Why are the changes needed?
https://github.com/unicode-org/icu/releases/tag/release-75-1 [CLDR 45](https://cldr.unicode.org/index/downloads/cldr-45)
https://github.com/unicode-org/icu/releases/tag/release-74-2 [CLDR 44.1](https://cldr.unicode.org/index/downloads/cldr-44#h.nvqx283jwsx)
https://github.com/unicode-org/icu/releases/tag/release-74-1 [CLDR 44](https://cldr.unicode.org/index/downloads/cldr-44)
https://github.com/unicode-org/icu/releases/tag/release-73-2 [CLDR 43.1](https://cldr.unicode.org/index/downloads/cldr-43#h.qobmda543waj)
https://github.com/unicode-org/icu/releases/tag/release-73-1 [CLDR 43](https://blog.unicode.org/2023/04/the-unicode-cldr-v43-released.html)

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
