### PR TITLE
[SPARK-47995][PYTHON][INFRA][TESTS] Upgrade `pyarrow` to 17.0.0 in GitHub Action CI

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -89,7 +89,7 @@ RUN curl -sS https://bootstrap.pypa.io/get-pip.py | pypy3
 RUN pypy3 -m pip install numpy 'six==1.16.0' 'pandas==2.0.3' scipy coverage matplotlib lxml
 
 
-ARG BASIC_PIP_PKGS="numpy pyarrow>=15.0.0 six==1.16.0 pandas<=2.2.2 scipy plotly>=4.8 mlflow>=2.8.1 coverage matplotlib openpyxl memory-profiler>=0.61.0 scikit-learn>=1.3.2"
+ARG BASIC_PIP_PKGS="numpy pyarrow>=16.0.0 six==1.16.0 pandas<=2.2.2 scipy plotly>=4.8 mlflow>=2.8.1 coverage matplotlib openpyxl memory-profiler>=0.61.0 scikit-learn>=1.3.2"
 # Python deps for Spark Connect
 ARG CONNECT_PIP_PKGS="grpcio==1.62.0 grpcio-status==1.62.0 protobuf==4.25.1 googleapis-common-protos==1.56.4"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `pyarrow` `17.0.0` in GitHub Action CI for Apache Spark 4.0.0.

### Why are the changes needed?

- https://pypi.org/project/pyarrow/17.0.0/ (July 16)
- https://pypi.org/project/pyarrow/16.0.0/ (April 20)

Our CI is still using `15.0.2`.
- https://github.com/apache/spark/actions/runs/8836369949/job/24262819474
```
pyarrow                  15.0.2
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.