### PR TITLE
[SPARK-48432][SQL] Avoid unboxing integers in UnivocityParser

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/UnivocityParser.scala
@@ -63,8 +63,7 @@ class UnivocityParser(
   private type ValueConverter = String => Any
 
   // This index is used to reorder parsed tokens
-  private val tokenIndexArr =
-    requiredSchema.map(f => java.lang.Integer.valueOf(dataSchema.indexOf(f))).toArray
+  private val tokenIndexArr = requiredSchema.map(f => dataSchema.indexOf(f)).toArray
 
   // True if we should inform the Univocity CSV parser to select which fields to read by their
   // positions. Generally assigned by input configuration options, except when input column(s) have
@@ -81,7 +80,8 @@ class UnivocityParser(
     // When to-be-parsed schema is shorter than the to-be-read data schema, we let Univocity CSV
     // parser select a sequence of fields for reading by their positions.
     if (parsedSchema.length < dataSchema.length) {
-      parserSetting.selectIndexes(tokenIndexArr: _*)
+      // Box into Integer here to avoid unboxing where `tokenIndexArr` is used during parsing
+      parserSetting.selectIndexes(tokenIndexArr.map(java.lang.Integer.valueOf(_)): _*)
     }
     new CsvParser(parserSetting)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
`tokenIndexArr` is created as an array of `java.lang.Integers`. However, it is used not only for the wrapped java parser, but also during parsing to identify the correct token index.


### Why are the changes needed?
This noticeably improves CSV parsing performance


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
`testOnly org.apache.spark.sql.catalyst.csv.UnivocityParserSuite`


### Was this patch authored or co-authored using generative AI tooling?
No