### PR TITLE
[SPARK-48046][K8S] Remove `clock` parameter from `DriverServiceFeatureStep`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStep.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStep.scala
@@ -24,11 +24,9 @@ import org.apache.spark.deploy.k8s.{KubernetesDriverConf, SparkPod}
 import org.apache.spark.deploy.k8s.Config.{KUBERNETES_DNS_LABEL_NAME_MAX_LENGTH, KUBERNETES_DRIVER_SERVICE_IP_FAMILIES, KUBERNETES_DRIVER_SERVICE_IP_FAMILY_POLICY}
 import org.apache.spark.deploy.k8s.Constants._
 import org.apache.spark.internal.{config, Logging}
-import org.apache.spark.util.{Clock, SystemClock}
 
 private[spark] class DriverServiceFeatureStep(
-    kubernetesConf: KubernetesDriverConf,
-    clock: Clock = new SystemClock())
+    kubernetesConf: KubernetesDriverConf)
   extends KubernetesFeatureConfigStep with Logging {
   import DriverServiceFeatureStep._
 

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStepSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/features/DriverServiceFeatureStepSuite.scala
@@ -120,7 +120,7 @@ class DriverServiceFeatureStepSuite extends SparkFunSuite {
         resourceNamePrefix = Some(LONG_RESOURCE_NAME_PREFIX),
         labels = DRIVER_LABELS,
         clock = clock)
-      val configurationStep = new DriverServiceFeatureStep(kconf, clock = clock)
+      val configurationStep = new DriverServiceFeatureStep(kconf)
       val serviceName = configurationStep
         .getAdditionalKubernetesResources()
         .head


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `clock` parameter from `DriverServiceFeatureStep`.

### Why are the changes needed?

Since SPARK-48038, this is not used.
- #46276

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.