### PR TITLE
[SPARK-48426][SQL][DOCS] Add documentation for SQL operator precedence

### DIFF
--- a/docs/_data/menu-sql.yaml
+++ b/docs/_data/menu-sql.yaml
@@ -85,6 +85,8 @@
       url: sql-ref-datetime-pattern.html
     - text: Number Pattern
       url: sql-ref-number-pattern.html
+    - text: Operators
+      url: sql-ref-operators.html
     - text: Functions
       url: sql-ref-functions.html
     - text: Identifiers

--- a/docs/sql-ref-operators.md
+++ b/docs/sql-ref-operators.md
@@ -32,19 +32,99 @@ An operator on higher precedence is evaluated before an operator on a lower leve
 In the following table, the operators in descending order of precedence, a.k.a. 0 is the highest level and 11 is the lowest.
 Operators listed on the same table cell have the same precedence and are evaluated from left to right or right to left based on the associativity.
 
-| Precedence | Operator                                                                                            | Operation                                                                   | Associativity |
-|------------|-----------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|---------------|
-| 1          | ., []                                                                                               | member access                                                               | Left to right |
-| 2          | ::                                                                                                  | cast                                                                        | Left to right |
-| 3          | +<br/>-<br/>~                                                                                       | unary plus<br/>unary minus<br/>bitwise NOT                                  | Right to left |
-| 4          | *<br/>/<br/>%<br/>DIV                                                                               | multiplication<br/>division, modulo<br/>integral division                   | Left to right |
-| 5          | +<br/>-<br/>\|\|                                                                                    | addition<br/>subtraction<br/>concatenation                                  | Left to right |
-| 6          | \<\< <br/> \>\> <br/> \>\>\>                                                                        | bitwise shift left<br/>bitwise shift right<br/>bitwise shift right unsigned | Left to right |
-| 7          | &                                                                                                   | bitwise AND                                                                 | Left to right |
-| 8          | ^                                                                                                   | bitwise XOR(exclusive or)                                                   | Left to right |
-| 9          | \|                                                                                                  | bitwise OR(inclusive or)                                                    | Left to right |
-| 10         | =, ==<br/>&lt;&gt;, !=<br/>&lt;, &lt;=<br/>&gt;, &gt;=<br/>                                         | comparison operators                                                        | Left to right |
-| 11         | NOT, !<br/>EXISTS                                                                                   | logical NOT<br/>existence                                                   | Right to left |
-| 12         | BETWEEN<br/>IN<br/>RLIKE, REGEXP<br/>ILIKE<br/>LIKE<br/>IS [NULL, TRUE, FALSE]<br/>IS DISTINCT FROM | other predicates                                                            | Left to right |
-| 13         | AND                                                                                                 | conjunction                                                                 | Left to right |
-| 14         | OR                                                                                                  | disjunction                                                                 | Left to right |
+<table>
+  <thead>
+    <tr>
+      <th>Precedence</th>
+      <th>Operator</th>
+      <th>Operation</th>
+      <th>Associativity</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>1</td>
+      <td>.<br/>[]</td>
+      <td>member access</td>
+      <td>Left to right</td>
+    </tr>
+    <tr>
+      <td>2</td>
+      <td>::</td>
+      <td>cast</td>
+      <td>Left to right</td>
+    </tr>
+    <tr>
+      <td>3</td>
+      <td>+<br/>-<br/>~</td>
+      <td>unary plus<br/>unary minus<br/>bitwise NOT</td>
+      <td>Right to left</td>
+    </tr>
+    <tr>
+      <td>4</td>
+      <td>*<br/>/<br/>%<br/>DIV</td>
+      <td>multiplication<br/>division, modulo<br/>integral division</td>
+      <td>Left to right</td>
+    </tr>
+    <tr>
+      <td>5</td>
+      <td>+<br/>-<br/>||</td>
+      <td>addition<br/>subtraction<br/>concatenation</td>
+      <td>Left to right</td>
+    </tr>
+    <tr>
+      <td>6</td>
+      <td>&lt;&lt;<br/>&gt;&gt;<br/>&gt;&gt;&gt;</td>
+      <td>bitwise shift left<br/>bitwise shift right<br/>bitwise shift right unsigned</td>
+      <td>Left to right</td>
+    </tr>
+    <tr>
+      <td>7</td>
+      <td>&</td>
+      <td>bitwise AND</td>
+      <td>Left to right</td>
+    </tr>
+    <tr>
+      <td>8</td>
+      <td>^</td>
+      <td>bitwise XOR(exclusive or)</td>
+      <td>Left to right</td>
+    </tr>
+    <tr>
+      <td>9</td>
+      <td>|</td>
+      <td>bitwise OR(inclusive or)</td>
+      <td>Left to right</td>
+    </tr>
+    <tr>
+      <td>10</td>
+      <td>=, ==<br/>&lt;&gt;, !=<br/>&lt;, &lt;=<br/>&gt;, &gt;=</td>
+      <td>comparison operators</td>
+      <td>Left to right</td>
+    </tr>
+    <tr>
+      <td>11</td>
+      <td>NOT, !<br/>EXISTS</td>
+      <td>logical NOT<br/>existence</td>
+      <td>Right to left</td>
+    </tr>
+    <tr>
+      <td>12</td>
+      <td>BETWEEN<br/>IN<br/>RLIKE, REGEXP<br/>ILIKE<br/>LIKE<br/>IS [NULL, TRUE, FALSE]<br/>IS DISTINCT FROM</td>
+      <td>other predicates</td>
+      <td>Left to right</td>
+    </tr>
+    <tr>
+      <td>13</td>
+      <td>AND</td>
+      <td>conjunction</td>
+      <td>Left to right</td>
+    </tr>
+    <tr>
+      <td>14</td>
+      <td>OR</td>
+      <td>disjunction</td>
+      <td>Left to right</td>
+    </tr>
+  </tbody>
+</table>

