### PR TITLE
[SPARK-48167][PYTHON][TESTS][FOLLOWUP][3.5] Reformat test_readwriter.py to fix Python Linter error

### DIFF
--- a/python/pyspark/sql/tests/test_readwriter.py
+++ b/python/pyspark/sql/tests/test_readwriter.py
@@ -247,7 +247,8 @@ class ReadwriterV2TestsMixin:
             self.assertEqual(100, self.spark.sql("select * from test_table").count())
 
     @unittest.skipIf(
-        "SPARK_SKIP_CONNECT_COMPAT_TESTS" in os.environ, "Known behavior change in 4.0")
+        "SPARK_SKIP_CONNECT_COMPAT_TESTS" in os.environ, "Known behavior change in 4.0"
+    )
     def test_create_without_provider(self):
         df = self.df
         with self.assertRaisesRegex(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of https://github.com/apache/spark/pull/46430 to fix Python linter failure.

### Why are the changes needed?

To recover `branch-3.5` CI,
- https://github.com/apache/spark/actions/runs/8981228745/job/24666400664

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass Python Linter in this PR builder.

### Was this patch authored or co-authored using generative AI tooling?

No.