### PR TITLE
[SPARK-48113][CONNECT] Allow Plugins to integrate with Spark Connect

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Column.scala
@@ -52,7 +52,7 @@ import org.apache.spark.util.ArrayImplicits._
  *
  * @since 3.4.0
  */
-class Column private[sql] (@DeveloperApi val expr: proto.Expression) extends Logging {
+class Column(@DeveloperApi val expr: proto.Expression) extends Logging {
 
   private[sql] def this(name: String, planId: Option[Long]) =
     this(Column.nameToExpression(name, planId))
@@ -1325,11 +1325,12 @@ class Column private[sql] (@DeveloperApi val expr: proto.Expression) extends Log
 
 object Column {
 
-  def apply(name: String): Column = new Column(name)
+  private[sql] def apply(name: String): Column = new Column(name)
 
-  def apply(name: String, planId: Option[Long]): Column = new Column(name, planId)
+  private[sql] def apply(name: String, planId: Option[Long]): Column = new Column(name, planId)
 
-  def nameToExpression(name: String, planId: Option[Long] = None): proto.Expression = {
+  private[sql] def nameToExpression(
+      name: String, planId: Option[Long] = None): proto.Expression = {
     val builder = proto.Expression.newBuilder()
     name match {
       case "*" =>

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Column.scala
@@ -1323,7 +1323,7 @@ class Column private[sql] (@DeveloperApi val expr: proto.Expression) extends Log
   def over(): Column = over(Window.spec)
 }
 
-private[sql] object Column {
+object Column {
 
   def apply(name: String): Column = new Column(name)
 
@@ -1344,21 +1344,11 @@ private[sql] object Column {
     builder.build()
   }
 
-  private[sql] def apply(f: proto.Expression.Builder => Unit): Column = {
+  @DeveloperApi
+  def apply(f: proto.Expression.Builder => Unit): Column = {
     val builder = proto.Expression.newBuilder()
     f(builder)
     new Column(builder.build())
-  }
-
-  @DeveloperApi
-  @deprecated("Use forExtension(Array[Byte]) instead", "4.0.0")
-  def apply(extension: com.google.protobuf.Any): Column = {
-    apply(_.setExtension(extension))
-  }
-
-  @DeveloperApi
-  def forExtension(extension: Array[Byte]): Column = {
-    apply(_.setExtension(com.google.protobuf.Any.parseFrom(extension)))
   }
 
   private[sql] def fn(name: String, inputs: Column*): Column = {

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Column.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.annotation.{DeveloperApi, Since}
 import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.Expression.SortOrder.NullOrdering
 import org.apache.spark.connect.proto.Expression.SortOrder.SortDirection
@@ -1344,6 +1344,7 @@ object Column {
     builder.build()
   }
 
+  @Since("4.0.0")
   @DeveloperApi
   def apply(f: proto.Expression.Builder => Unit): Column = {
     val builder = proto.Expression.newBuilder()

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -39,7 +39,6 @@ import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders.{BoxedLongEncoder
 import org.apache.spark.sql.connect.client.{ClassFinder, SparkConnectClient, SparkResult}
 import org.apache.spark.sql.connect.client.SparkConnectClient.Configuration
 import org.apache.spark.sql.connect.client.arrow.ArrowSerializer
-import org.apache.spark.sql.connect.common.ProtoUtils
 import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.internal.{CatalogImpl, SqlApiConf}
 import org.apache.spark.sql.streaming.DataStreamReader

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -28,7 +28,7 @@ import com.google.common.cache.{CacheBuilder, CacheLoader}
 import io.grpc.ClientInterceptor
 import org.apache.arrow.memory.RootAllocator
 
-import org.apache.spark.annotation.{DeveloperApi, Experimental}
+import org.apache.spark.annotation.{DeveloperApi, Experimental, Since}
 import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.ExecutePlanResponse
 import org.apache.spark.internal.Logging
@@ -482,11 +482,13 @@ class SparkSession private[sql] (
     }
   }
 
+  @Since("4.0.0")
   @DeveloperApi
   def newDataFrame(f: proto.Relation.Builder => Unit): DataFrame = {
     newDataset(UnboundRowEncoder)(f)
   }
 
+  @Since("4.0.0")
   @DeveloperApi
   def newDataset[T](encoder: AgnosticEncoder[T])(
       f: proto.Relation.Builder => Unit): Dataset[T] = {
@@ -543,6 +545,7 @@ class SparkSession private[sql] (
     client.execute(plan).foreach(_ => ())
   }
 
+  @Since("4.0.0")
   @DeveloperApi
   def execute(command: proto.Command): Seq[ExecutePlanResponse] = {
     val plan = proto.Plan.newBuilder().setCommand(command).build()

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientDatasetSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientDatasetSuite.scala
@@ -162,30 +162,6 @@ class ClientDatasetSuite extends ConnectFunSuite with BeforeAndAfterEach {
     }
   }
 
-  test("command extension deprecated") {
-    val extension = proto.ExamplePluginCommand.newBuilder().setCustomField("abc").build()
-    val command = proto.Command
-      .newBuilder()
-      .setExtension(com.google.protobuf.Any.pack(extension))
-      .build()
-    val expectedPlan = proto.Plan.newBuilder().setCommand(command).build()
-    ss.execute(com.google.protobuf.Any.pack(extension))
-    val actualPlan = service.getAndClearLatestInputPlan()
-    assert(actualPlan.equals(expectedPlan))
-  }
-
-  test("command extension") {
-    val extension = proto.ExamplePluginCommand.newBuilder().setCustomField("abc").build()
-    val command = proto.Command
-      .newBuilder()
-      .setExtension(com.google.protobuf.Any.pack(extension))
-      .build()
-    val expectedPlan = proto.Plan.newBuilder().setCommand(command).build()
-    ss.execute(com.google.protobuf.Any.pack(extension).toByteArray)
-    val actualPlan = service.getAndClearLatestInputPlan()
-    assert(actualPlan.equals(expectedPlan))
-  }
-
   test("serialize as null") {
     val session = newSparkSession()
     val ds = session.range(10)

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/PlanGenerationTestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/PlanGenerationTestSuite.scala
@@ -3227,34 +3227,12 @@ class PlanGenerationTestSuite
   }
 
   /* Extensions */
-  test("relation extension deprecated") {
-    val input = proto.ExamplePluginRelation
-      .newBuilder()
-      .setInput(simple.plan.getRoot)
-      .build()
-    session.newDataFrame(com.google.protobuf.Any.pack(input))
-  }
-
-  test("expression extension deprecated") {
-    val extension = proto.ExamplePluginExpression
-      .newBuilder()
-      .setChild(
-        proto.Expression
-          .newBuilder()
-          .setUnresolvedAttribute(proto.Expression.UnresolvedAttribute
-            .newBuilder()
-            .setUnparsedIdentifier("id")))
-      .setCustomField("abc")
-      .build()
-    simple.select(Column(com.google.protobuf.Any.pack(extension)))
-  }
-
   test("relation extension") {
     val input = proto.ExamplePluginRelation
       .newBuilder()
       .setInput(simple.plan.getRoot)
       .build()
-    session.newDataFrame(com.google.protobuf.Any.pack(input).toByteArray)
+    session.newDataFrame(_.setExtension(com.google.protobuf.Any.pack(input)))
   }
 
   test("expression extension") {
@@ -3268,7 +3246,7 @@ class PlanGenerationTestSuite
             .setUnparsedIdentifier("id")))
       .setCustomField("abc")
       .build()
-    simple.select(Column.forExtension(com.google.protobuf.Any.pack(extension).toByteArray))
+    simple.select(Column(_.setExtension(com.google.protobuf.Any.pack(extension))))
   }
 
   test("crosstab") {

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
@@ -358,6 +358,15 @@ object CheckConnectJvmClientCompatibility {
         .exclude[MissingClassProblem](
           "org.apache.spark.sql.expressions.SparkConnectClosureCleaner$"),
 
+      // Column
+      // developer API
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+        "org.apache.spark.sql.Column.apply"
+      ),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+        "org.apache.spark.sql.Column.expr"
+      ),
+
       // Dataset
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "org.apache.spark.sql.Dataset.plan"

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/ConnectProtoUtils.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/ConnectProtoUtils.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect
+
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.connect.proto
+import org.apache.spark.sql.connect.common.ProtoUtils
+
+/**
+ * Utility functions for parsing Spark Connect protocol buffers with a recursion limit.
+ * This is intended to be used by plugins, as they cannot use `ProtoUtils.parseWithRecursionLimit`
+ * due to the shading of the `com.google.protobuf` package.
+ */
+object ConnectProtoUtils {
+  @DeveloperApi
+  def parsePlanWithRecursionLimit(bytes: Array[Byte], recursionLimit: Int): proto.Plan = {
+    ProtoUtils.parseWithRecursionLimit(bytes, proto.Plan.parser(), recursionLimit)
+  }
+
+  @DeveloperApi
+  def parseRelationWithRecursionLimit(bytes: Array[Byte], recursionLimit: Int): proto.Relation = {
+    ProtoUtils.parseWithRecursionLimit(bytes, proto.Relation.parser(), recursionLimit)
+  }
+
+  @DeveloperApi
+  def parseCommandWithRecursionLimit(bytes: Array[Byte], recursionLimit: Int): proto.Command = {
+    ProtoUtils.parseWithRecursionLimit(bytes, proto.Command.parser(), recursionLimit)
+  }
+
+  @DeveloperApi
+  def parseExpressionWithRecursionLimit(
+      bytes: Array[Byte], recursionLimit: Int): proto.Expression = {
+    ProtoUtils.parseWithRecursionLimit(bytes, proto.Expression.parser(), recursionLimit)
+  }
+
+  @DeveloperApi
+  def parseDataTypeWithRecursionLimit(bytes: Array[Byte], recursionLimit: Int): proto.DataType = {
+    ProtoUtils.parseWithRecursionLimit(bytes, proto.DataType.parser(), recursionLimit)
+  }
+}

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -125,6 +125,7 @@ class SparkConnectPlanner(
    * @return
    *   The resolved logical plan.
    */
+  @DeveloperApi
   def transformRelation(rel: proto.Relation): LogicalPlan =
     transformRelation(rel, cachePlan = false)
 
@@ -138,6 +139,7 @@ class SparkConnectPlanner(
    * @return
    *   The resolved logical plan.
    */
+  @DeveloperApi
   def transformRelation(rel: proto.Relation, cachePlan: Boolean): LogicalPlan = {
     sessionHolder.usePlanCache(rel, cachePlan) { rel =>
       val plan = rel.getRelTypeCase match {
@@ -228,14 +230,6 @@ class SparkConnectPlanner(
       }
       plan
     }
-  }
-
-  @DeveloperApi
-  def transformRelation(bytes: Array[Byte]): LogicalPlan = {
-    val recursionLimit = session.conf.get(CONNECT_GRPC_MARSHALLER_RECURSION_LIMIT)
-    val relation =
-      ProtoUtils.parseWithRecursionLimit(bytes, proto.Relation.parser(), recursionLimit)
-    transformRelation(relation)
   }
 
   private def transformRelationPlugin(extension: ProtoAny): LogicalPlan = {
@@ -1472,6 +1466,7 @@ class SparkConnectPlanner(
    * @return
    *   Catalyst expression
    */
+  @DeveloperApi
   def transformExpression(exp: proto.Expression): Expression = {
     exp.getExprTypeCase match {
       case proto.Expression.ExprTypeCase.LITERAL => transformLiteral(exp.getLiteral)
@@ -1511,14 +1506,6 @@ class SparkConnectPlanner(
         throw InvalidPlanInput(
           s"Expression with ID: ${exp.getExprTypeCase.getNumber} is not supported")
     }
-  }
-
-  @DeveloperApi
-  def transformExpression(bytes: Array[Byte]): Expression = {
-    val recursionLimit = session.conf.get(CONNECT_GRPC_MARSHALLER_RECURSION_LIMIT)
-    val expression =
-      ProtoUtils.parseWithRecursionLimit(bytes, proto.Expression.parser(), recursionLimit)
-    transformExpression(expression)
   }
 
   private def toNamedExpression(expr: Expression): NamedExpression = expr match {

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -57,8 +57,8 @@ import org.apache.spark.sql.catalyst.plans.logical.{AppendColumns, CoGroup, Coll
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util.{CaseInsensitiveMap, CharVarcharUtils}
-import org.apache.spark.sql.connect.common.{DataTypeProtoConverter, ForeachWriterPacket, InvalidPlanInput, LiteralValueProtoConverter, ProtoUtils, StorageLevelProtoConverter, StreamingListenerPacket, UdfPacket}
-import org.apache.spark.sql.connect.config.Connect.{CONNECT_GRPC_ARROW_MAX_BATCH_SIZE, CONNECT_GRPC_MARSHALLER_RECURSION_LIMIT}
+import org.apache.spark.sql.connect.common.{DataTypeProtoConverter, ForeachWriterPacket, InvalidPlanInput, LiteralValueProtoConverter, StorageLevelProtoConverter, StreamingListenerPacket, UdfPacket}
+import org.apache.spark.sql.connect.config.Connect.CONNECT_GRPC_ARROW_MAX_BATCH_SIZE
 import org.apache.spark.sql.connect.plugin.SparkConnectPluginRegistry
 import org.apache.spark.sql.connect.service.{ExecuteHolder, SessionHolder, SparkConnectService}
 import org.apache.spark.sql.connect.utils.MetricGenerator

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerTestUtils.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerTestUtils.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.planner
+
+import io.grpc.stub.StreamObserver
+
+import org.apache.spark.connect.proto
+import org.apache.spark.connect.proto.ExecutePlanResponse
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connect.service.{ExecuteHolder, ExecuteStatus, SessionHolder, SessionStatus, SparkConnectService}
+
+object SparkConnectPlannerTestUtils {
+  def transform(spark: SparkSession, relation: proto.Relation): LogicalPlan = {
+    new SparkConnectPlanner(SessionHolder.forTesting(spark)).transformRelation(relation)
+  }
+
+  def transform(spark: SparkSession, command: proto.Command): Unit = {
+    val executeHolder = buildExecutePlanHolder(spark, command)
+    new SparkConnectPlanner(executeHolder).process(command, new MockObserver())
+  }
+
+  private def buildExecutePlanHolder(spark: SparkSession, command: proto.Command): ExecuteHolder = {
+    val sessionHolder = SessionHolder.forTesting(spark)
+    sessionHolder.eventManager.status_(SessionStatus.Started)
+
+    val context = proto.UserContext
+      .newBuilder()
+      .setUserId(sessionHolder.userId)
+      .build()
+    val plan = proto.Plan
+      .newBuilder()
+      .setCommand(command)
+      .build()
+    val request = proto.ExecutePlanRequest
+      .newBuilder()
+      .setPlan(plan)
+      .setSessionId(sessionHolder.sessionId)
+      .setUserContext(context)
+      .build()
+
+    val executeHolder = SparkConnectService.executionManager.createExecuteHolder(request)
+    executeHolder.eventsManager.status_(ExecuteStatus.Started)
+    executeHolder
+  }
+
+  private class MockObserver extends StreamObserver[proto.ExecutePlanResponse] {
+    override def onNext(value: ExecutePlanResponse): Unit = {}
+    override def onError(t: Throwable): Unit = {}
+    override def onCompleted(): Unit = {}
+  }
+}

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/plugin/SparkConnectPluginRegistrySuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/plugin/SparkConnectPluginRegistrySuite.scala
@@ -20,17 +20,17 @@ package org.apache.spark.sql.connect.plugin
 import java.util.Optional
 
 import com.google.protobuf
-import org.apache.spark.{SparkContext, SparkEnv, SparkException}
 
+import org.apache.spark.{SparkContext, SparkEnv, SparkException}
 import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.Relation
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.catalyst.expressions.{Alias, Expression}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connect.ConnectProtoUtils
 import org.apache.spark.sql.connect.common.InvalidPlanInput
 import org.apache.spark.sql.connect.config.Connect
 import org.apache.spark.sql.connect.planner.{SparkConnectPlanner, SparkConnectPlanTest}
-import org.apache.spark.sql.connect.ConnectProtoUtils
 import org.apache.spark.sql.test.SharedSparkSession
 
 class DummyPlugin extends RelationPlugin {

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/plugin/SparkConnectPluginRegistrySuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/plugin/SparkConnectPluginRegistrySuite.scala
@@ -20,8 +20,8 @@ package org.apache.spark.sql.connect.plugin
 import java.util.Optional
 
 import com.google.protobuf
-
 import org.apache.spark.{SparkContext, SparkEnv, SparkException}
+
 import org.apache.spark.connect.proto
 import org.apache.spark.connect.proto.Relation
 import org.apache.spark.sql.Dataset
@@ -30,6 +30,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.connect.common.InvalidPlanInput
 import org.apache.spark.sql.connect.config.Connect
 import org.apache.spark.sql.connect.planner.{SparkConnectPlanner, SparkConnectPlanTest}
+import org.apache.spark.sql.connect.ConnectProtoUtils
 import org.apache.spark.sql.test.SharedSparkSession
 
 class DummyPlugin extends RelationPlugin {
@@ -68,7 +69,9 @@ class ExampleRelationPlugin extends RelationPlugin {
       return Optional.empty()
     }
     val plugin = rel.unpack(classOf[proto.ExamplePluginRelation])
-    Optional.of(planner.transformRelation(plugin.getInput.toByteArray))
+    val input = ConnectProtoUtils.parseRelationWithRecursionLimit(
+      plugin.getInput.toByteArray, recursionLimit = 1024)
+    Optional.of(planner.transformRelation(input))
   }
 }
 
@@ -81,8 +84,9 @@ class ExampleExpressionPlugin extends ExpressionPlugin {
       return Optional.empty()
     }
     val exp = rel.unpack(classOf[proto.ExamplePluginExpression])
-    Optional.of(
-      Alias(planner.transformExpression(exp.getChild.toByteArray), exp.getCustomField)())
+    val child = ConnectProtoUtils.parseExpressionWithRecursionLimit(
+      exp.getChild.toByteArray, recursionLimit = 1024)
+    Optional.of(Alias(planner.transformExpression(child), exp.getCustomField)())
   }
 }
 
@@ -198,9 +202,7 @@ class SparkConnectPluginRegistrySuite extends SharedSparkSession with SparkConne
               .build()))
         .build()
 
-      val executeHolder = buildExecutePlanHolder(plan)
-      new SparkConnectPlanner(executeHolder)
-        .process(plan, new MockObserver())
+      transform(plan)
       assert(spark.sparkContext.getLocalProperty("testingProperty").equals("Martin"))
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR enables Spark Connect plugins to process `Relation`s and `Expression`s using `SparkConnectPlanner` on the server side and to create `DataFrame`s using `Relation`s on the client side. This has been difficult due to the shading of the protobuf libraries, which meant that Java classes generated for the plugin's Protobuf message usage different base classes than the Java classes for Spark's protobuf messages. This was previously worked around by adding methods that accept a byte array (containing a serialized protobuf message) instead of a protobuf message. Unfortunately, this was not scalable as a lot of methods (such as `DataTypeProtoConverter.toCatalystType`) did not have this alternative. Luckily, we can avoid having to do this as the generated Java classes are not shaded and can still be used from plugins. Instead, plugins should serialize their own version of the generated Java classes for Spark Connect's protobuf messages and then parse them using Spark's (using the `ConnectProtoUtils` added in this PR).

### Why are the changes needed?

Enable the development of Spark Connect plugins.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Existing tests

### Was this patch authored or co-authored using generative AI tooling?

No