### PR TITLE
[SPARK-48367][CONNECT] Fix lint-scala for scalafmt to detect files to format properly

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Column.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Column.scala
@@ -1330,7 +1330,8 @@ object Column {
   private[sql] def apply(name: String, planId: Option[Long]): Column = new Column(name, planId)
 
   private[sql] def nameToExpression(
-      name: String, planId: Option[Long] = None): proto.Expression = {
+      name: String,
+      planId: Option[Long] = None): proto.Expression = {
     val builder = proto.Expression.newBuilder()
     name match {
       case "*" =>

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -7209,8 +7209,8 @@ object functions {
    * Returns length of array or map.
    *
    * This function returns -1 for null input only if spark.sql.ansi.enabled is false and
-   * spark.sql.legacy.sizeOfNull is true. Otherwise, it returns null for null input.
-   * With the default settings, the function returns null for null input.
+   * spark.sql.legacy.sizeOfNull is true. Otherwise, it returns null for null input. With the
+   * default settings, the function returns null for null input.
    *
    * @group collection_funcs
    * @since 3.4.0
@@ -7687,8 +7687,8 @@ object functions {
    * Returns length of array or map. This is an alias of `size` function.
    *
    * This function returns -1 for null input only if spark.sql.ansi.enabled is false and
-   * spark.sql.legacy.sizeOfNull is true. Otherwise, it returns null for null input.
-   * With the default settings, the function returns null for null input.
+   * spark.sql.legacy.sizeOfNull is true. Otherwise, it returns null for null input. With the
+   * default settings, the function returns null for null input.
    *
    * @group collection_funcs
    * @since 3.5.0

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/CheckConnectJvmClientCompatibility.scala
@@ -357,12 +357,8 @@ object CheckConnectJvmClientCompatibility {
 
       // Column
       // developer API
-      ProblemFilters.exclude[IncompatibleMethTypeProblem](
-        "org.apache.spark.sql.Column.apply"
-      ),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem](
-        "org.apache.spark.sql.Column.expr"
-      ),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.spark.sql.Column.apply"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.spark.sql.Column.expr"),
 
       // Dataset
       ProblemFilters.exclude[DirectMissingMethodProblem](

--- a/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/ConnectProtoUtils.scala
+++ b/connector/connect/common/src/main/scala/org/apache/spark/sql/connect/ConnectProtoUtils.scala
@@ -22,9 +22,9 @@ import org.apache.spark.connect.proto
 import org.apache.spark.sql.connect.common.ProtoUtils
 
 /**
- * Utility functions for parsing Spark Connect protocol buffers with a recursion limit.
- * This is intended to be used by plugins, as they cannot use `ProtoUtils.parseWithRecursionLimit`
- * due to the shading of the `com.google.protobuf` package.
+ * Utility functions for parsing Spark Connect protocol buffers with a recursion limit. This is
+ * intended to be used by plugins, as they cannot use `ProtoUtils.parseWithRecursionLimit` due to
+ * the shading of the `com.google.protobuf` package.
  */
 object ConnectProtoUtils {
   @DeveloperApi
@@ -44,7 +44,8 @@ object ConnectProtoUtils {
 
   @DeveloperApi
   def parseExpressionWithRecursionLimit(
-      bytes: Array[Byte], recursionLimit: Int): proto.Expression = {
+      bytes: Array[Byte],
+      recursionLimit: Int): proto.Expression = {
     ProtoUtils.parseWithRecursionLimit(bytes, proto.Expression.parser(), recursionLimit)
   }
 

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SessionHolder.scala
@@ -107,7 +107,8 @@ case class SessionHolder(userId: String, sessionId: String, session: SparkSessio
   // Mapping from relation ID (passed to client) to runtime dataframe. Used for callbacks like
   // foreachBatch() in Streaming, and DataFrame.checkpoint API. Lazy since most sessions don't
   // need it.
-  private[spark] lazy val dataFrameCache: ConcurrentMap[String, DataFrame] = new ConcurrentHashMap()
+  private[spark] lazy val dataFrameCache: ConcurrentMap[String, DataFrame] =
+    new ConcurrentHashMap()
 
   // Mapping from id to StreamingQueryListener. Used for methods like removeListener() in
   // StreamingQueryManager.

--- a/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
+++ b/connector/connect/server/src/main/scala/org/apache/spark/sql/connect/service/SparkConnectService.scala
@@ -317,7 +317,8 @@ object SparkConnectService extends Logging {
 
   // For testing
   private[spark] def getOrCreateIsolatedSession(
-      userId: String, sessionId: String): SessionHolder = {
+      userId: String,
+      sessionId: String): SessionHolder = {
     getOrCreateIsolatedSession(userId, sessionId, None)
   }
 

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerTestUtils.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerTestUtils.scala
@@ -35,7 +35,9 @@ object SparkConnectPlannerTestUtils {
     new SparkConnectPlanner(executeHolder).process(command, new MockObserver())
   }
 
-  private def buildExecutePlanHolder(spark: SparkSession, command: proto.Command): ExecuteHolder = {
+  private def buildExecutePlanHolder(
+      spark: SparkSession,
+      command: proto.Command): ExecuteHolder = {
     val sessionHolder = SessionHolder.forTesting(spark)
     sessionHolder.eventManager.status_(SessionStatus.Started)
 

--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/plugin/SparkConnectPluginRegistrySuite.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/plugin/SparkConnectPluginRegistrySuite.scala
@@ -70,7 +70,8 @@ class ExampleRelationPlugin extends RelationPlugin {
     }
     val plugin = rel.unpack(classOf[proto.ExamplePluginRelation])
     val input = ConnectProtoUtils.parseRelationWithRecursionLimit(
-      plugin.getInput.toByteArray, recursionLimit = 1024)
+      plugin.getInput.toByteArray,
+      recursionLimit = 1024)
     Optional.of(planner.transformRelation(input))
   }
 }
@@ -85,7 +86,8 @@ class ExampleExpressionPlugin extends ExpressionPlugin {
     }
     val exp = rel.unpack(classOf[proto.ExamplePluginExpression])
     val child = ConnectProtoUtils.parseExpressionWithRecursionLimit(
-      exp.getChild.toByteArray, recursionLimit = 1024)
+      exp.getChild.toByteArray,
+      recursionLimit = 1024)
     Optional.of(Alias(planner.transformExpression(child), exp.getCustomField)())
   }
 }

--- a/dev/lint-scala
+++ b/dev/lint-scala
@@ -32,7 +32,7 @@ ERRORS=$(./build/mvn \
     -pl connector/connect/common \
     -pl connector/connect/server \
     -pl connector/connect/client/jvm \
-    2>&1 | grep -e "^Requires formatting" \
+    2>&1 | grep -e "Requires formatting" \
 )
 
 if test ! -z "$ERRORS"; then


### PR DESCRIPTION
### What changes were proposed in this pull request?

Seems like scalafmt upgrade (https://github.com/apache/spark/pull/44845) changed its output format. This PR proposes to fix `./dev/lint-scala` script to detect files format properly.

### Why are the changes needed?

To fix the regression in CI.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually ran the script.

### Was this patch authored or co-authored using generative AI tooling?

No.
