### PR TITLE
[SPARK-48213][SQL] Do not push down predicate if non-cheap expression exceed reused limit

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4805,6 +4805,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val MAX_EXPRESSION_REUSED_IN_PUSH_PREDICATE =
+    buildConf("spark.sql.optimizer.maxExpressionReuseInPushPredicate")
+      .internal()
+      .doc("An integer number indicates the maximum reused number of predicate expression, do " +
+        s"not push down and replace it if exceed limit and the predicate is non-cheap.")
+      .version("4.0.0")
+      .intConf
+      .createWithDefault(Int.MaxValue)
+
   val TIME_TRAVEL_TIMESTAMP_KEY =
     buildConf("spark.sql.timeTravelTimestampKey")
       .doc("The option name to specify the time travel timestamp when reading a table.")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Avoid push down predicate if non-cheap expression exceed reused limit. Push down predicate through project/aggregate need replace expression, if the expression is non-cheap and reused many times, the cost of repeated calculations may be greater than the benefits of pushdown predicates.


### Why are the changes needed?
Like #33958, to avoid performance regression caused by repeated evaluation of expensive expressions and larger plans such as case when nested, the difference is that push down will have additional benefits, so add limit of reused count conf instead of 1.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Unit test.


### Was this patch authored or co-authored using generative AI tooling?
No.
