### PR TITLE
[SPARK-48062][PYTHON][SS][TESTS] Add pyspark test for SimpleDataSourceStreamingReader

### DIFF
--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -144,7 +144,7 @@ class BasePythonStreamingDataSourceTestsMixin:
 
             def read(self, start: dict):
                 start_idx = start["offset"]
-                it = iter([(i, ) for i in range(start_idx, start_idx + 2)])
+                it = iter([(i,) for i in range(start_idx, start_idx + 2)])
                 return (it, {"offset": start_idx + 2})
 
             def commit(self, end):
@@ -153,7 +153,7 @@ class BasePythonStreamingDataSourceTestsMixin:
             def readBetweenOffsets(self, start: dict, end: dict):
                 start_idx = start["offset"]
                 end_idx = end["offset"]
-                return iter([(i, ) for i in range(start_idx, end_idx)])
+                return iter([(i,) for i in range(start_idx, end_idx)])
 
         class SimpleDataSource(DataSource):
             def schema(self):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add pyspark test for SimpleDataSourceStreamingReader.


### Why are the changes needed?
To make sure SimpleDataSourceStreamingReader works end to end.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Test change. Also trigger python_streaming_datasource and python_parity_streaming_datasource locally.

### Was this patch authored or co-authored using generative AI tooling?
No.
