### PR TITLE
[SPARK-48200][INFRA] Split `build_python.yml` into per-version cron jobs

### DIFF
--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -17,26 +17,18 @@
 # under the License.
 #
 
-# According to https://infra.apache.org/github-actions-policy.html,
-# all workflows SHOULD have a job concurrency level less than or equal to 15.
-# To do that, we run one python version per cron schedule
 name: "Build / Python-only (master, PyPy 3.9/Python 3.10/Python 3.12)"
 
 on:
   schedule:
     - cron: '0 15 * * *'
-    - cron: '0 17 * * *'
-    - cron: '0 19 * * *'
 
 jobs:
   run-build:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - pyversion: ${{ github.event.schedule == '0 15 * * *' && "pypy3" }}
-          - pyversion: ${{ github.event.schedule == '0 17 * * *' && "python3.10" }}
-          - pyversion: ${{ github.event.schedule == '0 19 * * *' && "python3.12" }}
+        pyversion: ["pypy3", "python3.10", "python3.12"]
     permissions:
       packages: write
     name: Run

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -34,9 +34,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - pyversion: ${{ github.event.schedule == '0 15 * * *' && 'pypy3' }}
-          - pyversion: ${{ github.event.schedule == '0 17 * * *' && 'python3.10' }}
-          - pyversion: ${{ github.event.schedule == '0 19 * * *' && 'python3.12' }}
+          - pyversion: ${{ github.event.schedule == '0 15 * * *' && "pypy3" }}
+          - pyversion: ${{ github.event.schedule == '0 17 * * *' && "python3.10" }}
+          - pyversion: ${{ github.event.schedule == '0 19 * * *' && "python3.12" }}
     permissions:
       packages: write
     name: Run

--- a/.github/workflows/build_python_3.10.yml
+++ b/.github/workflows/build_python_3.10.yml
@@ -17,18 +17,14 @@
 # under the License.
 #
 
-name: "Build / Python-only (master, PyPy 3.9/Python 3.10/Python 3.12)"
+name: "Build / Python-only (master, Python 3.10)"
 
 on:
   schedule:
-    - cron: '0 15 * * *'
+    - cron: '0 17 * * *'
 
 jobs:
   run-build:
-    strategy:
-      fail-fast: false
-      matrix:
-        pyversion: ["pypy3", "python3.10", "python3.12"]
     permissions:
       packages: write
     name: Run
@@ -40,7 +36,7 @@ jobs:
       hadoop: hadoop3
       envs: >-
         {
-          "PYTHON_TO_TEST": "${{ matrix.pyversion }}"
+          "PYTHON_TO_TEST": "python3.10"
         }
       jobs: >-
         {

--- a/.github/workflows/build_python_3.12.yml
+++ b/.github/workflows/build_python_3.12.yml
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Build / Python-only (master, Python 3.12)"
+
+on:
+  schedule:
+    - cron: '0 19 * * *'
+
+jobs:
+  run-build:
+    permissions:
+      packages: write
+    name: Run
+    uses: ./.github/workflows/build_and_test.yml
+    if: github.repository == 'apache/spark'
+    with:
+      java: 17
+      branch: master
+      hadoop: hadoop3
+      envs: >-
+        {
+          "PYTHON_TO_TEST": "python3.12"
+        }
+      jobs: >-
+        {
+          "pyspark": "true",
+          "pyspark-pandas": "true"
+        }

--- a/.github/workflows/build_python_pypy3.9.yml
+++ b/.github/workflows/build_python_pypy3.9.yml
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Build / Python-only (master, PyPy 3.9)"
+
+on:
+  schedule:
+    - cron: '0 15 * * *'
+
+jobs:
+  run-build:
+    permissions:
+      packages: write
+    name: Run
+    uses: ./.github/workflows/build_and_test.yml
+    if: github.repository == 'apache/spark'
+    with:
+      java: 17
+      branch: master
+      hadoop: hadoop3
+      envs: >-
+        {
+          "PYTHON_TO_TEST": "pypy3"
+        }
+      jobs: >-
+        {
+          "pyspark": "true",
+          "pyspark-pandas": "true"
+        }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to split `build_python.yml` into per-version cron jobs.

Technically, this includes a revert of SPARK-48149 and choose [the discussed alternative](https://github.com/apache/spark/pull/46407#discussion_r1591586209).

- https://github.com/apache/spark/pull/46407
- https://github.com/apache/spark/pull/46454

### Why are the changes needed?

To recover Python CI successfully in ASF INFRA policy.
- https://github.com/apache/spark/actions/workflows/build_python.yml

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.