### PR TITLE
[SPARK-48193][INFRA] Make `maven-deploy-plugin` retry 3 times

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3384,6 +3384,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>3.1.2</version>
+          <configuration>
+            <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to make maven plugin `maven-deploy-plugin` retry `3` times.


### Why are the changes needed?
I found that our `the daily scheduled publish snapshot` workflow of GA often failed. 
https://github.com/apache/spark/actions/workflows/publish_snapshot.yml
<img width="1031" alt="image" src="https://github.com/apache/spark/assets/15246973/2a759bf4-85de-4bc2-aff7-a226bd475321">
I tried to make it as successful as possible by changing the time of retries from `1`(default) to `3`.
https://maven.apache.org/plugins/maven-deploy-plugin/deploy-mojo.html#retryFailedDeploymentCount
https://maven.apache.org/plugins/maven-deploy-plugin/examples/deploy-network-issues.html#configuring-multiple-tries

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Keep observing `the daily scheduled publish snapshot` workflow of GA.
https://github.com/apache/spark/actions/workflows/publish_snapshot.yml


### Was this patch authored or co-authored using generative AI tooling?
No.
