### PR TITLE
[MINOR][CONNECT][TESTS] Improve test failure error message in StreamingParityTests

### DIFF
--- a/python/pyspark/sql/tests/connect/streaming/test_parity_streaming.py
+++ b/python/pyspark/sql/tests/connect/streaming/test_parity_streaming.py
@@ -21,10 +21,7 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 
 class StreamingParityTests(StreamingTestsMixin, ReusedConnectTestCase):
     def _assert_exception_tree_contains_msg(self, exception, msg):
-        self.assertTrue(
-            msg in exception._message,
-            "Exception tree doesn't contain the expected message: %s" % msg,
-        )
+        self.assertIn(msg, exception._message)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR improves the test failure error message in `StreamingParityTests`

### Why are the changes needed?

To see the original exception, and to make it easier to debug. Now it's difficult, see https://github.com/HyukjinKwon/spark/actions/runs/8978991632/job/24660689666#step:9:206

```
Traceback (most recent call last):
  File "/home/runner/work/spark/spark-3.5/python/pyspark/sql/tests/streaming/test_streaming.py", line 291, in test_stream_exception
    self._assert_exception_tree_contains_msg(e, "ZeroDivisionError")
  File "/home/runner/work/spark/spark-3.5/python/pyspark/sql/tests/streaming/test_streaming.py", line 300, in _assert_exception_tree_contains_msg
    self._assert_exception_tree_contains_msg_connect(exception, msg)
  File "/home/runner/work/spark/spark-3.5/python/pyspark/sql/tests/streaming/test_streaming.py", line 305, in _assert_exception_tree_contains_msg_connect
    self.assertTrue(
AssertionError: False is not true : Exception tree doesn't contain the expected message: ZeroDivisionError
```

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually

### Was this patch authored or co-authored using generative AI tooling?

No.