### PR TITLE
[SPARK-48006][SQL]add SortOrder for window function which has no orde…

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2432,7 +2432,7 @@ class AstBuilder extends DataTypeAstBuilder with SQLConfHelper with Logging {
   override def visitWindowDef(ctx: WindowDefContext): WindowSpecDefinition = withOrigin(ctx) {
     // CLUSTER BY ... | PARTITION BY ... ORDER BY ...
     val partition = ctx.partition.asScala.map(expression)
-    val order = ctx.sortItem.asScala.map(visitSortItem)
+    var order = ctx.sortItem.asScala.map(visitSortItem)
 
     // Add SortOrder for window expresssion
     if (ctx.sortItem.asScala.isEmpty && conf.hiveWindowFunctionOrderSpec) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2434,6 +2434,13 @@ class AstBuilder extends DataTypeAstBuilder with SQLConfHelper with Logging {
     val partition = ctx.partition.asScala.map(expression)
     val order = ctx.sortItem.asScala.map(visitSortItem)
 
+    // Add SortOrder for window expresssion
+    if (ctx.sortItem.asScala.isEmpty && conf.hiveWindowFunctionOrderSpec) {
+      order = ctx.partition.asScala.map { expr =>
+        SortOrder(expression(expr), Ascending, Ascending.defaultNullOrdering, Seq.empty)
+      }
+    }
+
     // RANGE/ROWS BETWEEN ...
     val frameSpecOption = Option(ctx.windowFrame).map { frame =>
       val frameType = frame.frameType.getType match {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2564,6 +2564,18 @@ object SQLConf {
       .intConf
       .createWithDefault(10)
 
+  val HIVE_WINDOW_FUNCTION_ORDER_SPEC =
+    buildConf("spark.sql.hive.window.function.orderSpec")
+      .internal()
+      .doc("Whether to add order expression for window function.The parser requires window to be" +
+        " ordered otherwise throw analyzed exception. When true, it will add order partition " +
+        "for  window function which has no orderSpec.")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(false)
+
+
+
   val FILE_SOURCE_LOG_CLEANUP_DELAY =
     buildConf("spark.sql.streaming.fileSource.log.cleanupDelay")
       .internal()
@@ -5043,6 +5055,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def fileSourceLogDeletion: Boolean = getConf(FILE_SOURCE_LOG_DELETION)
 
   def fileSourceLogCompactInterval: Int = getConf(FILE_SOURCE_LOG_COMPACT_INTERVAL)
+
+  def hiveWindowFunctionOrderSpec: Boolean = getConf(HIVE_WINDOW_FUNCTION_ORDER_SPEC)
 
   def fileSourceLogCleanupDelay: Long = getConf(FILE_SOURCE_LOG_CLEANUP_DELAY)
 


### PR DESCRIPTION


### What changes were proposed in this pull request?
I am doing Hive SQL to switch to Spark SQL.

 

In Hive SQL

 

hive> explain select *,row_number() over (partition by day) rn from testdb.zeropart_db;

OK
Explain

 

In Spark SQL

spark-sql> explain select *,row_number() over (partition by age ) rn  from testdb.zeropart_db;

plan

== Physical Plan ==

org.apache.spark.sql.AnalysisException: Window function row_number() requires window to be ordered, please add ORDER BY clause. For example SELECT row_number()(value_expr) OVER (PARTITION BY window_partition ORDER BY window_ordering) from table

Time taken: 0.172 seconds, Fetched 1 row(s)

 

For better compatibility with migration. For better compatibility with migration, new parameters are added to ensure compatibility with the same behavior as Hive SQL


### Why are the changes needed?
For better compatibility with migration. 


### Does this PR introduce _any_ user-facing change?
before this pr：

spark-sql> explain select *,row_number() over (partition by age ) rn  from testdb.zeropart_db;

plan

== Physical Plan ==

org.apache.spark.sql.AnalysisException: Window function row_number() requires window to be ordered, please add ORDER BY clause. For example SELECT row_number()(value_expr) OVER (PARTITION BY window_partition ORDER BY window_ordering) from table

Time taken: 0.172 seconds, Fetched 1 row(s)

after this pr：

spark-sql> explain select *,row_number() over (partition by age ) rn  from testdb.zeropart_db;
plan
== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=false
+- Window [row_number() windowspecdefinition(age#37, age#37 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#30], [age#37], [age#37 ASC NULLS FIRST]
   +- Sort [age#37 ASC NULLS FIRST, age#37 ASC NULLS FIRST], false, 0
      +- Exchange hashpartitioning(age#37, 1000), ENSURE_REQUIREMENTS, [id=#53]
         +- Scan hive testdb.zeropart_db [age#37, sex#38, name#39, day#40], HiveTableRelation [`bigdata_qa`.`zeropart_db`, org.apache.hadoop.hive.ql.io.orc.OrcSerde, Data Cols: [age#37, sex#38, name#39], Partition Cols: [day#40]]


Time taken: 0.154 seconds, Fetched 1 row(s)





### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
