### PR TITLE
[SPARK-48075] [SS] Add type checking for PySpark avro functions

### DIFF
--- a/python/pyspark/sql/avro/functions.py
+++ b/python/pyspark/sql/avro/functions.py
@@ -22,6 +22,7 @@ A collections of builtin avro functions
 
 from typing import Dict, Optional, TYPE_CHECKING, cast
 
+from pyspark.errors import PySparkTypeError
 from pyspark.sql.column import Column
 from pyspark.sql.utils import get_active_spark_context, try_remote_avro_functions
 from pyspark.util import _print_missing_jar
@@ -80,6 +81,31 @@ def from_avro(
     from py4j.java_gateway import JVMView
     from pyspark.sql.classic.column import _to_java_column
 
+    if not isinstance(data, (Column, str)):
+        raise PySparkTypeError(
+            error_class="INVALID_TYPE",
+            message_parameters={
+                "arg_name": "data",
+                "arg_type": ":class:`~pyspark.sql.Column` or str"
+            },
+        )
+    if not isinstance(jsonFormatSchema, str):
+        raise PySparkTypeError(
+            error_class="INVALID_TYPE",
+            message_parameters={
+                "arg_name": "jsonFormatSchema",
+                "arg_type": "str"
+            },
+        )
+    if options is not None and not isinstance(options, dict):
+        raise PySparkTypeError(
+            error_class="INVALID_TYPE",
+            message_parameters={
+                "arg_name": "options",
+                "arg_type": "dict, optional"
+            },
+        )
+
     sc = get_active_spark_context()
     try:
         jc = cast(JVMView, sc._jvm).org.apache.spark.sql.avro.functions.from_avro(
@@ -130,6 +156,23 @@ def to_avro(data: "ColumnOrName", jsonFormatSchema: str = "") -> Column:
     """
     from py4j.java_gateway import JVMView
     from pyspark.sql.classic.column import _to_java_column
+
+    if not isinstance(data, (Column, str)):
+        raise PySparkTypeError(
+            error_class="INVALID_TYPE",
+            message_parameters={
+                "arg_name": "data",
+                "arg_type": ":class:`~pyspark.sql.Column` or str"
+            },
+        )
+    if not isinstance(jsonFormatSchema, str):
+        raise PySparkTypeError(
+            error_class="INVALID_TYPE",
+            message_parameters={
+                "arg_name": "jsonFormatSchema",
+                "arg_type": "str"
+            },
+        )
 
     sc = get_active_spark_context()
     try:

--- a/python/pyspark/sql/avro/functions.py
+++ b/python/pyspark/sql/avro/functions.py
@@ -86,7 +86,7 @@ def from_avro(
             error_class="INVALID_TYPE",
             message_parameters={
                 "arg_name": "data",
-                "arg_type": ":class:`~pyspark.sql.Column` or str",
+                "arg_type": "pyspark.sql.Column or str",
             },
         )
     if not isinstance(jsonFormatSchema, str):
@@ -156,7 +156,7 @@ def to_avro(data: "ColumnOrName", jsonFormatSchema: str = "") -> Column:
             error_class="INVALID_TYPE",
             message_parameters={
                 "arg_name": "data",
-                "arg_type": ":class:`~pyspark.sql.Column` or str",
+                "arg_type": "pyspark.sql.Column or str",
             },
         )
     if not isinstance(jsonFormatSchema, str):

--- a/python/pyspark/sql/avro/functions.py
+++ b/python/pyspark/sql/avro/functions.py
@@ -86,24 +86,18 @@ def from_avro(
             error_class="INVALID_TYPE",
             message_parameters={
                 "arg_name": "data",
-                "arg_type": ":class:`~pyspark.sql.Column` or str"
+                "arg_type": ":class:`~pyspark.sql.Column` or str",
             },
         )
     if not isinstance(jsonFormatSchema, str):
         raise PySparkTypeError(
             error_class="INVALID_TYPE",
-            message_parameters={
-                "arg_name": "jsonFormatSchema",
-                "arg_type": "str"
-            },
+            message_parameters={"arg_name": "jsonFormatSchema", "arg_type": "str"},
         )
     if options is not None and not isinstance(options, dict):
         raise PySparkTypeError(
             error_class="INVALID_TYPE",
-            message_parameters={
-                "arg_name": "options",
-                "arg_type": "dict, optional"
-            },
+            message_parameters={"arg_name": "options", "arg_type": "dict, optional"},
         )
 
     sc = get_active_spark_context()
@@ -162,16 +156,13 @@ def to_avro(data: "ColumnOrName", jsonFormatSchema: str = "") -> Column:
             error_class="INVALID_TYPE",
             message_parameters={
                 "arg_name": "data",
-                "arg_type": ":class:`~pyspark.sql.Column` or str"
+                "arg_type": ":class:`~pyspark.sql.Column` or str",
             },
         )
     if not isinstance(jsonFormatSchema, str):
         raise PySparkTypeError(
             error_class="INVALID_TYPE",
-            message_parameters={
-                "arg_name": "jsonFormatSchema",
-                "arg_type": "str"
-            },
+            message_parameters={"arg_name": "jsonFormatSchema", "arg_type": "str"},
         )
 
     sc = get_active_spark_context()

--- a/python/pyspark/sql/connect/avro/functions.py
+++ b/python/pyspark/sql/connect/avro/functions.py
@@ -42,24 +42,18 @@ def from_avro(
             error_class="INVALID_TYPE",
             message_parameters={
                 "arg_name": "data",
-                "arg_type": ":class:`~pyspark.sql.Column` or str"
+                "arg_type": ":class:`~pyspark.sql.Column` or str",
             },
         )
     if not isinstance(jsonFormatSchema, str):
         raise PySparkTypeError(
             error_class="INVALID_TYPE",
-            message_parameters={
-                "arg_name": "jsonFormatSchema",
-                "arg_type": "str"
-            },
+            message_parameters={"arg_name": "jsonFormatSchema", "arg_type": "str"},
         )
     if options is not None and not isinstance(options, dict):
         raise PySparkTypeError(
             error_class="INVALID_TYPE",
-            message_parameters={
-                "arg_name": "options",
-                "arg_type": "dict, optional"
-            },
+            message_parameters={"arg_name": "options", "arg_type": "dict, optional"},
         )
 
     if options is None:
@@ -79,16 +73,13 @@ def to_avro(data: "ColumnOrName", jsonFormatSchema: str = "") -> Column:
             error_class="INVALID_TYPE",
             message_parameters={
                 "arg_name": "data",
-                "arg_type": ":class:`~pyspark.sql.Column` or str"
+                "arg_type": ":class:`~pyspark.sql.Column` or str",
             },
         )
     if not isinstance(jsonFormatSchema, str):
         raise PySparkTypeError(
             error_class="INVALID_TYPE",
-            message_parameters={
-                "arg_name": "jsonFormatSchema",
-                "arg_type": "str"
-            },
+            message_parameters={"arg_name": "jsonFormatSchema", "arg_type": "str"},
         )
 
     if jsonFormatSchema == "":

--- a/python/pyspark/sql/connect/avro/functions.py
+++ b/python/pyspark/sql/connect/avro/functions.py
@@ -19,6 +19,7 @@
 A collections of builtin avro functions
 """
 
+from pyspark.errors import PySparkTypeError
 from pyspark.sql.connect.utils import check_dependencies
 
 check_dependencies(__name__)
@@ -36,6 +37,31 @@ if TYPE_CHECKING:
 def from_avro(
     data: "ColumnOrName", jsonFormatSchema: str, options: Optional[Dict[str, str]] = None
 ) -> Column:
+    if not isinstance(data, (Column, str)):
+        raise PySparkTypeError(
+            error_class="INVALID_TYPE",
+            message_parameters={
+                "arg_name": "data",
+                "arg_type": ":class:`~pyspark.sql.Column` or str"
+            },
+        )
+    if not isinstance(jsonFormatSchema, str):
+        raise PySparkTypeError(
+            error_class="INVALID_TYPE",
+            message_parameters={
+                "arg_name": "jsonFormatSchema",
+                "arg_type": "str"
+            },
+        )
+    if options is not None and not isinstance(options, dict):
+        raise PySparkTypeError(
+            error_class="INVALID_TYPE",
+            message_parameters={
+                "arg_name": "options",
+                "arg_type": "dict, optional"
+            },
+        )
+
     if options is None:
         return _invoke_function("from_avro", _to_col(data), lit(jsonFormatSchema))
     else:
@@ -48,6 +74,23 @@ from_avro.__doc__ = PyAvroFunctions.from_avro.__doc__
 
 
 def to_avro(data: "ColumnOrName", jsonFormatSchema: str = "") -> Column:
+    if not isinstance(data, (Column, str)):
+        raise PySparkTypeError(
+            error_class="INVALID_TYPE",
+            message_parameters={
+                "arg_name": "data",
+                "arg_type": ":class:`~pyspark.sql.Column` or str"
+            },
+        )
+    if not isinstance(jsonFormatSchema, str):
+        raise PySparkTypeError(
+            error_class="INVALID_TYPE",
+            message_parameters={
+                "arg_name": "jsonFormatSchema",
+                "arg_type": "str"
+            },
+        )
+
     if jsonFormatSchema == "":
         return _invoke_function("to_avro", _to_col(data))
     else:

--- a/python/pyspark/sql/connect/avro/functions.py
+++ b/python/pyspark/sql/connect/avro/functions.py
@@ -42,7 +42,7 @@ def from_avro(
             error_class="INVALID_TYPE",
             message_parameters={
                 "arg_name": "data",
-                "arg_type": ":class:`~pyspark.sql.Column` or str",
+                "arg_type": "pyspark.sql.Column or str",
             },
         )
     if not isinstance(jsonFormatSchema, str):
@@ -73,7 +73,7 @@ def to_avro(data: "ColumnOrName", jsonFormatSchema: str = "") -> Column:
             error_class="INVALID_TYPE",
             message_parameters={
                 "arg_name": "data",
-                "arg_type": ":class:`~pyspark.sql.Column` or str",
+                "arg_type": "pyspark.sql.Column or str",
             },
         )
     if not isinstance(jsonFormatSchema, str):

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1531,7 +1531,7 @@ class FunctionsTestsMixin:
 
     def test_avro_type_check(self):
         parameters = ["data", "jsonFormatSchema", "options"]
-        expected_type = [":class:`~pyspark.sql.Column` or str", "str", "dict, optional"]
+        expected_type = ["pyspark.sql.Column or str", "str", "dict, optional"]
         dummyDF = self.spark.createDataFrame([Row(a=i, b=i) for i in range(5)])
 
         # test from_avro type checks for each parameter

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1547,10 +1547,7 @@ class FunctionsTestsMixin:
             self.check_error(
                 exception=from_avro_pes[i].exception,
                 error_class="INVALID_TYPE",
-                message_parameters={
-                    "arg_name": parameters[i],
-                    "arg_type": expected_type[i]
-                },
+                message_parameters={"arg_name": parameters[i], "arg_type": expected_type[i]},
             )
 
         # test to_avro type checks for each parameter
@@ -1565,6 +1562,7 @@ class FunctionsTestsMixin:
                 error_class="INVALID_TYPE",
                 message_parameters={"arg_name": parameters[i], "arg_type": expected_type[i]},
             )
