### PR TITLE
[SPARK-47803][FOLLOWUP] Check nulls when casting nested type to variant.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionEvalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionEvalUtils.scala
@@ -103,7 +103,8 @@ object VariantExpressionEvalUtils {
         val offsets = new java.util.ArrayList[java.lang.Integer](data.numElements())
         for (i <- 0 until data.numElements()) {
           offsets.add(builder.getWritePos - start)
-          buildVariant(builder, data.get(i, elementType), elementType)
+          val element = if (data.isNullAt(i)) null else data.get(i, elementType)
+          buildVariant(builder, element, elementType)
         }
         builder.finishWritingArray(start, offsets)
       case MapType(StringType, valueType, _) =>
@@ -116,7 +117,8 @@ object VariantExpressionEvalUtils {
           val key = keys.getUTF8String(i).toString
           val id = builder.addKey(key)
           fields.add(new VariantBuilder.FieldEntry(key, id, builder.getWritePos - start))
-          buildVariant(builder, values.get(i, valueType), valueType)
+          val value = if (values.isNullAt(i)) null else values.get(i, valueType)
+          buildVariant(builder, value, valueType)
         }
         builder.finishWritingObject(start, fields)
       case StructType(structFields) =>
@@ -127,7 +129,8 @@ object VariantExpressionEvalUtils {
           val key = structFields(i).name
           val id = builder.addKey(key)
           fields.add(new VariantBuilder.FieldEntry(key, id, builder.getWritePos - start))
-          buildVariant(builder, data.get(i, structFields(i).dataType), structFields(i).dataType)
+          val value = if (data.isNullAt(i)) null else data.get(i, structFields(i).dataType)
+          buildVariant(builder, value, structFields(i).dataType)
         }
         builder.finishWritingObject(start, fields)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

It adds null checks when accessing a nested element when casting a nested type to variant. It is necessary because the `get` API doesn't guarantee to return null when the slot is null. For example, `ColumnarArray.get` may return the default value of a primitive type if the slot is null.

### Why are the changes needed?

It is a bug fix is necessary for the cast-to-variant expression to work correctly.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Two new unit tests. One directly uses `ColumnarArray` as the input of the cast. The other creates a real-world situation where `ColumnarArray` is the input of the cast (scan). Both of them would fail without the code change in this PR.

### Was this patch authored or co-authored using generative AI tooling?

No.
