### PR TITLE
[SPARK-48436][SQL][TESTS] Use `c.m.c.j.Driver` instead of `c.m.j.Driver` in `MySQLNamespaceSuite`

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLNamespaceSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/MySQLNamespaceSuite.scala
@@ -40,7 +40,7 @@ class MySQLNamespaceSuite extends DockerJDBCIntegrationSuite with V2JDBCNamespac
 
   val map = new CaseInsensitiveStringMap(
     Map("url" -> db.getJdbcUrl(dockerIp, externalPort),
-      "driver" -> "com.mysql.jdbc.Driver").asJava)
+      "driver" -> "com.mysql.cj.jdbc.Driver").asJava)
 
   catalog.initialize("mysql", map)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to use `com.mysql.cj.jdbc.Driver` instead of `com.mysql.jdbc.Driver` in `MySQLNamespaceSuite`

### Why are the changes needed?
- The full class name of `mysql driver` has changed from `com.mysql.jdbc.Driver` (is deprecated) to `com.mysql.cj.jdbc.Driver`,

- Eliminate warnings:
<img width="953" alt="image" src="https://github.com/apache/spark/assets/15246973/8b135f30-4f89-4d10-a57a-35574e2331a9">



### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Manually test.
- Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
