### PR TITLE
[SPARK-48096][INFRA] Run `build_maven_java21_macos14.yml` every two days

### DIFF
--- a/.github/workflows/build_maven_java21_macos14.yml
+++ b/.github/workflows/build_maven_java21_macos14.yml
@@ -21,7 +21,7 @@ name: "Build / Maven (master, Scala 2.13, Hadoop 3, JDK 21, macos-14)"
 
 on:
   schedule:
-    - cron: '0 20 * * *'
+    - cron: '0 20 */2 * *'
 
 jobs:
   run-build:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to reduce `build_maven_java21_macos14.yml` frequency from once per day to every two days.

### Why are the changes needed?

To reduce GitHub Action usage to meet ASF INFRA policy.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.