### PR TITLE
[SPARK-48444][SQL][TESTS] Use withSQLConf in tests: Refactor SQLQuerySuite

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1112,7 +1112,6 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
   test("dynamic partition value test") {
     withTable("dynparttest1", "dynparttest2") {
       withSQLConf("hive.exec.dynamic.partition.mode" -> "strict") {
-        sql("set hive.exec.dynamic.partition.mode=nonstrict")
         // date
         sql("create table dynparttest1 (value int) partitioned by (pdate date)")
         sql(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -1111,7 +1111,7 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
 
   test("dynamic partition value test") {
     withTable("dynparttest1", "dynparttest2") {
-      withSQLConf("hive.exec.dynamic.partition.mode" -> "strict") {
+      withSQLConf("hive.exec.dynamic.partition.mode" -> "nonstrict") {
         // date
         sql("create table dynparttest1 (value int) partitioned by (pdate date)")
         sql(

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -727,7 +727,7 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
       }
     }
 
-    withSQLConf("spark.sql.variable.substitute" -> "true") {
+    withSQLConf("tbl2" -> "src", "spark.sql.variable.substitute" -> "true") {
       checkAnswer(
         sql("SELECT key FROM ${hiveconf:tbl2} ORDER BY key, value limit 1"),
         sql("SELECT key FROM src ORDER BY key, value limit 1").collect().toSeq)

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/SQLQuerySuite.scala
@@ -178,24 +178,24 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
             |PARTITIONED BY (state STRING, month INT)
             |STORED AS PARQUET
           """.stripMargin)
+        withSQLConf("hive.exec.dynamic.partition.mode" -> "nonstrict") {
+          sql("INSERT INTO TABLE orders PARTITION(state, month) SELECT * FROM orders1")
+          sql("INSERT INTO TABLE orderupdates PARTITION(state, month) SELECT * FROM orderupdates1")
 
-        sql("set hive.exec.dynamic.partition.mode=nonstrict")
-        sql("INSERT INTO TABLE orders PARTITION(state, month) SELECT * FROM orders1")
-        sql("INSERT INTO TABLE orderupdates PARTITION(state, month) SELECT * FROM orderupdates1")
-
-        checkAnswer(
-          sql(
-            """
-              |select orders.state, orders.month
-              |from orders
-              |join (
-              |  select distinct orders.state,orders.month
-              |  from orders
-              |  join orderupdates
-              |    on orderupdates.id = orders.id) ao
-              |  on ao.state = orders.state and ao.month = orders.month
+          checkAnswer(
+            sql(
+              """
+                |select orders.state, orders.month
+                |from orders
+                |join (
+                |  select distinct orders.state,orders.month
+                |  from orders
+                |  join orderupdates
+                |    on orderupdates.id = orders.id) ao
+                |  on ao.state = orders.state and ao.month = orders.month
             """.stripMargin),
-          (1 to 6).map(_ => Row("CA", 20151)))
+            (1 to 6).map(_ => Row("CA", 20151)))
+        }
       }
     }
   }
@@ -715,21 +715,23 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
   }
 
   test("command substitution") {
-    sql("set tbl=src")
-    checkAnswer(
-      sql("SELECT key FROM ${hiveconf:tbl} ORDER BY key, value limit 1"),
-      sql("SELECT key FROM src ORDER BY key, value limit 1").collect().toSeq)
-
-    sql("set spark.sql.variable.substitute=false") // disable the substitution
-    sql("set tbl2=src")
-    intercept[Exception] {
-      sql("SELECT key FROM ${hiveconf:tbl2} ORDER BY key, value limit 1").collect()
+    withSQLConf("tbl" -> "src") {
+      checkAnswer(
+        sql("SELECT key FROM ${hiveconf:tbl} ORDER BY key, value limit 1"),
+        sql("SELECT key FROM src ORDER BY key, value limit 1").collect().toSeq)
     }
 
-    sql("set spark.sql.variable.substitute=true") // enable the substitution
-    checkAnswer(
-      sql("SELECT key FROM ${hiveconf:tbl2} ORDER BY key, value limit 1"),
-      sql("SELECT key FROM src ORDER BY key, value limit 1").collect().toSeq)
+    withSQLConf("tbl2" -> "src", "spark.sql.variable.substitute" -> "false") {
+      intercept[Exception] {
+        sql("SELECT key FROM ${hiveconf:tbl2} ORDER BY key, value limit 1").collect()
+      }
+    }
+
+    withSQLConf("spark.sql.variable.substitute" -> "true") {
+      checkAnswer(
+        sql("SELECT key FROM ${hiveconf:tbl2} ORDER BY key, value limit 1"),
+        sql("SELECT key FROM src ORDER BY key, value limit 1").collect().toSeq)
+    }
   }
 
   test("ordering not in select") {
@@ -1108,35 +1110,31 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
   }
 
   test("dynamic partition value test") {
-    try {
-      sql("set hive.exec.dynamic.partition.mode=nonstrict")
-      // date
-      sql("drop table if exists dynparttest1")
-      sql("create table dynparttest1 (value int) partitioned by (pdate date)")
-      sql(
-        """
-          |insert into table dynparttest1 partition(pdate)
-          | select count(*), cast('2015-05-21' as date) as pdate from src
-        """.stripMargin)
-      checkAnswer(
-        sql("select * from dynparttest1"),
-        Seq(Row(500, java.sql.Date.valueOf("2015-05-21"))))
+    withTable("dynparttest1", "dynparttest2") {
+      withSQLConf("hive.exec.dynamic.partition.mode" -> "strict") {
+        sql("set hive.exec.dynamic.partition.mode=nonstrict")
+        // date
+        sql("create table dynparttest1 (value int) partitioned by (pdate date)")
+        sql(
+          """
+             |insert into table dynparttest1 partition(pdate)
+             | select count(*), cast('2015-05-21' as date) as pdate from src
+          """.stripMargin)
+        checkAnswer(
+          sql("select * from dynparttest1"),
+          Seq(Row(500, java.sql.Date.valueOf("2015-05-21"))))
 
-      // decimal
-      sql("drop table if exists dynparttest2")
-      sql("create table dynparttest2 (value int) partitioned by (pdec decimal(5, 1))")
-      sql(
-        """
-          |insert into table dynparttest2 partition(pdec)
-          | select count(*), cast('100.12' as decimal(5, 1)) as pdec from src
-        """.stripMargin)
-      checkAnswer(
-        sql("select * from dynparttest2"),
-        Seq(Row(500, new java.math.BigDecimal("100.1"))))
-    } finally {
-      sql("drop table if exists dynparttest1")
-      sql("drop table if exists dynparttest2")
-      sql("set hive.exec.dynamic.partition.mode=strict")
+        // decimal
+        sql("create table dynparttest2 (value int) partitioned by (pdec decimal(5, 1))")
+        sql(
+          """
+             |insert into table dynparttest2 partition(pdec)
+             | select count(*), cast('100.12' as decimal(5, 1)) as pdec from src
+          """.stripMargin)
+        checkAnswer(
+            sql("select * from dynparttest2"),
+            Seq(Row(500, new java.math.BigDecimal("100.1"))))
+      }
     }
   }
 
@@ -1911,14 +1909,14 @@ abstract class SQLQuerySuiteBase extends QueryTest with SQLTestUtils with TestHi
   }
 
   test("SPARK-17354: Partitioning by dates/timestamps works with Parquet vectorized reader") {
-    withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "true") {
+    withSQLConf(SQLConf.PARQUET_VECTORIZED_READER_ENABLED.key -> "true",
+      "hive.exec.dynamic.partition.mode" -> "nonstrict") {
       sql(
         """CREATE TABLE order(id INT)
           |PARTITIONED BY (pd DATE, pt TIMESTAMP)
           |STORED AS PARQUET
         """.stripMargin)
 
-      sql("set hive.exec.dynamic.partition.mode=nonstrict")
       sql(
         """INSERT INTO TABLE order PARTITION(pd, pt)
           |SELECT 1 AS id, CAST('1990-02-24' AS DATE) AS pd, CAST('1990-02-24' AS TIMESTAMP) AS pt


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Use withSQLConf in tests when it is appropriate.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Enforce good practice for setting config in test cases.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
NO

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing UT

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
NO