### PR TITLE
[SPARK-48132][INFRA] Run `k8s-integration-tests` only in PR builder and Daily CIs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -81,11 +81,12 @@ jobs:
           pyspark=`./dev/is-changed.py -m $pyspark_modules`
           if [[ "${{ github.repository }}" != 'apache/spark' ]]; then
             pandas=$pyspark
+            kubernetes=`./dev/is-changed.py -m kubernetes`
           else
             pandas=false
+            kubernetes=false
           fi
           sparkr=`./dev/is-changed.py -m sparkr`
-          kubernetes=`./dev/is-changed.py -m kubernetes`
           # 'build' is always true for now.
           # It does not save significant time and most of PRs trigger the build.
           precondition="


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to run `k8s-integration-tests` only in PR builder and Daily Python CIs. In other words, only the commit builder will skip it by default. 

Please note that 
- K8s unit tests will be covered by the commit builder still.
- All PR builders are not consuming ASF resources and they provide lots of test coverage everyday also.

### Why are the changes needed?

To reduce GitHub Action usage to meet ASF INFRA policy.
- https://infra.apache.org/github-actions-policy.html

    > All workflows MUST have a job concurrency level less than or equal to 20. This means a workflow cannot have more than 20 jobs running at the same time across all matrices.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.