### PR TITLE
[SPARK-47973][CORE] Log call site in SparkContext.stop() and later in SparkContext.assertNotStopped()

### DIFF
--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -1317,7 +1317,9 @@ class RDDSuite extends SparkFunSuite with SharedSparkContext with Eventually {
       val thrown = intercept[IllegalStateException] {
         block
       }
-      assert(thrown.getMessage.contains("stopped"))
+      assert(thrown.getMessage.contains("Cannot call methods on a stopped SparkContext"))
+      assert(thrown.getMessage.contains("This stopped SparkContext was created at:"))
+      assert(thrown.getMessage.contains("And it was stopped at:"))
     }
     assertFails { sc.parallelize(1 to 100) }
     assertFails { sc.textFile("/nonexistent-path") }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This change logs and stores the call site when SparkContext.stop() is called, and later when SparkContext.assertNotStopped() is called. 

### Why are the changes needed?
This is for better debuggability. 

### Does this PR introduce _any_ user-facing change?
Yes, the error message shown 

### How was this patch tested?
Updated unit tests.


### Was this patch authored or co-authored using generative AI tooling?
No.