### PR TITLE
[SPARK-48295][PS] Turn on `compute.ops_on_diff_frames` by default

### DIFF
--- a/python/docs/source/migration_guide/pyspark_upgrade.rst
+++ b/python/docs/source/migration_guide/pyspark_upgrade.rst
@@ -72,6 +72,7 @@ Upgrading from PySpark 3.5 to 4.0
 * In Spark 4.0, ``pyspark.testing.assertPandasOnSparkEqual`` has been removed from Pandas API on Spark, use ``pyspark.pandas.testing.assert_frame_equal`` instead.
 * In Spark 4.0, the aliases ``Y``, ``M``, ``H``, ``T``, ``S`` have been deprecated from Pandas API on Spark, use ``YE``, ``ME``, ``h``, ``min``, ``s`` instead respectively.
 * In Spark 4.0, the schema of a map column is inferred by merging the schemas of all pairs in the map. To restore the previous behavior where the schema is only inferred from the first non-null pair, you can set ``spark.sql.pyspark.legacy.inferMapTypeFromFirstPair.enabled`` to ``true``.
+* In Spark 4.0, `compute.ops_on_diff_frames` is on by default. To restore the previous behavior, set `compute.ops_on_diff_frames` to `false`.
 
 
 

--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -169,7 +169,7 @@ _options: List[Option] = [
             "can be expensive in general. So, if `compute.ops_on_diff_frames` variable is not "
             "True, that method throws an exception."
         ),
