### PR TITLE
[SPARK-41794][FOLLOWUP] Add `try_remainder` to python API references

### DIFF
--- a/python/docs/source/reference/pyspark.sql/functions.rst
+++ b/python/docs/source/reference/pyspark.sql/functions.rst
@@ -143,6 +143,7 @@ Mathematical Functions
     try_add
     try_divide
     try_multiply
+    try_remainder
     try_subtract
     unhex
     width_bucket


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `try_remainder` to python API references

### Why are the changes needed?
new methods should be added to API references


### Does this PR introduce _any_ user-facing change?
doc changes

### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no