### PR TITLE
[SPARK-48048][CONNECT][SS] Added client side listener support for Scala

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -299,8 +299,8 @@ final class DataStreamWriter[T] private[sql] (ds: Dataset[T]) extends Logging {
 
     val resp = ds.sparkSession.execute(startCmd).head
     if (resp.getWriteStreamOperationStartResult.hasQueryStartedEventJson) {
-      val event = QueryStartedEvent.fromJson(resp.getWriteStreamOperationStartResult
-        .getQueryStartedEventJson)
+      val event = QueryStartedEvent.fromJson(
+        resp.getWriteStreamOperationStartResult.getQueryStartedEventJson)
       ds.sparkSession.streams.streamingQueryListenerBus.postToAll(event)
     }
     RemoteStreamingQuery.fromStartCommandResponse(ds.sparkSession, resp)

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/DataStreamWriter.scala
@@ -36,6 +36,7 @@ import org.apache.spark.sql.execution.streaming.AvailableNowTrigger
 import org.apache.spark.sql.execution.streaming.ContinuousTrigger
 import org.apache.spark.sql.execution.streaming.OneTimeTrigger
 import org.apache.spark.sql.execution.streaming.ProcessingTimeTrigger
+import org.apache.spark.sql.streaming.StreamingQueryListener.QueryStartedEvent
 import org.apache.spark.sql.types.NullType
 import org.apache.spark.util.SparkSerDeUtils
 
@@ -297,6 +298,11 @@ final class DataStreamWriter[T] private[sql] (ds: Dataset[T]) extends Logging {
       .build()
 
     val resp = ds.sparkSession.execute(startCmd).head
+    if (resp.getWriteStreamOperationStartResult.hasQueryStartedEventJson) {
+      val event = QueryStartedEvent.fromJson(resp.getWriteStreamOperationStartResult
+        .getQueryStartedEventJson)
+      ds.sparkSession.streams.streamingQueryListenerBus.postToAll(event)
+    }
     RemoteStreamingQuery.fromStartCommandResponse(ds.sparkSession, resp)
   }
 

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListenerBus.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListenerBus.scala
@@ -57,9 +57,6 @@ class StreamingQueryListenerBus(sparkSession: SparkSession) extends Logging {
       }))
       // Start the thread
       executionThread.get.start()
-      logInfo(
-        "Started the execution thread for StreamingQueryListenerBus with name: " +
-          executionThread.get.getName())
     }
   }
 
