### PR TITLE
[MINOR][PYTHON][TESTS] Test `test_mixed_udf_and_sql` with parent `Colum` class

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/connect/test_parity_pandas_udf_scalar.py
@@ -15,14 +15,12 @@
 # limitations under the License.
 #
 import unittest
-from pyspark.sql.connect.column import Column
 from pyspark.sql.tests.pandas.test_pandas_udf_scalar import ScalarPandasUDFTestsMixin
 from pyspark.testing.connectutils import ReusedConnectTestCase
 
 
 class PandasUDFScalarParityTests(ScalarPandasUDFTestsMixin, ReusedConnectTestCase):
-    def test_mixed_udf_and_sql(self):
-        self._test_mixed_udf_and_sql(Column)
+    pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?
Test `test_mixed_udf_and_sql` with parent `Colum` class

Don't find other similar cases in parity tests


### Why are the changes needed?
to make this parity test exactly same as the Spark Classic


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
