### PR TITLE
[SPARK-48108][INFRA] Skip `tpcds-1g` and `docker-integration-tests` tests from `RocksDB UI-Backend` job

### DIFF
--- a/.github/workflows/build_rockdb_as_ui_backend.yml
+++ b/.github/workflows/build_rockdb_as_ui_backend.yml
@@ -42,7 +42,5 @@ jobs:
         {
           "build": "true",
           "pyspark": "true",
-          "sparkr": "true",
-          "tpcds-1g": "true",
-          "docker-integration-tests": "true"
+          "sparkr": "true"
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to skip `tpcds-1g` and `docker-integration-tests` tests from `RocksDB UI-Backend` job, `build_rockdb_as_ui_backend.yml`.

### Why are the changes needed?

To reduce GitHub Action usage to meet ASF INFRA policy.
- https://infra.apache.org/github-actions-policy.html

    > The average number of minutes a project uses in any consecutive five-day period MUST NOT exceed the equivalent of 30 full-time runners (216,000 minutes, or 3,600 hours).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review because this is a daily CI update.

### Was this patch authored or co-authored using generative AI tooling?

No.