@@ -124,7 +121,8 @@ class StreamingQueryListenerBus(sparkSession: SparkSession) extends Logging {
       }
     } catch {
       case e: Exception =>
-        logWarning("Failed to handle the event, please add the listener again. ", e)
+        logWarning("StreamingQueryListenerBus Handler thread received exception, all client" +
+          " side listeners are removed and handler thread is terminated.", e)
         lock.synchronized {
           executionThread = Option.empty
           listeners.forEach(remove(_))

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListenerBus.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListenerBus.scala
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.streaming
+
+import java.util.concurrent.CopyOnWriteArrayList
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.spark.connect.proto.{Command, ExecutePlanResponse, Plan, StreamingQueryEventType}
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.connect.client.CloseableIterator
+import org.apache.spark.sql.streaming.StreamingQueryListener.{Event, QueryIdleEvent, QueryProgressEvent, QueryStartedEvent, QueryTerminatedEvent}
+
+class StreamingQueryListenerBus (sparkSession: SparkSession) extends Logging {
+  private val listeners = new CopyOnWriteArrayList[StreamingQueryListener]()
+  private var executionThread: Option[Thread] = Option.empty
+
+  val lock = new Object()
+
+  def close(): Unit = {
+    listeners.forEach(remove(_))
+  }
+
+  def append(listener: StreamingQueryListener): Unit = lock.synchronized {
+    listeners.add(listener)
+
+    if (listeners.size() == 1) {
+      var iter: Option[CloseableIterator[ExecutePlanResponse]] = Option.empty
+      try {
+        iter = Some(registerServerSideListener())
+      } catch {
+        case e: Exception =>
+          logWarning("Failed to add the listener, please add it again.", e)
+          listeners.remove(listener)
+          return
+      }
+      if (iter.isDefined) {
+        executionThread = Some(new Thread(new Runnable {
+          def run(): Unit = {
+            queryEventHandler(iter.get)
+          }
+        }))
+        // Start the thread
+        executionThread.get.start()
+        logInfo("Started the execution thread for StreamingQueryListenerBus with name: " +
+          executionThread.get.getName())
+      }
+    }
+  }
+
+  def remove(listener: StreamingQueryListener): Unit = lock.synchronized {
+    if (listeners.size() == 1) {
+      val cmdBuilder = Command.newBuilder()
+      cmdBuilder.getStreamingQueryListenerBusCommandBuilder
+        .setRemoveListenerBusListener(true)
+      try {
+        sparkSession.execute(cmdBuilder.build())
+      } catch {
+        case e: Exception =>
+          logWarning("Failed to remove the listener, please remove it again.", e)
+          return
+      }
+      if (executionThread.isDefined) {
+        executionThread.get.interrupt()
+        executionThread = Option.empty
+      }
+    }
+    listeners.remove(listener)
+  }
+
+  def list(): Array[StreamingQueryListener] = lock.synchronized {
+    listeners.asScala.toArray
+  }
+
+  def registerServerSideListener(): CloseableIterator[ExecutePlanResponse] = {
+    val cmdBuilder = Command.newBuilder()
+    cmdBuilder.getStreamingQueryListenerBusCommandBuilder
+      .setAddListenerBusListener(true)
+
+    val plan = Plan.newBuilder().setCommand(cmdBuilder.build()).build()
+    val iterator = sparkSession.client.execute(plan)
+    while (iterator.hasNext) {
+      val response = iterator.next()
+      if (response.getStreamingQueryListenerEventsResult.hasListenerBusListenerAdded &&
+        response.getStreamingQueryListenerEventsResult.getListenerBusListenerAdded) {
+        return iterator
+      }
+    }
+    iterator
+  }
+
+  def queryEventHandler(iter: CloseableIterator[ExecutePlanResponse]): Unit = {
+    try {
+      while (iter.hasNext) {
+        val response = iter.next()
+        val listenerEvents = response.getStreamingQueryListenerEventsResult.getEventsList
+        listenerEvents.forEach(event => {
+          event.getEventType match {
+            case StreamingQueryEventType.QUERY_PROGRESS_EVENT =>
+              postToAll(QueryProgressEvent.fromJson(event.getEventJson))
+            case StreamingQueryEventType.QUERY_IDLE_EVENT =>
+              postToAll(QueryIdleEvent.fromJson(event.getEventJson))
+            case StreamingQueryEventType.QUERY_TERMINATED_EVENT =>
+              postToAll(QueryTerminatedEvent.fromJson(event.getEventJson))
+            case _ =>
+              logWarning(s"Unknown StreamingQueryListener event: $event")
+          }
+        })
+      }
+    } catch {
+      case e: Exception =>
+        logWarning("Failed to handle the event, please add the listener again.", e)
+        lock.synchronized {
+          executionThread = Option.empty
+          listeners.forEach(remove(_))
+        }
+    }
+
+  }
+
+  def postToAll(event: Event): Unit = lock.synchronized {
+    listeners.forEach(
+      listener => try {event match {
+        case t: QueryStartedEvent =>
+          listener.onQueryStarted(event.asInstanceOf[QueryStartedEvent])
+        case t: QueryProgressEvent =>
+          listener.onQueryProgress(event.asInstanceOf[QueryProgressEvent])
+        case t: QueryIdleEvent =>
+          listener.onQueryIdle(event.asInstanceOf[QueryIdleEvent])
+        case t: QueryTerminatedEvent =>
+          listener.onQueryTerminated(event.asInstanceOf[QueryTerminatedEvent])
+        case _ => logWarning(s"Unknown StreamingQueryListener event: $event")
+      }
+      } catch {
+        case e: Exception =>
+          logWarning(s"Listener $listener threw an exception", e)
+      })
+  }
+}

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListenerBus.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListenerBus.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connect.client.CloseableIterator
 import org.apache.spark.sql.streaming.StreamingQueryListener.{Event, QueryIdleEvent, QueryProgressEvent, QueryStartedEvent, QueryTerminatedEvent}
 
-class StreamingQueryListenerBus (sparkSession: SparkSession) extends Logging {
+class StreamingQueryListenerBus(sparkSession: SparkSession) extends Logging {
   private val listeners = new CopyOnWriteArrayList[StreamingQueryListener]()
   private var executionThread: Option[Thread] = Option.empty
 
@@ -57,8 +57,9 @@ class StreamingQueryListenerBus (sparkSession: SparkSession) extends Logging {
       }))
       // Start the thread
       executionThread.get.start()
-      logInfo("Started the execution thread for StreamingQueryListenerBus with name: " +
-        executionThread.get.getName())
+      logInfo(
+        "Started the execution thread for StreamingQueryListenerBus with name: " +
+          executionThread.get.getName())
     }
   }
 
