### PR TITLE
[SPARK-48253][PS][SQL] Support default mode for Pandas API on Spark

### DIFF
--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -18,6 +18,7 @@
 """
 Infrastructure of options for pandas-on-Spark.
 """
+import warnings
 from contextlib import contextmanager
 import json
 from typing import Any, Callable, Dict, Iterator, List, Tuple, Union
@@ -400,6 +401,10 @@ def set_option(key: str, value: Any) -> None:
     spark_session = default_session()
     if not get_default_mode():
         spark_session.conf.set(_key_format(key), json.dumps(value))
+    warnings.warn(
+        "As the static conf `spark.sql.pyspark.pandas.defaultMode` is set to True, "
+        "`set_option` is ignored and only default values are used."
+    )
 
 
 def reset_option(key: str) -> None:
@@ -421,6 +426,10 @@ def reset_option(key: str) -> None:
     spark_session = default_session()
     if not get_default_mode():
         spark_session.conf.unset(_key_format(key))
+    warnings.warn(
+        "As the static conf `spark.sql.pyspark.pandas.defaultMode` is set to True, "
+        "`set_option` is ignored and only default values are used."
+    )
 
 
 @contextmanager

--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -376,7 +376,7 @@ def get_option(key: str, default: Union[Any, _NoValueType] = _NoValue) -> Any:
     _options_dict[key].validate(default)
     spark_session = default_session()
     if get_default_mode():
-        return json.dumps(default)
+        return default
     else:
         return json.loads(spark_session.conf.get(_key_format(key), default=json.dumps(default)))
 
@@ -401,10 +401,11 @@ def set_option(key: str, value: Any) -> None:
     spark_session = default_session()
     if not get_default_mode():
         spark_session.conf.set(_key_format(key), json.dumps(value))
-    warnings.warn(
-        "As the static conf `spark.sql.pyspark.pandas.defaultMode` is set to True, "
-        "`set_option` is ignored and only default values are used."
-    )
+    else:
+        warnings.warn(
+            "As the static conf `spark.sql.pyspark.pandas.defaultMode` is set to True, "
+            "`set_option` is ignored and only default values are used."
+        )
 
 
 def reset_option(key: str) -> None:
@@ -426,10 +427,11 @@ def reset_option(key: str) -> None:
     spark_session = default_session()
     if not get_default_mode():
         spark_session.conf.unset(_key_format(key))
-    warnings.warn(
-        "As the static conf `spark.sql.pyspark.pandas.defaultMode` is set to True, "
-        "`set_option` is ignored and only default values are used."
-    )
+    else:
+        warnings.warn(
+            "As the static conf `spark.sql.pyspark.pandas.defaultMode` is set to True, "
+            "`reset_option` is ignored and only default values are used."
+        )
 
 
 @contextmanager

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -71,6 +71,18 @@ ERROR_MESSAGE_CANNOT_COMBINE = (
 SPARK_CONF_ARROW_ENABLED = "spark.sql.execution.arrow.pyspark.enabled"
 
 
+default_mode = None
+
+
+def get_default_mode() -> Optional[bool]:
+    return default_mode
+
+
+def set_default_mode(value: bool) -> None:
+    global default_mode
+    default_mode = value
+
+
 class PandasAPIOnSparkAdviceWarning(Warning):
     pass
 
@@ -492,6 +504,10 @@ def default_session() -> SparkSession:
             "from pandas API on Spark since pandas API on Spark follows "
             "the behavior of pandas, not SQL."
         )
+    default_mode_value = get_default_mode()
+    if default_mode_value is None:
+        default_mode_from_conf = spark.conf.get("spark.sql.pyspark.pandas.defaultMode") == "true"
+        set_default_mode(default_mode_from_conf)
 
     return spark
 

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -506,7 +506,9 @@ def default_session() -> SparkSession:
         )
     default_mode_value = get_default_mode()
     if default_mode_value is None:
-        default_mode_from_conf = spark.conf.get("spark.sql.pyspark.pandas.defaultMode") == "true"
+        default_mode_from_conf = (
+            spark.conf.get("spark.sql.pyspark.pandas.defaultMode", "false") == "true"
+        )
         set_default_mode(default_mode_from_conf)
 
     return spark

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -280,7 +280,7 @@ object StaticSQLConf {
       .createWithDefault("")
 
   val DEFAULT_MODE = buildStaticConf("spark.sql.pyspark.pandas.defaultMode")
-    .doc("When set to true, set_option and reset_option will all be ignored, and only default" +
+    .doc("When set to true, set_option and reset_option will all be ignored, and only default " +
       "values are used in Pandas API on Spark. This reduces communication overhead between " +
       "Python process and JVM.")
     .version("4.0.0")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -278,4 +278,12 @@ object StaticSQLConf {
       .version("3.1.0")
       .stringConf
       .createWithDefault("")
+
+  val DEFAULT_MODE = buildStaticConf("spark.sql.pyspark.pandas.defaultMode")
+    .doc("When set to true, set_option and reset_option will all be ignored, and only default" +
+      "values are used in Pandas API on Spark. This reduces communication overhead between " +
+      "Python process and JVM.")
+    .version("4.0.0")
+    .booleanConf
+    .createWithDefault(false)
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?

This PR proposes to support default mode for Pandas API on Spark.

### Why are the changes needed?

To provide option to users for reducing the communication cost between Python process and JVM when they don't want to manage the pandas-on-Spark options.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

```shell
./bin/pyspark --conf "spark.sql.pyspark.pandas.defaultMode=true"
```

```python
>>> import pyspark.pandas as ps
>>> ps.set_option("plotting.max_rows", 10)
>>> ps.get_option("plotting.max_rows")
'1000'
```


### Was this patch authored or co-authored using generative AI tooling?

No
