### PR TITLE
[MINOR][TESTS] Rename test_union to test_eqnullsafe at ColumnTestsMixin

### DIFF
--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -259,7 +259,7 @@ class ColumnTestsMixin:
             message_parameters={"arg_name": "window", "arg_type": "int"},
         )
 
-    def test_union_classmethod_usage(self):
+    def test_eqnullsafe_classmethod_usage(self):
         df = self.spark.range(1)
         self.assertEqual(df.select(Column.eqNullSafe(df.id, df.id)).first()[0], True)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to rename `test_union` to `test_eqnullsafe` at `ColumnTestsMixin`.

### Why are the changes needed?

To avoid confusion from the test name.

### Does this PR introduce _any_ user-facing change?

No, test-only

### How was this patch tested?

CI in this PR.

### Was this patch authored or co-authored using generative AI tooling?

No.