### PR TITLE
[SPARK-48274][BUILD] Upgrade GenJavadoc to `0.19`

### DIFF
--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -266,7 +266,7 @@ object SparkBuild extends PomBuild {
       .orElse(sys.props.get("java.home").map { p => new File(p).getParentFile().getAbsolutePath() })
       .map(file),
     publishMavenStyle := true,
-    unidocGenjavadocVersion := "0.18",
+    unidocGenjavadocVersion := "0.19",
 
     // Override SBT's default resolvers:
     resolvers := Seq(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR upgrades `GenJavadoc` plugin from `0.18` to `0.19`.

### Why are the changes needed?
1.The full release notes: https://github.com/lightbend/genjavadoc/releases/tag/v0.19

2.The latest version supports scala `2.13.14`, which is a `prerequisite` for us to upgrade spark's scala `2.13.14`.
https://mvnrepository.com/artifact/com.typesafe.genjavadoc/genjavadoc-plugin

3.The last upgrade occurred 3 years ago https://github.com/apache/spark/pull/33383


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Built the doc:

```
./build/sbt -Phadoop-3 -Pkubernetes -Pkinesis-asl -Phive-thriftserver -Pdocker-integration-tests -Pyarn -Phadoop-cloud -Pspark-ganglia-lgpl -Phive -Pjvm-profiler unidoc
```
<img width="501" alt="image" src="https://github.com/apache/spark/assets/15246973/58d3fac8-c968-44e0-83f3-84cf00a5084f">

### Was this patch authored or co-authored using generative AI tooling?
No.
