### PR TITLE
[SPARK-48225][BUILD] Upgrade `sbt` to 1.10.0

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=1.9.3
+sbt.version=1.10.0


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to try `sbt` to 1.10.0. 

### Why are the changes needed?

So far, we couldn't upgrade SBT like the following.
- #45345
- #45312
- #44407
- #44516
- #44008
- #42673


Previously, we couldn't upgrade SBT due to its issues like the dependency resolution. SBT 1.10.0 is updated with Coursier 2.1.9 .

- https://github.com/sbt/sbt/releases/tag/v1.10.0
- https://github.com/sbt/sbt/releases/tag/v1.9.9
- https://github.com/sbt/sbt/releases/tag/v1.9.8
- https://github.com/sbt/sbt/releases/tag/v1.9.7
- https://github.com/sbt/sbt/releases/tag/v1.9.6
- https://github.com/sbt/sbt/releases/tag/v1.9.5
- https://github.com/sbt/sbt/releases/tag/v1.9.4


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.