### PR TITLE
[SPARK-48434][PYTHON][CONNECT] Make `printSchema` use the cached schema

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1811,7 +1811,10 @@ class DataFrame(ParentDataFrame):
         return result
 
     def printSchema(self, level: Optional[int] = None) -> None:
-        print(self._tree_string(level))
+        if level:
+            print(self.schema.treeString(level))
+        else:
+            print(self.schema.treeString())
 
     def inputFiles(self) -> List[str]:
         query = self._plan.to_proto(self._session.client)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `printSchema` use the cached schema


### Why are the changes needed?
to avoid extra RPCs


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
added tests


### Was this patch authored or co-authored using generative AI tooling?
no