### PR TITLE
[SPARK-48107][PYTHON] Exclude tests from Python distribution

### DIFF
--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -16,7 +16,7 @@
 
 # Reference: https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html
 
-graft pyspark
+recursive-include pyspark *.pyi py.typed *.json
 recursive-include deps/jars *.jar
 graft deps/bin
 recursive-include deps/sbin spark-config.sh spark-daemon.sh start-history-server.sh stop-history-server.sh


### PR DESCRIPTION
### What changes were proposed in this pull request?

Change the Python manifest so that tests are excluded from the packages that are built for distribution.

### Why are the changes needed?

Tests were unintentionally included in the distributions as part of #44920. See [this comment](https://github.com/apache/spark/pull/44920/files#r1586979834).

### Does this PR introduce _any_ user-facing change?

No, since #44920 hasn't been released to any users yet.

### How was this patch tested?

I built Python packages and inspected `SOURCES.txt` to confirm that tests were excluded:

```sh
cd python
rm -rf pyspark.egg-info || echo "No existing egg info file, skipping deletion"
python3 packaging/classic/setup.py sdist
python3 packaging/connect/setup.py sdist
find dist -name '*.tar.gz' | xargs -I _ tar xf _ --directory=dist
cd ..
open python/dist
find python/dist -name SOURCES.txt | xargs code
```

### Was this patch authored or co-authored using generative AI tooling?

No.