### PR TITLE
[SPARK-48325][CORE] Always specify messages in ExecutorRunner.killProcess

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/worker/ExecutorRunner.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/ExecutorRunner.scala
@@ -88,7 +88,7 @@ private[deploy] class ExecutorRunner(
       if (state == ExecutorState.LAUNCHING || state == ExecutorState.RUNNING) {
         state = ExecutorState.FAILED
       }
-      killProcess(Some("Worker shutting down")) }
+      killProcess("Worker shutting down") }
   }
 
   /**
@@ -96,7 +96,7 @@ private[deploy] class ExecutorRunner(
    *
    * @param message the exception message which caused the executor's death
    */
-  private def killProcess(message: Option[String]): Unit = {
+  private def killProcess(message: String): Unit = {
     var exitCode: Option[Int] = None
     if (process != null) {
       logInfo("Killing process!")
@@ -113,7 +113,7 @@ private[deploy] class ExecutorRunner(
       }
     }
     try {
-      worker.send(ExecutorStateChanged(appId, execId, state, message, exitCode))
+      worker.send(ExecutorStateChanged(appId, execId, state, Some(message), exitCode))
     } catch {
       case e: IllegalStateException => logWarning(log"${MDC(ERROR, e.getMessage())}", e)
     }
@@ -206,11 +206,11 @@ private[deploy] class ExecutorRunner(
       case interrupted: InterruptedException =>
         logInfo("Runner thread for executor " + fullId + " interrupted")
         state = ExecutorState.KILLED
-        killProcess(None)
+        killProcess(s"Runner thread for executor $fullId interrupted")
       case e: Exception =>
         logError("Error running executor", e)
         state = ExecutorState.FAILED
-        killProcess(Some(e.toString))
+        killProcess(s"Error running executor: $e")
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This change is to always specify the message in `ExecutorRunner.killProcess`.

### Why are the changes needed?
This is to get the occurrence rate for different cases when killing the executor process, in order to analyze executor running stability.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
N/A

### Was this patch authored or co-authored using generative AI tooling?
No