### PR TITLE
[MINOR][PYTHON][TESTS] Call `test_apply_schema_to_dict_and_rows` in `test_apply_schema_to_row` 

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_types.py
+++ b/python/pyspark/sql/tests/connect/test_parity_types.py
@@ -32,7 +32,7 @@ class TypesParityTests(TypesTestsMixin, ReusedConnectTestCase):
 
     @unittest.skip("Spark Connect does not support RDD but the tests depend on them.")
     def test_apply_schema_to_row(self):
-        super().test_apply_schema_to_dict_and_rows()
+        super().test_apply_schema_to_row()
 
     @unittest.skip("Spark Connect does not support RDD but the tests depend on them.")
     def test_create_dataframe_schema_mismatch(self):


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the test `test_apply_schema_to_row` to call `test_apply_schema_to_row` instead of `test_apply_schema_to_dict_and_rows`. It was a mistake.

### Why are the changes needed?

To avoid a mistake when it's enabled in the future.

### Does this PR introduce _any_ user-facing change?

No, test-only

### How was this patch tested?

CI in this PR.

### Was this patch authored or co-authored using generative AI tooling?

No.