### PR TITLE
[SPARK-48367][CONNECT][FOLLOWUP] Replace keywords that identify `lint-scala` detection results

### DIFF
--- a/dev/lint-scala
+++ b/dev/lint-scala
@@ -32,7 +32,7 @@ ERRORS=$(./build/mvn \
     -pl connector/connect/common \
     -pl connector/connect/server \
     -pl connector/connect/client/jvm \
-    2>&1 | grep -e "Requires formatting" \
+    2>&1 | grep -e "Unformatted files found" \
 )
 
 if test ! -z "$ERRORS"; then


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr is following up https://github.com/apache/spark/pull/46679.
The pr aims to replace `keywords` (from `Requires formatting` to `Unformatted files found`) that identify `lint-scala` detection results.

### Why are the changes needed?
According to the discussion and analysis of https://github.com/apache/spark/pull/46679#issuecomment-2122142979, with the upgrade of `org.antipathy:mvn-scalafmt_*` version, it seems more general to use `Unformatted files found` as the keyword, because it directly comes from `the prompt of error level output`.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Manually test
```
(base) ➜  spark-community git:(SPARK-48367_FOLLOWUP) ✗ dev/lint-scala
Scalastyle checks passed.
Scalafmt checks passed.
```
- Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
