### PR TITLE
[SPARK-47965][SQL][FOLLOW-UP] Uses `null` as its default value for `OptionalConfigEntry`

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala
@@ -227,7 +227,7 @@ private[spark] class OptionalConfigEntry[T](
     prependSeparator,
     alternatives,
     s => Some(rawValueConverter(s)),
-    v => v.map(rawStringConverter).getOrElse(ConfigEntry.UNDEFINED),
+    v => v.map(rawStringConverter).orNull,
     doc,
     isPublic,
     version


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR partially reverts https://github.com/apache/spark/pull/46197 because of the behaviour change below:

```python
>>> spark.conf.get("spark.sql.optimizer.excludedRules")
'<undefined>'
```

### Why are the changes needed?

To avoid behaviour change.

### Does this PR introduce _any_ user-facing change?

No, the main change has not been released out yet.

### How was this patch tested?

Manually as described above.

### Was this patch authored or co-authored using generative AI tooling?

No.