--- a/docs/sql-ref-operators.md
+++ b/docs/sql-ref-operators.md
@@ -1,0 +1,50 @@
+---
+layout: global
+title: Operators
+displayTitle: Operators
+license: |
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+---
+
+An SQL operator is a symbol specifying an action that is performed on one or more expressions. Operators are represented by special characters or by keywords.
+
+### Operator Precedence
+
+When a complex expression has multiple operators, operator precedence determines the sequence of operations in the expression,
+e.g. in expression `1 + 2 * 3`, `*` has higher precedence than `+`, so the expression is evaluated as `1 + (2 * 3) = 7`.
+The order of execution can significantly affect the resulting value.
+
+Operators have the precedence levels shown in the following table.
+An operator on higher precedence is evaluated before an operator on a lower level.
+In the following table, the operators in descending order of precedence, a.k.a. 0 is the highest level and 11 is the lowest.
+Operators listed on the same table cell have the same precedence and are evaluated from left to right or right to left based on the associativity.
+
+| Precedence | Operator                                                                                            | Operation                                                                   | Associativity |
+|------------|-----------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|---------------|
+| 1          | ., []                                                                                               | member access                                                               | Left to right |
+| 2          | ::                                                                                                  | cast                                                                        | Left to right |
+| 3          | +<br/>-<br/>~                                                                                       | unary plus<br/>unary minus<br/>bitwise NOT                                  | Right to left |
+| 4          | *<br/>/<br/>%<br/>DIV                                                                               | multiplication<br/>division, modulo<br/>integral division                   | Left to right |
+| 5          | +<br/>-<br/>\|\|                                                                                    | addition<br/>subtraction<br/>concatenation                                  | Left to right |
+| 6          | \<\< <br/> \>\> <br/> \>\>\>                                                                        | bitwise shift left<br/>bitwise shift right<br/>bitwise shift right unsigned | Left to right |
+| 7          | &                                                                                                   | bitwise AND                                                                 | Left to right |
+| 8          | ^                                                                                                   | bitwise XOR(exclusive or)                                                   | Left to right |
+| 9          | \|                                                                                                  | bitwise OR(inclusive or)                                                    | Left to right |
+| 10         | =, ==<br/>&lt;&gt;, !=<br/>&lt;, &lt;=<br/>&gt;, &gt;=<br/>                                         | comparison operators                                                        | Left to right |
+| 11         | NOT, !<br/>EXISTS                                                                                   | logical NOT<br/>existence                                                   | Right to left |
+| 12         | BETWEEN<br/>IN<br/>RLIKE, REGEXP<br/>ILIKE<br/>LIKE<br/>IS [NULL, TRUE, FALSE]<br/>IS DISTINCT FROM | other predicates                                                            | Left to right |
+| 13         | AND                                                                                                 | conjunction                                                                 | Left to right |
+| 14         | OR                                                                                                  | disjunction                                                                 | Left to right |

--- a/docs/sql-ref-operators.md
+++ b/docs/sql-ref-operators.md
@@ -29,7 +29,7 @@ The order of execution can significantly affect the resulting value.
 
 Operators have the precedence levels shown in the following table.
 An operator on higher precedence is evaluated before an operator on a lower level.
