### PR TITLE
[SPARK-48041][SQL] Avoid call conf.resolver repeated in TableOutputResolver

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -1371,7 +1371,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
         partitionSpec: Map[String, Option[String]]): Unit = {
       // check that each partition name is a partition column. otherwise, it is not valid
       partitionSpec.keySet.foreach { partitionName =>
-        partitionColumnNames.find(name => conf.resolver(name, partitionName)) match {
+        partitionColumnNames.find(name => resolver(name, partitionName)) match {
           case Some(_) =>
           case None =>
             throw QueryCompilationErrors.nonPartitionColError(partitionName)
@@ -1398,11 +1398,11 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
               // column names. We need to make sure the static partition column name doesn't appear
               // there to catch the following ambiguous query:
               // INSERT OVERWRITE t PARTITION (c='1') (c) VALUES ('2')
-              if (query.output.exists(col => conf.resolver(col.name, staticName))) {
+              if (query.output.exists(col => resolver(col.name, staticName))) {
                 throw QueryCompilationErrors.staticPartitionInUserSpecifiedColumnsError(staticName)
               }
             }
-            relation.output.find(col => conf.resolver(col.name, staticName)) match {
+            relation.output.find(col => resolver(col.name, staticName)) match {
               case Some(attr) =>
                 attr.name -> staticName
               case _ =>
@@ -1445,7 +1445,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
         Literal(true)
       } else {
         staticPartitions.map { case (name, value) =>
-          relation.output.find(col => conf.resolver(col.name, name)) match {
+          relation.output.find(col => resolver(col.name, name)) match {
             case Some(attr) =>
               // the delete expression must reference the table's column names, but these attributes
               // are not available when CheckAnalysis runs because the relation is not a child of
@@ -3816,7 +3816,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
             case u: UnresolvedFieldPosition => u.position match {
               case after: After =>
                 val allFields = parentSchema.fieldNames ++ fieldsAdded
-                allFields.find(n => conf.resolver(n, after.column())) match {
+                allFields.find(n => resolver(n, after.column())) match {
                   case Some(colName) =>
                     ResolvedFieldPosition(ColumnPosition.after(colName))
                   case None =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -881,7 +881,6 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
   }
 
   object ResolveUnpivot extends Rule[LogicalPlan] {
-    val resolver = conf.resolver
 
     def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsWithPruning(
       _.containsPattern(UNPIVOT), ruleId) {
@@ -942,7 +941,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
   private def isReferredTempViewName(nameParts: Seq[String]): Boolean = {
     AnalysisContext.get.referredTempViewNames.exists { n =>
       (n.length == nameParts.length) && n.zip(nameParts).forall {
-        case (a, b) => conf.resolver(a, b)
+        case (a, b) => resolver(a, b)
       }
     }
   }
@@ -3554,13 +3553,13 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
     import org.apache.spark.sql.catalyst.util._
 
     val leftKeys = joinNames.map { keyName =>
-      left.output.find(attr => conf.resolver(attr.name, keyName)).getOrElse {
+      left.output.find(attr => resolver(attr.name, keyName)).getOrElse {
         throw QueryCompilationErrors.unresolvedUsingColForJoinError(
           keyName, left.schema.fieldNames.sorted.map(toSQLId).mkString(", "), "left")
       }
     }
     val rightKeys = joinNames.map { keyName =>
-      right.output.find(attr => conf.resolver(attr.name, keyName)).getOrElse {
+      right.output.find(attr => resolver(attr.name, keyName)).getOrElse {
         throw QueryCompilationErrors.unresolvedUsingColForJoinError(
           keyName, right.schema.fieldNames.sorted.map(toSQLId).mkString(", "), "right")
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -881,7 +881,6 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
   }
 
   object ResolveUnpivot extends Rule[LogicalPlan] {
-
     def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsWithPruning(
       _.containsPattern(UNPIVOT), ruleId) {
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -881,6 +881,8 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
   }
 
   object ResolveUnpivot extends Rule[LogicalPlan] {
+    val resolver = conf.resolver
+
     def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsWithPruning(
       _.containsPattern(UNPIVOT), ruleId) {
 
@@ -940,7 +942,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
   private def isReferredTempViewName(nameParts: Seq[String]): Boolean = {
     AnalysisContext.get.referredTempViewNames.exists { n =>
       (n.length == nameParts.length) && n.zip(nameParts).forall {
-        case (a, b) => resolver(a, b)
+        case (a, b) => conf.resolver(a, b)
       }
     }
   }
@@ -1371,7 +1373,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
         partitionSpec: Map[String, Option[String]]): Unit = {
       // check that each partition name is a partition column. otherwise, it is not valid
       partitionSpec.keySet.foreach { partitionName =>
-        partitionColumnNames.find(name => resolver(name, partitionName)) match {
+        partitionColumnNames.find(name => conf.resolver(name, partitionName)) match {
           case Some(_) =>
           case None =>
             throw QueryCompilationErrors.nonPartitionColError(partitionName)
@@ -1398,11 +1400,11 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
               // column names. We need to make sure the static partition column name doesn't appear
               // there to catch the following ambiguous query:
               // INSERT OVERWRITE t PARTITION (c='1') (c) VALUES ('2')
-              if (query.output.exists(col => resolver(col.name, staticName))) {
+              if (query.output.exists(col => conf.resolver(col.name, staticName))) {
                 throw QueryCompilationErrors.staticPartitionInUserSpecifiedColumnsError(staticName)
               }
             }
-            relation.output.find(col => resolver(col.name, staticName)) match {
+            relation.output.find(col => conf.resolver(col.name, staticName)) match {
               case Some(attr) =>
                 attr.name -> staticName
               case _ =>
@@ -1445,7 +1447,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
         Literal(true)
       } else {
         staticPartitions.map { case (name, value) =>
-          relation.output.find(col => resolver(col.name, name)) match {
+          relation.output.find(col => conf.resolver(col.name, name)) match {
             case Some(attr) =>
               // the delete expression must reference the table's column names, but these attributes
               // are not available when CheckAnalysis runs because the relation is not a child of
@@ -3552,13 +3554,13 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
     import org.apache.spark.sql.catalyst.util._
 
     val leftKeys = joinNames.map { keyName =>
-      left.output.find(attr => resolver(attr.name, keyName)).getOrElse {
+      left.output.find(attr => conf.resolver(attr.name, keyName)).getOrElse {
         throw QueryCompilationErrors.unresolvedUsingColForJoinError(
           keyName, left.schema.fieldNames.sorted.map(toSQLId).mkString(", "), "left")
       }
     }
     val rightKeys = joinNames.map { keyName =>
-      right.output.find(attr => resolver(attr.name, keyName)).getOrElse {
+      right.output.find(attr => conf.resolver(attr.name, keyName)).getOrElse {
         throw QueryCompilationErrors.unresolvedUsingColForJoinError(
           keyName, right.schema.fieldNames.sorted.map(toSQLId).mkString(", "), "right")
       }
@@ -3816,7 +3818,7 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
             case u: UnresolvedFieldPosition => u.position match {
               case after: After =>
                 val allFields = parentSchema.fieldNames ++ fieldsAdded
-                allFields.find(n => resolver(n, after.column())) match {
+                allFields.find(n => conf.resolver(n, after.column())) match {
                   case Some(colName) =>
                     ResolvedFieldPosition(ColumnPosition.after(colName))
                   case None =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TableOutputResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TableOutputResolver.scala
@@ -38,6 +38,8 @@ import org.apache.spark.sql.types.{ArrayType, DataType, DecimalType, IntegralTyp
 
 object TableOutputResolver extends SQLConfHelper with Logging {
 
+  val resolver = conf.resolver
+
   def resolveVariableOutputColumns(
       expected: Seq[VariableReference],
       query: LogicalPlan,
@@ -219,7 +221,7 @@ object TableOutputResolver extends SQLConfHelper with Logging {
       fillDefaultValue: Boolean = false): Seq[NamedExpression] = {
     val matchedCols = mutable.HashSet.empty[String]
     val reordered = expectedCols.flatMap { expectedCol =>
-      val matched = inputCols.filter(col => conf.resolver(col.name, expectedCol.name))
+      val matched = inputCols.filter(col => resolver(col.name, expectedCol.name))
       val newColPath = colPath :+ expectedCol.name
       if (matched.isEmpty) {
         val defaultExpr = if (fillDefaultValue) {
@@ -477,8 +479,8 @@ object TableOutputResolver extends SQLConfHelper with Logging {
       expected: Seq[Attribute],
       queryOutput: Seq[Attribute]): Unit = {
     if (!byName && expected.size == queryOutput.size &&
-      expected.forall(e => queryOutput.exists(p => conf.resolver(p.name, e.name))) &&
-      expected.zip(queryOutput).exists(e => !conf.resolver(e._1.name, e._2.name))) {
+      expected.forall(e => queryOutput.exists(p => resolver(p.name, e.name))) &&
+      expected.zip(queryOutput).exists(e => !resolver(e._1.name, e._2.name))) {
       logWarning("The query columns and the table columns have same names but different " +
         "orders. You can use INSERT [INTO | OVERWRITE] BY NAME to reorder the query columns to " +
         "align with the table columns.")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR aim to call conf.resolver for each call in Analyzer.


### Why are the changes needed?
conf.resolver be called repeated in TableOutputResolver，with change can reuse the same resolver.


### Does this PR introduce _any_ user-facing change?
none


### How was this patch tested?
no need


### Was this patch authored or co-authored using generative AI tooling?
no
