### PR TITLE
[SPARK-48167][CONNECT][TESTS] Skip known behaviour change by SPARK-46122

### DIFF
--- a/python/pyspark/sql/tests/test_readwriter.py
+++ b/python/pyspark/sql/tests/test_readwriter.py
@@ -16,6 +16,7 @@
 #
 
 import os
+import unittest
 import shutil
 import tempfile
 
@@ -245,6 +246,8 @@ class ReadwriterV2TestsMixin:
             df.writeTo("test_table").using("parquet").create()
             self.assertEqual(100, self.spark.sql("select * from test_table").count())
 
+    @unittest.skipIf(
+        "SPARK_SKIP_CONNECT_COMPAT_TESTS" in os.environ, "Known behavior change in 4.0")
     def test_create_without_provider(self):
         df = self.df
         with self.assertRaisesRegex(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to skip `test_create_without_provider` in backward compatibility test in https://github.com/apache/spark/actions/workflows/build_python_connect35.yml 

### Why are the changes needed?

This is a intentional behaviour change (SPARK-46122)

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Tested in my fork

### Was this patch authored or co-authored using generative AI tooling?

No.