### PR TITLE
[SPARK-48040][CONNECT][WIP]Spark connect supports scheduler pool

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -809,6 +809,33 @@ class SparkSession private[sql] (
   }
 
   /**
+   * Set the scheduler pool used to execute all the operations by this thread in this session.
+   *
+   * Spark supports FIFO scheduler (default) and Fair scheduler. When fair scheduler is enabled,
+   * jobs will be grouped into pools and each pool gets an assigned share of cluster resources.
+   * Application programmers can use this method to assign a pool to all the operations started
+   * by this thread in this session. This pool should exists in the server. If not, will
+   * fallback to FIFO scheduler.
+   *
+   * Note: this doesn't make sense for FIFO scheduler.
+   *
+   * @param pool
+   *   The scheduler pool name. Cannot be an empty string.
+   *
+   * @since 4.0.0
+   */
+  def setSchedulerPool(pool: String): Unit = {
+    client.setSchedulerPool(pool)
+  }
+
+  /**
+   * Clear the current thread's scheduler pool. After cleared, default scheduler pool will be used.
+   */
+  def clearSchedulerPool(): Unit = {
+    client.clearSchedulerPool()
+  }
+
+  /**
    * We cannot deserialize a connect [[SparkSession]] because of a class clash on the server side.
    * We null out the instance for now.
    */

--- a/connector/connect/common/src/main/protobuf/spark/connect/base.proto
+++ b/connector/connect/common/src/main/protobuf/spark/connect/base.proto
@@ -94,6 +94,7 @@ message AnalyzePlanRequest {
     Persist persist = 14;
     Unpersist unpersist = 15;
     GetStorageLevel get_storage_level = 16;
+    SchedulingMode scheduler_mode = 18;
   }
 
   message Schema {
@@ -199,6 +200,8 @@ message AnalyzePlanRequest {
     // (Required) The logical plan to get the storage level.
     Relation relation = 1;
   }
+
+  message SchedulingMode {}
 }
 
 // Response to performing analysis of the query. Contains relevant metadata to be able to
@@ -224,6 +227,7 @@ message AnalyzePlanResponse {
     Persist persist = 12;
     Unpersist unpersist = 13;
     GetStorageLevel get_storage_level = 14;
+    SchedulingMode scheduling_mode = 16;
   }
 
   message Schema {
@@ -274,6 +278,22 @@ message AnalyzePlanResponse {
   message GetStorageLevel {
     // (Required) The StorageLevel as a result of get_storage_level request.
     StorageLevel storage_level = 1;
+  }
+
+  message SchedulingMode {
+    // (Required) mode is "FIFO" or "FAIR"
+    string mode = 1;
+    // (Optional) if mode is "FIFO", pools should be empty
+    repeated SchedulablePool pools = 2;
+
+    message SchedulablePool {
+      // (Required) pool name
+      string name = 1;
+      // (Required) mode is "FIFO" or "FAIR"
+      string scheduling_mode = 2;
+      int32 weight = 3;
+      int32 min_share = 4;
+    }
   }
 }
 

--- a/connector/connect/common/src/main/protobuf/spark/connect/base.proto
+++ b/connector/connect/common/src/main/protobuf/spark/connect/base.proto
@@ -329,6 +329,11 @@ message ExecutePlanRequest {
   // Tags cannot contain ',' character and cannot be empty strings.
   // Used by Interrupt with interrupt.tag.
   repeated string tags = 7;
+
+  // (Optional)
+  // Scheduler pool to execute this query when server runs in fair-scheduler fashion.
+  // This field doesn't make sense for FIFO scheduler.
+  optional string scheduler_pool = 9;
 }
 
 // The response of a query, can be one or more for each request. Responses belonging to the

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SchedulingMode.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SchedulingMode.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.client
+
+/**
+ * Scheduler the remote server is running to schedule tasks.
+ *
+ * Note: The spark connect client cannot change the scheduling mode.
+ *
+ * @param mode
+ *   FIFO or FAIR.
+ * @param pools
+ *   Tasks will be enqueued into these pools.
+ */
+class SchedulingMode(val mode: SchedulingMode.Mode, val pools: Seq[SchedulerPool]) {
+  /**
+   * Return the pool associated with the given name, if noe exists.
+   */
+  def getPoolForName(pool: String): Option[SchedulerPool] = {
+    pools.find(_.name == pool)
+  }
+}
+
+/**
+ * Spark support FIFO and FAIR scheduler, the former will queue up tasks behind each other, the
+ * latter will share the pool's resources fairly. The FAIR scheduler also supports grouping jobs
+ * into pools and setting different scheduling options (e.g. weight) for each pool.
+ */
+object SchedulingMode extends Enumeration {
+  type Mode = Value
+  val FAIR, FIFO = Value
+}
+
+/**
+ * Schedulable pool for tasks.
+ *
+ * Note: The spark connect client cannot create a new pool, but can choose which pool to run jobs.
+ *
+ * @param name
+ *   Pool name.
+ * @param mode
+ *   FIFO or FAIR.
+ * @param weight
+ *   Pool's share of the cluster relative to other pools.
+ * @param minShare
+ *   A pool can always get up to minShare number of resources.
+ */
+case class SchedulerPool(name: String, mode: SchedulingMode.Mode, weight: Int, minShare: Int)

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteThreadRunner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteThreadRunner.scala
@@ -177,7 +177,7 @@ private[connect] class ExecuteThreadRunner(executeHolder: ExecuteHolder) extends
         s"Spark Connect - ${StringUtils.abbreviate(debugString, 128)}")
       session.sparkContext.setInterruptOnCancel(true)
 
