### PR TITLE
[SPARK-48039][PYTHON][CONNECT] Update the error class for `group.apply`

### DIFF
--- a/python/pyspark/sql/pandas/group_ops.py
+++ b/python/pyspark/sql/pandas/group_ops.py
@@ -18,7 +18,7 @@ import sys
 from typing import List, Union, TYPE_CHECKING, cast
 import warnings
 
-from pyspark.errors import PySparkValueError
+from pyspark.errors import PySparkTypeError
 from pyspark.util import PythonEvalType
 from pyspark.sql.column import Column
 from pyspark.sql.dataframe import DataFrame
@@ -100,11 +100,9 @@ class PandasGroupedOpsMixin:
                 != PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF
             )
         ):
-            raise PySparkValueError(
-                error_class="INVALID_PANDAS_UDF",
-                message_parameters={
-                    "detail": "the udf argument must be a pandas_udf of type GROUPED_MAP."
-                },
+            raise PySparkTypeError(
+                error_class="INVALID_UDF_EVAL_TYPE",
+                message_parameters={"eval_type": "SQL_GROUPED_MAP_PANDAS_UDF"},
             )
 
         warnings.warn(

--- a/python/pyspark/sql/tests/connect/test_parity_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_grouped_map.py
@@ -31,10 +31,6 @@ class GroupedApplyInPandasTests(GroupedApplyInPandasTestsMixin, ReusedConnectTes
         super().test_wrong_return_type()
 
     @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_wrong_args(self):
-        super().test_wrong_args()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
     def test_unsupported_types(self):
         super().test_unsupported_types()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update the error class for `group.apply`



### Why are the changes needed?
https://github.com/apache/spark/commit/eae91ee3c96b6887581e59821d905b8ea94f6bc0 introduced a dedicated error class `INVALID_UDF_EVAL_TYPE` for `group.apply`, but only used it in Spark Connect.

This PR uses this error class in Spark Classic, to make it consistent. And also enable a parity test `GroupedApplyInPandasTests.test_wrong_args `


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no