### PR TITLE
[SPARK-47793][TEST][FOLLOWUP] Fix flaky test for Python data source exactly once.

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonStreamingDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonStreamingDataSourceSuite.scala
@@ -326,8 +326,11 @@ class PythonStreamingDataSourceSuite extends PythonDataSourceSuiteBase {
         lastBatch = q.lastProgress.batchId.toInt
       }
       assert(lastBatch > 20)
+      val rowCount = spark.read.format("json").load(outputDir.getAbsolutePath).count()
+      // There may be one uncommitted batch that is not recorded in query progress.
+      assert(rowCount == 2 * lastBatch + 2 || rowCount == 2 * lastBatch + 4)
       checkAnswer(spark.read.format("json").load(outputDir.getAbsolutePath),
-        (0 to  2 * lastBatch + 1).map(Row(_)))
+        (0 until rowCount.toInt).map(Row(_)))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonStreamingDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonStreamingDataSourceSuite.scala
@@ -299,7 +299,7 @@ class PythonStreamingDataSourceSuite extends PythonDataSourceSuiteBase {
       val checkpointDir = new File(path, "checkpoint")
       val outputDir = new File(path, "output")
       val df = spark.readStream.format(dataSourceName).load()
-      var lastBatch = 0
+      var lastBatchId = 0
       // Restart streaming query multiple times to verify exactly once guarantee.
       for (i <- 1 to 5) {
 
@@ -323,12 +323,13 @@ class PythonStreamingDataSourceSuite extends PythonDataSourceSuiteBase {
         }
         q.stop()
         q.awaitTermination()
-        lastBatch = q.lastProgress.batchId.toInt
+        lastBatchId = q.lastProgress.batchId.toInt
       }
-      assert(lastBatch > 20)
+      assert(lastBatchId > 20)
       val rowCount = spark.read.format("json").load(outputDir.getAbsolutePath).count()
       // There may be one uncommitted batch that is not recorded in query progress.
-      assert(rowCount == 2 * lastBatch + 2 || rowCount == 2 * lastBatch + 4)
+      // The number of batch can be lastBatchId + 1 or lastBatchId + 2.
+      assert(rowCount == 2 * (lastBatchId + 1) || rowCount == 2 * (lastBatchId + 2))
       checkAnswer(spark.read.format("json").load(outputDir.getAbsolutePath),
         (0 until rowCount.toInt).map(Row(_)))
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix the flakiness in python streaming source exactly once test. The last executed batch may not be recorded in query progress, which cause the expected rows doesn't match. This fix takes the uncompleted batch into account and relax the condition


### Why are the changes needed?
Fix flaky test.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Test change.


### Was this patch authored or co-authored using generative AI tooling?
No.