### PR TITLE
[SPARK-45220][FOLLOWUP][DOCS][TESTS] Make a `dataframe.join` doctest deterministic

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -2524,7 +2524,7 @@ class DataFrame:
 
         Outer join on multiple columns
 
-        >>> df.join(df3, ["name", "age"], "outer").show()
+        >>> df.join(df3, ["name", "age"], "outer").sort("name", "age").show()
         +-----+----+------+
         | name| age|height|
         +-----+----+------+


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make a `dataframe.join` doctest deterministic


### Why are the changes needed?
it fails with different cpu:

```
File "/home/jenkins/python/pyspark/sql/connect/dataframe.py", line 759, in pyspark.sql.connect.dataframe.DataFrame.join
Failed example:
    df.join(df3, ["name", "age"], "outer").show()
Expected:
    +-----+----+------+
    | name| age|height|
    +-----+----+------+
    | NULL|NULL|  NULL|
    |Alice|   2|  NULL|
    |Alice|  10|    80|
    |  Bob|   5|  NULL|
    |  Tom|NULL|  NULL|
    +-----+----+------+
Got:
    +-----+----+------+
    | name| age|height|
    +-----+----+------+
    |Alice|  10|    80|
    |  Bob|   5|  NULL|
    |  Tom|NULL|  NULL|
    | NULL|NULL|  NULL|
    |Alice|   2|  NULL|
    +-----+----+------+
    <BLANKLINE>

```


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no