### PR TITLE
[SPARK-48424][INFRA] Make dev/is-changed.py to return true it it fails

### DIFF
--- a/dev/is-changed.py
+++ b/dev/is-changed.py
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+import warnings
+import traceback
 import os
 import sys
 from argparse import ArgumentParser
@@ -82,4 +84,8 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except Exception:
+        warnings.warn(f"Ignored exception:\n\n{traceback.format_exc()}")
+        print("true")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to make dev/is-changed.py to return true it it fails

### Why are the changes needed?

To make the test robust. GitHub Actions sometimes fail to set the hash for commit properly, e.g., https://github.com/apache/spark/actions/runs/9244026522/job/25435224163?pr=46747

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

Manually tested:

```bash
GITHUB_SHA=a29c9653f3d48d97875ae446d82896bdf0de61ca GITHUB_PREV_SHA=0000000000000000000000000000000000000000 ./dev/is-changed.py -m root
```

```bash
a=`GITHUB_SHA=a29c9653f3d48d97875ae446d82896bdf0de61ca GITHUB_PREV_SHA=0000000000000000000000000000000000000000 ./dev/is-changed.py -m root`
echo $a
```

```bash
GITHUB_SHA=a29c9653f3d48d97875ae446d82896bdf0de61ca GITHUB_PREV_SHA=3346afd4b250c3aead5a237666d4942018a463e0 ./dev/is-changed.py -m root
```

### Was this patch authored or co-authored using generative AI tooling?

No.