### PR TITLE
[SPARK-48219][CORE] StreamReader Charset fix with UTF8

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XSDToSchema.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XSDToSchema.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.execution.datasources.xml
 
 import java.io.StringReader
-import java.nio.charset.StandardCharsets
 
 import scala.jdk.CollectionConverters._
 
@@ -49,7 +48,7 @@ object XSDToSchema extends Logging{
     val in = ValidatorUtil.openSchemaFile(xsdPath)
     val xmlSchemaCollection = new XmlSchemaCollection()
     xmlSchemaCollection.setBaseUri(xsdPath.toString)
-    val xmlSchema = xmlSchemaCollection.read(new InputStreamReader(in, StandardCharsets.UTF_8))
+    val xmlSchema = xmlSchemaCollection.read(new InputStreamReader(in))
     getStructType(xmlSchema)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XSDToSchema.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XSDToSchema.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.execution.datasources.xml
 
 import java.io.StringReader
+import java.nio.charset.StandardCharsets
 
 import scala.jdk.CollectionConverters._
 
@@ -48,7 +49,7 @@ object XSDToSchema extends Logging{
     val in = ValidatorUtil.openSchemaFile(xsdPath)
     val xmlSchemaCollection = new XmlSchemaCollection()
     xmlSchemaCollection.setBaseUri(xsdPath.toString)
-    val xmlSchema = xmlSchemaCollection.read(new InputStreamReader(in))
+    val xmlSchema = xmlSchemaCollection.read(new InputStreamReader(in, StandardCharsets.UTF_8))
     getStructType(xmlSchema)
   }
 

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/HiveSessionImpl.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/cli/session/HiveSessionImpl.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -171,7 +172,7 @@ public class HiveSessionImpl implements HiveSession {
       FileInputStream initStream = null;
       BufferedReader bufferedReader = null;
       initStream = new FileInputStream(fileName);
-      bufferedReader = new BufferedReader(new InputStreamReader(initStream));
+      bufferedReader = new BufferedReader(new InputStreamReader(initStream, StandardCharsets.UTF_8));
       return bufferedReader;
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix some StreamReader not set with UTF8，if we actually default charset not support Chinese chars such as latin and conf contain Chinese chars，it would not resolve success，so we need set it as utf8 in StreamReader，we can find all StreamReader with utf8 charset in other compute framework，such as Calcite、Hive、Hudi and so on.


### Why are the changes needed?
May cause string decode not as expected


### Does this PR introduce _any_ user-facing change?
Yes


### How was this patch tested?
Not need


### Was this patch authored or co-authored using generative AI tooling?
No
