### PR TITLE
[SPARK-48242][BUILD] Upgrade extra-enforcer-rules to 1.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3012,7 +3012,7 @@
             <dependency>
               <groupId>org.codehaus.mojo</groupId>
               <artifactId>extra-enforcer-rules</artifactId>
-              <version>1.7.0</version>
+              <version>1.8.0</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `extra-enforcer-rules to 1.8.0` from `1.7.0` to `1.8.0`.

### Why are the changes needed?
The full release notes:
https://github.com/mojohaus/extra-enforcer-rules/releases/tag/1.8.0


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Manually test.
```
sh dev/test-dependencies.sh
```
- Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
