### PR TITLE
[SPARK-47964][PYTHON][CONNECT] Hide SQLContext and HiveContext in pyspark-connect

### DIFF
--- a/python/pyspark/__init__.py
+++ b/python/pyspark/__init__.py
@@ -128,7 +128,7 @@ if not is_remote_only():
     # for back compatibility
     from pyspark.sql import SQLContext, HiveContext  # noqa: F401
 
-from pyspark.sql import Row
+from pyspark.sql import Row  # noqa: F401
 
 __all__ = [
     "SparkConf",

--- a/python/pyspark/__init__.py
+++ b/python/pyspark/__init__.py
@@ -125,8 +125,10 @@ if not is_remote_only():
     # for backward compatibility references.
     sys.modules["pyspark.context"] = context
 
-# for back compatibility
-from pyspark.sql import SQLContext, HiveContext, Row  # noqa: F401
+    # for back compatibility
+    from pyspark.sql import SQLContext, HiveContext  # noqa: F401
+
+from pyspark.sql import Row
 
 __all__ = [
     "SparkConf",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR hides SQLContext and HiveContext in `pyspark-connect`. They do not exist there.

### Why are the changes needed?

To recover https://github.com/apache/spark/actions/runs/8805830494

### Does this PR introduce _any_ user-facing change?

No, the main change has not been released yet.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.