### PR TITLE
[SPARK-48427][BUILD] Upgrade `scala-parser-combinators` to 2.4

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -250,7 +250,7 @@ scala-collection-compat_2.13/2.7.0//scala-collection-compat_2.13-2.7.0.jar
 scala-compiler/2.13.14//scala-compiler-2.13.14.jar
 scala-library/2.13.14//scala-library-2.13.14.jar
 scala-parallel-collections_2.13/1.0.4//scala-parallel-collections_2.13-1.0.4.jar
-scala-parser-combinators_2.13/2.3.0//scala-parser-combinators_2.13-2.3.0.jar
+scala-parser-combinators_2.13/2.4.0//scala-parser-combinators_2.13-2.4.0.jar
 scala-reflect/2.13.14//scala-reflect-2.13.14.jar
 scala-xml_2.13/2.2.0//scala-xml_2.13-2.2.0.jar
 slf4j-api/2.0.13//slf4j-api-2.0.13.jar

--- a/pom.xml
+++ b/pom.xml
@@ -1151,7 +1151,7 @@
       <dependency>
         <groupId>org.scala-lang.modules</groupId>
         <artifactId>scala-parser-combinators_${scala.binary.version}</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
       </dependency>
       <dependency>
         <groupId>jline</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade `scala-parser-combinators` from 2.3 to 2.4

### Why are the changes needed?
This version begins to validate the build and testing for Java 21. The full release note as follows:
- https://github.com/scala/scala-parser-combinators/releases/tag/v2.4.0

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No