### PR TITLE
[SPARK-48305][SQL] Add collation support for CurrentLike expressions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -200,7 +200,7 @@ object AssertTrue {
   since = "1.6.0",
   group = "misc_funcs")
 case class CurrentDatabase() extends LeafExpression with Unevaluable {
-  override def dataType: DataType = StringType
+  override def dataType: DataType = SQLConf.get.defaultStringType
   override def nullable: Boolean = false
   override def prettyName: String = "current_schema"
   final override val nodePatterns: Seq[TreePattern] = Seq(CURRENT_LIKE)
@@ -219,7 +219,7 @@ case class CurrentDatabase() extends LeafExpression with Unevaluable {
   since = "3.1.0",
   group = "misc_funcs")
 case class CurrentCatalog() extends LeafExpression with Unevaluable {
-  override def dataType: DataType = StringType
+  override def dataType: DataType = SQLConf.get.defaultStringType
   override def nullable: Boolean = false
   override def prettyName: String = "current_catalog"
   final override val nodePatterns: Seq[TreePattern] = Seq(CURRENT_LIKE)
@@ -335,7 +335,7 @@ case class TypeOf(child: Expression) extends UnaryExpression {
 // scalastyle:on line.size.limit
 case class CurrentUser() extends LeafExpression with Unevaluable {
   override def nullable: Boolean = false
-  override def dataType: DataType = StringType
+  override def dataType: DataType = SQLConf.get.defaultStringType
   override def prettyName: String =
     getTagValue(FunctionRegistry.FUNC_ALIAS).getOrElse("current_user")
   final override val nodePatterns: Seq[TreePattern] = Seq(CURRENT_LIKE)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/finishAnalysis.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.{convertSpecialDate, convertSpecialTimestamp, convertSpecialTimestampNTZ, instantToMicros, localDateTimeToMicros}
 import org.apache.spark.sql.catalyst.util.TypeUtils.toSQLExpr
 import org.apache.spark.sql.connector.catalog.CatalogManager
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 
 
@@ -151,11 +152,11 @@ case class ReplaceCurrentLike(catalogManager: CatalogManager) extends Rule[Logic
 
     plan.transformAllExpressionsWithPruning(_.containsPattern(CURRENT_LIKE)) {
       case CurrentDatabase() =>
-        Literal.create(currentNamespace, StringType)
+        Literal.create(currentNamespace, SQLConf.get.defaultStringType)
       case CurrentCatalog() =>
-        Literal.create(currentCatalog, StringType)
+        Literal.create(currentCatalog, SQLConf.get.defaultStringType)
       case CurrentUser() =>
-        Literal.create(currentUser, StringType)
+        Literal.create(currentUser, SQLConf.get.defaultStringType)
     }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSQLExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSQLExpressionsSuite.scala
@@ -1004,16 +1004,6 @@ class CollationSQLExpressionsSuite
         val queryDatabase = sql("SELECT current_schema()")
         val queryCatalog = sql("SELECT current_catalog()")
         val queryUser = sql("SELECT current_user()")
-        // Result
-        val queryDatabaseResult = queryDatabase.collect().head.getString(0)
-        val databaseFormat = "^default$"
-        assert(queryDatabaseResult.matches(databaseFormat))
-        val queryCatalogResult = queryCatalog.collect().head.getString(0)
-        val catalogFormat = "^spark_catalog"
-        assert(queryCatalogResult.matches(catalogFormat))
-        val queryUserResult = queryUser.collect().head.getString(0)
-        val userFormat = "^[\\w\\.\\-]+$"
-        assert(queryUserResult.matches(userFormat))
         // Data type
         val dataType = StringType(collationName)
         assert(queryDatabase.schema.fields.head.dataType.sameType(dataType))

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSQLExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSQLExpressionsSuite.scala
@@ -997,6 +997,32 @@ class CollationSQLExpressionsSuite
     })
   }
 
+  test("Support CurrentDatabase/Catalog/User expressions with collation") {
+    // Supported collations
+    Seq("UTF8_BINARY_LCASE", "UNICODE", "UNICODE_CI").foreach(collationName =>
+      withSQLConf(SqlApiConf.DEFAULT_COLLATION -> collationName) {
+        val queryDatabase = sql("SELECT current_schema()")
+        val queryCatalog = sql("SELECT current_catalog()")
+        val queryUser = sql("SELECT current_user()")
+        // Result
+        val queryDatabaseResult = queryDatabase.collect().head.getString(0)
+        val databaseFormat = "^default$"
+        assert(queryDatabaseResult.matches(databaseFormat))
+        val queryCatalogResult = queryCatalog.collect().head.getString(0)
+        val catalogFormat = "^spark_catalog"
+        assert(queryCatalogResult.matches(catalogFormat))
+        val queryUserResult = queryUser.collect().head.getString(0)
+        val userFormat = "^[\\w\\.\\-]+$"
+        assert(queryUserResult.matches(userFormat))
+        // Data type
+        val dataType = StringType(collationName)
+        assert(queryDatabase.schema.fields.head.dataType.sameType(dataType))
+        assert(queryCatalog.schema.fields.head.dataType.sameType(dataType))
+        assert(queryUser.schema.fields.head.dataType.sameType(dataType))
+      }
+    )
+  }
+
   test("Support Uuid misc expression with collation") {
     // Supported collations
     Seq("UTF8_BINARY_LCASE", "UNICODE", "UNICODE_CI").foreach(collationName =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Introduce collation awareness for CurrentLike expressions: current_database/current_schema, current_catalog, user/current_user/session_user.


### Why are the changes needed?
Add collation support for CurrentLike expressions in Spark.


### Does this PR introduce _any_ user-facing change?
Yes, users should now be able to use collated strings within arguments for CurrentLike functions: current_database/current_schema, current_catalog, user/current_user/session_user.


### How was this patch tested?
E2e sql tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
