### PR TITLE
[SPARK-48056][PYTHON][CONNECT][FOLLOW-UP] Use `assertEqual` instead of `assertEquals` for Python 3.12

### DIFF
--- a/python/pyspark/sql/tests/connect/client/test_client.py
+++ b/python/pyspark/sql/tests/connect/client/test_client.py
@@ -372,10 +372,10 @@ class SparkConnectClientReattachTestCase(unittest.TestCase):
                 pass
 
             def checks():
-                self.assertEquals(2, stub.execute_calls)
-                self.assertEquals(0, stub.attach_calls)
-                self.assertEquals(0, stub.release_calls)
-                self.assertEquals(0, stub.release_until_calls)
+                self.assertEqual(2, stub.execute_calls)
+                self.assertEqual(0, stub.attach_calls)
+                self.assertEqual(0, stub.release_calls)
+                self.assertEqual(0, stub.release_until_calls)
 
             eventually(timeout=1, catch_assertions=True)(checks)()
 
@@ -406,10 +406,10 @@ class SparkConnectClientReattachTestCase(unittest.TestCase):
             self.assertTrue("RESPONSE_ALREADY_RECEIVED" in e.exception.getMessage())
 
             def checks():
-                self.assertEquals(1, stub.execute_calls)
-                self.assertEquals(1, stub.attach_calls)
-                self.assertEquals(0, stub.release_calls)
-                self.assertEquals(0, stub.release_until_calls)
+                self.assertEqual(1, stub.execute_calls)
+                self.assertEqual(1, stub.attach_calls)
+                self.assertEqual(0, stub.release_calls)
+                self.assertEqual(0, stub.release_until_calls)
 
             eventually(timeout=1, catch_assertions=True)(checks)()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of
- #46297

This PR aims to use `assertEqual` instead of `assertEquals` for Python 3.12.

### Why are the changes needed?

To recover Python CI,
- https://github.com/apache/spark/actions/workflows/build_python.yml

From Python 3.12, `assertEquals` doesn't exist.

https://docs.python.org/3/library/unittest.html#assert-methods

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.