### PR TITLE
SPARK-48380: SerDeUtil.javaToPython to support batchSize parameter

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -211,7 +211,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         <class 'pyspark.rdd.RDD'>
         """
         if self._lazy_rdd is None:
-            jrdd = self._jdf.javaToPython()
+            jrdd = self._jdf.javaToPython(0)
             self._lazy_rdd = RDD(
                 jrdd, self.sparkSession._sc, BatchedSerializer(CPickleSerializer())
             )


### PR DESCRIPTION
### What changes were proposed in this pull request?
This simple PR adds a parameter `batchSize` to the underlying `javaToPython` function.  This parameter is already available on `pairRDDToPython`.  

### Why are the changes needed?
With this, pyspark program can decide to use a different batch size when the default AutoBatchPickler ends up with 2GB exceeded error as in the JIRA ticket: https://issues.apache.org/jira/browse/SPARK-48380

### Does this PR introduce _any_ user-facing change?
This introduces a new way to access python RDD from python DataFrame:

```
# python
# The existing way to convert dataframe to RDD with auto batching (NO CHANGES)
df.rdd
# The new way to convert dataframe to RDD with batchSize of 1 (New API)
df._jdf.javaToPython(1)
```


### How was this patch tested?
mvn test
(still testing)

### Was this patch authored or co-authored using generative AI tooling?
No.