### PR TITLE
[SPARK-47990][BUILD] Upgrade `zstd-jni` to 1.5.6-3

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -278,4 +278,4 @@ xz/1.9//xz-1.9.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.9.2//zookeeper-jute-3.9.2.jar
 zookeeper/3.9.2//zookeeper-3.9.2.jar
-zstd-jni/1.5.6-2//zstd-jni-1.5.6-2.jar
+zstd-jni/1.5.6-3//zstd-jni-1.5.6-3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -800,7 +800,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.5.6-2</version>
+        <version>1.5.6-3</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `zstd-jni` from `1.5.6-2` to `1.5.6-3`.

### Why are the changes needed?
1.This version fix a potential memory leak problem, as follows:
<img width="927" alt="image" src="https://github.com/apache/spark/assets/15246973/eeae3e7f-0c44-443d-838b-fa39b9e45d64">

2.https://github.com/luben/zstd-jni/compare/v1.5.6-2...v1.5.6-3

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
