### PR TITLE
[MINOR][INFRA] Make pure Python build compatible with other setuptools versions

### DIFF
--- a/.github/workflows/build_python_connect.yml
+++ b/.github/workflows/build_python_connect.yml
@@ -70,7 +70,7 @@ jobs:
           cd python
           python packaging/connect/setup.py sdist
           cd dist
-          pip install pyspark-connect-*.tar.gz
+          pip install pyspark*connect-*.tar.gz
           pip install 'six==1.16.0' 'pandas<=2.2.2' scipy 'plotly>=4.8' 'mlflow>=2.8.1' coverage matplotlib openpyxl 'memory-profiler>=0.61.0' 'scikit-learn>=1.3.2' torch torchvision torcheval deepspeed unittest-xml-reporting
       - name: Run tests
         env:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is related to https://github.com/apache/spark/pull/46751. For now, we're using low `setuptools` version so the build is not affected, but it will be broken if we happen to upgrade it at some point. This PR makes the build compatible with `_` and `-`.

### Why are the changes needed?

This is a proactive action to prevent breaking the build. 

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually

### Was this patch authored or co-authored using generative AI tooling?

No.