### PR TITLE
[MINOR] Fix the grammar of some comments on renaming error classes

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
+++ b/common/utils/src/main/scala/org/apache/spark/SparkThrowableHelper.scala
@@ -33,7 +33,7 @@ private[spark] object ErrorMessageFormat extends Enumeration {
 private[spark] object SparkThrowableHelper {
   val errorReader = new ErrorClassesJsonReader(
     // Note that though we call them "error classes" here, the proper name is "error conditions",
-    // hence why the name of the JSON file different. We will address this inconsistency as part
+    // hence why the name of the JSON file is different. We will address this inconsistency as part
     // of this ticket: https://issues.apache.org/jira/browse/SPARK-47429
     Seq(SparkClassUtils.getSparkClassLoader.getResource("error/error-conditions.json")))
 

--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaExceptions.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaExceptions.scala
@@ -27,8 +27,8 @@ private object KafkaExceptionsHelper {
   val errorClassesJsonReader: ErrorClassesJsonReader =
     new ErrorClassesJsonReader(
       // Note that though we call them "error classes" here, the proper name is "error conditions",
-      // hence why the name of the JSON file different. We will address this inconsistency as part
-      // of this ticket: https://issues.apache.org/jira/browse/SPARK-47429
+      // hence why the name of the JSON file is different. We will address this inconsistency as
+      // part of this ticket: https://issues.apache.org/jira/browse/SPARK-47429
       Seq(getClass.getClassLoader.getResource("error/kafka-error-conditions.json")))
 }
 

--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -51,7 +51,7 @@ class SparkThrowableSuite extends SparkFunSuite {
 
   private val errorJsonFilePath = getWorkspaceFilePath(
     // Note that though we call them "error classes" here, the proper name is "error conditions",
-    // hence why the name of the JSON file different. We will address this inconsistency as part
+    // hence why the name of the JSON file is different. We will address this inconsistency as part
     // of this ticket: https://issues.apache.org/jira/browse/SPARK-47429
     "common", "utils", "src", "main", "resources", "error", "error-conditions.json")
 

--- a/python/pyspark/errors/error_classes.py
+++ b/python/pyspark/errors/error_classes.py
@@ -19,7 +19,7 @@ import json
 import importlib.resources
 
 # Note: Though we call them "error classes" here, the proper name is "error conditions",
-#   hence why the name of the JSON file different.
+#   hence why the name of the JSON file is different.
 #   For more information, please see: https://issues.apache.org/jira/browse/SPARK-46810
 #   This discrepancy will be resolved as part of: https://issues.apache.org/jira/browse/SPARK-47429
 ERROR_CLASSES_JSON = (


### PR DESCRIPTION
### What changes were proposed in this pull request?

Minor fixes to the English of some comments I added in #44920.

### Why are the changes needed?

Proper English -- OK, not _proper_, but more correct at least -- makes things easier to read.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Not tested beyond CI.

### Was this patch authored or co-authored using generative AI tooling?

No.