-      executeHolder.schedulerPool.foreach{pool =>
+      executeHolder.schedulerPool.foreach { pool =>
         session.sparkContext.setLocalProperty(SparkContext.SPARK_SCHEDULER_POOL, pool)
       }
 

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteThreadRunner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteThreadRunner.scala
@@ -177,9 +177,8 @@ private[connect] class ExecuteThreadRunner(executeHolder: ExecuteHolder) extends
         s"Spark Connect - ${StringUtils.abbreviate(debugString, 128)}")
       session.sparkContext.setInterruptOnCancel(true)
 
-      executeHolder.schedulerPool.foreach { pool =>
-        session.sparkContext.setLocalProperty(SparkContext.SPARK_SCHEDULER_POOL, pool)
-      }
+      session.sparkContext
+        .setLocalProperty(SparkContext.SPARK_SCHEDULER_POOL, executeHolder.schedulerPool.orNull)
 
       // Add debug information to the query execution so that the jobs are traceable.
       session.sparkContext.setLocalProperty(

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteThreadRunner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/ExecuteThreadRunner.scala
@@ -25,7 +25,7 @@ import scala.util.control.NonFatal
 import com.google.protobuf.Message
 import org.apache.commons.lang3.StringUtils
 
-import org.apache.spark.SparkSQLException
+import org.apache.spark.{SparkContext, SparkSQLException}
 import org.apache.spark.connect.proto
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.connect.common.ProtoUtils
@@ -176,6 +176,10 @@ private[connect] class ExecuteThreadRunner(executeHolder: ExecuteHolder) extends
       session.sparkContext.setJobDescription(
         s"Spark Connect - ${StringUtils.abbreviate(debugString, 128)}")
       session.sparkContext.setInterruptOnCancel(true)
+
+      executeHolder.schedulerPool.foreach{pool =>
+        session.sparkContext.setLocalProperty(SparkContext.SPARK_SCHEDULER_POOL, pool)
+      }
 
       // Add debug information to the query execution so that the jobs are traceable.
       session.sparkContext.setLocalProperty(

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
@@ -75,6 +75,19 @@ private[connect] class ExecuteHolder(
     .toSet
 
   /**
+   * If pool is set, the Spark jobs ran this execution will be submitted to this pool. If
+   * not set, default pool will be used.
+   */
+  val schedulerPool: Option[String] = if (request.hasSchedulerPool) {
+    if (request.getSchedulerPool.isEmpty) {
+      throw new IllegalArgumentException("Spark scheduler pool cannot be empty.")
+    }
+    Some(request.getSchedulerPool)
+  } else {
+    None
+  }
+
+  /**
    * If execution is reattachable, it's life cycle is not limited to a single ExecutePlanRequest,
    * but can be reattached with ReattachExecute, and released with ReleaseExecute
    */

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/ExecuteHolder.scala
@@ -75,8 +75,8 @@ private[connect] class ExecuteHolder(
     .toSet
 
   /**
-   * If pool is set, the Spark jobs ran this execution will be submitted to this pool. If
-   * not set, default pool will be used.
+   * If pool is set, the Spark jobs ran this execution will be submitted to this pool. If not set,
+   * default pool will be used.
    */
   val schedulerPool: Option[String] = if (request.hasSchedulerPool) {
     if (request.getSchedulerPool.isEmpty) {

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAnalyzeHandler.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectAnalyzeHandler.scala
@@ -206,6 +206,23 @@ private[connect] class SparkConnectAnalyzeHandler(
             .setStorageLevel(StorageLevelProtoConverter.toConnectProtoType(storageLevel))
             .build())
 
+      case proto.AnalyzePlanRequest.AnalyzeCase.SCHEDULER_MODE =>
+        val pools = session.sparkContext.getAllPools.map { pool =>
+          proto.AnalyzePlanResponse.SchedulingMode.SchedulablePool
+            .newBuilder()
+            .setName(pool.name)
+            .setSchedulingMode(pool.schedulingMode.toString)
+            .setMinShare(pool.minShare)
+            .setWeight(pool.weight)
+            .build()
+        }.toSeq
+        builder.setSchedulingMode(
+          proto.AnalyzePlanResponse.SchedulingMode
+            .newBuilder()
+            .setMode(session.sparkContext.getSchedulingMode.toString)
+            .addAllPools(pools.asJava)
+            .build())
+
       case other => throw InvalidPlanInput(s"Unknown Analyze Method $other!")
     }
 

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceE2ESuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/service/SparkConnectServiceE2ESuite.scala
@@ -251,18 +251,14 @@ class SparkConnectServiceE2ESuite extends SparkConnectServerTest {
       // set schedulerPool as default
       client.setSchedulerPool("pool1")
       client.execute(buildPlan("SELECT 1")).hasNext
-      assert(
-        eventuallyGetExecutionHolder.schedulerPool.get == "pool1"
-      )
+      assert(eventuallyGetExecutionHolder.schedulerPool.get == "pool1")
       client.releaseSession()
     }
     withClient(sessionId = UUID.randomUUID().toString) { client =>
       // clear schedulerPool
       client.clearSchedulerPool()
       client.execute(buildPlan("SELECT 1")).hasNext
-      assert(
-        eventuallyGetExecutionHolder.schedulerPool.isEmpty
-      )
+      assert(eventuallyGetExecutionHolder.schedulerPool.isEmpty)
       client.releaseSession()
     }
     withClient(sessionId = UUID.randomUUID().toString) { client =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This patch makes spark connect supporting set scheduler pool name like vanilla spark.

A new field `scheduler_pool` in `ExecutePlanRequest` rpc is added. User could call `SparkSession.setSchedulerPool` to set pool name and `SparkSession.clearSchedulerPool` to clear. Server will call SparkContext.setLocalProperty if field `scheduler_pool` is set.

### Why are the changes needed?

Spark fair scheduler is better for multi-user settings, and spark connect could be deployed in multi-user environment, so it's natural for spark connect to support set fair scheduler pool name.

### Does this PR introduce _any_ user-facing change?

Yes, two connect api is added: `SparkSession.setSchedulerPool`, `SparkSession.clearSchedulerPool`


### How was this patch tested?

Add a new Unit test.


### Was this patch authored or co-authored using generative AI tooling?

No
