### PR TITLE
[SPARK-48086][PYTHON][TESTS][3.5] Remove obsolete comment

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_udf_scalar.py
@@ -32,7 +32,6 @@ class PandasUDFScalarParityTests(ScalarPandasUDFTestsMixin, ReusedConnectTestCas
     def test_vectorized_udf_struct_with_empty_partition(self):
         super().test_vectorized_udf_struct_with_empty_partition()
 
-    # TODO(SPARK-48086): Reenable this test case
     @unittest.skipIf(
         "SPARK_SKIP_CONNECT_COMPAT_TESTS" in os.environ, "Failed with different Client <> Server"
     )

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf.py
@@ -262,7 +262,6 @@ class PandasUDFTestsMixin:
             .collect,
         )
 
-    # TODO(SPARK-48086): Reenable this test case
     @unittest.skipIf(
         "SPARK_SKIP_CONNECT_COMPAT_TESTS" in os.environ, "Failed with different Client <> Server"
     )
@@ -289,7 +288,6 @@ class PandasUDFTestsMixin:
         with self.sql_conf({"spark.sql.execution.pandas.convertToArrowArraySafely": False}):
             df.select(["A"]).withColumn("udf", udf("A")).collect()
 
-    # TODO(SPARK-48086): Reenable this test case
     @unittest.skipIf(
         "SPARK_SKIP_CONNECT_COMPAT_TESTS" in os.environ, "Failed with different Client <> Server"
     )


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to remove those comments for skipped tests related to different Arrow version in JVM.

### Why are the changes needed?

Arrow version incompatibility is something we cannot avoid. We should just skip those tests for now.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Linters.

### Was this patch authored or co-authored using generative AI tooling?

No.
