### PR TITLE
[SPARK-48202][INFRA] Spin off `pyspark` tests from `build_branch35.yml` Daily CI

### DIFF
--- a/.github/workflows/build_branch35_python.yml
+++ b/.github/workflows/build_branch35_python.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: "Build (branch-3.5, Scala 2.13, Hadoop 3, JDK 8)"
+name: "Build / Python-only (branch-3.5)"
 
 on:
   schedule:
@@ -36,16 +36,10 @@ jobs:
       hadoop: hadoop3
       envs: >-
         {
-          "SCALA_PROFILE": "scala2.13",
-          "PYTHON_TO_TEST": "",
-          "ORACLE_DOCKER_IMAGE_NAME": "gvenzl/oracle-xe:21.3.0"
+          "PYTHON_TO_TEST": ""
         }
       jobs: >-
         {
-          "build": "true",
-          "sparkr": "true",
-          "tpcds-1g": "true",
-          "docker-integration-tests": "true",
-          "k8s-integration-tests": "true",
-          "lint" : "true"
+          "pyspark": "true",
+          "pyspark-pandas": "true"
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to create `build_branch35_python.yml` in order to spin off `pyspark` tests from `build_branch35.yml` Daily CI.

### Why are the changes needed?

Currently, `build_branch35.yml` creates more than 15 test pipelines concurrently which is beyond of ASF Infra policy.
- https://github.com/apache/spark/actions/workflows/build_branch35.yml

We had better offload this to `Python only Daily CI` like `master` branch's `Python Only` Daily CI.
- https://github.com/apache/spark/actions/workflows/build_python_3.10.yml

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.