### PR TITLE
[SPARK-48341][CONNECT] Allow plugins to use QueryTest in their tests

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Column.scala
@@ -1330,7 +1330,8 @@ object Column {
   private[sql] def apply(name: String, planId: Option[Long]): Column = new Column(name, planId)
 
   private[sql] def nameToExpression(
-      name: String, planId: Option[Long] = None): proto.Expression = {
+      name: String,
+      planId: Option[Long] = None): proto.Expression = {
     val builder = proto.Expression.newBuilder()
     name match {
       case "*" =>

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -7209,8 +7209,8 @@ object functions {
    * Returns length of array or map.
    *
    * This function returns -1 for null input only if spark.sql.ansi.enabled is false and
-   * spark.sql.legacy.sizeOfNull is true. Otherwise, it returns null for null input.
-   * With the default settings, the function returns null for null input.
+   * spark.sql.legacy.sizeOfNull is true. Otherwise, it returns null for null input. With the
+   * default settings, the function returns null for null input.
    *
    * @group collection_funcs
    * @since 3.4.0
@@ -7687,8 +7687,8 @@ object functions {
    * Returns length of array or map. This is an alias of `size` function.
    *
    * This function returns -1 for null input only if spark.sql.ansi.enabled is false and
-   * spark.sql.legacy.sizeOfNull is true. Otherwise, it returns null for null input.
-   * With the default settings, the function returns null for null input.
+   * spark.sql.legacy.sizeOfNull is true. Otherwise, it returns null for null input. With the
+   * default settings, the function returns null for null input.
    *
    * @group collection_funcs
    * @since 3.5.0

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/CatalogSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/CatalogSuite.scala
@@ -22,11 +22,11 @@ import java.io.{File, FilenameFilter}
 import org.apache.commons.io.FileUtils
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.test.{RemoteSparkSession, SQLHelper}
+import org.apache.spark.sql.test.{ConnectFunSuite, RemoteSparkSession, SQLHelper}
 import org.apache.spark.sql.types.{DoubleType, LongType, StructType}
 import org.apache.spark.storage.StorageLevel
 
-class CatalogSuite extends RemoteSparkSession with SQLHelper {
+class CatalogSuite extends ConnectFunSuite with RemoteSparkSession with SQLHelper {
 
   test("Database APIs") {
     val currentDb = spark.catalog.currentDatabase

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientDataFrameStatSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientDataFrameStatSuite.scala
@@ -22,9 +22,9 @@ import java.util.Random
 import org.scalatest.matchers.must.Matchers._
 
 import org.apache.spark.SparkIllegalArgumentException
-import org.apache.spark.sql.test.RemoteSparkSession
+import org.apache.spark.sql.test.{ConnectFunSuite, RemoteSparkSession}
 
-class ClientDataFrameStatSuite extends RemoteSparkSession {
+class ClientDataFrameStatSuite extends ConnectFunSuite with RemoteSparkSession {
   private def toLetter(i: Int): String = (i + 97).toChar.toString
 
   test("approxQuantile") {

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -40,12 +40,13 @@ import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.connect.client.{SparkConnectClient, SparkResult}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.internal.SqlApiConf
-import org.apache.spark.sql.test.{IntegrationTestUtils, RemoteSparkSession, SQLHelper}
+import org.apache.spark.sql.test.{ConnectFunSuite, IntegrationTestUtils, RemoteSparkSession, SQLHelper}
 import org.apache.spark.sql.test.SparkConnectServerUtils.port
 import org.apache.spark.sql.types._
 import org.apache.spark.util.SparkThreadUtils
 
-class ClientE2ETestSuite extends RemoteSparkSession with SQLHelper with PrivateMethodTester {
+class ClientE2ETestSuite
+  extends ConnectFunSuite with RemoteSparkSession with SQLHelper with PrivateMethodTester {
 
   test("throw SparkException with null filename in stack trace elements") {
     withSQLConf("spark.sql.connect.enrichError.enabled" -> "true") {

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/ClientE2ETestSuite.scala
@@ -46,7 +46,10 @@ import org.apache.spark.sql.types._
 import org.apache.spark.util.SparkThreadUtils
 
 class ClientE2ETestSuite
-  extends ConnectFunSuite with RemoteSparkSession with SQLHelper with PrivateMethodTester {
+    extends ConnectFunSuite
+    with RemoteSparkSession
+    with SQLHelper
+    with PrivateMethodTester {
 
   test("throw SparkException with null filename in stack trace elements") {
     withSQLConf("spark.sql.connect.enrichError.enabled" -> "true") {

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/DataFrameNaFunctionSuite.scala
@@ -20,10 +20,10 @@ package org.apache.spark.sql
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.sql.internal.SqlApiConf
-import org.apache.spark.sql.test.{QueryTest, SQLHelper}
+import org.apache.spark.sql.test.{QueryTest, RemoteSparkSession}
 import org.apache.spark.sql.types.{StringType, StructType}
 
-class DataFrameNaFunctionSuite extends QueryTest with SQLHelper {
+class DataFrameNaFunctionSuite extends QueryTest with RemoteSparkSession {
   private def createDF(): DataFrame = {
     val sparkSession = spark
     import sparkSession.implicits._

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/KeyValueGroupedDatasetE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/KeyValueGroupedDatasetE2ETestSuite.scala
@@ -22,7 +22,7 @@ import java.util.Arrays
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes.Append
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.streaming.{GroupState, GroupStateTimeout}
-import org.apache.spark.sql.test.{QueryTest, SQLHelper}
+import org.apache.spark.sql.test.{QueryTest, RemoteSparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.SparkSerDeUtils
 
@@ -33,7 +33,7 @@ case class ClickState(id: String, count: Int)
 /**
  * All tests in this class requires client UDF artifacts synced with the server.
  */
-class KeyValueGroupedDatasetE2ETestSuite extends QueryTest with SQLHelper {
+class KeyValueGroupedDatasetE2ETestSuite extends QueryTest with RemoteSparkSession {
 
   lazy val session: SparkSession = spark
   import session.implicits._

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/SparkSessionE2ESuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/SparkSessionE2ESuite.scala
@@ -26,7 +26,7 @@ import scala.util.{Failure, Success}
 import org.scalatest.concurrent.Eventually._
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.test.RemoteSparkSession
+import org.apache.spark.sql.test.{ConnectFunSuite, RemoteSparkSession}
 import org.apache.spark.util.SparkThreadUtils.awaitResult
 
 /**
@@ -34,7 +34,7 @@ import org.apache.spark.util.SparkThreadUtils.awaitResult
  * class, whether explicit or implicit, as it will trigger a UDF deserialization error during
  * Maven build/test.
  */
-class SparkSessionE2ESuite extends RemoteSparkSession {
+class SparkSessionE2ESuite extends ConnectFunSuite with RemoteSparkSession {
 
   test("interrupt all - background queries, foreground interrupt") {
     val session = spark

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/StubbingTestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/StubbingTestSuite.scala
@@ -17,9 +17,9 @@
 package org.apache.spark.sql
 
 import org.apache.spark.sql.connect.client.ToStub
-import org.apache.spark.sql.test.RemoteSparkSession
+import org.apache.spark.sql.test.{ConnectFunSuite, RemoteSparkSession}
 
-class StubbingTestSuite extends RemoteSparkSession {
+class StubbingTestSuite extends ConnectFunSuite with RemoteSparkSession {
   private def eval[T](f: => T): T = f
 
   test("capture of to-be stubbed class") {

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/UDFClassLoadingE2ESuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/UDFClassLoadingE2ESuite.scala
@@ -23,9 +23,9 @@ import scala.util.Properties
 
 import org.apache.spark.sql.connect.common.ProtoDataTypes
 import org.apache.spark.sql.expressions.ScalarUserDefinedFunction
-import org.apache.spark.sql.test.RemoteSparkSession
+import org.apache.spark.sql.test.{ConnectFunSuite, RemoteSparkSession}
 
-class UDFClassLoadingE2ESuite extends RemoteSparkSession {
+class UDFClassLoadingE2ESuite extends ConnectFunSuite with RemoteSparkSession {
 
   private val scalaVersion = Properties.versionNumberString
     .split("\\.")

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/UserDefinedFunctionE2ETestSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/UserDefinedFunctionE2ETestSuite.scala
@@ -27,13 +27,13 @@ import org.apache.spark.api.java.function._
 import org.apache.spark.sql.api.java.UDF2
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders.{PrimitiveIntEncoder, PrimitiveLongEncoder}
 import org.apache.spark.sql.functions.{col, struct, udf}
-import org.apache.spark.sql.test.QueryTest
+import org.apache.spark.sql.test.{QueryTest, RemoteSparkSession}
 import org.apache.spark.sql.types.IntegerType
 
 /**
  * All tests in this class requires client UDF defined in this test class synced with the server.
  */
-class UserDefinedFunctionE2ETestSuite extends QueryTest {
+class UserDefinedFunctionE2ETestSuite extends QueryTest with RemoteSparkSession {
   test("Dataset typed filter") {
     val rows = spark.range(10).filter(n => n % 2 == 0).collectAsList()
     assert(rows == Arrays.asList[Long](0, 2, 4, 6, 8))

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/application/ReplE2ESuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/application/ReplE2ESuite.scala
@@ -25,13 +25,13 @@ import scala.util.Properties
 import org.apache.commons.io.output.ByteArrayOutputStream
 import org.scalatest.BeforeAndAfterEach
 
-import org.apache.spark.sql.test.{IntegrationTestUtils, RemoteSparkSession}
+import org.apache.spark.sql.test.{ConnectFunSuite, IntegrationTestUtils, RemoteSparkSession}
 import org.apache.spark.tags.AmmoniteTest
 import org.apache.spark.util.IvyTestUtils
 import org.apache.spark.util.MavenUtils.MavenCoordinate
 
 @AmmoniteTest
-class ReplE2ESuite extends RemoteSparkSession with BeforeAndAfterEach {
+class ReplE2ESuite extends ConnectFunSuite with RemoteSparkSession with BeforeAndAfterEach {
 
   private val executorService = Executors.newSingleThreadExecutor()
   private val TIMEOUT_SECONDS = 30

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
@@ -357,12 +357,8 @@ object CheckConnectJvmClientCompatibility {
 
       // Column
       // developer API
-      ProblemFilters.exclude[IncompatibleMethTypeProblem](
-        "org.apache.spark.sql.Column.apply"
-      ),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem](
-        "org.apache.spark.sql.Column.expr"
-      ),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.spark.sql.Column.apply"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.spark.sql.Column.expr"),
 
       // Dataset
       ProblemFilters.exclude[DirectMissingMethodProblem](

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/ClientStreamingQuerySuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/ClientStreamingQuerySuite.scala
@@ -33,11 +33,11 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DataFrame, ForeachWriter, Row, SparkSession}
 import org.apache.spark.sql.functions.{col, lit, udf, window}
 import org.apache.spark.sql.streaming.StreamingQueryListener.{QueryIdleEvent, QueryProgressEvent, QueryStartedEvent, QueryTerminatedEvent}
-import org.apache.spark.sql.test.{IntegrationTestUtils, QueryTest, SQLHelper}
+import org.apache.spark.sql.test.{IntegrationTestUtils, QueryTest, RemoteSparkSession}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.apache.spark.util.SparkFileUtils
 
-class ClientStreamingQuerySuite extends QueryTest with SQLHelper with Logging {
+class ClientStreamingQuerySuite extends QueryTest with RemoteSparkSession with Logging {
 
   private val testDataPath = Paths
     .get(

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/FlatMapGroupsWithStateStreamingSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/FlatMapGroupsWithStateStreamingSuite.scala
@@ -25,14 +25,14 @@ import org.scalatest.time.SpanSugar._
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes.Append
-import org.apache.spark.sql.test.{QueryTest, SQLHelper}
+import org.apache.spark.sql.test.{QueryTest, RemoteSparkSession}
 import org.apache.spark.sql.types.{StringType, StructField, StructType, TimestampType}
 
 case class ClickEvent(id: String, timestamp: Timestamp)
 
 case class ClickState(id: String, count: Int)
 
-class FlatMapGroupsWithStateStreamingSuite extends QueryTest with SQLHelper {
+class FlatMapGroupsWithStateStreamingSuite extends QueryTest with RemoteSparkSession {
 
   val flatMapGroupsWithStateSchema: StructType = StructType(
     Array(StructField("id", StringType), StructField("timestamp", TimestampType)))

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/test/ConnectFunSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/test/ConnectFunSuite.scala
@@ -34,7 +34,7 @@ trait ConnectFunSuite extends AnyFunSuite { // scalastyle:ignore funsuite
     java.nio.file.Paths.get(sparkHome, first +: more: _*)
   }
 
-  protected val baseResourcePath: Path = {
+  protected def baseResourcePath: Path = {
     getWorkspaceFilePath(
       "connector",
       "connect",
@@ -45,7 +45,7 @@ trait ConnectFunSuite extends AnyFunSuite { // scalastyle:ignore funsuite
       "resources").toAbsolutePath
   }
 
-  protected val commonResourcePath: Path = {
+  protected def commonResourcePath: Path = {
     getWorkspaceFilePath(
       "connector",
       "connect",

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/test/QueryTest.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/test/QueryTest.scala
@@ -21,11 +21,13 @@ import java.util.TimeZone
 
 import org.scalatest.Assertions
 
-import org.apache.spark.sql.{DataFrame, Dataset, Row}
+import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
 import org.apache.spark.sql.catalyst.util.SparkStringUtils.sideBySide
 import org.apache.spark.util.ArrayImplicits._
 
-abstract class QueryTest extends RemoteSparkSession {
+abstract class QueryTest extends ConnectFunSuite with SQLHelper {
+
+  def spark: SparkSession
 
   /**
    * Runs the plan and makes sure the answer matches the expected result.

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/test/RemoteSparkSession.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/test/RemoteSparkSession.scala
@@ -24,8 +24,8 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
 
 import org.scalatest.{BeforeAndAfterAll, Suite}
-import org.apache.spark.SparkBuildInfo
 
+import org.apache.spark.SparkBuildInfo
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connect.client.RetryPolicy
 import org.apache.spark.sql.connect.client.SparkConnectClient

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/test/RemoteSparkSession.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/test/RemoteSparkSession.scala
@@ -23,9 +23,9 @@ import java.util.concurrent.TimeUnit
 
 import scala.concurrent.duration.FiniteDuration
 
-import org.scalatest.BeforeAndAfterAll
-
+import org.scalatest.{BeforeAndAfterAll, Suite}
 import org.apache.spark.SparkBuildInfo
+
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.connect.client.RetryPolicy
 import org.apache.spark.sql.connect.client.SparkConnectClient
@@ -204,7 +204,7 @@ object SparkConnectServerUtils {
   }
 }
 
-trait RemoteSparkSession extends ConnectFunSuite with BeforeAndAfterAll {
+trait RemoteSparkSession extends BeforeAndAfterAll { self: Suite =>
   import SparkConnectServerUtils._
   var spark: SparkSession = _
   protected lazy val serverPort: Int = port

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/ConnectProtoUtils.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/ConnectProtoUtils.scala
@@ -22,9 +22,9 @@ import org.apache.spark.connect.proto
 import org.apache.spark.sql.connect.common.ProtoUtils
 
 /**
- * Utility functions for parsing Spark Connect protocol buffers with a recursion limit.
- * This is intended to be used by plugins, as they cannot use `ProtoUtils.parseWithRecursionLimit`
- * due to the shading of the `com.google.protobuf` package.
+ * Utility functions for parsing Spark Connect protocol buffers with a recursion limit. This is
+ * intended to be used by plugins, as they cannot use `ProtoUtils.parseWithRecursionLimit` due to
+ * the shading of the `com.google.protobuf` package.
  */
 object ConnectProtoUtils {
   @DeveloperApi
@@ -44,7 +44,8 @@ object ConnectProtoUtils {
 
   @DeveloperApi
   def parseExpressionWithRecursionLimit(
-      bytes: Array[Byte], recursionLimit: Int): proto.Expression = {
+      bytes: Array[Byte],
+      recursionLimit: Int): proto.Expression = {
     ProtoUtils.parseWithRecursionLimit(bytes, proto.Expression.parser(), recursionLimit)
   }
 

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerTestUtils.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerTestUtils.scala
@@ -35,7 +35,9 @@ object SparkConnectPlannerTestUtils {
     new SparkConnectPlanner(executeHolder).process(command, new MockObserver())
   }
 
-  private def buildExecutePlanHolder(spark: SparkSession, command: proto.Command): ExecuteHolder = {
+  private def buildExecutePlanHolder(
+      spark: SparkSession,
+      command: proto.Command): ExecuteHolder = {
     val sessionHolder = SessionHolder.forTesting(spark)
     sessionHolder.eventManager.status_(SessionStatus.Started)
 

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/plugin/SparkConnectPluginRegistrySuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/plugin/SparkConnectPluginRegistrySuite.scala
@@ -70,7 +70,8 @@ class ExampleRelationPlugin extends RelationPlugin {
     }
     val plugin = rel.unpack(classOf[proto.ExamplePluginRelation])
     val input = ConnectProtoUtils.parseRelationWithRecursionLimit(
-      plugin.getInput.toByteArray, recursionLimit = 1024)
+      plugin.getInput.toByteArray,
+      recursionLimit = 1024)
     Optional.of(planner.transformRelation(input))
   }
 }
@@ -85,7 +86,8 @@ class ExampleExpressionPlugin extends ExpressionPlugin {
     }
     val exp = rel.unpack(classOf[proto.ExamplePluginExpression])
     val child = ConnectProtoUtils.parseExpressionWithRecursionLimit(
-      exp.getChild.toByteArray, recursionLimit = 1024)
+      exp.getChild.toByteArray,
+      recursionLimit = 1024)
     Optional.of(Alias(planner.transformExpression(child), exp.getCustomField)())
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes `QueryTest` to no longer depend on `RemoteSparkSession`.

### Why are the changes needed?

This allows the tests for Spark Connect plugin to provide their version of `RemoteSparkSession` (which depends on some idiosyncrasies of how Spark is built).

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Existing tests to ensure that nothing breaks. Manually tested that this allows a plugin to use `QueryTest`.

### Was this patch authored or co-authored using generative AI tooling?

No
