### PR TITLE
[SPARK-48018][SS] Fix null groupId causing missing param error when throwing KafkaException.couldNotReadOffsetRange

### DIFF
--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaExceptions.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaExceptions.scala
@@ -97,7 +97,7 @@ object KafkaExceptions {
         "startOffset" -> startOffset.toString,
         "endOffset" -> endOffset.toString,
         "topicPartition" -> topicPartition.toString,
-        "groupId" -> groupId),
+        "groupId" -> Option(groupId).getOrElse("null")),
       cause = cause)
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix:
[INTERNAL_ERROR] Undefined error message parameter for error class: 'KAFKA_DATA_LOSS.COULD_NOT_READ_OFFSET_RANGE'

This happens when groupId is null when we are about to throw KafkaException.couldNotReadOffsetRange error. The error framework requires all params to be non-null.


### Why are the changes needed?
fix error


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
existing


### Was this patch authored or co-authored using generative AI tooling?
No
