### PR TITLE
[SPARK-48270][SQL] Improve the OptimizeRepartition with Repartition

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1299,10 +1299,10 @@ object CollapseRepartition extends Rule[LogicalPlan] {
 object OptimizeRepartition extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = plan.transformWithPruning(
     _.containsPattern(REPARTITION_OPERATION), ruleId) {
-    case r @ RepartitionByExpression(partitionExpressions, _, numPartitions, _)
+    case r @ RepartitionByExpression(partitionExpressions, logicalPlan, numPartitions, _)
       if partitionExpressions.nonEmpty && partitionExpressions.forall(_.foldable) &&
         numPartitions.isEmpty =>
-      r.copy(optNumPartitions = Some(1))
+      Repartition(1, shuffle = true, logicalPlan)
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -36,7 +36,7 @@ import org.apache.spark.sql.catalyst.expressions.Cast._
 import org.apache.spark.sql.catalyst.expressions.aggregate.{Complete, Partial}
 import org.apache.spark.sql.catalyst.optimizer.{ConvertToLocalRelation, NestedColumnAliasingSuite}
 import org.apache.spark.sql.catalyst.parser.ParseException
-import org.apache.spark.sql.catalyst.plans.logical.{LocalLimit, Project, RepartitionByExpression, Sort}
+import org.apache.spark.sql.catalyst.plans.logical.{LocalLimit, Project, Repartition, RepartitionByExpression, Sort}
 import org.apache.spark.sql.connector.catalog.CatalogManager.SESSION_CATALOG_NAME
 import org.apache.spark.sql.execution.{CommandResultExec, UnionExec}
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
@@ -3801,7 +3801,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
         val plan = sql(s"select * from values (1), (2), (3) t(a) distribute by $expr")
           .queryExecution.optimizedPlan
         val res = plan.collect {
-          case r: RepartitionByExpression if r.numPartitions == 1 => true
+          case r: Repartition if r.numPartitions == 1 => true
         }
         assert(res.nonEmpty)
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR propose to improve the `OptimizeRepartition` with `Repartition`.


### Why are the changes needed?
`Repartition` is cheaper than `RepartitionByExpression`.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
GA


### Was this patch authored or co-authored using generative AI tooling?
'No'.
