### PR TITLE
[SPARK-48192][INFRA] Enable TPC-DS tests in forked repository

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -83,6 +83,8 @@ jobs:
             yarn=`./dev/is-changed.py -m yarn`
             kubernetes=`./dev/is-changed.py -m kubernetes`
             sparkr=`./dev/is-changed.py -m sparkr`
+            tpcds=`./dev/is-changed.py -m sql`
+            docker=`./dev/is-changed.py -m docker-integration-tests`
             buf=true
             ui=true
             docs=true
@@ -91,6 +93,8 @@ jobs:
             yarn=false
             kubernetes=false
             sparkr=false
+            tpcds=false
+            docker=false
             buf=false
             ui=false
             docs=false
@@ -102,8 +106,8 @@ jobs:
               \"pyspark\": \"$pyspark\",
               \"pyspark-pandas\": \"$pandas\",
               \"sparkr\": \"$sparkr\",
-              \"tpcds-1g\": \"false\",
-              \"docker-integration-tests\": \"false\",
+              \"tpcds-1g\": \"$tpcds\",
+              \"docker-integration-tests\": \"$docker\",
               \"lint\" : \"true\",
               \"docs\" : \"$docs\",
               \"yarn\" : \"$yarn\",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a sort of a followup of https://github.com/apache/spark/pull/46361. It proposes to run TPC-DS and Docker integration tests in PRs (that does not consume ASF resources).

### Why are the changes needed?

TPC-DS and Docker integration stuff at least have to be tested in the PR if the PR touches the codes related to that.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually

### Was this patch authored or co-authored using generative AI tooling?

No.