### PR TITLE
[SPARK-48099][INFRA] Run `maven-build` test only on `Java 21 on MacOS14 (Apple Silicon)`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -794,10 +794,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - java: 17
-            os: ubuntu-latest
-          - java: 21
-            os: ubuntu-latest
           - java: 21
             os: macos-14 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to reduce the concurrency of GitHub Action Job, `build_and_test.yml`, by run `maven-build` test only on `Java 21 on MacOS 14 (Apple Silicon)`.

### Why are the changes needed?

- According to ASF INFRA policy, we need to reduce the job concurrency level to 
    - https://infra.apache.org/github-actions-policy.html
    > All workflows MUST have a job concurrency level less than or equal to 20.

- `Java 21 on MacOS 14 (Apple Silicon)` is the fastest Maven build job and covers both `Java 21` and `Apple Silicon`.
    <img width="632" alt="Screenshot 2024-05-02 at 14 59 14" src="https://github.com/apache/spark/assets/9700541/735819f5-6974-4fe7-ab28-3543ea67fd45">

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Check the CI of this PR.
- https://github.com/dongjoon-hyun/spark/actions/runs/8931039406/job/24532621876

<img width="283" alt="Screenshot 2024-05-02 at 15 33 12" src="https://github.com/apache/spark/assets/9700541/ea02f524-add8-4cdb-9b61-191513cb4cea">


### Was this patch authored or co-authored using generative AI tooling?

No.