### PR TITLE
[SPARK-48340][PYTHON] Support TimestampNTZ infer schema miss prefer_timestamp_ntz

### DIFF
--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -2171,6 +2171,7 @@ def _infer_type(
                 obj,
                 infer_dict_as_struct=infer_dict_as_struct,
                 infer_array_from_first_element=infer_array_from_first_element,
+                prefer_timestamp_ntz=prefer_timestamp_ntz,
             )
         except TypeError:
             raise PySparkTypeError(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support TimestampNTZ infer schema miss prefer_timestamp_ntz


### Why are the changes needed?
Fix bug


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?



### Was this patch authored or co-authored using generative AI tooling?
No
