### PR TITLE
[SPARK-48020][INFRA][PYTHON] Pin 'pandas==2.2.2'

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -86,10 +86,10 @@ RUN mkdir -p /usr/local/pypy/pypy3.9 && \
     ln -sf /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3.8 && \
     ln -sf /usr/local/pypy/pypy3.9/bin/pypy /usr/local/bin/pypy3
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | pypy3
-RUN pypy3 -m pip install numpy 'six==1.16.0' 'pandas==2.0.3' scipy coverage matplotlib lxml
+RUN pypy3 -m pip install numpy 'six==1.16.0' 'pandas==2.2.2' scipy coverage matplotlib lxml
 
 
-ARG BASIC_PIP_PKGS="numpy pyarrow>=15.0.0 six==1.16.0 pandas<=2.2.2 scipy plotly>=4.8 mlflow>=2.8.1 coverage matplotlib openpyxl memory-profiler>=0.61.0 scikit-learn>=1.3.2"
+ARG BASIC_PIP_PKGS="numpy pyarrow>=15.0.0 six==1.16.0 pandas==2.2.2 scipy plotly>=4.8 mlflow>=2.8.1 coverage matplotlib openpyxl memory-profiler>=0.61.0 scikit-learn>=1.3.2"
 # Python deps for Spark Connect
 ARG CONNECT_PIP_PKGS="grpcio==1.62.0 grpcio-status==1.62.0 protobuf==4.25.1 googleapis-common-protos==1.56.4"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, pin 'pandas==2.2.2' for `pypy3.9`
2, also change `pandas<=2.2.2` to 'pandas==2.2.2' to avoid unexpected version installation (e.g. for pypy3.8 `pandas<=2.2.2` actually installs version 2.0.3)

### Why are the changes needed?
pypy had been upgraded


### Does this PR introduce _any_ user-facing change?
no, test only


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no