### PR TITLE
[SPARK-47999][SS] Improve logging around snapshot creation and adding/removing entries from state cache map in HDFS backed state store provider

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -438,11 +438,16 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
       newVersion: Long,
       map: HDFSBackedStateStoreMap): Unit = synchronized {
     val loadedEntries = loadedMaps.size()
-    val lastKey: Option[Long] = if (loadedEntries > 0) Some(loadedMaps.lastKey()) else None
-    if (lastKey.isDefined) {
+    val earliestLoadedVersion: Option[Long] = if (loadedEntries > 0) {
+      Some(loadedMaps.lastKey())
+    } else {
+      None
+    }
+
+    if (earliestLoadedVersion.isDefined) {
       logInfo(s"Trying to add version=$newVersion to state cache map with " +
-        s"current_size=$loadedEntries and last_loaded_version=${lastKey.get} and " +
-        s"max_versions_to_retain_in_memory=$numberOfVersionsToRetainInMemory")
+        s"current_size=$loadedEntries and earliest_loaded_version=${earliestLoadedVersion.get} " +
+        s"and max_versions_to_retain_in_memory=$numberOfVersionsToRetainInMemory")
     } else {
       logInfo(s"Trying to add version=$newVersion to state cache map with " +
         s"current_size=$loadedEntries and " +


### PR DESCRIPTION
### What changes were proposed in this pull request?
 Improve logging around snapshot creation and adding/removing entries from state cache map


### Why are the changes needed?
Sometimes we have insufficient context while debugging issues related to HDFS provider snapshot creation as well as entries kept in `loadedMaps`. This change tries to improve that

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manually verified the logs:

```
sql/core/target/unit-tests.log:3128298:14:02:56.329 pool-1-thread-1-ScalaTest-running-StateStoreSuite INFO HDFSBackedStateStoreProvider: Trying to add version=1 to state cache map with current_size=0 and max_versions_to_retain_in_memory=2
sql/core/target/unit-tests.log:3128302:14:02:56.329 pool-1-thread-1-ScalaTest-running-StateStoreSuite INFO HDFSBackedStateStoreProvider: Trying to add version=2 to state cache map with current_size=1 and last_loaded_version=1 and max_versions_to_retain_in_memory=2

sql/core/target/unit-tests.log:3127709:14:02:48.877 pool-1-thread-1-ScalaTest-running-StateStoreSuite INFO HDFSBackedStateStoreProvider: Written snapshot file for version 6 of HDFSStateStoreProvider[id = (op=37816994,part=0),dir = /Users/anish.shrigondekar/spark/spark/target/tmp/spark-d22ddc2f-b868-426c-a3d7-47995b6c9766/37816994/0] at /Users/anish.shrigondekar/spark/spark/target/tmp/spark-d22ddc2f-b868-426c-a3d7-47995b6c9766/37816994/0/6.snapshot for maintenance
sql/core/target/unit-tests.log:3127807:14:02:51.185 pool-1-thread-1-ScalaTest-running-StateStoreSuite INFO HDFSBackedStateStoreProvider: Written snapshot file for version 20 of HDFSStateStoreProvider[id = (op=37816994,part=0),dir = /Users/anish.shrigondekar/spark/spark/target/tmp/spark-d22ddc2f-b868-426c-a3d7-47995b6c9766/37816994/0] at /Users/anish.shrigondekar/spark/spark/target/tmp/spark-d22ddc2f-b868-426c-a3d7-47995b6c9766/37816994/0/20.snapshot for maintenance
```

Ran existing tests:
```
14:02:56.599 INFO org.apache.spark.util.ShutdownHookManager: Deleting directory /Users/anish.shrigondekar/spark/spark/target/tmp/spark-8b56ca8b-cb02-4895-802c-536c93251766
[info] Run completed in 2 minutes, 57 seconds.
[info] Total number of tests run: 152
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 152, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```

### Was this patch authored or co-authored using generative AI tooling?
No
