### PR TITLE
[SPARK-48415][PYTHON] Refactor `TypeName` to support parameterized datatypes

### DIFF
--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -65,6 +65,7 @@ from pyspark.sql.types import (
     StringType,
     DateType,
     StructType,
+    DataType,
 )
 from pyspark.sql.dataframe import DataFrame as PySparkDataFrame
 from pyspark import pandas as ps
@@ -2228,7 +2229,9 @@ def get_dummies(
     ):
         raise NotImplementedError(
             "get_dummies currently only accept {} values".format(
-                ", ".join([t.__name__ for t in _get_dummies_acceptable_types])
+                ", ".join(
+                    [cast(Type[DataType], t).typeName() for t in _get_dummies_acceptable_types]
+                )
             )
         )
 

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -65,7 +65,6 @@ from pyspark.sql.types import (
     StringType,
     DateType,
     StructType,
-    DataType,
 )
 from pyspark.sql.dataframe import DataFrame as PySparkDataFrame
 from pyspark import pandas as ps
@@ -2229,9 +2228,7 @@ def get_dummies(
     ):
         raise NotImplementedError(
             "get_dummies currently only accept {} values".format(
-                ", ".join(
-                    [cast(Type[DataType], t).typeName() for t in _get_dummies_acceptable_types]
-                )
+                ", ".join([t.__name__ for t in _get_dummies_acceptable_types])
             )
         )
 

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -81,6 +81,67 @@ from pyspark.testing.utils import PySparkErrorTestUtils
 
 
 class TypesTestsMixin:
+    def test_class_method_type_name(self):
+        for dataType, name in [
+            (StringType, "string"),
+            (CharType, "char"),
+            (VarcharType, "varchar"),
+            (BinaryType, "binary"),
+            (BooleanType, "boolean"),
+            (DecimalType, "decimal"),
+            (FloatType, "float"),
+            (DoubleType, "double"),
+            (ByteType, "byte"),
+            (ShortType, "short"),
+            (IntegerType, "integer"),
+            (LongType, "long"),
+            (DateType, "date"),
+            (TimestampType, "timestamp"),
+            (TimestampNTZType, "timestamp_ntz"),
+            (NullType, "void"),
+            (VariantType, "variant"),
+            (YearMonthIntervalType, "yearmonthinterval"),
+            (DayTimeIntervalType, "daytimeinterval"),
+            (CalendarIntervalType, "interval"),
+        ]:
+            self.assertEqual(dataType.typeName(), name)
+
+    def test_instance_method_type_name(self):
+        for dataType, name in [
+            (StringType(), "string"),
+            (CharType(5), "char(5)"),
+            (VarcharType(10), "varchar(10)"),
+            (BinaryType(), "binary"),
+            (BooleanType(), "boolean"),
+            (DecimalType(), "decimal(10,0)"),
+            (DecimalType(10, 2), "decimal(10,2)"),
+            (FloatType(), "float"),
+            (DoubleType(), "double"),
+            (ByteType(), "byte"),
+            (ShortType(), "short"),
+            (IntegerType(), "integer"),
+            (LongType(), "long"),
+            (DateType(), "date"),
+            (TimestampType(), "timestamp"),
+            (TimestampNTZType(), "timestamp_ntz"),
+            (NullType(), "void"),
+            (VariantType(), "variant"),
+            (YearMonthIntervalType(), "interval year to month"),
+            (YearMonthIntervalType(YearMonthIntervalType.YEAR), "interval year"),
+            (
+                YearMonthIntervalType(YearMonthIntervalType.YEAR, YearMonthIntervalType.MONTH),
+                "interval year to month",
+            ),
+            (DayTimeIntervalType(), "interval day to second"),
+            (DayTimeIntervalType(DayTimeIntervalType.DAY), "interval day"),
+            (
+                DayTimeIntervalType(DayTimeIntervalType.HOUR, DayTimeIntervalType.SECOND),
+                "interval hour to second",
+            ),
+            (CalendarIntervalType(), "interval"),
+        ]:
+            self.assertEqual(dataType.typeName(), name)
+
     def test_apply_schema_to_row(self):
         df = self.spark.read.json(self.sc.parallelize(["""{"a":2}"""]))
         df2 = self.spark.createDataFrame(df.rdd.map(lambda x: x), df.schema)

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -82,7 +82,7 @@ from pyspark.testing.utils import PySparkErrorTestUtils
 
 class TypesTestsMixin:
     def test_class_method_type_name(self):
