### PR TITLE
[Draft][CORE][SQL] Add debugging operator to identify skew in datasets inline

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -4139,9 +4139,10 @@ object DebugInlineColumnsCountPushDown extends Rule[LogicalPlan] {
     plan.transform {
       case DebugInlineColumnsCount(j @ ExtractEquiJoinKeys(_, leftKeys, rightKeys, _, _,
       left, right, _), sampleColumns) if sampleColumns.isEmpty =>
-        val newLeftChild = DebugInlineColumnsCount(left, leftKeys)
-        val newRightChild = DebugInlineColumnsCount(right, rightKeys)
-        j.withNewChildren(Seq(newLeftChild, newRightChild))
+          DebugInlineColumnsCount(j, leftKeys ++ rightKeys)
+//        val newLeftChild = DebugInlineColumnsCount(left, leftKeys)
+//        val newRightChild = DebugInlineColumnsCount(right, rightKeys)
+//        j.withNewChildren(Seq(newLeftChild, newRightChild))
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -4138,7 +4138,10 @@ object DebugInlineColumnsCountInference extends Rule[LogicalPlan] {
     plan.transform {
       case DebugInlineColumnsCount(j @ ExtractEquiJoinKeys(_, leftKeys, rightKeys, _, _,
       _, _, _), sampleColumns) if sampleColumns.isEmpty =>
-          DebugInlineColumnsCount(j, leftKeys)
+        val left = DebugInlineColumnsCount(j.left, leftKeys)
+        val right = DebugInlineColumnsCount(j.right, rightKeys)
+        val joinWithInputDebug = j.withNewChildren(Seq(left, right))
+        DebugInlineColumnsCount(joinWithInputDebug, leftKeys)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -4137,8 +4137,8 @@ object DebugInlineColumnsCountInference extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = {
     plan.transform {
       case DebugInlineColumnsCount(j @ ExtractEquiJoinKeys(_, leftKeys, rightKeys, _, _,
-      _, _, _), sampleColumns) if sampleColumns.isEmpty =>
-          DebugInlineColumnsCount(j, leftKeys ++ rightKeys)
+      _, _, _), sampleColumns, _) if sampleColumns.isEmpty =>
+          DebugInlineColumnsCount(j, leftKeys, Some("join output"))
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -4131,8 +4131,8 @@ object RemoveTempResolvedColumn extends Rule[LogicalPlan] {
 
 /**
  * This infers the columns to use for [[DebugInlineColumnsCount]] when possible.
- * For joins, it will use the join key columns so the application code does not need to specify it for both
- * the inputs and output.
+ * For joins, it will use the join key columns so the application code does not need
+ * to specify it for both the inputs and output.
  */
 object DebugInlineColumnsCountInference extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -4137,11 +4137,11 @@ object DebugInlineColumnsCountInference extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = {
     plan.transform {
       case DebugInlineColumnsCount(j @ ExtractEquiJoinKeys(_, leftKeys, rightKeys, _, _,
-      _, _, _), sampleColumns) if sampleColumns.isEmpty =>
-        val left = DebugInlineColumnsCount(j.left, leftKeys)
-        val right = DebugInlineColumnsCount(j.right, rightKeys)
+      _, _, _), sampleColumns, maxKeys) if sampleColumns.isEmpty =>
+        val left = DebugInlineColumnsCount(j.left, leftKeys, maxKeys)
+        val right = DebugInlineColumnsCount(j.right, rightKeys, maxKeys)
         val joinWithInputDebug = j.withNewChildren(Seq(left, right))
-        DebugInlineColumnsCount(joinWithInputDebug, leftKeys)
+        DebugInlineColumnsCount(joinWithInputDebug, leftKeys, maxKeys)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -4137,8 +4137,8 @@ object DebugInlineColumnsCountInference extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = {
     plan.transform {
       case DebugInlineColumnsCount(j @ ExtractEquiJoinKeys(_, leftKeys, rightKeys, _, _,
-      _, _, _), sampleColumns, _) if sampleColumns.isEmpty =>
-          DebugInlineColumnsCount(j, leftKeys, Some("join output"))
+      _, _, _), sampleColumns) if sampleColumns.isEmpty =>
+          DebugInlineColumnsCount(j, leftKeys)
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/debug.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/debug.scala
@@ -20,11 +20,11 @@ package org.apache.spark.sql.catalyst.plans.logical
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 
 
-case class DebugSampleColumn(
+case class DebugInlineColumnsCount(
   child: LogicalPlan,
   sampleColumns: Seq[Expression]) extends UnaryNode {
 
-  override protected def withNewChildInternal(newChild: LogicalPlan): DebugSampleColumn =
+  override protected def withNewChildInternal(newChild: LogicalPlan): DebugInlineColumnsCount =
     copy(child = newChild)
 
   override def output: Seq[Attribute] = child.output

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/debug.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/debug.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+
+
+case class DebugSampleColumn(
+  child: LogicalPlan,
+  sampleColumns: Seq[Expression]) extends UnaryNode {
+
+  override protected def withNewChildInternal(newChild: LogicalPlan): DebugSampleColumn =
+    copy(child = newChild)
+
+  override def output: Seq[Attribute] = child.output
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/debug.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/debug.scala
@@ -22,7 +22,9 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 
 case class DebugInlineColumnsCount(
   child: LogicalPlan,
-  sampleColumns: Seq[Expression]) extends UnaryNode {
+  sampleColumns: Seq[Expression],
+  maxKeys: Int
+) extends UnaryNode {
 
   override protected def withNewChildInternal(newChild: LogicalPlan): DebugInlineColumnsCount =
     copy(child = newChild)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/debug.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/debug.scala
@@ -22,9 +22,7 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 
 case class DebugInlineColumnsCount(
   child: LogicalPlan,
-  sampleColumns: Seq[Expression],
-  name: Option[String] = None
-) extends UnaryNode {
+  sampleColumns: Seq[Expression]) extends UnaryNode {
 
   override protected def withNewChildInternal(newChild: LogicalPlan): DebugInlineColumnsCount =
     copy(child = newChild)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/debug.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/debug.scala
@@ -22,7 +22,9 @@ import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 
 case class DebugInlineColumnsCount(
   child: LogicalPlan,
-  sampleColumns: Seq[Expression]) extends UnaryNode {
+  sampleColumns: Seq[Expression],
+  name: Option[String] = None
+) extends UnaryNode {
 
   override protected def withNewChildInternal(newChild: LogicalPlan): DebugInlineColumnsCount =
     copy(child = newChild)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3969,6 +3969,12 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val MAX_INLINE_COLUMN_COUNT_KEYS = buildConf("spark.sql.debug.maxInlineColumnCountKeys")
+    .doc("Maximum number of keys to maintain when counting the frequency of each key.")
+    .version("4.0.0")
+    .intConf
+    .createWithDefault(3)
+
   val MAX_TO_STRING_FIELDS = buildConf("spark.sql.debug.maxToStringFields")
     .doc("Maximum number of fields of sequence-like entries can be converted to strings " +
       "in debug output. Any elements beyond the limit will be dropped and replaced by a" +
@@ -5720,6 +5726,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def nameNonStructGroupingKeyAsValue: Boolean =
     getConf(SQLConf.NAME_NON_STRUCT_GROUPING_KEY_AS_VALUE)
+
+  def maxInlineColumnCountKeys: Int = getConf(SQLConf.MAX_INLINE_COLUMN_COUNT_KEYS)
 
   override def maxToStringFields: Int = getConf(SQLConf.MAX_TO_STRING_FIELDS)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkPlanner.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.execution.adaptive.LogicalQueryStageStrategy
 import org.apache.spark.sql.execution.command.v2.V2CommandStrategy
 import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, FileSourceStrategy}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Strategy
+import org.apache.spark.sql.execution.debug.DebugPlanner
 
 class SparkPlanner(val session: SparkSession, val experimentalMethods: ExperimentalMethods)
   extends SparkStrategies with SQLConfHelper {
@@ -47,7 +48,8 @@ class SparkPlanner(val session: SparkSession, val experimentalMethods: Experimen
       JoinSelection ::
       InMemoryScans ::
       SparkScripts ::
-      BasicOperators :: Nil)
+      BasicOperators ::
+      DebugPlanner :: Nil)
 
   /**
    * Override to add extra planning strategies to the planner. These strategies are tried after

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.expressions.codegen.{ByteCodeStats, CodeFormatter, CodegenContext, CodeGenerator, ExprCode}
-import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UnaryNode}
+import org.apache.spark.sql.catalyst.plans.logical.{DebugSampleColumn, LogicalPlan}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.trees.TreeNodeRef
 import org.apache.spark.sql.catalyst.util.StringConcat
@@ -299,16 +299,6 @@ package object debug {
 
     override protected def withNewChildInternal(newChild: SparkPlan): DebugExec =
       copy(child = newChild)
-  }
-
-  case class DebugSampleColumn(
-    child: LogicalPlan,
-    sampleColumns: Seq[Expression]) extends UnaryNode {
-
-    override protected def withNewChildInternal(newChild: LogicalPlan): DebugSampleColumn =
-      copy(child = newChild)
-
-    override def output: Seq[Attribute] = child.output
   }
 
   case class DebugSampleColumnExec(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
@@ -305,7 +305,8 @@ package object debug {
     child: LogicalPlan,
     sampleColumns: Seq[Expression]) extends UnaryNode {
 
-    override protected def withNewChildInternal(newChild: LogicalPlan): DebugSampleColumn = copy(child = newChild)
+    override protected def withNewChildInternal(newChild: LogicalPlan): DebugSampleColumn =
+      copy(child = newChild)
 
     override def output: Seq[Attribute] = child.output
   }
@@ -323,5 +324,15 @@ package object debug {
     }
 
     override def output: Seq[Attribute] = child.output
+  }
+
+  object DebugPlanner extends SparkStrategy {
+    override def apply(plan: LogicalPlan): Seq[SparkPlan] = {
+      plan match {
+        case DebugSampleColumn(child, sampleColumns) =>
+          DebugSampleColumnExec(planLater(child), sampleColumns) :: Nil
+        case _ => Nil
+      }
+    }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
@@ -316,7 +316,7 @@ package object debug {
     val accumulator = new DebugAccumulator
     accumulator.register(
       session.sparkContext,
-      Some(s"${child.simpleStringWithNodeId()} top values for ${sampleColumns.mkString(",")}"))
+      Some(s"${child.nodeName} top values for ${sampleColumns.mkString(",")}"))
 
     override protected def withNewChildInternal(newChild: SparkPlan): DebugInlineColumnsCountExec =
       copy(child = newChild)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
@@ -341,27 +341,29 @@ package object debug {
     }
 
     private def valToString(dataType: DataType, value: Any): String = {
-      dataType match {
-        case _: StructType | _: ArrayType | _: MapType | _: VariantType =>
-          Utils.tryWithResource(new StringWriter()) { writer =>
-            val gen = new JacksonGenerator(dataType, writer, jsonOptions)
+      Option(value).map { v =>
+        dataType match {
+          case _: StructType | _: ArrayType | _: MapType | _: VariantType =>
+            Utils.tryWithResource(new StringWriter()) { writer =>
+              val gen = new JacksonGenerator(dataType, writer, jsonOptions)
 
-            dataType match {
-              case _: StructType =>
-                gen.write(value.asInstanceOf[InternalRow])
-              case _: ArrayType =>
-                gen.write(value.asInstanceOf[ArrayData])
-              case _: MapType =>
-                gen.write(value.asInstanceOf[MapData])
-              case _: VariantType =>
-                gen.write(value.asInstanceOf[VariantVal])
+              dataType match {
+                case _: StructType =>
+                  gen.write(v.asInstanceOf[InternalRow])
+                case _: ArrayType =>
+                  gen.write(v.asInstanceOf[ArrayData])
+                case _: MapType =>
+                  gen.write(v.asInstanceOf[MapData])
+                case _: VariantType =>
+                  gen.write(v.asInstanceOf[VariantVal])
+              }
+
+              gen.flush()
+              writer.toString
             }
-
-            gen.flush()
-            writer.toString
-          }
-        case _ => value.toString
-      }
+          case _ => v.toString
+        }
+      }.orNull
     }
 
     override def output: Seq[Attribute] = child.output

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/debug/package.scala
@@ -342,31 +342,21 @@ package object debug {
 
     private def valToString(dataType: DataType, value: Any): String = {
       dataType match {
-        case s: StructType =>
+        case _: StructType | _: ArrayType | _: MapType | _: VariantType =>
           Utils.tryWithResource(new StringWriter()) { writer =>
-            val gen = new JacksonGenerator(s, writer, jsonOptions)
-            gen.write(value.asInstanceOf[InternalRow])
-            gen.flush()
-            writer.toString
-          }
-        case a: ArrayType =>
-          Utils.tryWithResource(new StringWriter()) { writer =>
-            val gen = new JacksonGenerator(a, writer, jsonOptions)
-            gen.write(value.asInstanceOf[ArrayData])
-            gen.flush()
-            writer.toString
-          }
-        case m: MapType =>
-          Utils.tryWithResource(new StringWriter()) { writer =>
-            val gen = new JacksonGenerator(m, writer, jsonOptions)
-            gen.write(value.asInstanceOf[MapData])
-            gen.flush()
-            writer.toString
-          }
-        case v: VariantType =>
-          Utils.tryWithResource(new StringWriter()) { writer =>
-            val gen = new JacksonGenerator(v, writer, jsonOptions)
-            gen.write(value.asInstanceOf[VariantVal])
+            val gen = new JacksonGenerator(dataType, writer, jsonOptions)
+
+            dataType match {
+              case _: StructType =>
+                gen.write(value.asInstanceOf[InternalRow])
+              case _: ArrayType =>
+                gen.write(value.asInstanceOf[ArrayData])
+              case _: MapType =>
+                gen.write(value.asInstanceOf[MapData])
+              case _: VariantType =>
+                gen.write(value.asInstanceOf[VariantVal])
+            }
+
             gen.flush()
             writer.toString
           }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This introduces a new operator to approximate the frequency of unique combinations of column values. This is done inline so it dos not require significant code changes when debugging issues, like skew. I wrote this with joins in mind, but it is not limited to that.

The solution does not guarantee the top keys will be surfaced because it only maintains the top N keys to reduce the overhead. For most cases, this will be sufficient to find the skewed keys. If it doesn't then the new config `spark.sql.debug.maxInlineColumnCountKeys` can be increased to increase the keys maintained, which increases the chances of finding the top key frequencies.

### Why are the changes needed?
When skew is discovered, the natural next step is to determine what key is causing skew. Today, this requires you to write custom queries or refactor code to identify the hot key. After this change, someone can call `Dataset.inlineColumnsCount()` to count the key frequencies inline and publish the top results to an accumulator. This will result in much less code to identify skew issues, especially in complex transformations.

Future enhancements I would like to make are:

1. The same debug for other APIs (SQL hint, Python)
2. A config only way to enable this. This will be a useful way to debug without needing a code change. I tried adding a config, plus an analyzer rule to automatically add the new operator to all joins, but it requires more consideration because when calling `Dataset.join` it calls the analyzer and assumes the analyzed plan has a join as the root.
3. Extend the analyzer to infer the keys in more places, like exchanges.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. This includes:
1. A new operator to count the occurrence for a combination of column values that are written to an accumulator.
2. It adds a debug method to use the new operator.
4. A new config to control how many unique values are maintained while counting their frequencies.

### How was this patch tested?
Manual testing:
```
import org.apache.spark.sql.execution.debug._

val a = spark.range(50)
val b = spark.range(100).withColumn("id2", when($"id" > 10, 10).otherwise($"id")).select($"id2")

val c = a.join(b, $"id" === $"id2").inlineColumnsCount()
c.collect
```

This is what it looks like in the SHS UI. a's output:
<img width="913" alt="image" src="https://github.com/apache/spark/assets/5604993/26aa3014-5c80-41a9-ac2e-726845fa9e79">
b's output:
<img width="946" alt="image" src="https://github.com/apache/spark/assets/5604993/dcce28d6-edcf-4fba-847b-6d9dcfaf0563">
c's output:
<img width="949" alt="image" src="https://github.com/apache/spark/assets/5604993/244650e6-8d19-4943-9aa5-4b7a98a70d80">


Here is an example of what the plan looks like:
```
== Parsed Logical Plan ==
DebugInlineColumnsCount 3
+- Join Inner, (id#0L = id2#4L)
   :- Range (0, 50, step=1, splits=Some(12))
   +- Project [id2#4L]
      +- Project [id#2L, CASE WHEN (id#2L > cast(10 as bigint)) THEN cast(10 as bigint) ELSE id#2L END AS id2#4L]
         +- Range (0, 100, step=1, splits=Some(12))

== Analyzed Logical Plan ==
id: bigint, id2: bigint
DebugInlineColumnsCount [id#0L], 3
+- Join Inner, (id#0L = id2#4L)
   :- DebugInlineColumnsCount [id#0L], 3
   :  +- Range (0, 50, step=1, splits=Some(12))
   +- DebugInlineColumnsCount [id2#4L], 3
      +- Project [id2#4L]
         +- Project [id#2L, CASE WHEN (id#2L > cast(10 as bigint)) THEN cast(10 as bigint) ELSE id#2L END AS id2#4L]
            +- Range (0, 100, step=1, splits=Some(12))

== Optimized Logical Plan ==
DebugInlineColumnsCount [id#0L], 3
+- Join Inner, (id#0L = id2#4L)
   :- DebugInlineColumnsCount [id#0L], 3
   :  +- Range (0, 50, step=1, splits=Some(12))
   +- DebugInlineColumnsCount [id2#4L], 3
      +- Project [CASE WHEN (id#2L > 10) THEN 10 ELSE id#2L END AS id2#4L]
         +- Range (0, 100, step=1, splits=Some(12))

== Physical Plan ==
AdaptiveSparkPlan isFinalPlan=true
+- == Final Plan ==
   DebugInlineColumnsCount [id#0L], 3
   +- *(5) SortMergeJoin [id#0L], [id2#4L], Inner
      :- *(3) Sort [id#0L ASC NULLS FIRST], false, 0
      :  +- AQEShuffleRead coalesced
      :     +- ShuffleQueryStage 0
      :        +- Exchange hashpartitioning(id#0L, 200), ENSURE_REQUIREMENTS, [plan_id=42]
      :           +- DebugInlineColumnsCount [id#0L], 3
      :              +- *(1) Range (0, 50, step=1, splits=12)
      +- *(4) Sort [id2#4L ASC NULLS FIRST], false, 0
         +- AQEShuffleRead coalesced
            +- ShuffleQueryStage 1
               +- Exchange hashpartitioning(id2#4L, 200), ENSURE_REQUIREMENTS, [plan_id=59]
                  +- DebugInlineColumnsCount [id2#4L], 3
                     +- *(2) Project [CASE WHEN (id#2L > 10) THEN 10 ELSE id#2L END AS id2#4L]
                        +- *(2) Range (0, 100, step=1, splits=12)
+- == Initial Plan ==
   DebugInlineColumnsCount [id#0L], 3
   +- SortMergeJoin [id#0L], [id2#4L], Inner
      :- Sort [id#0L ASC NULLS FIRST], false, 0
      :  +- Exchange hashpartitioning(id#0L, 200), ENSURE_REQUIREMENTS, [plan_id=29]
      :     +- DebugInlineColumnsCount [id#0L], 3
      :        +- Range (0, 50, step=1, splits=12)
      +- Sort [id2#4L ASC NULLS FIRST], false, 0
         +- Exchange hashpartitioning(id2#4L, 200), ENSURE_REQUIREMENTS, [plan_id=30]
            +- DebugInlineColumnsCount [id2#4L], 3
               +- Project [CASE WHEN (id#2L > 10) THEN 10 ELSE id#2L END AS id2#4L]
                  +- Range (0, 100, step=1, splits=12)
```

### Was this patch authored or co-authored using generative AI tooling?
No
