### PR TITLE
[SPARK-48116][INFRA][FOLLOWUP] Fix `if` statement to check repository

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -79,7 +79,7 @@ jobs:
           pyspark=true; sparkr=true;
           pyspark_modules=`cd dev && python -c "import sparktestsupport.modules as m; print(','.join(m.name for m in m.all_modules if m.name.startswith('pyspark')))"`
           pyspark=`./dev/is-changed.py -m $pyspark_modules`
-          if [ "${{ github.repository != 'apache/spark' }}" ]; then
+          if [[ "${{ github.repository }}" != 'apache/spark' ]]; then
             pandas=$pyspark
           else
             pandas=false


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of the following to fix `if` statement.
- #46367

### Why are the changes needed?

Currently, master branch works like the following.

https://github.com/apache/spark/actions/runs/8947915962/job/24580432178

It was a mistake to use string evaluation type which goes to `then` statement as a result.
```
    if [ "false" ]; then
      pandas=$pyspark
    else
      pandas=false
    fi
```

Like the following, this PR fixes `if` statement.

https://github.com/apache/spark/blob/1904dee475d735533ff5d0d2d3580e4e83b7520b/.github/workflows/build_and_test.yml#L269

The following is the new result on this PR Builder.
```
    if [[ "dongjoon-hyun/spark" != 'apache/spark' ]]; then
      pandas=$pyspark
    else
      pandas=false
    fi
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.