### PR TITLE
[SPARK-48047][SQL] Reduce memory pressure of empty TreeNode tags

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -78,6 +78,8 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
   /**
    * A mutable map for holding auxiliary information of this tree node. It will be carried over
    * when this node is copied via `makeCopy`, or transformed via `transformUp`/`transformDown`.
+   * We lazily evaluate the `tags` since the default size of a `mutable.Map` is nonzero. This
+   * will reduce unnecessary memory pressure.
    */
   private[this] var _tags: mutable.Map[TreeNodeTag[_], Any] = null
   private def tags: mutable.Map[TreeNodeTag[_], Any] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -164,12 +164,6 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
     }
   }
 
-  def resetTags(): Unit = {
-    if (!(_tags eq null)) {
-      tags.clear()
-    }
-  }
-
   def setTagValue[T](tag: TreeNodeTag[T], value: T): Unit = {
     tags(tag) = value
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -155,11 +155,13 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
     ineffectiveRules.get(ruleId.id)
   }
 
+  def isTagsEmpty: Boolean = (_tags eq null) || _tags.isEmpty
+
   def copyTagsFrom(other: BaseType): Unit = {
     // SPARK-32753: it only makes sense to copy tags to a new node
     // but it's too expensive to detect other cases likes node removal
     // so we make a compromise here to copy tags to node with no tags
-    if ((_tags eq null) || _tags.isEmpty) {
+    if (isTagsEmpty && !other.isTagsEmpty) {
       tags ++= other.tags
     }
   }
@@ -169,7 +171,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
   }
 
   def getTagValue[T](tag: TreeNodeTag[T]): Option[T] = {
-    if (_tags eq null) {
+    if (isTagsEmpty) {
       None
     } else {
       tags.get(tag).map(_.asInstanceOf[T])
@@ -177,7 +179,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
   }
 
   def unsetTagValue[T](tag: TreeNodeTag[T]): Unit = {
-    if (_tags ne null) {
+    if (!isTagsEmpty) {
       tags -= tag
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -177,7 +177,7 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
   }
 
   def unsetTagValue[T](tag: TreeNodeTag[T]): Unit = {
-    if (!(_tags eq null)) {
+    if (_tags ne null) {
       tags -= tag
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/trees/TreeNode.scala
@@ -75,6 +75,10 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
 
   override val origin: Origin = CurrentOrigin.get
 
+  /**
+   * A mutable map for holding auxiliary information of this tree node. It will be carried over
+   * when this node is copied via `makeCopy`, or transformed via `transformUp`/`transformDown`.
+   */
   private[this] var _tags: mutable.Map[TreeNodeTag[_], Any] = null
   private def tags: mutable.Map[TreeNodeTag[_], Any] = {
     if (_tags eq null) {
@@ -158,6 +162,12 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
     }
   }
 
+  def resetTags(): Unit = {
+    if (!(_tags eq null)) {
+      tags.clear()
+    }
+  }
+
   def setTagValue[T](tag: TreeNodeTag[T], value: T): Unit = {
     tags(tag) = value
   }
@@ -171,7 +181,9 @@ abstract class TreeNode[BaseType <: TreeNode[BaseType]]
   }
 
   def unsetTagValue[T](tag: TreeNodeTag[T]): Unit = {
-    tags -= tag
+    if (!(_tags eq null)) {
+      tags -= tag
+    }
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Changed the `tags` variable of the `TreeNode` class to initialize lazily. This will reduce unnecessary driver memory pressure.

### Why are the changes needed?

- Plans with large expression or operator trees are known to cause driver memory pressure; this is one step in alleviating that issue.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing UT covers behavior. Outwards facing behavior does not change. 

### Was this patch authored or co-authored using generative AI tooling?

No