### PR TITLE
[SPARK-48437][SQL] Improve IsolatedClientLoader

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/HiveUtils.scala
@@ -194,7 +194,7 @@ private[spark] object HiveUtils extends Logging {
     .createWithDefault(jdbcPrefixes)
 
   private def jdbcPrefixes = Seq(
-    "com.mysql.jdbc", "org.postgresql", "com.microsoft.sqlserver", "oracle.jdbc")
+    "com.mysql.jdbc", "com.mysql.cj", "org.postgresql", "com.microsoft.sqlserver", "oracle.jdbc")
 
   val HIVE_METASTORE_BARRIER_PREFIXES = buildStaticConf("spark.sql.hive.metastore.barrierPrefixes")
     .doc("A comma separated list of class prefixes that should explicitly be reloaded for each " +

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/IsolatedClientLoader.scala
@@ -242,8 +242,7 @@ private[hive] class IsolatedClientLoader(
           // In Java 9, the boot classloader can see few JDK classes. The intended parent
           // classloader for delegation is now the platform classloader.
           // See http://java9.wtf/class-loading/
-          val platformCL = classOf[ClassLoader].getMethod("getPlatformClassLoader")
-            .invoke(null).asInstanceOf[ClassLoader]
+          val platformCL = ClassLoader.getPlatformClassLoader
           // Check to make sure that the root classloader does not know about Hive.
           assert(Try(platformCL.loadClass("org.apache.hadoop.hive.conf.HiveConf")).isFailure)
           platformCL


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to improve `IsolatedClientLoader`, includes:
- use `direct` call to method `getPlatformClassLoader` instead of reflection call to the method `getPlatformClassLoader`
- append `com.mysql.cj` to the default value of `sharedPrefixes`.

### Why are the changes needed?
- In `Spark 4.0`, the `minimum supported JDK version is `17`, `ClassLoader#getPlatformClassLoader` can be directly called. Before `Spark 4.0`, it was necessary to be `compatible with `JDK 1.8`, and the `ClassLoader#getPlatformClassLoader` method of the class `ClassLoader` in `JDK 1.8` did not exist. Reflection was used to enable it to compile through `JDK 1.8`.
JDK 1.8 (Method `getPlatformClassLoader` does not exist):
https://github.com/openjdk/jdk/blob/jdk8-b120/jdk/src/share/classes/java/lang/ClassLoader.java

2.The package name of `mysql` has changed from `com.mysql.jdbc.*` (is deprecated) to `com.mysql.cj.*`,


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
No.
