### PR TITLE
[SPARK-48124][CORE] Disable structured logging for Connect-Repl by default

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/application/ConnectRepl.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/application/ConnectRepl.scala
@@ -26,6 +26,7 @@ import ammonite.compiler.iface.CodeWrapper
 import ammonite.util.{Bind, Imports, Name, Util}
 
 import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connect.client.{SparkConnectClient, SparkConnectClientParser}
 
@@ -55,6 +56,10 @@ object ConnectRepl {
       inputStream: InputStream = System.in,
       outputStream: OutputStream = System.out,
       errorStream: OutputStream = System.err): Unit = {
+    // For interpreters, structured logging is disabled by default to avoid generating mixed
+    // plain text and structured logs on the same console.
+    Logging.disableStructuredLogging()
+
     // Build the client.
     val client =
       try {


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr is followup https://github.com/apache/spark/pull/46383, to `disable` structured logging for` Connect-Repl` by default.

### Why are the changes needed?
Before:
<img width="1397" alt="image" src="https://github.com/apache/spark/assets/15246973/10d93a09-f098-4653-9e95-571481dd03e9">

After:
<img width="1406" alt="image" src="https://github.com/apache/spark/assets/15246973/e3354359-d6bc-4b2c-801b-8a2c3697f78e">



### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manually test.


### Was this patch authored or co-authored using generative AI tooling?
No.