-        for dataType, name in [
+        for dataType, expected in [
             (StringType, "string"),
             (CharType, "char"),
             (VarcharType, "varchar"),
@@ -104,10 +104,10 @@ class TypesTestsMixin:
             (DayTimeIntervalType, "daytimeinterval"),
             (CalendarIntervalType, "interval"),
         ]:
-            self.assertEqual(dataType.typeName(), name)
+            self.assertEqual(dataType.typeName(), expected)
 
     def test_instance_method_type_name(self):
-        for dataType, name in [
+        for dataType, expected in [
             (StringType(), "string"),
             (CharType(5), "char(5)"),
             (VarcharType(10), "varchar(10)"),
@@ -140,7 +140,79 @@ class TypesTestsMixin:
             ),
             (CalendarIntervalType(), "interval"),
         ]:
-            self.assertEqual(dataType.typeName(), name)
+            self.assertEqual(dataType.typeName(), expected)
+
+    def test_simple_string(self):
+        for dataType, expected in [
+            (StringType(), "string"),
+            (CharType(5), "char(5)"),
+            (VarcharType(10), "varchar(10)"),
+            (BinaryType(), "binary"),
+            (BooleanType(), "boolean"),
+            (DecimalType(), "decimal(10,0)"),
+            (DecimalType(10, 2), "decimal(10,2)"),
+            (FloatType(), "float"),
+            (DoubleType(), "double"),
+            (ByteType(), "tinyint"),
+            (ShortType(), "smallint"),
+            (IntegerType(), "int"),
+            (LongType(), "bigint"),
+            (DateType(), "date"),
+            (TimestampType(), "timestamp"),
+            (TimestampNTZType(), "timestamp_ntz"),
+            (NullType(), "void"),
+            (VariantType(), "variant"),
+            (YearMonthIntervalType(), "interval year to month"),
+            (YearMonthIntervalType(YearMonthIntervalType.YEAR), "interval year"),
+            (
+                YearMonthIntervalType(YearMonthIntervalType.YEAR, YearMonthIntervalType.MONTH),
+                "interval year to month",
+            ),
+            (DayTimeIntervalType(), "interval day to second"),
+            (DayTimeIntervalType(DayTimeIntervalType.DAY), "interval day"),
+            (
+                DayTimeIntervalType(DayTimeIntervalType.HOUR, DayTimeIntervalType.SECOND),
+                "interval hour to second",
+            ),
+            (CalendarIntervalType(), "interval"),
+        ]:
+            self.assertEqual(dataType.simpleString(), expected)
+
+    def test_json_value(self):
+        for dataType, expected in [
+            (StringType(), "string"),
+            (CharType(5), "char(5)"),
+            (VarcharType(10), "varchar(10)"),
+            (BinaryType(), "binary"),
+            (BooleanType(), "boolean"),
+            (DecimalType(), "decimal(10,0)"),
+            (DecimalType(10, 2), "decimal(10,2)"),
+            (FloatType(), "float"),
+            (DoubleType(), "double"),
+            (ByteType(), "byte"),
+            (ShortType(), "short"),
+            (IntegerType(), "integer"),
+            (LongType(), "long"),
+            (DateType(), "date"),
+            (TimestampType(), "timestamp"),
+            (TimestampNTZType(), "timestamp_ntz"),
+            (NullType(), "void"),
+            (VariantType(), "variant"),
+            (YearMonthIntervalType(), "interval year to month"),
+            (YearMonthIntervalType(YearMonthIntervalType.YEAR), "interval year"),
+            (
+                YearMonthIntervalType(YearMonthIntervalType.YEAR, YearMonthIntervalType.MONTH),
+                "interval year to month",
+            ),
+            (DayTimeIntervalType(), "interval day to second"),
+            (DayTimeIntervalType(DayTimeIntervalType.DAY), "interval day"),
+            (
+                DayTimeIntervalType(DayTimeIntervalType.HOUR, DayTimeIntervalType.SECOND),
+                "interval hour to second",
+            ),
+            (CalendarIntervalType(), "interval"),
+        ]:
+            self.assertEqual(dataType.jsonValue(), expected)
 
     def test_apply_schema_to_row(self):
         df = self.spark.read.json(self.sc.parallelize(["""{"a":2}"""]))


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, refactor instance method `TypeName` to support parameterized datatypes
2, remove redundant simpleString/jsonValue methods, since they are type name by default.

### Why are the changes needed?
to be consistent with the Scala side


### Does this PR introduce _any_ user-facing change?

type names changes:
`CharType(10)`: `char` -> `char(10)`
`VarcharType(10)`: `varchar` -> `varchar(10)`
`DecimalType(10, 2)`: `decimal` -> `decimal(10,2)`
`DayTimeIntervalType(DAY, HOUR)`: `daytimeinterval` -> `interval day to hour`
`YearMonthIntervalType(YEAR, MONTH)`: `yearmonthinterval` -> `interval year to month`




### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no