### PR TITLE
[SPARK-47967][SQL] Make `JdbcUtils.makeGetter` handle reading time type as NTZ correctly

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/MsSqlServerIntegrationSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.jdbc
 
 import java.math.BigDecimal
 import java.sql.{Connection, Date, Timestamp}
+import java.time.LocalDateTime
 import java.util.Properties
 
 import org.apache.spark.SparkSQLException
@@ -222,24 +223,30 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationSuite {
 
   test("Date types") {
     withDefaultTimeZone(UTC) {
-      val df = spark.read.jdbc(jdbcUrl, "dates", new Properties)
-      val rows = df.collect()
-      assert(rows.length == 1)
-      val row = rows(0)
-      val types = row.toSeq.map(x => x.getClass.toString)
-      assert(types.length == 6)
-      assert(types(0).equals("class java.sql.Date"))
-      assert(types(1).equals("class java.sql.Timestamp"))
-      assert(types(2).equals("class java.sql.Timestamp"))
-      assert(types(3).equals("class java.lang.String"))
-      assert(types(4).equals("class java.sql.Timestamp"))
-      assert(types(5).equals("class java.sql.Timestamp"))
-      assert(row.getAs[Date](0).equals(Date.valueOf("1991-11-09")))
-      assert(row.getAs[Timestamp](1).equals(Timestamp.valueOf("1999-01-01 13:23:35.0")))
-      assert(row.getAs[Timestamp](2).equals(Timestamp.valueOf("9999-12-31 23:59:59.0")))
-      assert(row.getString(3).equals("1901-05-09 23:59:59.0000000 +14:00"))
-      assert(row.getAs[Timestamp](4).equals(Timestamp.valueOf("1996-01-01 23:24:00.0")))
-      assert(row.getAs[Timestamp](5).equals(Timestamp.valueOf("1970-01-01 13:31:24.0")))
+      {
+        val df = spark.read
+          .option("preferTimestampNTZ", "false")
+          .jdbc(jdbcUrl, "dates", new Properties)
+        checkAnswer(df, Row(
+          Date.valueOf("1991-11-09"),
+          Timestamp.valueOf("1999-01-01 13:23:35"),
+          Timestamp.valueOf("9999-12-31 23:59:59"),
+          "1901-05-09 23:59:59.0000000 +14:00",
+          Timestamp.valueOf("1996-01-01 23:24:00"),
+          Timestamp.valueOf("1970-01-01 13:31:24")))
+      }
+      {
+        val df = spark.read
+          .option("preferTimestampNTZ", "true")
+          .jdbc(jdbcUrl, "dates", new Properties)
+        checkAnswer(df, Row(
+          Date.valueOf("1991-11-09"),
+          LocalDateTime.of(1999, 1, 1, 13, 23, 35),
+          LocalDateTime.of(9999, 12, 31, 23, 59, 59),
+          "1901-05-09 23:59:59.0000000 +14:00",
+          LocalDateTime.of(1996, 1, 1, 23, 24, 0),
+          LocalDateTime.of(1970, 1, 1, 13, 31, 24)))
+      }
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala
@@ -498,12 +498,6 @@ object JdbcUtils extends Logging with SQLConfHelper {
         }
       }
 
-    case TimestampNTZType if metadata.contains("logical_time_type") =>
-      (rs: ResultSet, row: InternalRow, pos: Int) =>
-        val micros = nullSafeConvert[java.sql.Time](rs.getTime(pos + 1), t =>
-          localDateTimeToMicros(LocalDateTime.of(LocalDate.EPOCH, t.toLocalTime)))
-        row.update(pos, micros)
-
     case TimestampType =>
       (rs: ResultSet, row: InternalRow, pos: Int) =>
         val t = rs.getTimestamp(pos + 1)
@@ -512,6 +506,12 @@ object JdbcUtils extends Logging with SQLConfHelper {
         } else {
           row.update(pos, null)
         }
+
+    case TimestampNTZType if metadata.contains("logical_time_type") =>
+      (rs: ResultSet, row: InternalRow, pos: Int) =>
+        val micros = nullSafeConvert[java.sql.Time](rs.getTime(pos + 1), t =>
+          localDateTimeToMicros(LocalDateTime.of(LocalDate.EPOCH, t.toLocalTime)))
+        row.update(pos, micros)
 
     case TimestampNTZType =>
       (rs: ResultSet, row: InternalRow, pos: Int) =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


This PR adds a specific rule for reading the JDBC TIME value as Spark TimestampNTZ. Currently, we use getTimestamp API to retrieve a time value when reading as TimestampNTZ, which is inconsistent with reading as TimestampLTZ. Some JDBC sources might return a value not adjusted to EPOCH day, 1900 from MS SQL Server for example.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
bugfix

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

no
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

new tests
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no