### PR TITLE
[SPARK-48364][SQL] Add AbstractMapType type casting and fix RaiseError parameter map to work with collated strings

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCasts.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCasts.scala
@@ -18,13 +18,14 @@
 package org.apache.spark.sql.catalyst.analysis
 
 import javax.annotation.Nullable
+
+import scala.annotation.tailrec
+
 import org.apache.spark.sql.catalyst.analysis.TypeCoercion.{hasStringType, haveSameType}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StringType}
-
-import scala.annotation.tailrec
 
 object CollationTypeCasts extends TypeCoercionRule {
   override val transform: PartialFunction[Expression, Expression] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCasts.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCasts.scala
@@ -19,13 +19,11 @@ package org.apache.spark.sql.catalyst.analysis
 
 import javax.annotation.Nullable
 
-import scala.annotation.tailrec
-
 import org.apache.spark.sql.catalyst.analysis.TypeCoercion.{hasStringType, haveSameType}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{ArrayType, DataType, StringType}
+import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StringType}
 
 object CollationTypeCasts extends TypeCoercionRule {
   override val transform: PartialFunction[Expression, Expression] = {
@@ -81,10 +79,13 @@ object CollationTypeCasts extends TypeCoercionRule {
   /**
    * Extracts StringTypes from filtered hasStringType
    */
-  @tailrec
   private def extractStringType(dt: DataType): StringType = dt match {
     case st: StringType => st
     case ArrayType(et, _) => extractStringType(et)
+    case MapType(kt, vt, _) => extractStringType(kt) match {
+      case st: StringType => st
+      case _ => extractStringType(vt)
+    }
   }
 
   /**
@@ -102,6 +103,14 @@ object CollationTypeCasts extends TypeCoercionRule {
       case st: StringType if st.collationId != castType.collationId => castType
       case ArrayType(arrType, nullable) =>
         castStringType(arrType, castType).map(ArrayType(_, nullable)).orNull
+      case MapType(keyType, valueType, nullable) =>
+        val newKeyType = castStringType(keyType, castType).getOrElse(keyType)
+        val newValueType = castStringType(valueType, castType).getOrElse(valueType)
+        if (newKeyType != keyType || newValueType != valueType) {
+          MapType(newKeyType, newValueType, nullable)
+        } else {
+          null
+        }
       case _ => null
     }
     Option(ret)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -1090,15 +1090,11 @@ object TypeCoercion extends TypeCoercionBase {
    * Whether the data type contains StringType.
    */
   def hasStringType(dt: DataType): Boolean = dt match {
-    case _: StringType =>
-      true
-    case ArrayType(et, _) =>
-      hasStringType(et)
-    case MapType(kt, vt, _) =>
-      hasStringType(kt) || hasStringType(vt)
+    case _: StringType => true
+    case ArrayType(et, _) => hasStringType(et)
+    case MapType(kt, vt, _) => hasStringType(kt) || hasStringType(vt)
     // Add StructType if we support string promotion for struct fields in the future.
-    case _ =>
-      false
+    case _ => false
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -1090,11 +1090,15 @@ object TypeCoercion extends TypeCoercionBase {
    * Whether the data type contains StringType.
    */
   def hasStringType(dt: DataType): Boolean = dt match {
-    case _: StringType => true
-    case ArrayType(et, _) => hasStringType(et)
-    case MapType(kt, vt, _) => hasStringType(kt) || hasStringType(vt)
+    case _: StringType =>
+      true
+    case ArrayType(et, _) =>
+      hasStringType(et)
+    case MapType(kt, vt, _) =>
+      hasStringType(kt) || hasStringType(vt)
     // Add StructType if we support string promotion for struct fields in the future.
-    case _ => false
+    case _ =>
+      false
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/misc.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.catalyst.util.{MapData, RandomUUIDGenerator}
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.errors.QueryExecutionErrors.raiseError
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.types.StringTypeAnyCollation
+import org.apache.spark.sql.internal.types.{AbstractMapType, StringTypeAnyCollation}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -85,7 +85,7 @@ case class RaiseError(errorClass: Expression, errorParms: Expression, dataType: 
   override def foldable: Boolean = false
   override def nullable: Boolean = true
   override def inputTypes: Seq[AbstractDataType] =
-    Seq(StringTypeAnyCollation, MapType(StringType, StringType))
+    Seq(StringTypeAnyCollation, AbstractMapType(StringTypeAnyCollation, StringTypeAnyCollation))
 
   override def left: Expression = errorClass
   override def right: Expression = errorParms

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveAliasesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveAliasesSuite.scala
@@ -99,18 +99,18 @@ class ResolveAliasesSuite extends AnalysisTest {
     withSQLConf(SQLConf.STABLE_DERIVED_COLUMN_ALIAS_ENABLED.key -> "true") {
       Seq(
         // Literals
-//        "' 1'" -> "' 1'",
-//        """"abc"""" -> """"abc"""",
-//        """'\t\n xyz \t\r'""" -> """'\t\n xyz \t\r'""",
-//        "1l" -> "1L", "1S" -> "1S",
-//        "date'-0001-1-28'" -> "DATE'-0001-1-28'",
-//        "interval 3 year 1 month" -> "INTERVAL3YEAR1MONTH",
-//        "x'00'" -> "X'00'",
-//        // Preserve case
-//        "CAST(1 as tinyint)" -> "CAST(1ASTINYINT)",
-//        // Brackets
-//        "getbit(11L, 2 + 1)" -> "getbit(11L,2+1)",
-//        "string(int(shiftleft(int(-1), 31))+1)" -> "string(int(shiftleft(int(-1),31))+1)",
+        "' 1'" -> "' 1'",
+        """"abc"""" -> """"abc"""",
+        """'\t\n xyz \t\r'""" -> """'\t\n xyz \t\r'""",
+        "1l" -> "1L", "1S" -> "1S",
+        "date'-0001-1-28'" -> "DATE'-0001-1-28'",
+        "interval 3 year 1 month" -> "INTERVAL3YEAR1MONTH",
+        "x'00'" -> "X'00'",
+        // Preserve case
+        "CAST(1 as tinyint)" -> "CAST(1ASTINYINT)",
+        // Brackets
+        "getbit(11L, 2 + 1)" -> "getbit(11L,2+1)",
+        "string(int(shiftleft(int(-1), 31))+1)" -> "string(int(shiftleft(int(-1),31))+1)",
         "map(1, 'a') [ 5 ]" -> "map(1,'a')[5]",
         // Preserve type
         "CAST('123.a' AS long)" -> "CAST('123.a'ASLONG)",

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveAliasesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveAliasesSuite.scala
@@ -99,18 +99,18 @@ class ResolveAliasesSuite extends AnalysisTest {
     withSQLConf(SQLConf.STABLE_DERIVED_COLUMN_ALIAS_ENABLED.key -> "true") {
       Seq(
         // Literals
-        "' 1'" -> "' 1'",
-        """"abc"""" -> """"abc"""",
-        """'\t\n xyz \t\r'""" -> """'\t\n xyz \t\r'""",
-        "1l" -> "1L", "1S" -> "1S",
-        "date'-0001-1-28'" -> "DATE'-0001-1-28'",
-        "interval 3 year 1 month" -> "INTERVAL3YEAR1MONTH",
-        "x'00'" -> "X'00'",
-        // Preserve case
-        "CAST(1 as tinyint)" -> "CAST(1ASTINYINT)",
-        // Brackets
-        "getbit(11L, 2 + 1)" -> "getbit(11L,2+1)",
-        "string(int(shiftleft(int(-1), 31))+1)" -> "string(int(shiftleft(int(-1),31))+1)",
+//        "' 1'" -> "' 1'",
+//        """"abc"""" -> """"abc"""",
+//        """'\t\n xyz \t\r'""" -> """'\t\n xyz \t\r'""",
+//        "1l" -> "1L", "1S" -> "1S",
+//        "date'-0001-1-28'" -> "DATE'-0001-1-28'",
+//        "interval 3 year 1 month" -> "INTERVAL3YEAR1MONTH",
+//        "x'00'" -> "X'00'",
+//        // Preserve case
+//        "CAST(1 as tinyint)" -> "CAST(1ASTINYINT)",
+//        // Brackets
+//        "getbit(11L, 2 + 1)" -> "getbit(11L,2+1)",
+//        "string(int(shiftleft(int(-1), 31))+1)" -> "string(int(shiftleft(int(-1),31))+1)",
         "map(1, 'a') [ 5 ]" -> "map(1,'a')[5]",
         // Preserve type
         "CAST('123.a' AS long)" -> "CAST('123.a'ASLONG)",

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSQLExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSQLExpressionsSuite.scala
@@ -21,8 +21,8 @@ import java.text.SimpleDateFormat
 
 import scala.collection.immutable.Seq
 
-import org.apache.spark.{SparkException, SparkIllegalArgumentException, SparkRuntimeException}
-import org.apache.spark.sql.internal.SqlApiConf
+import org.apache.spark.{SparkConf, SparkException, SparkIllegalArgumentException, SparkRuntimeException}
+import org.apache.spark.sql.internal.{SqlApiConf, SQLConf}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
@@ -1588,3 +1588,9 @@ class CollationSQLExpressionsSuite
 
 }
 // scalastyle:on nonascii
+
+class CollationSQLExpressionsANSIOffSuite extends CollationSQLExpressionsSuite {
+  override protected def sparkConf: SparkConf =
+    super.sparkConf.set(SQLConf.ANSI_ENABLED, false)
+
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
 import org.apache.spark.sql.execution.aggregate.{HashAggregateExec, ObjectHashAggregateExec}
 import org.apache.spark.sql.execution.joins.{BroadcastHashJoinExec, SortMergeJoinExec}
 import org.apache.spark.sql.internal.SqlApiConf
+import org.apache.spark.sql.internal.types.{AbstractMapType, StringTypeAnyCollation}
 import org.apache.spark.sql.types.{MapType, StringType, StructField, StructType}
 
 class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
@@ -954,7 +955,7 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
         errorClass = "DATATYPE_MISMATCH.INVALID_ORDERING_TYPE",
         parameters = Map(
           "functionName" -> "`=`",
-          "dataType" -> toSQLType(MapType(StringType, StringType)),
+          "dataType" -> toSQLType(AbstractMapType(StringTypeAnyCollation, StringTypeAnyCollation)),
           "sqlExpr" -> "\"(m = m)\""),
         context = ExpectedContext(ctx, query.length - ctx.length, query.length - 1))
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
@@ -954,10 +954,7 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
         errorClass = "DATATYPE_MISMATCH.INVALID_ORDERING_TYPE",
         parameters = Map(
           "functionName" -> "`=`",
-          "dataType" -> toSQLType(MapType(
-            StringType(CollationFactory.collationNameToId("UTF8_BINARY_LCASE")),
-            StringType
-          )),
+          "dataType" -> toSQLType(MapType(StringType, StringType)),
           "sqlExpr" -> "\"(m = m)\""),
         context = ExpectedContext(ctx, query.length - ctx.length, query.length - 1))
     }
@@ -1010,25 +1007,6 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
         |select map('a' collate utf8_binary_lcase, 1, 'b' collate utf8_binary_lcase, 2)
         |['A' collate utf8_binary_lcase]
         |""".stripMargin), Seq(Row(1)))
-    val ctx = "map('aaa' collate utf8_binary_lcase, 1, 'AAA' collate utf8_binary_lcase, 2)['AaA']"
-    val query = s"select $ctx"
-    checkError(
-      exception = intercept[AnalysisException](sql(query)),
-      errorClass = "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
-      parameters = Map(
-        "sqlExpr" -> "\"map(collate(aaa), 1, collate(AAA), 2)[AaA]\"",
-        "paramIndex" -> "second",
-        "inputSql" -> "\"AaA\"",
-        "inputType" -> toSQLType(StringType),
-        "requiredType" -> toSQLType(StringType(
-          CollationFactory.collationNameToId("UTF8_BINARY_LCASE")))
-      ),
-      context = ExpectedContext(
-        fragment = ctx,
-        start = query.length - ctx.length,
-        stop = query.length - 1
-      )
-    )
   }
 
   test("window aggregates should respect collation") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Following up on the introduction of AbstractMapType (https://github.com/apache/spark/pull/46458) and changes that introduce collation awareness for RaiseError expression (https://github.com/apache/spark/pull/46461), this PR should add the appropriate type casting rules for AbstractMapType.


### Why are the changes needed?
Fix the CI failure for the `Support RaiseError misc expression with collation` test when ANSI is off.


### Does this PR introduce _any_ user-facing change?
Yes, type casting is now allowed for map types with collated strings.


### How was this patch tested?
Extended suite `CollationSQLExpressionsANSIOffSuite` with ANSI disabled.


### Was this patch authored or co-authored using generative AI tooling?
No.
