### PR TITLE
[SPARK-48258][PYTHON][CONNECT][FOLLOW-UP] Bind relation ID to the plan instead of DataFrame

### DIFF
--- a/python/pyspark/sql/connect/conversion.py
+++ b/python/pyspark/sql/connect/conversion.py
@@ -577,7 +577,8 @@ def proto_to_remote_cached_dataframe(relation: pb2.CachedRemoteRelation) -> "Dat
     from pyspark.sql.connect.session import SparkSession
     import pyspark.sql.connect.plan as plan
 
+    session = SparkSession.active()
     return DataFrame(
-        plan=plan.CachedRemoteRelation(relation.relation_id),
-        session=SparkSession.active(),
+        plan=plan.CachedRemoteRelation(relation.relation_id, session),
+        session=session,
     )

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -16,7 +16,6 @@
 #
 
 # mypy: disable-error-code="override"
-from pyspark.sql.connect.proto import base_pb2 as spark_dot_connect_dot_base__pb2
 from pyspark.errors.exceptions.base import (
     SessionNotSameException,
     PySparkIndexError,
@@ -138,41 +137,6 @@ class DataFrame(ParentDataFrame):
         # by __repr__ and _repr_html_ while eager evaluation opens.
         self._support_repr_html = False
         self._cached_schema: Optional[StructType] = None
-        self._cached_remote_relation_id: Optional[str] = None
-
-    def __del__(self) -> None:
-        # If session is already closed, all cached DataFrame should be released.
-        if not self._session.client.is_closed and self._cached_remote_relation_id is not None:
-            try:
-                command = plan.RemoveRemoteCachedRelation(
-                    plan.CachedRemoteRelation(relationId=self._cached_remote_relation_id)
-                ).command(session=self._session.client)
-                req = self._session.client._execute_plan_request_with_metadata()
-                if self._session.client._user_id:
-                    req.user_context.user_id = self._session.client._user_id
-                req.plan.command.CopyFrom(command)
-
-                for attempt in self._session.client._retrying():
-                    with attempt:
-                        # !!HACK ALERT!!
-                        # unary_stream does not work on Python's exit for an unknown reasons
-                        # Therefore, here we open unary_unary channel instead.
-                        # See also :class:`SparkConnectServiceStub`.
-                        request_serializer = (
-                            spark_dot_connect_dot_base__pb2.ExecutePlanRequest.SerializeToString
-                        )
-                        response_deserializer = (
-                            spark_dot_connect_dot_base__pb2.ExecutePlanResponse.FromString
-                        )
-                        channel = self._session.client._channel.unary_unary(
-                            "/spark.connect.SparkConnectService/ExecutePlan",
-                            request_serializer=request_serializer,
-                            response_deserializer=response_deserializer,
-                        )
-                        metadata = self._session.client._builder.metadata()
-                        channel(req, metadata=metadata)  # type: ignore[arg-type]
-            except Exception as e:
-                warnings.warn(f"RemoveRemoteCachedRelation failed with exception: {e}.")
 
     def __reduce__(self) -> Tuple:
         """
@@ -2137,7 +2101,6 @@ class DataFrame(ParentDataFrame):
         assert "checkpoint_command_result" in properties
         checkpointed = properties["checkpoint_command_result"]
         assert isinstance(checkpointed._plan, plan.CachedRemoteRelation)
-        checkpointed._cached_remote_relation_id = checkpointed._plan._relationId
         return checkpointed
 
     def localCheckpoint(self, eager: bool = True) -> "DataFrame":
@@ -2146,7 +2109,6 @@ class DataFrame(ParentDataFrame):
         assert "checkpoint_command_result" in properties
         checkpointed = properties["checkpoint_command_result"]
         assert isinstance(checkpointed._plan, plan.CachedRemoteRelation)
-        checkpointed._cached_remote_relation_id = checkpointed._plan._relationId
         return checkpointed
 
     if not is_remote_only():

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -926,7 +926,7 @@ class SparkSession:
         This is used in ForeachBatch() runner, where the remote DataFrame refers to the
         output of a micro batch.
         """
-        return DataFrame(CachedRemoteRelation(remote_id), self)
+        return DataFrame(CachedRemoteRelation(remote_id, spark_session=self), self)
 
     @staticmethod
     def _start_connect_server(master: str, opts: Dict[str, Any]) -> None:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR addresses https://github.com/apache/spark/pull/46683#discussion_r1608527529 comment within Python, by using ID at the plan instead of DataFrame itself.

### Why are the changes needed?

Because the DataFrame holds the relation ID, if DataFrame B are derived from DataFrame A, and DataFrame A is garbage-collected, then the cache might not exist anymore. See the example below:

```python
df = spark.range(1).localCheckpoint()
df2 = df.repartition(10)
del df
df2.collect()
```

```
pyspark.errors.exceptions.connect.SparkConnectGrpcException: (org.apache.spark.sql.connect.common.InvalidPlanInput) No DataFrame with id a4efa660-897c-4500-bd4e-bd57cd0263d2 is found in the session cd4764b4-90a9-4249-9140-12a6e4a98cd3
```

### Does this PR introduce _any_ user-facing change?

No, the main change has not been released out yet.

### How was this patch tested?

Manually tested, and added a unittest.

### Was this patch authored or co-authored using generative AI tooling?

No.
