### PR TITLE
[SPARK-48165][BUILD] Update `ap-loader` to 3.0-9

### DIFF
--- a/connector/profiler/pom.xml
+++ b/connector/profiler/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>me.bechberger</groupId>
       <artifactId>ap-loader-all</artifactId>
-      <version>3.0-8</version>
+      <version>3.0-9</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to  update `me.bechberger:ap-loader-all` from `3.0-8` to `3.0-9`.


### Why are the changes needed?
The full release notes:
https://github.com/jvm-profiling-tools/ap-loader/releases/tag/3.0-9
Fix FlameGraph converter https://github.com/jvm-profiling-tools/ap-loader/issues/22


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Manually test about the new version `3.0-9`
  <img width="1364" alt="image" src="https://github.com/apache/spark/assets/15246973/50f38e65-cd93-45d1-b01a-d66d53c2831b">


### Was this patch authored or co-authored using generative AI tooling?
No.
