### PR TITLE
[SPARK-48220][PYTHON] Allow passing PyArrow Table to createDataFrame()

### DIFF
--- a/examples/src/main/python/sql/arrow.py
+++ b/examples/src/main/python/sql/arrow.py
@@ -33,20 +33,23 @@ require_minimum_pandas_version()
 require_minimum_pyarrow_version()
 
 
-def dataframe_to_arrow_table_example(spark: SparkSession) -> None:
-    import pyarrow as pa  # noqa: F401
-    from pyspark.sql.functions import rand
+def dataframe_to_from_arrow_table_example(spark: SparkSession) -> None:
+    import pyarrow as pa
+    import numpy as np
 
-    # Create a Spark DataFrame
-    df = spark.range(100).drop("id").withColumns({"0": rand(), "1": rand(), "2": rand()})
+    # Create a PyArrow Table
+    table = pa.table([pa.array(np.random.rand(100)) for i in range(3)], names=["a", "b", "c"])
+
+    # Create a Spark DataFrame from the PyArrow Table
+    df = spark.createDataFrame(table)
 
     # Convert the Spark DataFrame to a PyArrow Table
-    table = df.select("*").toArrow()
+    result_table = df.select("*").toArrow()
 
-    print(table.schema)
-    # 0: double not null
-    # 1: double not null
-    # 2: double not null
+    print(result_table.schema)
+    # a: double
+    # b: double
+    # c: double
 
 
 def dataframe_with_arrow_example(spark: SparkSession) -> None:
@@ -319,7 +322,7 @@ if __name__ == "__main__":
         .getOrCreate()
 
     print("Running Arrow conversion example: DataFrame to Table")
-    dataframe_to_arrow_table_example(spark)
+    dataframe_to_from_arrow_table_example(spark)
     print("Running Pandas to/from conversion example")
     dataframe_with_arrow_example(spark)
     print("Running pandas_udf example: Series to Frame")

--- a/python/docs/source/user_guide/sql/arrow_pandas.rst
+++ b/python/docs/source/user_guide/sql/arrow_pandas.rst
@@ -39,14 +39,16 @@ is installed and available on all cluster nodes.
 You can install it using pip or conda from the conda-forge channel. See PyArrow
 `installation <https://arrow.apache.org/docs/python/install.html>`_ for details.
 
-Conversion to Arrow Table
--------------------------
+Conversion to/from Arrow Table
+------------------------------
 
-You can call :meth:`DataFrame.toArrow` to convert a Spark DataFrame to a PyArrow Table.
+In Spark 4.0.0 and higher, you can create a Spark DataFrame from a PyArrow Table with
+:meth:`SparkSession.createDataFrame`, and you can call :meth:`DataFrame.toArrow` to convert a Spark
+DataFrame to a PyArrow Table.
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 37-49
+    :lines: 37-52
     :dedent: 4
 
 Note that :meth:`DataFrame.toArrow` results in the collection of all records in the DataFrame to
@@ -67,7 +69,7 @@ This can be controlled by ``spark.sql.execution.arrow.pyspark.fallback.enabled``
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 53-68
+    :lines: 56-71
     :dedent: 4
 
 Using the above optimizations with Arrow will produce the same results as when Arrow is not
@@ -104,7 +106,7 @@ specify the type hints of ``pandas.Series`` and ``pandas.DataFrame`` as below:
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 72-96
+    :lines: 75-99
     :dedent: 4
 
 In the following sections, it describes the combinations of the supported type hints. For simplicity,
@@ -127,7 +129,7 @@ The following example shows how to create this Pandas UDF that computes the prod
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 100-130
+    :lines: 103-133
     :dedent: 4
 
 For detailed usage, please see :func:`pandas_udf`.
@@ -166,7 +168,7 @@ The following example shows how to create this Pandas UDF:
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 134-156
+    :lines: 137-159
     :dedent: 4
 
 For detailed usage, please see :func:`pandas_udf`.
@@ -188,7 +190,7 @@ The following example shows how to create this Pandas UDF:
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 160-183
+    :lines: 163-186
     :dedent: 4
 
 For detailed usage, please see :func:`pandas_udf`.
@@ -219,7 +221,7 @@ and window operations:
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 187-228
+    :lines: 190-231
     :dedent: 4
 
 .. currentmodule:: pyspark.sql.functions
@@ -284,7 +286,7 @@ in the group.
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 232-250
+    :lines: 235-253
     :dedent: 4
 
 For detailed usage, please see  please see :meth:`GroupedData.applyInPandas`
@@ -302,7 +304,7 @@ The following example shows how to use :meth:`DataFrame.mapInPandas`:
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 254-265
+    :lines: 257-268
     :dedent: 4
 
 For detailed usage, please see :meth:`DataFrame.mapInPandas`.
@@ -341,7 +343,7 @@ The following example shows how to use ``DataFrame.groupby().cogroup().applyInPa
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 269-291
+    :lines: 272-294
     :dedent: 4
 
 
@@ -363,7 +365,7 @@ Here's an example that demonstrates the usage of both a default, pickled Python 
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
-    :lines: 295-313
+    :lines: 298-316
     :dedent: 4
 
 Compared to the default, pickled Python UDFs, Arrow Python UDFs provide a more coherent type coercion mechanism. UDF
@@ -414,11 +416,15 @@ and each column will be converted to the Spark session time zone then localized 
 zone, which removes the time zone and displays values as local time. This will occur
 when calling :meth:`DataFrame.toPandas()` or ``pandas_udf`` with timestamp columns.
 
-When timestamp data is transferred from Pandas to Spark, it will be converted to UTC microseconds. This
-occurs when calling :meth:`SparkSession.createDataFrame` with a Pandas DataFrame or when returning a timestamp from a
-``pandas_udf``. These conversions are done automatically to ensure Spark will have data in the
-expected format, so it is not necessary to do any of these conversions yourself. Any nanosecond
-values will be truncated.
+When timestamp data is transferred from Spark to a PyArrow Table, it will remain in microsecond
+resolution with the UTC time zone. This will occur when calling :meth:`DataFrame.toArrow()` with
+timestamp columns.
+
+When timestamp data is transferred from Pandas or PyArrow to Spark, it will be converted to UTC
+microseconds. This occurs when calling :meth:`SparkSession.createDataFrame` with a Pandas DataFrame
+or PyArrow Table, or when returning a timestamp from a ``pandas_udf``. These conversions are done
+automatically to ensure Spark will have data in the expected format, so it is not necessary to do
+any of these conversions yourself. Any nanosecond values will be truncated.
 
 Note that a standard UDF (non-Pandas) will load timestamp data as Python datetime objects, which is
 different from a Pandas timestamp. It is recommended to use Pandas time series functionality when

--- a/python/docs/source/user_guide/sql/arrow_pandas.rst
+++ b/python/docs/source/user_guide/sql/arrow_pandas.rst
@@ -42,9 +42,9 @@ You can install it using pip or conda from the conda-forge channel. See PyArrow
 Conversion to/from Arrow Table
 ------------------------------
 
-In Spark 4.0.0 and higher, you can create a Spark DataFrame from a PyArrow Table with
-:meth:`SparkSession.createDataFrame`, and you can call :meth:`DataFrame.toArrow` to convert a Spark
-DataFrame to a PyArrow Table.
+From Spark 4.0, you can create a Spark DataFrame from a PyArrow Table with
+:meth:`SparkSession.createDataFrame`, and you can convert a Spark DataFrame to a PyArrow Table
+with :meth:`DataFrame.toArrow`.
 
 .. literalinclude:: ../../../../../examples/src/main/python/sql/arrow.py
     :language: python
@@ -52,8 +52,8 @@ DataFrame to a PyArrow Table.
     :dedent: 4
 
 Note that :meth:`DataFrame.toArrow` results in the collection of all records in the DataFrame to
-the driver program and should be done on a small subset of the data. Not all Spark data types are
-currently supported and an error can be raised if a column has an unsupported type.
+the driver program and should be done on a small subset of the data. Not all Spark and Arrow data
+types are currently supported and an error can be raised if a column has an unsupported type.
 
 Enabling for Conversion to/from Pandas
 --------------------------------------
@@ -417,7 +417,7 @@ zone, which removes the time zone and displays values as local time. This will o
 when calling :meth:`DataFrame.toPandas()` or ``pandas_udf`` with timestamp columns.
 
 When timestamp data is transferred from Spark to a PyArrow Table, it will remain in microsecond
