### PR TITLE
[SPARK-48425][PYTHON][BUILD] Replaces pyspark-connect to pyspark_connect for its output name

### DIFF
--- a/dev/create-release/release-build.sh
+++ b/dev/create-release/release-build.sh
@@ -126,12 +126,12 @@ if [[ "$1" == "finalize" ]]; then
     --repository-url https://upload.pypi.org/legacy/ \
     "pyspark-$RELEASE_VERSION.tar.gz" \
     "pyspark-$RELEASE_VERSION.tar.gz.asc"
-  svn update "pyspark-connect-$RELEASE_VERSION.tar.gz"
-  svn update "pyspark-connect-$RELEASE_VERSION.tar.gz.asc"
+  svn update "pyspark_connect-$RELEASE_VERSION.tar.gz"
+  svn update "pyspark_connect-$RELEASE_VERSION.tar.gz.asc"
   TWINE_USERNAME=spark-upload TWINE_PASSWORD="$PYPI_PASSWORD" twine upload \
     --repository-url https://upload.pypi.org/legacy/ \
-    "pyspark-connect-$RELEASE_VERSION.tar.gz" \
-    "pyspark-connect-$RELEASE_VERSION.tar.gz.asc"
+    "pyspark_connect-$RELEASE_VERSION.tar.gz" \
+    "pyspark_connect-$RELEASE_VERSION.tar.gz.asc"
   cd ..
   rm -rf svn-spark
   echo "PySpark uploaded"
@@ -314,7 +314,7 @@ if [[ "$1" == "package" ]]; then
         --detach-sig $PYTHON_DIST_NAME
       shasum -a 512 $PYTHON_DIST_NAME > $PYTHON_DIST_NAME.sha512
 
-      PYTHON_CONNECT_DIST_NAME=pyspark-connect-$PYSPARK_VERSION.tar.gz
+      PYTHON_CONNECT_DIST_NAME=pyspark_connect-$PYSPARK_VERSION.tar.gz
       cp spark-$SPARK_VERSION-bin-$NAME/python/dist/$PYTHON_CONNECT_DIST_NAME .
 
       echo $GPG_PASSPHRASE | $GPG --passphrase-fd 0 --armour \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to replace `pyspark-connect` to `pyspark_connect` for its output name.

### Why are the changes needed?

`setuptools` from 69.X.X changes the output name. It replaces dash in package name to underscore (`pyspark_connect-4.0.0.dev1.tar.gz` vs `pyspark-connect-4.0.0.dev1.tar.gz`), I think it is https://github.com/pypa/setuptools/issues/4214.

### Does this PR introduce _any_ user-facing change?

No, this package has not been released out yet.

### How was this patch tested?

Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.