### PR TITLE
[SPARK-48149][INFRA] Serialize `build_python.yml` to run a single Python version per cron schedule

### DIFF
--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -17,18 +17,26 @@
 # under the License.
 #
 
+# According to https://infra.apache.org/github-actions-policy.html,
+# all workflows SHOULD have a job concurrency level less than or equal to 15.
+# To do that, we run one python version per cron schedule
 name: "Build / Python-only (master, PyPy 3.9/Python 3.10/Python 3.12)"
 
 on:
   schedule:
     - cron: '0 15 * * *'
+    - cron: '0 17 * * *'
+    - cron: '0 19 * * *'
 
 jobs:
   run-build:
     strategy:
       fail-fast: false
       matrix:
-        pyversion: ["pypy3", "python3.10", "python3.12"]
+        include:
+          - pyversion: ${{ github.event.schedule == '0 15 * * *' && "pypy3" }}
+          - pyversion: ${{ github.event.schedule == '0 17 * * *' && "python3.10" }}
+          - pyversion: ${{ github.event.schedule == '0 19 * * *' && "python3.12" }}
     permissions:
       packages: write
     name: Run


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to serialize `build_python.yml` to run a single Python version per cron schedule to reduce the maximum concurrency per single GitHub Action job.

### Why are the changes needed?

Currently, `build_python.yml` triggers 60 jobs. `30` of `60` jobs are running concurrently because 10 test pipelines are required per Python version.

- https://github.com/apache/spark/actions/workflows/build_python.yml

<img width="731" alt="Screenshot 2024-05-06 at 14 28 08" src="https://github.com/apache/spark/assets/9700541/e4f4e9d2-2b2e-43b9-a760-6b9943c7b5b7">

According to https://infra.apache.org/github-actions-policy.html,
> All workflows SHOULD have a job concurrency level less than or equal to 15.

After this PR, the maximum concurrently level will be 10.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review because this is a daily CI.

### Was this patch authored or co-authored using generative AI tooling?

No.