### PR TITLE
[SPARK-47988][SQL] When the collationId is invalid, throw `COLLATION_INVALID_ID`

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -461,6 +461,12 @@
     ],
     "sqlState" : "42704"
   },
+  "COLLATION_INVALID_ID" : {
+    "message" : [
+      "The collationId value <collationId> must be between <valueRange>."
+    ],
+    "sqlState" : "42704"
+  },
   "COLLATION_INVALID_NAME" : {
     "message" : [
       "The value <collationName> does not represent a correct collation name. Suggested valid collation name: [<proposal>]."

--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -361,27 +361,30 @@ abstract class SparkFunSuite
     } else {
       assert(expectedParameters === parameters)
     }
-    val actualQueryContext = exception.getQueryContext()
-    assert(actualQueryContext.length === queryContext.length, "Invalid length of the query context")
-    actualQueryContext.zip(queryContext).foreach { case (actual, expected) =>
-      assert(actual.contextType() === expected.contextType,
-        "Invalid contextType of a query context Actual:" + actual.toString)
-      if (actual.contextType() == QueryContextType.SQL) {
-        assert(actual.objectType() === expected.objectType,
-          "Invalid objectType of a query context Actual:" + actual.toString)
-        assert(actual.objectName() === expected.objectName,
-          "Invalid objectName of a query context. Actual:" + actual.toString)
-        assert(actual.startIndex() === expected.startIndex,
-          "Invalid startIndex of a query context. Actual:" + actual.toString)
-        assert(actual.stopIndex() === expected.stopIndex,
-          "Invalid stopIndex of a query context. Actual:" + actual.toString)
-        assert(actual.fragment() === expected.fragment,
-          "Invalid fragment of a query context. Actual:" + actual.toString)
-      } else if (actual.contextType() == QueryContextType.DataFrame) {
-        assert(actual.fragment() === expected.fragment,
-          "Invalid code fragment of a query context. Actual:" + actual.toString)
-        assert(actual.callSite().matches(expected.callSitePattern),
-          "Invalid callSite of a query context. Actual:" + actual.toString)
+    val actualQueryContext = exception.getQueryContext
+    if (actualQueryContext != null) {
+      assert(actualQueryContext.length === queryContext.length,
+        "Invalid length of the query context")
+      actualQueryContext.zip(queryContext).foreach { case (actual, expected) =>
+        assert(actual.contextType() === expected.contextType,
+          "Invalid contextType of a query context Actual:" + actual.toString)
+        if (actual.contextType() == QueryContextType.SQL) {
+          assert(actual.objectType() === expected.objectType,
+            "Invalid objectType of a query context Actual:" + actual.toString)
+          assert(actual.objectName() === expected.objectName,
+            "Invalid objectName of a query context. Actual:" + actual.toString)
+          assert(actual.startIndex() === expected.startIndex,
+            "Invalid startIndex of a query context. Actual:" + actual.toString)
+          assert(actual.stopIndex() === expected.stopIndex,
+            "Invalid stopIndex of a query context. Actual:" + actual.toString)
+          assert(actual.fragment() === expected.fragment,
+            "Invalid fragment of a query context. Actual:" + actual.toString)
+        } else if (actual.contextType() == QueryContextType.DataFrame) {
+          assert(actual.fragment() === expected.fragment,
+            "Invalid code fragment of a query context. Actual:" + actual.toString)
+          assert(actual.callSite().matches(expected.callSitePattern),
+            "Invalid callSite of a query context. Actual:" + actual.toString)
+        }
       }
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -776,7 +776,7 @@ object SQLConf {
         "DEFAULT_COLLATION",
         name =>
           Map(
-            "proposal" -> CollationFactory.getClosestCollation(name)
+            "proposal" -> CollationFactory.getClosestCollation(name).collationName
           ))
       .createWithDefault("UTF8_BINARY")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to 
- convert `ArrayIndexOutOfBoundsException` to `SparkArrayIndexOutOfBoundsException`.
- refactor `CollationFactory` to extract some of the same logic into a method, reduce redundancy.
- when calling `String#toUpperCase()` with parameters `Locale.ROOT`, which conforms to the traditional rules of Spark, as follows:
https://github.com/apache/spark/blob/master/scalastyle-config.xml#L247-L258

### Why are the changes needed?
Before:
<img width="789" alt="image" src="https://github.com/apache/spark/assets/15246973/e06ef2a1-e500-4498-a2ee-0ab03721e4a5">

After:
<img width="1222" alt="image" src="https://github.com/apache/spark/assets/15246973/91c34ee3-b8d3-4417-b786-3cc3e311d26e">


### Does this PR introduce _any_ user-facing change?
Yes, When the `collationId` is invalid, the user will get a more `friendly error prompt`.


### How was this patch tested?
- Add new UT.
- Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
