### PR TITLE
[SPARK-47864][FOLLOWUP][PYTHON][DOCS] Fix minor typo: "MLLib" -> "MLlib"

### DIFF
--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -244,7 +244,7 @@ Additional libraries that enhance functionality but are not included in the inst
 - **matplotlib**: Provide plotting for visualization. The default is **plotly**.
 
 
-MLLib DataFrame-based API
+MLlib DataFrame-based API
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Installable with ``pip install "pyspark[ml]"``.
@@ -252,7 +252,7 @@ Installable with ``pip install "pyspark[ml]"``.
 ======= ================= ======================================
 Package Supported version Note
 ======= ================= ======================================
-`numpy` >=1.21            Required for MLLib DataFrame-based API
+`numpy` >=1.21            Required for MLlib DataFrame-based API
 ======= ================= ======================================
 
 Additional libraries that enhance functionality but are not included in the installation packages:
@@ -272,5 +272,5 @@ Installable with ``pip install "pyspark[mllib]"``.
 ======= ================= ==================
 Package Supported version Note
 ======= ================= ==================
-`numpy` >=1.21            Required for MLLib
+`numpy` >=1.21            Required for MLlib
 ======= ================= ==================


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR followups for https://github.com/apache/spark/pull/46096 to fix minor typo.

### Why are the changes needed?

To use official naming from documentation for `MLlib` instead of `MLLib`. See https://spark.apache.org/mllib/.

### Does this PR introduce _any_ user-facing change?

No API change, but the user-facing documentation will be updated.

### How was this patch tested?

Manually built the doc from local test envs.

### Was this patch authored or co-authored using generative AI tooling?

No.