### PR TITLE
[SPARK-48166][SQL] Avoid using BadRecordException as user-facing error in VariantExpressionEvalUtils

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionEvalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionEvalUtils.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.expressions.variant
 import scala.util.control.NonFatal
 
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.util.{ArrayData, BadRecordException, MapData}
+import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.types._
 import org.apache.spark.types.variant.{Variant, VariantBuilder, VariantSizeLimitException, VariantUtil}
@@ -48,7 +48,7 @@ object VariantExpressionEvalUtils {
           .variantSizeLimitError(VariantUtil.SIZE_LIMIT, "parse_json"))
       case NonFatal(e) =>
         parseJsonFailure(QueryExecutionErrors.malformedRecordsDetectedInRecordParsingError(
-          input.toString, BadRecordException(() => input, cause = e)))
+          input.toString, e))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Stop using `BadRecordException` in a user-facing context. Currently it is thrown then the `parse_json` input is malformed.


### Why are the changes needed?
`BadRecordException` is an internal exception designed for `FailureSafeParser`.


### Does this PR introduce _any_ user-facing change?
Yes, `parse_json` will not expose `BadRecordException` in error.


### How was this patch tested?
`testOnly org.apache.spark.sql.catalyst.expressions.variant.VariantExpressionEvalUtilsSuite`


### Was this patch authored or co-authored using generative AI tooling?
No
