### PR TITLE
[SPARK-48095][INFRA] Run `build_non_ansi.yml` once per day

### DIFF
--- a/.github/workflows/build_non_ansi.yml
+++ b/.github/workflows/build_non_ansi.yml
@@ -21,7 +21,7 @@ name: "Build / NON-ANSI (master, Hadoop 3, JDK 17, Scala 2.13)"
 
 on:
   schedule:
-    - cron: '0 1,13 * * *'
+    - cron: '0 1 * * *'
 
 jobs:
   run-build:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to reduce `build_non_ansi.yml` frequency from twice per day to once per day.

### Why are the changes needed?

To reduce GitHub Action usage to meet ASF INFRA policy.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.