### PR TITLE
[SPARK-48069][INFRA] Handle `PEP-632` by checking `ModuleNotFoundError` on `setuptools` in Python 3.12

### DIFF
--- a/dev/lint-python
+++ b/dev/lint-python
@@ -84,7 +84,10 @@ function satisfies_min_version {
     local expected_version="$2"
     echo "$(
         "$PYTHON_EXECUTABLE" << EOM
-from setuptools.extern.packaging import version
+try:
+    from setuptools.extern.packaging import version
+except ModuleNotFoundError:
+    from packaging import version
 print(version.parse('$provided_version') >= version.parse('$expected_version'))
 EOM
     )"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to handle `PEP-632` by checking `ModuleNotFoundError` on `setuptools`.
- [PEP 632 – Deprecate distutils module](https://peps.python.org/pep-0632/)

### Why are the changes needed?

Use `Python 3.12`.
```
$ python3 --version
Python 3.12.2
```

**BEFORE**
```
$ dev/lint-python --mypy | grep ModuleNotFoundError
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'setuptools'
```

**AFTER**
```
$ dev/lint-python --mypy | grep ModuleNotFoundError
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and manual test.

### Was this patch authored or co-authored using generative AI tooling?

No.