### PR TITLE
[MINOR][TESTS] Fix `DslLogicalPlan.as`

### DIFF
--- a/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/dsl/package.scala
+++ b/connector/connect/server/src/test/scala/org/apache/spark/sql/connect/dsl/package.scala
@@ -690,7 +690,7 @@ package object dsl {
 
       def as(alias: String): Relation = {
         Relation
-          .newBuilder(logicalPlan)
+          .newBuilder()
           .setSubqueryAlias(SubqueryAlias.newBuilder().setAlias(alias).setInput(logicalPlan))
           .build()
       }
@@ -720,9 +720,10 @@ package object dsl {
           .setNullOrdering(Expression.SortOrder.NullOrdering.SORT_NULLS_FIRST)
           .setDirection(Expression.SortOrder.SortDirection.SORT_DIRECTION_ASCENDING)
           .setChild(
-            Expression.newBuilder
+            Expression
+              .newBuilder()
               .setUnresolvedAttribute(
-                Expression.UnresolvedAttribute.newBuilder.setUnparsedIdentifier(col).build())
+                Expression.UnresolvedAttribute.newBuilder().setUnparsedIdentifier(col).build())
               .build())
           .build()
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, Fix `DslLogicalPlan.as`, initialize without any plan; No similar cases in the `dsl`
2, btw, `newBuilder` -> `newBuilder()` to avoid warnings

### Why are the changes needed?
it should not initialize with the input `logicalPlan`


### Does this PR introduce _any_ user-facing change?
no, test only


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
No
