### PR TITLE
[SPARK-48035][SQL][FOLLOWUP] Fix try_add/try_multiply being semantic equal to add/multiply

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -1378,20 +1378,6 @@ trait CommutativeExpression extends Expression {
       }
     reorderResult
   }
-
-  /**
-   * Helper method to collect the evaluation mode of the commutative expressions. This is
-   * used by the canonicalized methods of [[Add]] and [[Multiply]] operators to ensure that
-   * all operands have the same evaluation mode before reordering the operands.
-   */
-  protected def collectEvalModes(
-      e: Expression,
-      f: PartialFunction[CommutativeExpression, Seq[EvalMode.Value]]
-  ): Seq[EvalMode.Value] = e match {
-    case c: CommutativeExpression if f.isDefinedAt(c) =>
-      f(c) ++ c.children.flatMap(collectEvalModes(_, f))
-    case _ => Nil
-  }
 }
 
 /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
- This is a follow-up to the previous PR: https://github.com/apache/spark/pull/46307.
- With the new changes we do the evalMode check in the `collectOperands` function instead of introducing a new function.

### Why are the changes needed?
- Better code quality and readability.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Existing unit tests.

### Was this patch authored or co-authored using generative AI tooling?
- No