### PR TITLE
[SPARK-48145][CORE] Remove logDebug and logTrace with MDC in JAVA structured logging framework

### DIFF
--- a/common/utils/src/main/java/org/apache/spark/internal/Logger.java
+++ b/common/utils/src/main/java/org/apache/spark/internal/Logger.java
@@ -110,49 +110,42 @@ public class Logger {
     slf4jLogger.debug(msg);
   }
 
+  public void debug(String format, Object arg) {
+    slf4jLogger.debug(format, arg);
+  }
+
+  public void debug(String format, Object arg1, Object arg2) {
+    slf4jLogger.debug(format, arg1, arg2);
+  }
+
+  public void debug(String format, Object... arguments) {
+    slf4jLogger.debug(format, arguments);
+  }
+
   public void debug(String msg, Throwable throwable) {
     slf4jLogger.debug(msg, throwable);
-  }
-
-  public void debug(String msg, MDC... mdcs) {
-    if (mdcs == null || mdcs.length == 0) {
-      slf4jLogger.debug(msg);
-    } else if (slf4jLogger.isDebugEnabled()) {
-      withLogContext(msg, mdcs, null, mt -> slf4jLogger.debug(mt.message));
-    }
-  }
-
-  public void debug(String msg, Throwable throwable, MDC... mdcs) {
-    if (mdcs == null || mdcs.length == 0) {
-      slf4jLogger.debug(msg);
-    } else if (slf4jLogger.isDebugEnabled()) {
-      withLogContext(msg, mdcs, throwable, mt -> slf4jLogger.debug(mt.message, mt.throwable));
-    }
   }
 
   public void trace(String msg) {
     slf4jLogger.trace(msg);
   }
 
+  public void trace(String format, Object arg) {
+    slf4jLogger.trace(format, arg);
+  }
+
+  public void trace(String format, Object arg1, Object arg2) {
+    slf4jLogger.trace(format, arg1, arg2);
+  }
+
+  public void trace(String format, Object... arguments) {
+    slf4jLogger.trace(format, arguments);
+  }
+
   public void trace(String msg, Throwable throwable) {
     slf4jLogger.trace(msg, throwable);
   }
 
