### PR TITLE
[SPARK-44838][SQL][FOLLOW-UP] Fix the test for raise_error by using default type for strings

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -969,6 +969,8 @@ object TypeCoercion extends TypeCoercionBase {
     // Note that ret is nullable to avoid typing a lot of Some(...) in this local scope.
     // We wrap immediately an Option after this.
     @Nullable val ret: DataType = (inType, expectedType) match {
+      case (_: StringType, _: StringType) => expectedType.defaultConcreteType
+
       // If the expected type is already a parent of the input type, no need to cast.
       case _ if expectedType.acceptsType(inType) => inType
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -969,8 +969,6 @@ object TypeCoercion extends TypeCoercionBase {
     // Note that ret is nullable to avoid typing a lot of Some(...) in this local scope.
     // We wrap immediately an Option after this.
     @Nullable val ret: DataType = (inType, expectedType) match {
-      case (_: StringType, _: StringType) => expectedType.defaultConcreteType
-
       // If the expected type is already a parent of the input type, no need to cast.
       case _ if expectedType.acceptsType(inType) => inType
 
@@ -1049,6 +1047,9 @@ object TypeCoercion extends TypeCoercionBase {
             null
           }
         }
+
+      // Allows the cast between different collated strings to match with ANSI behavior.
+      case (_: StringType, _: StringType) => expectedType.defaultConcreteType
 
       case _ => null
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.util.{MapData, RandomUUIDGenerator}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.errors.QueryExecutionErrors.raiseError
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.types.StringTypeAnyCollation
+import org.apache.spark.sql.internal.types.{AbstractMapType, StringTypeAnyCollation}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -85,7 +85,7 @@ case class RaiseError(errorClass: Expression, errorParms: Expression, dataType: 
   override def foldable: Boolean = false
   override def nullable: Boolean = true
   override def inputTypes: Seq[AbstractDataType] =
-    Seq(StringTypeAnyCollation, MapType(StringType, StringType))
+    Seq(StringTypeAnyCollation, AbstractMapType(StringTypeAnyCollation, StringTypeAnyCollation))
 
   override def left: Expression = errorClass
   override def right: Expression = errorParms

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.util.{MapData, RandomUUIDGenerator}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.errors.QueryExecutionErrors.raiseError
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.types.{AbstractMapType, StringTypeAnyCollation}
+import org.apache.spark.sql.internal.types.StringTypeAnyCollation
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -85,7 +85,7 @@ case class RaiseError(errorClass: Expression, errorParms: Expression, dataType: 
   override def foldable: Boolean = false
   override def nullable: Boolean = true
   override def inputTypes: Seq[AbstractDataType] =
-    Seq(StringTypeAnyCollation, AbstractMapType(StringTypeAnyCollation, StringTypeAnyCollation))
+    Seq(StringTypeAnyCollation, MapType(StringType, StringType))
 
   override def left: Expression = errorClass
   override def right: Expression = errorParms


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/46461 that fixes the CI failure when ANSI is off:

```
[info] - Support RaiseError misc expression with collation *** FAILED *** (21 milliseconds)
[info]   Expected exception org.apache.spark.SparkRuntimeException to be thrown, but org.apache.spark.sql.catalyst.ExtendedAnalysisException was thrown (CollationSQLExpressionsSuite.scala:991)
[info]   org.scalatest.exceptions.TestFailedException:
[info]   at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
[info]   at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:471)
[info]   at org.scalatest.funsuite.AnyFunSuite.newAssertionFailedException(AnyFunSuite.scala:1564)
[info]   at org.scalatest.Assertions.intercept(Assertions.scala:756)
[info]   at org.scalatest.Assertions.intercept$(Assertions.scala:746)
[info]   at org.scalatest.funsuite.AnyFunSuite.intercept(AnyFunSuite.scala:1564)
[info]   at org.apache.spark.sql.CollationSQLExpressionsSuite.$anonfun$new$124(CollationSQLExpressionsSuite.scala:991)
[info]   at org.apache.spark.sql.catalyst.SQLConfHelper.withSQLConf(SQLConfHelper.scala:56)
[info]   at org.apache.spark.sql.catalyst.SQLConfHelper.withSQLConf$(SQLConfHelper.scala:38)
[info]   at org.apache.spark.sql.CollationSQLExpressionsSuite.org$apache$spark$sql$test$SQLTestUtilsBase$$super$withSQLConf(CollationSQLExpressionsSuite.scala:30)
[info]   at org.apache.spark.sql.test.SQLTestUtilsBase.withSQLConf(SQLTestUtils.scala:248)
[info]   at org.apache.spark.sql.test.SQLTestUtilsBase.withSQLConf$(SQLTestUtils.scala:246)
[info]   at org.apache.spark.sql.CollationSQLExpressionsSuite.withSQLConf(CollationSQLExpressionsSuite.scala:30)
[info]   at org.apache.spark.sql.CollationSQLExpressionsSuite.$anonfun$new$123(CollationSQLExpressionsSuite.scala:988)
[info]   at scala.collection.immutable.List.foreach(List.scala:334)
[info]   at org.apache.spark.sql.CollationSQLExpressionsSuite.$anonfun$new$122(CollationSQLExpressionsSuite.scala:987)
```

### Why are the changes needed?

CI is broken https://github.com/apache/spark/actions/runs/9136253329

### Does this PR introduce _any_ user-facing change?

No, the main change has not been released out.

### How was this patch tested?

Manually ran the test with ANSI disabled.

### Was this patch authored or co-authored using generative AI tooling?

No.
