### PR TITLE
[SPARK-48354][SQL] JDBC Connectors predicate pushdown testing

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2IntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DB2IntegrationSuite.scala
@@ -45,7 +45,8 @@ class DB2IntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTest {
     "scan with aggregate push-down: REGR_INTERCEPT with DISTINCT",
     "scan with aggregate push-down: REGR_SLOPE with DISTINCT",
     "scan with aggregate push-down: REGR_R2 with DISTINCT",
-    "scan with aggregate push-down: REGR_SXY with DISTINCT")
+    "scan with aggregate push-down: REGR_SXY with DISTINCT",
+    "column pruning with unsupported filter")
 
   override val catalogName: String = "db2"
   override val namespaceOpt: Option[String] = Some("DB2INST1")

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerIntegrationSuite.scala
@@ -55,8 +55,7 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JD
     "scan with aggregate push-down: REGR_R2 with DISTINCT",
     "scan with aggregate push-down: REGR_R2 without DISTINCT",
     "scan with aggregate push-down: REGR_SXY with DISTINCT",
-    "scan with aggregate push-down: REGR_SXY without DISTINCT",
-    "CREATE TABLE with table comment")
+    "scan with aggregate push-down: REGR_SXY without DISTINCT")
 
   override val catalogName: String = "mssql"
   override val db = new MsSQLServerDatabaseOnDocker

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerIntegrationSuite.scala
@@ -55,7 +55,8 @@ class MsSqlServerIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JD
     "scan with aggregate push-down: REGR_R2 with DISTINCT",
     "scan with aggregate push-down: REGR_R2 without DISTINCT",
     "scan with aggregate push-down: REGR_SXY with DISTINCT",
-    "scan with aggregate push-down: REGR_SXY without DISTINCT")
+    "scan with aggregate push-down: REGR_SXY without DISTINCT",
+    "CREATE TABLE with table comment")
 
   override val catalogName: String = "mssql"
   override val db = new MsSQLServerDatabaseOnDocker

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerPushdownIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerPushdownIntegrationSuite.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.jdbc.v2
+
+import java.sql.Connection
+
+import test.scala.org.apache.spark.sql.jdbc.v2.V2JDBCPushdownTest
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
+import org.apache.spark.sql.jdbc.{DatabaseOnDocker, DockerJDBCIntegrationSuite, MsSQLServerDatabaseOnDocker}
+
+class MsSqlServerPushdownIntegrationSuite
+  extends DockerJDBCIntegrationSuite
+    with V2JDBCPushdownTest {
+
+  override def excluded: Seq[String] = Seq(
+    "case when in predicate and IIF")
+
+  override def sparkConf: SparkConf = super.sparkConf
+    .set("spark.sql.catalog.sqlserver", classOf[JDBCTableCatalog].getName)
+    .set("spark.sql.catalog.sqlserver.url", db.getJdbcUrl(dockerIp, externalPort))
+    .set("spark.sql.catalog.sqlserver.pushDownAggregate", "true")
+    .set("spark.sql.catalog.sqlserver.pushDownLimit", "true")
+
+  override val db: DatabaseOnDocker = new MsSQLServerDatabaseOnDocker
+
+  override protected val catalog: String = "sqlserver"
+  override protected val tablePrefix: String = "testtbl"
+  override protected val schema: String = "testschema"
+
+  override protected def executeUpdate(sql: String): Unit = {
+    getConnection().prepareStatement(sql).executeUpdate()
+  }
+
+  override def prepareTable(): Unit = {
+    executeUpdate(
+      s"""CREATE SCHEMA "$schema""""
+    )
+
+    executeUpdate(
+      s"""CREATE TABLE "$schema"."$tablePrefix"
+         | (id INTEGER, st VARCHAR(MAX), random_col INT);""".stripMargin
+    )
+
+    executeUpdate(
+      s"""CREATE TABLE "$schema"."${tablePrefix}_coalesce"
+         | (id INTEGER, col1 VARCHAR(128), col2 INT);""".stripMargin
+    )
+
+    executeUpdate(
+      s"""CREATE TABLE "$schema"."${tablePrefix}_escape_test"
+         | (id INTEGER, st VARCHAR(MAX), random_col INT);""".stripMargin
+    )
+
+    executeUpdate(
+      s"""CREATE TABLE "$schema"."${tablePrefix}_with_nulls"
+         | (id INTEGER, st VARCHAR(MAX));""".stripMargin
+    )
+  }
+
+  /**
+   * Prepare databases and tables for testing.
+   */
+  override def dataPreparation(connection: Connection): Unit = prepareData()
+
+  override protected def commonAssertionOnDataFrame(df: DataFrame): Unit = {
+
+  }
+}

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerPushdownIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerPushdownIntegrationSuite.scala
@@ -31,7 +31,7 @@ class MsSqlServerPushdownIntegrationSuite
     with V2JDBCPushdownTest {
 
   override def excluded: Seq[String] = Seq(
-    "case when in predicate and IIF")
+    "case when in predicate and IIF push down")
 
   override def sparkConf: SparkConf = super.sparkConf
     .set("spark.sql.catalog.sqlserver", classOf[JDBCTableCatalog].getName)
