### PR TITLE
[SPARK-48212][PYTHON][CONNECT][TESTS] Fully enable `PandasUDFParityTests.test_udf_wrong_arg`

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_pandas_udf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_udf.py
@@ -19,10 +19,7 @@ from pyspark.sql.tests.pandas.test_pandas_udf import PandasUDFTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
-class PandasUDFParityTests(
-    PandasUDFTestsMixin,
-    ReusedConnectTestCase,
-):
+class PandasUDFParityTests(PandasUDFTestsMixin, ReusedConnectTestCase):
     pass
 
 

--- a/python/pyspark/sql/tests/connect/test_parity_pandas_udf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_udf.py
@@ -19,9 +19,11 @@ from pyspark.sql.tests.pandas.test_pandas_udf import PandasUDFTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
-class PandasUDFParityTests(PandasUDFTestsMixin, ReusedConnectTestCase):
-    def test_udf_wrong_arg(self):
-        self.check_udf_wrong_arg()
+class PandasUDFParityTests(
+    PandasUDFTestsMixin,
+    ReusedConnectTestCase,
+):
+    pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fully enable `PandasUDFParityTests.test_udf_wrong_arg`

it was partially enabled before (only `check_udf_wrong_arg` in `test_udf_wrong_arg`):

https://github.com/apache/spark/blob/678aeb7ef7086bd962df7ac6d1c5f39151a0515b/python/pyspark/sql/tests/pandas/test_pandas_udf.py#L127-L157

### Why are the changes needed?
test coverage


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no