### PR TITLE
[SPARK-48153][INFRA] Run `build` job of `build_and_test.yml` only if needed

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -93,11 +93,10 @@ jobs:
             buf=false
             ui=false
           fi
-          # 'build' is always true for now.
-          # It does not save significant time and most of PRs trigger the build.
+          build=`./dev/is-changed.py -m "core,unsafe,kvstore,avro,utils,network-common,network-shuffle,repl,launcher,examples,sketch,variant,api,catalyst,hive-thriftserver,mllib-local,mllib,graphx,streaming,sql-kafka-0-10,streaming-kafka-0-10,streaming-kinesis-asl,kubernetes,hadoop-cloud,spark-ganglia-lgpl,protobuf,yarn,connect,sql,hive"`
           precondition="
             {
-              \"build\": \"true\",
+              \"build\": \"$build\",
               \"pyspark\": \"$pyspark\",
               \"pyspark-pandas\": \"$pandas\",
               \"sparkr\": \"$sparkr\",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to run `build` job of `build_and_test.yml` only if needed to reduce the maximum concurrency of Apache Spark GitHub Action usage.

### Why are the changes needed?

To meet ASF Infra GitHub Action policy, we need to reduce the maximum concurrency.
- https://infra.apache.org/github-actions-policy.html

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.