### PR TITLE
[SPARK-47579][CORE][PART3][FOLLOWUP] Fix KubernetesSuite

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DecommissionSuite.scala
@@ -175,7 +175,7 @@ private[spark] trait DecommissionSuite { k8sSuite: KubernetesSuite =>
         expectedDriverLogOnCompletion = Seq(
           "Finished waiting, stopping Spark",
           "Decommission executors",
-          "Remove reason statistics: (gracefully decommissioned: 1, decommision unfinished: 0, " +
+          "Remove reason statistics: (gracefully decommissioned: 1, decommission unfinished: 0, " +
             "driver killed: 0, unexpectedly exited: 0)."),
         appArgs = Array.empty[String],
         driverPodChecker = doBasicDriverPyPodCheck,


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr is following up https://github.com/apache/spark/pull/46739, and aims to fix `KubernetesSuite `.

1.Unfortunately, after `correcting` the `typo` from `decommision` to `decommission`, it seems that GA has been broken. 
<img width="971" alt="image" src="https://github.com/apache/spark/assets/15246973/6212debb-0ff6-4d22-8999-e37aa2cb2c10">

2.https://github.com/panbingkun/spark/actions/runs/9232744348/job/25406127982
<img width="925" alt="image" src="https://github.com/apache/spark/assets/15246973/4e71598c-22f3-4fd2-afba-fd91ddce5f55">


### Why are the changes needed?
Only fix `KubernetesSuite`.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
