### PR TITLE
[SPARK-48074][Core] Improve the readability of JSON loggings

### DIFF
--- a/common/utils/src/main/resources/org/apache/spark/SparkLayout.json
+++ b/common/utils/src/main/resources/org/apache/spark/SparkLayout.json
@@ -1,6 +1,11 @@
 {
   "ts": {
-    "$resolver": "timestamp"
+    "$resolver": "timestamp",
+    "pattern": {
+      "format": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+      "timeZone": "UTC",
+      "locale": "en_US"
+    }
   },
   "level": {
     "$resolver": "level",
@@ -27,12 +32,30 @@
       "$resolver": "exception",
       "field": "stackTrace",
       "stackTrace": {
-        "stringified": true
+        "elementTemplate": {
+          "class": {
+            "$resolver": "stackTraceElement",
+            "field": "className"
+          },
+          "method": {
+            "$resolver": "stackTraceElement",
+            "field": "methodName"
+          },
+          "file": {
+            "$resolver": "stackTraceElement",
+            "field": "fileName"
+          },
+          "line": {
+            "$resolver": "stackTraceElement",
+            "field": "lineNumber"
+          }
+        }
       }
     }
   },
   "logger": {
-    "$resolver": "logger",
-    "field": "name"
+    "$resolver": "pattern",
+    "pattern": "%c{1}",
+    "stackTraceEnabled": false
   }
 }

--- a/common/utils/src/main/resources/org/apache/spark/SparkLayout.json
+++ b/common/utils/src/main/resources/org/apache/spark/SparkLayout.json
@@ -7,10 +7,6 @@
       "locale": "en_US"
     }
   },
-  "level": {
-    "$resolver": "level",
-    "field": "name"
-  },
   "msg": {
     "$resolver": "message",
     "stringified": true
@@ -52,6 +48,10 @@
         }
       }
     }
+  },
+  "level": {
+    "$resolver": "level",
+    "field": "name"
   },
   "logger": {
     "$resolver": "pattern",

--- a/common/utils/src/main/resources/org/apache/spark/SparkLayout.json
+++ b/common/utils/src/main/resources/org/apache/spark/SparkLayout.json
@@ -7,6 +7,10 @@
       "locale": "en_US"
     }
   },
+  "level": {
+    "$resolver": "level",
+    "field": "name"
+  },
   "msg": {
     "$resolver": "message",
     "stringified": true
@@ -48,10 +52,6 @@
         }
       }
     }
-  },
-  "level": {
-    "$resolver": "level",
-    "field": "name"
   },
   "logger": {
     "$resolver": "pattern",

--- a/common/utils/src/test/scala/org/apache/spark/util/StructuredLoggingSuite.scala
+++ b/common/utils/src/test/scala/org/apache/spark/util/StructuredLoggingSuite.scala
@@ -176,7 +176,7 @@ trait LoggingSuiteBase
 }
 
 class StructuredLoggingSuite extends LoggingSuiteBase {
-  override def className: String = classOf[StructuredLoggingSuite].getName
+  override def className: String = classOf[StructuredLoggingSuite].getSimpleName
   override def logFilePath: String = "target/structured.log"
 
   private val jsonMapper = new ObjectMapper().registerModule(DefaultScalaModule)

--- a/common/utils/src/test/scala/org/apache/spark/util/StructuredLoggingSuite.scala
+++ b/common/utils/src/test/scala/org/apache/spark/util/StructuredLoggingSuite.scala
@@ -192,8 +192,8 @@ class StructuredLoggingSuite extends LoggingSuiteBase {
       s"""
         {
           "ts": "<timestamp>",
-          "level": "$level",
           "msg": "This is a log message",
+          "level": "$level",
           "logger": "$className"
         }""")
   }
@@ -203,13 +203,13 @@ class StructuredLoggingSuite extends LoggingSuiteBase {
       s"""
         {
           "ts": "<timestamp>",
-          "level": "$level",
           "msg": "This is a log message",
           "exception": {
             "class": "java.lang.RuntimeException",
             "msg": "OOM",
             "stacktrace": "<stacktrace>"
           },
+          "level": "$level",
           "logger": "$className"
         }""")
   }
@@ -219,11 +219,11 @@ class StructuredLoggingSuite extends LoggingSuiteBase {
       s"""
         {
           "ts": "<timestamp>",
-          "level": "$level",
           "msg": "Lost executor 1.",
           "context": {
              "executor_id": "1"
           },
+          "level": "$level",
           "logger": "$className"
         }""")
     }
@@ -233,11 +233,11 @@ class StructuredLoggingSuite extends LoggingSuiteBase {
       s"""
         {
           "ts": "<timestamp>",
-          "level": "$level",
           "msg": "Lost executor null.",
           "context": {
              "executor_id": null
           },
+          "level": "$level",
           "logger": "$className"
         }""")
   }
@@ -247,7 +247,6 @@ class StructuredLoggingSuite extends LoggingSuiteBase {
       s"""
         {
           "ts": "<timestamp>",
-          "level": "$level",
           "msg": "Error in executor 1.",
           "context": {
             "executor_id": "1"
@@ -257,6 +256,7 @@ class StructuredLoggingSuite extends LoggingSuiteBase {
             "msg": "OOM",
             "stacktrace": "<stacktrace>"
           },
+          "level": "$level",
           "logger": "$className"
         }""")
   }
