### PR TITLE
[SPARK-48317][PYTHON][CONNECT][TESTS] Enable `test_udtf_with_analyze_using_archive` and `test_udtf_with_analyze_using_file`

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_udtf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udtf.py
@@ -25,7 +25,6 @@ if should_test_connect:
     sql.udtf.UserDefinedTableFunction = UserDefinedTableFunction
     from pyspark.sql.connect.functions import lit, udtf
 
-from pyspark.util import is_remote_only
 from pyspark.sql.tests.test_udtf import BaseUDTFTestsMixin, UDTFArrowTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 from pyspark.errors.exceptions.connect import SparkConnectGrpcException, PythonException

--- a/python/pyspark/sql/tests/connect/test_parity_udtf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udtf.py
@@ -68,13 +68,11 @@ class UDTFParityTests(BaseUDTFTestsMixin, ReusedConnectTestCase):
     def test_udtf_with_analyze_using_accumulator(self):
         super().test_udtf_with_analyze_using_accumulator()
 
-    @unittest.skipIf(is_remote_only(), "pyspark-connect does not have SparkFiles")
     def test_udtf_with_analyze_using_archive(self):
-        super().test_udtf_with_analyze_using_archive()
+        super().check_udtf_with_analyze_using_archive(".")
 
-    @unittest.skipIf(is_remote_only(), "pyspark-connect does not have SparkFiles")
     def test_udtf_with_analyze_using_file(self):
-        super().test_udtf_with_analyze_using_file()
+        super().check_udtf_with_analyze_using_file(".")
 
     @unittest.skip("pyspark-connect can serialize SparkSession, but fails on executor")
     def test_udtf_access_spark_session(self):

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -1801,6 +1801,9 @@ class BaseUDTFTestsMixin:
     def test_udtf_with_analyze_using_archive(self):
         from pyspark.core.files import SparkFiles
 
+        self.check_udtf_with_analyze_using_archive(SparkFiles.getRootDirectory())
+
+    def check_udtf_with_analyze_using_archive(self, exec_root_dir):
         with tempfile.TemporaryDirectory(prefix="test_udtf_with_analyze_using_archive") as d:
             archive_path = os.path.join(d, "my_archive")
             os.mkdir(archive_path)
@@ -1815,9 +1818,7 @@ class BaseUDTFTestsMixin:
                 @staticmethod
                 def read_my_archive() -> str:
                     with open(
-                        os.path.join(
-                            SparkFiles.getRootDirectory(), "my_files", "my_archive", "my_file.txt"
-                        ),
+                        os.path.join(exec_root_dir, "my_files", "my_archive", "my_file.txt"),
                         "r",
                     ) as my_file:
                         return my_file.read().strip()
@@ -1850,6 +1851,9 @@ class BaseUDTFTestsMixin:
     def test_udtf_with_analyze_using_file(self):
         from pyspark.core.files import SparkFiles
 
+        self.check_udtf_with_analyze_using_file(SparkFiles.getRootDirectory())
+
+    def check_udtf_with_analyze_using_file(self, exec_root_dir):
         with tempfile.TemporaryDirectory(prefix="test_udtf_with_analyze_using_file") as d:
             file_path = os.path.join(d, "my_file.txt")
             with open(file_path, "w") as f:
@@ -1860,9 +1864,7 @@ class BaseUDTFTestsMixin:
             class TestUDTF:
                 @staticmethod
                 def read_my_file() -> str:
-                    with open(
-                        os.path.join(SparkFiles.getRootDirectory(), "my_file.txt"), "r"
-                    ) as my_file:
+                    with open(os.path.join(exec_root_dir, "my_file.txt"), "r") as my_file:
                         return my_file.read().strip()
 
                 @staticmethod


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to enable the tests `test_udtf_with_analyze_using_archive` and `test_udtf_with_analyze_using_file`.

### Why are the changes needed?

To make sure on the test coverage

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

CI in this PR.

### Was this patch authored or co-authored using generative AI tooling?

No.
