### PR TITLE
[SPARK-47933][PYTHON][CONNECT][FOLLOW-UP] Add a check of `__name__` at `_with_origin`

### DIFF
--- a/python/pyspark/errors/utils.py
+++ b/python/pyspark/errors/utils.py
@@ -174,7 +174,7 @@ def _with_origin(func: Callable[..., Any]) -> Callable[..., Any]:
         from pyspark.sql import SparkSession
 
         spark = SparkSession.getActiveSession()
-        if spark is not None:
+        if spark is not None and hasattr(func, "__name__"):
             assert spark._jvm is not None
             pyspark_origin = spark._jvm.org.apache.spark.sql.catalyst.trees.PySparkCurrentOrigin
 


### PR DESCRIPTION
### What changes were proposed in this pull request?


This PR is a followup of https://github.com/apache/spark/pull/46155 that adds check of `__name__` at `_with_origin`.

### Why are the changes needed?

It is possible for a callable instance without __name__ attribute or/and __module__ attribute to be wrapped. For example, functools.partial.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

`./bin/pyspark`

### Was this patch authored or co-authored using generative AI tooling?

No.