### PR TITLE
[SPARK-48442][PYTHON][TESTS] Add parenthesis to awaitTermination

### DIFF
--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -27,6 +27,7 @@ from pyspark.sql.datasource import (
     SimpleDataSourceStreamReader,
     WriterCommitMessage,
 )
+from pyspark.sql.streaming import StreamingQueryException
 from pyspark.sql.types import Row
 from pyspark.testing.sqlutils import (
     have_pyarrow,
@@ -231,6 +232,8 @@ class BasePythonStreamingDataSourceTestsMixin:
                 [Row("failed in batch 1")],
             )
             q.awaitTermination()
+        except StreamingQueryException as e:
+            self.assertIn("invalid value", str(e))
         finally:
             input_dir.cleanup()
             output_dir.cleanup()

--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -152,7 +152,7 @@ class BasePythonStreamingDataSourceTestsMixin:
         while current_batch_id < 10:
             time.sleep(0.2)
         q.stop()
-        q.awaitTermination
+        q.awaitTermination()
         self.assertIsNone(q.exception(), "No exception has to be propagated.")
 
     def test_simple_stream_reader(self):
@@ -230,7 +230,7 @@ class BasePythonStreamingDataSourceTestsMixin:
                 self.spark.read.text(os.path.join(output_dir.name, "1.txt")),
                 [Row("failed in batch 1")],
             )
-            q.awaitTermination
+            q.awaitTermination()
         finally:
             input_dir.cleanup()
             output_dir.cleanup()


### PR DESCRIPTION
### Why are the changes needed?
In `test_stream_reader` and `test_stream_writer` of `test_python_streaming_datasource.py`, the call `q.awaitTermination` does not invoke a function call as intended, but instead returns a python function object. The fix is to change this to `q.awaitTermination()`.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Tests were not added since it is correcting a bug in a test file.


### Was this patch authored or co-authored using generative AI tooling?
No
