### PR TITLE
[SPARK-48449][SQL] Using `getPropertyInfo` instead of `reflection` to obtain `JAAS application name`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MSSQLConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/MSSQLConnectionProvider.scala
@@ -38,18 +38,16 @@ private[sql] class MSSQLConnectionProvider extends SecureConnectionProvider {
     val parseURL = try {
       // The default parser method signature is the following:
       // private Properties parseAndMergeProperties(String Url, Properties suppliedProperties)
-      val m = driver.getClass.getDeclaredMethod(parserMethod, classOf[String], classOf[Properties])
-      m.setAccessible(true)
-      Some(m)
+      Some(driver.getClass.getDeclaredMethod(parserMethod, classOf[String], classOf[Properties]))
     } catch {
       case _: NoSuchMethodException => None
     }
 
     parseURL match {
-      case Some(m) =>
+      case Some(_) =>
         logDebug("Property parser method found, using it")
-        m.invoke(driver, options.url, null).asInstanceOf[Properties]
-          .getProperty(configName, appEntryDefault)
+        driver.getPropertyInfo(options.url, null).
+          find(_.name.equals(configName)).map(_.value).getOrElse(appEntryDefault)
 
       case None =>
         logDebug("Property parser method not found, using custom parsing mechanism")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/connection/PostgresConnectionProvider.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.execution.datasources.jdbc.connection
 
 import java.sql.Driver
-import java.util.Properties
 
 import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 
@@ -28,8 +27,7 @@ private[jdbc] class PostgresConnectionProvider extends SecureConnectionProvider 
   override val name: String = "postgres"
 
   override def appEntry(driver: Driver, options: JDBCOptions): String = {
-    val parseURL = driver.getClass.getMethod("parseURL", classOf[String], classOf[Properties])
-    val properties = parseURL.invoke(driver, options.url, null).asInstanceOf[Properties]
-    properties.getProperty("jaasApplicationName", "pgjdbc")
+    driver.getPropertyInfo(options.url, null).
+      find(_.name.equals("jaasApplicationName")).map(_.value).getOrElse("pgjdbc")
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to using `getPropertyInfo` instead of `reflection` to obtain `JAAS application name`, includes:
- MSSQLConnectionProvider
- PostgresConnectionProvider


### Why are the changes needed?
We should use the `public method` of the `Driver interface` and try to avoid using `private method` implemented by different `Drivers` to obtain `JAAS application name`


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Existed UT
  MSSQLConnectionProviderSuite
  PostgresConnectionProviderSuite
- Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
