### PR TITLE
[SPARK-48380][CORE][WIP]: SerDeUtil.javaToPython to support rows up to 2GB

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/SerDeUtil.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/SerDeUtil.scala
@@ -93,9 +93,10 @@ private[spark] object SerDeUtil extends Logging {
         buffer += iter.next()
       }
       // Pickle the buffer (or a part of it)
-      val bytes
-      Int elementsToDump = buffer.length
+      var bytes: Array[Byte] = null
+      var elementsToDump: Int = buffer.length
       while (true) {
+        // Try pickling; if it fails, adjust the batch size and retry
         try {
           bytes = pickle.dumps(
             (elementsToDump == buffer.length)

--- a/core/src/main/scala/org/apache/spark/api/python/SerDeUtil.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/SerDeUtil.scala
@@ -100,14 +100,17 @@ private[spark] object SerDeUtil extends Logging {
         // Try pickling; if it fails, adjust the batch size and retry
         try {
           bytes = pickle.dumps(
-            if (elementsToDump == buffer.length)
-            buffer.toArray
-            else buffer.take(elementsToDump).toArray
+            if (elementsToDump == buffer.length) {
+              buffer.toArray
+            } else {
+              buffer.take(elementsToDump).toArray
+            }
           )
           done = true
         } catch {
-          // Example: java.lang.IllegalArgumentException: Cannot grow BufferHolder by size 578595584 because the size after growing exceeds size limitation 2147483632
-          case e: java.lang.IllegalArgumentException => {
+          // Example: java.lang.IllegalArgumentException: Cannot grow BufferHolder by size
+          // 578595584 because the size after growing exceeds size limitation 2147483632
+          case e: java.lang.IllegalArgumentException =>
             if (elementsToDump == 1) {
               // if we can't even pickle a single element, throw the exception
               throw e;
@@ -115,7 +118,6 @@ private[spark] object SerDeUtil extends Logging {
               // retry with fewer elements
               elementsToDump /= 2
             }
-          }
         }
       }
 

--- a/core/src/main/scala/org/apache/spark/api/python/SerDeUtil.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/SerDeUtil.scala
@@ -105,7 +105,7 @@ private[spark] object SerDeUtil extends Logging {
           )
         } catch {
           // Example: java.lang.IllegalArgumentException: Cannot grow BufferHolder by size 578595584 because the size after growing exceeds size limitation 2147483632
-          case e: java.lang.IllegalArgumentException =>
+          case e: java.lang.IllegalArgumentException => {
             if (elementsToDump == 1) {
               // if we can't even pickle a single element, throw the exception
               throw e;

--- a/core/src/main/scala/org/apache/spark/api/python/SerDeUtil.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/SerDeUtil.scala
@@ -99,9 +99,9 @@ private[spark] object SerDeUtil extends Logging {
         // Try pickling; if it fails, adjust the batch size and retry
         try {
           bytes = pickle.dumps(
-            (elementsToDump == buffer.length)
-            ? buffer.toArray
-            : buffer.take(elementsToDump).toArray
+            if (elementsToDump == buffer.length)
+            buffer.toArray
+            else buffer.take(elementsToDump).toArray
           )
         } catch {
           // Example: java.lang.IllegalArgumentException: Cannot grow BufferHolder by size 578595584 because the size after growing exceeds size limitation 2147483632

--- a/core/src/test/scala/org/apache/spark/api/python/SerDeUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/api/python/SerDeUtilSuite.scala
@@ -34,14 +34,15 @@ class SerDeUtilSuite extends SparkFunSuite with SharedSparkContext {
   }
 
   test("Converting an large RDD to python RDD does not throw an exception (SPARK-48380)") {
+    val largeString = "1" * 1000_000_000
     val largeRdd = sc.makeRDD(Seq[(Any, Any)](
       ("", ""),
       ("", ""),
       ("", ""),
-      ("", "1" * 1000_000_000),
-      ("", "1" * 1000_000_000),
-      ("", "1" * 1000_000_000),
-      ("", "1" * 1000_000_000),
+      ("", largeString),
+      ("", largeString),
+      ("", largeString),
+      ("", largeString),
     ))
     val javaRdd = largeRdd.toJavaRDD()
     val pythonRdd = SerDeUtil.javaToPython(javaRdd)

--- a/core/src/test/scala/org/apache/spark/api/python/SerDeUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/api/python/SerDeUtilSuite.scala
@@ -33,18 +33,18 @@ class SerDeUtilSuite extends SparkFunSuite with SharedSparkContext {
     SerDeUtil.pythonToPairRDD(pythonRdd, false)
   }
 
-  test("Converting an large RDD to python RDD does not throw an exception (SPARK-48380)") {
+  test("Testing AutoBatchedPickler in supporting large rows (SPARK-48380)") {
+    val emptyString = ""
     val largeString = "1" * 1000_000_000
-    val largeRdd = sc.makeRDD(Seq[(Any, Any)](
-      ("", ""),
-      ("", ""),
-      ("", ""),
-      ("", largeString),
-      ("", largeString),
-      ("", largeString),
-      ("", largeString)
-    ))
-    val javaRdd = largeRdd.toJavaRDD()
-    val pythonRdd = SerDeUtil.javaToPython(javaRdd)
+    val inputIterator = Iterator(
+      emptyString,
+      emptyString,
+      emptyString,
+      largeString,
+      largeString,
+      largeString,
+    )
+    val outputIterator = AutoBatchedPickler(inputIterator)
+    outputIterator.foreach(_ => ())
   }
 }

--- a/core/src/test/scala/org/apache/spark/api/python/SerDeUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/api/python/SerDeUtilSuite.scala
@@ -42,10 +42,9 @@ class SerDeUtilSuite extends SparkFunSuite with SharedSparkContext {
       ("", largeString),
       ("", largeString),
       ("", largeString),
-      ("", largeString),
+      ("", largeString)
     ))
     val javaRdd = largeRdd.toJavaRDD()
     val pythonRdd = SerDeUtil.javaToPython(javaRdd)
-    SerDeUtil.pythonToPairRDD(pythonRdd, false)
   }
 }

--- a/core/src/test/scala/org/apache/spark/api/python/SerDeUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/api/python/SerDeUtilSuite.scala
@@ -32,5 +32,19 @@ class SerDeUtilSuite extends SparkFunSuite with SharedSparkContext {
     val pythonRdd = SerDeUtil.javaToPython(javaRdd)
     SerDeUtil.pythonToPairRDD(pythonRdd, false)
   }
-}
 
+  test("Converting an large RDD to python RDD does not throw an exception (SPARK-48380)") {
+    val largeRdd = sc.makeRDD(Seq[(Any, Any)](
+      ("", ""),
+      ("", ""),
+      ("", ""),
+      ("", "1" * 1000_000_000),
+      ("", "1" * 1000_000_000),
+      ("", "1" * 1000_000_000),
+      ("", "1" * 1000_000_000),
+    ))
+    val javaRdd = largeRdd.toJavaRDD()
+    val pythonRdd = SerDeUtil.javaToPython(javaRdd)
+    SerDeUtil.pythonToPairRDD(pythonRdd, false)
+  }
+}

--- a/core/src/test/scala/org/apache/spark/api/python/SerDeUtilSuite.scala
+++ b/core/src/test/scala/org/apache/spark/api/python/SerDeUtilSuite.scala
@@ -34,17 +34,18 @@ class SerDeUtilSuite extends SparkFunSuite with SharedSparkContext {
   }
 
   test("Testing AutoBatchedPickler in supporting large rows (SPARK-48380)") {
-    val emptyString = ""
     val largeString = "1" * 1000_000_000
-    val inputIterator = Iterator(
-      emptyString,
-      emptyString,
-      emptyString,
-      largeString,
-      largeString,
-      largeString,
-    )
-    val outputIterator = AutoBatchedPickler(inputIterator)
-    outputIterator.foreach(_ => ())
+    val largeRdd = sc.parallelize(Seq[(Any, Any)](
+      ("", ""),
+      ("", ""),
+      ("", ""),
+      ("", largeString),
+      ("", largeString),
+      ("", largeString),
+      ("", largeString)
+    ), 1)
+    val javaRdd = largeRdd.toJavaRDD()
+    val pythonRdd = SerDeUtil.javaToPython(javaRdd)
+    pythonRdd.count()
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This simple PR changes the behavior of AutoBatchPickler to be able to catch situations where a single row is smaller than 2GB, but a batch of them exceeds 2GB and cause issues in underlying buffer management.

### Why are the changes needed?
With this, pyspark program can decide to use a different batch size when the default AutoBatchPickler ends up with 2GB exceeded error as in the JIRA ticket: https://issues.apache.org/jira/browse/SPARK-48380

### Does this PR introduce _any_ user-facing change?
No.  This code is entirely transparent to users.

```

### How was this patch tested?
```
> build/sbt -mem 32000
sbt:spark-parent> project core
sbt:spark-core> testOnly org.apache.spark.api.python.SerDeUtilSuite
```

### Was this patch authored or co-authored using generative AI tooling?
No.