### PR TITLE
[SPARK-48036][DOCS] Update `sql-ref-ansi-compliance.md` and `sql-ref-identifier.md`

### DIFF
--- a/docs/sql-ref-ansi-compliance.md
+++ b/docs/sql-ref-ansi-compliance.md
@@ -26,7 +26,7 @@ By default, `spark.sql.ansi.enabled` is `true` and Spark SQL uses an ANSI compli
 Moreover, Spark SQL has an independent option to control implicit casting behaviours when inserting rows in a table.
 The casting behaviours are defined as store assignment rules in the standard.
 
-When `spark.sql.storeAssignmentPolicy` is set to `ANSI`, Spark SQL complies with the ANSI store assignment rules. This is a separate configuration because its default value is `ANSI`, while the configuration `spark.sql.ansi.enabled` is disabled by default.
+By default, `spark.sql.storeAssignmentPolicy` is `ANSI` and Spark SQL complies with the ANSI store assignment rules.
 
 <table class="spark-config">
 <thead><tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr></thead>
@@ -67,10 +67,8 @@ The following subsections present behaviour changes in arithmetic operations, ty
 
 ### Arithmetic Operations
 
-In Spark SQL, arithmetic operations performed on numeric types (with the exception of decimal) are not checked for overflows by default.
-This means that in case an operation causes overflows, the result is the same with the corresponding operation in a Java/Scala program (e.g., if the sum of 2 integers is higher than the maximum value representable, the result is a negative number).
-On the other hand, Spark SQL returns null for decimal overflows.
-When `spark.sql.ansi.enabled` is set to `true` and an overflow occurs in numeric and interval arithmetic operations, it throws an arithmetic exception at runtime.
+In Spark SQL, by default, Spark throws an artithmetic exception at runtime for non-decimal numeric overflows and returns null for decimal type overflows.
+If `spark.sql.ansi.enabled` is set to `false`, the result is the same with the corresponding operation in a Java/Scala program (e.g., if the sum of 2 integers is higher than the maximum value representable, the result is a negative number) which is the behavior of Spark 3 or older.
 
 ```sql
 -- `spark.sql.ansi.enabled=true`

--- a/docs/sql-ref-ansi-compliance.md
+++ b/docs/sql-ref-ansi-compliance.md
@@ -67,8 +67,8 @@ The following subsections present behaviour changes in arithmetic operations, ty
 
 ### Arithmetic Operations
 
-In Spark SQL, by default, Spark throws an artithmetic exception at runtime for non-decimal numeric overflows and returns null for decimal type overflows.
-If `spark.sql.ansi.enabled` is set to `false`, the result is the same with the corresponding operation in a Java/Scala program (e.g., if the sum of 2 integers is higher than the maximum value representable, the result is a negative number) which is the behavior of Spark 3 or older.
+In Spark SQL, by default, Spark throws an arithmetic exception at runtime for both interval and numeric type overflows.
+If `spark.sql.ansi.enabled` is `false`, then the decimal type will produce `null` values and other numeric types will behave in the same way as the corresponding operation in a Java/Scala program (e.g., if the sum of 2 integers is higher than the maximum value representable, the result is a negative number) which is the behavior of Spark 3 or older.
 
 ```sql
 -- `spark.sql.ansi.enabled=true`

--- a/docs/sql-ref-ansi-compliance.md
+++ b/docs/sql-ref-ansi-compliance.md
@@ -21,7 +21,7 @@ license: |
 
 In Spark SQL, there are two options to comply with the SQL standard: `spark.sql.ansi.enabled` and `spark.sql.storeAssignmentPolicy` (See a table below for details).
 
-When `spark.sql.ansi.enabled` is set to `true`, Spark SQL uses an ANSI compliant dialect instead of being Hive compliant. For example, Spark will throw an exception at runtime instead of returning null results if the inputs to a SQL operator/function are invalid. Some ANSI dialect features may be not from the ANSI SQL standard directly, but their behaviors align with ANSI SQL's style.
+By default, `spark.sql.ansi.enabled` is `true` and Spark SQL uses an ANSI compliant dialect instead of being Hive compliant. For example, Spark will throw an exception at runtime instead of returning null results if the inputs to a SQL operator/function are invalid. Some ANSI dialect features may be not from the ANSI SQL standard directly, but their behaviors align with ANSI SQL's style.
 
 Moreover, Spark SQL has an independent option to control implicit casting behaviours when inserting rows in a table.
 The casting behaviours are defined as store assignment rules in the standard.
@@ -32,7 +32,7 @@ When `spark.sql.storeAssignmentPolicy` is set to `ANSI`, Spark SQL complies with
 <thead><tr><th>Property Name</th><th>Default</th><th>Meaning</th><th>Since Version</th></tr></thead>
 <tr>
   <td><code>spark.sql.ansi.enabled</code></td>
-  <td>false</td>
+  <td>true</td>
   <td>
     When true, Spark tries to conform to the ANSI SQL specification: <br/>
     1. Spark SQL will throw runtime exceptions on invalid operations, including integer overflow
@@ -393,7 +393,7 @@ With the default parser, Spark SQL has two kinds of keywords:
 * Non-reserved keywords: Same definition as the one when the ANSI mode enabled.
 * Strict-non-reserved keywords: A strict version of non-reserved keywords, which can not be used as table alias.
 
-By default, both `spark.sql.ansi.enabled` and `spark.sql.ansi.enforceReservedKeywords` are false.
+By default, `spark.sql.ansi.enforceReservedKeywords` is false.
 
 Below is a list of all the keywords in Spark SQL.
 

--- a/docs/sql-ref-identifier.md
+++ b/docs/sql-ref-identifier.md
@@ -30,7 +30,7 @@ An identifier is a string used to identify a database object such as a table, vi
 ```sql
 { letter | digit | '_' } [ , ... ]
 ```
-**Note:** If `spark.sql.ansi.enabled` is set to true, ANSI SQL reserved keywords cannot be used as identifiers. For more details, please refer to [ANSI Compliance](sql-ref-ansi-compliance.html).
+**Note:** If `spark.sql.ansi.enforceReservedKeywords` is set to true, ANSI SQL reserved keywords cannot be used as identifiers. For more details, please refer to [ANSI Compliance](sql-ref-ansi-compliance.html).
 
 #### Delimited Identifier
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `sql-ref-ansi-compliance.md` and `sql-ref-identifier.md`.

### Why are the changes needed?

- Since SPARK-44444, `spark.sql.ansi.enabled` is `true`.
  - 46013
- Apache Spark uses `spark.sql.ansi.enforceReservedKeywords` to enforce `ANSI SQL reserved keywords` instead of `spark.sql.ansi.enabled`.

### Does this PR introduce _any_ user-facing change?

No, this is only a documentation fix.

### How was this patch tested?

Manual review.

<img width="903" alt="Screenshot 2024-04-28 at 21 56 28" src="https://github.com/apache/spark/assets/9700541/91ab3d99-3c44-488d-a5cf-10231548c586">
<img width="898" alt="Screenshot 2024-04-28 at 21 56 42" src="https://github.com/apache/spark/assets/9700541/37cd6906-524b-41ce-9e67-9ce0a6ff2f93">
<img width="908" alt="Screenshot 2024-04-28 at 21 57 07" src="https://github.com/apache/spark/assets/9700541/12458ea7-17c6-428f-8e65-8f591c2e55fc">


### Was this patch authored or co-authored using generative AI tooling?

No.