-resolution with the UTC time zone. This will occur when calling :meth:`DataFrame.toArrow()` with
+resolution with the UTC time zone. This occurs when calling :meth:`DataFrame.toArrow()` with
 timestamp columns.
 
 When timestamp data is transferred from Pandas or PyArrow to Spark, it will be converted to UTC

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -82,7 +82,7 @@ from pyspark.sql.connect.expressions import (
     UnresolvedStar,
 )
 from pyspark.sql.connect.functions import builtin as F
-from pyspark.sql.pandas.types import from_arrow_schema
+from pyspark.sql.pandas.types import from_arrow_schema, to_arrow_schema
 from pyspark.sql.pandas.functions import _validate_pandas_udf  # type: ignore[attr-defined]
 
 
@@ -1770,8 +1770,9 @@ class DataFrame(ParentDataFrame):
         return (table, schema)
 
     def toArrow(self) -> "pa.Table":
+        schema = to_arrow_schema(self.schema)
         table, _ = self._to_table()
-        return table
+        return table.cast(schema)
 
     def toPandas(self) -> "PandasDataFrameLike":
         query = self._plan.to_proto(self._session.client)

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1770,7 +1770,7 @@ class DataFrame(ParentDataFrame):
         return (table, schema)
 
     def toArrow(self) -> "pa.Table":
-        schema = to_arrow_schema(self.schema)
+        schema = to_arrow_schema(self.schema, error_on_duplicated_field_names_in_struct=True)
         table, _ = self._to_table()
         return table.cast(schema)
 

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -478,97 +478,103 @@ class SparkSession:
 
         _table: Optional[pa.Table] = None
 
-        if isinstance(data, pd.DataFrame) or isinstance(data, pa.Table):
+        if schema is None and isinstance(data, pd.DataFrame):
             # Logic was borrowed from `_create_from_pandas_with_arrow` in
             # `pyspark.sql.pandas.conversion.py`. Should ideally deduplicate the logics.
 
             # If no schema supplied by user then get the names of columns only
-            if schema is None:
-                if isinstance(data, pd.DataFrame):
-                    _cols = [str(x) if not isinstance(x, str) else x for x in data.columns]
-                    infer_pandas_dict_as_map = (
-                        str(
-                            self.conf.get("spark.sql.execution.pandas.inferPandasDictAsMap")
-                        ).lower()
-                        == "true"
-                    )
-                    if infer_pandas_dict_as_map:
-                        struct = StructType()
-                        pa_schema = pa.Schema.from_pandas(data)
-                        spark_type: Union[MapType, DataType]
-                        for field in pa_schema:
-                            field_type = field.type
-                            if isinstance(field_type, pa.StructType):
-                                if len(field_type) == 0:
-                                    raise PySparkValueError(
-                                        error_class="CANNOT_INFER_EMPTY_SCHEMA",
-                                        message_parameters={},
-                                    )
-                                arrow_type = field_type.field(0).type
-                                spark_type = MapType(StringType(), from_arrow_type(arrow_type))
-                            else:
-                                spark_type = from_arrow_type(field_type)
-                            struct.add(field.name, spark_type, nullable=field.nullable)
-                        schema = struct
-                elif isinstance(data, pa.Table):
-                    schema = from_arrow_schema(data.schema, prefer_timestamp_ntz=True)
-            elif isinstance(schema, (list, tuple)) and cast(int, _num_cols) < len(data.columns):
-                assert isinstance(_cols, list)
-                _cols.extend([f"_{i + 1}" for i in range(cast(int, _num_cols), len(data.columns))])
-                _num_cols = len(_cols)
+            _cols = [str(x) if not isinstance(x, str) else x for x in data.columns]
+            infer_pandas_dict_as_map = (
+                str(self.conf.get("spark.sql.execution.pandas.inferPandasDictAsMap")).lower()
+                == "true"
+            )
+            if infer_pandas_dict_as_map:
+                struct = StructType()
+                pa_schema = pa.Schema.from_pandas(data)
+                spark_type: Union[MapType, DataType]
+                for field in pa_schema:
+                    field_type = field.type
+                    if isinstance(field_type, pa.StructType):
+                        if len(field_type) == 0:
+                            raise PySparkValueError(
+                                error_class="CANNOT_INFER_EMPTY_SCHEMA",
+                                message_parameters={},
+                            )
+                        arrow_type = field_type.field(0).type
+                        spark_type = MapType(StringType(), from_arrow_type(arrow_type))
+                    else:
+                        spark_type = from_arrow_type(field_type)
+                    struct.add(field.name, spark_type, nullable=field.nullable)
+                schema = struct
 
-            # Determine arrow types to coerce data when creating batches
-            arrow_schema: Optional[pa.Schema] = None
-            spark_types: List[Optional[DataType]]
-            arrow_types: List[Optional[pa.DataType]]
-            if isinstance(schema, StructType):
-                deduped_schema = cast(StructType, _deduplicate_field_names(schema))
-                spark_types = [field.dataType for field in deduped_schema.fields]
-                arrow_schema = to_arrow_schema(deduped_schema)
-                arrow_types = [field.type for field in arrow_schema]
-                _cols = [str(x) if not isinstance(x, str) else x for x in schema.fieldNames()]
-            elif isinstance(schema, DataType):
-                raise PySparkTypeError(
-                    error_class="UNSUPPORTED_DATA_TYPE_FOR_ARROW",
-                    message_parameters={"data_type": str(schema)},
-                )
-            elif isinstance(data, pd.DataFrame):
-                # Any timestamps must be coerced to be compatible with Spark
-                spark_types = [
-                    TimestampType()
-                    if is_datetime64_dtype(t) or isinstance(t, pd.DatetimeTZDtype)
-                    else DayTimeIntervalType()
-                    if is_timedelta64_dtype(t)
-                    else None
-                    for t in data.dtypes
-                ]
-                arrow_types = [to_arrow_type(dt) if dt is not None else None for dt in spark_types]
+        elif schema is None and isinstance(data, pa.Table):
+            schema = from_arrow_schema(data.schema, prefer_timestamp_ntz=True)
 
+        elif (
+            isinstance(schema, (list, tuple))
+            and isinstance(data, (pd.DataFrame, pa.Table))
+            and cast(int, _num_cols) < len(data.columns)
+        ):
+            assert isinstance(_cols, list)
+            _cols.extend([f"_{i + 1}" for i in range(cast(int, _num_cols), len(data.columns))])
+            _num_cols = len(_cols)
+
+        # Determine arrow types to coerce data when creating batches
+        arrow_schema: Optional[pa.Schema] = None
+        spark_types: List[Optional[DataType]]
+        arrow_types: List[Optional[pa.DataType]]
+
+        if isinstance(schema, StructType) and isinstance(data, (pd.DataFrame, pa.Table)):
+            deduped_schema = cast(StructType, _deduplicate_field_names(schema))
+            spark_types = [field.dataType for field in deduped_schema.fields]
+            arrow_schema = to_arrow_schema(deduped_schema)
+            arrow_types = [field.type for field in arrow_schema]
+            _cols = [str(x) if not isinstance(x, str) else x for x in schema.fieldNames()]
+
+        elif isinstance(schema, DataType) and isinstance(data, (pd.DataFrame, pa.Table)):
+            raise PySparkTypeError(
+                error_class="UNSUPPORTED_DATA_TYPE_FOR_ARROW",
+                message_parameters={"data_type": str(schema)},
+            )
+
+        elif isinstance(data, pd.DataFrame):
+            # Any timestamps must be coerced to be compatible with Spark
+            spark_types = [
+                TimestampType()
+                if is_datetime64_dtype(t) or isinstance(t, pd.DatetimeTZDtype)
+                else DayTimeIntervalType()
+                if is_timedelta64_dtype(t)
+                else None
+                for t in data.dtypes
+            ]
+            arrow_types = [to_arrow_type(dt) if dt is not None else None for dt in spark_types]
+
+        if isinstance(data, pd.DataFrame):
             timezone, safecheck = self._client.get_configs(
                 "spark.sql.session.timeZone", "spark.sql.execution.pandas.convertToArrowArraySafely"
             )
 
             ser = ArrowStreamPandasSerializer(cast(str, timezone), safecheck == "true")
 
-            if isinstance(data, pd.DataFrame):
-                _table = pa.Table.from_batches(
-                    [
-                        ser._create_batch(
-                            [
-                                (c, at, st)
-                                for (_, c), at, st in zip(data.items(), arrow_types, spark_types)
-                            ]
-                        )
-                    ]
-                )
-            else:
-                _table = data
+            _table = pa.Table.from_batches(
+                [
+                    ser._create_batch(
+                        [
+                            (c, at, st)
+                            for (_, c), at, st in zip(data.items(), arrow_types, spark_types)
+                        ]
+                    )
+                ]
+            )
 