-In the following table, the operators in descending order of precedence, a.k.a. 0 is the highest level and 11 is the lowest.
+In the following table, the operators in descending order of precedence, a.k.a. 1 is the highest level.
 Operators listed on the same table cell have the same precedence and are evaluated from left to right or right to left based on the associativity.
 
 <table>
@@ -44,84 +44,78 @@ Operators listed on the same table cell have the same precedence and are evaluat
   <tbody>
     <tr>
       <td>1</td>
-      <td>.<br/>[]</td>
-      <td>member access</td>
+      <td>.<br/>[]<br/>::</td>
+      <td>member access<br/>element access<br/>cast</td>
       <td>Left to right</td>
     </tr>
     <tr>
       <td>2</td>
-      <td>::</td>
-      <td>cast</td>
-      <td>Left to right</td>
-    </tr>
-    <tr>
-      <td>3</td>
       <td>+<br/>-<br/>~</td>
       <td>unary plus<br/>unary minus<br/>bitwise NOT</td>
       <td>Right to left</td>
     </tr>
     <tr>
-      <td>4</td>
+      <td>3</td>
       <td>*<br/>/<br/>%<br/>DIV</td>
       <td>multiplication<br/>division, modulo<br/>integral division</td>
       <td>Left to right</td>
     </tr>
     <tr>
-      <td>5</td>
+      <td>4</td>
       <td>+<br/>-<br/>||</td>
       <td>addition<br/>subtraction<br/>concatenation</td>
       <td>Left to right</td>
     </tr>
     <tr>
-      <td>6</td>
+      <td>5</td>
       <td>&lt;&lt;<br/>&gt;&gt;<br/>&gt;&gt;&gt;</td>
       <td>bitwise shift left<br/>bitwise shift right<br/>bitwise shift right unsigned</td>
       <td>Left to right</td>
     </tr>
     <tr>
-      <td>7</td>
+      <td>6</td>
       <td>&</td>
       <td>bitwise AND</td>
       <td>Left to right</td>
     </tr>
     <tr>
-      <td>8</td>
+      <td>7</td>
       <td>^</td>
       <td>bitwise XOR(exclusive or)</td>
       <td>Left to right</td>
     </tr>
     <tr>
-      <td>9</td>
+      <td>8</td>
       <td>|</td>
       <td>bitwise OR(inclusive or)</td>
       <td>Left to right</td>
     </tr>
     <tr>
-      <td>10</td>
+      <td>9</td>
       <td>=, ==<br/>&lt;&gt;, !=<br/>&lt;, &lt;=<br/>&gt;, &gt;=</td>
       <td>comparison operators</td>
       <td>Left to right</td>
     </tr>
     <tr>
-      <td>11</td>
+      <td>10</td>
       <td>NOT, !<br/>EXISTS</td>
       <td>logical NOT<br/>existence</td>
       <td>Right to left</td>
     </tr>
     <tr>
-      <td>12</td>
+      <td>11</td>
       <td>BETWEEN<br/>IN<br/>RLIKE, REGEXP<br/>ILIKE<br/>LIKE<br/>IS [NULL, TRUE, FALSE]<br/>IS DISTINCT FROM</td>
       <td>other predicates</td>
       <td>Left to right</td>
     </tr>
     <tr>
-      <td>13</td>
+      <td>12</td>
       <td>AND</td>
       <td>conjunction</td>
       <td>Left to right</td>
     </tr>
     <tr>
-      <td>14</td>
+      <td>13</td>
       <td>OR</td>
       <td>disjunction</td>
       <td>Left to right</td>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR adds a doc for SQL operator precedence based on the current definition of `SqlBaseParser.g4`

Not related to this PR, I have found that our `^` and `!` operators have quite different precedences than other modern systems.

https://docs.oracle.com/cd/A58617_01/server.804/a58225/ch3all.htm
https://learn.microsoft.com/en-us/sql/t-sql/language-elements/operator-precedence-transact-sql?view=sql-server-ver16
https://dev.mysql.com/doc/refman/8.0/en/operator-precedence.html
https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-PRECEDENCE
https://mariadb.com/kb/en/operator-precedence/
https://docs.databricks.com/en/sql/language-manual/sql-ref-functions-builtin.html#operator-precedence


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
doc improvement 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
--> doc build

![image](https://github.com/apache/spark/assets/8326978/dd612740-dd8a-4dc9-af2c-488938f00dff)



### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->no
