### PR TITLE
[SPARK-48363][SQL] Cleanup some redundant codes in `from_xml`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xmlExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/xmlExpressions.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult.{DataTypeMismatch, TypeCheckSuccess}
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodegenFallback, ExprCode}
-import org.apache.spark.sql.catalyst.util.{ArrayData, DropMalformedMode, FailFastMode, FailureSafeParser, GenericArrayData, PermissiveMode}
+import org.apache.spark.sql.catalyst.util.{DropMalformedMode, FailFastMode, FailureSafeParser, PermissiveMode}
 import org.apache.spark.sql.catalyst.util.TypeUtils._
 import org.apache.spark.sql.catalyst.xml.{StaxXmlGenerator, StaxXmlParser, ValidatorUtil, XmlInferSchema, XmlOptions}
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryErrorsBase}
@@ -52,7 +52,7 @@ import org.apache.spark.unsafe.types.UTF8String
   since = "4.0.0")
 // scalastyle:on line.size.limit
 case class XmlToStructs(
-    schema: DataType,
+    schema: StructType,
     options: Map[String, String],
     child: Expression,
     timeZoneId: Option[String] = None)
@@ -74,7 +74,7 @@ case class XmlToStructs(
 
   // The XML input data might be missing certain fields. We force the nullability
   // of the user-provided schema to avoid data corruptions.
-  val nullableSchema = schema.asNullable
+  private val nullableSchema = schema.asNullable
 
   def this(child: Expression, schema: Expression) = this(child, schema, Map.empty[String, String])
 
@@ -87,42 +87,27 @@ case class XmlToStructs(
 
   // This converts parsed rows to the desired output by the given schema.
   @transient
-  lazy val converter = nullableSchema match {
-    case _: StructType =>
-      (rows: Iterator[InternalRow]) => if (rows.hasNext) rows.next() else null
-    case _: ArrayType =>
-      (rows: Iterator[InternalRow]) => if (rows.hasNext) rows.next().getArray(0) else null
-    case _: MapType =>
-      (rows: Iterator[InternalRow]) => if (rows.hasNext) rows.next().getMap(0) else null
-  }
+  private lazy val converter =
+    (rows: Iterator[InternalRow]) => if (rows.hasNext) rows.next() else null
 
-  val nameOfCorruptRecord = SQLConf.get.getConf(SQLConf.COLUMN_NAME_OF_CORRUPT_RECORD)
+  private val nameOfCorruptRecord = SQLConf.get.getConf(SQLConf.COLUMN_NAME_OF_CORRUPT_RECORD)
 
-  @transient lazy val parser = {
+  @transient
+  private lazy val parser = {
     val parsedOptions = new XmlOptions(options, timeZoneId.get, nameOfCorruptRecord)
     val mode = parsedOptions.parseMode
     if (mode != PermissiveMode && mode != FailFastMode) {
       throw QueryCompilationErrors.parseModeUnsupportedError("from_xml", mode)
     }
-    val (parserSchema, actualSchema) = nullableSchema match {
-      case s: StructType =>
-        ExprUtils.verifyColumnNameOfCorruptRecord(s, parsedOptions.columnNameOfCorruptRecord)
-        (s, StructType(s.filterNot(_.name == parsedOptions.columnNameOfCorruptRecord)))
-      case other =>
-        (StructType(Array(StructField("value", other))), other)
-    }
-
-    val rowSchema: StructType = schema match {
-      case st: StructType => st
-      case ArrayType(st: StructType, _) => st
-    }
-    val rawParser = new StaxXmlParser(rowSchema, parsedOptions)
+    ExprUtils.verifyColumnNameOfCorruptRecord(
+      nullableSchema, parsedOptions.columnNameOfCorruptRecord)
+    val rawParser = new StaxXmlParser(schema, parsedOptions)
     val xsdSchema = Option(parsedOptions.rowValidationXSDPath).map(ValidatorUtil.getSchema)
 
     new FailureSafeParser[String](
       input => rawParser.doParseColumn(input, mode, xsdSchema),
       mode,
-      parserSchema,
+      nullableSchema,
       parsedOptions.columnNameOfCorruptRecord)
   }
 
@@ -131,22 +116,11 @@ case class XmlToStructs(
   override def withTimeZone(timeZoneId: String): TimeZoneAwareExpression = {
     copy(timeZoneId = Option(timeZoneId))
   }
-  override def nullSafeEval(xml: Any): Any = xml match {
-    case arr: GenericArrayData =>
-      new GenericArrayData(arr.array.map(s => converter(parser.parse(s.toString))))
-    case arr: ArrayData =>
-      new GenericArrayData(arr.array.map(s => converter(parser.parse(s.toString))))
-    case _ =>
-      val str = xml.asInstanceOf[UTF8String].toString
-      converter(parser.parse(str))
-  }
+
+  override def nullSafeEval(xml: Any): Any =
+    converter(parser.parse(xml.asInstanceOf[UTF8String].toString))
 
   override def inputTypes: Seq[AbstractDataType] = StringTypeAnyCollation :: Nil
-
-  override def sql: String = schema match {
-    case _: MapType => "entries"
-    case _ => super.sql
-  }
 
   override def prettyName: String = "from_xml"
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/XmlFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/XmlFunctionsSuite.scala
@@ -111,6 +111,36 @@ class XmlFunctionsSuite extends QueryTest with SharedSparkSession {
       Row(Row(1, "haa")) :: Nil)
   }
 
+  test("SPARK-48363: from_xml with non struct schema") {
+    checkError(
+      exception = intercept[AnalysisException] {
+        Seq("1").toDS().select(from_xml($"value", lit("ARRAY<int>"), Map[String, String]().asJava))
+      },
+      errorClass = "INVALID_SCHEMA.NON_STRUCT_TYPE",
+      parameters = Map(
+        "inputSchema" -> "\"ARRAY<int>\"",
+        "dataType" -> "\"ARRAY<INT>\""
+      ),
+      context = ExpectedContext(fragment = "from_xml", getCurrentClassCallSitePattern)
+    )
+
+    checkError(
+      exception = intercept[AnalysisException] {
+        Seq("1").toDF("xml").selectExpr(s"from_xml(xml, 'ARRAY<int>')")
+      },
+      errorClass = "INVALID_SCHEMA.NON_STRUCT_TYPE",
+      parameters = Map(
+        "inputSchema" -> "\"ARRAY<int>\"",
+        "dataType" -> "\"ARRAY<INT>\""
+      ),
+      context = ExpectedContext(
+        fragment = "from_xml(xml, 'ARRAY<int>')",
+        start = 0,
+        stop = 26
+      )
+    )
+  }
+
   test("to_xml - struct") {
     val schema = StructType(StructField("a", IntegerType, nullable = false) :: Nil)
     val data = Seq(Row(1))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
@@ -1295,26 +1295,6 @@ class XmlSuite
     assert(result.select("decoded._foo").head().getString(0) === "bar")
   }
 
-  /*
-  test("from_xml array basic test") {
-    val xmlData =
-      """<parent><pid>12345</pid><name>dave guy</name></parent>
-        |<parent><pid>67890</pid><name>other guy</name></parent>""".stripMargin
-    val df = Seq((8, xmlData)).toDF("number", "payload")
-    val xmlSchema = ArrayType(
-      StructType(
-        StructField("pid", IntegerType) ::
-          StructField("name", StringType) :: Nil))
-    val expectedSchema = df.schema.add("decoded", xmlSchema)
-    val result = df.withColumn("decoded",
-      from_xml(df.col("payload"), xmlSchema))
-    assert(expectedSchema === result.schema)
-    // TODO: ArrayType and MapType support in from_xml
-    // assert(result.selectExpr("decoded[0].pid").head().getInt(0) === 12345)
-    // assert(result.selectExpr("decoded[1].pid").head().getInt(1) === 67890)
-  }
-  */
-
   test("from_xml error test") {
     // XML contains error
     val xmlData =


### PR DESCRIPTION
### What changes were proposed in this pull request?
The PR aims to cleanup some redundant codes (support for `ArrayType` & `MapType`)

### Why are the changes needed?
As discussed below, we will not support `ArrayType` and `MapType` in `from_xml`, so we can cleanup the logic related to them.
https://issues.apache.org/jira/browse/SPARK-44810
<img width="682" alt="image" src="https://github.com/apache/spark/assets/15246973/9b78abb2-7907-4ff5-9177-0e09b5f5a9b5">
<img width="706" alt="image" src="https://github.com/apache/spark/assets/15246973/64f61727-80c2-4946-826c-0940b3ab288d">


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Add new UT & existed UT.
- Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
No.
