### PR TITLE
[SPARK-48115][INFRA] Remove `Python 3.11` from `build_python.yml`

### DIFF
--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build / Python-only (master, PyPy 3.9/Python 3.10/Python 3.11/Python 3.12)"
+name: "Build / Python-only (master, PyPy 3.9/Python 3.10/Python 3.12)"
 
 on:
   schedule:

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pyversion: ["pypy3", "python3.10", "python3.11", "python3.12"]
+        pyversion: ["pypy3", "python3.10", "python3.12"]
     permissions:
       packages: write
     name: Run


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `Python 3.11` from `build_python.yml` Daily CI because `Python 3.11` is the main python version in the PR and commit build.
- https://github.com/apache/spark/actions/workflows/build_python.yml

### Why are the changes needed?

To reduce GitHub Action usage to meet ASF INFRA policy.
- https://infra.apache.org/github-actions-policy.html

    > The average number of minutes a project uses in any consecutive five-day period MUST NOT exceed the equivalent of 30 full-time runners (216,000 minutes, or 3,600 hours).

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.