### PR TITLE
[SPARK-45009][SQL][FOLLOW UP] Add error class and tests for decorrelation of predicate subqueries in join condition which reference both join child

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4731,9 +4731,10 @@
           "<treeNode>"
         ]
       },
-      "UNSUPPORTED_CORRELATED_EXPRESSION_IN_JOIN_CONDITION": {
+      "UNSUPPORTED_CORRELATED_EXPRESSION_IN_JOIN_CONDITION" : {
         "message" : [
-          "Correlated subqueries in the join predicate cannot reference both join inputs."
+          "Correlated subqueries in the join predicate cannot reference both join inputs:",
+          "<subqueryExpression>"
         ]
       },
       "UNSUPPORTED_CORRELATED_REFERENCE_DATA_TYPE" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4733,7 +4733,7 @@
       },
       "UNSUPPORTED_CORRELATED_EXPRESSION_IN_JOIN_CONDITION": {
         "message" : [
-          "Correlated subqueries in the join predicate that cannot reference both join inputs."
+          "Correlated subqueries in the join predicate cannot reference both join inputs."
         ]
       },
       "UNSUPPORTED_CORRELATED_REFERENCE_DATA_TYPE" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4731,6 +4731,11 @@
           "<treeNode>"
         ]
       },
+      "UNSUPPORTED_CORRELATED_EXPRESSION_IN_JOIN_CONDITION": {
+        "message" : [
+          "Correlated subqueries in the join predicate that cannot reference both join inputs."
+        ]
+      },
       "UNSUPPORTED_CORRELATED_REFERENCE_DATA_TYPE" : {
         "message" : [
           "Correlated column reference '<expr>' cannot be <dataType> type."

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/exists-subquery/exists-in-join-condition.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/exists-subquery/exists-in-join-condition.sql.out
@@ -1004,3 +1004,47 @@ Sort [x1#x ASC NULLS FIRST, x2#x ASC NULLS FIRST, y1#x ASC NULLS FIRST, y2#x ASC
          +- View (`y`, [y1#x, y2#x])
             +- Project [cast(col1#x as int) AS y1#x, cast(col2#x as int) AS y2#x]
                +- LocalRelation [col1#x, col2#x]
+
+
+-- !query
+select * from x join y on x1 = y1 and exists (select * from z where z2 = x2 AND z2 = y2) order by x1, x2, y1, y2
+-- !query analysis
+Sort [x1#x ASC NULLS FIRST, x2#x ASC NULLS FIRST, y1#x ASC NULLS FIRST, y2#x ASC NULLS FIRST], true
++- Project [x1#x, x2#x, y1#x, y2#x]
+   +- Join Inner, ((x1#x = y1#x) AND exists#x [x2#x && y2#x])
+      :  +- Project [z1#x, z2#x]
+      :     +- Filter ((z2#x = outer(x2#x)) AND (z2#x = outer(y2#x)))
+      :        +- SubqueryAlias z
+      :           +- View (`z`, [z1#x, z2#x])
+      :              +- Project [cast(col1#x as int) AS z1#x, cast(col2#x as int) AS z2#x]
+      :                 +- LocalRelation [col1#x, col2#x]
+      :- SubqueryAlias x
+      :  +- View (`x`, [x1#x, x2#x])
+      :     +- Project [cast(col1#x as int) AS x1#x, cast(col2#x as int) AS x2#x]
+      :        +- LocalRelation [col1#x, col2#x]
+      +- SubqueryAlias y
+         +- View (`y`, [y1#x, y2#x])
+            +- Project [cast(col1#x as int) AS y1#x, cast(col2#x as int) AS y2#x]
+               +- LocalRelation [col1#x, col2#x]
+
+
+-- !query
+select * from x join y on x1 = y1 and not exists (select * from z where z2 = x2 AND z2 = y2) order by x1, x2, y1, y2
+-- !query analysis
+Sort [x1#x ASC NULLS FIRST, x2#x ASC NULLS FIRST, y1#x ASC NULLS FIRST, y2#x ASC NULLS FIRST], true
++- Project [x1#x, x2#x, y1#x, y2#x]
+   +- Join Inner, ((x1#x = y1#x) AND NOT exists#x [x2#x && y2#x])
+      :  +- Project [z1#x, z2#x]
+      :     +- Filter ((z2#x = outer(x2#x)) AND (z2#x = outer(y2#x)))
+      :        +- SubqueryAlias z
+      :           +- View (`z`, [z1#x, z2#x])
+      :              +- Project [cast(col1#x as int) AS z1#x, cast(col2#x as int) AS z2#x]
+      :                 +- LocalRelation [col1#x, col2#x]
+      :- SubqueryAlias x
+      :  +- View (`x`, [x1#x, x2#x])
+      :     +- Project [cast(col1#x as int) AS x1#x, cast(col2#x as int) AS x2#x]
+      :        +- LocalRelation [col1#x, col2#x]
+      +- SubqueryAlias y
+         +- View (`y`, [y1#x, y2#x])
+            +- Project [cast(col1#x as int) AS y1#x, cast(col2#x as int) AS y2#x]
+               +- LocalRelation [col1#x, col2#x]

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/in-subquery/in-subquery-in-join-condition.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/in-subquery/in-subquery-in-join-condition.sql.out
@@ -916,3 +916,47 @@ Sort [x1#x ASC NULLS FIRST, x2#x ASC NULLS FIRST, y1#x ASC NULLS FIRST, y2#x ASC
          +- View (`y`, [y1#x, y2#x])
             +- Project [cast(col1#x as int) AS y1#x, cast(col2#x as int) AS y2#x]
                +- LocalRelation [col1#x, col2#x]
+
+
+-- !query
+select * from x left join y on x1 = y1 and x2 IN (select z1 from z where z2 = x2 AND z2 = y2) order by x1, x2, y1, y2
+-- !query analysis
+Sort [x1#x ASC NULLS FIRST, x2#x ASC NULLS FIRST, y1#x ASC NULLS FIRST, y2#x ASC NULLS FIRST], true
++- Project [x1#x, x2#x, y1#x, y2#x]
+   +- Join LeftOuter, ((x1#x = y1#x) AND x2#x IN (list#x [x2#x && y2#x]))
+      :  +- Project [z1#x]
+      :     +- Filter ((z2#x = outer(x2#x)) AND (z2#x = outer(y2#x)))
+      :        +- SubqueryAlias z
+      :           +- View (`z`, [z1#x, z2#x])
+      :              +- Project [cast(col1#x as int) AS z1#x, cast(col2#x as int) AS z2#x]
+      :                 +- LocalRelation [col1#x, col2#x]
+      :- SubqueryAlias x
+      :  +- View (`x`, [x1#x, x2#x])
+      :     +- Project [cast(col1#x as int) AS x1#x, cast(col2#x as int) AS x2#x]
+      :        +- LocalRelation [col1#x, col2#x]
+      +- SubqueryAlias y
+         +- View (`y`, [y1#x, y2#x])
+            +- Project [cast(col1#x as int) AS y1#x, cast(col2#x as int) AS y2#x]
+               +- LocalRelation [col1#x, col2#x]
+
+
+-- !query
+select * from x left join y on x1 = y1 and x2 not IN (select z1 from z where z2 = x2 AND z2 = y2) order by x1, x2, y1, y2
+-- !query analysis
+Sort [x1#x ASC NULLS FIRST, x2#x ASC NULLS FIRST, y1#x ASC NULLS FIRST, y2#x ASC NULLS FIRST], true
++- Project [x1#x, x2#x, y1#x, y2#x]
+   +- Join LeftOuter, ((x1#x = y1#x) AND NOT x2#x IN (list#x [x2#x && y2#x]))
+      :  +- Project [z1#x]
+      :     +- Filter ((z2#x = outer(x2#x)) AND (z2#x = outer(y2#x)))
+      :        +- SubqueryAlias z
+      :           +- View (`z`, [z1#x, z2#x])
+      :              +- Project [cast(col1#x as int) AS z1#x, cast(col2#x as int) AS z2#x]
+      :                 +- LocalRelation [col1#x, col2#x]
+      :- SubqueryAlias x
+      :  +- View (`x`, [x1#x, x2#x])
+      :     +- Project [cast(col1#x as int) AS x1#x, cast(col2#x as int) AS x2#x]
+      :        +- LocalRelation [col1#x, col2#x]
+      +- SubqueryAlias y
+         +- View (`y`, [y1#x, y2#x])
+            +- Project [cast(col1#x as int) AS y1#x, cast(col2#x as int) AS y2#x]
+               +- LocalRelation [col1#x, col2#x]

--- a/sql/core/src/test/resources/sql-tests/inputs/subquery/exists-subquery/exists-in-join-condition.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/subquery/exists-subquery/exists-in-join-condition.sql
@@ -89,3 +89,7 @@ select * from x inner join y on x1 = y1 and exists (select * from z where z1 = y
 select * from x inner join y on x1 = y1 and not exists (select * from z where z1 = y1) order by x1, x2, y1, y2;
 select * from x left join y on x1 = y1 and exists (select * from z where z1 = y1) order by x1, x2, y1, y2;
 select * from x left join y on x1 = y1 and not exists (select * from z where z1 = y1) order by x1, x2, y1, y2;
+
+-- Correlated subquery references both left and right children, errors
+select * from x join y on x1 = y1 and exists (select * from z where z2 = x2 AND z2 = y2) order by x1, x2, y1, y2;
+select * from x join y on x1 = y1 and not exists (select * from z where z2 = x2 AND z2 = y2) order by x1, x2, y1, y2;

--- a/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-subquery-in-join-condition.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/subquery/in-subquery/in-subquery-in-join-condition.sql
@@ -84,3 +84,7 @@ select * from x inner join y on x1 = y1 and y2 IN (select z1 from z where z1 = y
 select * from x inner join y on x1 = y1 and y2 not IN (select z1 from z where z1 = y1) order by x1, x2, y1, y2;
 select * from x left join y on x1 = y1 and y2 IN (select z1 from z where z1 = y1) order by x1, x2, y1, y2;
 select * from x left join y on x1 = y1 and y2 not IN (select z1 from z where z1 = y1) order by x1, x2, y1, y2;
+
+-- Correlated subquery references both left and right children, errors
+select * from x left join y on x1 = y1 and x2 IN (select z1 from z where z2 = x2 AND z2 = y2) order by x1, x2, y1, y2;
+select * from x left join y on x1 = y1 and x2 not IN (select z1 from z where z2 = x2 AND z2 = y2) order by x1, x2, y1, y2;

--- a/sql/core/src/test/resources/sql-tests/results/subquery/exists-subquery/exists-in-join-condition.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/exists-subquery/exists-in-join-condition.sql.out
@@ -472,3 +472,33 @@ struct<x1:int,x2:int,y1:int,y2:int>
 1	1	1	4
 2	1	NULL	NULL
 3	4	NULL	NULL
+
+
+-- !query
+select * from x join y on x1 = y1 and exists (select * from z where z2 = x2 AND z2 = y2) order by x1, x2, y1, y2
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.UNSUPPORTED_CORRELATED_EXPRESSION_IN_JOIN_CONDITION",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "subqueryExpression" : "exists(x.x2, y.y2, (z.z2 = x.x2), (z.z2 = y.y2))"
+  }
+}
+
+
+-- !query
+select * from x join y on x1 = y1 and not exists (select * from z where z2 = x2 AND z2 = y2) order by x1, x2, y1, y2
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.UNSUPPORTED_CORRELATED_EXPRESSION_IN_JOIN_CONDITION",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "subqueryExpression" : "exists(x.x2, y.y2, (z.z2 = x.x2), (z.z2 = y.y2))"
+  }
+}

--- a/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-subquery-in-join-condition.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/in-subquery/in-subquery-in-join-condition.sql.out
@@ -434,3 +434,33 @@ struct<x1:int,x2:int,y1:int,y2:int>
 1	1	1	4
 2	1	NULL	NULL
 3	4	NULL	NULL
+
+
+-- !query
+select * from x left join y on x1 = y1 and x2 IN (select z1 from z where z2 = x2 AND z2 = y2) order by x1, x2, y1, y2
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.UNSUPPORTED_CORRELATED_EXPRESSION_IN_JOIN_CONDITION",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "subqueryExpression" : "(x.x2 IN (listquery(x.x2, y.y2, (z.z2 = x.x2), (z.z2 = y.y2))))"
+  }
+}
+
+
+-- !query
+select * from x left join y on x1 = y1 and x2 not IN (select z1 from z where z2 = x2 AND z2 = y2) order by x1, x2, y1, y2
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.sql.AnalysisException
+{
+  "errorClass" : "UNSUPPORTED_SUBQUERY_EXPRESSION_CATEGORY.UNSUPPORTED_CORRELATED_EXPRESSION_IN_JOIN_CONDITION",
+  "sqlState" : "0A000",
+  "messageParameters" : {
+    "subqueryExpression" : "(x.x2 IN (listquery(x.x2, y.y2, (z.z2 = x.x2), (z.z2 = y.y2))))"
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is a follow up PR for https://github.com/apache/spark/pull/42725, which decorrelates predicate subqueries in join conditions. I forgot to add the error class definition for the case where the subquery references both join children, and test cases for it.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API
  2. If you fix a bug, you can clarify why it is a bug.
-->
To show a clear error message when the condition is hit.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added SQL test and golden files.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.