### PR TITLE
[DO-NOT-REVIEW] [SPARK-48093][SS][CONNECT][3.5] Add config to switch between client side and server side StreamingQueryListener

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -207,4 +207,13 @@ object Connect {
     .version("3.5.0")
     .intConf
     .createWithDefault(200)
+
+  val CONNECT_SERVER_SIDE_STREAMING_QUERY_LISTENER_ENABLED =
+    buildConf("spark.sql.connect.streaming.serverSideListener.enabled")
+      .doc("When true, the addListener call from StreamingQueryManager will register all" +
+        s" StreamingQueryListener on the server side. When false, it registers the listener on" +
+        " the client side.")
+      .version("3.5.0")
+      .booleanConf
+      .createWithDefault(false)
 }

--- a/python/pyspark/sql/tests/connect/streaming/test_parity_listener.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_listener.py
@@ -21,6 +21,7 @@ import time
 import pyspark.cloudpickle
 from pyspark.sql.tests.streaming.test_streaming_listener import StreamingListenerTestsMixin
 from pyspark.sql.streaming.listener import StreamingQueryListener
+from pyspark.sql.connect.streaming.query import StreamingQueryManager # EDGE
 from pyspark.sql.functions import count, lit
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
@@ -93,6 +94,14 @@ class StreamingListenerParityTests(StreamingListenerTestsMixin, ReusedConnectTes
 
             # Remove again to verify this won't throw any error
             self.spark.streams.removeListener(test_listener)
+
+    def test_server_side_listener_conf(self):
+        with self.sql_conf({"spark.sql.connect.streaming.serverSideListener.enabled": True}):
+            sqm = StreamingQueryManager(self.spark)
+            self.assertIsNone(sqm._sqlb)
+        with self.sql_conf({"spark.sql.connect.streaming.serverSideListener.enabled": False}):
+            sqm = StreamingQueryManager(self.spark)
+            self.assertIsNotNone(sqm._sqlb)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
We are backporting the client side StreamingQueryListenr to branch-3.5. In case there is usage of server side listener and users want to preserve this behavior, add this config handler in server, also the client can retrieve the config from the server on what type of listener to use. Note that on 4.0 and upwards we only have client side listener implemented in python client. So this config should only be sent to clients with spark version 3.5.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Backward compatibility

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added unit test 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No