### PR TITLE
[SPARK-48168][SQL][TESTS][FOLLOWUP] Regenerate the golden file for `int8.sql` for Java 21

### DIFF
--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/int8.sql.out.java21
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/int8.sql.out.java21
@@ -883,7 +883,7 @@ struct<id:bigint>
 -- !query
 SELECT string(shiftleft(bigint(-1), 63))
 -- !query schema
-struct<shiftleft(-1, 63):string>
+struct<(-1 << 63):string>
 -- !query output
 -9223372036854775808
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR regenerates the golden file for 'int8.sql' needed for testing with Java 21, in order to fix the test failures that occurred in the Java 21 daily test.

### Why are the changes needed?
For fix Java 21 daily test:

- https://github.com/apache/spark/actions/runs/9248989524/job/25440133046

```
[info] - postgreSQL/int8.sql *** FAILED *** (2 seconds, 224 milliseconds)
[info]   postgreSQL/int8.sql
[info]   Expected Some("struct<shiftleft(-1, 63):string>"), but got Some("struct<(-1 << 63):string>") Schema did not match for query #77
[info]   SELECT string(shiftleft(bigint(-1), 63)): -- !query
[info]   SELECT string(shiftleft(bigint(-1), 63))
[info]   -- !query schema
[info]   struct<(-1 << 63):string>
[info]   -- !query output
[info]   -9223372036854775808 (SQLQueryTestSuite.scala:659)
[info]   org.scalatest.exceptions.TestFailedException:
[info]   at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
```

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Manual testing with Java 21: `build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite -- -z int8.sql"`

**Before**

```
[info] - postgreSQL/int8.sql *** FAILED *** (3 seconds, 338 milliseconds)
[info]   postgreSQL/int8.sql
[info]   Expected Some("struct<shiftleft(-1, 63):string>"), but got Some("struct<(-1 << 63):string>") Schema did not match for query #77
[info]   SELECT string(shiftleft(bigint(-1), 63)): -- !query
[info]   SELECT string(shiftleft(bigint(-1), 63))
[info]   -- !query schema
[info]   struct<(-1 << 63):string>
[info]   -- !query output
[info]   -9223372036854775808 (SQLQueryTestSuite.scala:659)
[info]   org.scalatest.exceptions.TestFailedException:
```

**After**

```
info] Run completed in 10 seconds, 647 milliseconds.
[info] Total number of tests run: 2
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 2, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```

### Was this patch authored or co-authored using generative AI tooling?
No