### PR TITLE
[SPARK-48163][CONNECT][TESTS] Disable `SparkConnectServiceSuite.SPARK-43923: commands send events - get_resources_command`

### DIFF
--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectServiceSuite.scala
@@ -418,11 +418,14 @@ class SparkConnectServiceSuite
               .setInput(
                 proto.Relation.newBuilder().setSql(proto.SQL.newBuilder().setQuery("select 1")))),
         None),
+      // TODO(SPARK-48164) Reenable `commands send events - get_resources_command`
+      /*
       (
         proto.Command
           .newBuilder()
           .setGetResourcesCommand(proto.GetResourcesCommand.newBuilder()),
         None),
+      */
       (
         proto.Command
           .newBuilder()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to disable a flaky test, `SparkConnectServiceSuite.SPARK-43923: commands send events - get_resources_command`, temporarily.

To re-enable this, SPARK-48164 is created as a blocker issue for 4.0.0.

### Why are the changes needed?

This test case was added at `Apache Spark 3.5.0`, but it has been flaky and causes many re-tries in our GitHub Action CI environment.

- https://github.com/apache/spark/pull/42454

- https://github.com/apache/spark/actions/runs/8979348499/job/24661200052
```
[info] - SPARK-43923: commands send events ((get_resources_command {
[info] }
[info] ,None)) *** FAILED *** (35 milliseconds)
[info]   VerifyEvents.this.listener.executeHolder.isDefined was false (SparkConnectServiceSuite.scala:873)
```

This PR aims to stabilize CI first and to focus this flaky issue as a blocker level before going on `Spark Connect GA` in SPARK-48164 before Apache Spark 4.0.0.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.