### PR TITLE
[SPARK-48268][CORE] Add a configuration for SparkContext.setCheckpointDir

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -373,7 +373,8 @@ class SparkContext(config: SparkConf) extends Logging {
 
   private[spark] def cleaner: Option[ContextCleaner] = _cleaner
 
-  private[spark] var checkpointDir: Option[String] = conf.getOption(CHECKPOINT_DIR.key)
+  private[spark] var checkpointDir: Option[String] = None
+  conf.getOption(CHECKPOINT_DIR).foreach(setCheckpointDir)
 
   // Thread Local variable that can be used by users to pass information down the stack
   protected[spark] val localProperties = new InheritableThreadLocal[Properties] {

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -374,7 +374,7 @@ class SparkContext(config: SparkConf) extends Logging {
   private[spark] def cleaner: Option[ContextCleaner] = _cleaner
 
   private[spark] var checkpointDir: Option[String] = None
-  conf.getOption(CHECKPOINT_DIR).foreach(setCheckpointDir)
+  config.getOption(CHECKPOINT_DIR.key).foreach(setCheckpointDir)
 
   // Thread Local variable that can be used by users to pass information down the stack
   protected[spark] val localProperties = new InheritableThreadLocal[Properties] {

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -374,7 +374,6 @@ class SparkContext(config: SparkConf) extends Logging {
   private[spark] def cleaner: Option[ContextCleaner] = _cleaner
 
   private[spark] var checkpointDir: Option[String] = None
-  config.getOption(CHECKPOINT_DIR.key).foreach(setCheckpointDir)
 
   // Thread Local variable that can be used by users to pass information down the stack
   protected[spark] val localProperties = new InheritableThreadLocal[Properties] {
@@ -601,6 +600,8 @@ class SparkContext(config: SparkConf) extends Logging {
       _conf.get(SPARK_LOG_LEVEL)
         .foreach(logLevel => _schedulerBackend.updateExecutorsLogLevel(logLevel))
     }
+
+    _conf.get(CHECKPOINT_DIR).foreach(setCheckpointDir)
 
     val _executorMetricsSource =
       if (_conf.get(METRICS_EXECUTORMETRICS_SOURCE_ENABLED)) {

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -373,7 +373,7 @@ class SparkContext(config: SparkConf) extends Logging {
 
   private[spark] def cleaner: Option[ContextCleaner] = _cleaner
 
-  private[spark] var checkpointDir: Option[String] = None
+  private[spark] var checkpointDir: Option[String] = conf.getOption(CHECKPOINT_DIR.key)
 
   // Thread Local variable that can be used by users to pass information down the stack
   protected[spark] val localProperties = new InheritableThreadLocal[Properties] {

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1321,8 +1321,8 @@ package object config {
     ConfigBuilder("spark.checkpoint.dir")
       .doc(
         "Equivalent with SparkContext.setCheckpointDir. If set, the path becomes" +
-        "the default directory for checkpointing. It can be overwritten by" +
-        "SparkContext.setCheckpointDir.")
+          "the default directory for checkpointing. It can be overwritten by" +
+          "SparkContext.setCheckpointDir.")
       .version("4.0.0")
       .stringConf
       .createOptional

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1317,6 +1317,14 @@ package object config {
           s" be less than or equal to ${ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH}.")
       .createWithDefault(64 * 1024 * 1024)
 
+  private[spark] val CHECKPOINT_DIR =
+    ConfigBuilder("spark.checkpoint.dir")
+      .doc("Equivalent with SparkContext.setCheckpointDir. If set, the path becomes " +
+        "the directory for checkpointing.")
+      .version("4.0.0")
+      .stringConf
+      .createOptional
+
   private[spark] val CHECKPOINT_COMPRESS =
     ConfigBuilder("spark.checkpoint.compress")
       .doc("Whether to compress RDD checkpoints. Generally a good idea. Compression will use " +

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1319,8 +1319,10 @@ package object config {
 
   private[spark] val CHECKPOINT_DIR =
     ConfigBuilder("spark.checkpoint.dir")
-      .doc("Equivalent with SparkContext.setCheckpointDir. If set, the path becomes " +
-        "the directory for checkpointing.")
+      .doc(
+        "Equivalent with SparkContext.setCheckpointDir. If set, the path becomes" +
+        "the default directory for checkpointing. It can be overwritten by" +
+        "SparkContext.setCheckpointDir.")
       .version("4.0.0")
       .stringConf
       .createOptional

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1320,8 +1320,7 @@ package object config {
   private[spark] val CHECKPOINT_DIR =
     ConfigBuilder("spark.checkpoint.dir")
       .doc(
-        "Equivalent with SparkContext.setCheckpointDir. If set, the path becomes" +
-          "the default directory for checkpointing. It can be overwritten by" +
+          "Set the default directory for checkpointing. It can be overwritten by " +
           "SparkContext.setCheckpointDir.")
       .version("4.0.0")
       .stringConf

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1796,6 +1796,16 @@ Apart from these, the following properties are also available, and may be useful
   <td>0.6.0</td>
 </tr>
 <tr>
+  <td><code>spark.checkpoint.dir</code></td>
+  <td>(none)</td>
+  <td>
+    Equivalent with SparkContext.setCheckpointDir. If set, the path becomes
+    the default directory for checkpointing. It can be overwritten by
+    SparkContext.setCheckpointDir.
+  </td>
+  <td>4.0.0</td>
+</tr>
+<tr>
   <td><code>spark.checkpoint.compress</code></td>
   <td>false</td>
   <td>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1799,8 +1799,7 @@ Apart from these, the following properties are also available, and may be useful
   <td><code>spark.checkpoint.dir</code></td>
   <td>(none)</td>
   <td>
-    Equivalent with SparkContext.setCheckpointDir. If set, the path becomes
-    the default directory for checkpointing. It can be overwritten by
+    Set the default directory for checkpointing. It can be overwritten by
     SparkContext.setCheckpointDir.
   </td>
   <td>4.0.0</td>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds `spark.checkpoint.dir` configuration so users can set the checkpoint dir when they submit their application.

### Why are the changes needed?

Separate the configuration logic so the same app can run with a different checkpoint.
In addition, this would be useful for Spark Connect with https://github.com/apache/spark/pull/46570.

### Does this PR introduce _any_ user-facing change?

Yes, it adds a new user-facing configuration.

### How was this patch tested?

unittest added

### Was this patch authored or co-authored using generative AI tooling?

No.
