### PR TITLE
[WIP][SPARK-47353][SQL][Prototype of alternative algorithm] Enable collation support for the Mode expression using multiple experimental approaches

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
@@ -113,7 +113,6 @@ case class Mode(
   }
 
   private def isCollatedString(child: Expression): Boolean = {
-    println("child.dataType: " + child.dataType)
     child.dataType match {
       case s: StringType if s.collationId != CollationFactory.UTF8_BINARY_COLLATION_ID => true
       // maybe use supportsBinaryEquality or something else

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
@@ -119,7 +119,7 @@ case class Mode(
   }
 
   private def isCollatedString(child: Expression): Boolean = {
-    child match {
+    child.dataType match {
       case s: StringType if s.collationId != CollationFactory.UTF8_BINARY_COLLATION_ID => true
       // maybe use supportsBinaryEquality or something else
       case _ => false

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.catalyst.expressions.aggregate
 
 import scala.collection.mutable.TreeMap
+
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.{ExpressionBuilder, UnresolvedWithinGroup}
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Descending, Expression, ExpressionDescription, ImplicitCastInputTypes, SortOrder}
@@ -25,7 +26,6 @@ import org.apache.spark.sql.catalyst.trees.UnaryLike
 import org.apache.spark.sql.catalyst.types.PhysicalDataType
 import org.apache.spark.sql.catalyst.util.{CollationFactory, GenericArrayData}
 import org.apache.spark.sql.errors.QueryCompilationErrors
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{AbstractDataType, AnyDataType, ArrayType, BooleanType, DataType, StringType}
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.collection.OpenHashMap

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
@@ -109,10 +109,11 @@ case class Mode(
       }
       val ordering = Ordering.Tuple2(Ordering.Long, defaultKeyOrdering)
       buffer.maxBy { case (key, count) => (count, key) }(ordering)
-    }.getOrElse(buffer.maxBy(_._2))
+    }.getOrElse(buffer.maxBy(_._2))._1
   }
 
   private def isCollatedString(child: Expression): Boolean = {
+    println("child.dataType: " + child.dataType)
     child.dataType match {
       case s: StringType if s.collationId != CollationFactory.UTF8_BINARY_COLLATION_ID => true
       // maybe use supportsBinaryEquality or something else

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Mode.scala
@@ -101,7 +101,7 @@ case class Mode(
       buff
     }
 
-    val t2 = reverseOpt.map { reverse =>
+    reverseOpt.map { reverse =>
       val defaultKeyOrdering = if (reverse) {
         PhysicalDataType.ordering(child.dataType).asInstanceOf[Ordering[AnyRef]].reverse
       } else {
@@ -110,12 +110,6 @@ case class Mode(
       val ordering = Ordering.Tuple2(Ordering.Long, defaultKeyOrdering)
       buffer.maxBy { case (key, count) => (count, key) }(ordering)
     }.getOrElse(buffer.maxBy(_._2))
-
-    if (t2._2 == 0L) {
-      null
-    } else {
-      t2._1
-    }
   }
 
   private def isCollatedString(child: Expression): Boolean = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
@@ -345,7 +345,7 @@ class V2ExpressionBuilder(e: Expression, isPredicate: Boolean = false) {
     case aggregate.RegrSXY(PushableExpression(left), PushableExpression(right)) =>
       Some(new GeneralAggregateFunc("REGR_SXY", isDistinct, Array(left, right)))
     // Translate Mode if it is deterministic or reverse is defined.
-    case aggregate.Mode(PushableExpression(expr), _, _, Some(reverse), _) =>
+    case aggregate.Mode(PushableExpression(expr), _, _, Some(reverse)) =>
       Some(new GeneralAggregateFunc(
         "MODE", isDistinct, Array.empty, Array(generateSortValue(expr, !reverse))))
     case aggregate.Percentile(

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
@@ -345,7 +345,7 @@ class V2ExpressionBuilder(e: Expression, isPredicate: Boolean = false) {
     case aggregate.RegrSXY(PushableExpression(left), PushableExpression(right)) =>
       Some(new GeneralAggregateFunc("REGR_SXY", isDistinct, Array(left, right)))
     // Translate Mode if it is deterministic or reverse is defined.
-    case aggregate.Mode(PushableExpression(expr), _, _, Some(reverse)) =>
+    case aggregate.Mode(PushableExpression(expr), _, _, Some(reverse), _) =>
       Some(new GeneralAggregateFunc(
         "MODE", isDistinct, Array.empty, Array(generateSortValue(expr, !reverse))))
     case aggregate.Percentile(

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
@@ -816,8 +816,8 @@ class CollationStringExpressionsSuite
     case class ModeTestCase[R](collationId: String, bufferValues: Map[String, Long], result: R)
     val testCases = Seq(
       ModeTestCase("utf8_binary", Map("a" -> 3L, "b" -> 2L, "B" -> 2L), "a"),
-      ModeTestCase("utf8_binary_lcase", Map("a" -> 3L, "b" -> 2L, "B" -> 2L), "b"),
-      ModeTestCase("unicode_ci", Map("a" -> 3L, "b" -> 2L, "B" -> 2L), "b"),
+      ModeTestCase("utf8_binary_lcase", Map("a" -> 3L, "b" -> 2L, "B" -> 2L), "B"),
+      ModeTestCase("unicode_ci", Map("a" -> 3L, "b" -> 2L, "B" -> 2L), "B"),
       ModeTestCase("unicode", Map("a" -> 3L, "b" -> 2L, "B" -> 2L), "a")
     )
     testCases.foreach(t => {
@@ -844,7 +844,7 @@ class CollationStringExpressionsSuite
         "('b'), ('b'), ('b'), " +
         "('B'), ('B'), ('B'), ('B')")
       val query = "SELECT mode(collate(i, 'UTF8_BINARY_LCASE')) FROM t"
-      checkAnswer(sql(query), Row("b"))
+      checkAnswer(sql(query), Row("B"))
       assert(sql(query).schema.fields.head.dataType.sameType(StringType("UTF8_BINARY_LCASE")))
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
@@ -868,8 +868,12 @@ class CollationStringExpressionsSuite
       ModeTestCase("unicode_ci", bufferValues, "b"),
       ModeTestCase("unicode", bufferValues, "a"))
 
-    val bufferValuesUTF8String = Map(UTF8String.fromString("a") -> 5L, UTF8String.fromString("b") -> 4L,
-      UTF8String.fromString("B") -> 3L, UTF8String.fromString("d") -> 2L, UTF8String.fromString("e") -> 1L)
+    val bufferValuesUTF8String = Map(
+      UTF8String.fromString("a") -> 5L,
+      UTF8String.fromString("b") -> 4L,
+      UTF8String.fromString("B") -> 3L,
+      UTF8String.fromString("d") -> 2L,
+      UTF8String.fromString("e") -> 1L)
     val testCasesUTF8String = Seq(UTF8StringModeTestCase("utf8_binary", bufferValuesUTF8String, "a"),
       UTF8StringModeTestCase("utf8_binary_lcase", bufferValuesUTF8String, "b"),
       UTF8StringModeTestCase("unicode_ci", bufferValuesUTF8String, "b"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
@@ -819,17 +819,13 @@ class CollationStringExpressionsSuite
         "('B'), ('B'), ('B'), ('B')")
       val query = "SELECT mode(collate(i, 'UTF8_BINARY_LCASE')) FROM t"
       checkAnswer(sql(query), Row("b"))
+      assert(sql(query).schema.fields.head.dataType.sameType(StringType("UTF8_BINARY_LCASE")))
+
     }
   }
 
-  test("Support mode for string expression with collation ID") {
-    val query = "SELECT mode(collate('lorem epsum', 'UTF8_BINARY_LCASE'))"
-    checkAnswer(sql(query), Row("lorem epsum"))
-    assert(sql(query).schema.fields.head.dataType.sameType(StringType("UTF8_BINARY_LCASE")))
-  }
-
   test("Support Mode.eval(buffer)") {
-    val myMode = Mode(child = Literal("some_column_name"), collationEnabled = true)
+    val myMode = Mode(child = Literal("some_column_name"))
     val buffer = new OpenHashMap[AnyRef, Long](5)
     buffer.update("b", 1L)
     buffer.update("B", 1L)
@@ -848,8 +844,7 @@ class CollationStringExpressionsSuite
 
   test("Support Mode.eval(buffer) with non-default collation") {
     val myMode = Mode(
-      child = Literal.create("some_column_name", StringType("utf8_binary_lcase")),
-      collationEnabled = true)
+      child = Literal.create("some_column_name", StringType("utf8_binary_lcase")))
     val buffer = new OpenHashMap[AnyRef, Long](11)
     buffer.update("b", 2L)
     buffer.update("B", 2L)

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
@@ -859,35 +859,6 @@ class CollationStringExpressionsSuite
     assert(myMode.eval(buffer).toString == "B")
   }
 
-
-  test("Support Mode.eval(buffer) with some null values") {
-    val modeDefaultCollation = Mode(child = Literal("some_column_name"))
-    val modeLowercaseCollation = Mode(child =
-      Literal.create("some_column_name", StringType("unicode_ci")),
-      collationEnabled = true)
-    val buffer = new OpenHashMap[AnyRef, Long](7)
-    buffer.update("bb", 1L)
-    buffer.update("Bb", 1L)
-    buffer.update("BB", 1L)
-    buffer.update("c", 1L)
-    buffer.update(null, 1L)
-    buffer.update("a", 2L)
-    assert(modeDefaultCollation.eval(buffer).toString == "a")
-    assert(modeLowercaseCollation.eval(buffer).toString.toLowerCase() == "bb")
-  }
-
-  test("Support Mode.eval(buffer) with mode should = null (not yet implemented)") {
-    val modeDefaultCollation = Mode(child = Literal("some_column_name"))
-    val modeLowercaseCollation = Mode(
-      child = Literal.create("some_column_name", StringType("unicode_ci")),
-      collationEnabled = true)
-    val buffer = new OpenHashMap[AnyRef, Long](7)
-    buffer.update(null, 2L)
-    buffer.update("c", 1L)
-    assert(modeDefaultCollation.eval(buffer) == null)
-    assert(modeLowercaseCollation.eval(buffer) == null)
-  }
-
   // TODO: Add more tests for other string expressions
 
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
@@ -874,7 +874,9 @@ class CollationStringExpressionsSuite
       UTF8String.fromString("B") -> 3L,
       UTF8String.fromString("d") -> 2L,
       UTF8String.fromString("e") -> 1L)
-    val testCasesUTF8String = Seq(UTF8StringModeTestCase("utf8_binary", bufferValuesUTF8String, "a"),
+
+    val testCasesUTF8String = Seq(
+      UTF8StringModeTestCase("utf8_binary", bufferValuesUTF8String, "a"),
       UTF8StringModeTestCase("utf8_binary_lcase", bufferValuesUTF8String, "b"),
       UTF8StringModeTestCase("unicode_ci", bufferValuesUTF8String, "b"),
       UTF8StringModeTestCase("unicode", bufferValuesUTF8String, "a"))

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
@@ -882,7 +882,7 @@ class CollationStringExpressionsSuite
       val buffer = new OpenHashMap[AnyRef, Long](5)
       val myMode = Mode(child = Literal.create("some_column_name", StringType(t.collationId)))
       t.bufferValues.foreach { case (k, v) => buffer.update(k, v) }
-      assert(myMode.eval(buffer).toString == t.result)
+      assert(myMode.eval(buffer).toString.toLowerCase() == t.result.toLowerCase())
     })
 //
 //    testCasesUTF8String.foreach(t => {

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
@@ -865,18 +865,18 @@ class CollationStringExpressionsSuite
       ModeTestCase("unicode_ci", bufferValues, "b"),
       ModeTestCase("unicode", bufferValues, "a"))
 
-//    val bufferValuesUTF8String = Map(
-//      UTF8String.fromString("a") -> 5L,
-//      UTF8String.fromString("b") -> 4L,
-//      UTF8String.fromString("B") -> 3L,
-//      UTF8String.fromString("d") -> 2L,
-//      UTF8String.fromString("e") -> 1L)
-//
-//    val testCasesUTF8String = Seq(
-//      UTF8StringModeTestCase("utf8_binary", bufferValuesUTF8String, "a"),
-//      UTF8StringModeTestCase("utf8_binary_lcase", bufferValuesUTF8String, "b"),
-//      UTF8StringModeTestCase("unicode_ci", bufferValuesUTF8String, "b"),
-//      UTF8StringModeTestCase("unicode", bufferValuesUTF8String, "a"))
+    val bufferValuesUTF8String = Map(
+      UTF8String.fromString("a") -> 5L,
+      UTF8String.fromString("b") -> 4L,
+      UTF8String.fromString("B") -> 3L,
+      UTF8String.fromString("d") -> 2L,
+      UTF8String.fromString("e") -> 1L)
+
+    val testCasesUTF8String = Seq(
+      UTF8StringModeTestCase("utf8_binary", bufferValuesUTF8String, "a"),
+      UTF8StringModeTestCase("utf8_binary_lcase", bufferValuesUTF8String, "b"),
+      UTF8StringModeTestCase("unicode_ci", bufferValuesUTF8String, "b"),
+      UTF8StringModeTestCase("unicode", bufferValuesUTF8String, "a"))
 
     testCasesStrings.foreach(t => {
       val buffer = new OpenHashMap[AnyRef, Long](5)
@@ -884,13 +884,13 @@ class CollationStringExpressionsSuite
       t.bufferValues.foreach { case (k, v) => buffer.update(k, v) }
       assert(myMode.eval(buffer).toString.toLowerCase() == t.result.toLowerCase())
     })
-//
-//    testCasesUTF8String.foreach(t => {
-//      val buffer = new OpenHashMap[AnyRef, Long](5)
-//      val myMode = Mode(child = Literal.create("some_column_name", StringType(t.collationId)))
-//      t.bufferValues.foreach { case (k, v) => buffer.update(k, v) }
-//      assert(myMode.eval(buffer).toString == t.result)
-//    })
+
+    testCasesUTF8String.foreach(t => {
+      val buffer = new OpenHashMap[AnyRef, Long](5)
+      val myMode = Mode(child = Literal.create("some_column_name", StringType(t.collationId)))
+      t.bufferValues.foreach { case (k, v) => buffer.update(k, v) }
+      assert(myMode.eval(buffer).toString.toLowerCase() == t.result.toLowerCase())
+    })
   }
 
   // TODO: Add more tests for other string expressions

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
@@ -194,7 +194,7 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
       collationTypes: Seq[String],
       value: Seq[UTF8String]): Unit = {
     val benchmark = new Benchmark(
-      "collation unit benchmarks - mode",
+      s"collation unit benchmarks - mode - ${value.size} elements",
       value.size * 10,
       warmupTime = 10.seconds,
       output = output)
@@ -203,31 +203,32 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
         val modeDefaultCollation = Mode(child =
           Literal.create("some_column_name", StringType(collationType)))
         val buffer = new OpenHashMap[AnyRef, Long](value.size)
-        value.zipWithIndex.sliding(20, 20).foreach(slide => {
+        value.zipWithIndex.sliding(2000, 2000).foreach(slide => {
           slide.foreach { case (v: UTF8String, i: Int) =>
             buffer.update(v.toString + s"_${i.toString}", (i % 1000).toLong)
           }
           modeDefaultCollation.eval(buffer)
-
         })
       }
     }
     }
-    benchmark.addCase(s"Collation Not Enabled") { _ =>
+
+    benchmark.addCase(s"Collation Not Enabled - mode - ${value.size} elements") { _ =>
       val modeNoCollation = Mode(child =
         Literal("some_column_name"))
       val buffer = new OpenHashMap[AnyRef, Long](value.size)
-      value.zipWithIndex.sliding(20, 20).foreach(slide => {
+      value.zipWithIndex.sliding(2000, 2000).foreach(slide => {
         slide.foreach { case (v: UTF8String, i: Int) =>
           buffer.update(v.toString + s"_${i.toString}", (i % 1000).toLong)
         }
         modeNoCollation.eval(buffer)
       })
     }
-    benchmark.addCase(s"Numerical Type") { _ =>
+
+    benchmark.addCase(s"Numerical Type - mode - ${value.size} elements") { _ =>
       val modeIntType = Mode(child = Literal.create(1, IntegerType))
       val buffer = new OpenHashMap[AnyRef, Long](value.size)
-      value.zipWithIndex.sliding(20, 20).foreach(slide => {
+      value.zipWithIndex.sliding(2000, 2000).foreach(slide => {
         slide.foreach {
           case (_, i: Int) =>
             buffer.update(i.asInstanceOf[AnyRef], (i % 1000).toLong)
@@ -266,6 +267,8 @@ object CollationBenchmark extends CollationBenchmarkBase {
   override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
     val inputs = generateSeqInput(10000L)
     benchmarkMode(collationTypes, inputs)
+    benchmarkMode(collationTypes, generateSeqInput(5000L))
+    benchmarkMode(collationTypes, generateSeqInput(2500L))
     benchmarkUTFStringEquals(collationTypes, inputs)
     benchmarkUTFStringCompare(collationTypes, inputs)
     benchmarkUTFStringHashFunction(collationTypes, inputs)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
@@ -201,7 +201,7 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
     collationTypes.foreach { collationType => {
       benchmark.addCase(s"$collationType") { _ =>
         val modeDefaultCollation = Mode(child =
-          Literal.create("some_column_name", StringType(collationType)), collationEnabled = true)
+          Literal.create("some_column_name", StringType(collationType)))
         val buffer = new OpenHashMap[AnyRef, Long](value.size)
         value.zipWithIndex.sliding(20, 20).foreach(slide => {
           slide.foreach { case (v: UTF8String, i: Int) =>
@@ -215,7 +215,7 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
     }
     benchmark.addCase(s"Collation Not Enabled") { _ =>
       val modeNoCollation = Mode(child =
-        Literal("some_column_name"), collationEnabled = false)
+        Literal("some_column_name"))
       val buffer = new OpenHashMap[AnyRef, Long](value.size)
       value.zipWithIndex.sliding(20, 20).foreach(slide => {
         slide.foreach { case (v: UTF8String, i: Int) =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
@@ -199,14 +199,13 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
       warmupTime = 10.seconds,
       output = output)
     collationTypes.foreach { collationType => {
-      val collation = CollationFactory.fetchCollation(collationType)
       benchmark.addCase(s"$collationType") { _ =>
         val modeDefaultCollation = Mode(child =
           Literal.create("some_column_name", StringType(collationType)), collationEnabled = true)
         val buffer = new OpenHashMap[AnyRef, Long](value.size)
         value.zipWithIndex.sliding(20, 20).foreach(slide => {
           slide.foreach { case (v: UTF8String, i: Int) =>
-            buffer.update(v, (i % 1000).toLong)
+            buffer.update(v.toString + s"_${i.toString}", (i % 1000).toLong)
           }
           modeDefaultCollation.eval(buffer)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
@@ -199,7 +199,7 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
       warmupTime = 10.seconds,
       output = output)
     collationTypes.foreach { collationType => {
-      benchmark.addCase(s"$collationType") { _ =>
+      benchmark.addCase(s"$collationType - mode - ${value.size} elements") { _ =>
         val modeDefaultCollation = Mode(child =
           Literal.create("some_column_name", StringType(collationType)))
         val buffer = new OpenHashMap[AnyRef, Long](value.size)
@@ -211,18 +211,6 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
         })
       }
     }
-    }
-
-    benchmark.addCase(s"Collation Not Enabled - mode - ${value.size} elements") { _ =>
-      val modeNoCollation = Mode(child =
-        Literal("some_column_name"))
-      val buffer = new OpenHashMap[AnyRef, Long](value.size)
-      value.zipWithIndex.sliding(2000, 2000).foreach(slide => {
-        slide.foreach { case (v: UTF8String, i: Int) =>
-          buffer.update(v.toString + s"_${i.toString}", (i % 1000).toLong)
-        }
-        modeNoCollation.eval(buffer)
-      })
     }
 
     benchmark.addCase(s"Numerical Type - mode - ${value.size} elements") { _ =>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
@@ -219,7 +219,7 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
       val buffer = new OpenHashMap[AnyRef, Long](value.size)
       value.zipWithIndex.sliding(20, 20).foreach(slide => {
         slide.foreach { case (v: UTF8String, i: Int) =>
-          buffer.update(v, (i % 1000).toLong)
+          buffer.update(v.toString + s"_${i.toString}", (i % 1000).toLong)
         }
         modeNoCollation.eval(buffer)
       })


### PR DESCRIPTION
Here is the PR description for the alternative PR:

---
### PR Description

#### Introduction
This PR proposes an alternative approach to the original implementation using `TreeMap` with a custom comparator for collation-sensitive grouping. The primary objective is to improve performance by leveraging `OpenHashMap` with a custom hashing strategy.

#### Benchmark Results
The initial `TreeMap` approach led to significant performance degradation, especially for unicode collations. After implementing a proof of concept using `OpenHashMap`, the slowdown was reduced considerably.

**Benchmark Results Overview**

| Approach           | Slowdown (UTF8_BINARY Reference) |
|--------------------|----------------------------------|
| `TreeMap`          | 16.9x - 56x                      |
| `OpenHashMap`      | 9.5x - 15x                       |

**Details:**
- **UTF8_BINARY (Baseline)**
  - Red-Black Tree / TreeMap Implementation: Slowdown ranges from 16.9x to 56x
  - `OpenHashMap` Implementation: Slowdown ranges from 9.5x to 15x
- The numerical benchmark case has been ignored for this analysis.

#### Proposed Implementation
- **Custom Hasher**: Introduced a custom `Hasher` to allow collation-sensitive grouping.
  - Modified `org.apache.spark.util.collection.OpenHashSet.Hasher.hash()`, specifically an override of `hash()` within `Hasher[String with Collation]`.
  - This new `Hasher` branches to an alternative hashing method that is collation-sensitive.
- **Benchmark Enhancement**: Benchmarks now include multiple collation types and evaluate different algorithms.

**Approach 3 (Prototype)**
In addition to `TreeMap` and `OpenHashMap`, a third approach has been introduced:
```scala
private def impl3(buff: OpenHashMap[AnyRef, Long]) = {
  val modeMap = buff.toSeq.groupMapReduce {
    case (key: String, _) =>
      CollationFactory.getCollationKey(UTF8String.fromString(key), collationId)
    case (key: UTF8String, _) =>
      CollationFactory.getCollationKey(key, collationId)
    case (key, _) => key
  }(x => x)((x, y) => (x._1, x._2 + y._2)).values
  modeMap
}
```

#### Next Steps
- **Cardinality and Duplicates**: Further analysis needed to determine expected cardinalities in realistic scenarios. For example, even in large datasets with 1 trillion rows, it's unlikely that all rows will have unique values.
- **Benchmark Diversity**: More varied benchmarks needed, especially in the experimental branch, to better evaluate different algorithms with varied duplicate values.

## OpenJDK Benchmark Results

**Configuration**:  
- **Java Version**: OpenJDK 64-Bit Server VM 21.0.2+13-LTS  
- **OS**: Mac OS X 14.4.1  
- **CPU**: Apple M3 Max  

### Collation Unit Benchmarks - Mode - 2000 Elements

| Mode                         | Map Type  | Best Time (ms) | Avg Time (ms) | Stdev (ms) | Rate (M/s) | Per Row (ns) | Relative |
|------------------------------|-----------|----------------|---------------|------------|-------------|---------------|----------|
| Numerical Type               |   N/A | 0              | 0             | 0          | 30.5        | 32.8         | 9.7X     |
| UTF8_BINARY                  |   N/A | 0              | 0             | 0          | 16.4        | 60.8         | 5.2X     |
| UTF8_BINARY_LCASE            | treemap   | 1              | 1             | 0          | 3.1         | 318.3        | 1.0X     |
| UNICODE                      | treemap   | 2              | 2             | 0          | 1.2         | 829.7        | 0.4X     |
| UNICODE_CI                   | treemap   | 2              | 2             | 0          | 1.1         | 877.5        | 0.4X     |
| UTF8_BINARY_LCASE            | hashmap   | 1              | 1             | 0          | 3.4         | 298.3        | 1.1X     |
| UNICODE                      | hashmap   | 1              | 1             | 0          | 2.2         | 452.9        | 0.7X     |
| UNICODE_CI                   | hashmap   | 1              | 1             | 0          | 2.1         | 467.3        | 0.7X     |
| UTF8_BINARY_LCASE            | mapreduce | 0              | 0             | 0          | 5.3         | 187.6        | 1.7X     |
| UNICODE                      | mapreduce | 0              | 0             | 0          | 5.9         | 169.6        | 1.9X     |
| UNICODE_CI                   | mapreduce | 1              | 1             | 0          | 3.1         | 327.2        | 1.0X     |

 
### Collation Unit Benchmarks - Mode - 4000 Elements

| Mode                         | Map Type  | Best Time (ms) | Avg Time (ms) | Stdev (ms) | Rate (M/s) | Per Row (ns) | Relative |
|------------------------------|-----------|----------------|---------------|------------|-------------|---------------|----------|
| UTF8_BINARY_LCASE            | treemap   | 2              | 2             | 0          | 2.4         | 409.3        | 1.0X     |
| UNICODE                      | treemap   | 5              | 5             | 0          | 0.8         | 1190.5       | 0.3X     |
| UTF8_BINARY                  | N/A   | 0              | 0             | 0          | 14.4        | 69.2         | 5.9X     |
| UNICODE_CI                   | treemap   | 5              | 5             | 0          | 0.8         | 1213.4       | 0.3X     |
| Numerical Type               | N/A   | 0              | 0             | 0          | 24.5        | 40.8         | 10.0X    |
| UTF8_BINARY_LCASE            | hashmap   | 1              | 1             | 0          | 3.4         | 295.9        | 1.4X     |
| UNICODE                      | hashmap   | 2              | 2             | 0          | 1.8         | 556.8        | 0.7X     |
| UNICODE_CI                   | hashmap   | 2              | 2             | 0          | 2.2         | 459.8        | 0.9X     |
| UTF8_BINARY_LCASE            | mapreduce | 1              | 1             | 0          | 4.5         | 220.3        | 1.9X     |
| UNICODE                      | mapreduce | 1              | 1             | 0          | 5.1         | 196.4        | 2.1X     |
| UNICODE_CI                   | mapreduce | 1              | 2             | 0          | 2.7         | 364.8        | 1.1X     |


| Mode                         | Map Type  | Best Time (ms) | Avg Time (ms) | Stdev (ms) | Rate (M/s) | Per Row (ns) | Relative |
|------------------------------|-----------|----------------|---------------|------------|-------------|---------------|----------|
| UTF8_BINARY_LCASE            | treemap   | 4              | 4             | 0          | 2.1         | 473.8        | 1.0X     |
| UNICODE                      | treemap   | 11             | 12            | 1          | 0.7         | 1385.7       | 0.3X     |
| UTF8_BINARY                  | treemap   | 1              | 1             | 0          | 13.9        | 71.7         | 6.6X     |
| UNICODE_CI                   | treemap   | 11             | 11            | 0          | 0.7         | 1348.2       | 0.4X     |
| Numerical Type               | treemap   | 0              | 0             | 0          | 22.7        | 44.0         | 10.8X    |
| UTF8_BINARY_LCASE            | hashmap   | 3              | 3             | 0          | 2.9         | 339.9        | 1.4X     |
| UNICODE                      | hashmap   | 5              | 5             | 0          | 1.8         | 568.0        | 0.8X     |
| UTF8_BINARY                  | hashmap   | 1              | 1             | 0          | 13.5        | 74.3         | 6.4X     |
| UNICODE_CI                   | hashmap   | 4              | 4             | 0          | 2.1         | 470.2        | 1.0X     |
| Numerical Type               | hashmap   | 0              | 0             | 0          | 23.2        | 43.2         | 11.0X    |
| UTF8_BINARY_LCASE            | mapreduce | 2              | 2             | 0          | 3.9         | 255.7        | 1.9X     |
| UNICODE                      | mapreduce | 2              | 2             | 0          | 4.3         | 230.2        | 2.1X     |
| UTF8_BINARY                  | mapreduce | 1              | 1             | 0          | 14.8        | 67.5         | 7.0X     |
| UNICODE_CI                   | mapreduce | 3              | 3             | 0          | 2.5         | 396.6        | 1.2X     |
| Numerical Type               | mapreduce | 0              | 0             | 0          | 23.7        | 42.2         | 11.2X    |

Thought: These benchmarks aren't on populations where the collation makes any difference.

## OpenJDK Benchmark Results

### Environment
- **JVM:** OpenJDK 64-Bit Server VM 21.0.2+13-LTS
- **OS:** Mac OS X 14.4.1
- **Hardware:** Apple M3 Max

### Collation Unit Benchmarks (6000 Elements)

| Mode                                | Implementation    | Best Time (ms) | Avg Time (ms) | Stdev (ms) | Rate (M/s) | Per Row (ns) | Relative |
| ------------------------------------| -----------------| -------------- | ------------- | ---------- | ----------- | -------------| -------- |
| UTF8_BINARY_LCASE                   | treemap          | 3              | 3             | 0          | 2.2         | 456.0        | 1.0X     |
| UNICODE                             | treemap          | 8              | 8             | 0          | 0.8         | 1274.2       | 0.4X     |
| UTF8_BINARY                         | treemap          | 0              | 1             | 1          | 14.1        | 71.0         | 6.4X     |
| UNICODE_CI                          | treemap          | 8              | 8             | 0          | 0.8         | 1273.0       | 0.4X     |
| Numerical Type                      | N/A              | 0              | 0             | 0          | 23.8        | 42.0         | 10.9X    |
| UTF8_BINARY_LCASE                   | hashmap          | 2              | 3             | 2          | 2.7         | 368.3        | 1.2X     |
| UNICODE_CI                          | hashmap          | 3              | 4             | 0          | 1.8         | 550.0        | 0.8X     |
| UTF8_BINARY_LCASE                   | mapreduce        | 1              | 2             | 0          | 4.1         | 242.4        | 1.9X     |
| UNICODE_CI                          | mapreduce        | 2              | 3             | 0          | 2.6         | 390.8        | 1.2X     |
| UTF8_BINARY_LCASE                   | treemap 0.05%    | 3              | 3             | 0          | 1.9         | 516.8        | 0.9X     |
| UTF8_BINARY                         | treemap 0.05%    | 0              | 1             | 0          | 13.2        | 76.0         | 6.0X     |
| UNICODE_CI                          | treemap 0.05%    | 8              | 9             | 2          | 0.8         | 1322.2       | 0.3X     |
| UTF8_BINARY_LCASE                   | hashmap 0.05%    | 2              | 2             | 0          | 2.8         | 362.8        | 1.3X     |
| UNICODE_CI                          | hashmap 0.05%    | 3              | 4             | 0          | 1.9         | 530.0        | 0.9X     |
| UTF8_BINARY_LCASE                   | mapreduce 0.05%  | 2              | 2             | 0          | 3.8         | 263.1        | 1.7X     |
| UNICODE_CI                          | mapreduce 0.05%  | 2              | 3             | 0          | 2.7         | 375.7        | 1.2X     |
| UTF8_BINARY_LCASE                   | treemap 0.1%     | 3              | 3             | 0          | 1.9         | 521.4        | 0.9X     |
| UTF8_BINARY                         | treemap 0.1%     | 0              | 1             | 0          | 12.6        | 79.4         | 5.7X     |
| UNICODE_CI                          | treemap 0.1%     | 8              | 9             | 1          | 0.7         | 1346.7       | 0.3X     |
| UTF8_BINARY_LCASE                   | hashmap 0.1%     | 2              | 2             | 0          | 2.8         | 356.8        | 1.3X     |
| UNICODE_CI                          | hashmap 0.1%     | 3              | 4             | 0          | 1.9         | 516.3        | 0.9X     |
| UTF8_BINARY_LCASE                   | mapreduce 0.1%   | 2              | 2             | 0          | 3.7         | 269.0        | 1.7X     |
| UNICODE_CI                          | mapreduce 0.1%   | 2              | 3             | 0          | 2.6         | 388.0        | 1.2X     |

### Collation Unit Benchmarks (12000 Elements)

| Mode                                | Implementation    | Best Time (ms) | Avg Time (ms) | Stdev (ms) | Rate (M/s) | Per Row (ns) | Relative |
| ------------------------------------| -----------------| -------------- | ------------- | ---------- | ----------- | -------------| -------- |
| UTF8_BINARY_LCASE                   | treemap          | 7              | 7             | 0          | 1.8         | 557.2        | 1.0X     |
| UNICODE                             | treemap          | 18             | 20            | 1          | 0.7         | 1492.5       | 0.4X     |
| UTF8_BINARY                         | treemap          | 1              | 1             | 0          | 11.9        | 84.3         | 6.6X     |
| UNICODE_CI                          | treemap          | 17             | 20            | 1          | 0.7         | 1433.1       | 0.4X     |
| Numerical Type                      | N/A              | 1              | 1             | 0          | 21.7        | 46.1         | 12.1X    |
| UTF8_BINARY_LCASE                   | hashmap          | 5              | 5             | 0          | 2.6         | 379.8        | 1.5X     |
| UNICODE_CI                          | hashmap          | 7              | 7             | 1          | 1.8         | 571.0        | 1.0X     |
| UTF8_BINARY_LCASE                   | mapreduce        | 3              | 4             | 0          | 3.6         | 279.3        | 2.0X     |
| UNICODE_CI                          | mapreduce        | 5              | 5             | 0          | 2.4         | 411.4        | 1.4X     |
| UTF8_BINARY_LCASE                   | treemap 0.05%    | 7              | 7             | 0          | 1.7         | 585.1        | 1.0X     |
| UTF8_BINARY                         | treemap 0.05%    | 1              | 1             | 0          | 10.8        | 92.5         | 6.0X     |
| UNICODE_CI                          | treemap 0.05%    | 17             | 19            | 1          | 0.7         | 1454.2       | 0.4X     |
| UTF8_BINARY_LCASE                   | hashmap 0.05%    | 5              | 5             | 0          | 2.5         | 400.6        | 1.4X     |
| UNICODE_CI                          | hashmap 0.05%    | 7              | 8             | 1          | 1.7         | 593.0        | 0.9X     |
| UTF8_BINARY_LCASE                   | mapreduce 0.05%  | 4              | 4             | 0          | 3.3         | 304.8        | 1.8X     |
| UNICODE_CI                          | mapreduce 0.05%  | 5              | 6             | 1          | 2.3         | 433.9        | 1.3X     |
| UTF8_BINARY_LCASE                   | treemap 0.1%     | 7              | 8             | 0          | 1.7         | 591.2        | 0.9X     |
| UTF8_BINARY                         | treemap 0.1%     | 1              | 1             | 0          | 11.1        | 90.5         | 6.2X     |
| UNICODE_CI                          | treemap 0.1%     | 18             | 19            | 1          | 0.7         | 1482.1       | 0.4X     |
| UTF8_BINARY_LCASE                   | hashmap 0.1%     | 4              | 5             | 0          | 2.7         | 373.5        | 1.5X     |
| UNICODE_CI                          | hashmap 0.1%     | 7              | 7             | 0          | 1.7         | 573.7        | 1.0X     |
| UTF8_BINARY_LCASE                   | mapreduce 0.1%   | 4              | 4             | 0          | 3.3         | 300.8        | 1.9X     |
| UNICODE_CI                          | mapreduce 0.1%   | 5              | 6             | 0          | 2.3         | 437.3        | 1.3X     |
