### PR TITLE
[SPARK-48299][BUILD] Upgrade `scala-maven-plugin` to 4.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
     <scala.version>2.13.13</scala.version>
     <scala.binary.version>2.13</scala.binary.version>
     <scalatest-maven-plugin.version>2.2.0</scalatest-maven-plugin.version>
-    <scala-maven-plugin.version>4.8.1</scala-maven-plugin.version>
+    <scala-maven-plugin.version>4.9.1</scala-maven-plugin.version>
     <maven.scaladoc.skip>false</maven.scaladoc.skip>
     <versions-maven-plugin.version>2.16.2</versions-maven-plugin.version>
     <!-- for now, not running scalafmt as part of default verify pipeline -->


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade `scala-maven-plugin` from 4.8.1 to 4.9.1

### Why are the changes needed?
The new version is built using Java 11 and has been upgraded to use zinc 1.10.0. For all changes, please refer to: 
- https://github.com/davidB/scala-maven-plugin/compare/4.8.1...4.9.1


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No
