### PR TITLE
[SPARK-48174][INFRA] Merge `connect` back to the original test pipeline

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -156,9 +156,8 @@ jobs:
             mllib-local, mllib, graphx
           - >-
             streaming, sql-kafka-0-10, streaming-kafka-0-10, streaming-kinesis-asl,
-            kubernetes, hadoop-cloud, spark-ganglia-lgpl, protobuf
+            kubernetes, hadoop-cloud, spark-ganglia-lgpl, protobuf, connect
           - yarn
-          - connect
         # Here, we split Hive and SQL tests into some of slow ones and the rest of them.
         included-tags: [""]
         excluded-tags: [""]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to merge connect back to the original test pipeline to reduce the maximum concurrency of GitHub Action by one.
- https://infra.apache.org/github-actions-policy.html
  > All workflows SHOULD have a job concurrency level less than or equal to 15. 

### Why are the changes needed?

This is a partial recover from the following.
- #45107

We stabilized the root cause of #45107 via the following PRs. In addition we will disable a flaky test case if exists.

- #46395
- #46396
- #46425

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.