### PR TITLE
[SPARK-48021][ML][BUILD][FOLLOWUP] add `--add-modules=jdk.incubator.vector` to maven compile args

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,6 +304,7 @@
     <!-- SPARK-36796 for JDK-17 test-->
     <extraJavaTestArgs>
       -XX:+IgnoreUnrecognizedVMOptions
+      --add-modules=jdk.incubator.vector
       --add-opens=java.base/java.lang=ALL-UNNAMED
       --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
       --add-opens=java.base/java.lang.reflect=ALL-UNNAMED


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr is following up https://github.com/apache/spark/pull/46246
The pr aims to  add `--add-modules=jdk.incubator.vector` to maven `compile args`.

### Why are the changes needed?
As commented by @LuciferYang , we need to be consistent in `maven` compile.
https://github.com/apache/spark/pull/46246#issuecomment-2081298219
<img width="907" alt="image" src="https://github.com/apache/spark/assets/15246973/26163da2-f27d-4ec2-893f-d9282b68aec1">

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
No.