-            if isinstance(schema, StructType):
-                assert arrow_schema is not None
-                _table = _table.rename_columns(
-                    cast(StructType, _deduplicate_field_names(schema)).names
-                ).cast(arrow_schema)
+        elif isinstance(data, pa.Table):
+            _table = data
+
+        if isinstance(schema, StructType) and isinstance(data, (pd.DataFrame, pa.Table)):
+            assert arrow_schema is not None
+            _table = _table.rename_columns(  # type: ignore[union-attr]
+                cast(StructType, _deduplicate_field_names(schema)).names
+            ).cast(arrow_schema)
 
         elif isinstance(data, np.ndarray):
             if _cols is None:
@@ -605,7 +611,7 @@ class SparkSession:
             # The _table should already have the proper column names.
             _cols = None
 
-        else:
+        elif not isinstance(data, (pd.DataFrame, pa.Table)):
             _data = list(data)
 
             if isinstance(_data[0], dict):
@@ -645,12 +651,12 @@ class SparkSession:
 
         # TODO: Beside the validation on number of columns, we should also check
         # whether the Arrow Schema is compatible with the user provided Schema.
-        if _num_cols is not None and _num_cols != _table.shape[1]:
+        if _num_cols is not None and _num_cols != _table.shape[1]:  # type: ignore[union-attr]
             raise PySparkValueError(
                 error_class="AXIS_LENGTH_MISMATCH",
                 message_parameters={
                     "expected_length": str(_num_cols),
-                    "actual_length": str(_table.shape[1]),
+                    "actual_length": str(_table.shape[1]),  # type: ignore[union-attr]
                 },
             )
 
@@ -661,7 +667,10 @@ class SparkSession:
 
         cache_threshold = self._client.get_configs("spark.sql.session.localRelationCacheThreshold")
         plan: LogicalPlan = local_relation
-        if cache_threshold[0] is not None and int(cache_threshold[0]) <= _table.nbytes:
+        if (
+            cache_threshold[0] is not None
+            and int(cache_threshold[0]) <= _table.nbytes  # type: ignore[union-attr]
+        ):
             plan = CachedLocalRelation(self._cache_local_relation(local_relation))
 
         df = DataFrame(plan, self)

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -421,9 +421,6 @@ class SparkSession:
         samplingRatio: Optional[float] = None,
         verifySchema: Optional[bool] = None,
     ) -> "ParentDataFrame":
