### PR TITLE
[SPARK-48332][BUILD][TESTS] Upgrade `jdbc` related test dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -323,11 +323,11 @@
       -Dio.netty.tryReflectionSetAccessible=true
     </extraJavaTestArgs>
     <mariadb.java.client.version>2.7.12</mariadb.java.client.version>
-    <mysql.connector.version>8.3.0</mysql.connector.version>
+    <mysql.connector.version>8.4.0</mysql.connector.version>
     <postgresql.version>42.7.3</postgresql.version>
     <db2.jcc.version>11.5.9.0</db2.jcc.version>
-    <mssql.jdbc.version>12.6.1.jre11</mssql.jdbc.version>
-    <ojdbc11.version>23.3.0.23.09</ojdbc11.version>
+    <mssql.jdbc.version>12.7.0</mssql.jdbc.version>
+    <ojdbc11.version>23.4.0.24.05</ojdbc11.version>
   </properties>
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -326,7 +326,7 @@
     <mysql.connector.version>8.4.0</mysql.connector.version>
     <postgresql.version>42.7.3</postgresql.version>
     <db2.jcc.version>11.5.9.0</db2.jcc.version>
-    <mssql.jdbc.version>12.7.0</mssql.jdbc.version>
+    <mssql.jdbc.version>12.6.1.jre11</mssql.jdbc.version>
     <ojdbc11.version>23.4.0.24.05</ojdbc11.version>
   </properties>
   <repositories>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `jdbc` related test dependencies, include:
- com.mysql:mysql-connector-j from `8.3.0` to `8.4.0`
- com.oracle.database.jdbc:ojdbc11 from `23.3.0.23.09` to `23.4.0.24.05`

### Why are the changes needed?
- com.mysql:mysql-connector-j from, release notes:
https://dev.mysql.com/doc/relnotes/connector-j/en/news-8-4-0.html

-  com.oracle.database.jdbc:ojdbc11, release notes:
https://download.oracle.com/otn-pub/otn_software/jdbc/23c/JDBC-UCP-ReleaseNotes-23ai.txt?AuthParam=1716161887_dbf7a096828486d544bee00a2383f42a
=======================================================================================
Known Problems Fixed in the Patch Release 23.4.0.24.05
=======================================================================================
Bug 36279736 - CONNECTION TO A PROXY USER FAILS WITH INVALID USERNAME/PASSWORD WHEN WALLET IS PROVIDED 
Bug 36187019 - LOB PROCESSING FAIL WHEN DB SET WITH EL8ISO8859P7 CHARACTER SET 
Bug 36152805 - GET CONNECTION AGAINST NORMAL PDB WITH TFO=ON SHOULD FAIL WITH ORA-18739 


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
