### PR TITLE
[SPARK-48384][BUILD] Exclude `io.netty:netty-tcnative-boringssl-static` from `zookeeper`

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -207,7 +207,6 @@ netty-common/4.1.109.Final//netty-common-4.1.109.Final.jar
 netty-handler-proxy/4.1.109.Final//netty-handler-proxy-4.1.109.Final.jar
 netty-handler/4.1.109.Final//netty-handler-4.1.109.Final.jar
 netty-resolver/4.1.109.Final//netty-resolver-4.1.109.Final.jar
-netty-tcnative-boringssl-static/2.0.61.Final//netty-tcnative-boringssl-static-2.0.61.Final.jar
 netty-tcnative-boringssl-static/2.0.65.Final/linux-aarch_64/netty-tcnative-boringssl-static-2.0.65.Final-linux-aarch_64.jar
 netty-tcnative-boringssl-static/2.0.65.Final/linux-x86_64/netty-tcnative-boringssl-static-2.0.65.Final-linux-x86_64.jar
 netty-tcnative-boringssl-static/2.0.65.Final/osx-aarch_64/netty-tcnative-boringssl-static-2.0.65.Final-osx-aarch_64.jar

--- a/pom.xml
+++ b/pom.xml
@@ -1840,6 +1840,10 @@
             <artifactId>netty-transport-native-epoll</artifactId>
           </exclusion>
           <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
           </exclusion>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to exclude `io.netty:netty-tcnative-boringssl-static` from `zookeeper`.


### Why are the changes needed?
1.According to:
https://github.com/netty/netty-tcnative/blob/c9b4b6ab62cdbfb4aab6ab3efb8dd7cf73f353ad/boringssl-static/pom.xml#L970-L982
the `io.netty:netty-tcnative-boringssl-static` is composed of:
`io.netty:netty-tcnative-boringssl-static:linux-aarch_64`
`io.netty:netty-tcnative-boringssl-static:linux-x86_64`
`io.netty:netty-tcnative-boringssl-static:osx-aarch_64`
`io.netty:netty-tcnative-boringssl-static:osx-x86_64`
`io.netty:netty-tcnative-boringssl-staticwindows-x86_64`
and our `common/network-common/pom.xml` file already explicitly depends on them.

2.Their versions are different in `dev/deps/spark-deps-hadoop-3-hive-2.3`
<img width="975" alt="image" src="https://github.com/apache/spark/assets/15246973/f85534f5-7727-41ae-9337-741fb76d4d2f">
Let's keep one version to avoid conflicts.

3.In the `pom.xml` file, zookeeper already has other `netty` related exclusions, eg:
https://github.com/apache/spark/blob/master/pom.xml#L1838-L1842
<img width="673" alt="image" src="https://github.com/apache/spark/assets/15246973/79294318-fa45-4a4c-8bf5-774e91297fc7">

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
