### PR TITLE
[SPARK-47952][CORE][CONNECT] Support retrieving the real SparkConnectService GRPC address and port programmatically when running on Yarn

### DIFF
--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/common/config/ConnectCommon.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/common/config/ConnectCommon.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql.connect.common.config
 
 private[sql] object ConnectCommon {
   val CONNECT_GRPC_BINDING_PORT: Int = 15002
+  val CONNECT_GRPC_PORT_MAX_RETRIES: Int = 0
   val CONNECT_GRPC_MAX_MESSAGE_SIZE: Int = 128 * 1024 * 1024
   val CONNECT_GRPC_MARSHALLER_RECURSION_LIMIT: Int = 1024
 }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -38,6 +38,14 @@ object Connect {
       .intConf
       .createWithDefault(ConnectCommon.CONNECT_GRPC_BINDING_PORT)
 
+  val CONNECT_GRPC_PORT_MAX_RETRIES =
+    buildStaticConf("spark.connect.grpc.port.maxRetries")
+      .doc("The max port retry attempts for the gRPC server binding." +
+        "By default, it's set to 0, and the server will fail fast in case of port conflicts.")
+      .version("4.0.0")
+      .intConf
+      .createWithDefault(ConnectCommon.CONNECT_GRPC_PORT_MAX_RETRIES)
+
   val CONNECT_GRPC_INTERCEPTOR_CLASSES =
     buildStaticConf("spark.connect.grpc.interceptor.classes")
       .doc(

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectInterceptorRegistry.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectInterceptorRegistry.scala
@@ -46,8 +46,13 @@ object SparkConnectInterceptorRegistry {
    * @param sb
    */
   def chainInterceptors(sb: NettyServerBuilder): Unit = {
+    chainInterceptors(sb, createConfiguredInterceptors())
+  }
+
+  def chainInterceptors(sb: NettyServerBuilder,
+                        additionalInterceptors: Seq[ServerInterceptor]): Unit = {
     interceptorChain.foreach(i => sb.intercept(i()))
-    createConfiguredInterceptors().foreach(sb.intercept(_))
+    additionalInterceptors.foreach(sb.intercept(_))
   }
 
   // Type used to identify the closure responsible to instantiate a ServerInterceptor.

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectInterceptorRegistry.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectInterceptorRegistry.scala
@@ -49,8 +49,9 @@ object SparkConnectInterceptorRegistry {
     chainInterceptors(sb, createConfiguredInterceptors())
   }
 
-  def chainInterceptors(sb: NettyServerBuilder,
-                        additionalInterceptors: Seq[ServerInterceptor]): Unit = {
+  def chainInterceptors(
+      sb: NettyServerBuilder,
+      additionalInterceptors: Seq[ServerInterceptor]): Unit = {
     interceptorChain.foreach(i => sb.intercept(i()))
     additionalInterceptors.foreach(sb.intercept(_))
   }

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -369,7 +369,7 @@ object SparkConnectService extends Logging {
     val protoReflectionService = if (debugMode) Some(ProtoReflectionService.newInstance()) else None
     val configuredInterceptors = SparkConnectInterceptorRegistry.createConfiguredInterceptors()
 
-    val startService = (port: Int) => {
+    val startServiceFn = (port: Int) => {
       val sb = bindAddress match {
         case Some(hostname) =>
           logInfo(log"start GRPC service at: ${MDC(HOST, hostname)}")

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -366,7 +366,8 @@ object SparkConnectService extends Logging {
     val bindAddress = SparkEnv.get.conf.get(CONNECT_GRPC_BINDING_ADDRESS)
     val startPort = SparkEnv.get.conf.get(CONNECT_GRPC_BINDING_PORT)
     val sparkConnectService = new SparkConnectService(debugMode)
-    val protoReflectionService = if (debugMode) Some(ProtoReflectionService.newInstance()) else None
+    val protoReflectionService =
+      if (debugMode) Some(ProtoReflectionService.newInstance()) else None
     val configuredInterceptors = SparkConnectInterceptorRegistry.createConfiguredInterceptors()
 
     val startServiceFn = (port: Int) => {
@@ -403,12 +404,7 @@ object SparkConnectService extends Logging {
     }
 
     val maxRetries: Int = SparkEnv.get.conf.get(CONNECT_GRPC_PORT_MAX_RETRIES)
-    Utils.startServiceOnPort[Server](
-      startPort,
-      startServiceFn,
-      maxRetries,
-      getClass.getName
-    )
+    Utils.startServiceOnPort[Server](startPort, startServiceFn, maxRetries, getClass.getName)
   }
 
   // Starts the service
@@ -456,8 +452,8 @@ object SparkConnectService extends Logging {
   }
 
   /**
-   * Post the event that the Spark Connect service has started.
-   * This is expected to be called only once after the service is ready.
+   * Post the event that the Spark Connect service has started. This is expected to be called only
+   * once after the service is ready.
    */
   private def postSparkConnectServiceStarted(sc: SparkContext): Unit = {
     postServiceEvent(isa =>
@@ -473,15 +469,12 @@ object SparkConnectService extends Logging {
    */
   private[connect] def postSparkConnectServiceEnd(): Unit = {
     postServiceEvent(isa =>
-      SparkListenerConnectServiceEnd(
-        hostAddress,
-        isa.getPort,
-        System.currentTimeMillis()))
+      SparkListenerConnectServiceEnd(hostAddress, isa.getPort, System.currentTimeMillis()))
   }
 
   /**
-   * Post the event to the Spark listener bus.
-   * To deliver the event to the listeners, the listener bus must be active in this time.
+   * Post the event to the Spark listener bus. To deliver the event to the listeners, the listener
+   * bus must be active in this time.
    */
   private def postServiceEvent(eventBuilder: InetSocketAddress => SparkListenerEvent): Unit = {
     // Sanity checks
@@ -498,8 +491,7 @@ object SparkConnectService extends Logging {
     }
 
     if (listenerBus == null) {
-      logWarning(
-        "The Spark Connect event was dropped because the listener bus has not been set.")
+      logWarning("The Spark Connect event was dropped because the listener bus has not been set.")
       return
     }
 
@@ -521,8 +513,8 @@ object SparkConnectService extends Logging {
 }
 
 /**
- * The event is sent after the Spark Connect service has started
- * and is ready to receive the inbound requests.
+ * The event is sent after the Spark Connect service has started and is ready to receive the
+ * inbound requests.
  *
  * @param hostAddress:
  *   The host address of the started Spark Connect service.
@@ -538,12 +530,12 @@ case class SparkListenerConnectServiceStarted(
     bindingPort: Int,
     sparkConf: SparkConf,
     eventTime: Long)
-  extends SparkListenerEvent
+    extends SparkListenerEvent
 
 /**
- * The event is sent to inform that Spark Connect service has already been shutdown.
- * This event indicates the end of the service, and any in-processing requests
- * or upcoming requests are not guaranteed to be handled properly by the service.
+ * The event is sent to inform that Spark Connect service has already been shutdown. This event
+ * indicates the end of the service, and any in-processing requests or upcoming requests are not
+ * guaranteed to be handled properly by the service.
  *
  * @param hostAddress:
  *   The host address of the Spark Connect service.
@@ -552,8 +544,5 @@ case class SparkListenerConnectServiceStarted(
  * @param eventTime:
  *   The time in ms when the event was generated.
  */
-case class SparkListenerConnectServiceEnd(
-   hostAddress: String,
-   bindingPort: Int,
-   eventTime: Long)
-  extends SparkListenerEvent
+case class SparkListenerConnectServiceEnd(hostAddress: String, bindingPort: Int, eventTime: Long)
+    extends SparkListenerEvent

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -405,7 +405,7 @@ object SparkConnectService extends Logging {
     val maxRetries: Int = SparkEnv.get.conf.get(CONNECT_GRPC_PORT_MAX_RETRIES)
     Utils.startServiceOnPort[Server](
       startPort,
-      startService,
+      startServiceFn,
       maxRetries,
       getClass.getName
     )

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -31,18 +31,20 @@ import io.grpc.protobuf.services.ProtoReflectionService
 import io.grpc.stub.StreamObserver
 import org.apache.commons.lang3.StringUtils
 
-import org.apache.spark.{SparkContext, SparkEnv}
+import org.apache.spark.{SparkConf, SparkContext, SparkEnv}
 import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.{AddArtifactsRequest, AddArtifactsResponse, SparkConnectServiceGrpc}
 import org.apache.spark.connect.proto.SparkConnectServiceGrpc.AsyncService
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys.HOST
 import org.apache.spark.internal.config.UI.UI_ENABLED
-import org.apache.spark.sql.connect.config.Connect.{CONNECT_GRPC_BINDING_ADDRESS, CONNECT_GRPC_BINDING_PORT, CONNECT_GRPC_MARSHALLER_RECURSION_LIMIT, CONNECT_GRPC_MAX_INBOUND_MESSAGE_SIZE}
+import org.apache.spark.scheduler.{LiveListenerBus, SparkListenerEvent}
+import org.apache.spark.sql.connect.config.Connect.{CONNECT_GRPC_BINDING_ADDRESS, CONNECT_GRPC_BINDING_PORT, CONNECT_GRPC_MARSHALLER_RECURSION_LIMIT, CONNECT_GRPC_MAX_INBOUND_MESSAGE_SIZE, CONNECT_GRPC_PORT_MAX_RETRIES}
 import org.apache.spark.sql.connect.execution.ConnectProgressExecutionListener
 import org.apache.spark.sql.connect.ui.{SparkConnectServerAppStatusStore, SparkConnectServerListener, SparkConnectServerTab}
 import org.apache.spark.sql.connect.utils.ErrorUtils
 import org.apache.spark.status.ElementTrackingStore
+import org.apache.spark.util.Utils
 
 /**
  * The SparkConnectService implementation.
@@ -283,10 +285,12 @@ class SparkConnectService(debug: Boolean) extends AsyncService with BindableServ
 object SparkConnectService extends Logging {
 
   private[connect] var server: Server = _
+  private[connect] var bindingAddress: InetSocketAddress = _
 
   private[connect] var uiTab: Option[SparkConnectServerTab] = None
   private[connect] var listener: SparkConnectServerListener = _
   private[connect] var executionListener: Option[ConnectProgressExecutionListener] = None
+  private[connect] var listenerBus: LiveListenerBus = _
 
   // For testing purpose, it's package level private.
   private[connect] def localPort: Int = {
@@ -296,12 +300,20 @@ object SparkConnectService extends Logging {
     server.getPort
   }
 
+  private[connect] def hostAddress: String = {
+    Utils.localCanonicalHostName()
+  }
+
   private[connect] lazy val executionManager = new SparkConnectExecutionManager()
 
   private[connect] lazy val sessionManager = new SparkConnectSessionManager()
 
   private[connect] val streamingSessionManager =
     new SparkConnectStreamingQueryCache()
+
+  // Package level private for testing purpose.
+  @volatile private[connect] var started = false
+  @volatile private[connect] var stopped = false
 
   /**
    * Based on the userId and sessionId, find or create a new SparkSession.
@@ -343,6 +355,7 @@ object SparkConnectService extends Logging {
     // Add the execution listener needed for query progress.
     executionListener = Some(new ConnectProgressExecutionListener)
     sc.addSparkListener(executionListener.get)
+    listenerBus = sc.listenerBus
   }
 
   /**
@@ -351,35 +364,79 @@ object SparkConnectService extends Logging {
   private def startGRPCService(): Unit = {
     val debugMode = SparkEnv.get.conf.getBoolean("spark.connect.grpc.debug.enabled", true)
     val bindAddress = SparkEnv.get.conf.get(CONNECT_GRPC_BINDING_ADDRESS)
-    val port = SparkEnv.get.conf.get(CONNECT_GRPC_BINDING_PORT)
-    val sb = bindAddress match {
-      case Some(hostname) =>
-        logInfo(log"start GRPC service at: ${MDC(HOST, hostname)}")
-        NettyServerBuilder.forAddress(new InetSocketAddress(hostname, port))
-      case _ => NettyServerBuilder.forPort(port)
-    }
-    sb.maxInboundMessageSize(SparkEnv.get.conf.get(CONNECT_GRPC_MAX_INBOUND_MESSAGE_SIZE).toInt)
-      .addService(new SparkConnectService(debugMode))
+    val startPort = SparkEnv.get.conf.get(CONNECT_GRPC_BINDING_PORT)
+    val sparkConnectService = new SparkConnectService(debugMode)
+    val protoReflectionService = if (debugMode) Some(ProtoReflectionService.newInstance()) else None
+    val configuredInterceptors = SparkConnectInterceptorRegistry.createConfiguredInterceptors()
 
-    // Add all registered interceptors to the server builder.
-    SparkConnectInterceptorRegistry.chainInterceptors(sb)
+    val startService = (port: Int) => {
+      val sb = bindAddress match {
+        case Some(hostname) =>
+          logInfo(log"start GRPC service at: ${MDC(HOST, hostname)}")
+          NettyServerBuilder.forAddress(new InetSocketAddress(hostname, port))
+        case _ => NettyServerBuilder.forPort(port)
+      }
+      sb.maxInboundMessageSize(SparkEnv.get.conf.get(CONNECT_GRPC_MAX_INBOUND_MESSAGE_SIZE).toInt)
+        .addService(sparkConnectService)
 
-    // If debug mode is configured, load the ProtoReflection service so that tools like
-    // grpcurl can introspect the API for debugging.
-    if (debugMode) {
-      sb.addService(ProtoReflectionService.newInstance())
+      // Add all registered interceptors to the server builder.
+      SparkConnectInterceptorRegistry.chainInterceptors(sb, configuredInterceptors)
+
+      // If debug mode is configured, load the ProtoReflection service so that tools like
+      // grpcurl can introspect the API for debugging.
+      protoReflectionService.foreach(service => sb.addService(service))
+
+      server = sb.build
+      server.start()
+
+      // It will throw an IllegalStateException if you want to access the binding address
+      // while the server is in a terminated state, so record the actual binding address
+      // immediately after the server starts.
+      // There should only be one address, get the actual binding address
+      // of the server according the `server.port()`
+      bindingAddress = server.getListenSockets.asScala
+        .find(_.isInstanceOf[InetSocketAddress])
+        .get
+        .asInstanceOf[InetSocketAddress]
+
+      (server, server.getPort)
     }
-    server = sb.build
-    server.start()
+
+    val maxRetries: Int = SparkEnv.get.conf.get(CONNECT_GRPC_PORT_MAX_RETRIES)
+    Utils.startServiceOnPort[Server](
+      startPort,
+      startService,
+      maxRetries,
+      getClass.getName
+    )
   }
 
   // Starts the service
-  def start(sc: SparkContext): Unit = {
+  def start(sc: SparkContext): Unit = synchronized {
+    if (started) {
+      logWarning("The Spark Connect service has already started.")
+      return
+    }
+
     startGRPCService()
     createListenerAndUI(sc)
+
+    started = true
+    stopped = false
+    postSparkConnectServiceStarted(sc)
   }
 
-  def stop(timeout: Option[Long] = None, unit: Option[TimeUnit] = None): Unit = {
+  def stop(timeout: Option[Long] = None, unit: Option[TimeUnit] = None): Unit = synchronized {
+    if (stopped) {
+      logWarning("The Spark Connect service has already been stopped.")
+      return
+    }
+
+    if (!started) {
+      throw new IllegalStateException(
+        "Attempting to stop the Spark Connect service that has not been started.")
+    }
+
     if (server != null) {
       if (timeout.isDefined && unit.isDefined) {
         server.shutdown()
@@ -392,6 +449,61 @@ object SparkConnectService extends Logging {
     executionManager.shutdown()
     sessionManager.shutdown()
     uiTab.foreach(_.detach())
+
+    started = false
+    stopped = true
+    postSparkConnectServiceEnd()
+  }
+
+  /**
+   * Post the event that the Spark Connect service has started.
+   * This is expected to be called only once after the service is ready.
+   */
+  private def postSparkConnectServiceStarted(sc: SparkContext): Unit = {
+    postServiceEvent(isa =>
+      SparkListenerConnectServiceStarted(
+        hostAddress,
+        isa.getPort,
+        sc.conf,
+        System.currentTimeMillis()))
+  }
+
+  /**
+   * Post the event that the Spark Connect service is offline.
+   */
+  private[connect] def postSparkConnectServiceEnd(): Unit = {
+    postServiceEvent(isa =>
+      SparkListenerConnectServiceEnd(
+        hostAddress,
+        isa.getPort,
+        System.currentTimeMillis()))
+  }
+
+  /**
+   * Post the event to the Spark listener bus.
+   * To deliver the event to the listeners, the listener bus must be active in this time.
+   */
+  private def postServiceEvent(eventBuilder: InetSocketAddress => SparkListenerEvent): Unit = {
+    // Sanity checks
+    if (server == null) {
+      logWarning(
+        "The Spark Connect event was dropped because the server bus has not been created and set.")
+      return
+    }
+
+    if (bindingAddress == null) {
+      logWarning(
+        "The Spark Connect event was dropped because the internal server address is not set.")
+      return
+    }
+
+    if (listenerBus == null) {
+      logWarning(
+        "The Spark Connect event was dropped because the listener bus has not been set.")
+      return
+    }
+
+    listenerBus.post(eventBuilder(bindingAddress))
   }
 
   def extractErrorMessage(st: Throwable): String = {
@@ -407,3 +519,41 @@ object SparkConnectService extends Logging {
     }
   }
 }
+
+/**
+ * The event is sent after the Spark Connect service has started
+ * and is ready to receive the inbound requests.
+ *
+ * @param hostAddress:
+ *   The host address of the started Spark Connect service.
+ * @param bindingPort:
+ *   The binding port of the started Spark Connect service.
+ * @param sparkConf:
+ *   The SparkConf of the active SparkContext that associated with the service.
+ * @param eventTime:
+ *   The time in ms when the event was generated.
+ */
+case class SparkListenerConnectServiceStarted(
+    hostAddress: String,
+    bindingPort: Int,
+    sparkConf: SparkConf,
+    eventTime: Long)
+  extends SparkListenerEvent
+
+/**
+ * The event is sent to inform that Spark Connect service has already been shutdown.
+ * This event indicates the end of the service, and any in-processing requests
+ * or upcoming requests are not guaranteed to be handled properly by the service.
+ *
+ * @param hostAddress:
+ *   The host address of the Spark Connect service.
+ * @param bindingPort:
+ *   The binding port of the Spark Connect service.
+ * @param eventTime:
+ *   The time in ms when the event was generated.
+ */
+case class SparkListenerConnectServiceEnd(
+   hostAddress: String,
+   bindingPort: Int,
+   eventTime: Long)
+  extends SparkListenerEvent

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceInternalServerSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceInternalServerSuite.scala
@@ -267,9 +267,6 @@ class SparkConnectServiceSuite extends SparkFunSuite with LocalSparkContext {
     assert(SparkConnectService.stopped)
     // The listener should receive the `SparkListenerConnectServiceEnd` event
     endEventSignal.acquire()
-
-    // The event `SparkListenerConnectServiceEnd` should be posted and received by the listener
-    assert(listenerInstance.serviceEndEvents.size() == 1)
   }
 
   def withPortOccupied(startPort: Int, endPort: Int)(f: => Unit): Unit = {

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceInternalServerSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceInternalServerSuite.scala
@@ -79,6 +79,7 @@ class SparkConnectServiceInternalServerSuite extends SparkFunSuite with LocalSpa
         val portConflicts = intercept[Throwable] {
           SparkConnectService.start(sc)
         }
+        portConflicts.printStackTrace()
         assert(Utils.isBindCollision(portConflicts))
       }
     }

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceInternalServerSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceInternalServerSuite.scala
@@ -51,6 +51,7 @@ class SparkConnectServiceInternalServerSuite extends SparkFunSuite with LocalSpa
         val portConflicts = intercept[Throwable] {
           SparkConnectService.start(sc)
         }
+        portConflicts.printStackTrace()
         assert(Utils.isBindCollision(portConflicts))
       }
     }

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceInternalServerSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceInternalServerSuite.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.connect.SparkConnectPlugin
 import org.apache.spark.sql.connect.config.Connect.{CONNECT_GRPC_BINDING_PORT, CONNECT_GRPC_PORT_MAX_RETRIES}
 import org.apache.spark.util.Utils
 
-class SparkConnectServiceSuite extends SparkFunSuite with LocalSparkContext {
+class SparkConnectServiceInternalServerSuite extends SparkFunSuite with LocalSparkContext {
 
   override def afterEach(): Unit = {
     super.afterEach()

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceInternalServerSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceInternalServerSuite.scala
@@ -1,0 +1,333 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.connect.service
+
+import java.net.ServerSocket
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Semaphore
+
+import scala.collection.mutable
+
+import org.apache.spark.{LocalSparkContext, SparkConf, SparkContext, SparkFunSuite}
+import org.apache.spark.internal.config._
+import org.apache.spark.launcher.SparkLauncher
+import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent}
+import org.apache.spark.sql.connect.SparkConnectPlugin
+import org.apache.spark.sql.connect.config.Connect.{CONNECT_GRPC_BINDING_PORT, CONNECT_GRPC_PORT_MAX_RETRIES}
+import org.apache.spark.util.Utils
+
+class SparkConnectServiceSuite extends SparkFunSuite with LocalSparkContext {
+
+  override def afterEach(): Unit = {
+    super.afterEach()
+    SparkConnectServiceLifeCycleListener.reset()
+  }
+
+  test("The SparkConnectService will retry using different ports in case of conflicts") {
+    val conf = new SparkConf()
+      .setAppName(getClass().getName())
+      .set(SparkLauncher.SPARK_MASTER, "local[1]")
+    sc = new SparkContext(conf)
+
+    // 1. By default there is no retry, the SparkConnectService will fail to start
+    //    if the port is already in use.
+    val startPort = 15002
+    withSparkEnvConfs((CONNECT_GRPC_BINDING_PORT.key, startPort.toString)) {
+      withPortOccupied(startPort, startPort) {
+        val portConflicts = intercept[Throwable] {
+          SparkConnectService.start(sc)
+        }
+        assert(Utils.isBindCollision(portConflicts))
+      }
+    }
+
+    // 2. Enable the port retry, the SparkConnectService will retry using different ports
+    //    until it finds an available port before reaching the maximum number of retries.
+    withSparkEnvConfs(
+      (CONNECT_GRPC_BINDING_PORT.key, startPort.toString),
+      (CONNECT_GRPC_PORT_MAX_RETRIES.key, "3")) {
+      // 15002, 15003, 15004 occupied
+      withPortOccupied(startPort, startPort + 2) {
+        SparkConnectService.start(sc)
+        assert(SparkConnectService.started)
+        assert(SparkConnectService.server.getPort == startPort + 3) // 15005 available
+        SparkConnectService.stop()
+      }
+    }
+
+    // 3. It will fail if not able to find an available port
+    //    before reaching the maximum number of retries.
+    withSparkEnvConfs(
+      (CONNECT_GRPC_BINDING_PORT.key, startPort.toString),
+      (CONNECT_GRPC_PORT_MAX_RETRIES.key, "1")) {
+      // 15002, 15003 occupied but only retried on 15003 and reach the maximum number of retries
+      withPortOccupied(startPort, startPort + 1) {
+        val portConflicts = intercept[Throwable] {
+          SparkConnectService.start(sc)
+        }
+        assert(Utils.isBindCollision(portConflicts))
+      }
+    }
+
+    // 4. The value of port will be validated before the service starts
+    Seq((CONNECT_GRPC_BINDING_PORT.key, (1024 - 1).toString),
+      (CONNECT_GRPC_BINDING_PORT.key, (65535 + 1).toString)).foreach(
+      conf => {
+        withSparkEnvConfs(conf) {
+          val invalidPort = intercept[IllegalArgumentException] {
+            SparkConnectService.start(sc)
+          }
+          assert(invalidPort.getMessage.contains(
+            "requirement failed: startPort should be between 1024 and 65535 (inclusive)," +
+              " or 0 for a random free port."))
+        }
+      }
+    )
+  }
+
+  test("The SparkConnectService will post events for each pair of start and stop") {
+    // Future validations when listener receive the `SparkListenerConnectServiceStarted` event
+    val startedEventValidations: CopyOnWriteArrayList[(String, Boolean)] =
+      new CopyOnWriteArrayList[(String, Boolean)]()
+    val startedEventSignal = new Semaphore(0)
+    SparkConnectServiceLifeCycleListener.checksOnServiceStartedEvent = Some(Seq(
+      _ => {
+        startedEventSignal.release()
+        startedEventValidations.add((
+          "The listener should receive the `SparkListenerConnectServiceStarted` event.",
+          true))
+      },
+      _ => {
+        startedEventValidations.add((
+          "The server should has already been started" +
+            " if the listener receives the `SparkListenerConnectServiceStarted` event.",
+          SparkConnectService.started &&
+            !SparkConnectService.stopped &&
+            SparkConnectService.server != null))
+      },
+      serviceStarted => {
+        startedEventValidations.add((
+          "The SparkConnectService should post it's address " +
+            "by the `SparkListenerConnectServiceStarted` event",
+          serviceStarted.bindingPort == SparkConnectService.server.getPort &&
+            serviceStarted.hostAddress == SparkConnectService.hostAddress
+        ))
+      }
+    ))
+
+    // Future validations when listener receive the `SparkListenerConnectServiceEnd` event
+    val endEventValidations: CopyOnWriteArrayList[(String, Boolean)] =
+      new CopyOnWriteArrayList[(String, Boolean)]()
+    val endEventSignal = new Semaphore(0)
+    SparkConnectServiceLifeCycleListener.checksOnServiceEndEvent = Some(Seq(
+      _ => {
+        endEventSignal.release()
+        startedEventValidations.add((
+          "The listener should receive the `SparkListenerConnectServiceEnd` event.",
+          true))
+      },
+      _ => {
+        endEventValidations.add((
+          "The server has already been stopped" +
+            " if the listener receives the `SparkListenerConnectServiceEnd` event.",
+          SparkConnectService.stopped &&
+            !SparkConnectService.started &&
+            SparkConnectService.server.isShutdown))
+      },
+      serviceEnd => {
+        endEventValidations.add((
+          "The SparkConnectService should post it's address " +
+            "by the `SparkListenerConnectServiceEnd` event",
+          serviceEnd.bindingPort == SparkConnectService.server.getPort &&
+            serviceEnd.hostAddress == SparkConnectService.hostAddress))
+      }
+    ))
+
+    val conf = new SparkConf()
+      .setAppName(getClass().getName())
+      .set(SparkLauncher.SPARK_MASTER, "local[1]")
+    sc = new SparkContext(conf)
+
+    val listenerInstance = new SparkConnectServiceLifeCycleListener()
+    sc.addSparkListener(listenerInstance)
+
+    // Start the SparkConnectService and wait for the listener
+    // to receive the `SparkListenerConnectServiceStarted` event.
+    SparkConnectService.start(sc)
+    startedEventSignal.acquire()
+    // Now the listener should have already received the `SparkListenerConnectServiceStarted` event.
+
+    // The internal server of SparkConnectService should has
+    // already been created and started in this time.
+    assert(SparkConnectService.started && SparkConnectService.server != null)
+
+    // The event `SparkListenerConnectServiceStarted` should be posted
+    // during the startup of the SparkConnectService.
+    assert(listenerInstance.serviceStartedEvents.size() == 1)
+    // The server should already been started when the listener receive the event
+    // and the server address should be the same as the address of service
+    startedEventValidations.forEach { case (msg, validated) =>
+      assert(validated, msg)
+    }
+    // In the meanwhile, no any end event should be posted
+    assert(listenerInstance.serviceEndEvents.size() == 0)
+
+    // The listener is able to get the SparkConf from the event
+    val event = listenerInstance.serviceStartedEvents.get(0)
+    assert(event.sparkConf != null)
+    val sparkConf = event.sparkConf
+    assert(sparkConf.contains("spark.driver.host"))
+    assert(sparkConf.contains("spark.app.id"))
+
+    // Try to start an already started SparkConnectService
+    SparkConnectService.start(sc)
+    // The listener should still receive only one started event
+    // because the server has not been stopped yet, and there won't be duplicated service start
+    assert(listenerInstance.serviceStartedEvents.size() == 1)
+
+    // Stop the SparkConnectService
+    SparkConnectService.stop()
+    assert(SparkConnectService.stopped)
+    // The listener should receive the `SparkListenerConnectServiceEnd` event
+    endEventSignal.acquire()
+
+    // The event `SparkListenerConnectServiceEnd` should be posted and received by the listener
+    assert(listenerInstance.serviceEndEvents.size() == 1)
+    // The server should already been stopped when the listener receive the event
+    // and the server address should be the same as the address of service
+    endEventValidations.forEach { case (msg, validated) =>
+      assert(validated, msg)
+    }
+
+    // Try to stop an already stopped SparkConnectService
+    SparkConnectService.stop()
+    // The listener should still receive only one end event,
+    // no duplicated `SparkListenerConnectServiceEnd` event posted
+    assert(listenerInstance.serviceEndEvents.size() == 1)
+  }
+
+  test("SparkConnectPlugin will post started and end events that can be received by listeners") {
+    // Future validations when listener receive the `SparkListenerConnectServiceStarted` event
+    val startedEventSignal = new Semaphore(0)
+    SparkConnectServiceLifeCycleListener.checksOnServiceStartedEvent = Some(Seq(
+      _ => {
+        startedEventSignal.release()
+      }
+    ))
+
+    // Future validations when listener receive the `SparkListenerConnectServiceEnd` event
+    val endEventSignal = new Semaphore(0)
+    SparkConnectServiceLifeCycleListener.checksOnServiceEndEvent = Some(Seq(
+      _ => {
+        endEventSignal.release()
+      }
+    ))
+
+    val conf = new SparkConf()
+      .setAppName(getClass().getName())
+      // Start the SparkConnectService from SparkConnectPlugin
+      .set(PLUGINS, Seq(classOf[SparkConnectPlugin].getName()))
+      // In this case, the listener need to be registered via the configuration
+      // otherwise the listener will not be able to receive the events that post during
+      // the initialization of the SparkConnectPlugin
+      .set(EXTRA_LISTENERS, Seq(classOf[SparkConnectServiceLifeCycleListener].getName()))
+      .set(SparkLauncher.SPARK_MASTER, "local[1]")
+
+    // Create the SparkContext, initialize the SparkConnectPlugin and start the SparkConnectService
+    sc = new SparkContext(conf)
+
+    val listenerInstance = SparkConnectServiceLifeCycleListener.currentInstance
+    assert(listenerInstance != null)
+    // The internal server of SparkConnectService should has
+    // already been created and started during the initializing of the SparkConnectPlugin.
+    assert(SparkConnectService.started && SparkConnectService.server != null)
+    // The event `SparkListenerConnectServiceStarted` should be posted and received by the listener
+    startedEventSignal.acquire()
+    // Only one `SparkListenerConnectServiceStarted` event should be received by the listener
+    assert(listenerInstance.serviceStartedEvents.size() == 1)
+
+    // Stop the SparkContext, the SparkConnectService will be stopped during the shutdown of
+    // SparkConnectPlugin and the message will be posted to the listener via active ListenerBus.
+    // This requires the ListenerBus can accept events if the SparkPlugins has not been shutdown.
+    sc.stop()
+    assert(SparkConnectService.stopped)
+    // The listener should receive the `SparkListenerConnectServiceEnd` event
+    endEventSignal.acquire()
+
+    // The event `SparkListenerConnectServiceEnd` should be posted and received by the listener
+    assert(listenerInstance.serviceEndEvents.size() == 1)
+  }
+
+  def withPortOccupied(startPort: Int, endPort: Int)(f: => Unit): Unit = {
+    val startedServers = new mutable.ArrayBuffer[ServerSocket]()
+    try {
+      for (toBeOccupiedPort <- startPort to endPort) {
+        val server = new ServerSocket(toBeOccupiedPort)
+        startedServers += server
+      }
+      f
+    } finally {
+      startedServers.foreach(
+        server => {
+          try {
+            server.close()
+          } catch {
+            case _: Throwable =>
+          }
+        }
+      )
+    }
+  }
+}
+
+private class SparkConnectServiceLifeCycleListener extends SparkListener {
+
+  SparkConnectServiceLifeCycleListener.currentInstance = this
+
+  val serviceStartedEvents: CopyOnWriteArrayList[SparkListenerConnectServiceStarted] =
+    new CopyOnWriteArrayList[SparkListenerConnectServiceStarted]()
+  val serviceEndEvents: CopyOnWriteArrayList[SparkListenerConnectServiceEnd] =
+    new CopyOnWriteArrayList[SparkListenerConnectServiceEnd]()
+
+  override def onOtherEvent(event: SparkListenerEvent): Unit = {
+    event match {
+      case serviceStarted: SparkListenerConnectServiceStarted =>
+        serviceStartedEvents.add(serviceStarted)
+        SparkConnectServiceLifeCycleListener.checksOnServiceStartedEvent.foreach { checks =>
+          checks.foreach(_(serviceStarted))
+        }
+      case serviceEnd: SparkListenerConnectServiceEnd =>
+        serviceEndEvents.add(serviceEnd)
+        SparkConnectServiceLifeCycleListener.checksOnServiceEndEvent.foreach { checks =>
+          checks.foreach(_(serviceEnd))
+        }
+    }
+  }
+}
+
+private object SparkConnectServiceLifeCycleListener {
+
+  var currentInstance: SparkConnectServiceLifeCycleListener = _
+  var checksOnServiceStartedEvent: Option[Seq[(SparkListenerConnectServiceStarted) => Unit]] = None
+  var checksOnServiceEndEvent: Option[Seq[(SparkListenerConnectServiceEnd) => Unit]] = None
+
+  def reset(): Unit = {
+    currentInstance = null
+    checksOnServiceStartedEvent = None
+    checksOnServiceEndEvent = None
+  }
+}

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -2321,6 +2321,11 @@ class SparkContext(config: SparkConf) extends Logging {
       }
       _dagScheduler = null
     }
+    // In case there are still events being posted during the shutdown of plugins,
+    // invoke the shutdown of each plugin before the listenerBus is stopped.
+    Utils.tryLogNonFatalError {
+      _plugins.foreach(_.shutdown())
+    }
     if (_listenerBusStarted) {
       Utils.tryLogNonFatalError {
         listenerBus.stop()
@@ -2331,9 +2336,6 @@ class SparkContext(config: SparkConf) extends Logging {
       Utils.tryLogNonFatalError {
         env.metricsSystem.report()
       }
-    }
-    Utils.tryLogNonFatalError {
-      _plugins.foreach(_.shutdown())
     }
     Utils.tryLogNonFatalError {
       FallbackStorage.cleanUp(_conf, _hadoopConfiguration)

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2136,26 +2136,37 @@ private[spark] object Utils
 
   /**
    * Attempt to start a service on the given port, or fail after a number of attempts.
-   * Each subsequent attempt uses 1 + the port used in the previous attempt (unless the port is 0).
-   *
-   * @param startPort The initial port to start the service on.
-   * @param startService Function to start service on a given port.
-   *                     This is expected to throw java.net.BindException on port collision.
-   * @param conf A SparkConf used to get the maximum number of retries when binding to a port.
-   * @param serviceName Name of the service.
-   * @return (service: T, port: Int)
+   * Use a shared configuration for the maximum number of port retries.
    */
   def startServiceOnPort[T](
       startPort: Int,
       startService: Int => (T, Int),
       conf: SparkConf,
       serviceName: String = ""): (T, Int) = {
+    startServiceOnPort(startPort, startService, portMaxRetries(conf), serviceName)
+  }
+
+  /**
+   * Attempt to start a service on the given port, or fail after a number of attempts.
+   * Each subsequent attempt uses 1 + the port used in the previous attempt (unless the port is 0).
+   *
+   * @param startPort The initial port to start the service on.
+   * @param startService Function to start service on a given port.
+   *                     This is expected to throw java.net.BindException on port collision.
+   * @param maxRetries The maximum number of retries when binding to a port.
+   * @param serviceName Name of the service.
+   * @return (service: T, port: Int)
+   */
+  def startServiceOnPort[T](
+      startPort: Int,
+      startService: Int => (T, Int),
+      maxRetries: Int,
+      serviceName: String): (T, Int) = {
 
     require(startPort == 0 || (1024 <= startPort && startPort < 65536),
       "startPort should be between 1024 and 65535 (inclusive), or 0 for a random free port.")
 
     val serviceString = if (serviceName.isEmpty) "" else s" '$serviceName'"
-    val maxRetries = portMaxRetries(conf)
     for (offset <- 0 to maxRetries) {
       // Do not increment port if startPort is 0, which is treated as a special port
       val tryPort = if (startPort == 0) {

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2231,6 +2231,9 @@ private[spark] object Utils
       case e: NativeIoException =>
         (e.getMessage != null && e.getMessage.startsWith("bind() failed: ")) ||
           isBindCollision(e.getCause)
+      case e: IOException =>
+        (e.getMessage != null && e.getMessage.startsWith("Failed to bind to address")) ||
+          isBindCollision(e.getCause)
       case e: Exception => isBindCollision(e.getCause)
       case _ => false
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
1. Add configuration `spark.connect.grpc.port.maxRetries` (default 0, no retries).

   [Before this PR]: The SparkConnectService would fail to start in case of port conflicts on Yarn.
   [After this PR]: Allow the internal GRPC server to retry new ports until it finds an available port before reaching the maxRetries.

2. Post SparkListenerEvent containing the location of the remote SparkConnectService on Yarn.

   [Before this PR]: We needed to manually find the final location (host and port) of the SparkConnectService on Yarn and then use the SparkConnect Client to connect.
   [After this PR]: The location will be posted via SparkListenerEvent
                                                  `SparkListenerConnectServiceStarted`
                                                  `SparkListenerConnectServiceEnd`
 Allowing users to register a listener to receive this event and expose it by some way like sending it to a third coordinator server.

3. Shutdown SparkPlugins before stopping the ListenerBus.

   [Before this PR]: If the SparkConnectService was launched in the SparkConnectPlugin way, currently the SparkPlugins would be shutdown after the stop of ListenerBus, causing events posted during the shutdown to not be delivered to the listener.
   [After this PR]: The SparkPlugins will be shutdown before the stop of ListenerBus, ensuring that the ListenerBus remains active during the shutdown and the listener can receive the SparkConnectService stop event.

4. Minor method refactoring for 1~3.


### Why are the changes needed?
#User Story:
Our data analysts and data scientists use Jupyter notebooks provisioned on Kubernetes (k8s) with limited CPU/memory resources to run Spark-shell/pyspark for interactively development via terminal under Yarn Client mode.

However, Yarn Client mode consumes significant local memory if the job is heavy, and the total resource pool of k8s for notebooks is limited.

To leverage the abundant resources of our Hadoop cluster for scalability purposes, we aim to utilize SparkConnect.
This allows the driver on Yarn with SparkConnectService started and uses SparkConnect client to connect to the remote driver.

To provide a seamless experience with one command startup for both server and client, we've wrapped the following processes in one script:

1) Start a local coordinator server (implemented by us internally, not in this PR) in the host of jupyter notebook.
2) Start SparkConnectServer by spark-submit via Yarn Cluster mode with user-input Spark configurations and the local coordinator server's address and port.
   Append an additional listener class in the configuration for SparkConnectService callback with the actual address and port on Yarn to the coordinator server.
3) Wait for the coordinator server to receive the address callback from the SparkConnectService on Yarn and export the real address.
4) Start the client (pyspark --remote $callback_address) with the remote address.

Finally, a remote SparkConnect Server is started on Yarn with a local SparkConnect client connected. Users no longer need to start the server beforehand and connect to the remote server after they manually explore the address on Yarn.

#Problem statement of this change:
1) The specified port for the SparkConnectService GRPC server might be occupied on the node of the Hadoop Cluster.
   To increase the success rate of startup, it needs to retry on conflicts rather than fail directly.
2) Because the final binding port could be uncertain based on 1) when retry and the remote address is also unpredictable on Yarn, we need to retrieve the address and port programmatically and inject it automatically on the start of 'pyspark --remote'. To get the address of SparkConnectService on Yarn programmatically, the SparkConnectService needs to communicate its location back to the launcher side.


### Does this PR introduce _any_ user-facing change?
1. Add configuration `spark.connect.grpc.port.maxRetries` to enable port retries until an available port is found before reaching the maximum number of retries.

3. The start and stop events of the SparkConnectService are observable through the SparkListener.
   Two new events have been introduced:
   - SparkListenerConnectServiceStarted: the SparkConnectService(with address and port) tis online for serving
   - SparkListenerConnectServiceEnd: the SparkConnectService(with address and port) is offline

### How was this patch tested?
By UT and verified the feature in our production environment by our binary build

### Was this patch authored or co-authored using generative AI tooling?
No