### PR TITLE
[SPARK-48197][SQL][TESTS][FOLLOWUP][3.5] Regenerate golden files

### DIFF
--- a/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/higher-order-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/higher-order-functions.sql.out
@@ -40,7 +40,6 @@ select ceil(x -> x) as v
 org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "INVALID_LAMBDA_FUNCTION_CALL.NON_HIGHER_ORDER_FUNCTION",
-  "sqlState" : "42K0D",
   "messageParameters" : {
     "class" : "org.apache.spark.sql.catalyst.expressions.CeilExpressionBuilder$"
   },

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/higher-order-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/higher-order-functions.sql.out
@@ -40,7 +40,6 @@ select ceil(x -> x) as v
 org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "INVALID_LAMBDA_FUNCTION_CALL.NON_HIGHER_ORDER_FUNCTION",
-  "sqlState" : "42K0D",
   "messageParameters" : {
     "class" : "org.apache.spark.sql.catalyst.expressions.CeilExpressionBuilder$"
   },

--- a/sql/core/src/test/resources/sql-tests/results/ansi/higher-order-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/higher-order-functions.sql.out
@@ -40,7 +40,6 @@ struct<>
 org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "INVALID_LAMBDA_FUNCTION_CALL.NON_HIGHER_ORDER_FUNCTION",
-  "sqlState" : "42K0D",
   "messageParameters" : {
     "class" : "org.apache.spark.sql.catalyst.expressions.CeilExpressionBuilder$"
   },

--- a/sql/core/src/test/resources/sql-tests/results/higher-order-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/higher-order-functions.sql.out
@@ -40,7 +40,6 @@ struct<>
 org.apache.spark.sql.AnalysisException
 {
   "errorClass" : "INVALID_LAMBDA_FUNCTION_CALL.NON_HIGHER_ORDER_FUNCTION",
-  "sqlState" : "42K0D",
   "messageParameters" : {
     "class" : "org.apache.spark.sql.catalyst.expressions.CeilExpressionBuilder$"
   },


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a follow-up to regenerate golden files for branch-3.5
- #46475 

### Why are the changes needed?

To recover branch-3.5 CI.
- https://github.com/apache/spark/actions/runs/9011670853/job/24786397001
```
[info] *** 4 TESTS FAILED ***
[error] Failed: Total 3036, Failed 4, Errors 0, Passed 3032, Ignored 3
[error] Failed tests:
[error] 	org.apache.spark.sql.SQLQueryTestSuite
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.