### PR TITLE
[SPARK-47933][CONNECT][PYTHON][FOLLOW-UP] Remove `pyspark.sql.classic` reference in `pyspark.ml.stat`

### DIFF
--- a/python/pyspark/ml/stat.py
+++ b/python/pyspark/ml/stat.py
@@ -23,7 +23,6 @@ from pyspark.ml.common import _java2py, _py2java
 from pyspark.ml.linalg import Matrix, Vector
 from pyspark.ml.wrapper import JavaWrapper, _jvm
 from pyspark.sql.column import Column
-from pyspark.sql.classic.column import _to_seq
 from pyspark.sql.dataframe import DataFrame
 from pyspark.sql.functions import lit
 
@@ -432,6 +431,7 @@ class Summarizer:
         :py:class:`pyspark.ml.stat.SummaryBuilder`
         """
         from pyspark.core.context import SparkContext
+        from pyspark.sql.classic.column import _to_seq
 
         sc = SparkContext._active_spark_context
         assert sc is not None


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/46155 that removes the reference of `_to_seq` that `pyspark-connect` package does not have.

### Why are the changes needed?

To recover the CI https://github.com/apache/spark/actions/runs/8861971303

### Does this PR introduce _any_ user-facing change?

No, the main change has not been released out yet.

### How was this patch tested?

Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.
