### PR TITLE
[SPARK-48397][SQL] Add data write time metric to FileFormatDataWriter

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/WriteStatsTracker.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/WriteStatsTracker.scala
@@ -67,10 +67,11 @@ trait WriteTaskStatsTracker {
   /**
    * Returns the final statistics computed so far.
    * @param taskCommitTime Time of committing the task.
+   * @param writeTime Time of writing data
    * @note This may only be called once. Further use of the object may lead to undefined behavior.
    * @return An object of subtype of [[WriteTaskStats]], to be sent to the driver.
    */
-  def getFinalStats(taskCommitTime: Long): WriteTaskStats
+  def getFinalStats(taskCommitTime: Long, writeTime: Long): WriteTaskStats
 }
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/BasicWriteTaskStatsTrackerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/BasicWriteTaskStatsTrackerSuite.scala
@@ -73,7 +73,7 @@ class BasicWriteTaskStatsTrackerSuite extends SparkFunSuite {
   }
 
   private def finalStatus(tracker: BasicWriteTaskStatsTracker): BasicWriteTaskStats = {
-    tracker.getFinalStats(0L).asInstanceOf[BasicWriteTaskStats]
+    tracker.getFinalStats(0L, 0L).asInstanceOf[BasicWriteTaskStats]
   }
 
   test("No files in run") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/CustomWriteTaskStatsTrackerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/CustomWriteTaskStatsTrackerSuite.scala
@@ -25,7 +25,8 @@ import org.apache.spark.sql.catalyst.InternalRow
 class CustomWriteTaskStatsTrackerSuite extends SparkFunSuite {
 
   def checkFinalStats(tracker: CustomWriteTaskStatsTracker, result: Map[String, Int]): Unit = {
-    assert(tracker.getFinalStats(0L).asInstanceOf[CustomWriteTaskStats].numRowsPerFile == result)
+    assert(tracker.getFinalStats(0L, 0L)
+      .asInstanceOf[CustomWriteTaskStats].numRowsPerFile == result)
   }
 
   test("sequential file writing") {
@@ -64,7 +65,7 @@ class CustomWriteTaskStatsTracker extends WriteTaskStatsTracker {
     numRowsPerFile(filePath) += 1
   }
 
-  override def getFinalStats(taskCommitTime: Long): WriteTaskStats = {
+  override def getFinalStats(taskCommitTime: Long, writeTime: Long): WriteTaskStats = {
     CustomWriteTaskStats(numRowsPerFile.toMap)
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -837,7 +837,8 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
     }
   }
 
-  test("SPARK-34399: Add job commit duration metrics for DataWritingCommand") {
+  test("SPARK-34399: Add job commit duration metrics for DataWritingCommand" +
+    " and SPARK-48397: Data write time metric for DataWritingCommand") {
     withSQLConf(SQLConf.FILE_COMMIT_PROTOCOL_CLASS.key ->
       "org.apache.spark.sql.execution.metric.CustomFileCommitProtocol") {
       withTable("t", "t2") {
@@ -852,6 +853,8 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
         assert(insert.head.metrics.contains(BasicWriteJobStatsTracker.TASK_COMMIT_TIME))
         assert(insert.head.metrics(BasicWriteJobStatsTracker.JOB_COMMIT_TIME).value > 0)
         assert(insert.head.metrics(BasicWriteJobStatsTracker.TASK_COMMIT_TIME).value > 0)
+        // SPARK-48397: check data write time metric
+        assert(insert.head.metrics(BasicWriteJobStatsTracker.WRITE_TIME).value > 0)
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
For FileFormatDataWriter we currently record metrics of "task commit time" and "job commit time" in `org.apache.spark.sql.execution.datasources.BasicWriteJobStatsTracker#metrics`:
```
      TASK_COMMIT_TIME -> SQLMetrics.createTimingMetric(sparkContext, "task commit time"),
      JOB_COMMIT_TIME -> SQLMetrics.createTimingMetric(sparkContext, "job commit time"),
```
We may also record the time spent on "data write" (together with the time spent on producing records from the iterator), which is usually one of the major parts of the total duration of a writing operation. 

### Why are the changes needed?
We find that the write duration is very helpful for us to identify the bottleneck and time skew during the data write, and it also helps on the generic performance tuning.

### Does this PR introduce _any_ user-facing change?
Yes, in the SQL page of the Spark History Server (and live UI), a new "data write time" metric is shown on the data write command/operation nodes. For example, a `InsertIntoHadoopFsRelationCommand` node with the newly added `data write time` metric:
<img width="492" alt="image" src="https://github.com/apache/spark/assets/14141331/bd06b4a6-e1b8-4b36-967a-376abd793fa7">

### How was this patch tested?
Unit test case and manual tests.

### Was this patch authored or co-authored using generative AI tooling?
No