### PR TITLE
[SPARK-48109][INFRA] Enable `k8s-integration-tests` only for `kubernetes` module change

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -82,6 +82,7 @@ jobs:
           sparkr=`./dev/is-changed.py -m sparkr`
           tpcds=`./dev/is-changed.py -m sql`
           docker=`./dev/is-changed.py -m docker-integration-tests`
+          kubernetes=`./dev/is-changed.py -m kubernetes`
           # 'build' and 'maven-build' are always true for now.
           # It does not save significant time and most of PRs trigger the build.
           precondition="
@@ -93,7 +94,7 @@ jobs:
               \"docker-integration-tests\": \"$docker\",
               \"maven-build\": \"true\",
               \"lint\" : \"true\",
-              \"k8s-integration-tests\" : \"true\",
+              \"k8s-integration-tests\" : \"$kubernetes\",
               \"buf\" : \"true\",
               \"ui\" : \"true\",
             }"

--- a/.github/workflows/build_branch34.yml
+++ b/.github/workflows/build_branch34.yml
@@ -47,5 +47,6 @@ jobs:
           "sparkr": "true",
           "tpcds-1g": "true",
           "docker-integration-tests": "true",
+          "k8s-integration-tests": "true",
           "lint" : "true"
         }

--- a/.github/workflows/build_branch35.yml
+++ b/.github/workflows/build_branch35.yml
@@ -47,5 +47,6 @@ jobs:
           "sparkr": "true",
           "tpcds-1g": "true",
           "docker-integration-tests": "true",
+          "k8s-integration-tests": "true",
           "lint" : "true"
         }

--- a/.github/workflows/build_java21.yml
+++ b/.github/workflows/build_java21.yml
@@ -46,5 +46,6 @@ jobs:
           "pyspark": "true",
           "sparkr": "true",
           "tpcds-1g": "true",
-          "docker-integration-tests": "true"
+          "docker-integration-tests": "true",
+          "k8s-integration-tests": "true"
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable `k8s-integration-tests` only for `kubernetes` module change.

Although there is a chance of missing `core` module change, the daily CI test coverage will reveal that.

### Why are the changes needed?

To reduce GitHub Action usage to meet ASF INFRA policy.
- https://infra.apache.org/github-actions-policy.html

    > The average number of minutes a project uses in any consecutive five-day period MUST NOT exceed the equivalent of 30 full-time runners (216,000 minutes, or 3,600 hours).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.