### PR TITLE
[SPARK-48001][CORE] Remove unused `private implicit def arrayToArrayWritable` from `SparkContext`

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -35,7 +35,7 @@ import scala.util.control.NonFatal
 import com.google.common.collect.MapMaker
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
-import org.apache.hadoop.io.{ArrayWritable, BooleanWritable, BytesWritable, DoubleWritable, FloatWritable, IntWritable, LongWritable, NullWritable, Text, Writable}
+import org.apache.hadoop.io.{BooleanWritable, BytesWritable, DoubleWritable, FloatWritable, IntWritable, LongWritable, NullWritable, Text, Writable}
 import org.apache.hadoop.mapred.{FileInputFormat, InputFormat, JobConf, SequenceFileInputFormat, TextInputFormat}
 import org.apache.hadoop.mapreduce.{InputFormat => NewInputFormat, Job => NewHadoopJob}
 import org.apache.hadoop.mapreduce.lib.input.{FileInputFormat => NewFileInputFormat}
@@ -3037,14 +3037,6 @@ object SparkContext extends Logging {
       throw new IllegalArgumentException(
         "Spark job tag cannot be an empty string.")
     }
-  }
-
-  private implicit def arrayToArrayWritable[T <: Writable : ClassTag](arr: Iterable[T])
-    : ArrayWritable = {
-    def anyToWritable[U <: Writable](u: U): Writable = u
-
-    new ArrayWritable(classTag[T].runtimeClass.asInstanceOf[Class[Writable]],
-        arr.map(x => anyToWritable(x)).toArray)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -28,7 +28,6 @@ import scala.collection.concurrent.{Map => ScalaConcurrentMap}
 import scala.collection.immutable
 import scala.collection.mutable.HashMap
 import scala.jdk.CollectionConverters._
-import scala.language.implicitConversions
 import scala.reflect.{classTag, ClassTag}
 import scala.util.control.NonFatal
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The private implicit function `arrayToArrayWritable` was introduced alongside other implicit functions such as `rddToPairRDDExtras`, `rddToSequencePairRDDExtras`, `intToIntWritable`, etc., in the commit https://github.com/apache/spark/commit/38f2ba99cc32584f0645f3875f051516b4b738d2. Apart from `arrayToArrayWritable`, the other implicit functions were deprecated in SPARK-4397 and SPARK-4795, and subsequently removed in SPARK-12615. `arrayToArrayWritable` remained as a leftover private implicit function from that time, but it is currently no longer being used. Therefore, this PR removes it from SparkContext.

### Why are the changes needed?
Clean up useless code.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No