-  public void trace(String msg, MDC... mdcs) {
-    if (mdcs == null || mdcs.length == 0) {
-      slf4jLogger.trace(msg);
-    } else if (slf4jLogger.isTraceEnabled()) {
-      withLogContext(msg, mdcs, null, mt -> slf4jLogger.trace(mt.message));
-    }
-  }
-
-  public void trace(String msg, Throwable throwable, MDC... mdcs) {
-    if (mdcs == null || mdcs.length == 0) {
-      slf4jLogger.trace(msg);
-    } else if (slf4jLogger.isTraceEnabled()) {
-      withLogContext(msg, mdcs, throwable, mt -> slf4jLogger.trace(mt.message, mt.throwable));
-    }
-  }
 
   private void withLogContext(
       String pattern,

--- a/common/utils/src/test/java/org/apache/spark/util/LoggerSuiteBase.java
+++ b/common/utils/src/test/java/org/apache/spark/util/LoggerSuiteBase.java
@@ -145,9 +145,7 @@ public abstract class LoggerSuiteBase {
     List.of(
         Pair.of(Level.ERROR, errorFn),
         Pair.of(Level.WARN, warnFn),
-        Pair.of(Level.INFO, infoFn),
-        Pair.of(Level.DEBUG, debugFn),
-        Pair.of(Level.TRACE, traceFn)).forEach(pair -> {
+        Pair.of(Level.INFO, infoFn)).forEach(pair -> {
       try {
         assert (captureLogOutput(pair.getRight()).matches(
             expectedPatternForMsgWithMDC(pair.getLeft())));
@@ -162,14 +160,10 @@ public abstract class LoggerSuiteBase {
     Runnable errorFn = () -> logger().error(msgWithMDCs, mdcs);
     Runnable warnFn = () -> logger().warn(msgWithMDCs, mdcs);
     Runnable infoFn = () -> logger().info(msgWithMDCs, mdcs);
-    Runnable debugFn = () -> logger().debug(msgWithMDCs, mdcs);
-    Runnable traceFn = () -> logger().trace(msgWithMDCs, mdcs);
     List.of(
         Pair.of(Level.ERROR, errorFn),
         Pair.of(Level.WARN, warnFn),
-        Pair.of(Level.INFO, infoFn),
-        Pair.of(Level.DEBUG, debugFn),
-        Pair.of(Level.TRACE, traceFn)).forEach(pair -> {
+        Pair.of(Level.INFO, infoFn)).forEach(pair -> {
       try {
         assert (captureLogOutput(pair.getRight()).matches(
             expectedPatternForMsgWithMDCs(pair.getLeft())));
@@ -185,14 +179,10 @@ public abstract class LoggerSuiteBase {
     Runnable errorFn = () -> logger().error(msgWithMDCs, exception, mdcs);
     Runnable warnFn = () -> logger().warn(msgWithMDCs, exception, mdcs);
     Runnable infoFn = () -> logger().info(msgWithMDCs, exception, mdcs);
-    Runnable debugFn = () -> logger().debug(msgWithMDCs, exception, mdcs);
-    Runnable traceFn = () -> logger().trace(msgWithMDCs, exception, mdcs);
     List.of(
         Pair.of(Level.ERROR, errorFn),
         Pair.of(Level.WARN, warnFn),
-        Pair.of(Level.INFO, infoFn),
-        Pair.of(Level.DEBUG, debugFn),
-        Pair.of(Level.TRACE, traceFn)).forEach(pair -> {
+        Pair.of(Level.INFO, infoFn)).forEach(pair -> {
       try {
         assert (captureLogOutput(pair.getRight()).matches(
             expectedPatternForMsgWithMDCsAndException(pair.getLeft())));
@@ -207,14 +197,10 @@ public abstract class LoggerSuiteBase {
     Runnable errorFn = () -> logger().error(msgWithMDC, executorIDMDCValueIsNull);
     Runnable warnFn = () -> logger().warn(msgWithMDC, executorIDMDCValueIsNull);
     Runnable infoFn = () -> logger().info(msgWithMDC, executorIDMDCValueIsNull);
-    Runnable debugFn = () -> logger().debug(msgWithMDC, executorIDMDCValueIsNull);
-    Runnable traceFn = () -> logger().trace(msgWithMDC, executorIDMDCValueIsNull);
     List.of(
         Pair.of(Level.ERROR, errorFn),
         Pair.of(Level.WARN, warnFn),
-        Pair.of(Level.INFO, infoFn),
-        Pair.of(Level.DEBUG, debugFn),
-        Pair.of(Level.TRACE, traceFn)).forEach(pair -> {
+        Pair.of(Level.INFO, infoFn)).forEach(pair -> {
       try {
         assert (captureLogOutput(pair.getRight()).matches(
             expectedPatternForMsgWithMDCValueIsNull(pair.getLeft())));
@@ -229,14 +215,10 @@ public abstract class LoggerSuiteBase {
     Runnable errorFn = () -> logger().error("{}", externalSystemCustomLog);
     Runnable warnFn = () -> logger().warn("{}", externalSystemCustomLog);
     Runnable infoFn = () -> logger().info("{}", externalSystemCustomLog);
-    Runnable debugFn = () -> logger().debug("{}", externalSystemCustomLog);
-    Runnable traceFn = () -> logger().trace("{}", externalSystemCustomLog);
     List.of(
         Pair.of(Level.ERROR, errorFn),
         Pair.of(Level.WARN, warnFn),
-        Pair.of(Level.INFO, infoFn),
-        Pair.of(Level.DEBUG, debugFn),
-        Pair.of(Level.TRACE, traceFn)).forEach(pair -> {
+        Pair.of(Level.INFO, infoFn)).forEach(pair -> {
       try {
         assert (captureLogOutput(pair.getRight()).matches(
             expectedPatternForExternalSystemCustomLogKey(pair.getLeft())));


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Since we are targeting on migration INFO/WARN/ERROR level logs to structure logging, this PR removes the logDebug and logTrace methods from the JAVA structured logging framework.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In the log migration PR https://github.com/apache/spark/pull/46390, there are unnecessary changes such as updating
```
logger.debug("Task {} need to spill {} for {}", taskAttemptId,
            Utils.bytesToString(required - got), requestingConsumer);
```
to
```
LOGGER.debug("Task {} need to spill {} for {}", String.valueOf(taskAttemptId),
            Utils.bytesToString(required - got), requestingConsumer.toString());
```

With this PR, we can avoid such changes during log migrations.
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Existing UT.
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