@@ -266,11 +266,11 @@ class StructuredLoggingSuite extends LoggingSuiteBase {
       s"""
         {
           "ts": "<timestamp>",
-          "level": "$level",
           "msg": "External system custom log message.",
           "context": {
               "custom_log_key": "External system custom log message."
           },
+          "level": "$level",
           "logger": "$className"
         }"""
     )
@@ -281,12 +281,12 @@ class StructuredLoggingSuite extends LoggingSuiteBase {
       s"""
         {
           "ts": "<timestamp>",
-          "level": "$level",
           "msg": "Min Size: 2, Max Size: 4. Please double check.",
           "context": {
             "min_size": "2",
             "max_size": "4"
           },
+          "level": "$level",
           "logger": "$className"
         }""")
 
@@ -294,12 +294,12 @@ class StructuredLoggingSuite extends LoggingSuiteBase {
       s"""
         {
           "ts": "<timestamp>",
-          "level": "$level",
           "msg": "Min Size: 2, Max Size: 4. Please double check.",
           "context": {
             "max_size": "4",
             "min_size": "2"
           },
+          "level": "$level",
           "logger": "$className"
         }""")
     assert(pattern1.r.matches(logOutput) || pattern2.r.matches(logOutput))

--- a/common/utils/src/test/scala/org/apache/spark/util/StructuredLoggingSuite.scala
+++ b/common/utils/src/test/scala/org/apache/spark/util/StructuredLoggingSuite.scala
@@ -192,8 +192,8 @@ class StructuredLoggingSuite extends LoggingSuiteBase {
       s"""
         {
           "ts": "<timestamp>",
-          "msg": "This is a log message",
           "level": "$level",
+          "msg": "This is a log message",
           "logger": "$className"
         }""")
   }
@@ -203,13 +203,13 @@ class StructuredLoggingSuite extends LoggingSuiteBase {
       s"""
         {
           "ts": "<timestamp>",
+          "level": "$level",
           "msg": "This is a log message",
           "exception": {
             "class": "java.lang.RuntimeException",
             "msg": "OOM",
             "stacktrace": "<stacktrace>"
           },
-          "level": "$level",
           "logger": "$className"
         }""")
   }
@@ -219,11 +219,11 @@ class StructuredLoggingSuite extends LoggingSuiteBase {
       s"""
         {
           "ts": "<timestamp>",
+          "level": "$level",
           "msg": "Lost executor 1.",
           "context": {
              "executor_id": "1"
           },
-          "level": "$level",
           "logger": "$className"
         }""")
     }
@@ -233,11 +233,11 @@ class StructuredLoggingSuite extends LoggingSuiteBase {
       s"""
         {
           "ts": "<timestamp>",
+          "level": "$level",
           "msg": "Lost executor null.",
           "context": {
              "executor_id": null
           },
-          "level": "$level",
           "logger": "$className"
         }""")
   }
@@ -247,6 +247,7 @@ class StructuredLoggingSuite extends LoggingSuiteBase {
       s"""
         {
           "ts": "<timestamp>",
+          "level": "$level",
           "msg": "Error in executor 1.",
           "context": {
             "executor_id": "1"
@@ -256,7 +257,6 @@ class StructuredLoggingSuite extends LoggingSuiteBase {
             "msg": "OOM",
             "stacktrace": "<stacktrace>"
           },
-          "level": "$level",
           "logger": "$className"
         }""")
   }
@@ -266,11 +266,11 @@ class StructuredLoggingSuite extends LoggingSuiteBase {
       s"""
         {
           "ts": "<timestamp>",
+          "level": "$level",
           "msg": "External system custom log message.",
           "context": {
               "custom_log_key": "External system custom log message."
           },
-          "level": "$level",
           "logger": "$className"
         }"""
     )
@@ -281,12 +281,12 @@ class StructuredLoggingSuite extends LoggingSuiteBase {
       s"""
         {
           "ts": "<timestamp>",
+          "level": "$level",
           "msg": "Min Size: 2, Max Size: 4. Please double check.",
           "context": {
             "min_size": "2",
             "max_size": "4"
           },
-          "level": "$level",
           "logger": "$className"
         }""")
 
@@ -294,12 +294,12 @@ class StructuredLoggingSuite extends LoggingSuiteBase {
       s"""
         {
           "ts": "<timestamp>",
+          "level": "$level",
           "msg": "Min Size: 2, Max Size: 4. Please double check.",
           "context": {
             "max_size": "4",
             "min_size": "2"
           },
-          "level": "$level",
           "logger": "$className"
         }""")
     assert(pattern1.r.matches(logOutput) || pattern2.r.matches(logOutput))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Improve the readability of JSON loggings via:
1. Use UTC in the timestamp so that the timestamp field value is more concise.
2. Display the simple name of the logger instead of the full qualified name.
3. Display the stack trace elements with `class`/`method`/`file`/`line` instead of stringifying everything into a long string.

Before changes:
<img width="2129" alt="image" src="https://github.com/apache/spark/assets/1097932/a7458293-2f84-4699-bbc2-3183a078a543">



After changes:
<img width="2341" alt="image" src="https://github.com/apache/spark/assets/1097932/23742bc0-4e1e-491c-83c9-b6695f41e57e">

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  6. If you fix a bug, you can clarify why it is a bug.
-->

Improve the readability of Spark logs
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing UT and manually reviews

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No