@@ -65,7 +65,7 @@ class MsSqlServerPushdownIntegrationSuite
     )
 
     executeUpdate(
-      s"""CREATE TABLE "$schema"."${tablePrefix}_escape_test"
+      s"""CREATE TABLE "$schema"."${tablePrefix}_string_test"
          | (id INTEGER, st VARCHAR(MAX), random_col INT);""".stripMargin
     )
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerPushdownIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerPushdownIntegrationSuite.scala
@@ -19,12 +19,11 @@ package org.apache.spark.sql.jdbc.v2
 
 import java.sql.Connection
 
-import test.scala.org.apache.spark.sql.jdbc.v2.V2JDBCPushdownTest
-
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
 import org.apache.spark.sql.jdbc.{DatabaseOnDocker, DockerJDBCIntegrationSuite, MsSQLServerDatabaseOnDocker}
+import org.apache.spark.sql.jdbc.v2.V2JDBCPushdownTest
 
 class MsSqlServerPushdownIntegrationSuite
   extends DockerJDBCIntegrationSuite

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerPushdownIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerPushdownIntegrationSuite.scala
@@ -73,6 +73,11 @@ class MsSqlServerPushdownIntegrationSuite
       s"""CREATE TABLE "$schema"."${tablePrefix}_with_nulls"
          | (id INTEGER, st VARCHAR(MAX));""".stripMargin
     )
+
+    executeUpdate(
+      s"""CREATE TABLE "$schema"."${tablePrefix}_numeric_test"
+         | (id INTEGER, dec DECIMAL(10, 2));""".stripMargin
+    )
   }
 
   /**

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerPushdownIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerPushdownIntegrationSuite.scala
@@ -30,7 +30,9 @@ class MsSqlServerPushdownIntegrationSuite
   extends DockerJDBCIntegrationSuite
     with V2JDBCPushdownTest {
 
-  override def excluded: Seq[String] = Seq()
+  override def excluded: Seq[String] = Seq(
+    "LENGTH predicate push down"
+  )
 
   override def sparkConf: SparkConf = super.sparkConf
     .set("spark.sql.catalog.sqlserver", classOf[JDBCTableCatalog].getName)

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerPushdownIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerPushdownIntegrationSuite.scala
@@ -56,7 +56,7 @@ class MsSqlServerPushdownIntegrationSuite
 
     executeUpdate(
       s"""CREATE TABLE "$schema"."$tablePrefix"
-         | (id INTEGER, st VARCHAR(MAX), random_col INT);""".stripMargin
+         | (id INTEGER, st VARCHAR(MAX), num_col INT);""".stripMargin
     )
 
     executeUpdate(
@@ -66,7 +66,7 @@ class MsSqlServerPushdownIntegrationSuite
 
     executeUpdate(
       s"""CREATE TABLE "$schema"."${tablePrefix}_string_test"
-         | (id INTEGER, st VARCHAR(MAX), random_col INT);""".stripMargin
+         | (id INTEGER, st VARCHAR(MAX), num_col INT);""".stripMargin
     )
 
     executeUpdate(

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerPushdownIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerPushdownIntegrationSuite.scala
@@ -75,7 +75,7 @@ class MsSqlServerPushdownIntegrationSuite
 
     executeUpdate(
       s"""CREATE TABLE "$schema"."${tablePrefix}_numeric_test"
-         | (id INTEGER, dec DECIMAL(10, 2));""".stripMargin
+         | (id INTEGER, dec_col DECIMAL(10, 2));""".stripMargin
     )
   }
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerPushdownIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MsSqlServerPushdownIntegrationSuite.scala
@@ -30,8 +30,7 @@ class MsSqlServerPushdownIntegrationSuite
   extends DockerJDBCIntegrationSuite
     with V2JDBCPushdownTest {
 
-  override def excluded: Seq[String] = Seq(
-    "case when in predicate and IIF push down")
+  override def excluded: Seq[String] = Seq()
 
   override def sparkConf: SparkConf = super.sparkConf
     .set("spark.sql.catalog.sqlserver", classOf[JDBCTableCatalog].getName)

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySqlPushdownIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySqlPushdownIntegrationSuite.scala
@@ -19,12 +19,11 @@ package org.apache.spark.sql.jdbc.v2
 
 import java.sql.Connection
 
-import test.scala.org.apache.spark.sql.jdbc.v2.V2JDBCPushdownTest
-
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
 import org.apache.spark.sql.jdbc.{DatabaseOnDocker, DockerJDBCIntegrationSuite, MySQLDatabaseOnDocker}
+import org.apache.spark.sql.jdbc.v2.V2JDBCPushdownTest
 
 class MySqlPushdownIntegrationSuite
   extends DockerJDBCIntegrationSuite

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySqlPushdownIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySqlPushdownIntegrationSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.jdbc.v2
+
+import java.sql.Connection
+
+import test.scala.org.apache.spark.sql.jdbc.v2.V2JDBCPushdownTest
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
+import org.apache.spark.sql.jdbc.{DatabaseOnDocker, DockerJDBCIntegrationSuite, MySQLDatabaseOnDocker}
+
+class MySqlPushdownIntegrationSuite
+  extends DockerJDBCIntegrationSuite
+    with V2JDBCPushdownTest {
+
+  override val db: DatabaseOnDocker = new MySQLDatabaseOnDocker
+
+  override def sparkConf: SparkConf = super.sparkConf
+    .set("spark.sql.catalog.mysql", classOf[JDBCTableCatalog].getName)
+    .set("spark.sql.catalog.mysql.url", db.getJdbcUrl(dockerIp, externalPort))
+    .set("spark.sql.catalog.mysql.pushDownAggregate", "true")
+    .set("spark.sql.catalog.mysql.pushDownLimit", "true")
+
+  /**
+   * Prepare databases and tables for testing.
+   */
+  override def dataPreparation(connection: Connection): Unit = prepareData()
+
+  override protected val catalog: String = "mysql"
+  override protected val tablePrefix: String = "testtbl"
+  override protected val schema: String = "testschema"
+
+  override protected def executeUpdate(sql: String): Unit = {
+    getConnection().prepareStatement(sql).executeUpdate()
+  }
+
+  override protected def commonAssertionOnDataFrame(df: DataFrame): Unit = {
+
+  }
+}

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySqlPushdownIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySqlPushdownIntegrationSuite.scala
@@ -54,4 +54,77 @@ class MySqlPushdownIntegrationSuite
   override protected def commonAssertionOnDataFrame(df: DataFrame): Unit = {
 
   }
+
+  override def prepareTable(): Unit = {
+    executeUpdate(
+      s"""CREATE SCHEMA $schema"""
+    )
+
+    executeUpdate(
+      s"""CREATE TABLE $schema.$tablePrefix
+         | (id INTEGER, st TEXT, num_col INT);""".stripMargin
+    )
+
+    executeUpdate(
+      s"""CREATE TABLE $schema.${tablePrefix}_coalesce
+         | (id INTEGER, col1 TEXT, col2 INT);""".stripMargin
+    )
+
+    executeUpdate(
+      s"""CREATE TABLE $schema.${tablePrefix}_string_test
+         | (id INTEGER, st TEXT, num_col INT);""".stripMargin
+    )
+
+    executeUpdate(
+      s"""CREATE TABLE $schema.${tablePrefix}_with_nulls
+         | (id INTEGER, st TEXT);""".stripMargin
+    )
+
+    executeUpdate(
+      s"""CREATE TABLE $schema.${tablePrefix}_numeric_test
+         | (id INTEGER,
+         | dec_col DECIMAL(10,2)
+         | );""".stripMargin
+    )
+  }
+
+  override protected def prepareData(): Unit = {
+
+    prepareTable()
+
+    executeUpdate(s"""INSERT INTO $schema.${tablePrefix}_coalesce VALUES (1, NULL, 1)""")
+    executeUpdate(s"""INSERT INTO $schema.${tablePrefix}_coalesce VALUES (2, '2', NULL)""")
+    executeUpdate(s"""INSERT INTO $schema.${tablePrefix}_coalesce VALUES (3, NULL, NULL)""")
+
+    executeUpdate(
+      s"""INSERT INTO $schema.${tablePrefix}_with_nulls VALUES (1, 'first')""")
+    executeUpdate(
+      s"""INSERT INTO $schema.${tablePrefix}_with_nulls VALUES (2, 'second')""")
+    executeUpdate(
+      s"""INSERT INTO $schema.${tablePrefix}_with_nulls VALUES (3, 'third')""")
+    executeUpdate(
+      s"""INSERT INTO $schema.${tablePrefix}_with_nulls VALUES (NULL, 'null')""")
+
+    executeUpdate(
+      s"""INSERT INTO $schema.${tablePrefix}_string_test VALUES (0, 'ab''', 1000)""")
+    executeUpdate(
+      s"""INSERT INTO $schema.${tablePrefix}_string_test VALUES (0, 'FiRs''T', 1000)""")
+    executeUpdate(
+      s"""INSERT INTO $schema.${tablePrefix}_string_test VALUES (0, 'sE Co nD', 1000)""")
+    executeUpdate(
+      s"""INSERT INTO $schema.${tablePrefix}_string_test VALUES (0, '   forth   ', 1000)""")
+
+    executeUpdate(s"""INSERT INTO $schema.$tablePrefix VALUES (1, 'ab', 1000)""")
+    executeUpdate(s"""INSERT INTO $schema.$tablePrefix VALUES (2, 'aba', NULL)""")
+    executeUpdate(s"""INSERT INTO $schema.$tablePrefix VALUES (3, 'abb', 800)""")
+    executeUpdate(s"""INSERT INTO $schema.$tablePrefix VALUES (4, 'abc', NULL)""")
+    executeUpdate(s"""INSERT INTO $schema.$tablePrefix VALUES (5, 'abd', 1200)""")
+    executeUpdate(s"""INSERT INTO $schema.$tablePrefix VALUES (6, 'abe', 1250)""")
+    executeUpdate(s"""INSERT INTO $schema.$tablePrefix VALUES (7, 'abf', 1200)""")
+    executeUpdate(s"""INSERT INTO $schema.$tablePrefix VALUES (8, 'abg', -1300)""")
+
+    executeUpdate(
+      s"""INSERT INTO $schema.${tablePrefix}_numeric_test VALUES (1, 42.42)""")
+  }
+
 }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
