### PR TITLE
[SPARK-48005][PS][CONNECT][TESTS] Enable `DefaultIndexParityTests.test_index_distributed_sequence_cleanup`

### DIFF
--- a/python/pyspark/pandas/tests/connect/indexes/test_parity_default.py
+++ b/python/pyspark/pandas/tests/connect/indexes/test_parity_default.py
@@ -26,9 +26,7 @@ class DefaultIndexParityTests(
     PandasOnSparkTestUtils,
     ReusedConnectTestCase,
 ):
-    @unittest.skip("Test depends on SparkContext which is not supported from Spark Connect.")
-    def test_index_distributed_sequence_cleanup(self):
-        super().test_index_distributed_sequence_cleanup()
+    pass
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/connect/indexes/test_parity_default.py
+++ b/python/pyspark/pandas/tests/connect/indexes/test_parity_default.py
@@ -19,6 +19,7 @@ import unittest
 from pyspark.pandas.tests.indexes.test_default import DefaultIndexTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.testing.pandasutils import PandasOnSparkTestUtils
+from pyspark.util import is_remote_only
 
 
 class DefaultIndexParityTests(
@@ -26,7 +27,9 @@ class DefaultIndexParityTests(
     PandasOnSparkTestUtils,
     ReusedConnectTestCase,
 ):
-    pass
+    @unittest.skipIf(is_remote_only(), "Requires JVM access")
+    def test_index_distributed_sequence_cleanup(self):
+        super().test_index_distributed_sequence_cleanup()
 
 
 if __name__ == "__main__":

--- a/python/pyspark/pandas/tests/indexes/test_default.py
+++ b/python/pyspark/pandas/tests/indexes/test_default.py
@@ -44,7 +44,7 @@ class DefaultIndexTestsMixin:
             "compute.default_index_type", "distributed-sequence"
         ), ps.option_context("compute.ops_on_diff_frames", True):
             with ps.option_context("compute.default_index_cache", "LOCAL_CHECKPOINT"):
-                cached_rdd_ids = [rdd_id for rdd_id in self.spark._jsc.getPersistentRDDs()]
+                cached_rdd_ids = [rdd_id for rdd_id in self._legacy_sc._jsc.getPersistentRDDs()]
 
                 psdf1 = (
                     self.spark.range(0, 100, 1, 10).withColumn("Key", F.col("id") % 33).pandas_api()
@@ -61,13 +61,13 @@ class DefaultIndexTestsMixin:
                 self.assertTrue(
                     any(
                         rdd_id not in cached_rdd_ids
-                        for rdd_id in self.spark._jsc.getPersistentRDDs()
+                        for rdd_id in self._legacy_sc._jsc.getPersistentRDDs()
                     )
                 )
 
             for storage_level in ["NONE", "DISK_ONLY_2", "MEMORY_AND_DISK_SER"]:
                 with ps.option_context("compute.default_index_cache", storage_level):
-                    cached_rdd_ids = [rdd_id for rdd_id in self.spark._jsc.getPersistentRDDs()]
+                    cached_rdd_ids = [rdd_id for rdd_id in self._legacy_sc._jsc.getPersistentRDDs()]
 
                     psdf1 = (
                         self.spark.range(0, 100, 1, 10)
@@ -86,7 +86,7 @@ class DefaultIndexTestsMixin:
                     self.assertTrue(
                         all(
                             rdd_id in cached_rdd_ids
-                            for rdd_id in self.spark._jsc.getPersistentRDDs()
+                            for rdd_id in self._legacy_sc._jsc.getPersistentRDDs()
                         )
                     )
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable `DefaultIndexParityTests. test_index_distributed_sequence_cleanup`


### Why are the changes needed?
this test requires `sc` access, can be enabled in `Spark Connect with JVM` mode


### Does this PR introduce _any_ user-facing change?
no, test only


### How was this patch tested?
ci, also manually test:
```
python/run-tests -k --python-executables python3 --testnames 'pyspark.pandas.tests.connect.indexes.test_parity_default DefaultIndexParityTests.test_index_distributed_sequence_cleanup'
Running PySpark tests. Output is in /Users/ruifeng.zheng/Dev/spark/python/unit-tests.log
Will test against the following Python executables: ['python3']
Will test the following Python tests: ['pyspark.pandas.tests.connect.indexes.test_parity_default DefaultIndexParityTests.test_index_distributed_sequence_cleanup']
python3 python_implementation is CPython
python3 version is: Python 3.12.2
Starting test(python3): pyspark.pandas.tests.connect.indexes.test_parity_default DefaultIndexParityTests.test_index_distributed_sequence_cleanup (temp output: /Users/ruifeng.zheng/Dev/spark/python/target/ccd3da45-f774-4f5f-8283-a91a8ee12212/python3__pyspark.pandas.tests.connect.indexes.test_parity_default_DefaultIndexParityTests.test_index_distributed_sequence_cleanup__p9yved3e.log)
Finished test(python3): pyspark.pandas.tests.connect.indexes.test_parity_default DefaultIndexParityTests.test_index_distributed_sequence_cleanup (16s)
Tests passed in 16 seconds
```


### Was this patch authored or co-authored using generative AI tooling?
no