### PR TITLE
[SPARK-48133][INFRA] Run `sparkr` only in PR builders and Daily CIs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -76,17 +76,17 @@ jobs:
       id: set-outputs
       run: |
         if [ -z "${{ inputs.jobs }}" ]; then
-          pyspark=true; sparkr=true;
           pyspark_modules=`cd dev && python -c "import sparktestsupport.modules as m; print(','.join(m.name for m in m.all_modules if m.name.startswith('pyspark')))"`
           pyspark=`./dev/is-changed.py -m $pyspark_modules`
           if [[ "${{ github.repository }}" != 'apache/spark' ]]; then
             pandas=$pyspark
             kubernetes=`./dev/is-changed.py -m kubernetes`
+            sparkr=`./dev/is-changed.py -m sparkr`
           else
             pandas=false
             kubernetes=false
+            sparkr=false
           fi
-          sparkr=`./dev/is-changed.py -m sparkr`
           # 'build' is always true for now.
           # It does not save significant time and most of PRs trigger the build.
           precondition="


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to run `sparkr` only in PR builder and Daily Python CIs. In other words, only the commit builder will skip it by default. 

### Why are the changes needed?

To reduce GitHub Action usage to meet ASF INFRA policy.
- https://infra.apache.org/github-actions-policy.html

    > All workflows MUST have a job concurrency level less than or equal to 20. This means a workflow cannot have more than 20 jobs running at the same time across all matrices.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.