@@ -69,7 +69,8 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
     "scan with aggregate push-down: REGR_INTERCEPT with DISTINCT",
     "scan with aggregate push-down: REGR_SLOPE with DISTINCT",
     "scan with aggregate push-down: REGR_R2 with DISTINCT",
-    "scan with aggregate push-down: REGR_SXY with DISTINCT")
+    "scan with aggregate push-down: REGR_SXY with DISTINCT",
+    "column pruning with unsupported filter")
 
   override val catalogName: String = "oracle"
   override val namespaceOpt: Option[String] = Some("SYSTEM")

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresPushdownIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresPushdownIntegrationSuite.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.jdbc.v2
+
+import java.sql.Connection
+
+import test.scala.org.apache.spark.sql.jdbc.v2.V2JDBCPushdownTest
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
+import org.apache.spark.sql.jdbc.{DatabaseOnDocker, DockerJDBCIntegrationSuite}
+
+class PostgresPushdownIntegrationSuite
+  extends DockerJDBCIntegrationSuite
+    with V2JDBCPushdownTest {
+  override val db: DatabaseOnDocker = new DatabaseOnDocker {
+    override val imageName = sys.env.getOrElse("POSTGRES_DOCKER_IMAGE_NAME", "postgres:16.2-alpine")
+    override val env = Map(
+      "POSTGRES_PASSWORD" -> "rootpass"
+    )
+    override val usesIpc = false
+    override val jdbcPort = 5432
+
+    override def getJdbcUrl(ip: String, port: Int): String =
+      s"jdbc:postgresql://$ip:$port/postgres?user=postgres&password=rootpass"
+  }
+
+  override def sparkConf: SparkConf = super.sparkConf
+    .set("spark.sql.catalog.postgres", classOf[JDBCTableCatalog].getName)
+    .set("spark.sql.catalog.postgres.url", db.getJdbcUrl(dockerIp, externalPort))
+    .set("spark.sql.catalog.postgres.pushDownAggregate", "true")
+    .set("spark.sql.catalog.postgres.pushDownLimit", "true")
+
+  /**
+   * Prepare databases and tables for testing.
+   */
+  override def dataPreparation(connection: Connection): Unit = prepareData()
+
+  override protected val catalog: String = "postgres"
+  override protected val tablePrefix: String = "testtbl"
+  override protected val schema: String = "testschema"
+
+  override protected def executeUpdate(sql: String): Unit = {
+    getConnection().prepareStatement(sql).executeUpdate()
+  }
+
+  override protected def commonAssertionOnDataFrame(df: DataFrame): Unit = {
+
+  }
+
+  override def prepareTable(): Unit = {
+    executeUpdate(
+      s"""CREATE SCHEMA "$schema""""
+    )
+
+    executeUpdate(
+      s"""CREATE TABLE "$schema"."$tablePrefix"
+         | (id INTEGER, st TEXT, num_col INT);""".stripMargin
+    )
+
+    executeUpdate(
+      s"""CREATE TABLE "$schema"."${tablePrefix}_coalesce"
+         | (id INTEGER, col1 TEXT, col2 INT);""".stripMargin
+    )
+
+    executeUpdate(
+      s"""CREATE TABLE "$schema"."${tablePrefix}_string_test"
+         | (id INTEGER, st TEXT, num_col INT);""".stripMargin
+    )
+
+    executeUpdate(
+      s"""CREATE TABLE "$schema"."${tablePrefix}_with_nulls"
+         | (id INTEGER, st TEXT);""".stripMargin
+    )
+
+    executeUpdate(
+      s"""CREATE TABLE "$schema"."${tablePrefix}_numeric_test"
+         | (id INTEGER, dec DECIMAL(10, 2));""".stripMargin
+    )
+  }
+}

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresPushdownIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresPushdownIntegrationSuite.scala
@@ -19,12 +19,11 @@ package org.apache.spark.sql.jdbc.v2
 
 import java.sql.Connection
 
-import test.scala.org.apache.spark.sql.jdbc.v2.V2JDBCPushdownTest
-
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
 import org.apache.spark.sql.jdbc.{DatabaseOnDocker, DockerJDBCIntegrationSuite}
