### PR TITLE
[MINOR][DOCS] Remove space in the middle of configuration name in Arrow-optimized Python UDF page

### DIFF
--- a/python/docs/source/user_guide/sql/arrow_pandas.rst
+++ b/python/docs/source/user_guide/sql/arrow_pandas.rst
@@ -339,9 +339,9 @@ Arrow Python UDFs
 Arrow Python UDFs are user defined functions that are executed row-by-row, utilizing Arrow for efficient batch data
 transfer and serialization. To define an Arrow Python UDF, you can use the :meth:`udf` decorator or wrap the function
 with the :meth:`udf` method, ensuring the ``useArrow`` parameter is set to True. Additionally, you can enable Arrow
-optimization for Python UDFs throughout the entire SparkSession by setting the Spark configuration ``spark.sql
-.execution.pythonUDF.arrow.enabled`` to true. It's important to note that the Spark configuration takes effect only
-when ``useArrow`` is either not set or set to None.
+optimization for Python UDFs throughout the entire SparkSession by setting the Spark configuration
+``spark.sql.execution.pythonUDF.arrow.enabled`` to true. It's important to note that the Spark configuration takes
+effect only when ``useArrow`` is either not set or set to None.
 
 The type hints for Arrow Python UDFs should be specified in the same way as for default, pickled Python UDFs.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes a space in the middle of configuration name in Arrow-optimized Python UDF page.

![Screenshot 2024-04-29 at 1 53 42 PM](https://github.com/apache/spark/assets/6477701/46b7c448-fb30-4838-a5ba-c8f1c23398fd)

https://spark.apache.org/docs/latest/api/python/user_guide/sql/arrow_pandas.html#arrow-python-udfs

### Why are the changes needed?

So users can copy and paste the configuration names properly.

### Does this PR introduce _any_ user-facing change?

Yes it fixes the doc.

### How was this patch tested?

Manually built the docs, and checked.

### Was this patch authored or co-authored using generative AI tooling?

No.