### PR TITLE
[SPARK-48431][SQL] Do not forward predicates on collated columns to file readers

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -597,11 +597,12 @@ object DataSourceStrategy
     : Option[Filter] = {
 
     def translateAndRecordLeafNodeFilter(filter: Expression): Option[Filter] = {
-      val filter = translateLeafNodeFilter(filter, PushableColumn(nestedPredicatePushdownEnabled))
-      if (filter.isDefined && translatedFilterToExpr.isDefined) {
-        translatedFilterToExpr.get(filter.get) = predicate
+      val translatedFilter =
+        translateLeafNodeFilter(filter, PushableColumn(nestedPredicatePushdownEnabled))
+      if (translatedFilter.isDefined && translatedFilterToExpr.isDefined) {
+        translatedFilterToExpr.get(translatedFilter.get) = predicate
       }
-      filter
+      translatedFilter
     }
 
     predicate match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -595,6 +595,15 @@ object DataSourceStrategy
       translatedFilterToExpr: Option[mutable.HashMap[sources.Filter, Expression]],
       nestedPredicatePushdownEnabled: Boolean)
     : Option[Filter] = {
+
+    def translateAndRecordLeafNodeFilter(filter: Expression): Option[Filter] = {
+      val filter = translateLeafNodeFilter(filter, PushableColumn(nestedPredicatePushdownEnabled))
+      if (filter.isDefined && translatedFilterToExpr.isDefined) {
+        translatedFilterToExpr.get(filter.get) = predicate
+      }
+      filter
+    }
+
     predicate match {
       case expressions.And(left, right) =>
         // See SPARK-12218 for detailed discussion
@@ -623,41 +632,23 @@ object DataSourceStrategy
 
       case notNull @ expressions.IsNotNull(_: AttributeReference) =>
         // Not null filters on attribute references can always be pushed, also for collated columns.
-        val filter =
-          translateLeafNodeFilter(notNull, PushableColumn(nestedPredicatePushdownEnabled))
-        if (filter.isDefined && translatedFilterToExpr.isDefined) {
-          translatedFilterToExpr.get(filter.get) = predicate
-        }
-        filter
+        translateAndRecordLeafNodeFilter(notNull)
 
       case isNull @ expressions.IsNull(_: AttributeReference) =>
         // Is null filters on attribute references can always be pushed, also for collated columns.
-        val filter =
-          translateLeafNodeFilter(isNull, PushableColumn(nestedPredicatePushdownEnabled))
-        if (filter.isDefined && translatedFilterToExpr.isDefined) {
-          translatedFilterToExpr.get(filter.get) = predicate
-        }
-        filter
+        translateAndRecordLeafNodeFilter(isNull)
 
       case p if p.references.exists(ref => SchemaUtils.hasNonUTF8BinaryCollation(ref.dataType)) =>
-        // The filter cannot be pushed and we widen it to be AlwaysTrue().
-        val filter = translateLeafNodeFilter(Literal.TrueLiteral,
-          PushableColumn(nestedPredicatePushdownEnabled))
-        if (filter.isDefined && translatedFilterToExpr.isDefined) {
-          translatedFilterToExpr.get(filter.get) = predicate
-        }
-        filter
+        // The filter cannot be pushed and we widen it to be AlwaysTrue(). This is only valid if
+        // the result of the filter is not negated by a Not expression it is wrapped in.
+        translateAndRecordLeafNodeFilter(Literal.TrueLiteral)
 
       case expressions.Not(child) =>
         translateFilterWithMapping(child, translatedFilterToExpr, nestedPredicatePushdownEnabled)
           .map(sources.Not)
 
       case other =>
-        val filter = translateLeafNodeFilter(other, PushableColumn(nestedPredicatePushdownEnabled))
-        if (filter.isDefined && translatedFilterToExpr.isDefined) {
-          translatedFilterToExpr.get(filter.get) = predicate
-        }
-        filter
+        translateAndRecordLeafNodeFilter(other)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

[SPARK-47657](https://issues.apache.org/jira/browse/SPARK-47657) allows to push filters on collated columns to file sources that support it. If such filters are pushed to file sources, those file sources must not push those filters to the actual file readers (i.e. parquet or csv readers), because there is no guarantee that those support collations.

In this PR we are widening filters on collations to be AlwaysTrue when we translate filters for file sources.


### Why are the changes needed?

Without this, no file source can implement filter pushdown

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Added unit tests. No component tests are possible because there is no file source with filter pushdown yet.

### Was this patch authored or co-authored using generative AI tooling?

No