+import org.apache.spark.sql.jdbc.v2.V2JDBCPushdownTest
 
 class PostgresPushdownIntegrationSuite
   extends DockerJDBCIntegrationSuite

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresPushdownIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresPushdownIntegrationSuite.scala
@@ -91,7 +91,7 @@ class PostgresPushdownIntegrationSuite
 
     executeUpdate(
       s"""CREATE TABLE "$schema"."${tablePrefix}_numeric_test"
-         | (id INTEGER, dec DECIMAL(10, 2));""".stripMargin
+         | (id INTEGER, dec_col DECIMAL(10, 2));""".stripMargin
     )
   }
 }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCPushdownTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCPushdownTest.scala
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test.scala.org.apache.spark.sql.jdbc.v2
+
+import org.apache.spark.sql.{DataFrame, QueryTest, Row}
+import org.apache.spark.sql.execution.FilterExec
+import org.apache.spark.sql.jdbc.DockerIntegrationFunSuite
+import org.apache.spark.sql.test.SharedSparkSession
+import org.apache.spark.tags.DockerTest
+
+@DockerTest
+trait V2JDBCPushdownTest extends SharedSparkSession with DockerIntegrationFunSuite {
+  protected def isFilterRemoved(df: DataFrame): Boolean = {
+    df.queryExecution.sparkPlan.collectFirst {
+      case f: FilterExec => f
+    }.isEmpty
+  }
+
+  protected val catalog: String
+
+  protected val tablePrefix: String
+
+  protected val schema: String
+
+  protected def executeUpdate(sql: String): Unit
+
+  protected def commonAssertionOnDataFrame(df: DataFrame): Unit
+
+  protected def prepareTable(): Unit = {
+    executeUpdate(
+      s"""CREATE SCHEMA "$schema""""
+    )
+
+    executeUpdate(
+      s"""CREATE TABLE "$schema"."$tablePrefix"
+         | (id INTEGER, st STRING, random_col INT);""".stripMargin
+    )
+
+    executeUpdate(
+      s"""CREATE TABLE "$schema"."${tablePrefix}_coalesce"
+         | (id INTEGER, col1 VARCHAR(128), col2 INT);""".stripMargin
+    )
+
+    executeUpdate(
+      s"""CREATE TABLE "$schema"."${tablePrefix}_escape_test"
+         | (id INTEGER, st STRING, random_col INT);""".stripMargin
+    )
+
+    executeUpdate(
+      s"""CREATE TABLE "$schema"."${tablePrefix}_with_nulls"
+         | (id INTEGER, st STRING);""".stripMargin
+    )
+  }
+
+  protected def prepareData(): Unit = {
+
+    prepareTable()
+
+    executeUpdate(s"""INSERT INTO "$schema"."${tablePrefix}_coalesce" VALUES (1, NULL, 1)""")
+    executeUpdate(s"""INSERT INTO "$schema"."${tablePrefix}_coalesce" VALUES (2, '2', NULL)""")
+    executeUpdate(s"""INSERT INTO "$schema"."${tablePrefix}_coalesce" VALUES (3, NULL, NULL)""")
+
+    executeUpdate(
+      s"""INSERT INTO "$schema"."${tablePrefix}_with_nulls" VALUES (1, 'first')""")
+    executeUpdate(
+      s"""INSERT INTO "$schema"."${tablePrefix}_with_nulls" VALUES (2, 'second')""")
+    executeUpdate(
+      s"""INSERT INTO "$schema"."${tablePrefix}_with_nulls" VALUES (3, 'third')""")
+    executeUpdate(
+      s"""INSERT INTO "$schema"."${tablePrefix}_with_nulls" VALUES (NULL, 'null')""")
+
+    executeUpdate(
+      s"""INSERT INTO "$schema"."${tablePrefix}_escape_test" VALUES (0, 'ab''', 1000)""")
+
+    executeUpdate(s"""INSERT INTO "$schema"."$tablePrefix" VALUES (1, 'ab', 1000)""")
+    executeUpdate(s"""INSERT INTO "$schema"."$tablePrefix" VALUES (2, 'aba', 900)""")
+    executeUpdate(s"""INSERT INTO "$schema"."$tablePrefix" VALUES (3, 'abb', 800)""")
+    executeUpdate(s"""INSERT INTO "$schema"."$tablePrefix" VALUES (4, 'abc', 1100)""")
+    executeUpdate(s"""INSERT INTO "$schema"."$tablePrefix" VALUES (5, 'abd', 1200)""")
+    executeUpdate(s"""INSERT INTO "$schema"."$tablePrefix" VALUES (6, 'abe', 1250)""")
+    executeUpdate(s"""INSERT INTO "$schema"."$tablePrefix" VALUES (7, 'abf', 1200)""")
+  }
+
+  protected def checkAnswer(df: DataFrame, expectedAnswer: Seq[Row]): Unit =
+    QueryTest.checkAnswer(df, expectedAnswer)
+
+  protected def checkAnswer(df: DataFrame, expectedAnswer: Row): Unit =
+    QueryTest.checkAnswer(df, Seq(expectedAnswer))
+
+  protected def cleanData(): Unit = {
+    executeUpdate(s"""DROP TABLE IF EXISTS "$schema"."$tablePrefix"""")
+    executeUpdate(s"""DROP TABLE IF EXISTS "$schema"."${tablePrefix}_escape_test"""")
+    executeUpdate(s"""DROP TABLE IF EXISTS "$schema"."${tablePrefix}_with_nulls"""")
+    executeUpdate(s"""DROP SCHEMA IF EXISTS "$schema"""")
+  }
+
+  test("String escaping test") {
+    val df = sql(
+      s"SELECT 'ab\\'', st " +
+        s"FROM `$catalog`.`$schema`.`${tablePrefix}_escape_test` where st = 'ab\\''")
+    checkAnswer(df, Row("ab'", "ab'"))
+    assert(isFilterRemoved(df))
+    commonAssertionOnDataFrame(df)
+  }
+
+  test("boolean AND and OR predicate") {
+    val df = sql(
+      s"SELECT id FROM `$catalog`.`$schema`.`$tablePrefix` where (id > 1 AND id < 4) OR id = 7"
+    )
+    checkAnswer(df, Seq(Row(2), Row(3), Row(7)))
+    assert(isFilterRemoved(df))
+    commonAssertionOnDataFrame(df)
+  }
+
+  test("in predicate getting pushed down") {
+    // even mix types, we expect spark to insert casts
+    val df =
+      sql(s"SELECT * FROM `$catalog`.`$schema`.`${tablePrefix}_with_nulls` " +
+        s"where id in (1, '2', NULL)")
+
+    // we do not expect NULL equality to work in IN
+    checkAnswer(df, Seq(Row(1, "first"), Row(2, "second")))
+    assert(isFilterRemoved(df))
+    commonAssertionOnDataFrame(df)
+
+    val df2 =
+      sql(s"SELECT * FROM `$catalog`.`$schema`.`${tablePrefix}_with_nulls` " +
+        s"where NOT id in (1, '2')")
+
+    // we do not expect NULL equality to work in IN
+    checkAnswer(df2, Seq(Row(3, "third")))
+    assert(isFilterRemoved(df2))
+    commonAssertionOnDataFrame(df2)
+  }
+
+  test("case when in predicate and IIF") {
+      val df = sql(
+        s"""SELECT id FROM `$catalog`.`$schema`.`$tablePrefix` WHERE
+           |CASE WHEN id = 3 THEN 2 ELSE 3 END = 2""".stripMargin)
+      checkAnswer(df, Seq(Row(3)))
+      assert(isFilterRemoved(df))
+      commonAssertionOnDataFrame(df)
+
+      val df2 = sql(
+        s"""SELECT id FROM `$catalog`.`$schema`.`$tablePrefix` WHERE
+           |CASE WHEN id = 3 THEN 2 ELSE 3 END = 2""".stripMargin)
+      checkAnswer(df2, Seq(Row(3)))
+      assert(isFilterRemoved(df2))
+      commonAssertionOnDataFrame(df2)
+
+      val df3 = sql(
+        s"""SELECT id FROM `$catalog`.`$schema`.`$tablePrefix` WHERE
+           |IFF(id = 3, 2, 0) = 2""".stripMargin)
+      checkAnswer(df3, Seq(Row(3)))
+      assert(isFilterRemoved(df3))
+      commonAssertionOnDataFrame(df3)
+  }
+
+  test("coalesce") {
+    withSQLConf("spark.sql.ansi.enabled" -> "true") {
+      val cases = Seq(
+        "COALESCE(col1, col2) = 1" -> Seq(Row(1)),
+        "COALESCE(col1, col2) = 2" -> Seq(Row(2)),
+        "COALESCE(col1, col2) IS NULL" -> Seq(Row(3)),
+        "COALESCE(col1, col2) IS NOT NULL" -> Seq(Row(1), Row(2))
+      )
+
+      cases.foreach({ case (predicate, expected) =>
+        val df =
+          sql(s"SELECT id FROM `$catalog`.`$schema`.`${tablePrefix}_coalesce` WHERE $predicate")
+        checkAnswer(df, expected)
+        assert(isFilterRemoved(df))
+        commonAssertionOnDataFrame(df)
+      })
+    }
+  }
+
+  test("unary minus") {
+    withSQLConf("spark.sql.ansi.enabled" -> "true") {
+      val df = sql(
+        s"""SELECT id FROM `$catalog`.`$schema`.`$tablePrefix` WHERE
+           |WHERE -id=3""".stripMargin)
+      checkAnswer(df, Seq.empty)
+      assert(isFilterRemoved(df))
+      commonAssertionOnDataFrame(df)
+    }
+  }
+
+  test("not predicate getting pushed down") {
+    val df = sql(s"SELECT id FROM `$catalog`.`$schema`.`$tablePrefix` where NOT id = 1")
+    checkAnswer(df, (2 to 7).map(Row(_)))
+    assert(isFilterRemoved(df))
+    commonAssertionOnDataFrame(df)
+  }
+
+  test("null predicate") {
+    val df =
+      sql(s"SELECT * FROM `$catalog`.`$schema`.`${tablePrefix}_with_nulls` where id is NULL")
+    checkAnswer(df, Row(null, "null"))
+    assert(isFilterRemoved(df))
+    commonAssertionOnDataFrame(df)
+
+    val df2 = sql(
+      s"SELECT id FROM `$catalog`.`$schema`.`${tablePrefix}_with_nulls` where id is not NULL")
+    checkAnswer(df2, Seq(Row(1), Row(2), Row(3)))
+    assert(isFilterRemoved(df2))
+    commonAssertionOnDataFrame(df2)
+  }
+
+}

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCPushdownTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCPushdownTest.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package test.scala.org.apache.spark.sql.jdbc.v2
+package org.apache.spark.sql.jdbc.v2
 
 import scala.collection.immutable.Seq
 

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCPushdownTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCPushdownTest.scala
@@ -325,4 +325,13 @@ trait V2JDBCPushdownTest extends SharedSparkSession with DockerIntegrationFunSui
     assert(isAggregateRemoved(df))
     commonAssertionOnDataFrame(df)
   }
+
+  test("COUNT aggregate push down") {
+    val df = sql(
+      s"SELECT COUNT(num_col) " +
+        s"FROM `$catalog`.`$schema`.`$tablePrefix`")
+    checkAnswer(df, Row(6))
+    assert(isAggregateRemoved(df))
+    commonAssertionOnDataFrame(df)
+  }
 }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCPushdownTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCPushdownTest.scala
@@ -23,9 +23,7 @@ import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LocalLimit}
 import org.apache.spark.sql.execution.FilterExec
 import org.apache.spark.sql.test.SharedSparkSession
-import org.apache.spark.tags.DockerTest
 
-@DockerTest
 trait V2JDBCPushdownTest extends SharedSparkSession {
   protected def isFilterRemoved(df: DataFrame): Boolean = {
     df.queryExecution.sparkPlan.collectFirst {

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCPushdownTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCPushdownTest.scala
@@ -281,6 +281,13 @@ trait V2JDBCPushdownTest extends SharedSparkSession {
     checkAnswer(df, Row("   forth   "))
     assert(isFilterRemoved(df))
     commonAssertionOnDataFrame(df)
+
+    val df2 = sql(
+      s"SELECT st " +
+        s"FROM `$catalog`.`$schema`.`${tablePrefix}_string_test` where length(id) = 1")
+    assert(df2.collect().length == 4)
+    assert(isFilterRemoved(df2))
+    commonAssertionOnDataFrame(df2)
   }
 
   test("ABS predicate push down") {

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCPushdownTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCPushdownTest.scala
@@ -75,7 +75,7 @@ trait V2JDBCPushdownTest extends SharedSparkSession with DockerIntegrationFunSui
 
     executeUpdate(
       s"""CREATE TABLE "$schema"."${tablePrefix}_numeric_test"
-         | (id INTEGER, dec DECIMAL(10, 2));""".stripMargin
+         | (id INTEGER, dec_col DECIMAL(10, 2));""".stripMargin
     )
   }
 
