### PR TITLE
[SPARK-48233][SS][TESTS] Tests for streaming on columns with non-default collations

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationSuite.scala
@@ -20,12 +20,14 @@ package org.apache.spark.sql.streaming
 import java.io.File
 
 import org.apache.commons.io.FileUtils
+import org.apache.spark.SparkUnsupportedOperationException
 
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes._
 import org.apache.spark.sql.execution.streaming.MemoryStream
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.StringType
 import org.apache.spark.tags.SlowSQLTest
 import org.apache.spark.util.Utils
 
@@ -482,6 +484,50 @@ class StreamingDeduplicationSuite extends StateStoreMetricsTest {
 
       AddData(inputData, ("a", 5, "a"), ("b", 2, "b"), ("c", 9, "c")),
       CheckLastBatch(("c", 9, "c"))
+    )
+  }
+
+  test("collation aware deduplication") {
+    val inputData = MemoryStream[(String, Int)]
+    val result = inputData.toDF()
+      .select(col("_1")
+        .try_cast(StringType("UNICODE")).as("str"),
+        col("_2").as("int"))
+      .dropDuplicates("str")
+
+    testStream(result, Append)(
+      AddData(inputData, "a" -> 1),
+      CheckLastBatch("a" -> 1),
+      assertNumStateRows(total = 1, updated = 1, droppedByWatermark = 0),
+      AddData(inputData, "a" -> 2), // Dropped
+      CheckLastBatch(),
+      assertNumStateRows(total = 1, updated = 0, droppedByWatermark = 0),
+      AddData(inputData, "ä" -> 1),
+      CheckLastBatch("ä" -> 1),
+      assertNumStateRows(total = 2, updated = 1, droppedByWatermark = 0)
+    )
+  }
+
+  test("non-binary collation aware deduplication not supported") {
+    val inputData = MemoryStream[(String)]
+    val result = inputData.toDF()
+      .select(col("value")
+        .try_cast(StringType("UTF8_BINARY_LCASE")).as("str"))
+      .dropDuplicates("str")
+
+    val ex = intercept[StreamingQueryException] {
+      testStream(result, Append)(
+        AddData(inputData, "a"),
+        CheckLastBatch("a"))
+    }
+
+    checkError(
+      ex.getCause.asInstanceOf[SparkUnsupportedOperationException],
+      errorClass = "STATE_STORE_UNSUPPORTED_OPERATION_BINARY_INEQUALITY",
+      parameters = Map(
+        "schema" -> ".+\"type\":\"string collate UTF8_BINARY_LCASE\".+"
+      ),
+      matchPVals = true
     )
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingDeduplicationSuite.scala
@@ -20,8 +20,8 @@ package org.apache.spark.sql.streaming
 import java.io.File
 
 import org.apache.commons.io.FileUtils
-import org.apache.spark.SparkUnsupportedOperationException
 
+import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes._
 import org.apache.spark.sql.execution.streaming.MemoryStream
@@ -502,8 +502,10 @@ class StreamingDeduplicationSuite extends StateStoreMetricsTest {
       AddData(inputData, "a" -> 2), // Dropped
       CheckLastBatch(),
       assertNumStateRows(total = 1, updated = 0, droppedByWatermark = 0),
+      // scalastyle:off
       AddData(inputData, "ä" -> 1),
       CheckLastBatch("ä" -> 1),
+      // scalastyle:on
       assertNumStateRows(total = 2, updated = 1, droppedByWatermark = 0)
     )
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -53,7 +53,6 @@ import org.apache.spark.sql.streaming.util.{BlockingSource, MockSourceProvider, 
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.tags.SlowSQLTest
 
-//noinspection ScalaStyle
 @SlowSQLTest
 class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging with MockitoSugar {
 
@@ -1382,12 +1381,14 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
       testStream(filteredDf)(
         StartStream(triggerClock = clock, trigger = Trigger.ProcessingTime(100)),
         Execute { _ =>
-          spark.createDataFrame(Seq("aaa" -> 1, "AAA" -> 2, "bbb" -> 3, "aa" -> 4)).toDF("key", "value_stream")
-            .write.format("parquet").mode(SaveMode.Append).saveAsTable("parquet_streaming_tbl")
+          spark.createDataFrame(Seq("aaa" -> 1, "AAA" -> 2, "bbb" -> 3, "aa" -> 4))
+            .toDF("key", "value_stream")
+            .write.format("parquet").mode(SaveMode.Append)
+            .saveAsTable("parquet_streaming_tbl")
         },
         AdvanceManualClock(150),
         waitUntilBatchProcessed(clock),
-        CheckLastBatch(("aaa", 1), ("AAA", 2)),
+        CheckLastBatch(("aaa", 1), ("AAA", 2))
       )
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This change covers tests for streaming operations under columns of string type that are collated with non-utf8-binary collations. PR introduces following tests:
1) Non-stateful streaming for non-binary collated columns. We use `UTF8_BINARY_LCASE` non-binary collation as the input and assert that streaming propagates collation and that filtering behaves under rules of given collation.
2) Stateful streaming for binary collations. We use `UNICODE` collation as source and make sure that stateful operations (deduplication as taken as the example) work.
3) More tests that assert that stateful operations in combination with non-binary collations throw proper exception.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
You can find more information about collation effort in document attached to root jira ticket.

This PR adds tests for basic non-stateful streaming operations with collations (e.g. filtering).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
PR is test only.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No