### PR TITLE
[SPARK-48088][PYTHON][CONNECT][TESTS][FOLLOW-UP][3.5] Skips another that that requires JVM access

### DIFF
--- a/python/pyspark/ml/tests/connect/test_connect_pipeline.py
+++ b/python/pyspark/ml/tests/connect/test_connect_pipeline.py
@@ -22,6 +22,7 @@ from pyspark.sql import SparkSession
 from pyspark.ml.tests.connect.test_legacy_mode_pipeline import PipelineTestsMixin
 
 
+@unittest.skipIf("SPARK_SKIP_CONNECT_COMPAT_TESTS" in os.environ, "Requires JVM access")
 class PipelineTestsOnConnect(PipelineTestsMixin, unittest.TestCase):
     def setUp(self) -> None:
         self.spark = (


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/46334 that missed one more test case.

### Why are the changes needed?

See https://github.com/apache/spark/pull/46334

### Does this PR introduce _any_ user-facing change?

See https://github.com/apache/spark/pull/46334

### How was this patch tested?

Manually

### Was this patch authored or co-authored using generative AI tooling?

No.