@@ -132,21 +133,22 @@ class StreamingQueryListenerBus (sparkSession: SparkSession) extends Logging {
   }
 
   def postToAll(event: Event): Unit = lock.synchronized {
-    listeners.forEach(
-      listener => try {event match {
-        case t: QueryStartedEvent =>
-          listener.onQueryStarted(t)
-        case t: QueryProgressEvent =>
-          listener.onQueryProgress(t)
-        case t: QueryIdleEvent =>
-          listener.onQueryIdle(t)
-        case t: QueryTerminatedEvent =>
-          listener.onQueryTerminated(t)
-        case _ => logWarning(s"Unknown StreamingQueryListener event: $event")
-      }
-    } catch {
-      case e: Exception =>
-        logWarning(s"Listener $listener threw an exception", e)
-    })
+    listeners.forEach(listener =>
+      try {
+        event match {
+          case t: QueryStartedEvent =>
+            listener.onQueryStarted(t)
+          case t: QueryProgressEvent =>
+            listener.onQueryProgress(t)
+          case t: QueryIdleEvent =>
+            listener.onQueryIdle(t)
+          case t: QueryTerminatedEvent =>
+            listener.onQueryTerminated(t)
+          case _ => logWarning(s"Unknown StreamingQueryListener event: $event")
+        }
+      } catch {
+        case e: Exception =>
+          logWarning(s"Listener $listener threw an exception", e)
+      })
   }
 }

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
@@ -49,7 +49,7 @@ class StreamingQueryManager private[sql] (sparkSession: SparkSession) extends Lo
 
   private[spark] val streamingQueryListenerBus = new StreamingQueryListenerBus(sparkSession)
 
