### PR TITLE
[SPARK-48330][SS][PYTHON] Fix the python streaming data source timeout issue for large trigger interval

### DIFF
--- a/python/pyspark/sql/streaming/python_streaming_source_runner.py
+++ b/python/pyspark/sql/streaming/python_streaming_source_runner.py
@@ -210,7 +210,8 @@ if __name__ == "__main__":
     # Read information about how to connect back to the JVM from the environment.
     java_port = int(os.environ["PYTHON_WORKER_FACTORY_PORT"])
     auth_secret = os.environ["PYTHON_WORKER_FACTORY_SECRET"]
-    (sock_file, _) = local_connect_and_auth(java_port, auth_secret)
+    (sock_file, sock) = local_connect_and_auth(java_port, auth_secret)
+    sock.settimeout(None)
     write_int(os.getpid(), sock_file)
     sock_file.flush()
     main(sock_file, sock_file)

--- a/python/pyspark/sql/streaming/python_streaming_source_runner.py
+++ b/python/pyspark/sql/streaming/python_streaming_source_runner.py
@@ -211,6 +211,7 @@ if __name__ == "__main__":
     java_port = int(os.environ["PYTHON_WORKER_FACTORY_PORT"])
     auth_secret = os.environ["PYTHON_WORKER_FACTORY_SECRET"]
     (sock_file, sock) = local_connect_and_auth(java_port, auth_secret)
+    # Prevent the socket from timeout error when query trigger interval is large.
     sock.settimeout(None)
     write_int(os.getpid(), sock_file)
     sock_file.flush()

--- a/python/pyspark/sql/worker/python_streaming_sink_runner.py
+++ b/python/pyspark/sql/worker/python_streaming_sink_runner.py
@@ -20,7 +20,7 @@ import sys
 from typing import IO
 
 from pyspark.accumulators import _accumulatorRegistry
