### PR TITLE
[SPARK-48053][PYTHON][CONNECT] SparkSession.createDataFrame should warn for unsupported options

### DIFF
--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -402,6 +402,8 @@ class SparkSession:
         self,
         data: Union["pd.DataFrame", "np.ndarray", Iterable[Any]],
         schema: Optional[Union[AtomicType, StructType, str, List[str], Tuple[str, ...]]] = None,
+        samplingRatio: Optional[float] = None,
+        verifySchema: Optional[bool] = None,
     ) -> "ParentDataFrame":
         assert data is not None
         if isinstance(data, DataFrame):
@@ -409,6 +411,12 @@ class SparkSession:
                 error_class="INVALID_TYPE",
                 message_parameters={"arg_name": "data", "arg_type": "DataFrame"},
             )
+
+        if samplingRatio is not None:
+            warnings.warn("'samplingRatio' is ignored. It is not supported with Spark Connect.")
+
+        if verifySchema is not None:
+            warnings.warn("'verifySchema' is ignored. It is not supported with Spark Connect.")
 
         _schema: Optional[Union[AtomicType, StructType]] = None
         _cols: Optional[List[str]] = None

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1365,12 +1365,14 @@ class SparkSession(SparkConversionMixin):
             later.
         samplingRatio : float, optional
             the sample ratio of rows used for inferring. The first few rows will be used
-            if ``samplingRatio`` is ``None``.
+            if ``samplingRatio`` is ``None``. This option is effective only when the input is
+            :class:`RDD`.
         verifySchema : bool, optional
             verify data types of every row against schema. Enabled by default.
             When the input is :class:`pandas.DataFrame` and
             `spark.sql.execution.arrow.pyspark.enabled` is enabled, this option is not
-            effective. It follows Arrow type coercion.
+            effective. It follows Arrow type coercion. This option is not supported with
+            Spark Connect.
 
             .. versionadded:: 2.1.0
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to warn that `samplingRatio` and `verifySchema` are not supported with Spark Connect.

### Why are the changes needed?

For better compatibility in Spark Connect.

### Does this PR introduce _any_ user-facing change?

Yes, it shows a warning to the end users when they use those. For now, it complains that there's no such argument that `createDataFrame` can take.

### How was this patch tested?

Manually tested as below:

```bash
bin/pyspark --remote local
```

```python
>>> spark.createDataFrame([1,2,3], samplingRatio=0.5)
/.../pyspark/sql/connect/session.py:416: UserWarning: 'samplingRatio' is ignored. It is not supported with Spark Connect.
  warnings.warn("'samplingRatio' is ignored. It is not supported with Spark Connect.")
DataFrame[_1: bigint]
>>> spark.createDataFrame([1,2,3], verifySchema=True)
/.../pyspark/sql/connect/session.py:419: UserWarning: 'verifySchema' is ignored. It is not supported with Spark Connect.
  warnings.warn("'verifySchema' is ignored. It is not supported with Spark Connect.")
DataFrame[_1: bigint]
>>> spark.createDataFrame([1,2,3])
DataFrame[_1: bigint]
```

### Was this patch authored or co-authored using generative AI tooling?

No.
