### PR TITLE
[SPARK-48024][PYTHON][CONNECT][TESTS] Enable `UDFParityTests.test_udf_timestamp_ntz`

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_udf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udf.py
@@ -44,10 +44,6 @@ class UDFParityTests(BaseUDFTestsMixin, ReusedConnectTestCase):
     def test_same_accumulator_in_udfs(self):
         super().test_same_accumulator_in_udfs()
 
-    @unittest.skip("Spark Connect does not support spark.conf but the test depends on it.")
-    def test_udf_timestamp_ntz(self):
-        super().test_udf_timestamp_ntz()
-
     @unittest.skip("Spark Connect does not support broadcast but the test depends on it.")
     def test_broadcast_in_udf(self):
         super().test_broadcast_in_udf()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable `UDFParityTests.test_udf_timestamp_ntz`


### Why are the changes needed?
for test coverage


### Does this PR introduce _any_ user-facing change?
no, test only


### How was this patch tested?
ci and manually test:
```
(spark_dev_312) ➜  spark git:(master) ✗ python/run-tests -k --python-executables python3 --testnames 'pyspark.sql.tests.connect.test_parity_udf UDFParityTests.test_udf_timestamp_ntz'
Running PySpark tests. Output is in /Users/ruifeng.zheng/Dev/spark/python/unit-tests.log
Will test against the following Python executables: ['python3']
Will test the following Python tests: ['pyspark.sql.tests.connect.test_parity_udf UDFParityTests.test_udf_timestamp_ntz']
python3 python_implementation is CPython
python3 version is: Python 3.12.2
Starting test(python3): pyspark.sql.tests.connect.test_parity_udf UDFParityTests.test_udf_timestamp_ntz (temp output: /Users/ruifeng.zheng/Dev/spark/python/target/90afedde-8472-496c-8741-a3fd5792f6e2/python3__pyspark.sql.tests.connect.test_parity_udf_UDFParityTests.test_udf_timestamp_ntz__7yrowv9l.log)
Finished test(python3): pyspark.sql.tests.connect.test_parity_udf UDFParityTests.test_udf_timestamp_ntz (10s)
Tests passed in 10 seconds
```


### Was this patch authored or co-authored using generative AI tooling?
no