### PR TITLE
[SPARK-48373][PYTHON] Allow schema parameter of createDataFrame() to be length-1 list or tuple of StructType

### DIFF
--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -448,9 +448,12 @@ class SparkSession:
                 _num_cols = 1
 
         elif isinstance(schema, (list, tuple)):
-            # Must re-encode any unicode strings to be consistent with StructField names
-            _cols = [x.encode("utf-8") if not isinstance(x, str) else x for x in schema]
-            _num_cols = len(_cols)
+            if len(schema) and isinstance(schema[0], StructType):
+                schema = schema[0]
+            else:
+                # Must re-encode any unicode strings to be consistent with StructField names
+                _cols = [x.encode("utf-8") if not isinstance(x, str) else x for x in schema]
+                _num_cols = len(_cols)
 
         elif schema is not None:
             raise PySparkTypeError(

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -1490,8 +1490,11 @@ class SparkSession(SparkConversionMixin):
         if isinstance(schema, str):
             schema = cast(Union[AtomicType, StructType, str], _parse_datatype_string(schema))
         elif isinstance(schema, (list, tuple)):
-            # Must re-encode any unicode strings to be consistent with StructField names
-            schema = [x.encode("utf-8") if not isinstance(x, str) else x for x in schema]
+            if len(schema) and isinstance(schema[0], StructType):
+                schema = schema[0]
+            else:
+                # Must re-encode any unicode strings to be consistent with StructField names
+                schema = [x.encode("utf-8") if not isinstance(x, str) else x for x in schema]
 
         try:
             import pandas as pd

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -487,10 +487,18 @@ class ArrowTestsMixin:
 
     def test_createDataFrame_with_schema(self):
         pdf = self.create_pandas_data_frame()
-        df = self.spark.createDataFrame(pdf, schema=self.schema)
-        self.assertEqual(self.schema, df.schema)
-        pdf_arrow = df.toPandas()
-        assert_frame_equal(pdf_arrow, pdf)
+        for schema in [
+            self.schema,
+            (self.schema,),
+            [
+                self.schema,
+            ],
+        ]:
+            with self.subTest(schema=schema):
+                df = self.spark.createDataFrame(pdf, schema=schema)
+                self.assertEqual(self.schema, df.schema)
+                pdf_arrow = df.toPandas()
+                assert_frame_equal(pdf_arrow, pdf)
 
     def test_createDataFrame_with_incorrect_schema(self):
         with self.quiet():


### PR DESCRIPTION
### What changes were proposed in this pull request?
Users will no longer get an error if they pass a length-1 list or tuple of StructType as the schema argument to createDataFrame()

### Why are the changes needed?
In Python code it is easy to accidentally create a length-1 tuple of `StructType` instead of just a `StructType` if you leave a trailing comma at the end of a line.

### Does this PR introduce _any_ user-facing change?
It prevents an unhelpful error message in this case.

### How was this patch tested?
I modified one of the existing tests to test this.

### Was this patch authored or co-authored using generative AI tooling?
No