+
 
 class FunctionsTests(ReusedSQLTestCase, FunctionsTestsMixin):
     pass

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -26,6 +26,7 @@ import unittest
 
 from pyspark.errors import PySparkTypeError, PySparkValueError, SparkRuntimeException
 from pyspark.sql import Row, Window, functions as F, types
+from pyspark.sql.avro.functions import from_avro, to_avro
 from pyspark.sql.column import Column
 from pyspark.testing.sqlutils import ReusedSQLTestCase, SQLTestUtils
 from pyspark.testing.utils import have_numpy
@@ -1528,6 +1529,42 @@ class FunctionsTestsMixin:
             lambda: df.select(F.json_tuple(df.jstring)),
         )
 
+    def test_avro_type_check(self):
+        parameters = ["data", "jsonFormatSchema", "options"]
+        expected_type = [":class:`~pyspark.sql.Column` or str", "str", "dict, optional"]
+        dummyDF = self.spark.createDataFrame([Row(a=i, b=i) for i in range(5)])
+
+        # test from_avro type checks for each parameter
+        wrong_type_value = 1
+        with self.assertRaises(PySparkTypeError) as pe1:
+            dummyDF.select(from_avro(wrong_type_value, "jsonSchema", None))
+        with self.assertRaises(PySparkTypeError) as pe2:
+            dummyDF.select(from_avro("value", wrong_type_value, None))
+        with self.assertRaises(PySparkTypeError) as pe3:
+            dummyDF.select(from_avro("value", "jsonSchema", wrong_type_value))
+        from_avro_pes = [pe1, pe2, pe3]
+        for i in range(3):
+            self.check_error(
+                exception=from_avro_pes[i].exception,
+                error_class="INVALID_TYPE",
+                message_parameters={
+                    "arg_name": parameters[i],
+                    "arg_type": expected_type[i]
+                },
+            )
+
+        # test to_avro type checks for each parameter
+        with self.assertRaises(PySparkTypeError) as pe4:
+            dummyDF.select(to_avro(wrong_type_value, "jsonSchema"))
+        with self.assertRaises(PySparkTypeError) as pe5:
+            dummyDF.select(to_avro("value", wrong_type_value))
+        to_avro_pes = [pe4, pe5]
+        for i in range(2):
+            self.check_error(
+                exception=to_avro_pes[i].exception,
+                error_class="INVALID_TYPE",
+                message_parameters={"arg_name": parameters[i], "arg_type": expected_type[i]},
+            )
 
 class FunctionsTests(ReusedSQLTestCase, FunctionsTestsMixin):
     pass


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add type checking for `to_avro` and `from_avro` for PySpark.

### Why are the changes needed?
If we perform type checking for arguments and output sensible errors when the type of arguments passed into the functions don’t match, we can give the user a better user experience

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit test

### Was this patch authored or co-authored using generative AI tooling?
No