### PR TITLE
[SPARK-48412][PYTHON] Refactor data type json parse

### DIFF
--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -1139,7 +1139,7 @@ class TypesTestsMixin:
     def test_parse_datatype_json_string(self):
         from pyspark.sql.types import _parse_datatype_json_string
 
-        for dateType in [
+        for dataType in [
             StringType(),
             CharType(5),
             VarcharType(10),
@@ -1166,7 +1166,9 @@ class TypesTestsMixin:
             DayTimeIntervalType(DayTimeIntervalType.HOUR, DayTimeIntervalType.SECOND),
             CalendarIntervalType(),
         ]:
-            self.assertEqual(dateType, _parse_datatype_json_string(dateType.json()))
+            json_str = dataType.json()
+            parsed = _parse_datatype_json_string(json_str)
+            self.assertEqual(dataType, parsed)
 
     def test_parse_datatype_string(self):
         from pyspark.sql.types import _all_mappable_types, _parse_datatype_string

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -1136,12 +1136,44 @@ class TypesTestsMixin:
         self.assertRaises(IndexError, lambda: struct1[9])
         self.assertRaises(TypeError, lambda: struct1[9.9])
 
-    def test_parse_datatype_string(self):
-        from pyspark.sql.types import _all_atomic_types, _parse_datatype_string
+    def test_parse_datatype_json_string(self):
+        from pyspark.sql.types import _parse_datatype_json_string
 
-        for k, t in _all_atomic_types.items():
-            if k != "varchar" and k != "char":
-                self.assertEqual(t(), _parse_datatype_string(k))
+        for dateType in [
+            StringType(),
+            CharType(5),
+            VarcharType(10),
+            BinaryType(),
+            BooleanType(),
+            DecimalType(),
+            DecimalType(10, 2),
+            FloatType(),
+            DoubleType(),
+            ByteType(),
+            ShortType(),
+            IntegerType(),
+            LongType(),
+            DateType(),
+            TimestampType(),
+            TimestampNTZType(),
+            NullType(),
+            VariantType(),
+            YearMonthIntervalType(),
+            YearMonthIntervalType(YearMonthIntervalType.YEAR),
+            YearMonthIntervalType(YearMonthIntervalType.YEAR, YearMonthIntervalType.MONTH),
+            DayTimeIntervalType(),
+            DayTimeIntervalType(DayTimeIntervalType.DAY),
+            DayTimeIntervalType(DayTimeIntervalType.HOUR, DayTimeIntervalType.SECOND),
+            CalendarIntervalType(),
+        ]:
+            self.assertEqual(dateType, _parse_datatype_json_string(dateType.json()))
+
+    def test_parse_datatype_string(self):
+        from pyspark.sql.types import _all_mappable_types, _parse_datatype_string
+
+        for k, t in _all_mappable_types.items():
+            self.assertEqual(t(), _parse_datatype_string(k))
+
         self.assertEqual(IntegerType(), _parse_datatype_string("int"))
         self.assertEqual(StringType(), _parse_datatype_string("string"))
         self.assertEqual(CharType(1), _parse_datatype_string("char(1)"))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Refactor data type json parse

### Why are the changes needed?
the `_all_atomic_types` causes confusions:

- it is only used in json parse, so it should use the `jsonValue` instead of `typeName` (and so it causes the `typeName` not consistent with Scala, will fix in separate PR);
- not all atomic types are included in it (e.g. `YearMonthIntervalType`);
- not all atomic types should be placed in it (e.g. `VarcharType` which has to be excluded here and there)




### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci, added tests

### Was this patch authored or co-authored using generative AI tooling?
no