-from pyspark.errors import PySparkAssertionError
+from pyspark.errors import PySparkAssertionError, PySparkRuntimeError
 from pyspark.serializers import (
     read_bool,
     read_int,

--- a/python/pyspark/sql/worker/python_streaming_sink_runner.py
+++ b/python/pyspark/sql/worker/python_streaming_sink_runner.py
@@ -14,18 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 import os
 import sys
 from typing import IO
 
 from pyspark.accumulators import _accumulatorRegistry
-from pyspark.errors import PySparkAssertionError, PySparkRuntimeError
-from pyspark.util import local_connect_and_auth
+from pyspark.errors import PySparkAssertionError
 from pyspark.serializers import (
     read_bool,
-    read_int,
     read_long,
+    read_int,
     write_int,
     SpecialLengths,
 )
@@ -34,12 +32,13 @@ from pyspark.sql.types import (
     _parse_datatype_json_string,
     StructType,
 )
-from pyspark.util import handle_worker_exception
+from pyspark.util import handle_worker_exception, local_connect_and_auth
 from pyspark.worker_util import (
     check_python_version,
     read_command,
     pickleSer,
     send_accumulator_updates,
+    setup_broadcasts,
     setup_memory_limits,
     setup_spark_files,
     utf8_deserializer,
@@ -47,12 +46,22 @@ from pyspark.worker_util import (
 
 
 def main(infile: IO, outfile: IO) -> None:
+    """
+    Main method for committing or aborting a data source write operation.
+
+    This process is invoked from the `UserDefinedPythonDataSourceCommitRunner.runInPython`
+    method in the BatchWrite implementation of the PythonTableProvider. It is
+    responsible for invoking either the `commit` or the `abort` method on a data source
+    writer instance, given a list of commit messages.
+    """
     try:
         check_python_version(infile)
-        setup_spark_files(infile)
 
         memory_limit_mb = int(os.environ.get("PYSPARK_PLANNER_MEMORY_MB", "-1"))
         setup_memory_limits(memory_limit_mb)
+
+        setup_spark_files(infile)
+        setup_broadcasts(infile)
 
         _accumulatorRegistry.clear()
 
@@ -82,45 +91,47 @@ def main(infile: IO, outfile: IO) -> None:
         overwrite = read_bool(infile)
         # Instantiate data source reader.
         try:
+            # Create the data source writer instance.
             writer = data_source.streamWriter(schema=schema, overwrite=overwrite)
-            # Initialization succeed.
+
+            # Receive the commit messages.
+            num_messages = read_int(infile)
+            commit_messages = []
+            for _ in range(num_messages):
+                message = pickleSer._read_with_length(infile)
+                if message is not None and not isinstance(message, WriterCommitMessage):
+                    raise PySparkAssertionError(
+                        error_class="PYTHON_DATA_SOURCE_TYPE_MISMATCH",
+                        message_parameters={
+                            "expected": "an instance of WriterCommitMessage",
+                            "actual": f"'{type(message).__name__}'",
+                        },
+                    )
+                commit_messages.append(message)
+
+            batch_id = read_long(infile)
+            abort = read_bool(infile)
+
+            # Commit or abort the Python data source write.
+            # Note the commit messages can be None if there are failed tasks.
+            if abort:
+                writer.abort(commit_messages, batch_id)  # type: ignore[arg-type]
+            else:
+                writer.commit(commit_messages, batch_id)  # type: ignore[arg-type]
+                # Send a status code back to JVM.
             write_int(0, outfile)
             outfile.flush()
-
-            # handle method call from socket
-            while True:
-                num_messages = read_int(infile)
-                commit_messages = []
-                for _ in range(num_messages):
-                    message = pickleSer._read_with_length(infile)
-                    if message is not None and not isinstance(message, WriterCommitMessage):
-                        raise PySparkAssertionError(
-                            error_class="PYTHON_DATA_SOURCE_TYPE_MISMATCH",
-                            message_parameters={
-                                "expected": "an instance of WriterCommitMessage",
-                                "actual": f"'{type(message).__name__}'",
-                            },
-                        )
-                    commit_messages.append(message)
-                batch_id = read_long(infile)
-                abort = read_bool(infile)
-                # Commit or abort the Python data source write.
-                # Note the commit messages can be None if there are failed tasks.
-                if abort:
-                    writer.abort(commit_messages, batch_id)  # type: ignore[arg-type]
-                else:
-                    writer.commit(commit_messages, batch_id)  # type: ignore[arg-type]
-                write_int(0, outfile)
-                outfile.flush()
         except Exception as e:
             error_msg = "data source {} throw exception: {}".format(data_source.name, e)
             raise PySparkRuntimeError(
                 error_class="PYTHON_STREAMING_DATA_SOURCE_RUNTIME_ERROR",
                 message_parameters={"action": "commitOrAbort", "error": error_msg},
             )
+
     except BaseException as e:
         handle_worker_exception(e, outfile)
         sys.exit(-1)
+
     send_accumulator_updates(outfile)
 
     # check end of stream

--- a/python/pyspark/sql/worker/python_streaming_sink_runner.py
+++ b/python/pyspark/sql/worker/python_streaming_sink_runner.py
@@ -118,7 +118,7 @@ def main(infile: IO, outfile: IO) -> None:
                 writer.abort(commit_messages, batch_id)  # type: ignore[arg-type]
             else:
                 writer.commit(commit_messages, batch_id)  # type: ignore[arg-type]
-                # Send a status code back to JVM.
+            # Send a status code back to JVM.
             write_int(0, outfile)
             outfile.flush()
         except Exception as e:

--- a/python/pyspark/sql/worker/python_streaming_sink_runner.py
+++ b/python/pyspark/sql/worker/python_streaming_sink_runner.py
@@ -23,8 +23,8 @@ from pyspark.accumulators import _accumulatorRegistry
 from pyspark.errors import PySparkAssertionError
 from pyspark.serializers import (
     read_bool,
-    read_long,
     read_int,
+    read_long,
     write_int,
     SpecialLengths,
 )
@@ -48,10 +48,10 @@ from pyspark.worker_util import (
 
 def main(infile: IO, outfile: IO) -> None:
     """
-    Main method for committing or aborting a data source write operation.
+    Main method for committing or aborting a data source streaming write operation.
 
-    This process is invoked from the `UserDefinedPythonDataSourceCommitRunner.runInPython`
-    method in the BatchWrite implementation of the PythonTableProvider. It is
+    This process is invoked from the `PythonStreamingSinkCommitRunner.runInPython`
+    method in the StreamingWrite implementation of the PythonTableProvider. It is
     responsible for invoking either the `commit` or the `abort` method on a data source
     writer instance, given a list of commit messages.
     """

--- a/python/pyspark/sql/worker/python_streaming_sink_runner.py
+++ b/python/pyspark/sql/worker/python_streaming_sink_runner.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 import os
 import sys
 from typing import IO
@@ -56,12 +57,11 @@ def main(infile: IO, outfile: IO) -> None:
     """
     try:
         check_python_version(infile)
+        setup_spark_files(infile)
+        setup_broadcasts(infile)
 
         memory_limit_mb = int(os.environ.get("PYSPARK_PLANNER_MEMORY_MB", "-1"))
         setup_memory_limits(memory_limit_mb)
-
-        setup_spark_files(infile)
-        setup_broadcasts(infile)
 
         _accumulatorRegistry.clear()
 
@@ -127,11 +127,9 @@ def main(infile: IO, outfile: IO) -> None:
                 error_class="PYTHON_STREAMING_DATA_SOURCE_RUNTIME_ERROR",
                 message_parameters={"action": "commitOrAbort", "error": error_msg},
             )
-
     except BaseException as e:
         handle_worker_exception(e, outfile)
         sys.exit(-1)
-
     send_accumulator_updates(outfile)
 
     # check end of stream

--- a/python/pyspark/sql/worker/python_streaming_sink_runner.py
+++ b/python/pyspark/sql/worker/python_streaming_sink_runner.py
@@ -51,7 +51,7 @@ def main(infile: IO, outfile: IO) -> None:
     Main method for committing or aborting a data source streaming write operation.
 
     This process is invoked from the `PythonStreamingSinkCommitRunner.runInPython`
-    method in the StreamingWrite implementation of the PythonTableProvider. It is
+    method in the StreamingWrite implementation of the PythonDataSourceV2. It is
     responsible for invoking either the `commit` or the `abort` method on a data source
     writer instance, given a list of commit messages.
     """

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonStreamingSinkCommitRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonStreamingSinkCommitRunner.scala
@@ -17,18 +17,14 @@
 
 package org.apache.spark.sql.execution.datasources.v2.python
 
-import java.io.{BufferedInputStream, BufferedOutputStream, DataInputStream, DataOutputStream}
+import java.io.{DataInputStream, DataOutputStream}
 
-import scala.jdk.CollectionConverters._
+import net.razorvine.pickle.Pickler
 
-import org.apache.spark.SparkEnv
-import org.apache.spark.api.python.{PythonFunction, PythonWorker, PythonWorkerFactory, PythonWorkerUtils, SpecialLengths}
-import org.apache.spark.internal.{Logging, MDC}
-import org.apache.spark.internal.LogKeys.PYTHON_EXEC
-import org.apache.spark.internal.config.BUFFER_SIZE
-import org.apache.spark.internal.config.Python.PYTHON_AUTH_SOCKET_TIMEOUT
+import org.apache.spark.api.python.{PythonFunction, PythonWorkerUtils, SpecialLengths}
 import org.apache.spark.sql.connector.write.WriterCommitMessage
 import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.execution.python.PythonPlannerRunner
 import org.apache.spark.sql.types.StructType
 
 /**
@@ -39,78 +35,22 @@ import org.apache.spark.sql.types.StructType
  * from the socket, then commit or abort a microbatch.
  */
 class PythonStreamingSinkCommitRunner(
-    func: PythonFunction,
+    dataSourceCls: PythonFunction,
     schema: StructType,
-    overwrite: Boolean) extends Logging {
-  val workerModule: String = "pyspark.sql.worker.python_streaming_sink_runner"
+    messages: Array[WriterCommitMessage],
+    batchId: Long,
+    overwrite: Boolean,
+    abort: Boolean) extends PythonPlannerRunner[Unit](dataSourceCls) {
+  override val workerModule: String = "pyspark.sql.worker.python_streaming_sink_runner"
 
-  private val conf = SparkEnv.get.conf
-  protected val bufferSize: Int = conf.get(BUFFER_SIZE)
-  protected val authSocketTimeout = conf.get(PYTHON_AUTH_SOCKET_TIMEOUT)
-
-  private val envVars: java.util.Map[String, String] = func.envVars
-  private val pythonExec: String = func.pythonExec
-  private var pythonWorker: Option[PythonWorker] = None
-  private var pythonWorkerFactory: Option[PythonWorkerFactory] = None
-  protected val pythonVer: String = func.pythonVer
-
-  private var dataOut: DataOutputStream = null
-  private var dataIn: DataInputStream = null
-
-  /**
-   * Initializes the Python worker for running the streaming sink committer.
-   */
-  def init(): Unit = {
-    logInfo(log"Initializing Python runner pythonExec: ${MDC(PYTHON_EXEC, pythonExec)}")
-    val env = SparkEnv.get
-
-    val localdir = env.blockManager.diskBlockManager.localDirs.map(f => f.getPath()).mkString(",")
-    envVars.put("SPARK_LOCAL_DIRS", localdir)
-
-    envVars.put("SPARK_AUTH_SOCKET_TIMEOUT", authSocketTimeout.toString)
-    envVars.put("SPARK_BUFFER_SIZE", bufferSize.toString)
-
-    val workerFactory =
-      new PythonWorkerFactory(pythonExec, workerModule, envVars.asScala.toMap, false)
-    val (worker: PythonWorker, _) = workerFactory.createSimpleWorker(blockingMode = true)
-    pythonWorker = Some(worker)
-    pythonWorkerFactory = Some(workerFactory)
-
-    val stream = new BufferedOutputStream(
-      pythonWorker.get.channel.socket().getOutputStream, bufferSize)
-    dataOut = new DataOutputStream(stream)
-
-    PythonWorkerUtils.writePythonVersion(pythonVer, dataOut)
-
-    val pythonIncludes = func.pythonIncludes.asScala.toSet
-    PythonWorkerUtils.writeSparkFiles(Some("streaming_job"), pythonIncludes, dataOut)
-
+  override protected def writeToPython(dataOut: DataOutputStream, pickler: Pickler): Unit = {
     // Send the user function to python process
-    PythonWorkerUtils.writePythonFunction(func, dataOut)
-
+    PythonWorkerUtils.writePythonFunction(dataSourceCls, dataOut)
+    // Send the Python data source writer.
     PythonWorkerUtils.writeUTF(schema.json, dataOut)
-
     dataOut.writeBoolean(overwrite)
 
-    dataOut.flush()
-
-    dataIn = new DataInputStream(
-      new BufferedInputStream(pythonWorker.get.channel.socket().getInputStream, bufferSize))
-
-    val initStatus = dataIn.readInt()
-    if (initStatus == SpecialLengths.PYTHON_EXCEPTION_THROWN) {
-      val msg = PythonWorkerUtils.readUTF(dataIn)
-      throw QueryExecutionErrors.pythonStreamingDataSourceRuntimeError(
-        action = "initialize streaming sink", msg)
-    }
-  }
-
-  init()
-
-  def commitOrAbort(
-      messages: Array[WriterCommitMessage],
-      batchId: Long,
-      abort: Boolean): Unit = {
+    // Send the commit messages.
     dataOut.writeInt(messages.length)
     messages.foreach { message =>
       // Commit messages can be null if there are task failures.
@@ -122,13 +62,19 @@ class PythonStreamingSinkCommitRunner(
       }
     }
     dataOut.writeLong(batchId)
+
+    // Send whether to invoke `abort` instead of `commit`.
     dataOut.writeBoolean(abort)
-    dataOut.flush()
-    val status = dataIn.readInt()
-    if (status == SpecialLengths.PYTHON_EXCEPTION_THROWN) {
+  }
+
+  override protected def receiveFromPython(dataIn: DataInputStream): Unit = {
+    // Receive any exceptions thrown in the Python worker.
+    val code = dataIn.readInt()
+    if (code == SpecialLengths.PYTHON_EXCEPTION_THROWN) {
       val msg = PythonWorkerUtils.readUTF(dataIn)
-      val action = if (abort) "abort" else "commit"
-      throw QueryExecutionErrors.pythonStreamingDataSourceRuntimeError(action, msg)
+      println(msg)
+      throw QueryExecutionErrors.pythonStreamingDataSourceRuntimeError(
+        action = "Commit streaming sink", msg)
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonStreamingSinkCommitRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonStreamingSinkCommitRunner.scala
@@ -62,7 +62,6 @@ class PythonStreamingSinkCommitRunner(
       }
     }
     dataOut.writeLong(batchId)
-
     // Send whether to invoke `abort` instead of `commit`.
     dataOut.writeBoolean(abort)
   }
@@ -72,8 +71,8 @@ class PythonStreamingSinkCommitRunner(
     val code = dataIn.readInt()
     if (code == SpecialLengths.PYTHON_EXCEPTION_THROWN) {
       val msg = PythonWorkerUtils.readUTF(dataIn)
-      throw QueryExecutionErrors.pythonStreamingDataSourceRuntimeError(
-        action = "Commit streaming sink", msg)
+      val action = if (abort) "abort" else "commit"
+      throw QueryExecutionErrors.pythonStreamingDataSourceRuntimeError(action, msg)
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonStreamingSinkCommitRunner.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/python/PythonStreamingSinkCommitRunner.scala
@@ -44,9 +44,9 @@ class PythonStreamingSinkCommitRunner(
   override val workerModule: String = "pyspark.sql.worker.python_streaming_sink_runner"
 
   override protected def writeToPython(dataOut: DataOutputStream, pickler: Pickler): Unit = {
-    // Send the user function to python process
+    // Send the user function to python process.
     PythonWorkerUtils.writePythonFunction(dataSourceCls, dataOut)
-    // Send the Python data source writer.
+    // Send the output schema.
     PythonWorkerUtils.writeUTF(schema.json, dataOut)
     dataOut.writeBoolean(overwrite)
 
@@ -72,7 +72,6 @@ class PythonStreamingSinkCommitRunner(
     val code = dataIn.readInt()
     if (code == SpecialLengths.PYTHON_EXCEPTION_THROWN) {
       val msg = PythonWorkerUtils.readUTF(dataIn)
-      println(msg)
       throw QueryExecutionErrors.pythonStreamingDataSourceRuntimeError(
         action = "Commit streaming sink", msg)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonStreamingDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonStreamingDataSourceSuite.scala
@@ -466,6 +466,42 @@ class PythonStreamingDataSourceSuite extends PythonDataSourceSuiteBase {
     q.awaitTermination()
   }
 
+  // Verify that socket between python runner and JVM doesn't timeout with large trigger interval.
+  test("Read from test data stream source, trigger interval=20 seconds") {
+    assume(shouldTestPandasUDFs)
+    val dataSourceScript =
+      s"""
+         |from pyspark.sql.datasource import DataSource
+         |$testDataStreamReaderScript
+         |
+         |class $dataSourceName(DataSource):
+         |    def schema(self) -> str:
+         |        return "id INT"
+         |    def streamReader(self, schema):
+         |        return TestDataStreamReader()
+         |""".stripMargin
+
+    val dataSource = createUserDefinedPythonDataSource(dataSourceName, dataSourceScript)
+    spark.dataSource.registerPython(dataSourceName, dataSource)
+    assert(spark.sessionState.dataSourceManager.dataSourceExists(dataSourceName))
+    val df = spark.readStream.format(dataSourceName).load()
+
+    val stopSignal = new CountDownLatch(1)
+
+    val q = df.writeStream.foreachBatch((df: DataFrame, batchId: Long) => {
+      // checkAnswer may materialize the dataframe more than once
+      // Cache here to make sure the numInputRows metrics is consistent.
+      df.cache()
+      checkAnswer(df, Seq(Row(batchId * 2), Row(batchId * 2 + 1)))
+      if (batchId >= 2) stopSignal.countDown()
+    }).trigger(ProcessingTimeTrigger(20 * 1000)).start()
+    stopSignal.await()
+    assert(q.recentProgress.forall(_.numInputRows == 2))
+    q.stop()
+    q.awaitTermination()
+    assert(q.exception.isEmpty)
+  }
+
   test("Streaming data source read with custom partitions") {
     assume(shouldTestPandasUDFs)
     val dataSourceScript =
@@ -760,6 +796,36 @@ class PythonStreamingDataSourceSuite extends PythonDataSourceSuiteBase {
         q.awaitTermination()
         assert(q.exception.isEmpty)
       }
+    }
+  }
+
+  // Verify that commit runner work correctly with large timeout interval.
+  test(s"data source stream write, trigger interval=20 seconds") {
+    assume(shouldTestPandasUDFs)
+    val dataSource =
+      createUserDefinedPythonDataSource(dataSourceName, simpleDataStreamWriterScript)
+    spark.dataSource.registerPython(dataSourceName, dataSource)
+    val inputData = MemoryStream[Int](numPartitions = 3)
+    val df = inputData.toDF()
+    withTempDir { dir =>
+      val path = dir.getAbsolutePath
+      val checkpointDir = new File(path, "checkpoint")
+      checkpointDir.mkdir()
+      val outputDir = new File(path, "output")
+      outputDir.mkdir()
+      val q = df
+        .writeStream
+        .format(dataSourceName)
+        .option("checkpointLocation", checkpointDir.getAbsolutePath)
+        .trigger(ProcessingTimeTrigger(20 * 1000))
+        .start(outputDir.getAbsolutePath)
+      eventually(timeout(waitTimeout * 5)) {
+        inputData.addData(1 to 3)
+        assert(q.lastProgress.batchId >= 2)
+      }
+      q.stop()
+      q.awaitTermination()
+      assert(q.exception.isEmpty)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix the python streaming data source timeout issue for large trigger interval
For python streaming source, keep the long running worker archaetecture but set the socket timeout to be infinity to avoid timeout error.
For python streaming sink, since StreamingWrite is also created per microbatch in scala side, long running worker cannot be attached to s StreamingWrite instance. Therefore we abandon the long running worker architecture, simply call commit() or abort() and exit the worker and allow spark to reuse worker for us.


### Why are the changes needed?
Currently we run long running python worker process for python streaming source and sink to perform planning, commit and abort in driver side. Testing indicate that current implementation cause connection timeout error when streaming query has large trigger interval.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
add integration test


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
