### PR TITLE
[MINOR][DOCS] correct the doc error in configuration page (fix rest to reset)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3396,7 +3396,7 @@ Spark subsystems.
 
 Runtime SQL configurations are per-session, mutable Spark SQL configurations. They can be set with initial values by the config file
 and command-line options with `--conf/-c` prefixed, or by setting `SparkConf` that are used to create `SparkSession`.
-Also, they can be set and queried by SET commands and rest to their initial values by RESET command,
+Also, they can be set and queried by SET commands and reset to their initial values by RESET command,
 or by `SparkSession.conf`'s setter and getter methods in runtime.
 
 {% include_api_gen generated-runtime-sql-config-table.html %}


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. correct the doc error in spark-docs's  `configuration` page, it should be ```reset to their initial values by RESET command```, not ```rest to their initial values by RESET command```

### Why are the changes needed?
1. correct the doc error to make the doc clearer

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
no need to test, just spell a word incorrectly 

### Was this patch authored or co-authored using generative AI tooling?
No