### PR TITLE
[SPARK-47971][PYTHON][CONNECT][TESTS] Reenable `PandasUDFGroupedAggParityTests.test_grouped_with_empty_partition`

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_pandas_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_udf_grouped_agg.py
@@ -26,10 +26,6 @@ class PandasUDFGroupedAggParityTests(GroupedAggPandasUDFTestsMixin, ReusedConnec
     def test_unsupported_types(self):
         super().test_unsupported_types()
 
-    @unittest.skip("Spark Connect doesn't support RDD but the test depends on it.")
-    def test_grouped_with_empty_partition(self):
-        super().test_grouped_with_empty_partition()
-
     @unittest.skip("Spark Connect does not support convert UNPARSED to catalyst types.")
     def test_manual(self):
         super().test_manual()

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_grouped_agg.py
@@ -538,11 +538,11 @@ class GroupedAggPandasUDFTestsMixin:
         data = [Row(id=1, x=2), Row(id=1, x=3), Row(id=2, x=4)]
         expected = [Row(id=1, sum=5), Row(id=2, x=4)]
         num_parts = len(data) + 1
-        df = self.spark.createDataFrame(self.sc.parallelize(data, numSlices=num_parts))
+        df = self.spark.createDataFrame(data).repartition(num_parts)
 
         f = pandas_udf(lambda x: x.sum(), "int", PandasUDFType.GROUPED_AGG)
 
-        result = df.groupBy("id").agg(f(df["x"]).alias("sum")).collect()
+        result = df.groupBy("id").agg(f(df["x"]).alias("sum")).sort("id").collect()
         self.assertEqual(result, expected)
 
     def test_grouped_without_group_by_clause(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Reenable `PandasUDFGroupedAggParityTests. test_grouped_with_empty_partition`


### Why are the changes needed?
for test coverage

the test needs a dataframe with empty partitions, switch to `df.repartition` to be able to reuse it in Spark Connect


### Does this PR introduce _any_ user-facing change?
no, test only


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
