### PR TITLE
[SPARK-48031] Grandfather legacy views to SCHEMA BINDING

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/interface.scala
@@ -402,14 +402,14 @@ case class CatalogTable(
   }
 
   /**
-   * Return the schema binding mode. Defaults to SchemaCompensation if not a view or an older
+   * Return the schema binding mode. Defaults to SchemaBinding if not a view or an older
    * version, unless the viewSchemaBindingMode config is set to false
    */
   def viewSchemaMode: ViewSchemaMode = {
     if (!SQLConf.get.viewSchemaBindingEnabled) {
       SchemaUnsupported
     } else {
-      val schemaMode = properties.getOrElse(VIEW_SCHEMA_MODE, SchemaCompensation.toString)
+      val schemaMode = properties.getOrElse(VIEW_SCHEMA_MODE, SchemaBinding.toString)
       schemaMode match {
         case SchemaBinding.toString => SchemaBinding
         case SchemaEvolution.toString => SchemaEvolution

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -742,10 +742,9 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
   private def getViewPlan(metadata: CatalogTable): LogicalPlan = {
     import org.apache.spark.sql.catalyst.dsl.expressions._
     val projectList = metadata.schema.map { field =>
-      Cast(
+      UpCast(
         GetViewColumnByNameAndOrdinal(metadata.identifier.toString, field.name, 0, 1, None),
-        field.dataType,
-        ansiEnabled = true).as(field.name)
+        field.dataType).as(field.name)
     }
     Project(projectList, CatalystSqlParser.parsePlan(metadata.viewText.get))
   }

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/view-schema-binding-config.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/view-schema-binding-config.sql.out
@@ -665,6 +665,142 @@ DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type
 
 
 -- !query
+SET spark.sql.legacy.viewSchemaBindingMode = false
+-- !query analysis
+SetCommand (spark.sql.legacy.viewSchemaBindingMode,Some(false))
+
+
+-- !query
+SET spark.sql.legacy.viewSchemaCompensation = false
+-- !query analysis
+SetCommand (spark.sql.legacy.viewSchemaCompensation,Some(false))
+
+
+-- !query
+CREATE OR REPLACE VIEW v AS SELECT 1
+-- !query analysis
+CreateViewCommand `spark_catalog`.`default`.`v`, SELECT 1, false, true, PersistedView, UNSUPPORTED, true
+   +- Project [1 AS 1#x]
+      +- OneRowRelation
+
+
+-- !query
+SET spark.sql.legacy.viewSchemaBindingMode = true
+-- !query analysis
+SetCommand (spark.sql.legacy.viewSchemaBindingMode,Some(true))
+
+
+-- !query
+DESCRIBE EXTENDED v
+-- !query analysis
+DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
+
+
+-- !query
+SHOW TABLE EXTENDED LIKE 'v'
+-- !query analysis
+ShowTablesCommand default, v, [namespace#x, tableName#x, isTemporary#x, information#x], true
+
+
+-- !query
+SHOW CREATE TABLE v
+-- !query analysis
+ShowCreateTableCommand `spark_catalog`.`default`.`v`, [createtab_stmt#x]
+
+
+-- !query
+SET spark.sql.legacy.viewSchemaCompensation = true
+-- !query analysis
+SetCommand (spark.sql.legacy.viewSchemaCompensation,Some(true))
+
+
+-- !query
+DESCRIBE EXTENDED v
+-- !query analysis
+DescribeTableCommand `spark_catalog`.`default`.`v`, true, [col_name#x, data_type#x, comment#x]
+
+
+-- !query
+SHOW TABLE EXTENDED LIKE 'v'
+-- !query analysis
+ShowTablesCommand default, v, [namespace#x, tableName#x, isTemporary#x, information#x], true
+
+
+-- !query
+SHOW CREATE TABLE v
+-- !query analysis
+ShowCreateTableCommand `spark_catalog`.`default`.`v`, [createtab_stmt#x]
+
+
+-- !query
+DROP VIEW IF EXISTS v
+-- !query analysis
+DropTableCommand `spark_catalog`.`default`.`v`, true, true, false
+
+
+-- !query
+SET spark.sql.legacy.viewSchemaBindingMode = false
+-- !query analysis
+SetCommand (spark.sql.legacy.viewSchemaBindingMode,Some(false))
+
+
+-- !query
+SET spark.sql.legacy.viewSchemaCompensation = false
+-- !query analysis
+SetCommand (spark.sql.legacy.viewSchemaCompensation,Some(false))
+
+
+-- !query
+CREATE OR REPLACE TEMPORARY VIEW v AS SELECT 1
+-- !query analysis
+CreateViewCommand `v`, SELECT 1, false, true, LocalTempView, UNSUPPORTED, true
+   +- Project [1 AS 1#x]
+      +- OneRowRelation
+
+
+-- !query
+SET spark.sql.legacy.viewSchemaBindingMode = true
+-- !query analysis
+SetCommand (spark.sql.legacy.viewSchemaBindingMode,Some(true))
+
+
+-- !query
+DESCRIBE EXTENDED v
+-- !query analysis
+DescribeTableCommand `v`, true, [col_name#x, data_type#x, comment#x]
+
+
+-- !query
+SHOW TABLE EXTENDED LIKE 'v'
+-- !query analysis
+ShowTablesCommand default, v, [namespace#x, tableName#x, isTemporary#x, information#x], true
+
+
+-- !query
+SET spark.sql.legacy.viewSchemaCompensation = true
+-- !query analysis
+SetCommand (spark.sql.legacy.viewSchemaCompensation,Some(true))
+
+
+-- !query
+DESCRIBE EXTENDED v
+-- !query analysis
+DescribeTableCommand `v`, true, [col_name#x, data_type#x, comment#x]
+
+
+-- !query
+SHOW TABLE EXTENDED LIKE 'v'
+-- !query analysis
+ShowTablesCommand default, v, [namespace#x, tableName#x, isTemporary#x, information#x], true
+
+
+-- !query
+DROP VIEW IF EXISTS v
+-- !query analysis
+DropTempViewCommand v
+
+
+-- !query
 DROP VIEW IF EXISTS v
 -- !query analysis
 DropTableCommand `spark_catalog`.`default`.`v`, true, true, false

--- a/sql/core/src/test/resources/sql-tests/inputs/view-schema-binding-config.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/view-schema-binding-config.sql
@@ -138,6 +138,35 @@ CREATE TABLE t(c3 INT NOT NULL, c2 INT) USING PARQUET;
 SELECT * FROM v;
 DESCRIBE EXTENDED v;
 
+-- 3. Test the behavior of grandfathered views and temp views
+SET spark.sql.legacy.viewSchemaBindingMode = false;
+SET spark.sql.legacy.viewSchemaCompensation = false;
+CREATE OR REPLACE VIEW v AS SELECT 1;
+SET spark.sql.legacy.viewSchemaBindingMode = true;
+DESCRIBE EXTENDED v;
+SHOW TABLE EXTENDED LIKE 'v';
+SHOW CREATE TABLE v;
+
+SET spark.sql.legacy.viewSchemaCompensation = true;
+DESCRIBE EXTENDED v;
+SHOW TABLE EXTENDED LIKE 'v';
+SHOW CREATE TABLE v;
+
+DROP VIEW IF EXISTS v;
+
+SET spark.sql.legacy.viewSchemaBindingMode = false;
+SET spark.sql.legacy.viewSchemaCompensation = false;
+CREATE OR REPLACE TEMPORARY VIEW v AS SELECT 1;
+SET spark.sql.legacy.viewSchemaBindingMode = true;
+DESCRIBE EXTENDED v;
+SHOW TABLE EXTENDED LIKE 'v';
+
+SET spark.sql.legacy.viewSchemaCompensation = true;
+DESCRIBE EXTENDED v;
+SHOW TABLE EXTENDED LIKE 'v';
+
+DROP VIEW IF EXISTS v;
+
 -- 99 Cleanup
 DROP VIEW IF EXISTS v;
 DROP TABLE IF EXISTS t;

--- a/sql/core/src/test/resources/sql-tests/results/show-tables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/show-tables.sql.out
@@ -124,7 +124,7 @@ Created Time [not included in comparison]
 Last Access [not included in comparison]
 Created By [not included in comparison]
 Type: VIEW
-View Schema Mode: COMPENSATION
+View Schema Mode: BINDING
 Schema: root
  |-- e: integer (nullable = true)
 

--- a/sql/core/src/test/resources/sql-tests/results/view-schema-binding-config.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/view-schema-binding-config.sql.out
@@ -958,6 +958,262 @@ View Query Output Columns	[c1, c2]
 
 
 -- !query
+SET spark.sql.legacy.viewSchemaBindingMode = false
+-- !query schema
+struct<key:string,value:string>
+-- !query output
+spark.sql.legacy.viewSchemaBindingMode	false
+
+
+-- !query
+SET spark.sql.legacy.viewSchemaCompensation = false
+-- !query schema
+struct<key:string,value:string>
+-- !query output
+spark.sql.legacy.viewSchemaCompensation	false
+
+
+-- !query
+CREATE OR REPLACE VIEW v AS SELECT 1
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+SET spark.sql.legacy.viewSchemaBindingMode = true
+-- !query schema
+struct<key:string,value:string>
+-- !query output
+spark.sql.legacy.viewSchemaBindingMode	true
+
+
+-- !query
+DESCRIBE EXTENDED v
+-- !query schema
+struct<col_name:string,data_type:string,comment:string>
+-- !query output
+1                   	int                 	                    
+                    	                    	                    
+# Detailed Table Information	                    	                    
+Catalog             	spark_catalog       	                    
+Database            	default             	                    
+Table               	v                   	                    
+Created Time [not included in comparison]
+Last Access [not included in comparison]
+Created By [not included in comparison]
+Type                	VIEW                	                    
+View Text           	SELECT 1            	                    
+View Original Text  	SELECT 1            	                    
+View Schema Mode    	BINDING             	                    
+View Catalog and Namespace	spark_catalog.default	                    
+View Query Output Columns	[1]
+
+
+-- !query
+SHOW TABLE EXTENDED LIKE 'v'
+-- !query schema
+struct<namespace:string,tableName:string,isTemporary:boolean,information:string>
+-- !query output
+default	v	false	Catalog: spark_catalog
+Database: default
+Table: v
+Created Time [not included in comparison]
+Last Access [not included in comparison]
+Created By [not included in comparison]
+Type: VIEW
+View Text: SELECT 1
+View Original Text: SELECT 1
+View Schema Mode: BINDING
+View Catalog and Namespace: spark_catalog.default
+View Query Output Columns: [1]
+Schema: root
+ |-- 1: integer (nullable = false)
+
+
+-- !query
+SHOW CREATE TABLE v
+-- !query schema
+struct<createtab_stmt:string>
+-- !query output
+CREATE VIEW default.v (
+  `1`)
+WITH SCHEMA BINDING
+AS SELECT 1
+
+
+-- !query
+SET spark.sql.legacy.viewSchemaCompensation = true
+-- !query schema
+struct<key:string,value:string>
+-- !query output
+spark.sql.legacy.viewSchemaCompensation	true
+
+
+-- !query
+DESCRIBE EXTENDED v
+-- !query schema
+struct<col_name:string,data_type:string,comment:string>
+-- !query output
+1                   	int                 	                    
+                    	                    	                    
+# Detailed Table Information	                    	                    
+Catalog             	spark_catalog       	                    
+Database            	default             	                    
+Table               	v                   	                    
+Created Time [not included in comparison]
+Last Access [not included in comparison]
+Created By [not included in comparison]
+Type                	VIEW                	                    
+View Text           	SELECT 1            	                    
+View Original Text  	SELECT 1            	                    
+View Schema Mode    	BINDING             	                    
+View Catalog and Namespace	spark_catalog.default	                    
+View Query Output Columns	[1]
+
+
+-- !query
+SHOW TABLE EXTENDED LIKE 'v'
+-- !query schema
+struct<namespace:string,tableName:string,isTemporary:boolean,information:string>
+-- !query output
+default	v	false	Catalog: spark_catalog
+Database: default
+Table: v
+Created Time [not included in comparison]
+Last Access [not included in comparison]
+Created By [not included in comparison]
+Type: VIEW
+View Text: SELECT 1
+View Original Text: SELECT 1
+View Schema Mode: BINDING
+View Catalog and Namespace: spark_catalog.default
+View Query Output Columns: [1]
+Schema: root
+ |-- 1: integer (nullable = false)
+
+
+-- !query
+SHOW CREATE TABLE v
+-- !query schema
+struct<createtab_stmt:string>
+-- !query output
+CREATE VIEW default.v (
+  `1`)
+WITH SCHEMA BINDING
+AS SELECT 1
+
+
+-- !query
+DROP VIEW IF EXISTS v
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+SET spark.sql.legacy.viewSchemaBindingMode = false
+-- !query schema
+struct<key:string,value:string>
+-- !query output
+spark.sql.legacy.viewSchemaBindingMode	false
+
+
+-- !query
+SET spark.sql.legacy.viewSchemaCompensation = false
+-- !query schema
+struct<key:string,value:string>
+-- !query output
+spark.sql.legacy.viewSchemaCompensation	false
+
+
+-- !query
+CREATE OR REPLACE TEMPORARY VIEW v AS SELECT 1
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
+SET spark.sql.legacy.viewSchemaBindingMode = true
+-- !query schema
+struct<key:string,value:string>
+-- !query output
+spark.sql.legacy.viewSchemaBindingMode	true
+
+
+-- !query
+DESCRIBE EXTENDED v
+-- !query schema
+struct<col_name:string,data_type:string,comment:string>
+-- !query output
+1                   	int
+
+
+-- !query
+SHOW TABLE EXTENDED LIKE 'v'
+-- !query schema
+struct<namespace:string,tableName:string,isTemporary:boolean,information:string>
+-- !query output
+	v	true	Table: v
+Created Time [not included in comparison]
+Last Access [not included in comparison]
+Created By [not included in comparison]
+Type: VIEW
+View Text: SELECT 1
+View Schema Mode: BINDING
+View Catalog and Namespace: spark_catalog.default
+View Query Output Columns: [1]
+Schema: root
+ |-- 1: integer (nullable = false)
+
+
+-- !query
+SET spark.sql.legacy.viewSchemaCompensation = true
+-- !query schema
+struct<key:string,value:string>
+-- !query output
+spark.sql.legacy.viewSchemaCompensation	true
+
+
+-- !query
+DESCRIBE EXTENDED v
+-- !query schema
+struct<col_name:string,data_type:string,comment:string>
+-- !query output
+1                   	int
+
+
+-- !query
+SHOW TABLE EXTENDED LIKE 'v'
+-- !query schema
+struct<namespace:string,tableName:string,isTemporary:boolean,information:string>
+-- !query output
+	v	true	Table: v
+Created Time [not included in comparison]
+Last Access [not included in comparison]
+Created By [not included in comparison]
+Type: VIEW
+View Text: SELECT 1
+View Schema Mode: BINDING
+View Catalog and Namespace: spark_catalog.default
+View Query Output Columns: [1]
+Schema: root
+ |-- 1: integer (nullable = false)
+
+
+-- !query
+DROP VIEW IF EXISTS v
+-- !query schema
+struct<>
+-- !query output
+
+
+
+-- !query
 DROP VIEW IF EXISTS v
 -- !query schema
 struct<>

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuiteBase.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/ShowTablesSuiteBase.scala
@@ -351,7 +351,7 @@ trait ShowTablesSuiteBase extends QueryTest with DDLCommandTestUtils {
              |Created By: <created by>
              |Type: VIEW
              |View Text: SELECT id FROM $catalog.$namespace.$table
-             |View Schema Mode: COMPENSATION
+             |View Schema Mode: BINDING
              |View Catalog and Namespace: spark_catalog.default
              |View Query Output Columns: [id]
              |Schema: root
@@ -378,7 +378,7 @@ trait ShowTablesSuiteBase extends QueryTest with DDLCommandTestUtils {
              |Created By: <created by>
              |Type: VIEW
              |View Text: SELECT id FROM $catalog.$namespace.$table
-             |View Schema Mode: COMPENSATION
+             |View Schema Mode: BINDING
              |View Catalog and Namespace: spark_catalog.default
              |View Query Output Columns: [id]
              |Schema: root
@@ -396,7 +396,7 @@ trait ShowTablesSuiteBase extends QueryTest with DDLCommandTestUtils {
              |Created By: <created by>
              |Type: VIEW
              |View Text: SELECT id FROM $catalog.$namespace.$table
-             |View Schema Mode: COMPENSATION
+             |View Schema Mode: BINDING
              |View Catalog and Namespace: spark_catalog.default
              |View Query Output Columns: [id]
              |Schema: root


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
When enabling schema evolution for views, legacy views created prior should always use SCHEMA BINDING for compatibility. This is independent of the default mode.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Get predictable behavior.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No, because it's a fix for unreleased feature.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Add new tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No