### PR TITLE
[SPARK-46894][PYTHON][FOLLOW-UP] Includes `error-conditions.json` into PyPI package

### DIFF
--- a/python/packaging/connect/setup.py
+++ b/python/packaging/connect/setup.py
@@ -180,6 +180,7 @@ try:
         author_email="dev@spark.apache.org",
         url="https://github.com/apache/spark/tree/master/python",
         packages=connect_packages + test_packages,
+        include_package_data=True,
         license="http://www.apache.org/licenses/LICENSE-2.0",
         # Don't forget to update python/docs/source/getting_started/install.rst
         # if you're updating the versions or dependencies.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/44920 that includes `error-conditions.json` into PyPI package.

### Why are the changes needed?

So PyPI packages work with pip install. https://github.com/apache/spark/actions/runs/8913716987/job/24479781481 is broken for now.

### Does this PR introduce _any_ user-facing change?

No, the main change has not been released out yet.

### How was this patch tested?

Manually tested the packaging, and check the file exists in the package.

### Was this patch authored or co-authored using generative AI tooling?

No.
