### PR TITLE
[SPARK-48171][CORE] Clean up the use of deprecated constructors of `o.rocksdb.Logger`

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/util/RocksDBProvider.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/util/RocksDBProvider.java
@@ -136,7 +136,7 @@ public class RocksDBProvider {
         private static final Logger LOG = LoggerFactory.getLogger(RocksDBLogger.class);
 
         RocksDBLogger(Options options) {
-          super(options);
+          super(options.infoLogLevel());
         }
 
         @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to clean up the use of deprecated constructors of `o.rocksdb.Logger`, the change ref to

https://github.com/facebook/rocksdb/blob/5c2be544f5509465957706c955b6d623e889ac4e/java/src/main/java/org/rocksdb/Logger.java#L39-L54

```
/**
   * <p>AbstractLogger constructor.</p>
   *
   * <p><strong>Important:</strong> the log level set within
   * the {@link org.rocksdb.Options} instance will be used as
   * maximum log level of RocksDB.</p>
   *
   * @param options {@link org.rocksdb.Options} instance.
   *
   * @deprecated Use {@link Logger#Logger(InfoLogLevel)} instead, e.g. {@code new
   *     Logger(options.infoLogLevel())}.
   */
  @Deprecated
  public Logger(final Options options) {
    this(options.infoLogLevel());
  }
```

### Why are the changes needed?
Clean up deprecated api usage.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No