### PR TITLE
[SPARK-48031][SQL][FOLLOW-UP] Use ANSI-enabled cast in view lookup test

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -744,7 +744,8 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
     val projectList = metadata.schema.map { field =>
       Cast(
         GetViewColumnByNameAndOrdinal(metadata.identifier.toString, field.name, 0, 1, None),
-        field.dataType).as(field.name)
+        field.dataType,
+        ansiEnabled = true).as(field.name)
     }
     Project(projectList, CatalystSqlParser.parsePlan(metadata.viewText.get))
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/46267 that uses ANSI-enabled cast in the tests. It intentionally uses ANSI-enabled cast in `castColToType` when you look up a view.

### Why are the changes needed?

In order to fix the scheduled CI build without ANSI:

- https://github.com/apache/spark/actions/runs/9072308206/job/24960016975
- https://github.com/apache/spark/actions/runs/9072308206/job/24960019187

```
[info] - look up view relation *** FAILED *** (72 milliseconds)
[info]   == FAIL: Plans do not match ===
[info]    'SubqueryAlias spark_catalog.db3.view1                                                                                                                                                                                                                                                                                                                                                                          'SubqueryAlias spark_catalog.db3.view1
[info]    +- View (`spark_catalog`.`db3`.`view1`, ['col1, 'col2, 'a, 'b])                                                                                                                                                                                                                                                                                                                                                 +- View (`spark_catalog`.`db3`.`view1`, ['col1, 'col2, 'a, 'b])
[info]       +- 'Project [cast(getviewcolumnbynameandordinal(`spark_catalog`.`db3`.`view1`, col1, 0, 1) as int) AS col1#0, cast(getviewcolumnbynameandordinal(`spark_catalog`.`db3`.`view1`, col2, 0, 1) as string) AS col2#0, cast(getviewcolumnbynameandordinal(`spark_catalog`.`db3`.`view1`, a, 0, 1) as int) AS a#0, cast(getviewcolumnbynameandordinal(`spark_catalog`.`db3`.`view1`, b, 0, 1) as string) AS b#0]      +- 'Project [cast(getviewcolumnbynameandordinal(`spark_catalog`.`db3`.`view1`, col1, 0, 1) as int) AS col1#0, cast(getviewcolumnbynameandordinal(`spark_catalog`.`db3`.`view1`, col2, 0, 1) as string) AS col2#0, cast(getviewcolumnbynameandordinal(`spark_catalog`.`db3`.`view1`, a, 0, 1) as int) AS a#0, cast(getviewcolumnbynameandordinal(`spark_catalog`.`db3`.`view1`, b, 0, 1) as string) AS b#0]
[info]          +- 'Project [*]                                                                                                                                                                                                                                                                                                                                                                                                 +- 'Project [*]
[info]             +- 'UnresolvedRelation [tbl1], [], false        
```

```
[info] - look up view created before Spark 3.0 *** FAILED *** (452 milliseconds)
[info]   == FAIL: Plans do not match ===
[info]    'SubqueryAlias spark_catalog.db3.view2                                                                                                                                                                                                                                                                                                          'SubqueryAlias spark_catalog.db3.view2
[info]    +- View (`db3`.`view2`, ['col1, 'col2, 'a, 'b])                                                                                                                                                                                                                                                                                                 +- View (`db3`.`view2`, ['col1, 'col2, 'a, 'b])
[info]       +- 'Project [cast(getviewcolumnbynameandordinal(`db3`.`view2`, col1, 0, 1) as int) AS col1#0, cast(getviewcolumnbynameandordinal(`db3`.`view2`, col2, 0, 1) as string) AS col2#0, cast(getviewcolumnbynameandordinal(`db3`.`view2`, a, 0, 1) as int) AS a#0, cast(getviewcolumnbynameandordinal(`db3`.`view2`, b, 0, 1) as string) AS b#0]      +- 'Project [cast(getviewcolumnbynameandordinal(`db3`.`view2`, col1, 0, 1) as int) AS col1#0, cast(getviewcolumnbynameandordinal(`db3`.`view2`, col2, 0, 1) as string) AS col2#0, cast(getviewcolumnbynameandordinal(`db3`.`view2`, a, 0, 1) as int) AS a#0, cast(getviewcolumnbynameandordinal(`db3`.`view2`, b, 0, 1) as string) AS b#0]
[info]          +- 'Project [*]                                                                                                                                                                                                                                                                                                                                 +- 'Project [*]
[info]             +- 'UnresolvedRelation [tbl1], [], false                                                                                                                                                                                                                                                                                                        +- 'UnresolvedRelation [tbl1], [], false (PlanTest.scala:179)

```

### Does this PR introduce _any_ user-facing change?

No, the main change has not been released yet.

### How was this patch tested?

Manually ran the tests after ANSI disabled.

### Was this patch authored or co-authored using generative AI tooling?

No.