-  def close(): Unit = {
+  private[spark] def close(): Unit = {
     streamingQueryListenerBus.close()
   }
 

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryManager.scala
@@ -22,16 +22,13 @@ import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
 
 import scala.jdk.CollectionConverters._
 
-import com.google.protobuf.ByteString
-
 import org.apache.spark.annotation.Evolving
 import org.apache.spark.connect.proto.Command
 import org.apache.spark.connect.proto.StreamingQueryManagerCommand
 import org.apache.spark.connect.proto.StreamingQueryManagerCommandResult
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.connect.common.{InvalidPlanInput, StreamingListenerPacket}
-import org.apache.spark.util.SparkSerDeUtils
+import org.apache.spark.sql.connect.common.InvalidPlanInput
 
 /**
  * A class to manage all the [[StreamingQuery]] active in a `SparkSession`.
@@ -49,6 +46,12 @@ class StreamingQueryManager private[sql] (sparkSession: SparkSession) extends Lo
   // removes the same listener instance multiple times properly.
   private lazy val listenerCache: ConcurrentMap[String, StreamingQueryListener] =
     new ConcurrentHashMap()
+
+  private[spark] val streamingQueryListenerBus = new StreamingQueryListenerBus(sparkSession)
+
+  def close(): Unit = {
+    streamingQueryListenerBus.close()
+  }
 
   /**
    * Returns a list of active queries associated with this SQLContext
@@ -153,17 +156,7 @@ class StreamingQueryManager private[sql] (sparkSession: SparkSession) extends Lo
    * @since 3.5.0
    */
   def addListener(listener: StreamingQueryListener): Unit = {
-    // TODO: [SPARK-44400] Improve the Listener to provide users a way to access the Spark session
-    //  and perform arbitrary actions inside the Listener. Right now users can use
-    //  `val spark = SparkSession.builder.getOrCreate()` to create a Spark session inside the
-    //  Listener, but this is a legacy session instead of a connect remote session.
-    val id = UUID.randomUUID.toString
-    cacheListenerById(id, listener)
-    executeManagerCmd(
-      _.getAddListenerBuilder
-        .setListenerPayload(ByteString.copyFrom(SparkSerDeUtils
-          .serialize(StreamingListenerPacket(id, listener))))
-        .setId(id))
+    streamingQueryListenerBus.append(listener)
   }
 
   /**
@@ -172,11 +165,7 @@ class StreamingQueryManager private[sql] (sparkSession: SparkSession) extends Lo
    * @since 3.5.0
    */
   def removeListener(listener: StreamingQueryListener): Unit = {
-    val id = getIdByListener(listener)
-    executeManagerCmd(
-      _.getRemoveListenerBuilder
-        .setId(id))
-    removeCachedListener(id)
+    streamingQueryListenerBus.remove(listener)
   }
 
   /**
@@ -185,10 +174,7 @@ class StreamingQueryManager private[sql] (sparkSession: SparkSession) extends Lo
    * @since 3.5.0
    */
   def listListeners(): Array[StreamingQueryListener] = {
-    executeManagerCmd(_.setListListeners(true)).getListListeners.getListenerIdsList.asScala
-      .filter(listenerCache.containsKey(_))
-      .map(listenerCache.get(_))
-      .toArray
+    streamingQueryListenerBus.list()
   }
 
   private def executeManagerCmd(

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
@@ -440,6 +440,10 @@ object CheckConnectJvmClientCompatibility {
         "org.apache.spark.sql.streaming.RemoteStreamingQuery"),
       ProblemFilters.exclude[MissingClassProblem](
         "org.apache.spark.sql.streaming.RemoteStreamingQuery$"),
+      // Skip client side listener specific class
+      ProblemFilters.exclude[MissingClassProblem](
+        "org.apache.spark.sql.streaming.StreamingQueryListenerBus"
+      ),
 
       // Encoders are in the wrong JAR
       ProblemFilters.exclude[MissingClassProblem]("org.apache.spark.sql.Encoders"),

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/ClientStreamingQuerySuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/ClientStreamingQuerySuite.scala
@@ -446,13 +446,7 @@ class ClientStreamingQuerySuite extends QueryTest with SQLHelper with Logging {
   }
 
   test("streaming query listener") {
-    testStreamingQueryListener(new EventCollectorV1, "_v1")
-    testStreamingQueryListener(new EventCollectorV2, "_v2")
-  }
-
-  private def testStreamingQueryListener(
-      listener: StreamingQueryListener,
-      tablePostfix: String): Unit = {
+    val listener = new MyListener
     assert(spark.streams.listListeners().length == 0)
 
     spark.streams.addListener(listener)
@@ -468,21 +462,16 @@ class ClientStreamingQuerySuite extends QueryTest with SQLHelper with Logging {
       q.processAllAvailable()
       eventually(timeout(30.seconds)) {
         assert(q.isActive)
-
-        assert(!spark.table(s"listener_start_events$tablePostfix").toDF().isEmpty)
-        assert(!spark.table(s"listener_progress_events$tablePostfix").toDF().isEmpty)
+        assert(listener.start.length == 1)
+        assert(listener.progress.nonEmpty)
       }
     } finally {
       q.stop()
 
       eventually(timeout(30.seconds)) {
         assert(!q.isActive)
-        assert(!spark.table(s"listener_terminated_events$tablePostfix").toDF().isEmpty)
+        assert(listener.terminate.nonEmpty)
       }
-
-      spark.sql(s"DROP TABLE IF EXISTS listener_start_events$tablePostfix")
-      spark.sql(s"DROP TABLE IF EXISTS listener_progress_events$tablePostfix")
-      spark.sql(s"DROP TABLE IF EXISTS listener_terminated_events$tablePostfix")
     }
 
     // List listeners after adding a new listener, length should be 1.
@@ -490,7 +479,7 @@ class ClientStreamingQuerySuite extends QueryTest with SQLHelper with Logging {
     assert(listeners.length == 1)
 
     // Add listener1 as another instance of EventCollector and validate
-    val listener1 = new EventCollectorV2
+    val listener1 = new MyListener
     spark.streams.addListener(listener1)
     assert(spark.streams.listListeners().length == 2)
     spark.streams.removeListener(listener1)
@@ -570,56 +559,27 @@ case class TestClass(value: Int) {
   override def toString: String = value.toString
 }
 
-abstract class EventCollector extends StreamingQueryListener {
-  private lazy val spark = SparkSession.builder().getOrCreate()
+class MyListener extends StreamingQueryListener {
 
-  protected def tablePostfix: String
+  var start: Seq[String] = Seq.empty
+  var progress: Seq[String] = Seq.empty
+  var terminate: Seq[String] = Seq.empty
 
-  protected def handleOnQueryStarted(event: QueryStartedEvent): Unit = {
-    val df = spark.createDataFrame(Seq((event.json, 0)))
-    df.write.mode("append").saveAsTable(s"listener_start_events$tablePostfix")
+  override def onQueryStarted(event: QueryStartedEvent): Unit = {
+    start = start :+ event.json
   }
 
-  protected def handleOnQueryProgress(event: QueryProgressEvent): Unit = {
-    val df = spark.createDataFrame(Seq((event.json, 0)))
-    df.write.mode("append").saveAsTable(s"listener_progress_events$tablePostfix")
+  override def onQueryProgress(event: QueryProgressEvent): Unit = {
+    progress = progress :+ event.json
   }
 
-  protected def handleOnQueryTerminated(event: QueryTerminatedEvent): Unit = {
-    val df = spark.createDataFrame(Seq((event.json, 0)))
-    df.write.mode("append").saveAsTable(s"listener_terminated_events$tablePostfix")
+  override def onQueryIdle(event: QueryIdleEvent): Unit = {
+    // Do nothing
   }
-}
 
-/**
- * V1: Initial interface of StreamingQueryListener containing methods `onQueryStarted`,
- * `onQueryProgress`, `onQueryTerminated`. It is prior to Spark 3.5.
- */
-class EventCollectorV1 extends EventCollector {
-  override protected def tablePostfix: String = "_v1"
-
-  override def onQueryStarted(event: QueryStartedEvent): Unit = handleOnQueryStarted(event)
-
-  override def onQueryProgress(event: QueryProgressEvent): Unit = handleOnQueryProgress(event)
-
-  override def onQueryTerminated(event: QueryTerminatedEvent): Unit =
-    handleOnQueryTerminated(event)
-}
-
-/**
- * V2: The interface after the method `onQueryIdle` is added. It is Spark 3.5+.
- */
-class EventCollectorV2 extends EventCollector {
-  override protected def tablePostfix: String = "_v2"
-
-  override def onQueryStarted(event: QueryStartedEvent): Unit = handleOnQueryStarted(event)
-
-  override def onQueryProgress(event: QueryProgressEvent): Unit = handleOnQueryProgress(event)
-
-  override def onQueryIdle(event: QueryIdleEvent): Unit = {}
-
-  override def onQueryTerminated(event: QueryTerminatedEvent): Unit =
-    handleOnQueryTerminated(event)
+  override def onQueryTerminated(event: QueryTerminatedEvent): Unit = {
+    terminate = terminate :+ event.json
+  }
 }
 
 class ForeachBatchFn(val viewName: String)

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/ClientStreamingQuerySuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/ClientStreamingQuerySuite.scala
@@ -588,7 +588,7 @@ class ClientStreamingQuerySuite extends QueryTest with SQLHelper with Logging {
       val df = spark.createDataFrame(Seq((event.json, 0)))
       df.write.mode("append").saveAsTable(s"listener_terminated_events$tablePostfix")
     }
-}
+  }
 
   /**
    * V1: Initial interface of StreamingQueryListener containing methods `onQueryStarted`,

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/test/IntegrationTestUtils.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/test/IntegrationTestUtils.scala
@@ -32,7 +32,10 @@ object IntegrationTestUtils {
   private val DEBUG_SC_JVM_CLIENT = "spark.debug.sc.jvm.client"
   private val DEBUG_SC_JVM_CLIENT_ENV = "SPARK_DEBUG_SC_JVM_CLIENT"
   // Enable this flag to print all server logs to the console
-  private[sql] val isDebug = true
+  private[sql] val isDebug = {
+    System.getProperty(DEBUG_SC_JVM_CLIENT, "false").toBoolean ||
+    Option(System.getenv(DEBUG_SC_JVM_CLIENT_ENV)).exists(_.toBoolean)
+  }
 
   private[sql] lazy val scalaVersion = {
     versionNumberString.split('.') match {

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/test/IntegrationTestUtils.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/test/IntegrationTestUtils.scala
@@ -32,10 +32,7 @@ object IntegrationTestUtils {
   private val DEBUG_SC_JVM_CLIENT = "spark.debug.sc.jvm.client"
   private val DEBUG_SC_JVM_CLIENT_ENV = "SPARK_DEBUG_SC_JVM_CLIENT"
   // Enable this flag to print all server logs to the console
-  private[sql] val isDebug = {
-    System.getProperty(DEBUG_SC_JVM_CLIENT, "false").toBoolean ||
-    Option(System.getenv(DEBUG_SC_JVM_CLIENT_ENV)).exists(_.toBoolean)
-  }
+  private[sql] val isDebug = true
 
   private[sql] lazy val scalaVersion = {
     versionNumberString.split('.') match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListener.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/StreamingQueryListener.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql.streaming
 
 import java.util.UUID
 
+import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
+import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
 import org.json4s.{JObject, JString}
 import org.json4s.JsonAST.JValue
 import org.json4s.JsonDSL.{jobject2assoc, pair2Assoc}
@@ -140,6 +142,21 @@ object StreamingQueryListener extends Serializable {
     }
   }
 
+  private[spark] object QueryStartedEvent {
+    private val mapper = {
+      val ret = new ObjectMapper() with ClassTagExtensions
+      ret.registerModule(DefaultScalaModule)
+      ret.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+      ret
+    }
+
+    private[spark] def jsonString(event: QueryStartedEvent): String =
+      mapper.writeValueAsString(event)
+
+    private[spark] def fromJson(json: String): QueryStartedEvent =
+      mapper.readValue[QueryStartedEvent](json)
+  }
+
   /**
    * Event representing any progress updates in a query.
    * @param progress The query progress updates.
@@ -152,6 +169,21 @@ object StreamingQueryListener extends Serializable {
     def json: String = compact(render(jsonValue))
 
     private def jsonValue: JValue = JObject("progress" -> progress.jsonValue)
+  }
+
+  private[spark] object QueryProgressEvent {
+    private val mapper = {
+      val ret = new ObjectMapper() with ClassTagExtensions
+      ret.registerModule(DefaultScalaModule)
+      ret.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+      ret
+    }
+
+    private[spark] def jsonString(event: QueryProgressEvent): String =
+      mapper.writeValueAsString(event)
+
+    private[spark] def fromJson(json: String): QueryProgressEvent =
+      mapper.readValue[QueryProgressEvent](json)
   }
 
   /**
@@ -175,6 +207,21 @@ object StreamingQueryListener extends Serializable {
       ("runId" -> JString(runId.toString)) ~
       ("timestamp" -> JString(timestamp))
     }
+  }
+
+  private[spark] object QueryIdleEvent {
+    private val mapper = {
+      val ret = new ObjectMapper() with ClassTagExtensions
+      ret.registerModule(DefaultScalaModule)
+      ret.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+      ret
+    }
+
+    private[spark] def jsonString(event: QueryTerminatedEvent): String =
+      mapper.writeValueAsString(event)
+
+    private[spark] def fromJson(json: String): QueryTerminatedEvent =
+      mapper.readValue[QueryTerminatedEvent](json)
   }
 
   /**
@@ -210,5 +257,20 @@ object StreamingQueryListener extends Serializable {
       ("exception" -> JString(exception.orNull)) ~
       ("errorClassOnException" -> JString(errorClassOnException.orNull))
     }
+  }
+
+  private[spark] object QueryTerminatedEvent {
+    private val mapper = {
+      val ret = new ObjectMapper() with ClassTagExtensions
+      ret.registerModule(DefaultScalaModule)
+      ret.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+      ret
+    }
+
+    private[spark] def jsonString(event: QueryTerminatedEvent): String =
+      mapper.writeValueAsString(event)
+
+    private[spark] def fromJson(json: String): QueryTerminatedEvent =
+      mapper.readValue[QueryTerminatedEvent](json)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Added client side Streaming Listener support for Scala

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Support Streaming Listener on client side for Spark Connect which has better user experience (no breaking change compared to legacy mode) compared to previous server side listener.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added unit test.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.