### PR TITLE
[SPARK-48058][SPARK-43727][PYTHON][CONNECT] `UserDefinedFunction.returnType` parse the DDL string

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_cogrouped_map.py
@@ -25,14 +25,6 @@ class CogroupedApplyInPandasTests(CogroupedApplyInPandasTestsMixin, ReusedConnec
     def test_wrong_args(self):
         self.check_wrong_args()
 
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_apply_in_pandas_returning_incompatible_type(self):
-        super().test_apply_in_pandas_returning_incompatible_type()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_wrong_return_type(self):
-        super().test_wrong_return_type()
-
 
 if __name__ == "__main__":
     from pyspark.sql.tests.connect.test_parity_pandas_cogrouped_map import *  # noqa: F401

--- a/python/pyspark/sql/tests/connect/test_parity_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_grouped_map.py
@@ -26,18 +26,6 @@ class GroupedApplyInPandasTests(GroupedApplyInPandasTestsMixin, ReusedConnectTes
     def test_supported_types(self):
         super().test_supported_types()
 
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_wrong_return_type(self):
-        super().test_wrong_return_type()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_unsupported_types(self):
-        super().test_unsupported_types()
-
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_apply_in_pandas_returning_incompatible_type(self):
-        super().test_apply_in_pandas_returning_incompatible_type()
-
 
 if __name__ == "__main__":
     from pyspark.sql.tests.connect.test_parity_pandas_grouped_map import *  # noqa: F401

--- a/python/pyspark/sql/tests/connect/test_parity_pandas_udf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_udf.py
@@ -15,11 +15,9 @@
 # limitations under the License.
 #
 from pyspark.sql.functions import pandas_udf, PandasUDFType
+from pyspark.sql.types import DoubleType, StructType, StructField
 from pyspark.sql.tests.pandas.test_pandas_udf import PandasUDFTestsMixin
-from pyspark.testing.connectutils import should_test_connect, ReusedConnectTestCase
-
-if should_test_connect:
-    from pyspark.sql.connect.types import UnparsedDataType
+from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class PandasUDFParityTests(PandasUDFTestsMixin, ReusedConnectTestCase):
@@ -31,31 +29,31 @@ class PandasUDFParityTests(PandasUDFTestsMixin, ReusedConnectTestCase):
         def foo(x):
             return x
 
-        self.assertEqual(foo.returnType, UnparsedDataType("v double"))
+        self.assertEqual(foo.returnType, StructType([StructField("v", DoubleType(), True)]))
         self.assertEqual(foo.evalType, PandasUDFType.GROUPED_MAP)
 
         @pandas_udf(returnType="double", functionType=PandasUDFType.SCALAR)
         def foo(x):
             return x
 
-        self.assertEqual(foo.returnType, UnparsedDataType("double"))
+        self.assertEqual(foo.returnType, DoubleType())
         self.assertEqual(foo.evalType, PandasUDFType.SCALAR)
 
     def test_pandas_udf_basic_with_return_type_string(self):
         udf = pandas_udf(lambda x: x, "double", PandasUDFType.SCALAR)
-        self.assertEqual(udf.returnType, UnparsedDataType("double"))
+        self.assertEqual(udf.returnType, DoubleType())
         self.assertEqual(udf.evalType, PandasUDFType.SCALAR)
 
         udf = pandas_udf(lambda x: x, "v double", PandasUDFType.GROUPED_MAP)
-        self.assertEqual(udf.returnType, UnparsedDataType("v double"))
+        self.assertEqual(udf.returnType, StructType([StructField("v", DoubleType(), True)]))
         self.assertEqual(udf.evalType, PandasUDFType.GROUPED_MAP)
 
         udf = pandas_udf(lambda x: x, "v double", functionType=PandasUDFType.GROUPED_MAP)
-        self.assertEqual(udf.returnType, UnparsedDataType("v double"))
+        self.assertEqual(udf.returnType, StructType([StructField("v", DoubleType(), True)]))
         self.assertEqual(udf.evalType, PandasUDFType.GROUPED_MAP)
 
         udf = pandas_udf(lambda x: x, returnType="v double", functionType=PandasUDFType.GROUPED_MAP)
-        self.assertEqual(udf.returnType, UnparsedDataType("v double"))
+        self.assertEqual(udf.returnType, StructType([StructField("v", DoubleType(), True)]))
         self.assertEqual(udf.evalType, PandasUDFType.GROUPED_MAP)
 
 

--- a/python/pyspark/sql/tests/connect/test_parity_pandas_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_udf_grouped_agg.py
@@ -21,11 +21,6 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class PandasUDFGroupedAggParityTests(GroupedAggPandasUDFTestsMixin, ReusedConnectTestCase):
-    # TODO(SPARK-43727): Parity returnType check in Spark Connect
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_unsupported_types(self):
-        super().test_unsupported_types()
-
     @unittest.skip("Spark Connect does not support convert UNPARSED to catalyst types.")
     def test_manual(self):
         super().test_manual()

--- a/python/pyspark/sql/tests/connect/test_parity_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_udf_scalar.py
@@ -21,11 +21,6 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class PandasUDFScalarParityTests(ScalarPandasUDFTestsMixin, ReusedConnectTestCase):
-    # TODO(SPARK-43727): Parity returnType check in Spark Connect
-    @unittest.skip("Fails in Spark Connect, should enable.")
-    def test_vectorized_udf_wrong_return_type(self):
-        super().test_vectorized_udf_wrong_return_type()
-
     def test_mixed_udf_and_sql(self):
         self._test_mixed_udf_and_sql(Column)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
`UserDefinedFunction.returnType` parse the DDL string


### Why are the changes needed?
1, the return type check is missing in Python Connect;
2, to enable a group of tests;



### Does this PR introduce _any_ user-facing change?
yes


```
In [1]: import pandas as pd

In [2]: from pyspark.sql.functions import pandas_udf

In [3]: @pandas_udf("int")
   ...: def slen(s: pd.Series) -> pd.Series:
   ...:     return s.str.len()
   ...:

In [4]: slen.returnType
```


before:
```
Out[4]: UnparsedDataType('int')
```

after:
```
Out[4]: IntegerType()
```


### How was this patch tested?
enabled tests


### Was this patch authored or co-authored using generative AI tooling?
no