### PR TITLE
[SPARK-48050][SS] Log logical plan at query start

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -320,6 +320,10 @@ abstract class StreamExecution(
           batchWatermarkMs = 0, batchTimestampMs = 0, sparkSessionForStream.conf)
 
         if (state.compareAndSet(INITIALIZING, ACTIVE)) {
+          // Log logical plan at the start of the query to help debug issues related to
+          // plan changes.
+          logInfo(s"Finish initializing with logical plan:\n$logicalPlan")
+
           // Unblock `awaitInitialization`
           initializationLatch.countDown()
           runActivatedStream(sparkSessionForStream)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Log the logical plan of queries at query start.  

### Why are the changes needed?
This will help debug issues in which the spark plan has changed.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manual testing using custom image

### Was this patch authored or co-authored using generative AI tooling?
No