### PR TITLE
[SPARK-48237][BUILD] Clean up `dev/pr-deps` at the end of `test-dependencies.sh` script

### DIFF
--- a/dev/test-dependencies.sh
+++ b/dev/test-dependencies.sh
@@ -140,4 +140,8 @@ for HADOOP_HIVE_PROFILE in "${HADOOP_HIVE_PROFILES[@]}"; do
   fi
 done
 
+if [[ -d "$FWDIR/dev/pr-deps" ]]; then
+  rm -rf "$FWDIR/dev/pr-deps"
+fi
+
 exit 0


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to delete the dir `dev/pr-deps` after executing `test-dependencies.sh`.


### Why are the changes needed?
We'd better clean the `temporary files` generated at the end.
Before:
```
sh dev/test-dependencies.sh
```
<img width="569" alt="image" src="https://github.com/apache/spark/assets/15246973/39a56983-774c-4c2d-897d-26a7d0999456">

After:
```
sh dev/test-dependencies.sh
```
<img width="534" alt="image" src="https://github.com/apache/spark/assets/15246973/f7e76e22-63cf-4411-99d0-5e844f8d5a7a">


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manually test.


### Was this patch authored or co-authored using generative AI tooling?
No.
