### PR TITLE
[SPARK-48243][SQL][HIVE] Support push down char and varchar predicates to Hive Metastore

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1342,6 +1342,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val HIVE_METASTORE_PARTITION_PRUNING_VARCHAR =
+    buildConf("spark.sql.hive.metastorePartitionPruningVarchar")
+      .doc("When true, predicates of char and varchar type will also be pushed down into " +
+        "the Hive Metastore.")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val HIVE_MANAGE_FILESOURCE_PARTITIONS =
     buildConf("spark.sql.hive.manageFilesourcePartitions")
       .doc("When true, enable metastore partition management for file source tables as well. " +
@@ -5274,6 +5282,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def metastorePartitionPruningFastFallback: Boolean =
     getConf(HIVE_METASTORE_PARTITION_PRUNING_FAST_FALLBACK)
+
+  def metastorePartitionPruningVarchar: Boolean = getConf(HIVE_METASTORE_PARTITION_PRUNING_VARCHAR)
 
   def manageFilesourcePartitions: Boolean = getConf(HIVE_MANAGE_FILESOURCE_PARTITIONS)
 

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -723,18 +723,19 @@ private[client] class Shim_v2_0 extends Shim with Logging {
       }
     }
 
-    // hive varchar is treated as catalyst string, which can be pushed down to
-    // Hive Metastore since HIVE-26661.
-    lazy val varcharKeys = table.getPartitionKeys.asScala
-        .filter(col => col.getType.startsWith(serdeConstants.VARCHAR_TYPE_NAME) ||
-          col.getType.startsWith(serdeConstants.CHAR_TYPE_NAME))
-        .map(col => col.getName).toSet
-
     object SupportedAttribute {
+      // hive varchar is treated as catalyst string, which can be pushed down to
+      // Hive Metastore since HIVE-26661.
+      val unsupportedKeys = if (!SQLConf.get.metastorePartitionPruningVarchar) {
+        table.getPartitionKeys.asScala
+          .filter(col => col.getType.startsWith(serdeConstants.VARCHAR_TYPE_NAME) ||
+              col.getType.startsWith(serdeConstants.CHAR_TYPE_NAME))
+          .map(col => col.getName).toSet
+      } else Set.empty
+
       def unapply(attr: Attribute): Option[String] = {
         val resolver = SQLConf.get.resolver
-        if (!SQLConf.get.metastorePartitionPruningVarchar &&
-            varcharKeys.exists(c => resolver(c, attr.name))) {
+        if (unsupportedKeys.exists(c => resolver(c, attr.name))) {
           None
         } else if (attr.dataType.isInstanceOf[IntegralType] || attr.dataType == StringType ||
             attr.dataType == DateType) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a new configure `spark.sql.hive.metastorePartitionPruningVarchar` to support push down `char` and `varchar` into HMS.

### Why are the changes needed?
Function enhancement.

### Does this PR introduce _any_ user-facing change?
Yes, add a new configure.


### How was this patch tested?
Add unit test.
```bash
mvn test -Dtest=none -Dsuites="org.apache.spark.sql.hive.client.FiltersSuite" -pl :spark-hive_2.13
```

### Was this patch authored or co-authored using generative AI tooling?
No.
