### PR TITLE
[SPARK-48183][PYTHON][DOCS] Update error contribution guide to respect new error class file

### DIFF
--- a/python/docs/source/development/contributing.rst
+++ b/python/docs/source/development/contributing.rst
@@ -248,7 +248,7 @@ Usage
 
 1. Check if an appropriate error class already exists in `Error classes in PySpark <errors.rst#error-classes-in-pyspark>`_.
    If true, use the error class and skip to step 3.
-2. Add a new class to `error_classes.py <https://github.com/apache/spark/blob/master/python/pyspark/errors/error_classes.py>`_; keep in mind the invariants below.
+2. Add a new class to `error-conditions.json <https://github.com/apache/spark/blob/master/python/pyspark/errors/error-conditions.json>`_; keep in mind the invariants below.
 3. Check if the exception type already extends `PySparkException`.
    If true, skip to step 5.
 4. Mix `PySparkException` into the exception.
@@ -266,7 +266,7 @@ Throw with arbitrary error message:
 
 **After**
 
-`error_classes.py`
+`error-conditions.json`
 
 .. code-block:: python
 

--- a/python/pyspark/errors/utils.py
+++ b/python/pyspark/errors/utils.py
@@ -32,7 +32,7 @@ T = TypeVar("T")
 
 class ErrorClassesReader:
     """
-    A reader to load error information from error_classes.py.
+    A reader to load error information from error-conditions.json.
     """
 
     def __init__(self) -> None:
@@ -60,11 +60,11 @@ class ErrorClassesReader:
 
     def get_message_template(self, error_class: str) -> str:
         """
-        Returns the message template for corresponding error class from error_classes.py.
+        Returns the message template for corresponding error class from error-conditions.json.
 
         For example,
         when given `error_class` is "EXAMPLE_ERROR_CLASS",
-        and corresponding error class in error_classes.py looks like the below:
+        and corresponding error class in error-conditions.json looks like the below:
 
         .. code-block:: python
 
@@ -78,7 +78,7 @@ class ErrorClassesReader:
         "Problem <A> because of <B>."
 
         For sub error class, when given `error_class` is "EXAMPLE_ERROR_CLASS.SUB_ERROR_CLASS",
-        and corresponding error class in error_classes.py looks like the below:
+        and corresponding error class in error-conditions.json looks like the below:
 
         .. code-block:: python
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to update error contribution guide to respect new error class file.

### Why are the changes needed?

SPARK-46894 recently moved the error class definition from `error_classes.py` to `error-conditions.json`, but some of documentation still describes the old file.


### Does this PR introduce _any_ user-facing change?

No API changes, but the user-facing documentation will be updated.

### How was this patch tested?

Passed `dev/lint-python`, and also the existing CI should pass.

### Was this patch authored or co-authored using generative AI tooling?

No.