### PR TITLE
[SPARK-48293][SS] Add test for when ForeachBatchUserFuncException wraps interrupted exception due to query stop

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/ForeachBatchSink.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/sources/ForeachBatchSink.scala
@@ -63,7 +63,7 @@ class ForeachBatchSink[T](batchWriter: (Dataset[T], Long) => Unit, encoder: Expr
 /**
  * Exception that wraps the exception thrown in the user provided function in ForeachBatch sink.
  */
-private[streaming] case class ForeachBatchUserFuncException(cause: Throwable)
+private[sql] case class ForeachBatchUserFuncException(cause: Throwable)
   extends SparkException(
     errorClass = "FOREACH_BATCH_USER_FUNCTION_ERROR",
     messageParameters = Map("reason" -> Option(cause.getMessage).getOrElse("")),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add test for when ForeachBatchUserFuncException wraps interrupted exception due to query stop


### Why are the changes needed?
test


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
test added


### Was this patch authored or co-authored using generative AI tooling?
No
