### PR TITLE
[SPARK-48232][PYTHON][TESTS] Fix 'pyspark.sql.tests.connect.test_connect_session' in Python 3.12 build

### DIFF
--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -38,7 +38,7 @@ from itertools import zip_longest
 have_scipy = False
 have_numpy = False
 try:
-    import scipy.sparse  # noqa: F401
+    import scipy  # noqa: F401
 
     have_scipy = True
 except ImportError:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR avoids importing `scipy.sparse` directly which hangs indeterministically specifically with Python 3.12


### Why are the changes needed?

To fix the build with Python 3.12 https://github.com/apache/spark/actions/runs/9022174253/job/24804919747
I was able to reproduce this in my local but a bit indeterministic.


### Does this PR introduce _any_ user-facing change?

No, test-only.


### How was this patch tested?

Manually tested in my local.

### Was this patch authored or co-authored using generative AI tooling?

No.