### PR TITLE
[SPARK-48226][BUILD] Add `spark-ganglia-lgpl` to `lint-java` & `spark-ganglia-lgpl` and `jvm-profiler` to `sbt-checkstyle`

### DIFF
--- a/dev/lint-java
+++ b/dev/lint-java
@@ -20,7 +20,7 @@
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 SPARK_ROOT_DIR="$(dirname $SCRIPT_DIR)"
 
-ERRORS=$($SCRIPT_DIR/../build/mvn -Pkinesis-asl -Pkubernetes -Pyarn -Phive -Phive-thriftserver checkstyle:check | grep ERROR)
+ERRORS=$($SCRIPT_DIR/../build/mvn -Pkinesis-asl -Pspark-ganglia-lgpl -Pkubernetes -Pyarn -Phive -Phive-thriftserver checkstyle:check | grep ERROR)
 
 if test ! -z "$ERRORS"; then
     echo -e "Checkstyle checks failed at following occurrences:\n$ERRORS"

--- a/dev/sbt-checkstyle
+++ b/dev/sbt-checkstyle
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-SPARK_PROFILES=${1:-"-Pkinesis-asl -Pkubernetes -Pyarn -Phive -Phive-thriftserver"}
+SPARK_PROFILES=${1:-"-Pkinesis-asl -Pspark-ganglia-lgpl -Pkubernetes -Pyarn -Phive -Phive-thriftserver -Pjvm-profiler"}
 
 # NOTE: echo "q" is needed because SBT prompts the user for input on encountering a build file
 # with failure (either resolution or compilation); the "q" makes SBT quit.


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to add
- `spark-ganglia-lgpl` to `lint-java`
- `spark-ganglia-lgpl` and `jvm-profiler` to `sbt-checkstyle`

### Why are the changes needed?
1.Because the module `spark-ganglia-lgpl` has `java` code
2.Because the module `spark-ganglia-lgpl` & `jvm-profiler` has `scala` code
3.Although these module codes currently comply with the specification, in order to avoid problems like https://github.com/apache/spark/pull/46376, they will occur again in future modifications.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Manually test.
- Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
