### PR TITLE
[SPARK-48321][CONNECT][TESTS] Avoid using deprecated methods in dsl

### DIFF
--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/dsl/package.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/dsl/package.scala
@@ -1019,7 +1019,13 @@ package object dsl {
             WithColumnsRenamed
               .newBuilder()
               .setInput(logicalPlan)
-              .putAllRenameColumnsMap(renameColumnsMap.asJava))
+              .addAllRenames(renameColumnsMap.toSeq.map { case (k, v) =>
+                WithColumnsRenamed.Rename
+                  .newBuilder()
+                  .setColName(k)
+                  .setNewColName(v)
+                  .build()
+              }.asJava))
           .build()
       }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Avoid using deprecated methods in dsl


### Why are the changes needed?
`putAllRenameColumnsMap` was deprecated


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no
