### PR TITLE
[SPARK-48146][SQL] Fix aggregate function in With expression child assertion

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/With.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/With.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
-import org.apache.spark.sql.catalyst.trees.TreePattern.{AGGREGATE_EXPRESSION, COMMON_EXPR_REF, TreePattern, WITH_EXPRESSION}
+import org.apache.spark.sql.catalyst.trees.TreePattern.{COMMON_EXPR_REF, TreePattern, WITH_EXPRESSION}
 import org.apache.spark.sql.types.DataType
 
 /**
@@ -27,10 +27,6 @@ import org.apache.spark.sql.types.DataType
  */
 case class With(child: Expression, defs: Seq[CommonExpressionDef])
   extends Expression with Unevaluable {
-  // We do not allow With to be created with an AggregateExpression in the child, as this would
-  // create a dangling CommonExpressionRef after rewriting it in RewriteWithExpression.
-  assert(!child.containsPattern(AGGREGATE_EXPRESSION))
-
   override val nodePatterns: Seq[TreePattern] = Seq(WITH_EXPRESSION)
   override def dataType: DataType = child.dataType
   override def nullable: Boolean = child.nullable

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/With.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/With.scala
@@ -101,8 +101,8 @@ object With {
     withExpr.child.exists {
       case agg: AggregateExpression =>
         // Check that the aggregate expression does not contain a reference to a common expression
-        // in the outer With expression (it is ok if it contains a common expression reference
-        // within another nested With expression).
+        // in the outer With expression (it is ok if it contains a reference to a common expression
+        // for a nested With expression).
         agg.exists {
           case r: CommonExpressionRef => commonExprIds.contains(r.id)
           case _ => false

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
@@ -75,7 +75,7 @@ object RewriteWithExpression extends Rule[LogicalPlan] {
 
   private def fixDanglingCommonExpressionRefs(
     exprsWithDanglingRefs: Seq[Expression],
-    exprsWithMissingRefs: Seq[Expression],
+    exprsWithMissingRefs: Seq[Expression]
   ): (Seq[Expression], Seq[Expression]) = {
     lazy val defs = exprsWithMissingRefs.flatMap(_.collect {
       case d: CommonExpressionDef => d.id -> d.child

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
@@ -21,6 +21,7 @@ import scala.collection.mutable
 
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.planning.PhysicalAggregation
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan, PlanHelper, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -43,27 +44,49 @@ object RewriteWithExpression extends Rule[LogicalPlan] {
       // For aggregates, separate the computation of the aggregations themselves from the final
       // result by moving the final result computation into a projection above it. This prevents
       // this rule from producing an invalid Aggregate operator.
-      case p @ PhysicalAggregation(
-          groupingExpressions, aggregateExpressions, resultExpressions, child)
-          if p.expressions.exists(_.containsPattern(WITH_EXPRESSION)) =>
+      case p @ PhysicalAggregation(physGroupingExprs, physAggExprs, physResExprs, child)
+        if containsWithExpression(p) =>
+        // We need to handle a special case here: if there is an aggregate function in the child of
+        // a With expression, PhysicalAggregation will separate the With expression's reference(s)
+        // from its definition, leaving a dangling common expression reference.
+        val defs = physResExprs.flatMap(_.collect {
+          case d: CommonExpressionDef => d.id -> d.child
+        }).toMap
+        val aggExprs = physAggExprs.map {
+          // If there is a dangling reference, we find its definition in resultExpressions - by
+          // looking up by common expression ID in defs - and inline it.
+          case ae if ae.aggregateFunction.containsPattern(COMMON_EXPR_REF) &&
+            !ae.aggregateFunction.containsPattern(WITH_EXPRESSION) =>
+            ae.transformWithPruning(_.containsPattern(COMMON_EXPR_REF)) {
+              case ref: CommonExpressionRef => defs.getOrElse(ref.id, ref)
+            }.asInstanceOf[AggregateExpression]
+          case ae => ae
+        }
+        val resExprs = physResExprs.map(_.transformWithPruning(_.containsPattern(WITH_EXPRESSION)) {
+          // If there was a dangling reference in physAggExprs, then there will be a corresponding
+          // With expression in physResExprs without a reference, which we remove here.
+          case w: With if !w.containsPattern(COMMON_EXPR_REF) => w.child
+        })
         // PhysicalAggregation returns aggregateExpressions as attribute references, which we change
         // to aliases so that they can be referred to by resultExpressions.
-        val aggExprs = aggregateExpressions.map(
+        val aggExprsAliases = aggExprs.map(
           ae => Alias(ae, "_aggregateexpression")(ae.resultId))
-        val aggExprIds = aggExprs.map(_.exprId).toSet
-        val resExprs = resultExpressions.map(_.transform {
+        val aggExprIds = aggExprsAliases.map(_.exprId).toSet
+        val resExprsAttrs = resExprs.map(_.transform {
           case a: AttributeReference if aggExprIds.contains(a.exprId) =>
             a.withName("_aggregateexpression")
         }.asInstanceOf[NamedExpression])
         // Rewrite the projection and the aggregate separately and then piece them together.
-        val agg = Aggregate(groupingExpressions, groupingExpressions ++ aggExprs, child)
+        val agg = Aggregate(physGroupingExprs, physGroupingExprs ++ aggExprsAliases, child)
         val rewrittenAgg = applyInternal(agg)
-        val proj = Project(resExprs, rewrittenAgg)
+        val proj = Project(resExprsAttrs, rewrittenAgg)
         applyInternal(proj)
-      case p if p.expressions.exists(_.containsPattern(WITH_EXPRESSION)) =>
-        applyInternal(p)
+      case p if containsWithExpression(p) => applyInternal(p)
     }
   }
+
+  private def containsWithExpression(p: LogicalPlan): Boolean =
+    p.expressions.exists(_.containsPattern(WITH_EXPRESSION))
 
   private def applyInternal(p: LogicalPlan): LogicalPlan = {
     val inputPlans = p.children.toArray

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpression.scala
@@ -44,8 +44,8 @@ object RewriteWithExpression extends Rule[LogicalPlan] {
       // result by moving the final result computation into a projection above it. This prevents
       // this rule from producing an invalid Aggregate operator.
       case p @ PhysicalAggregation(
-        groupingExpressions, aggregateExpressions, resultExpressions, child)
-        if p.expressions.exists(_.containsPattern(WITH_EXPRESSION)) =>
+          groupingExpressions, aggregateExpressions, resultExpressions, child)
+          if p.expressions.exists(_.containsPattern(WITH_EXPRESSION)) =>
         // PhysicalAggregation returns aggregateExpressions as attribute references, which we change
         // to aliases so that they can be referred to by resultExpressions.
         val aggExprs = aggregateExpressions.map(
@@ -62,12 +62,8 @@ object RewriteWithExpression extends Rule[LogicalPlan] {
         applyInternal(proj)
       case p if p.expressions.exists(_.containsPattern(WITH_EXPRESSION)) =>
         applyInternal(p)
-      case p if containsWithExpression(p) => applyInternal(p)
     }
   }
-
-  private def containsWithExpression(p: LogicalPlan): Boolean =
-    p.expressions.exists(_.containsPattern(WITH_EXPRESSION))
 
   private def applyInternal(p: LogicalPlan): LogicalPlan = {
     val inputPlans = p.children.toArray

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpressionSuite.scala
@@ -353,17 +353,47 @@ class RewriteWithExpressionSuite extends PlanTest {
     )
   }
 
-  test("aggregate functions in child of WITH expression is not supported") {
+  test("aggregate function in child of WITH expression") {
     val a = testRelation.output.head
-    intercept[java.lang.AssertionError] {
-      val expr = With(a - 1) { case Seq(ref) =>
-        sum(ref * ref)
-      }
-      val plan = testRelation.groupBy(a)(
-        (a - 1).as("col1"),
-        expr.as("col2")
-      )
-      Optimizer.execute(plan)
+    val expr = With(a - 1) { case Seq(ref) =>
+      sum(ref * ref)
     }
+    val plan = testRelation.groupBy(a)(
+      (a - 1).as("col1"),
+      expr.as("col2")
+    )
+    val aggExprName = "_aggregateexpression"
+    comparePlans(
+      Optimizer.execute(plan),
+      testRelation
+        .groupBy(a)(a, sum((a - 1) * (a - 1)).as(aggExprName))
+        .select((a - 1).as("col1"), $"$aggExprName".as("col2"))
+        .analyze
+    )
+  }
+
+  test("aggregate functions in child of nested WITH expression") {
+    val a = testRelation.output.head
+    val expr = With(a + 1) { case Seq(ref) =>
+      ref * ref
+    }
+    val nestedExpr = With(a - 1) { case Seq(ref) =>
+      max(expr) + ref
+    }
+    val plan = testRelation.groupBy(a)(nestedExpr.as("col")).analyze
+    val commonExpr1Id = expr.defs.head.id.id
+    val commonExpr1Name = s"_common_expr_$commonExpr1Id"
+    val commonExpr2Id = nestedExpr.defs.head.id.id
+    val commonExpr2Name = s"_common_expr_$commonExpr2Id"
+    val aggExprName = "_aggregateexpression"
+    comparePlans(
+      Optimizer.execute(plan),
+      testRelation
+        .select(testRelation.output :+ (a + 1).as(commonExpr1Name): _*)
+        .groupBy(a)(a, max($"$commonExpr1Name" * $"$commonExpr1Name").as(aggExprName))
+        .select($"a", $"$aggExprName", (a - 1).as(commonExpr2Name))
+        .select(($"$aggExprName" + $"$commonExpr2Name").as("col"))
+        .analyze
+    )
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteWithExpressionSuite.scala
@@ -353,11 +353,11 @@ class RewriteWithExpressionSuite extends PlanTest {
     )
   }
 
-  test("aggregate function in child of WITH expression") {
+  test("aggregate functions in child of WITH expression with ref is not supported") {
     val a = testRelation.output.head
     intercept[java.lang.AssertionError] {
       val expr = With(a - 1) { case Seq(ref) =>
-        sum(ref) + ref
+        sum(ref * ref)
       }
       val plan = testRelation.groupBy(a)(
         (a - 1).as("col1"),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

In https://github.com/apache/spark/pull/46034, there was a complicated edge case where common expression references in aggregate functions in the child of a `With` expression could become dangling. An assertion was added to avoid that case from happening, but the assertion wasn't fully accurate as a query like:
```
select
  id between max(if(id between 1 and 2, 2, 1)) over () and id
from range(10)
```
would fail the assertion.

This PR fixes the assertion to be more accurate.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This addresses a regression in https://github.com/apache/spark/pull/46034.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Added unit tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.