### PR TITLE
[SPARK-48002][PYTHON][SS][TESTS] Adds sleep before event testing after query termination

### DIFF
--- a/python/pyspark/sql/tests/streaming/test_streaming_listener.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_listener.py
@@ -232,6 +232,8 @@ class StreamingListenerTestsMixin:
             while q.lastProgress is None or q.lastProgress["batchId"] == 0:
                 q.awaitTermination(0.5)
 
+            time.sleep(5)
+
             self.assertTrue(error_listener.num_rows > 0)
             self.assertTrue(error_listener.num_error_rows > 0)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/46237 that makes to wait 5 secs after the query termination to make sure the events arrive.

### Why are the changes needed?

To deflake the test. It's flaky (https://github.com/apache/spark/actions/runs/8873809388/job/24360221027)

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.
