### PR TITLE
[SPARK-48080][K8S] Promote `*MainAppResource` and `NonJVMResource` to `DeveloperApi`

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/MainAppResource.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/MainAppResource.scala
@@ -16,15 +16,38 @@
  */
 package org.apache.spark.deploy.k8s.submit
 
-private[spark] sealed trait MainAppResource
+import org.apache.spark.annotation.{DeveloperApi, Since, Stable}
 
-private[spark] sealed trait NonJVMResource
+/**
+ * :: DeveloperApi ::
+ *
+ * All traits and classes in this file are used by K8s module and Spark K8s operator.
+ */
 
-private[spark] case class JavaMainAppResource(primaryResource: Option[String])
+@Stable
+@DeveloperApi
+@Since("2.3.0")
+sealed trait MainAppResource
+
+@Stable
+@DeveloperApi
+@Since("2.4.0")
+sealed trait NonJVMResource
+
+@Stable
+@DeveloperApi
+@Since("3.0.0")
+case class JavaMainAppResource(primaryResource: Option[String])
   extends MainAppResource
 
-private[spark] case class PythonMainAppResource(primaryResource: String)
+@Stable
+@DeveloperApi
+@Since("2.4.0")
+case class PythonMainAppResource(primaryResource: String)
   extends MainAppResource with NonJVMResource
 
-private[spark] case class RMainAppResource(primaryResource: String)
+@Stable
+@DeveloperApi
+@Since("2.4.0")
+case class RMainAppResource(primaryResource: String)
   extends MainAppResource with NonJVMResource


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to promote `*MainAppResource` and `NonJVMResource` to `DeveloperApi`.

### Why are the changes needed?

Since `Apache Spark Kubernetes Operator` depends on these traits and classes, we had better maintain it as a developer API officially from `Apache Spark 4.0.0`.
- https://github.com/apache/spark-kubernetes-operator/pull/10

Since there are no changes after `3.0.0`, these are defined as `Stable`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.