-        import pandas as pd
-        import pyarrow as pa
-
         assert data is not None
         if isinstance(data, DataFrame):
             raise PySparkTypeError(

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -453,12 +453,9 @@ class SparkSession:
                 _num_cols = 1
 
         elif isinstance(schema, (list, tuple)):
-            if len(schema) and isinstance(schema[0], StructType):
-                schema = schema[0]
-            else:
-                # Must re-encode any unicode strings to be consistent with StructField names
-                _cols = [x.encode("utf-8") if not isinstance(x, str) else x for x in schema]
-                _num_cols = len(_cols)
+            # Must re-encode any unicode strings to be consistent with StructField names
+            _cols = [x.encode("utf-8") if not isinstance(x, str) else x for x in schema]
+            _num_cols = len(_cols)
 
         elif schema is not None:
             raise PySparkTypeError(

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -581,11 +581,13 @@ class SparkSession:
         if isinstance(schema, StructType) and isinstance(data, pa.Table):
             (timezone,) = self._client.get_configs("spark.sql.session.timeZone")
             _table = _check_arrow_table_timestamps_localize(_table, schema, True, timezone)
-            _table = _table.cast(to_arrow_schema(schema))
+            _table = _table.cast(
+                to_arrow_schema(schema, error_on_duplicated_field_names_in_struct=True)
+            )
 
         if isinstance(schema, StructType) and isinstance(data, (pd.DataFrame, pa.Table)):
             assert arrow_schema is not None
-            _table = _table.rename_columns(  # type: ignore[union-attr] # noqa: F821,F841
+            _table = _table.rename_columns(  # type: ignore[union-attr]
                 cast(StructType, _deduplicate_field_names(schema)).names
             ).cast(arrow_schema)
 

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -577,7 +577,7 @@ class SparkSession:
 
         if isinstance(schema, StructType) and isinstance(data, pa.Table):
             (timezone,) = self._client.get_configs("spark.sql.session.timeZone")
-            _table = _check_arrow_table_timestamps_localize(_table, schema, timezone)
+            _table = _check_arrow_table_timestamps_localize(_table, schema, True, timezone)
             _table = _table.cast(to_arrow_schema(schema))
 
         if isinstance(schema, StructType) and isinstance(data, (pd.DataFrame, pa.Table)):

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -453,9 +453,12 @@ class SparkSession:
                 _num_cols = 1
 
         elif isinstance(schema, (list, tuple)):
-            # Must re-encode any unicode strings to be consistent with StructField names
-            _cols = [x.encode("utf-8") if not isinstance(x, str) else x for x in schema]
-            _num_cols = len(_cols)
+            if len(schema) and isinstance(schema[0], StructType):
+                schema = schema[0]
+            else:
+                # Must re-encode any unicode strings to be consistent with StructField names
+                _cols = [x.encode("utf-8") if not isinstance(x, str) else x for x in schema]
+                _num_cols = len(_cols)
 
         elif schema is not None:
             raise PySparkTypeError(

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -21,7 +21,6 @@ from typing import (
     List,
     Optional,
     Union,
-    cast,
     no_type_check,
     overload,
     TYPE_CHECKING,
@@ -759,7 +758,6 @@ class SparkConversionMixin:
             from_arrow_type,
             from_arrow_schema,
             to_arrow_schema,
-            _deduplicate_field_names,
             _check_arrow_table_timestamps_localize,
         )
         from pyspark.sql.pandas.utils import require_minimum_pyarrow_version
@@ -781,7 +779,7 @@ class SparkConversionMixin:
             schema = struct
 
         if isinstance(schema, StructType):
-            schema = cast(StructType, _deduplicate_field_names(schema))
+            pass
         elif isinstance(schema, DataType):
             raise PySparkTypeError(
                 error_class="UNSUPPORTED_DATA_TYPE_FOR_ARROW",
@@ -792,7 +790,7 @@ class SparkConversionMixin:
             schema = from_arrow_schema(table.schema, prefer_timestamp_ntz=prefer_timestamp_ntz)
 
         table = _check_arrow_table_timestamps_localize(table, schema, True, timezone)
-        table = table.cast(to_arrow_schema(schema))
+        table = table.cast(to_arrow_schema(schema, error_on_duplicated_field_names_in_struct=True))
 
         # Chunk the Arrow Table into RecordBatches
         chunk_size = self._jconf.arrowMaxRecordsPerBatch()

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -768,6 +768,7 @@ class SparkConversionMixin:
 
         # Create the Spark schema from list of names passed in with Arrow types
         if isinstance(schema, (list, tuple)):
+            table = table.rename_columns(schema)
             arrow_schema = table.schema
             prefer_timestamp_ntz = is_timestamp_ntz_preferred()
             struct = StructType()

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -790,7 +790,7 @@ class SparkConversionMixin:
             prefer_timestamp_ntz = is_timestamp_ntz_preferred()
             schema = from_arrow_schema(table.schema, prefer_timestamp_ntz=prefer_timestamp_ntz)
 
-        table = _check_arrow_table_timestamps_localize(table, schema, timezone)
+        table = _check_arrow_table_timestamps_localize(table, schema, True, timezone)
         table = table.cast(to_arrow_schema(schema))
 
         # Chunk the Arrow Table into RecordBatches

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -384,6 +384,10 @@ class SparkConversionMixin:
 
             require_minimum_pyarrow_version()
 
+            import pyarrow as pa
+
+            assert isinstance(data, pa.Table)
+
             # If no schema supplied by user then get the names of columns only
             if schema is None:
                 schema = data.schema.names

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -374,6 +374,7 @@ def _check_arrow_array_timestamps_localize(
         )
     if types.is_map(a.type):
         mt: MapType = cast(MapType, dt)
+        # TODO(SPARK-48302): Do not replace nulls in MapArray with empty lists
         return pa.MapArray.from_arrays(
             a.offsets,
             _check_arrow_array_timestamps_localize(a.keys, mt.keyType, truncate, timezone),

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -365,6 +365,7 @@ def _check_arrow_array_timestamps_localize(
         return pa.ListArray.from_arrays(
             a.offsets,
             _check_arrow_array_timestamps_localize(a.values, at.elementType, truncate, timezone),
+            mask=a.is_null(),
         )
     if types.is_map(a.type):
         mt: MapType = cast(MapType, dt)
@@ -386,6 +387,7 @@ def _check_arrow_array_timestamps_localize(
                 for i in range(len(a.type))
             ],
             [a.type[i].name for i in range(len(a.type))],
+            mask=a.is_null(),
         )
     if types.is_dictionary(a.type):
         return pa.DictionaryArray.from_arrays(

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -312,41 +312,6 @@ def _get_local_timezone() -> str:
     return os.environ.get("TZ", "dateutil/:")
 
 
-def _check_arrow_table_timestamps_localize(
-    table: "pa.Table", schema: StructType, truncate: bool = True, timezone: Optional[str] = None
-) -> "pa.Table":
-    """
-    Convert timestamps in a PyArrow Table to timezone-naive in the specified timezone if the
-    corresponding Spark data type is TimestampType in the specified Spark schema is TimestampType,
-    and optionally truncate nanosecond timestamps to microseconds.
-
-    Parameters
-    ----------
-    table : :class:`pyarrow.Table`
-    schema : :class:`StructType`
-        The Spark schema corresponding to the schema of the Arrow Table.
-    truncate : bool, default True
-        Whether to truncate nanosecond timestamps to microseconds. (default ``True``)
-    timezone : str, optional
-        The timezone to convert from. If there is a timestamp type, it's required.
-
-    Returns
-    -------
-    :class:`pyarrow.Table`
-    """
-    import pyarrow as pa
-
-    assert len(table.schema) == len(schema.fields)
-
-    return pa.Table.from_arrays(
-        [
-            _check_arrow_array_timestamps_localize(a, f.dataType, truncate, timezone)
-            for a, f in zip(table.columns, schema.fields)
-        ],
-        schema=table.schema,
-    )
-
-
 def _check_arrow_array_timestamps_localize(
     a: Union["pa.Array", "pa.ChunkedArray"],
     dt: DataType,
@@ -428,6 +393,41 @@ def _check_arrow_array_timestamps_localize(
             _check_arrow_array_timestamps_localize(a.dictionary, dt, truncate, timezone),
         )
     return a
+
+
+def _check_arrow_table_timestamps_localize(
+    table: "pa.Table", schema: StructType, truncate: bool = True, timezone: Optional[str] = None
+) -> "pa.Table":
+    """
+    Convert timestamps in a PyArrow Table to timezone-naive in the specified timezone if the
+    corresponding Spark data type is TimestampType in the specified Spark schema is TimestampType,
+    and optionally truncate nanosecond timestamps to microseconds.
+
+    Parameters
+    ----------
+    table : :class:`pyarrow.Table`
+    schema : :class:`StructType`
+        The Spark schema corresponding to the schema of the Arrow Table.
+    truncate : bool, default True
+        Whether to truncate nanosecond timestamps to microseconds. (default ``True``)
+    timezone : str, optional
+        The timezone to convert from. If there is a timestamp type, it's required.
+
+    Returns
+    -------
+    :class:`pyarrow.Table`
+    """
+    import pyarrow as pa
+
+    assert len(table.schema) == len(schema.fields)
+
+    return pa.Table.from_arrays(
+        [
+            _check_arrow_array_timestamps_localize(a, f.dataType, truncate, timezone)
+            for a, f in zip(table.columns, schema.fields)
+        ],
+        schema=table.schema,
+    )
 
 
 def _check_series_localize_timestamps(s: "PandasSeriesLike", timezone: str) -> "PandasSeriesLike":

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -219,6 +219,8 @@ def from_arrow_type(at: "pa.DataType", prefer_timestamp_ntz: bool = False) -> Da
         spark_type = DayTimeIntervalType()
     elif types.is_list(at):
         spark_type = ArrayType(from_arrow_type(at.value_type, prefer_timestamp_ntz))
+    elif types.is_large_list(at):
+        spark_type = ArrayType(from_arrow_type(at.value_type, prefer_timestamp_ntz))
     elif types.is_map(at):
         spark_type = MapType(
             from_arrow_type(at.key_type, prefer_timestamp_ntz),

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -328,7 +328,7 @@ def _check_arrow_array_timestamps_localize(
     Convert Arrow timestamps to timezone-naive in the specified timezone if the specified Spark
     data type is TimestampType, and optionally truncate nanosecond timestamps to microseconds.
 
-    This function works on Arrow Arrays and  ChunkedArrays, and it recurses to convert nested
+    This function works on Arrow Arrays and ChunkedArrays, and it recurses to convert nested
     timestamps.
 
     Parameters

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -207,6 +207,8 @@ def from_arrow_type(at: "pa.DataType", prefer_timestamp_ntz: bool = False) -> Da
         spark_type = StringType()
     elif types.is_binary(at):
         spark_type = BinaryType()
+    elif types.is_fixed_size_binary(at):
+        spark_type = BinaryType()
     elif types.is_large_binary(at):
         spark_type = BinaryType()
     elif types.is_date32(at):
@@ -218,6 +220,8 @@ def from_arrow_type(at: "pa.DataType", prefer_timestamp_ntz: bool = False) -> Da
     elif types.is_duration(at):
         spark_type = DayTimeIntervalType()
     elif types.is_list(at):
+        spark_type = ArrayType(from_arrow_type(at.value_type, prefer_timestamp_ntz))
+    elif types.is_fixed_size_list(at):
         spark_type = ArrayType(from_arrow_type(at.value_type, prefer_timestamp_ntz))
     elif types.is_large_list(at):
         spark_type = ArrayType(from_arrow_type(at.value_type, prefer_timestamp_ntz))

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -52,7 +52,6 @@ from pyspark.sql.types import (
     _create_row,
 )
 from pyspark.errors import PySparkTypeError, UnsupportedOperationException, PySparkValueError
-from pyspark.loose_version import LooseVersion
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -243,8 +242,6 @@ def from_arrow_type(at: "pa.DataType", prefer_timestamp_ntz: bool = False) -> Da
         spark_type = StringType()
     elif types.is_binary(at):
         spark_type = BinaryType()
-    elif types.is_fixed_size_binary(at):
-        spark_type = BinaryType()
     elif types.is_large_binary(at):
         spark_type = BinaryType()
     elif types.is_date32(at):
@@ -256,18 +253,6 @@ def from_arrow_type(at: "pa.DataType", prefer_timestamp_ntz: bool = False) -> Da
     elif types.is_duration(at):
         spark_type = DayTimeIntervalType()
     elif types.is_list(at):
-        spark_type = ArrayType(from_arrow_type(at.value_type, prefer_timestamp_ntz))
-    elif types.is_fixed_size_list(at):
-        import pyarrow as pa
-
-        if LooseVersion(pa.__version__) < LooseVersion("14.0.0"):
-            # PyArrow versions before 14.0.0 do not support casting FixedSizeListArray to ListArray
-            raise PySparkTypeError(
-                error_class="UNSUPPORTED_DATA_TYPE_FOR_ARROW_CONVERSION",
-                message_parameters={"data_type": str(at)},
-            )
-        spark_type = ArrayType(from_arrow_type(at.value_type, prefer_timestamp_ntz))
-    elif types.is_large_list(at):
         spark_type = ArrayType(from_arrow_type(at.value_type, prefer_timestamp_ntz))
     elif types.is_map(at):
         spark_type = MapType(

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -67,6 +67,7 @@ from pyspark.errors import PySparkValueError, PySparkTypeError, PySparkRuntimeEr
 
 if TYPE_CHECKING:
     from py4j.java_gateway import JavaObject
+    import pyarrow as pa
     from pyspark.core.context import SparkContext
     from pyspark.core.rdd import RDD
     from pyspark.sql._typing import AtomicValue, RowLike, OptionalPrimitiveType
@@ -1256,7 +1257,7 @@ class SparkSession(SparkConversionMixin):
             spark = builder.getOrCreate()
         return spark
 
-    @overload
+    @overload  # type: ignore[override]
     def createDataFrame(
         self,
         data: Iterable["RowLike"],
@@ -1319,6 +1320,10 @@ class SparkSession(SparkConversionMixin):
         ...
 
     @overload
+    def createDataFrame(self, data: "pa.Table", samplingRatio: Optional[float] = ...) -> DataFrame:
+        ...
+
+    @overload
     def createDataFrame(
         self,
         data: "PandasDataFrameLike",
@@ -1327,28 +1332,40 @@ class SparkSession(SparkConversionMixin):
     ) -> DataFrame:
         ...
 
+    @overload
+    def createDataFrame(
+        self,
+        data: "pa.Table",
+        schema: Union[StructType, str],
+        verifySchema: bool = ...,
+    ) -> DataFrame:
+        ...
+
     def createDataFrame(  # type: ignore[misc]
         self,
-        data: Union["RDD[Any]", Iterable[Any], "PandasDataFrameLike", "ArrayLike"],
+        data: Union["RDD[Any]", Iterable[Any], "PandasDataFrameLike", "ArrayLike", "pa.Table"],
         schema: Optional[Union[AtomicType, StructType, str]] = None,
         samplingRatio: Optional[float] = None,
         verifySchema: bool = True,
     ) -> DataFrame:
         """
-        Creates a :class:`DataFrame` from an :class:`RDD`, a list, a :class:`pandas.DataFrame`
-        or a :class:`numpy.ndarray`.
+        Creates a :class:`DataFrame` from an :class:`RDD`, a list, a :class:`pandas.DataFrame`,
+        a :class:`numpy.ndarray`, or a :class:`pyarrow.Table`.
 
         .. versionadded:: 2.0.0
 
         .. versionchanged:: 3.4.0
             Supports Spark Connect.
 
+        .. versionchanged:: 4.0.0
+            Supports :class:`pyarrow.Table`.
+
         Parameters
         ----------
         data : :class:`RDD` or iterable
             an RDD of any kind of SQL data representation (:class:`Row`,
             :class:`tuple`, ``int``, ``boolean``, ``dict``, etc.), or :class:`list`,
-            :class:`pandas.DataFrame` or :class:`numpy.ndarray`.
+            :class:`pandas.DataFrame`, :class:`numpy.ndarray`, or :class:`pyarrow.Table`.
         schema : :class:`pyspark.sql.types.DataType`, str or list, optional
             a :class:`pyspark.sql.types.DataType` or a datatype string or a list of
             column names, default is None. The data type string format equals to
@@ -1374,10 +1391,10 @@ class SparkSession(SparkConversionMixin):
             :class:`RDD`.
         verifySchema : bool, optional
             verify data types of every row against schema. Enabled by default.
-            When the input is :class:`pandas.DataFrame` and
-            `spark.sql.execution.arrow.pyspark.enabled` is enabled, this option is not
-            effective. It follows Arrow type coercion. This option is not supported with
-            Spark Connect.
+            When the input is :class:`pyarrow.Table` or when the input class is
+            :class:`pandas.DataFrame` and `spark.sql.execution.arrow.pyspark.enabled` is enabled,
+            this option is not effective. It follows Arrow type coercion. This option is not
+            supported with Spark Connect.
 
             .. versionadded:: 2.1.0
 
@@ -1477,6 +1494,22 @@ class SparkSession(SparkConversionMixin):
         +---+---+
         |  1|  2|
         +---+---+
+
+        Create a DataFrame from a PyArrow Table.
+
+        >>> spark.createDataFrame(df.toArrow()).show()  # doctest: +SKIP
+        +-----+---+
+        | name|age|
+        +-----+---+
+        |Alice|  1|
+        +-----+---+
+        >>> table = pyarrow.table({'0': [1], '1': [2]})  # doctest: +SKIP
+        >>> spark.createDataFrame(table).collect()  # doctest: +SKIP
+        +---+---+
+        |  0|  1|
+        +---+---+
+        |  1|  2|
+        +---+---+
         """
         SparkSession._activeSession = self
         assert self._jvm is not None
@@ -1506,6 +1539,13 @@ class SparkSession(SparkConversionMixin):
             has_numpy = True
         except Exception:
             has_numpy = False
+
+        try:
+            import pyarrow as pa
+
+            has_pyarrow = True
+        except Exception:
+            has_pyarrow = False
 
         if has_numpy and isinstance(data, np.ndarray):
             # `data` of numpy.ndarray type will be converted to a pandas DataFrame,
@@ -1537,6 +1577,11 @@ class SparkSession(SparkConversionMixin):
 
         if has_pandas and isinstance(data, pd.DataFrame):
             # Create a DataFrame from pandas DataFrame.
+            return super(SparkSession, self).createDataFrame(  # type: ignore[call-overload]
+                data, schema, samplingRatio, verifySchema
+            )
+        if has_pyarrow and isinstance(data, pa.Table):
+            # Create a DataFrame from PyArrow Table.
             return super(SparkSession, self).createDataFrame(  # type: ignore[call-overload]
                 data, schema, samplingRatio, verifySchema
             )

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1523,11 +1523,8 @@ class SparkSession(SparkConversionMixin):
         if isinstance(schema, str):
             schema = cast(Union[AtomicType, StructType, str], _parse_datatype_string(schema))
         elif isinstance(schema, (list, tuple)):
-            if len(schema) and isinstance(schema[0], StructType):
-                schema = schema[0]
-            else:
-                # Must re-encode any unicode strings to be consistent with StructField names
-                schema = [x.encode("utf-8") if not isinstance(x, str) else x for x in schema]
+            # Must re-encode any unicode strings to be consistent with StructField names
+            schema = [x.encode("utf-8") if not isinstance(x, str) else x for x in schema]
 
         try:
             import pandas as pd

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1523,8 +1523,11 @@ class SparkSession(SparkConversionMixin):
         if isinstance(schema, str):
             schema = cast(Union[AtomicType, StructType, str], _parse_datatype_string(schema))
         elif isinstance(schema, (list, tuple)):
-            # Must re-encode any unicode strings to be consistent with StructField names
-            schema = [x.encode("utf-8") if not isinstance(x, str) else x for x in schema]
+            if len(schema) and isinstance(schema[0], StructType):
+                schema = schema[0]
+            else:
+                # Must re-encode any unicode strings to be consistent with StructField names
+                schema = [x.encode("utf-8") if not isinstance(x, str) else x for x in schema]
 
         try:
             import pandas as pd

--- a/python/pyspark/sql/tests/connect/test_parity_arrow.py
+++ b/python/pyspark/sql/tests/connect/test_parity_arrow.py
@@ -217,6 +217,18 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase, PandasOnSparkTest
     def test_createDataFrame_arrow_with_names(self):
         super().test_createDataFrame_arrow_with_names()
 
+    def test_createDataFrame_arrow_large_string(self):
+        super().test_createDataFrame_arrow_large_string()
+
+    def test_createDataFrame_arrow_large_binary(self):
+        super().test_createDataFrame_arrow_large_binary()
+
+    def test_createDataFrame_arrow_large_list(self):
+        super().test_createDataFrame_arrow_large_list()
+
+    def test_createDataFrame_arrow_large_list_int64_offset(self):
+        super().test_createDataFrame_arrow_large_list_int64_offset()
+
 
 if __name__ == "__main__":
     from pyspark.sql.tests.connect.test_parity_arrow import *  # noqa: F401

--- a/python/pyspark/sql/tests/connect/test_parity_arrow.py
+++ b/python/pyspark/sql/tests/connect/test_parity_arrow.py
@@ -229,6 +229,12 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase, PandasOnSparkTest
     def test_createDataFrame_arrow_large_list_int64_offset(self):
         super().test_createDataFrame_arrow_large_list_int64_offset()
 
+    def test_createDataFrame_arrow_fixed_size_binary(self):
+        super().test_createDataFrame_arrow_fixed_size_binary()
+
+    def test_createDataFrame_arrow_fixed_size_list(self):
+        super().test_createDataFrame_arrow_fixed_size_list()
+
 
 if __name__ == "__main__":
     from pyspark.sql.tests.connect.test_parity_arrow import *  # noqa: F401

--- a/python/pyspark/sql/tests/connect/test_parity_arrow.py
+++ b/python/pyspark/sql/tests/connect/test_parity_arrow.py
@@ -66,11 +66,32 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase, PandasOnSparkTest
     def test_create_data_frame_to_pandas_timestamp_ntz(self):
         self.check_create_data_frame_to_pandas_timestamp_ntz(True)
 
+    def test_create_data_frame_to_arrow_timestamp_ntz(self):
+        super().test_create_data_frame_to_arrow_timestamp_ntz()
+
     def test_create_data_frame_to_pandas_day_time_internal(self):
         self.check_create_data_frame_to_pandas_day_time_internal(True)
 
+    def test_createDataFrame_pandas_respect_session_timezone(self):
+        self.check_createDataFrame_pandas_respect_session_timezone(True)
+
+    def test_createDataFrame_arrow_respect_session_timezone(self):
+        super().test_createDataFrame_arrow_respect_session_timezone()
+
     def test_toPandas_respect_session_timezone(self):
         self.check_toPandas_respect_session_timezone(True)
+
+    def test_toArrow_keep_utc_timezone(self):
+        super().test_toArrow_keep_utc_timezone()
+
+    def test_createDataFrame_arrow_pandas(self):
+        super().test_createDataFrame_arrow_pandas()
+
+    def test_pandas_round_trip(self):
+        super().test_pandas_round_trip()
+
+    def test_arrow_round_trip(self):
+        super().test_arrow_round_trip()
 
     def test_toPandas_with_array_type(self):
         self.check_toPandas_with_array_type(True)
@@ -107,11 +128,20 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase, PandasOnSparkTest
     def test_createDataFrame_duplicate_field_names(self):
         self.check_createDataFrame_duplicate_field_names(True)
 
+    def test_toPandas_empty_rows(self):
+        self.check_toPandas_empty_rows(True)
+
+    def test_toArrow_empty_rows(self):
+        super().test_toArrow_empty_rows()
+
     def test_toPandas_empty_columns(self):
         self.check_toPandas_empty_columns(True)
 
-    def test_createDataFrame_nested_timestamp(self):
-        self.check_createDataFrame_nested_timestamp(True)
+    def test_toArrow_empty_columns(self):
+        super().test_toArrow_empty_columns()
+
+    def test_createDataFrame_pandas_nested_timestamp(self):
+        self.check_createDataFrame_pandas_nested_timestamp(True)
 
     def test_toPandas_nested_timestamp(self):
         self.check_toPandas_nested_timestamp(True)

--- a/python/pyspark/sql/tests/connect/test_parity_arrow.py
+++ b/python/pyspark/sql/tests/connect/test_parity_arrow.py
@@ -37,12 +37,6 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase, PandasOnSparkTest
     def test_createDataFrame_pandas_with_struct_type(self):
         self.check_createDataFrame_pandas_with_struct_type(True)
 
-    def test_createDataFrame_arrow_with_struct_type(self):
-        super().test_createDataFrame_arrow_with_struct_type()
-
-    def test_createDataFrame_arrow_truncate_timestamp(self):
-        super().test_createDataFrame_arrow_truncate_timestamp()
-
     def test_createDataFrame_with_ndarray(self):
         self.check_createDataFrame_with_ndarray(True)
 
@@ -75,41 +69,17 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase, PandasOnSparkTest
     def test_create_data_frame_to_pandas_timestamp_ntz(self):
         self.check_create_data_frame_to_pandas_timestamp_ntz(True)
 
-    def test_create_data_frame_to_arrow_timestamp_ntz(self):
-        super().test_create_data_frame_to_arrow_timestamp_ntz()
-
     def test_create_data_frame_to_pandas_day_time_internal(self):
         self.check_create_data_frame_to_pandas_day_time_internal(True)
-
-    def test_create_data_frame_to_arrow_day_time_internal(self):
-        super().test_create_data_frame_to_arrow_day_time_internal()
 
     def test_createDataFrame_pandas_respect_session_timezone(self):
         self.check_createDataFrame_pandas_respect_session_timezone(True)
 
-    def test_createDataFrame_arrow_respect_session_timezone(self):
-        super().test_createDataFrame_arrow_respect_session_timezone()
-
     def test_toPandas_respect_session_timezone(self):
         self.check_toPandas_respect_session_timezone(True)
 
-    def test_toArrow_keep_utc_timezone(self):
-        super().test_toArrow_keep_utc_timezone()
-
-    def test_createDataFrame_arrow_pandas(self):
-        super().test_createDataFrame_arrow_pandas()
-
-    def test_pandas_round_trip(self):
-        super().test_pandas_round_trip()
-
-    def test_arrow_round_trip(self):
-        super().test_arrow_round_trip()
-
     def test_toPandas_with_array_type(self):
         self.check_toPandas_with_array_type(True)
-
-    def test_toArrow_with_array_type(self):
-        super().test_toArrow_with_array_type()
 
     @unittest.skip("Spark Connect does not support fallback.")
     def test_toPandas_fallback_disabled(self):
@@ -122,30 +92,14 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase, PandasOnSparkTest
     def test_toPandas_with_map_type(self):
         self.check_toPandas_with_map_type(True)
 
-    def test_toArrow_with_map_type(self):
-        super().test_toArrow_with_map_type()
-
     def test_toPandas_with_map_type_nulls(self):
         self.check_toPandas_with_map_type_nulls(True)
-
-    @unittest.skip("SPARK-48302: Nulls are replaced with empty lists")
-    def test_toArrow_with_map_type_nulls(self):
-        super().test_toArrow_with_map_type_nulls()
 
     def test_createDataFrame_pandas_with_array_type(self):
         self.check_createDataFrame_pandas_with_array_type(True)
 
-    def test_createDataFrame_arrow_with_array_type(self):
-        super().test_createDataFrame_arrow_with_array_type()
-
     def test_createDataFrame_pandas_with_int_col_names(self):
         self.check_createDataFrame_pandas_with_int_col_names(True)
-
-    def test_createDataFrame_arrow_with_int_col_names(self):
-        super().test_createDataFrame_arrow_with_int_col_names()
-
-    def test_createDataFrame_with_dictionary_type(self):
-        super().test_createDataFrame_with_dictionary_type()
 
     def test_timestamp_nat(self):
         self.check_timestamp_nat(True)
@@ -153,42 +107,23 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase, PandasOnSparkTest
     def test_toPandas_error(self):
         self.check_toPandas_error(True)
 
-    def test_toArrow_error(self):
-        super().test_toArrow_error()
-
     def test_toPandas_duplicate_field_names(self):
         self.check_toPandas_duplicate_field_names(True)
 
-    @unittest.skip("Error is handled by PyArrow not PySpark")
-    def test_toArrow_duplicate_field_names(self):
-        super().test_toArrow_duplicate_field_names()
-
-    def test_createDataFrame_duplicate_field_names(self):
-        self.check_createDataFrame_duplicate_field_names(True)
+    def test_createDataFrame_pandas_duplicate_field_names(self):
+        self.check_createDataFrame_pandas_duplicate_field_names(True)
 
     def test_toPandas_empty_rows(self):
         self.check_toPandas_empty_rows(True)
 
-    def test_toArrow_empty_rows(self):
-        super().test_toArrow_empty_rows()
-
     def test_toPandas_empty_columns(self):
         self.check_toPandas_empty_columns(True)
-
-    def test_toArrow_empty_columns(self):
-        super().test_toArrow_empty_columns()
 
     def test_createDataFrame_pandas_nested_timestamp(self):
         self.check_createDataFrame_pandas_nested_timestamp(True)
 
-    def test_createDataFrame_arrow_nested_timestamp(self):
-        super().test_createDataFrame_arrow_nested_timestamp()
-
     def test_toPandas_nested_timestamp(self):
         self.check_toPandas_nested_timestamp(True)
-
-    def test_toArrow_nested_timestamp(self):
-        super().test_toArrow_nested_timestamp()
 
     def test_toPandas_timestmap_tzinfo(self):
         self.check_toPandas_timestmap_tzinfo(True)
@@ -201,39 +136,6 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase, PandasOnSparkTest
 
     def test_create_dataframe_namedtuples(self):
         self.check_create_dataframe_namedtuples(True)
-
-    def test_createDataFrame_pandas_with_schema(self):
-        super().test_createDataFrame_pandas_with_schema()
-
-    def test_createDataFrame_pandas_with_incorrect_schema(self):
-        super().test_createDataFrame_pandas_with_incorrect_schema()
-
-    def test_createDataFrame_arrow_with_incorrect_schema(self):
-        super().test_createDataFrame_arrow_with_incorrect_schema()
-
-    def test_createDataFrame_pandas_with_names(self):
-        super().test_createDataFrame_pandas_with_names()
-
-    def test_createDataFrame_arrow_with_names(self):
-        super().test_createDataFrame_arrow_with_names()
-
-    def test_createDataFrame_arrow_large_string(self):
-        super().test_createDataFrame_arrow_large_string()
-
-    def test_createDataFrame_arrow_large_binary(self):
-        super().test_createDataFrame_arrow_large_binary()
-
-    def test_createDataFrame_arrow_large_list(self):
-        super().test_createDataFrame_arrow_large_list()
-
-    def test_createDataFrame_arrow_large_list_int64_offset(self):
-        super().test_createDataFrame_arrow_large_list_int64_offset()
-
-    def test_createDataFrame_arrow_fixed_size_binary(self):
-        super().test_createDataFrame_arrow_fixed_size_binary()
-
-    def test_createDataFrame_arrow_fixed_size_list(self):
-        super().test_createDataFrame_arrow_fixed_size_list()
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/connect/test_parity_arrow.py
+++ b/python/pyspark/sql/tests/connect/test_parity_arrow.py
@@ -31,8 +31,17 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase, PandasOnSparkTest
     def test_createDataFrame_fallback_enabled(self):
         super().test_createDataFrame_fallback_enabled()
 
-    def test_createDataFrame_with_map_type(self):
-        self.check_createDataFrame_with_map_type(True)
+    def test_createDataFrame_pandas_with_map_type(self):
+        self.check_createDataFrame_pandas_with_map_type(True)
+
+    def test_createDataFrame_pandas_with_struct_type(self):
+        self.check_createDataFrame_pandas_with_struct_type(True)
+
+    def test_createDataFrame_arrow_with_struct_type(self):
+        super().test_createDataFrame_arrow_with_struct_type()
+
+    def test_createDataFrame_arrow_truncate_timestamp(self):
+        super().test_createDataFrame_arrow_truncate_timestamp()
 
     def test_createDataFrame_with_ndarray(self):
         self.check_createDataFrame_with_ndarray(True)
@@ -72,6 +81,9 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase, PandasOnSparkTest
     def test_create_data_frame_to_pandas_day_time_internal(self):
         self.check_create_data_frame_to_pandas_day_time_internal(True)
 
+    def test_create_data_frame_to_arrow_day_time_internal(self):
+        super().test_create_data_frame_to_arrow_day_time_internal()
+
     def test_createDataFrame_pandas_respect_session_timezone(self):
         self.check_createDataFrame_pandas_respect_session_timezone(True)
 
@@ -96,6 +108,9 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase, PandasOnSparkTest
     def test_toPandas_with_array_type(self):
         self.check_toPandas_with_array_type(True)
 
+    def test_toArrow_with_array_type(self):
+        super().test_toArrow_with_array_type()
+
     @unittest.skip("Spark Connect does not support fallback.")
     def test_toPandas_fallback_disabled(self):
         super().test_toPandas_fallback_disabled()
@@ -107,14 +122,30 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase, PandasOnSparkTest
     def test_toPandas_with_map_type(self):
         self.check_toPandas_with_map_type(True)
 
+    def test_toArrow_with_map_type(self):
+        super().test_toArrow_with_map_type()
+
     def test_toPandas_with_map_type_nulls(self):
         self.check_toPandas_with_map_type_nulls(True)
 
-    def test_createDataFrame_with_array_type(self):
-        self.check_createDataFrame_with_array_type(True)
+    @unittest.skip("SPARK-48302: Nulls are replaced with empty lists")
+    def test_toArrow_with_map_type_nulls(self):
+        super().test_toArrow_with_map_type_nulls()
 
-    def test_createDataFrame_with_int_col_names(self):
-        self.check_createDataFrame_with_int_col_names(True)
+    def test_createDataFrame_pandas_with_array_type(self):
+        self.check_createDataFrame_pandas_with_array_type(True)
+
+    def test_createDataFrame_arrow_with_array_type(self):
+        super().test_createDataFrame_arrow_with_array_type()
+
+    def test_createDataFrame_pandas_with_int_col_names(self):
+        self.check_createDataFrame_pandas_with_int_col_names(True)
+
+    def test_createDataFrame_arrow_with_int_col_names(self):
+        super().test_createDataFrame_arrow_with_int_col_names()
+
+    def test_createDataFrame_with_dictionary_type(self):
+        super().test_createDataFrame_with_dictionary_type()
 
     def test_timestamp_nat(self):
         self.check_timestamp_nat(True)
@@ -122,8 +153,15 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase, PandasOnSparkTest
     def test_toPandas_error(self):
         self.check_toPandas_error(True)
 
+    def test_toArrow_error(self):
+        super().test_toArrow_error()
+
     def test_toPandas_duplicate_field_names(self):
         self.check_toPandas_duplicate_field_names(True)
+
+    @unittest.skip("Error is handled by PyArrow not PySpark")
+    def test_toArrow_duplicate_field_names(self):
+        super().test_toArrow_duplicate_field_names()
 
     def test_createDataFrame_duplicate_field_names(self):
         self.check_createDataFrame_duplicate_field_names(True)
@@ -143,8 +181,14 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase, PandasOnSparkTest
     def test_createDataFrame_pandas_nested_timestamp(self):
         self.check_createDataFrame_pandas_nested_timestamp(True)
 
+    def test_createDataFrame_arrow_nested_timestamp(self):
+        super().test_createDataFrame_arrow_nested_timestamp()
+
     def test_toPandas_nested_timestamp(self):
         self.check_toPandas_nested_timestamp(True)
+
+    def test_toArrow_nested_timestamp(self):
+        super().test_toArrow_nested_timestamp()
 
     def test_toPandas_timestmap_tzinfo(self):
         self.check_toPandas_timestmap_tzinfo(True)
@@ -157,6 +201,21 @@ class ArrowParityTests(ArrowTestsMixin, ReusedConnectTestCase, PandasOnSparkTest
 
     def test_create_dataframe_namedtuples(self):
         self.check_create_dataframe_namedtuples(True)
+
+    def test_createDataFrame_pandas_with_schema(self):
+        super().test_createDataFrame_pandas_with_schema()
+
+    def test_createDataFrame_pandas_with_incorrect_schema(self):
+        super().test_createDataFrame_pandas_with_incorrect_schema()
+
+    def test_createDataFrame_arrow_with_incorrect_schema(self):
+        super().test_createDataFrame_arrow_with_incorrect_schema()
+
+    def test_createDataFrame_pandas_with_names(self):
+        super().test_createDataFrame_pandas_with_names()
+
+    def test_createDataFrame_arrow_with_names(self):
+        super().test_createDataFrame_arrow_with_names()
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -608,10 +608,18 @@ class ArrowTestsMixin:
 
     def test_createDataFrame_pandas_with_schema(self):
         pdf = self.create_pandas_data_frame()
-        df = self.spark.createDataFrame(pdf, schema=self.schema)
-        self.assertEqual(self.schema, df.schema)
-        pdf_arrow = df.toPandas()
-        assert_frame_equal(pdf_arrow, pdf)
+        for schema in [
+            self.schema,
+            (self.schema,),
+            [
+                self.schema,
+            ],
+        ]:
+            with self.subTest(schema=schema):
+                df = self.spark.createDataFrame(pdf, schema=schema)
+                self.assertEqual(self.schema, df.schema)
+                pdf_arrow = df.toPandas()
+                assert_frame_equal(pdf_arrow, pdf)
 
     def test_createDataFrame_pandas_with_incorrect_schema(self):
         with self.quiet():

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -677,6 +677,17 @@ class ArrowTestsMixin:
         self.spark.createDataFrame(pdf, schema=self.schema)
         self.assertTrue(pdf.equals(pdf_copy))
 
+    def test_createDataFrame_arrow_truncate_timestamp(self):
+        t_in = pa.Table.from_arrays(
+            [pa.array([1234567890123456789], type=pa.timestamp("ns", tz="UTC"))], names=["ts"]
+        )
+        df = self.spark.createDataFrame(t_in, schema=self.schema)
+        t_out = df.toArrow()
+        expected = pa.Table.from_arrays(
+            [pa.array([1234567890123456], type=pa.timestamp("us", tz="UTC"))], names=["ts"]
+        )
+        self.assertTrue(t_out.equals(expected))
+
     def test_schema_conversion_roundtrip(self):
         from pyspark.sql.pandas.types import from_arrow_schema, to_arrow_schema
 

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -1568,6 +1568,18 @@ class ArrowTestsMixin:
         with self.assertRaises(Exception):
             self.spark.createDataFrame(t)
 
+    def test_createDataFrame_arrow_fixed_size_binary(self):
+        a = pa.array(["a"] * 5, type=pa.binary(1))
+        t = pa.table([a], ["fsb"])
+        df = self.spark.createDataFrame(t)
+        self.assertIsInstance(df.schema["fsb"].dataType, BinaryType)
+
+    def test_createDataFrame_arrow_fixed_size_list(self):
+        a = pa.array([[-1, 3]] * 5, type=pa.list_(pa.int32(), 2))
+        t = pa.table([a], ["fsl"])
+        df = self.spark.createDataFrame(t)
+        self.assertIsInstance(df.schema["fsl"].dataType, ArrayType)
+
 
 @unittest.skipIf(
     not have_pandas or not have_pyarrow,

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -860,10 +860,8 @@ class ArrowTestsMixin:
 
                 for row in result:
                     i, m = row
-                    m = {} if m is None else m
                     self.assertEqual(m, map_data[i])
 
-    @unittest.skip("SPARK-48302: Nulls are replaced with empty lists")
     def test_createDataFrame_arrow_with_map_type_nulls(self):
         map_data = [{"a": 1}, {"b": 2, "c": 3}, {}, None, {"d": None}]
 
@@ -882,7 +880,6 @@ class ArrowTestsMixin:
 
                 for row in result:
                     i, m = row
-                    m = {} if m is None else m
                     self.assertEqual(m, map_data[i])
 
     def test_createDataFrame_pandas_with_struct_type(self):
@@ -1028,8 +1025,7 @@ class ArrowTestsMixin:
                 pdf = df.toPandas()
                 assert_frame_equal(origin, pdf)
 
-    @unittest.skip("SPARK-48302: Nulls are replaced with empty lists")
-    def test_toArrow_with_map_type_nulls(self, arrow_enabled):
+    def test_toArrow_with_map_type_nulls(self):
         map_data = [{"a": 1}, {"b": 2, "c": 3}, {}, None, {"d": None}]
 
         origin = pa.table(
@@ -1553,6 +1549,16 @@ class ArrowTestsMixin:
         )
 
         self.assertTrue(t.equals(expected))
+
+    @unittest.skip("SPARK-48302: Nulls are replaced with empty lists")
+    def test_arrow_map_timestamp_nulls_round_trip(self):
+        origin = pa.table(
+            [[dict(ts=datetime.datetime(2023, 1, 1, 8, 0, 0)), None]],
+            schema=pa.schema([("map", pa.map_(pa.string(), pa.timestamp("us", tz="UTC")))]),
+        )
+        df = self.spark.createDataFrame(origin)
+        t = df.toArrow()
+        self.assertTrue(origin.equals(t))
 
     def test_createDataFrame_udt(self):
         for arrow_enabled in [True, False]:

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -1258,12 +1258,12 @@ class ArrowTestsMixin:
         ):
             df.toArrow()
 
-    def test_createDataFrame_duplicate_field_names(self):
+    def test_createDataFrame_pandas_duplicate_field_names(self):
         for arrow_enabled in [True, False]:
             with self.subTest(arrow_enabled=arrow_enabled):
-                self.check_createDataFrame_duplicate_field_names(arrow_enabled)
+                self.check_createDataFrame_pandas_duplicate_field_names(arrow_enabled)
 
-    def check_createDataFrame_duplicate_field_names(self, arrow_enabled):
+    def check_createDataFrame_pandas_duplicate_field_names(self, arrow_enabled):
         schema = (
             StructType()
             .add("struct", StructType().add("x", StringType()).add("x", IntegerType()))

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -1542,6 +1542,32 @@ class ArrowTestsMixin:
             pdf = pd.DataFrame({"a": [123]})
             assert_frame_equal(pdf, self.spark.createDataFrame(pdf).toPandas())
 
+    def test_createDataFrame_arrow_large_string(self):
+        a = pa.array(["a"] * 5, type=pa.large_string())
+        t = pa.table([a], ["ls"])
+        df = self.spark.createDataFrame(t)
+        self.assertIsInstance(df.schema["ls"].dataType, StringType)
+
+    def test_createDataFrame_arrow_large_binary(self):
+        a = pa.array(["a"] * 5, type=pa.large_binary())
+        t = pa.table([a], ["lb"])
+        df = self.spark.createDataFrame(t)
+        self.assertIsInstance(df.schema["lb"].dataType, BinaryType)
+
+    def test_createDataFrame_arrow_large_list(self):
+        a = pa.array([[-1, 3]] * 5, type=pa.large_list(pa.int32()))
+        t = pa.table([a], ["ll"])
+        df = self.spark.createDataFrame(t)
+        self.assertIsInstance(df.schema["ll"].dataType, ArrayType)
+
+    def test_createDataFrame_arrow_large_list_int64_offset(self):
+        a = pa.LargeListArray.from_arrays(
+            [0, 2**31], pa.NullArray.from_buffers(pa.null(), 2**31, [None])
+        )
+        t = pa.table([a], ["ll"])
+        with self.assertRaises(Exception):
+            self.spark.createDataFrame(t)
+
 
 @unittest.skipIf(
     not have_pandas or not have_pyarrow,

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -608,18 +608,10 @@ class ArrowTestsMixin:
 
     def test_createDataFrame_pandas_with_schema(self):
         pdf = self.create_pandas_data_frame()
-        for schema in [
-            self.schema,
-            (self.schema,),
-            [
-                self.schema,
-            ],
-        ]:
-            with self.subTest(schema=schema):
-                df = self.spark.createDataFrame(pdf, schema=schema)
-                self.assertEqual(self.schema, df.schema)
-                pdf_arrow = df.toPandas()
-                assert_frame_equal(pdf_arrow, pdf)
+        df = self.spark.createDataFrame(pdf, schema=self.schema)
+        self.assertEqual(self.schema, df.schema)
+        pdf_arrow = df.toPandas()
+        assert_frame_equal(pdf_arrow, pdf)
 
     def test_createDataFrame_pandas_with_incorrect_schema(self):
         with self.quiet():

--- a/python/pyspark/sql/tests/typing/test_session.yml
+++ b/python/pyspark/sql/tests/typing/test_session.yml
@@ -51,25 +51,6 @@
     spark.createDataFrame(["foo", "bar"], "string")
 
 
-- case: createDataFrameScalarsInvalid
-  main: |
-    from pyspark.sql import SparkSession
-    from pyspark.sql.types import StructType, StructField, StringType, IntegerType
-
-    spark = SparkSession.builder.getOrCreate()
-
-    schema = StructType([
-        StructField("name", StringType(), True),
-        StructField("age", IntegerType(), True)
-    ])
-
-    # Invalid - scalars require schema
-    spark.createDataFrame(["foo", "bar"]) # E: Value of type variable "RowLike" of "createDataFrame" of "SparkSession" cannot be "str"  [type-var]
-
-    # Invalid - data has to match schema (either product -> struct or scalar -> atomic)
-    spark.createDataFrame([1, 2, 3], schema) # E: Value of type variable "RowLike" of "createDataFrame" of "SparkSession" cannot be "int"  [type-var]
-
-
 - case: createDataFrameStructsInvalid
   main: |
     from pyspark.sql import SparkSession
@@ -102,7 +83,9 @@
     main:18: note:     def [AtomicValue in (datetime, date, Decimal, bool, str, int, float)] createDataFrame(self, data: RDD[AtomicValue], schema: Union[AtomicType, str], verifySchema: bool = ...) -> DataFrame
     main:18: note:     def [AtomicValue in (datetime, date, Decimal, bool, str, int, float)] createDataFrame(self, data: Iterable[AtomicValue], schema: Union[AtomicType, str], verifySchema: bool = ...) -> DataFrame
     main:18: note:     def createDataFrame(self, data: DataFrame, samplingRatio: Optional[float] = ...) -> DataFrame
+    main:18: note:     def createDataFrame(self, data: Any, samplingRatio: Optional[float] = ...) -> DataFrame
     main:18: note:     def createDataFrame(self, data: DataFrame, schema: Union[StructType, str], verifySchema: bool = ...) -> DataFrame
+    main:18: note:     def createDataFrame(self, data: Any, schema: Union[StructType, str], verifySchema: bool = ...) -> DataFrame
 
 - case: createDataFrameFromEmptyRdd
   main: |


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Add support for passing a PyArrow Table to `createDataFrame()`.
- Document this on the **Apache Arrow in PySpark** user guide page.
- Fix an issue with timestamp and struct columns in `toArrow()`.

### Why are the changes needed?
This seems like a logical next step after the addition of a `toArrow()` DataFrame method in #45481.

### Does this PR introduce _any_ user-facing change?
Users will have the ability to pass PyArrow Tables to `createDataFrame()`. There are no changes to the parameters of `createDataFrame()`. The only difference is that `data` can now be a PyArrow Table.

### How was this patch tested?
Many tests were added, for Spark Classic and Spark Connect. I ran the tests locally with older versions of PyArrow installed (going back to 10.0).

### Was this patch authored or co-authored using generative AI tooling?
No