### PR TITLE
[SPARK-48316][PS][CONNECT][TESTS] Fix comments for SparkFrameMethodsParityTests.test_coalesce and test_repartition

### DIFF
--- a/python/pyspark/pandas/tests/connect/test_parity_frame_spark.py
+++ b/python/pyspark/pandas/tests/connect/test_parity_frame_spark.py
@@ -28,7 +28,9 @@ class SparkFrameMethodsParityTests(
     def test_checkpoint(self):
         super().test_checkpoint()
 
-    @unittest.skip("Test depends on RDD which is not supported from Spark Connect.")
+    @unittest.skip(
+        "Test depends on RDD, and cannot use SQL expression due to Catalyst optimization"
+    )
     def test_coalesce(self):
         super().test_coalesce()
 
@@ -36,7 +38,9 @@ class SparkFrameMethodsParityTests(
     def test_local_checkpoint(self):
         super().test_local_checkpoint()
 
-    @unittest.skip("Test depends on RDD which is not supported from Spark Connect.")
+    @unittest.skip(
+        "Test depends on RDD, and cannot use SQL expression due to Catalyst optimization"
+    )
     def test_repartition(self):
         super().test_repartition()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to enable `SparkFrameMethodsParityTests.test_coalesce` and `SparkFrameMethodsParityTests.test_repartition` in Spark Connect by avoiding RDD usage in the test.

### Why are the changes needed?

To make sure on the test coverage

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

CI in this PR.

### Was this patch authored or co-authored using generative AI tooling?

No.
