### PR TITLE
[SPARK-43815][SQL] Wrap NPE with AnalysisException in CSV, XML, and JSON options

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2417,6 +2417,12 @@
     },
     "sqlState" : "42K0E"
   },
+  "INVALID_LOCALE" : {
+    "message" : [
+      "The locale cannot be null"
+    ],
+    "sqlState" : "42616"
+  },
   "INVALID_NON_DETERMINISTIC_EXPRESSIONS" : {
     "message" : [
       "The operator expects a deterministic expression, but the actual expression is <sqlExprs>."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -149,12 +149,13 @@ class CSVOptions(
     parameters.getOrElse(DateTimeUtils.TIMEZONE_OPTION, defaultTimeZoneId))
 
   // A language tag in IETF BCP 47 format
-  val locale: Locale = parameters.get(LOCALE).map {
-    case null =>
-      throw QueryCompilationErrors.localeIsNull()
-    case value =>
-      Locale.forLanguageTag(value).getOrElse(Locale.US)
-  }
+  val locale: Locale = parameters.get(LOCALE)
+    .map {
+      case null =>
+        throw QueryCompilationErrors.localeIsNull()
+      case value => Locale.forLanguageTag(value)
+    }
+    .getOrElse(Locale.US)
 
   /**
    * Infer columns with all valid date entries as date type (otherwise inferred as string or

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -27,7 +27,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.{DataSourceOptions, FileSourceOptions}
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.catalyst.util.ResolveDefaultColumnsUtils.EXISTS_DEFAULT_COLUMN_METADATA_KEY
-import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.types.StructType
 
@@ -149,11 +149,11 @@ class CSVOptions(
     parameters.getOrElse(DateTimeUtils.TIMEZONE_OPTION, defaultTimeZoneId))
 
   // A language tag in IETF BCP 47 format
-  val locale: Locale = try {
-    parameters.get(LOCALE).map(Locale.forLanguageTag).getOrElse(Locale.US)
-  } catch {
-    case _: NullPointerException =>
+  val locale: Locale = parameters.get(LOCALE).map {
+    case null =>
       throw QueryCompilationErrors.localeIsNull()
+    case value =>
+      Locale.forLanguageTag(value).getOrElse(Locale.US)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -149,7 +149,12 @@ class CSVOptions(
     parameters.getOrElse(DateTimeUtils.TIMEZONE_OPTION, defaultTimeZoneId))
 
   // A language tag in IETF BCP 47 format
-  val locale: Locale = parameters.get(LOCALE).map(Locale.forLanguageTag).getOrElse(Locale.US)
+  val locale: Locale = try {
+    parameters.get(LOCALE).map(Locale.forLanguageTag).getOrElse(Locale.US)
+  } catch {
+    case _: NullPointerException =>
+      throw QueryCompilationErrors.localeIsNull()
+  }
 
   /**
    * Infer columns with all valid date entries as date type (otherwise inferred as string or

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -27,7 +27,7 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.{DataSourceOptions, FileSourceOptions}
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.catalyst.util.ResolveDefaultColumnsUtils.EXISTS_DEFAULT_COLUMN_METADATA_KEY
-import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
+import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.types.StructType
 
@@ -152,7 +152,7 @@ class CSVOptions(
   val locale: Locale = parameters.get(LOCALE)
     .map {
       case null =>
-        throw QueryCompilationErrors.localeIsNull()
+        throw QueryExecutionErrors.localeIsNull()
       case value => Locale.forLanguageTag(value)
     }
     .getOrElse(Locale.US)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -107,7 +107,12 @@ class JSONOptions(
   val writeNullIfWithDefaultValue = SQLConf.get.jsonWriteNullIfWithDefaultValue
 
   // A language tag in IETF BCP 47 format
-  val locale: Locale = parameters.get(LOCALE).map(Locale.forLanguageTag).getOrElse(Locale.US)
+  val locale: Locale = parameters.get(LOCALE).map {
+    case null =>
+      throw QueryCompilationErrors.localeIsNull()
+    case value =>
+      Locale.forLanguageTag(value).getOrElse(Locale.US)
+  }
 
   val zoneId: ZoneId = DateTimeUtils.getZoneId(
     parameters.getOrElse(DateTimeUtils.TIMEZONE_OPTION, defaultTimeZoneId))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.core.json.JsonReadFeature
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.{DataSourceOptions, FileSourceOptions}
 import org.apache.spark.sql.catalyst.util._
+import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 
 /**
@@ -107,12 +108,13 @@ class JSONOptions(
   val writeNullIfWithDefaultValue = SQLConf.get.jsonWriteNullIfWithDefaultValue
 
   // A language tag in IETF BCP 47 format
-  val locale: Locale = parameters.get(LOCALE).map {
-    case null =>
-      throw QueryCompilationErrors.localeIsNull()
-    case value =>
-      Locale.forLanguageTag(value).getOrElse(Locale.US)
-  }
+  val locale: Locale = parameters.get(LOCALE)
+    .map {
+      case null =>
+        throw QueryCompilationErrors.localeIsNull()
+      case value => Locale.forLanguageTag(value)
+    }
+    .getOrElse(Locale.US)
 
   val zoneId: ZoneId = DateTimeUtils.getZoneId(
     parameters.getOrElse(DateTimeUtils.TIMEZONE_OPTION, defaultTimeZoneId))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JSONOptions.scala
@@ -27,7 +27,7 @@ import com.fasterxml.jackson.core.json.JsonReadFeature
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.{DataSourceOptions, FileSourceOptions}
 import org.apache.spark.sql.catalyst.util._
-import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 
 /**
@@ -111,7 +111,7 @@ class JSONOptions(
   val locale: Locale = parameters.get(LOCALE)
     .map {
       case null =>
-        throw QueryCompilationErrors.localeIsNull()
+        throw QueryExecutionErrors.localeIsNull()
       case value => Locale.forLanguageTag(value)
     }
     .getOrElse(Locale.US)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlOptions.scala
@@ -163,7 +163,12 @@ class XmlOptions(
       parameters.getOrElse(TIME_ZONE, defaultTimeZoneId)))
 
   // A language tag in IETF BCP 47 format
-  val locale: Locale = parameters.get(LOCALE).map(Locale.forLanguageTag).getOrElse(Locale.US)
+  val locale: Locale = parameters.get(LOCALE).map {
+    case null =>
+      throw QueryCompilationErrors.localeIsNull()
+    case value =>
+      Locale.forLanguageTag(value).getOrElse(Locale.US)
+  }
 
   val multiLine = parameters.get(MULTI_LINE).map(_.toBoolean).getOrElse(true)
   val charset = parameters.getOrElse(ENCODING,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlOptions.scala
@@ -166,7 +166,7 @@ class XmlOptions(
   val locale: Locale = parameters.get(LOCALE)
     .map {
       case null =>
-        throw QueryCompilationErrors.localeIsNull()
+        throw QueryExecutionErrors.localeIsNull()
       case value => Locale.forLanguageTag(value)
     }
     .getOrElse(Locale.US)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/XmlOptions.scala
@@ -163,12 +163,13 @@ class XmlOptions(
       parameters.getOrElse(TIME_ZONE, defaultTimeZoneId)))
 
   // A language tag in IETF BCP 47 format
-  val locale: Locale = parameters.get(LOCALE).map {
-    case null =>
-      throw QueryCompilationErrors.localeIsNull()
-    case value =>
-      Locale.forLanguageTag(value).getOrElse(Locale.US)
-  }
+  val locale: Locale = parameters.get(LOCALE)
+    .map {
+      case null =>
+        throw QueryCompilationErrors.localeIsNull()
+      case value => Locale.forLanguageTag(value)
+    }
+    .getOrElse(Locale.US)
 
   val multiLine = parameters.get(MULTI_LINE).map(_.toBoolean).getOrElse(true)
   val charset = parameters.getOrElse(ENCODING,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -4074,4 +4074,10 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map()
     )
   }
+
+  def localeIsNull(): Throwable = {
+    new AnalysisException(
+      errorClass = "INVALID_LOCALE",
+      messageParameters = Map.empty)
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -4074,10 +4074,4 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map()
     )
   }
-
-  def localeIsNull(): Throwable = {
-    new AnalysisException(
-      errorClass = "INVALID_LOCALE",
-      messageParameters = Map.empty)
-  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -2773,4 +2773,8 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       )
     )
   }
+
+  def localeIsNull(): Throwable = {
+    new SparkIllegalArgumentException(errorClass = "INVALID_LOCALE")
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CsvExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CsvExpressionsSuite.scala
@@ -22,7 +22,7 @@ import java.util.{Calendar, Locale, TimeZone}
 
 import org.scalatest.exceptions.TestFailedException
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkFunSuite, SparkIllegalArgumentException}
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.plans.PlanTestBase
@@ -263,12 +263,13 @@ class CsvExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper with P
     val sdf = new SimpleDateFormat(dateFormat, locale)
     val dateStr = sdf.format(date)
     val options = Map("dateFormat" -> dateFormat, "locale" -> null)
+    val expr = CsvToStructs(schema, options, Literal.create(dateStr), UTC_OPT)
+    val row = InternalRow(17836) // number of days from 1970-01-01
 
     checkError(
-      intercept[AnalysisException] {
-        CsvToStructs(schema, options, Literal.create(dateStr), UTC_OPT)
+      intercept[SparkIllegalArgumentException] {
+        expr.eval(row)
       },
-      errorClass = "INVALID_LOCALE"
-    )
+      errorClass = "INVALID_LOCALE")
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CsvExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CsvExpressionsSuite.scala
@@ -22,7 +22,7 @@ import java.util.{Calendar, Locale, TimeZone}
 
 import org.scalatest.exceptions.TestFailedException
 
-import org.apache.spark.{SparkFunSuite, SparkIllegalArgumentException}
+import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.plans.PlanTestBase

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CsvExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CsvExpressionsSuite.scala
@@ -22,7 +22,7 @@ import java.util.{Calendar, Locale, TimeZone}
 
 import org.scalatest.exceptions.TestFailedException
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkFunSuite, SparkIllegalArgumentException}
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.plans.PlanTestBase
@@ -252,5 +252,23 @@ class CsvExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper with P
     val struct = CreateStruct.create(range.map(Literal.apply))
     val expected = range.mkString(",")
     checkEvaluation(StructsToCsv(Map.empty, struct), expected)
+  }
+
+  test("SPARK-48315: null locale should not raise NPE") {
+    val langTag = "en-US"
+    val locale = Locale.forLanguageTag(langTag)
+    val date = new SimpleDateFormat("yyyy-MM-dd").parse("2018-11-05")
+    val schema = new StructType().add("d", DateType)
+    val dateFormat = "MMM yyyy"
+    val sdf = new SimpleDateFormat(dateFormat, locale)
+    val dateStr = sdf.format(date)
+    val options = Map("dateFormat" -> dateFormat, "locale" -> null)
+
+    checkError(
+      intercept[AnalysisException] {
+        CsvToStructs(schema, options, Literal.create(dateStr), UTC_OPT)
+      },
+      errorClass = "INVALID_LOCALE"
+    )
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
@@ -906,4 +906,22 @@ class JsonExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper with 
       "QUESTION"
     )
   }
+
+  test("SPARK-48315: null locale should not raise NPE") {
+    val langTag = "en-US"
+    val locale = Locale.forLanguageTag(langTag)
+    val date = new SimpleDateFormat("yyyy-MM-dd").parse("2018-11-05")
+    val schema = new StructType().add("d", DateType)
+    val dateFormat = "MMM yyyy"
+    val sdf = new SimpleDateFormat(dateFormat, locale)
+    val dateStr = sdf.format(date)
+    val options = Map("dateFormat" -> dateFormat, "locale" -> null)
+
+    checkError(
+      intercept[AnalysisException] {
+        JsonToStructs(schema, options, Literal.create(dateStr), UTC_OPT)
+      },
+      errorClass = "INVALID_LOCALE"
+    )
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/JsonExpressionsSuite.scala
@@ -22,7 +22,7 @@ import java.util.{Calendar, Locale, TimeZone}
 
 import org.scalatest.exceptions.TestFailedException
 
-import org.apache.spark.{SparkException, SparkFunSuite}
+import org.apache.spark.{SparkException, SparkFunSuite, SparkIllegalArgumentException}
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.DataTypeMismatch
@@ -916,12 +916,13 @@ class JsonExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper with 
     val sdf = new SimpleDateFormat(dateFormat, locale)
     val dateStr = sdf.format(date)
     val options = Map("dateFormat" -> dateFormat, "locale" -> null)
+    val expr = JsonToStructs(schema, options, Literal.create(dateStr), UTC_OPT)
+    val row = InternalRow(17836) // number of days from 1970-01-01
 
     checkError(
-      intercept[AnalysisException] {
-        JsonToStructs(schema, options, Literal.create(dateStr), UTC_OPT)
+      intercept[SparkIllegalArgumentException] {
+        expr.eval(row)
       },
-      errorClass = "INVALID_LOCALE"
-    )
+      errorClass = "INVALID_LOCALE")
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/XmlExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/XmlExpressionsSuite.scala
@@ -442,4 +442,21 @@ class XmlExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper with P
     }
   }
 
+  test("SPARK-48315: null locale should not raise NPE") {
+    val langTag = "en-US"
+    val locale = Locale.forLanguageTag(langTag)
+    val date = new SimpleDateFormat("yyyy-MM-dd").parse("2018-11-05")
+    val schema = new StructType().add("d", DateType)
+    val dateFormat = "MMM yyyy"
+    val sdf = new SimpleDateFormat(dateFormat, locale)
+    val dateStr = sdf.format(date)
+    val options = Map("dateFormat" -> dateFormat, "locale" -> null)
+
+    checkError(
+      intercept[AnalysisException] {
+        XmlToStructs(schema, options, Literal.create(dateStr), UTC_OPT)
+      },
+      errorClass = "INVALID_LOCALE"
+    )
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/XmlExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/XmlExpressionsSuite.scala
@@ -22,7 +22,7 @@ import java.util.{Calendar, Locale, TimeZone}
 
 import org.scalatest.exceptions.TestFailedException
 
-import org.apache.spark.{SparkException, SparkFunSuite}
+import org.apache.spark.{SparkException, SparkFunSuite, SparkIllegalArgumentException}
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
@@ -451,12 +451,13 @@ class XmlExpressionsSuite extends SparkFunSuite with ExpressionEvalHelper with P
     val sdf = new SimpleDateFormat(dateFormat, locale)
     val dateStr = sdf.format(date)
     val options = Map("dateFormat" -> dateFormat, "locale" -> null)
+    val expr = XmlToStructs(schema, options, Literal.create(dateStr), UTC_OPT)
+    val row = InternalRow(17836) // number of days from 1970-01-01
 
     checkError(
-      intercept[AnalysisException] {
-        XmlToStructs(schema, options, Literal.create(dateStr), UTC_OPT)
+      intercept[SparkIllegalArgumentException] {
+        expr.eval(row)
       },
-      errorClass = "INVALID_LOCALE"
-    )
+      errorClass = "INVALID_LOCALE")
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

When user sets `locale` to be `null`, a NPE is raised. Instead, replace the NPE with a more understandable user facing error message.

### Why are the changes needed?

Improves usability of csv options.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Added tests pass.

### Was this patch authored or co-authored using generative AI tooling?

No
