### PR TITLE
[SPARK-48264][BUILD] Upgrade `datasketches-java` to 6.0.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -58,7 +58,7 @@ curator-recipes/5.6.0//curator-recipes-5.6.0.jar
 datanucleus-api-jdo/4.2.4//datanucleus-api-jdo-4.2.4.jar
 datanucleus-core/4.1.17//datanucleus-core-4.1.17.jar
 datanucleus-rdbms/4.1.19//datanucleus-rdbms-4.1.19.jar
-datasketches-java/5.0.1//datasketches-java-5.0.1.jar
+datasketches-java/6.0.0//datasketches-java-6.0.0.jar
 datasketches-memory/2.2.0//datasketches-memory-2.2.0.jar
 derby/10.16.1.1//derby-10.16.1.1.jar
 derbyshared/10.16.1.1//derbyshared-10.16.1.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -213,7 +213,7 @@
     <commons-cli.version>1.6.0</commons-cli.version>
     <bouncycastle.version>1.78</bouncycastle.version>
     <tink.version>1.13.0</tink.version>
-    <datasketches.version>5.0.1</datasketches.version>
+    <datasketches.version>6.0.0</datasketches.version>
     <netty.version>4.1.109.Final</netty.version>
     <netty-tcnative.version>2.0.65.Final</netty-tcnative.version>
     <icu4j.version>72.1</icu4j.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `datasketches-java` from `5.0.1` to `6.0.0`


### Why are the changes needed?
The full release notes:
- https://github.com/apache/datasketches-java/releases/tag/6.0.0
- https://github.com/apache/datasketches-java/releases/tag/5.0.2
  <img width="1169" alt="image" src="https://github.com/apache/spark/assets/15246973/fff5905a-25e8-4e2f-9492-1b6099b2bd05">



### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
No.
