### PR TITLE
[SPARK-47982][BUILD] Update some code style's plugins to latest version

### DIFF
--- a/dev/.scalafmt.conf
+++ b/dev/.scalafmt.conf
@@ -27,4 +27,4 @@ danglingParentheses.preset = false
 docstrings.style = Asterisk
 maxColumn = 98
 runner.dialect = scala213
-version = 3.8.0
+version = 3.8.1

--- a/pom.xml
+++ b/pom.xml
@@ -3548,7 +3548,7 @@
             -->
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.14.0</version>
+            <version>10.15.0</version>
           </dependency>
         </dependencies>
         <executions>
@@ -3610,7 +3610,7 @@
       <plugin>
         <groupId>org.antipathy</groupId>
         <artifactId>mvn-scalafmt_${scala.binary.version}</artifactId>
-        <version>1.1.1684076452.9f83818</version>
+        <version>1.1.1713302731.c3d0074</version>
         <configuration>
           <validateOnly>${scalafmt.validateOnly}</validateOnly> <!-- (Optional) skip formatting -->
           <skipSources>${scalafmt.skip}</skipSources>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,10 +20,10 @@ addSbtPlugin("software.purpledragon" % "sbt-checkstyle-plugin" % "4.0.1")
 // sbt-checkstyle-plugin uses an old version of checkstyle. Match it to Maven's.
 // If you are changing the dependency setting for checkstyle plugin,
 // please check pom.xml in the root of the source tree too.
-libraryDependencies += "com.puppycrawl.tools" % "checkstyle" % "10.14.0"
+libraryDependencies += "com.puppycrawl.tools" % "checkstyle" % "10.15.0"
 
-// checkstyle uses guava 31.0.1-jre.
-libraryDependencies += "com.google.guava" % "guava" % "31.0.1-jre"
+// checkstyle uses guava 33.1.0-jre.
+libraryDependencies += "com.google.guava" % "guava" % "33.1.0-jre"
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.2.0")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to update some some code style's plugins to latest version, include:
- `mvn-scalafmt_2.13` from `1.1.1684076452.9f83818` to `1.1.1713302731.c3d0074`.
- `checkstyle` from `10.14.0` to `10.15.0`.
- `scalafmt` from `3.8.0` to `3.8.1`.

### Why are the changes needed?
1.`mvn-scalafmt_2.13`
https://github.com/SimonJPegg/mvn_scalafmt/releases/tag/v2.13-1.1.1713302731.c3d0074
Minor version bumps and dropping 2.12

2.`checkstyle`
https://checkstyle.org/releasenotes.html#Release_10.15.0
https://checkstyle.org/releasenotes.html#Release_10.14.2
https://checkstyle.org/releasenotes.html#Release_10.14.1

3.`scalafmt`
https://github.com/scalameta/scalafmt/releases/tag/v3.8.1
<img width="408" alt="image" src="https://github.com/apache/spark/assets/15246973/657fb99a-2267-4d4f-84bb-1d2006818fdd">

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