-        default=False,
+        default=True,
         types=bool,
     ),
     Option(

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -491,7 +491,8 @@ class DataFrame(Frame, Generic[T]):
 
     >>> import pandas as pd
     >>> sdf = spark.createDataFrame([("Data", 1), ("Bricks", 2)], ["x", "y"])
-    >>> ps.DataFrame(data=sdf, index=pd.Index([0, 1, 2]))
+    >>> with ps.option_context("compute.ops_on_diff_frames", False):
+    ...     ps.DataFrame(data=sdf, index=pd.Index([0, 1, 2]))
     Traceback (most recent call last):
       ...
     ValueError: Cannot combine the series or dataframe...'compute.ops_on_diff_frames' option.
@@ -509,7 +510,8 @@ class DataFrame(Frame, Generic[T]):
 
     >>> import pandas as pd
     >>> sdf = spark.createDataFrame([("Data", 1), ("Bricks", 2)], ["x", "y"])
-    >>> ps.DataFrame(data=sdf, index=ps.Index([0, 1, 2]))
+    >>> with ps.option_context("compute.ops_on_diff_frames", False):
+    ...     ps.DataFrame(data=sdf, index=ps.Index([0, 1, 2]))
     Traceback (most recent call last):
       ...
     ValueError: Cannot combine the series or dataframe...'compute.ops_on_diff_frames' option.

--- a/python/pyspark/pandas/spark/accessors.py
+++ b/python/pyspark/pandas/spark/accessors.py
@@ -240,7 +240,8 @@ class SparkSeriesMethods(SparkIndexOpsMethods["ps.Series"]):
 
         However, it won't work with the same anchor Series.
 
-        >>> ser + ser.spark.analyzed
+        >>> with ps.option_context('compute.ops_on_diff_frames', False):
+        ...     ser + ser.spark.analyzed
         Traceback (most recent call last):
         ...
         ValueError: ... enable 'compute.ops_on_diff_frames' option.
@@ -290,7 +291,8 @@ class SparkIndexMethods(SparkIndexOpsMethods["ps.Index"]):
 
         However, it won't work with the same anchor Index.
 
-        >>> idx + idx.spark.analyzed
+        >>> with ps.option_context('compute.ops_on_diff_frames', False):
+        ...     idx + idx.spark.analyzed
         Traceback (most recent call last):
         ...
         ValueError: ... enable 'compute.ops_on_diff_frames' option.
@@ -1148,7 +1150,8 @@ class SparkFrameMethods:
 
         However, it won't work with the same anchor Series.
 
-        >>> df + df.spark.analyzed
+        >>> with ps.option_context('compute.ops_on_diff_frames', False):
+        ...     df + df.spark.analyzed
         Traceback (most recent call last):
         ...
         ValueError: ... enable 'compute.ops_on_diff_frames' option.

--- a/python/pyspark/pandas/tests/computation/test_binary_ops.py
+++ b/python/pyspark/pandas/tests/computation/test_binary_ops.py
@@ -49,11 +49,12 @@ class FrameBinaryOpsMixin:
         self.assert_eq(psdf + psdf.loc[:, ["A", "B"]], pdf + pdf.loc[:, ["A", "B"]])
         self.assert_eq(psdf.loc[:, ["A", "B"]] + psdf, pdf.loc[:, ["A", "B"]] + pdf)
 
-        self.assertRaisesRegex(
-            ValueError,
-            "it comes from a different dataframe",
-            lambda: ps.range(10).add(ps.range(10)),
-        )
+        with ps.option_context("compute.ops_on_diff_frames", False):
+            self.assertRaisesRegex(
+                ValueError,
+                "it comes from a different dataframe",
+                lambda: ps.range(10).add(ps.range(10)),
+            )
 
         self.assertRaisesRegex(
             TypeError,

--- a/python/pyspark/pandas/tests/computation/test_corr.py
+++ b/python/pyspark/pandas/tests/computation/test_corr.py
@@ -160,8 +160,9 @@ class FrameCorrMixin:
         psser1 = ps.from_pandas(pser1)
         psser2 = ps.from_pandas(pser2)
 
-        with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
-            psser1.corr(psser2)
+        with ps.option_context("compute.ops_on_diff_frames", False):
+            with self.assertRaisesRegex(ValueError, "Cannot combine the series or dataframe"):
+                psser1.corr(psser2)
 
         for method in ["pearson", "spearman", "kendall"]:
             with ps.option_context("compute.ops_on_diff_frames", True):

--- a/python/pyspark/pandas/tests/frame/test_constructor.py
+++ b/python/pyspark/pandas/tests/frame/test_constructor.py
@@ -137,13 +137,14 @@ class FrameConstructorMixin:
             pd.DataFrame(data=data, index=pd.Index([1, 2, 3, 5, 6])),
         )
 
-        err_msg = "Cannot combine the series or dataframe"
-        with self.assertRaisesRegex(ValueError, err_msg):
-            # test ps.DataFrame with ps.Index
-            ps.DataFrame(data=ps.DataFrame([1, 2]), index=ps.Index([1, 2]))
-        with self.assertRaisesRegex(ValueError, err_msg):
-            # test ps.DataFrame with pd.Index
-            ps.DataFrame(data=ps.DataFrame([1, 2]), index=pd.Index([3, 4]))
+        with ps.option_context("compute.ops_on_diff_frames", False):
+            err_msg = "Cannot combine the series or dataframe"
+            with self.assertRaisesRegex(ValueError, err_msg):
+                # test ps.DataFrame with ps.Index
+                ps.DataFrame(data=ps.DataFrame([1, 2]), index=ps.Index([1, 2]))
+            with self.assertRaisesRegex(ValueError, err_msg):
+                # test ps.DataFrame with pd.Index
+                ps.DataFrame(data=ps.DataFrame([1, 2]), index=pd.Index([3, 4]))
 
         with ps.option_context("compute.ops_on_diff_frames", True):
             # test pd.DataFrame with pd.Index

--- a/python/pyspark/pandas/tests/indexes/test_indexing.py
+++ b/python/pyspark/pandas/tests/indexes/test_indexing.py
@@ -235,7 +235,9 @@ class FrameIndexingMixin:
         self.assert_eq(psdf.sort_index(), pdf.sort_index(), almost=True)
 
         psser = ps.Series([4, 5, 6])
-        self.assertRaises(ValueError, lambda: psdf.insert(0, "y", psser))
+        with ps.option_context("compute.ops_on_diff_frames", False):
+            self.assertRaises(ValueError, lambda: psdf.insert(0, "y", psser))
+
         self.assertRaisesRegex(
             ValueError, "cannot insert b, already exists", lambda: psdf.insert(1, "b", 10)
         )
@@ -256,7 +258,9 @@ class FrameIndexingMixin:
         )
 
         self.assertRaises(ValueError, lambda: psdf.insert(0, "e", [7, 8, 9, 10]))
-        self.assertRaises(ValueError, lambda: psdf.insert(0, "f", ps.Series([7, 8])))
+        with ps.option_context("compute.ops_on_diff_frames", False):
+            self.assertRaises(ValueError, lambda: psdf.insert(0, "f", ps.Series([7, 8])))
+
         self.assertRaises(AssertionError, lambda: psdf.insert(100, "y", psser))
         self.assertRaises(AssertionError, lambda: psdf.insert(1, "y", psser, allow_duplicates=True))
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Turn on `compute.ops_on_diff_frames` by default


### Why are the changes needed?
1, in most cases, this config need to be turned on to enable computation with different dataframes;
2, enable `compute.ops_on_diff_frames` should not break any workloads, it should only enable more;


### Does this PR introduce _any_ user-facing change?
yes, this config is turned on by default


### How was this patch tested?
updated tests


### Was this patch authored or co-authored using generative AI tooling?
no