### PR TITLE
[SPARK-48396] Support configuring max cores can be used for SQL

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2746,16 +2746,4 @@ package object config {
       .version("4.0.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createOptional
-
-  private[spark] val EXECUTION_CORES_LIMIT_NUMBER =
-    ConfigBuilder("spark.sql.execution.coresLimitNumber")
-      .internal()
-      .doc("""
-             |Limit the maximum number of cores occupied during SQL execution to
-             |avoid a single SQL consuming too many core resources and affecting
-             |the execution of other tasks.
-             |""".stripMargin)
-      .version("3.5.0")
-      .intConf
-      .createOptional
 }

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -2746,4 +2746,16 @@ package object config {
       .version("4.0.0")
       .timeConf(TimeUnit.MILLISECONDS)
       .createOptional
+
+  private[spark] val EXECUTION_CORES_LIMIT_NUMBER =
+    ConfigBuilder("spark.sql.execution.coresLimitNumber")
+      .internal()
+      .doc("""
+             |Limit the maximum number of cores occupied during SQL execution to
+             |avoid a single SQL consuming too many core resources and affecting
+             |the execution of other tasks.
+             |""".stripMargin)
+      .version("3.5.0")
+      .intConf
+      .createOptional
 }

--- a/core/src/main/scala/org/apache/spark/scheduler/ExecutionLimitTracker.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ExecutionLimitTracker.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.internal.config.EXECUTION_CORES_LIMIT_NUMBER
+
+@DeveloperApi
+object ExecutionLimitTracker {
+
+  // executionId -> running tasks size
+  val RUNNING_TASKS = new ConcurrentHashMap[Long, AtomicInteger]()
+
+  val SQL_EXECUTION_ID_KEY = "spark.sql.execution.id"
+
+  def shouldLimit(taskSet: TaskSet): Boolean = {
+    if (!hasLegalConfig(taskSet)) {
+      return false
+    }
+    val executionId = taskSet.properties
+      .getProperty(TaskSchedulerImpl.SQL_EXECUTION_ID_KEY).toLong
+    val runningTasks = RUNNING_TASKS.getOrDefault(executionId, new AtomicInteger(0)).get()
+    val restrictNumber = taskSet.properties
+      .getProperty(EXECUTION_CORES_LIMIT_NUMBER.key).toInt
+    runningTasks >= restrictNumber
+  }
+
+  def increaseRunningTasksIfNeed(taskSet: TaskSet): Unit = {
+    if (!hasLegalConfig(taskSet)) {
+      return
+    }
+    val executionId = taskSet.properties
+      .getProperty(TaskSchedulerImpl.SQL_EXECUTION_ID_KEY).toLong
+    if (!RUNNING_TASKS.containsKey(executionId)) {
+      RUNNING_TASKS.put(executionId, new AtomicInteger(0))
+    }
+    RUNNING_TASKS.get(executionId).incrementAndGet()
+  }
+
+  def decreaseRunningTasksIfNeed(taskSet: TaskSet): Unit = {
+    if (!hasLegalConfig(taskSet)) {
+      return
+    }
+    val executionId = taskSet.properties
+      .getProperty(TaskSchedulerImpl.SQL_EXECUTION_ID_KEY).toLong
+    if (!RUNNING_TASKS.containsKey(executionId)) {
+      return
+    }
+    RUNNING_TASKS.get(executionId).decrementAndGet()
+  }
+
+  def cleanRunningTasks(executionId: Long): Unit = {
+    RUNNING_TASKS.remove(executionId)
+  }
+
+  private def hasLegalConfig(taskSet: TaskSet): Boolean = {
+    var legalRestrictNumber = false
+    if (taskSet.properties.containsKey(EXECUTION_CORES_LIMIT_NUMBER.key) &&
+      taskSet.properties.getProperty(EXECUTION_CORES_LIMIT_NUMBER.key).toInt > 0) {
+      legalRestrictNumber = true
+    }
+    taskSet.properties.containsKey(SQL_EXECUTION_ID_KEY) && legalRestrictNumber
+  }
+}

--- a/core/src/main/scala/org/apache/spark/scheduler/ExecutionLimitTracker.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ExecutionLimitTracker.scala
@@ -72,9 +72,11 @@ object ExecutionLimitTracker {
   }
 
   private def hasLegalConfig(taskSet: TaskSet): Boolean = {
+    if (taskSet.properties == null) {
+      return false
+    }
     var legalRestrictNumber = false
-    if (taskSet.properties != null &&
-      taskSet.properties.containsKey(EXECUTION_CORES_LIMIT_NUMBER.key) &&
+    if (taskSet.properties.containsKey(EXECUTION_CORES_LIMIT_NUMBER.key) &&
       taskSet.properties.getProperty(EXECUTION_CORES_LIMIT_NUMBER.key).toInt > 0) {
       legalRestrictNumber = true
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/ExecutionLimitTracker.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ExecutionLimitTracker.scala
@@ -36,7 +36,7 @@ object ExecutionLimitTracker {
       return false
     }
     val executionId = taskSet.properties
-      .getProperty(TaskSchedulerImpl.SQL_EXECUTION_ID_KEY).toLong
+      .getProperty(SQL_EXECUTION_ID_KEY).toLong
     val runningTasks = RUNNING_TASKS.getOrDefault(executionId, new AtomicInteger(0)).get()
     val restrictNumber = taskSet.properties
       .getProperty(EXECUTION_CORES_LIMIT_NUMBER.key).toInt
@@ -48,7 +48,7 @@ object ExecutionLimitTracker {
       return
     }
     val executionId = taskSet.properties
-      .getProperty(TaskSchedulerImpl.SQL_EXECUTION_ID_KEY).toLong
+      .getProperty(SQL_EXECUTION_ID_KEY).toLong
     if (!RUNNING_TASKS.containsKey(executionId)) {
       RUNNING_TASKS.put(executionId, new AtomicInteger(0))
     }
@@ -60,7 +60,7 @@ object ExecutionLimitTracker {
       return
     }
     val executionId = taskSet.properties
-      .getProperty(TaskSchedulerImpl.SQL_EXECUTION_ID_KEY).toLong
+      .getProperty(SQL_EXECUTION_ID_KEY).toLong
     if (!RUNNING_TASKS.containsKey(executionId)) {
       return
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/ExecutionLimitTracker.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ExecutionLimitTracker.scala
@@ -73,7 +73,8 @@ object ExecutionLimitTracker {
 
   private def hasLegalConfig(taskSet: TaskSet): Boolean = {
     var legalRestrictNumber = false
-    if (taskSet.properties.containsKey(EXECUTION_CORES_LIMIT_NUMBER.key) &&
+    if (taskSet.properties != null &&
+      taskSet.properties.containsKey(EXECUTION_CORES_LIMIT_NUMBER.key) &&
       taskSet.properties.getProperty(EXECUTION_CORES_LIMIT_NUMBER.key).toInt > 0) {
       legalRestrictNumber = true
     }

--- a/core/src/main/scala/org/apache/spark/scheduler/ExecutionLimitTracker.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ExecutionLimitTracker.scala
@@ -21,7 +21,6 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.spark.annotation.DeveloperApi
-import org.apache.spark.internal.config.EXECUTION_CORES_LIMIT_NUMBER
 
 @DeveloperApi
 object ExecutionLimitTracker {
@@ -31,6 +30,8 @@ object ExecutionLimitTracker {
 
   val SQL_EXECUTION_ID_KEY = "spark.sql.execution.id"
 
+  val EXECUTION_CORES_LIMIT_NUMBER = "spark.sql.execution.coresLimitNumber"
+
   def shouldLimit(taskSet: TaskSet): Boolean = {
     if (!hasLegalConfig(taskSet)) {
       return false
@@ -39,7 +40,7 @@ object ExecutionLimitTracker {
       .getProperty(SQL_EXECUTION_ID_KEY).toLong
     val runningTasks = RUNNING_TASKS.getOrDefault(executionId, new AtomicInteger(0)).get()
     val restrictNumber = taskSet.properties
-      .getProperty(EXECUTION_CORES_LIMIT_NUMBER.key).toInt
+      .getProperty(EXECUTION_CORES_LIMIT_NUMBER).toInt
     runningTasks >= restrictNumber
   }
 
@@ -76,8 +77,8 @@ object ExecutionLimitTracker {
       return false
     }
     var legalRestrictNumber = false
-    if (taskSet.properties.containsKey(EXECUTION_CORES_LIMIT_NUMBER.key) &&
-      taskSet.properties.getProperty(EXECUTION_CORES_LIMIT_NUMBER.key).toInt > 0) {
+    if (taskSet.properties.containsKey(EXECUTION_CORES_LIMIT_NUMBER) &&
+      taskSet.properties.getProperty(EXECUTION_CORES_LIMIT_NUMBER).toInt > 0) {
       legalRestrictNumber = true
     }
     taskSet.properties.containsKey(SQL_EXECUTION_ID_KEY) && legalRestrictNumber

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -1088,6 +1088,7 @@ private[spark] class TaskSetManager(
     if (runningTasksSet.add(tid) && parent != null) {
       parent.increaseRunningTasks(1)
     }
+    ExecutionLimitTracker.increaseRunningTasksIfNeed(taskSet)
   }
 
   /** If the given task ID is in the set of running tasks, removes it. */

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4972,6 +4972,18 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  private[spark] val EXECUTION_CORES_LIMIT_NUMBER =
+    buildConf("spark.sql.execution.coresLimitNumber")
+      .internal()
+      .doc("""
+             |Limit the maximum number of cores occupied during SQL execution to
+             |avoid a single SQL consuming too many core resources and affecting
+             |the execution of other tasks.
+             |""".stripMargin)
+      .version("4.0.0")
+      .intConf
+      .createOptional
+
   /**
    * Holds information about keys that have been deprecated.
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SQLExecution.scala
@@ -28,6 +28,7 @@ import org.apache.spark.SparkContext.{SPARK_JOB_DESCRIPTION, SPARK_JOB_INTERRUPT
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config.{SPARK_DRIVER_PREFIX, SPARK_EXECUTOR_PREFIX}
 import org.apache.spark.internal.config.Tests.IS_TESTING
+import org.apache.spark.scheduler.ExecutionLimitTracker
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec
 import org.apache.spark.sql.execution.ui.{SparkListenerSQLExecutionEnd, SparkListenerSQLExecutionStart}
@@ -202,6 +203,7 @@ object SQLExecution extends Logging {
       }
     } finally {
       executionIdToQueryExecution.remove(executionId)
+      ExecutionLimitTracker.cleanRunningTasks(executionId)
       sc.setLocalProperty(EXECUTION_ID_KEY, oldExecutionId)
       // Unset the "root" SQL Execution Id once the "root" SQL execution completes.
       // The current execution is the root execution if rootExecutionId == executionId.


### PR DESCRIPTION
### What changes were proposed in this pull request?
A new session level config `spark.sql.execution.coresLimitNumber` to configure the maximum number of cores can be used by SQL.

### Why are the changes needed?
When there is a long-running shared Spark SQL cluster, there always be a situation where a large SQL occupies all the cores of the cluster, affecting the execution of other SQLs. Therefore, it is hoped that there is a configuration that can limit the maximum cores used by SQL.

### Does this PR introduce _any_ user-facing change?
yes, add new config `spark.sql.execution.coresLimitNumber`.

### How was this patch tested?
I will add test unit later

### Was this patch authored or co-authored using generative AI tooling?
No