### PR TITLE
[SPARK-47050][SQL] Collect and publish partition level metrics for V1

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/PartitionMetricsWriteInfo.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/PartitionMetricsWriteInfo.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.write;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * An aggregator of partition metrics collected during write operations.
+ * <p>
+ * This is patterned after {@code org.apache.spark.util.AccumulatorV2}
+ * </p>
+ */
+public class PartitionMetricsWriteInfo implements Serializable {
+
+  private final Map<String, PartitionMetrics> metrics = new TreeMap<>();
+
+  /**
+   * Merges another same-type accumulator into this one and update its state, i.e. this should be
+   * merge-in-place.
+   *
+   * @param otherAccumulator Another object containing aggregated partition metrics
+   */
+  public void merge(PartitionMetricsWriteInfo otherAccumulator) {
+    otherAccumulator.metrics.forEach((p, m) ->
+        metrics.computeIfAbsent(p, key -> new PartitionMetrics(0L, 0L, 0))
+            .merge(m));
+  }
+
+  /**
+   * Update the partition metrics for the specified path by adding to the existing state.  This will
+   * add the partition if it has not been referenced previously.
+   *
+   * @param partitionPath The path for the written partition
+   * @param bytes The number of additional bytes
+   * @param records the number of addition records
+   * @param files the number of additional files
+   */
+  public void update(String partitionPath, long bytes, long records, int files) {
+    metrics.computeIfAbsent(partitionPath, key -> new PartitionMetrics(0L, 0L, 0))
+        .merge(new PartitionMetrics(bytes, records, files));
+  }
+
+  /**
+   * Update the partition metrics for the specified path by adding to the existing state from an
+   * individual file.  This will add the partition if it has not been referenced previously.
+   *
+   * @param partitionPath The path for the written partition
+   * @param bytes The number of additional bytes
+   * @param records the number of addition records
+   */
+  public void updateFile(String partitionPath, long bytes, long records) {
+    update(partitionPath, bytes, records, 1);
+  }
+
+  /**
+   * Convert this instance into an immutable {@code java.util.Map}.  This is used for posting to the
+   * listener bus
+   *
+   * @return an immutable map of partition paths to their metrics
+   */
+  public Map<String, PartitionMetrics> toMap() {
+    return Collections.unmodifiableMap(metrics);
+  }
+
+  /**
+   * Returns if this accumulator is zero value or not. For a map accumulator this indicates if the
+   * map is empty.
+   *
+   * @return {@code true} if there are no partition metrics
+   */
+  boolean isZero() {
+    return metrics.isEmpty();
+  }
+
+  @Override
+  public String toString() {
+    return "PartitionMetricsWriteInfo{" +
+        "metrics=" + metrics +
+        '}';
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/write/PartitionMetrics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/write/PartitionMetrics.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.write
+
+/**
+ * The metrics collected for an individual partition
+ *
+ * @param numBytes the number of bytes
+ * @param numRecords the number of records (rows)
+ * @param numFiles the number of files
+ */
+case class PartitionMetrics(var numBytes: Long = 0, var numRecords: Long = 0, var numFiles: Int = 0)
+  extends Serializable {
+
+  /**
+   * Updates the metrics for an individual file.
+   *
+   * @param bytes the number of bytes
+   * @param records the number of records (rows)
+   */
+  def updateFile(bytes: Long, records: Long): Unit = {
+    numBytes += bytes
+    numRecords += records
+    numFiles += 1
+  }
+
+  /**
+   * Merges another same-type accumulator into this one and update its state, i.e. this should be
+   * merge-in-place.
+
+   * @param other Another set of metrics for the same partition
+   */
+  def merge (other: PartitionMetrics): Unit = {
+    numBytes += other.numBytes
+    numRecords += other.numRecords
+    numFiles += other.numFiles
+  }
+
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/write/SparkListenerSQLPartitionMetrics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/write/SparkListenerSQLPartitionMetrics.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.write
+
+import org.apache.spark.SparkContext
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.scheduler.SparkListenerEvent
+
+@DeveloperApi
+case class SparkListenerSQLPartitionMetrics(executorId: Long,
+                                            metrics: java.util.Map[String, PartitionMetrics])
+  extends SparkListenerEvent
+
+object SQLPartitionMetrics {
+
+  /**
+   * Post any aggregated partition write statistics to the listener bus using a
+   * [[SparkListenerSQLPartitionMetrics]] event
+   *
+   * @param sc The Spark context
+   * @param executionId The identifier for the SQL execution that resulted in the partition writes
+   * @param writeInfo The aggregated partition writes for this SQL exectuion
+   */
+  def postDriverMetricUpdates(sc: SparkContext, executionId: String,
+                              writeInfo: PartitionMetricsWriteInfo): Unit = {
+    // Don't bother firing an event if there are no collected metrics
+    if (writeInfo.isZero) {
+      return
+    }
+
+    // There are some cases we don't care about the metrics and call `SparkPlan.doExecute`
+    // directly without setting an execution id. We should be tolerant to it.
+    if (executionId != null) {
+      sc.listenerBus.post(
+        SparkListenerSQLPartitionMetrics(executionId.toLong, writeInfo.toMap))
+    }
+  }
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatDataWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatDataWriter.scala
@@ -182,7 +182,7 @@ class SingleDirectoryDataWriter(
       dataSchema = description.dataColumns.toStructType,
       context = taskAttemptContext)
 
-    statsTrackers.foreach(_.newFile(currentPath, None))
+    statsTrackers.foreach(_.newFile(currentPath))
   }
 
   override def write(record: InternalRow): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatDataWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatDataWriter.scala
@@ -639,3 +639,13 @@ case class ExecutedWriteSummary(
     updatedPartitions: Set[String],
     stats: Seq[WriteTaskStats],
     updatedPartitionsMap: Map[InternalRow, String])
+
+object ExecutedWriteSummary {
+
+  // The original case class parameter list provided for backward compatibility.
+  def apply(
+    updatedPartitions: Set[String],
+    stats: Seq[WriteTaskStats]): ExecutedWriteSummary = new ExecutedWriteSummary (
+      updatedPartitions, stats, Map[InternalRow, String]())
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatDataWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatDataWriter.scala
@@ -56,6 +56,8 @@ abstract class FileFormatDataWriter(
    */
   protected val MAX_FILE_COUNTER: Int = 1000 * 1000
   protected val updatedPartitions: mutable.Set[String] = mutable.Set[String]()
+  protected val updatedPartitionsMap: mutable.Map[InternalRow, String]
+      = mutable.Map[InternalRow, String]()
   protected var currentWriter: OutputWriter = _
 
   /** Trackers for computing various statistics on the data as it's being written out. */
@@ -127,7 +129,8 @@ abstract class FileFormatDataWriter(
     }
     val summary = ExecutedWriteSummary(
       updatedPartitions = updatedPartitions.toSet,
-      stats = statsTrackers.map(_.getFinalStats(taskCommitTime)))
+      stats = statsTrackers.map(_.getFinalStats(taskCommitTime)),
+      updatedPartitionsMap.toMap)
     WriteTaskResult(taskCommitMessage, summary)
   }
 
@@ -179,7 +182,7 @@ class SingleDirectoryDataWriter(
       dataSchema = description.dataColumns.toStructType,
       context = taskAttemptContext)
 
-    statsTrackers.foreach(_.newFile(currentPath))
+    statsTrackers.foreach(_.newFile(currentPath, None))
   }
 
   override def write(record: InternalRow): Unit = {
@@ -288,6 +291,9 @@ abstract class BaseDynamicPartitionDataWriter(
 
     val partDir = partitionValues.map(getPartitionPath(_))
     partDir.foreach(updatedPartitions.add)
+    if (partDir.isDefined) {
+      partitionValues.foreach(updatedPartitionsMap(_) = partDir.get)
+    }
 
     val bucketIdStr = bucketId.map(BucketingUtils.bucketIdToString).getOrElse("")
 
@@ -316,7 +322,7 @@ abstract class BaseDynamicPartitionDataWriter(
       dataSchema = description.dataColumns.toStructType,
       context = taskAttemptContext)
 
-    statsTrackers.foreach(_.newFile(currentPath))
+    statsTrackers.foreach(_.newFile(currentPath, partitionValues))
   }
 
   /**
@@ -631,4 +637,5 @@ case class WriteTaskResult(commitMsg: TaskCommitMessage, summary: ExecutedWriteS
  */
 case class ExecutedWriteSummary(
     updatedPartitions: Set[String],
-    stats: Seq[WriteTaskStats])
+    stats: Seq[WriteTaskStats],
+    updatedPartitionsMap: Map[InternalRow, String])

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileBatchWrite.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileBatchWrite.scala
@@ -40,7 +40,8 @@ class FileBatchWrite(
       log"Elapsed time: ${MDC(LogKeys.ELAPSED_TIME, duration)} ms.")
 
     processStats(
-      description.statsTrackers, results.map(_.summary.stats).toImmutableArraySeq, duration)
+      description.statsTrackers, results.map(_.summary.stats).toImmutableArraySeq, duration,
+      results.map(_.summary.updatedPartitionsMap).reduce(_ ++ _))
     logInfo(log"Finished processing stats for write job ${MDC(LogKeys.UUID, description.uuid)}.")
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/CustomWriteTaskStatsTrackerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/CustomWriteTaskStatsTrackerSuite.scala
@@ -54,7 +54,7 @@ class CustomWriteTaskStatsTracker extends WriteTaskStatsTracker {
 
   override def newPartition(partitionValues: InternalRow): Unit = {}
 
-  override def newFile(filePath: String, partitionValues: Option[InternalRow]): Unit = {
+  override def newFile(filePath: String): Unit = {
     numRowsPerFile.put(filePath, 0)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/CustomWriteTaskStatsTrackerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/CustomWriteTaskStatsTrackerSuite.scala
@@ -54,7 +54,7 @@ class CustomWriteTaskStatsTracker extends WriteTaskStatsTracker {
 
   override def newPartition(partitionValues: InternalRow): Unit = {}
 
-  override def newFile(filePath: String): Unit = {
+  override def newFile(filePath: String, partitionValues: Option[InternalRow]): Unit = {
     numRowsPerFile.put(filePath, 0)
   }
 


### PR DESCRIPTION
We currently capture metrics which include the number of files, bytes and rows for a task along with the updated partitions. 
 This change captures metrics for each updated partition, reporting the partition sub-paths along with the number of files, bytes, and rows per partition for each task.

This is the V1 implementation, extracted from https://github.com/apache/spark/pull/45123

### What changes were proposed in this pull request?

1. Update the `WriteTaskStatsTracker` implementation to associate a partition with the file during writing, and to track the number of rows written to each file.  The final stats now include a map of partitions and the associated partition stats
2. Update the `WriteJobStatsTracker` implementation to capture the partition subpaths and to publish a new Event to the listener bus.  The processed stats aggregate the statistics for each partition

### Why are the changes needed?
This increases our understanding of written data by tracking the impact for each task on our datasets

### Does this PR introduce _any_ user-facing change?
This makes partition-level data accessible through a new event.

### How was this patch tested?
In addition to the new unit tests, this was run in a Kubernetes environment writing tables with differing partitioning strategies and validating the reported stats.  Unit tests using both `InsertIntoHadoopFsRelationCommand` and `InsertIntoHiveTable` now verify partition stats when dynamic partitioning is enabled.  We also verified that the aggregated partition metrics matched the existing metrics for number of files, bytes, and rows.

### Was this patch authored or co-authored using generative AI tooling?
No