### PR TITLE
[MINOR][SQL] Remove outdated `TODO`s from `UnsafeHashedRelation`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -396,8 +396,6 @@ private[joins] class UnsafeHashedRelation(
     val nKeys = readLong()
     val nValues = readLong()
     // This is used in Broadcast, shared by multiple tasks, so we use on-heap memory
-    // TODO(josh): This needs to be revisited before we merge this patch; making this change now
-    // so that tests compile:
     val taskMemoryManager = new TaskMemoryManager(
       new UnifiedMemoryManager(
         new SparkConf().set(MEMORY_OFFHEAP_ENABLED.key, "false"),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/HashedRelation.scala
@@ -407,9 +407,6 @@ private[joins] class UnsafeHashedRelation(
     val pageSizeBytes = Option(SparkEnv.get).map(_.memoryManager.pageSizeBytes)
       .getOrElse(new SparkConf().get(BUFFER_PAGESIZE).getOrElse(16L * 1024 * 1024))
 
-    // TODO(josh): We won't need this dummy memory manager after future refactorings; revisit
-    // during code review
-
     binaryMap = new BytesToBytesMap(
       taskMemoryManager,
       (nKeys * 1.5 + 1).toInt, // reduce hash collision


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr remove some outdated TODOs from `UnsafeHashedRelation`:

- Line 399:

```
// TODO(josh): This needs to be revisited before we merge this patch; making this change now
// so that tests compile:
```

and 

- Line 412:

```
// TODO(josh): We won't need this dummy memory manager after future refactorings; revisit
// during code review
```

### Why are the changes needed?
Remove outdated TODOs


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No
