### PR TITLE
[SPARK-47771][PYTHON][DOCS][TESTS][FOLLOWUP] Make `max_by, min_by` doctests deterministic

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -1275,7 +1275,7 @@ def max_by(col: "ColumnOrName", ord: "ColumnOrName") -> Column:
     >>> import pyspark.sql.functions as sf
     >>> df = spark.createDataFrame([
     ...     ("Consult", "Eva", 6), ("Finance", "Frank", 5),
-    ...     ("Finance", "George", 5), ("Consult", "Henry", 7)],
+    ...     ("Finance", "George", 9), ("Consult", "Henry", 7)],
     ...     schema=("department", "name", "years_in_dept"))
     >>> df.groupby("department").agg(
     ...     sf.max_by("name", "years_in_dept")
@@ -1356,7 +1356,7 @@ def min_by(col: "ColumnOrName", ord: "ColumnOrName") -> Column:
     >>> import pyspark.sql.functions as sf
     >>> df = spark.createDataFrame([
     ...     ("Consult", "Eva", 6), ("Finance", "Frank", 5),
-    ...     ("Finance", "George", 5), ("Consult", "Henry", 7)],
+    ...     ("Finance", "George", 9), ("Consult", "Henry", 7)],
     ...     schema=("department", "name", "years_in_dept"))
     >>> df.groupby("department").agg(
     ...     sf.min_by("name", "years_in_dept")
@@ -1365,7 +1365,7 @@ def min_by(col: "ColumnOrName", ord: "ColumnOrName") -> Column:
     |department|min_by(name, years_in_dept)|
     +----------+---------------------------+
     |   Consult|                        Eva|
-    |   Finance|                     George|
+    |   Finance|                      Frank|
     +----------+---------------------------+
     """
     return _invoke_function_over_columns("min_by", col, ord)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `max_by, min_by` doctests deterministic


### Why are the changes needed?
https://github.com/apache/spark/pull/45939 fixed this issue by sorting the rows,
unfortunately, it is not enough:

in group `department=Finance`, two rows `("Finance", "Frank", 5)` and `("Finance", "George", 5)` have the same value `years_in_dept=5`, so `min_by("name", "years_in_dept")` and `max_by("name", "years_in_dept")` is still non-deterministic. 

This test failed in some env:
```
**********************************************************************
File "/home/jenkins/python/pyspark/sql/connect/functions/builtin.py", line 1177, in pyspark.sql.connect.functions.builtin.max_by
Failed example:
    df.groupby("department").agg(
        sf.max_by("name", "years_in_dept")
    ).sort("department").show()
Expected:
    +----------+---------------------------+
    |department|max_by(name, years_in_dept)|
    +----------+---------------------------+
    |   Consult|                      Henry|
    |   Finance|                     George|
    +----------+---------------------------+
Got:
    +----------+---------------------------+
    |department|max_by(name, years_in_dept)|
    +----------+---------------------------+
    |   Consult|                      Henry|
    |   Finance|                      Frank|
    +----------+---------------------------+
    <BLANKLINE>
**********************************************************************
File "/home/jenkins/python/pyspark/sql/connect/functions/builtin.py", line 1205, in pyspark.sql.connect.functions.builtin.min_by
Failed example:
    df.groupby("department").agg(
        sf.min_by("name", "years_in_dept")
    ).sort("department").show()
Expected:
    +----------+---------------------------+
    |department|min_by(name, years_in_dept)|
    +----------+---------------------------+
    |   Consult|                        Eva|
    |   Finance|                     George|
    +----------+---------------------------+
Got:
    +----------+---------------------------+
    |department|min_by(name, years_in_dept)|
    +----------+---------------------------+
    |   Consult|                        Eva|
    |   Finance|                      Frank|
    +----------+---------------------------+
    <BLANKLINE>
**********************************************************************
```


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
