### PR TITLE
[SPARK-48058][SPARK-43727][PYTHON][CONNECT][TESTS][FOLLOWUP] Code clean up

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_pandas_udf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_udf.py
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from pyspark.sql.functions import pandas_udf, PandasUDFType
-from pyspark.sql.types import DoubleType, StructType, StructField
+
 from pyspark.sql.tests.pandas.test_pandas_udf import PandasUDFTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
@@ -23,38 +22,6 @@ from pyspark.testing.connectutils import ReusedConnectTestCase
 class PandasUDFParityTests(PandasUDFTestsMixin, ReusedConnectTestCase):
     def test_udf_wrong_arg(self):
         self.check_udf_wrong_arg()
-
-    def test_pandas_udf_decorator_with_return_type_string(self):
-        @pandas_udf("v double", PandasUDFType.GROUPED_MAP)
-        def foo(x):
-            return x
-
-        self.assertEqual(foo.returnType, StructType([StructField("v", DoubleType(), True)]))
-        self.assertEqual(foo.evalType, PandasUDFType.GROUPED_MAP)
-
-        @pandas_udf(returnType="double", functionType=PandasUDFType.SCALAR)
-        def foo(x):
-            return x
-
-        self.assertEqual(foo.returnType, DoubleType())
-        self.assertEqual(foo.evalType, PandasUDFType.SCALAR)
-
-    def test_pandas_udf_basic_with_return_type_string(self):
-        udf = pandas_udf(lambda x: x, "double", PandasUDFType.SCALAR)
-        self.assertEqual(udf.returnType, DoubleType())
-        self.assertEqual(udf.evalType, PandasUDFType.SCALAR)
-
-        udf = pandas_udf(lambda x: x, "v double", PandasUDFType.GROUPED_MAP)
-        self.assertEqual(udf.returnType, StructType([StructField("v", DoubleType(), True)]))
-        self.assertEqual(udf.evalType, PandasUDFType.GROUPED_MAP)
-
-        udf = pandas_udf(lambda x: x, "v double", functionType=PandasUDFType.GROUPED_MAP)
-        self.assertEqual(udf.returnType, StructType([StructField("v", DoubleType(), True)]))
-        self.assertEqual(udf.evalType, PandasUDFType.GROUPED_MAP)
-
-        udf = pandas_udf(lambda x: x, returnType="v double", functionType=PandasUDFType.GROUPED_MAP)
-        self.assertEqual(udf.returnType, StructType([StructField("v", DoubleType(), True)]))
-        self.assertEqual(udf.evalType, PandasUDFType.GROUPED_MAP)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?
after https://github.com/apache/spark/pull/46300, the two tests are actually the same as 

https://github.com/apache/spark/blob/678aeb7ef7086bd962df7ac6d1c5f39151a0515b/python/pyspark/sql/tests/pandas/test_pandas_udf.py#L110-L125

and

https://github.com/apache/spark/blob/678aeb7ef7086bd962df7ac6d1c5f39151a0515b/python/pyspark/sql/tests/pandas/test_pandas_udf.py#L55-L70


So no need to override them in the parity tests


### Why are the changes needed?
clean up


### Does this PR introduce _any_ user-facing change?
no, test only


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