@@ -288,7 +288,7 @@ trait V2JDBCPushdownTest extends SharedSparkSession with DockerIntegrationFunSui
   test("FLOOR predicate push down") {
     val df = sql(
       s"SELECT id " +
-        s"FROM `$catalog`.`$schema`.`${tablePrefix}_numeric_test` where floor(dec) = 42")
+        s"FROM `$catalog`.`$schema`.`${tablePrefix}_numeric_test` where floor(dec_col) = 42")
     checkAnswer(df, Row(1))
     assert(isFilterRemoved(df))
     commonAssertionOnDataFrame(df)

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCPushdownTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCPushdownTest.scala
@@ -170,27 +170,20 @@ trait V2JDBCPushdownTest extends SharedSparkSession with DockerIntegrationFunSui
     commonAssertionOnDataFrame(df2)
   }
 
-  test("case when in predicate and IIF push down") {
-      val df = sql(
-        s"""SELECT id FROM `$catalog`.`$schema`.`$tablePrefix` WHERE
-           |CASE WHEN id = 3 THEN 2 ELSE 3 END = 2""".stripMargin)
-      checkAnswer(df, Seq(Row(3)))
-      assert(isFilterRemoved(df))
-      commonAssertionOnDataFrame(df)
+  test("case when in predicate push down") {
+    val df = sql(
+      s"""SELECT id FROM `$catalog`.`$schema`.`$tablePrefix` WHERE
+         |CASE WHEN id = 3 THEN true ELSE false END""".stripMargin)
+    checkAnswer(df, Seq(Row(3)))
+    assert(isFilterRemoved(df))
+    commonAssertionOnDataFrame(df)
 
-      val df2 = sql(
-        s"""SELECT id FROM `$catalog`.`$schema`.`$tablePrefix` WHERE
-           |CASE WHEN id = 3 THEN 2 ELSE 3 END = 2""".stripMargin)
-      checkAnswer(df2, Seq(Row(3)))
-      assert(isFilterRemoved(df2))
-      commonAssertionOnDataFrame(df2)
-
-      val df3 = sql(
-        s"""SELECT id FROM `$catalog`.`$schema`.`$tablePrefix` WHERE
-           |IFF(id = 3, 2, 0) = 2""".stripMargin)
-      checkAnswer(df3, Seq(Row(3)))
-      assert(isFilterRemoved(df3))
-      commonAssertionOnDataFrame(df3)
+    val df2 = sql(
+      s"""SELECT id FROM `$catalog`.`$schema`.`$tablePrefix` WHERE
+         |CASE WHEN id = 3 THEN 2 ELSE 3 END = 2""".stripMargin)
+    checkAnswer(df2, Seq(Row(3)))
+    assert(isFilterRemoved(df2))
+    commonAssertionOnDataFrame(df2)
   }
 
   test("coalesce predicate push down") {

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCPushdownTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCPushdownTest.scala
@@ -22,12 +22,11 @@ import scala.collection.immutable.Seq
 import org.apache.spark.sql.{DataFrame, QueryTest, Row}
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LocalLimit}
 import org.apache.spark.sql.execution.FilterExec
-import org.apache.spark.sql.jdbc.DockerIntegrationFunSuite
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.tags.DockerTest
 
 @DockerTest
-trait V2JDBCPushdownTest extends SharedSparkSession with DockerIntegrationFunSuite {
+trait V2JDBCPushdownTest extends SharedSparkSession {
   protected def isFilterRemoved(df: DataFrame): Boolean = {
     df.queryExecution.sparkPlan.collectFirst {
       case f: FilterExec => f
@@ -340,7 +339,7 @@ trait V2JDBCPushdownTest extends SharedSparkSession with DockerIntegrationFunSui
     val df = sql(
       s"SELECT id " +
         s"FROM `$catalog`.`$schema`.`$tablePrefix` " +
-        s"ORDER BY num_col NULLS FIRST " +
+        s"ORDER BY num_col NULLS FIRST, id " +
         s"LIMIT 2 "
     )
     checkAnswer(df, Seq(Row(2), Row(4)))
@@ -350,7 +349,7 @@ trait V2JDBCPushdownTest extends SharedSparkSession with DockerIntegrationFunSui
     val df2 = sql(
       s"SELECT id " +
         s"FROM `$catalog`.`$schema`.`$tablePrefix` " +
-        s"ORDER BY num_col NULLS LAST " +
+        s"ORDER BY num_col NULLS LAST, id " +
         s"LIMIT 2 "
     )
     checkAnswer(df2, Seq(Row(8), Row(3)))
@@ -360,7 +359,7 @@ trait V2JDBCPushdownTest extends SharedSparkSession with DockerIntegrationFunSui
     val df3 = sql(
       s"SELECT id " +
         s"FROM `$catalog`.`$schema`.`$tablePrefix` " +
-        s"ORDER BY num_col DESC NULLS FIRST " +
+        s"ORDER BY num_col DESC NULLS FIRST, id " +
         s"LIMIT 2 "
     )
     checkAnswer(df3, Seq(Row(2), Row(4)))
@@ -370,7 +369,7 @@ trait V2JDBCPushdownTest extends SharedSparkSession with DockerIntegrationFunSui
     val df4 = sql(
       s"SELECT id " +
         s"FROM `$catalog`.`$schema`.`$tablePrefix` " +
-        s"ORDER BY num_col DESC NULLS LAST " +
+        s"ORDER BY num_col DESC NULLS LAST, id " +
         s"LIMIT 2 "
     )
     checkAnswer(df4, Seq(Row(6), Row(5)))

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCPushdownTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCPushdownTest.scala
@@ -316,4 +316,13 @@ trait V2JDBCPushdownTest extends SharedSparkSession with DockerIntegrationFunSui
     assert(isAggregateRemoved(df2))
     commonAssertionOnDataFrame(df2)
   }
+
+  test("AVG aggregate push down") {
+    val df = sql(
+      s"SELECT AVG(id) " +
+        s"FROM `$catalog`.`$schema`.`$tablePrefix`")
+    checkAnswer(df, Row(4.5))
+    assert(isAggregateRemoved(df))
+    commonAssertionOnDataFrame(df)
+  }
 }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -359,6 +359,12 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
     assert(scan.schema.names.sameElements(Seq(col)))
   }
 
+  test("column pruning with unsupported filter") {
+    val df = sql(s"SELECT url_decode(name) FROM $catalogAndNamespace." +
+      s"${caseConvert("employee")}")
+    checkColumnPruned(df, "name")
+  }
+
   test("SPARK-37038: Test TABLESAMPLE") {
     if (supportsTableSample) {
       withTable(s"$catalogName.new_table") {

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/V2JDBCTest.scala
@@ -363,6 +363,7 @@ private[v2] trait V2JDBCTest extends SharedSparkSession with DockerIntegrationFu
     val df = sql(s"SELECT url_decode(name) FROM $catalogAndNamespace." +
       s"${caseConvert("employee")}")
     checkColumnPruned(df, "name")
+  }
 
   test("SPARK-48172: Test CONTAINS") {
     val df1 = spark.sql(

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -167,7 +167,7 @@ private case class MsSqlServerDialect() extends JdbcDialect {
     case ByteType => Some(JdbcType("SMALLINT", java.sql.Types.TINYINT))
     case LongType => Some(JdbcType("BIGINT", java.sql.Types.BIGINT))
     case DoubleType => Some(JdbcType("FLOAT", java.sql.Types.FLOAT))
-    case _ => JdbcUtils.getCommonJDBCType(dt)
+    case _ => _
   }
 
   override def isCascadingTruncateTable(): Option[Boolean] = Some(false)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -53,7 +53,7 @@ private case class MsSqlServerDialect() extends JdbcDialect {
   // scalastyle:on line.size.limit
   private val supportedAggregateFunctions = Set("MAX", "MIN", "SUM", "COUNT", "AVG",
     "VAR_POP", "VAR_SAMP", "STDDEV_POP", "STDDEV_SAMP")
-  private val supportedStringFunctions = Set("UPPER", "LOWER", "SUBSTRING", "TRANSLATE")
+  private val supportedStringFunctions = Set("UPPER", "LOWER", "TRANSLATE")
   private val supportedMathFunctions = Set("SIN", "COS", "ABS")
   private val supportedSqlFunctions = Set("COALESCE")
   private val supportedFunctions =
@@ -86,14 +86,6 @@ private case class MsSqlServerDialect() extends JdbcDialect {
       case "STDDEV_POP" => "STDEVP"
       case "STDDEV_SAMP" => "STDEV"
       case _ => super.dialectFunctionName(funcName)
-    }
-
-    override def visitSQLFunction(funcName: String, inputs: Array[String]): String
-    = funcName match {
-      case "SUBSTRING" if inputs.length < 3 =>
-        super.visitSQLFunction(funcName, inputs :+ inputs(0).length.toString)
-      case _ =>
-        super.visitSQLFunction(funcName, inputs)
     }
 
     override def build(expr: Expression): String = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -53,7 +53,7 @@ private case class MsSqlServerDialect() extends JdbcDialect {
   // scalastyle:on line.size.limit
   private val supportedAggregateFunctions = Set("MAX", "MIN", "SUM", "COUNT", "AVG",
     "VAR_POP", "VAR_SAMP", "STDDEV_POP", "STDDEV_SAMP")
-  private val supportedStringFunctions = Set("UPPER", "LOWER", "TRANSLATE")
+  private val supportedStringFunctions = Set("UPPER", "LOWER", "TRANSLATE", "CHAR_LENGTH")
   private val supportedMathFunctions = Set("SIN", "COS", "ABS")
   private val supportedSqlFunctions = Set("COALESCE")
   private val supportedFunctions =
@@ -85,6 +85,7 @@ private case class MsSqlServerDialect() extends JdbcDialect {
       case "VAR_SAMP" => "VAR"
       case "STDDEV_POP" => "STDEVP"
       case "STDDEV_SAMP" => "STDEV"
+      case "CHAR_LENGTH" => "DATALENGTH"
       case _ => super.dialectFunctionName(funcName)
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.connector.expressions.{Cast, Expression, NullOrderin
 import org.apache.spark.sql.connector.expressions.aggregate.Avg
 import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
+import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JdbcUtils}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.jdbc.MsSqlServerDialect.{GEOGRAPHY, GEOMETRY}
 import org.apache.spark.sql.types._
@@ -167,7 +167,7 @@ private case class MsSqlServerDialect() extends JdbcDialect {
     case ByteType => Some(JdbcType("SMALLINT", java.sql.Types.TINYINT))
     case LongType => Some(JdbcType("BIGINT", java.sql.Types.BIGINT))
     case DoubleType => Some(JdbcType("FLOAT", java.sql.Types.FLOAT))
-    case _ => None
+    case _ => JdbcUtils.getCommonJDBCType(dt)
   }
 
   override def isCascadingTruncateTable(): Option[Boolean] = Some(false)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.connector.expressions.{Cast, Expression, NullOrderin
 import org.apache.spark.sql.connector.expressions.aggregate.Avg
 import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
+import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JdbcUtils}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.jdbc.MsSqlServerDialect.{GEOGRAPHY, GEOMETRY}
 import org.apache.spark.sql.types._
@@ -54,7 +54,7 @@ private case class MsSqlServerDialect() extends JdbcDialect {
   // scalastyle:on line.size.limit
   private val supportedAggregateFunctions = Set("MAX", "MIN", "SUM", "COUNT", "AVG",
     "VAR_POP", "VAR_SAMP", "STDDEV_POP", "STDDEV_SAMP")
-  private val supportedStringFunctions = Set("UPPER", "LOWER", "CHAR_LENGTH")
+  private val supportedStringFunctions = Set("UPPER", "LOWER")
   private val supportedMathFunctions = Set("SIN", "COS", "ABS", "FLOOR")
   private val supportedSqlFunctions = Set("COALESCE")
   private val supportedFunctions =
@@ -86,7 +86,6 @@ private case class MsSqlServerDialect() extends JdbcDialect {
       case "VAR_SAMP" => "VAR"
       case "STDDEV_POP" => "STDEVP"
       case "STDDEV_SAMP" => "STDEV"
-      case "CHAR_LENGTH" => "DATALENGTH"
       case _ => super.dialectFunctionName(funcName)
     }
 
@@ -163,6 +162,7 @@ private case class MsSqlServerDialect() extends JdbcDialect {
     case ByteType => Some(JdbcType("SMALLINT", java.sql.Types.TINYINT))
     case LongType => Some(JdbcType("BIGINT", java.sql.Types.BIGINT))
     case DoubleType => Some(JdbcType("FLOAT", java.sql.Types.FLOAT))
+    case _ if !SQLConf.get.legacyMsSqlServerNumericMappingEnabled => JdbcUtils.getCommonJDBCType(dt)
     case _ => None
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.connector.expressions.{Cast, Expression, NullOrderin
 import org.apache.spark.sql.connector.expressions.aggregate.Avg
 import org.apache.spark.sql.connector.expressions.filter.Predicate
 import org.apache.spark.sql.errors.QueryExecutionErrors
-import org.apache.spark.sql.execution.datasources.jdbc.{JDBCOptions, JdbcUtils}
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.jdbc.MsSqlServerDialect.{GEOGRAPHY, GEOMETRY}
 import org.apache.spark.sql.types._

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -66,10 +66,6 @@ private case class MsSqlServerDialect() extends JdbcDialect {
   override def isSupportedFunction(funcName: String): Boolean =
     supportedFunctions.contains(funcName)
 
-  override def quoteIdentifier(colName: String): String = {
-    s"[$colName]"
-  }
-
   class MsSqlServerSQLBuilder extends JDBCSQLBuilder {
     override def visitSortOrder(
         sortKey: String, sortDirection: SortDirection, nullOrdering: NullOrdering): String = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -167,7 +167,7 @@ private case class MsSqlServerDialect() extends JdbcDialect {
     case ByteType => Some(JdbcType("SMALLINT", java.sql.Types.TINYINT))
     case LongType => Some(JdbcType("BIGINT", java.sql.Types.BIGINT))
     case DoubleType => Some(JdbcType("FLOAT", java.sql.Types.FLOAT))
-    case _ => _
+    case _ => None
   }
 
   override def isCascadingTruncateTable(): Option[Boolean] = Some(false)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -53,7 +53,7 @@ private case class MsSqlServerDialect() extends JdbcDialect {
   // scalastyle:on line.size.limit
   private val supportedAggregateFunctions = Set("MAX", "MIN", "SUM", "COUNT", "AVG",
     "VAR_POP", "VAR_SAMP", "STDDEV_POP", "STDDEV_SAMP")
-  private val supportedStringFunctions = Set("UPPER", "LOWER", "TRANSLATE", "CHAR_LENGTH")
+  private val supportedStringFunctions = Set("UPPER", "LOWER", "CHAR_LENGTH")
   private val supportedMathFunctions = Set("SIN", "COS", "ABS", "FLOOR")
   private val supportedSqlFunctions = Set("COALESCE")
   private val supportedFunctions =

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/MsSqlServerDialect.scala
@@ -54,7 +54,7 @@ private case class MsSqlServerDialect() extends JdbcDialect {
   private val supportedAggregateFunctions = Set("MAX", "MIN", "SUM", "COUNT", "AVG",
     "VAR_POP", "VAR_SAMP", "STDDEV_POP", "STDDEV_SAMP")
   private val supportedStringFunctions = Set("UPPER", "LOWER", "TRANSLATE", "CHAR_LENGTH")
-  private val supportedMathFunctions = Set("SIN", "COS", "ABS")
+  private val supportedMathFunctions = Set("SIN", "COS", "ABS", "FLOOR")
   private val supportedSqlFunctions = Set("COALESCE")
   private val supportedFunctions =
     supportedAggregateFunctions ++

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -163,7 +163,7 @@ private case class PostgresDialect() extends JdbcDialect with SQLConfHelper {
         .orElse(JdbcUtils.getCommonJDBCType(et).map(_.databaseTypeDefinition))
         .map(typeName => JdbcType(s"$typeName[]", java.sql.Types.ARRAY))
     case LongType => Some(JdbcType("BIGINT", Types.BIGINT))
-    case _ => _
+    case _ => None
   }
 
   override def isCascadingTruncateTable(): Option[Boolean] = Some(false)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -163,7 +163,7 @@ private case class PostgresDialect() extends JdbcDialect with SQLConfHelper {
         .orElse(JdbcUtils.getCommonJDBCType(et).map(_.databaseTypeDefinition))
         .map(typeName => JdbcType(s"$typeName[]", java.sql.Types.ARRAY))
     case LongType => Some(JdbcType("BIGINT", Types.BIGINT))
-    case _ => None
+    case _ => JdbcUtils.getCommonJDBCType(dt)
   }
 
   override def isCascadingTruncateTable(): Option[Boolean] = Some(false)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -46,7 +46,14 @@ private case class PostgresDialect() extends JdbcDialect with SQLConfHelper {
   private val supportedAggregateFunctions = Set("MAX", "MIN", "SUM", "COUNT", "AVG",
     "VAR_POP", "VAR_SAMP", "STDDEV_POP", "STDDEV_SAMP", "COVAR_POP", "COVAR_SAMP", "CORR",
     "REGR_INTERCEPT", "REGR_R2", "REGR_SLOPE", "REGR_SXY")
-  private val supportedFunctions = supportedAggregateFunctions
+  private val supportedStringFunctions = Set("UPPER", "LOWER", "CHAR_LENGTH")
+  private val supportedMathFunctions = Set("SIN", "COS", "ABS", "FLOOR")
+  private val supportedSqlFunctions = Set("COALESCE")
+  private val supportedFunctions =
+    supportedAggregateFunctions ++
+      supportedStringFunctions ++
+      supportedMathFunctions ++
+      supportedSqlFunctions
 
   override def isSupportedFunction(funcName: String): Boolean =
     supportedFunctions.contains(funcName)
@@ -155,6 +162,7 @@ private case class PostgresDialect() extends JdbcDialect with SQLConfHelper {
       getJDBCType(et).map(_.databaseTypeDefinition)
         .orElse(JdbcUtils.getCommonJDBCType(et).map(_.databaseTypeDefinition))
         .map(typeName => JdbcType(s"$typeName[]", java.sql.Types.ARRAY))
+    case LongType => Some(JdbcType("BIGINT", Types.BIGINT))
     case _ => None
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -163,7 +163,7 @@ private case class PostgresDialect() extends JdbcDialect with SQLConfHelper {
         .orElse(JdbcUtils.getCommonJDBCType(et).map(_.databaseTypeDefinition))
         .map(typeName => JdbcType(s"$typeName[]", java.sql.Types.ARRAY))
     case LongType => Some(JdbcType("BIGINT", Types.BIGINT))
-    case _ => JdbcUtils.getCommonJDBCType(dt)
+    case _ => _
   }
 
   override def isCascadingTruncateTable(): Option[Boolean] = Some(false)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
In this PR, I add a new trait with tests for integration testing of JDBC connectors. Also, I propose changes to `MsSqlServerDialect` to support more filter push downs.


### Why are the changes needed?
These changes are needed for better testing of JDBC connectors and general improvements of push down capabilities.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
With added tests.


### Was this patch authored or co-authored using generative AI tooling?
No
