### PR TITLE
[SPARK-48111][INFRA] Disable Docker integration test and TPC-DS in commit builder

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -76,12 +76,10 @@ jobs:
       id: set-outputs
       run: |
         if [ -z "${{ inputs.jobs }}" ]; then
-          pyspark=true; sparkr=true; tpcds=true; docker=true;
+          pyspark=true; sparkr=true;
           pyspark_modules=`cd dev && python -c "import sparktestsupport.modules as m; print(','.join(m.name for m in m.all_modules if m.name.startswith('pyspark')))"`
           pyspark=`./dev/is-changed.py -m $pyspark_modules`
           sparkr=`./dev/is-changed.py -m sparkr`
-          tpcds=`./dev/is-changed.py -m sql`
-          docker=`./dev/is-changed.py -m docker-integration-tests`
           kubernetes=`./dev/is-changed.py -m kubernetes`
           # 'build' and 'maven-build' are always true for now.
           # It does not save significant time and most of PRs trigger the build.
@@ -90,8 +88,8 @@ jobs:
               \"build\": \"true\",
               \"pyspark\": \"$pyspark\",
               \"sparkr\": \"$sparkr\",
-              \"tpcds-1g\": \"$tpcds\",
-              \"docker-integration-tests\": \"$docker\",
+              \"tpcds-1g\": \"false\",
+              \"docker-integration-tests\": \"false\",
               \"maven-build\": \"true\",
               \"lint\" : \"true\",
               \"k8s-integration-tests\" : \"$kubernetes\",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to disable Docker integration test and TPC-DS in commit builder

### Why are the changes needed?

This is being tested in daily scheduled build: https://github.com/apache/spark/blob/master/.github/workflows/build_java21.yml#L48-L49

Both are pretty unlikely broken in my experience.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

CI in this PR should verify them

### Was this patch authored or co-authored using generative AI tooling?

No.
