### PR TITLE
[SPARK-48112][CONNECT] Expose session in SparkConnectPlanner to plugins

### DIFF
--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -30,7 +30,7 @@ import io.grpc.stub.StreamObserver
 import org.apache.commons.lang3.exception.ExceptionUtils
 
 import org.apache.spark.{Partition, SparkEnv, TaskContext}
-import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.annotation.{DeveloperApi, Since}
 import org.apache.spark.api.python.{PythonEvalType, SimplePythonFunction}
 import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.{CreateResourceProfileCommand, ExecutePlanResponse, SqlCommand, StreamingForeachFunction, StreamingQueryCommand, StreamingQueryCommandResult, StreamingQueryInstanceId, StreamingQueryManagerCommand, StreamingQueryManagerCommandResult, WriteStreamOperationStart, WriteStreamOperationStartResult}
@@ -101,6 +101,7 @@ class SparkConnectPlanner(
     throw new IllegalArgumentException("executeHolder does not belong to sessionHolder")
   }
 
+  @Since("4.0.0")
   @DeveloperApi
   def session: SparkSession = sessionHolder.session
 

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -101,7 +101,8 @@ class SparkConnectPlanner(
     throw new IllegalArgumentException("executeHolder does not belong to sessionHolder")
   }
 
-  private[connect] def session: SparkSession = sessionHolder.session
+  @DeveloperApi
+  def session: SparkSession = sessionHolder.session
 
   private[connect] def parser = session.sessionState.sqlParser
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes `session` in `SparkConnectPlanner` public so that it can be accessed by Spark Connect plugins. This method was public before but was made private. To prevent this from happening I have added `@DeveloperApi` as an annotation.

### Why are the changes needed?

To allow the development of Spark Connect plugins.


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

N/A


### Was this patch authored or co-authored using generative AI tooling?

No
