### PR TITLE
[SPARK-48151][INFRA] `build_and_test.yml` should use `Volcano` 1.7.0 for `branch-3.4/3.5`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1049,6 +1049,11 @@ jobs:
           minikube mount ${PVC_TESTS_HOST_PATH}:${PVC_TESTS_VM_PATH} --gid=0 --uid=185 &
           kubectl create clusterrolebinding serviceaccounts-cluster-admin --clusterrole=cluster-admin --group=system:serviceaccounts || true
           kubectl apply -f https://raw.githubusercontent.com/volcano-sh/volcano/v1.8.2/installer/volcano-development.yaml || true
+          if [[ "${{ inputs.branch }}" == 'branch-3.5' || "${{ inputs.branch }}" == 'branch-3.4' ]]; then
+            kubectl apply -f https://raw.githubusercontent.com/volcano-sh/volcano/v1.7.0/installer/volcano-development.yaml || true
+          else
+            kubectl apply -f https://raw.githubusercontent.com/volcano-sh/volcano/v1.8.2/installer/volcano-development.yaml || true
+          fi
           eval $(minikube docker-env)
           build/sbt -Phadoop-3 -Psparkr -Pkubernetes -Pvolcano -Pkubernetes-integration-tests -Dspark.kubernetes.test.volcanoMaxConcurrencyJobNum=1 -Dtest.exclude.tags=local "kubernetes-integration-tests/test"
       - name: Upload Spark on K8S integration tests log files


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `build_and_test.yml` to use `Volcano 1.7.0` for branch-3.4/3.5 while keeping `Volcano 1.8.2` for `master` branch.

Currently, both `branch-3.5` and `branch-3.4` commit builder passes K8s Integration tests while Daily CI fails.
- https://github.com/apache/spark/actions/runs/8958741168/job/24603341816 (Commit Builder Success on branch-3.5)
- https://github.com/apache/spark/actions/runs/8968052205/job/24626762418 (Daily CI Failure on branch-3.5)

### Why are the changes needed?

- **branch-3.5**: `Volcano 1.7.0`
https://github.com/apache/spark/blob/45befc07d2a064ab2a279a113489ed5c66f7a69d/.github/workflows/build_and_test.yml#L1039

- **branch-3.4**: `Volcano 1.7.0`
https://github.com/apache/spark/blob/2974e625aae16e8711a1d115731fdfe516752899/.github/workflows/build_and_test.yml#L997

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs. Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.