### PR TITLE
[SPARK-48054][INFRA][FOLLOW-UP] Rename SPARK_SKIP_JVM_REQUIRED_TESTS to SPARK_SKIP_CONNECT_COMPAT_TESTS

### DIFF
--- a/.github/workflows/build_python_connect35.yml
+++ b/.github/workflows/build_python_connect35.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Run tests
         env:
           SPARK_TESTING: 1
-          SPARK_SKIP_JVM_REQUIRED_TESTS: 1
+          SPARK_SKIP_CONNECT_COMPAT_TESTS: 1
           SPARK_CONNECT_TESTING_REMOTE: sc://localhost
         run: |
           # Make less noisy


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/46298 that properly uses the environment variable SPARK_SKIP_CONNECT_COMPAT_TESTS added at https://github.com/apache/spark/pull/46334

### Why are the changes needed?

To recover the compatibility test (https://github.com/apache/spark/actions/runs/8961109352/job/24608366499).

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually

### Was this patch authored or co-authored using generative AI tooling?

No.
