### PR TITLE
[SPARK-47986][CONNECT][PYTHON] Unable to create a new session when the default session is closed by the server

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1829,6 +1829,7 @@ class SparkConnectClient(object):
                 response.server_side_session_id
                 and response.server_side_session_id != self._server_session_id
             ):
+                self._closed = True
                 raise PySparkAssertionError(
                     "Received incorrect server side session identifier for request. "
                     "Please create a new Spark Session to reconnect. ("

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -238,7 +238,7 @@ class SparkSession:
             with SparkSession._lock:
                 session = SparkSession.getActiveSession()
                 if session is None:
-                    session = SparkSession.getDefaultSession()
+                    session = SparkSession._getDefaultSession()
                     if session is None:
                         session = self.create()
                 self._apply_options(session)
@@ -293,7 +293,7 @@ class SparkSession:
         return None
 
     @classmethod
-    def getDefaultSession(cls) -> Optional["SparkSession"]:
+    def _getDefaultSession(cls) -> Optional["SparkSession"]:
         s = cls._default_session
         if s is not None and not s.is_stopped:
             return s
@@ -325,7 +325,7 @@ class SparkSession:
     def active(cls) -> "SparkSession":
         session = cls.getActiveSession()
         if session is None:
-            session = cls.getDefaultSession()
+            session = cls._getDefaultSession()
             if session is None:
                 raise PySparkRuntimeError(
                     error_class="NO_ACTIVE_OR_DEFAULT_SESSION",

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -286,15 +286,15 @@ class SparkSession:
             cls._active_session.session = session
 
     @classmethod
-    def getActiveSession(cls) -> Optional["SparkSession"]:
-        s = getattr(cls._active_session, "session", None)
+    def _getDefaultSession(cls) -> Optional["SparkSession"]:
+        s = cls._default_session
         if s is not None and not s.is_stopped:
             return s
         return None
 
     @classmethod
-    def _getDefaultSession(cls) -> Optional["SparkSession"]:
-        s = cls._default_session
+    def getActiveSession(cls) -> Optional["SparkSession"]:
+        s = getattr(cls._active_session, "session", None)
         if s is not None and not s.is_stopped:
             return s
         return None

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -280,9 +280,9 @@ class SparkSession:
         active :class:`SparkSession` when they are not set yet.
         """
         with cls._lock:
-            if cls.getDefaultSession() is None:
+            if cls._default_session is None:
                 cls._default_session = session
-        if cls.getActiveSession() is None:
+        if getattr(cls._active_session, "session", None) is None:
             cls._active_session.session = session
 
     @classmethod

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -238,7 +238,7 @@ class SparkSession:
             with SparkSession._lock:
                 session = SparkSession.getActiveSession()
                 if session is None:
-                    session = SparkSession._getDefaultSession()
+                    session = SparkSession._get_default_session()
                     if session is None:
                         session = self.create()
                 self._apply_options(session)
@@ -286,7 +286,7 @@ class SparkSession:
             cls._active_session.session = session
 
     @classmethod
-    def _getDefaultSession(cls) -> Optional["SparkSession"]:
+    def _get_default_session(cls) -> Optional["SparkSession"]:
         s = cls._default_session
         if s is not None and not s.is_stopped:
             return s
@@ -325,7 +325,7 @@ class SparkSession:
     def active(cls) -> "SparkSession":
         session = cls.getActiveSession()
         if session is None:
-            session = cls._getDefaultSession()
+            session = cls._get_default_session()
             if session is None:
                 raise PySparkRuntimeError(
                     error_class="NO_ACTIVE_OR_DEFAULT_SESSION",

--- a/python/pyspark/sql/tests/connect/test_connect_session.py
+++ b/python/pyspark/sql/tests/connect/test_connect_session.py
@@ -242,13 +242,27 @@ class SparkConnectSessionTests(ReusedConnectTestCase):
         session = RemoteSparkSession.builder.channelBuilder(CustomChannelBuilder()).create()
         session.sql("select 1 + 1")
 
-    def test_reset_when_server_session_changes(self):
+    def test_reset_when_server_and_client_sessionids_mismatch(self):
         session = RemoteSparkSession.builder.remote("sc://localhost").getOrCreate()
         # run a simple query so the session id is synchronized.
         session.range(3).collect()
 
         # trigger a mismatch between client session id and server session id.
         session._client._session_id = str(uuid.uuid4())
+        with self.assertRaises(SparkConnectException):
+            session.range(3).collect()
+
+        # assert that getOrCreate() generates a new session
+        session = RemoteSparkSession.builder.remote("sc://localhost").getOrCreate()
+        session.range(3).collect()
+
+    def test_reset_when_server_session_id_mismatch(self):
+        session = RemoteSparkSession.builder.remote("sc://localhost").getOrCreate()
+        # run a simple query so the session id is synchronized.
+        session.range(3).collect()
+
+        # trigger a mismatch
+        session._client._server_session_id = str(uuid.uuid4())
         with self.assertRaises(SparkConnectException):
             session.range(3).collect()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up to a previous improvement - 7d04d0f0.

In some cases, particularly when running older versions of the Spark
cluster (3.5), the error actually manifests as a mismatch in the
observed server-side session id between calls.

With this fix, we also capture this case and ensure that this case is
also handled.

Further, we improve the implementation of `getActiveSession()`
and introduce a similar `getDefaultSession()` that accounts for
stopped sessions.
This ensures that all places where default or active session is used,
stopped sessions are considered neither default nor active.

### Why are the changes needed?

Explained above.


### Does this PR introduce _any_ user-facing change?

Previously, when client encounters a session mismatch, a user
cannot create a new session. With this change, a user can
call `getOrCreate()` on the SparkSession builder and create a
new session.


### How was this patch tested?

Attached unit tests.


### Was this patch authored or co-authored using generative AI tooling?

No.
