### PR TITLE
[SPARK-48392][CORE][FOLLOWUP] Add `--load-spark-defaults` flag to decide whether to load `spark-defaults.conf`

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -544,7 +544,9 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         |  --properties-file FILE      Path to a file from which to load extra properties. If not
         |                              specified, this will look for conf/spark-defaults.conf.
         |  --load-spark-defaults       Whether to load properties from conf/spark-defaults.conf,
-        |                              even if --properties-file is specified.
+        |                              even if --properties-file is specified. Configurations
+        |                              specified in --properties-file will take precedence over
+        |                              those in conf/spark-defaults.conf.
         |
         |  --driver-memory MEM         Memory for driver (e.g. 1000M, 2G) (Default: ${mem_mb}M).
         |  --driver-java-options       Extra Java options to pass to the driver.

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -50,7 +50,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
   var executorCores: String = null
   var totalExecutorCores: String = null
   var propertiesFile: String = null
-  private var extraPropertiesFiles: Boolean = false
+  private var loadSparkDefaults: Boolean = false
   var driverMemory: String = null
   var driverExtraClassPath: String = null
   var driverExtraLibraryPath: String = null
@@ -137,8 +137,8 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     // Also load properties from `spark-defaults.conf` if they do not exist in the properties file
     // and --conf list when:
     //   - no input properties file is specified
-    //   - input properties file is specified, but `--extra-properties-files` flag is set
-    if (propertiesFile == null || extraPropertiesFiles) {
+    //   - input properties file is specified, but `--load-spark-defaults` flag is set
+    if (propertiesFile == null || loadSparkDefaults) {
       loadPropertiesFromFile(Utils.getDefaultPropertiesFile(env))
     }
   }
@@ -397,8 +397,8 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
       case PROPERTIES_FILE =>
         propertiesFile = value
 
-      case EXTRA_PROPERTIES_FILES =>
-        extraPropertiesFiles = true
+      case LOAD_SPARK_DEFAULTS =>
+        loadSparkDefaults = true
 
       case KILL_SUBMISSION =>
         submissionToKill = value
@@ -543,7 +543,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         |  --conf, -c PROP=VALUE       Arbitrary Spark configuration property.
         |  --properties-file FILE      Path to a file from which to load extra properties. If not
         |                              specified, this will look for conf/spark-defaults.conf.
-        |  --extra-properties-files    Whether to load properties from conf/spark-defaults.conf,
+        |  --load-spark-defaults       Whether to load properties from conf/spark-defaults.conf,
         |                              even if --properties-file is specified.
         |
         |  --driver-memory MEM         Memory for driver (e.g. 1000M, 2G) (Default: ${mem_mb}M).

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -50,6 +50,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
   var executorCores: String = null
   var totalExecutorCores: String = null
   var propertiesFile: String = null
+  private var extraPropertiesFiles: Boolean = false
   var driverMemory: String = null
   var driverExtraClassPath: String = null
   var driverExtraLibraryPath: String = null
@@ -87,27 +88,6 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
 
   override protected def logName: String = classOf[SparkSubmitArguments].getName
 
-  /** Default properties present in the currently defined defaults file. */
-  lazy val defaultSparkProperties: HashMap[String, String] = {
-    val defaultProperties = new HashMap[String, String]()
-    if (verbose) {
-      logInfo(log"Using properties file: ${MDC(PATH, propertiesFile)}")
-    }
-    Option(propertiesFile).foreach { filename =>
-      val properties = Utils.getPropertiesFromFile(filename)
-      properties.foreach { case (k, v) =>
-        defaultProperties(k) = v
-      }
-      // Property files may contain sensitive information, so redact before printing
-      if (verbose) {
-        Utils.redact(properties).foreach { case (k, v) =>
-          logInfo(log"Adding default property: ${MDC(KEY, k)}=${MDC(VALUE, v)}")
-        }
-      }
-    }
-    defaultProperties
-  }
-
   // Set parameters from command line arguments
   parse(args.asJava)
 
@@ -123,31 +103,43 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
   validateArguments()
 
   /**
-   * Merge values from the default properties file with those specified through --conf.
-   * When this is called, `sparkProperties` is already filled with configs from the latter.
+   * Load properties from the file with the given path into `sparkProperties`.
+   * No-op if the file path is null
    */
-  private def mergeDefaultSparkProperties(): Unit = {
-    // Honor --conf before the specified properties file and defaults file
-    defaultSparkProperties.foreach { case (k, v) =>
-      if (!sparkProperties.contains(k)) {
-        sparkProperties(k) = v
+  private def loadPropertiesFromFile(filePath: String): Unit = {
+    if (filePath != null) {
+      if (verbose) {
+        logInfo(log"Using properties file: ${MDC(PATH, filePath)}")
       }
-    }
-
-    // Also load properties from `spark-defaults.conf` if they do not exist in the properties file
-    // and --conf list
-    val defaultSparkConf = Utils.getDefaultPropertiesFile(env)
-    Option(defaultSparkConf).foreach { filename =>
-      val properties = Utils.getPropertiesFromFile(filename)
+      val properties = Utils.getPropertiesFromFile(filePath)
       properties.foreach { case (k, v) =>
         if (!sparkProperties.contains(k)) {
           sparkProperties(k) = v
         }
       }
+      // Property files may contain sensitive information, so redact before printing
+      if (verbose) {
+        Utils.redact(properties).foreach { case (k, v) =>
+          logInfo(log"Adding default property: ${MDC(KEY, k)}=${MDC(VALUE, v)}")
+        }
+      }
     }
+  }
 
-    if (propertiesFile == null) {
-      propertiesFile = defaultSparkConf
+  /**
+   * Merge values from the default properties file with those specified through --conf.
+   * When this is called, `sparkProperties` is already filled with configs from the latter.
+   */
+  private def mergeDefaultSparkProperties(): Unit = {
+    // Honor --conf before the specified properties file and defaults file
+    loadPropertiesFromFile(propertiesFile)
+
+    // Also load properties from `spark-defaults.conf` if they do not exist in the properties file
+    // and --conf list when:
+    //   - no input properties file is specified
+    //   - input properties file is specified, but `--extra-properties-files` flag is set
+    if (propertiesFile == null || extraPropertiesFiles) {
+      loadPropertiesFromFile(Utils.getDefaultPropertiesFile(env))
     }
   }
 
@@ -405,6 +397,9 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
       case PROPERTIES_FILE =>
         propertiesFile = value
 
+      case EXTRA_PROPERTIES_FILES =>
+        extraPropertiesFiles = true
+
       case KILL_SUBMISSION =>
         submissionToKill = value
         if (action != null) {
@@ -548,6 +543,8 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         |  --conf, -c PROP=VALUE       Arbitrary Spark configuration property.
         |  --properties-file FILE      Path to a file from which to load extra properties. If not
         |                              specified, this will look for conf/spark-defaults.conf.
+        |  --extra-properties-files    Whether to load properties from conf/spark-defaults.conf,
+        |                              even if --properties-file is specified.
         |
         |  --driver-memory MEM         Memory for driver (e.g. 1000M, 2G) (Default: ${mem_mb}M).
         |  --driver-java-options       Extra Java options to pass to the driver.

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -1107,8 +1107,6 @@ class SparkSubmitSuite
         "--master", "local",
         unusedJar.toString)
       val appArgs = new SparkSubmitArguments(args, env = Map("SPARK_CONF_DIR" -> path))
-      assert(appArgs.propertiesFile != null)
-      assert(appArgs.propertiesFile.startsWith(path))
       appArgs.executorMemory should be ("3g")
     }
   }

--- a/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/SparkSubmitSuite.scala
@@ -1113,7 +1113,7 @@ class SparkSubmitSuite
     }
   }
 
-  test("SPARK-48392: load spark-defaults.conf when --extra-properties-files is set") {
+  test("SPARK-48392: load spark-defaults.conf when --load-spark-defaults is set") {
     forConfDir(Map("spark.executor.memory" -> "3g", "spark.driver.memory" -> "3g")) { path =>
       withPropertyFile("spark-conf.properties",
           Map("spark.executor.cores" -> "16", "spark.driver.memory" -> "4g")) { propsFile =>
@@ -1123,7 +1123,7 @@ class SparkSubmitSuite
           "--name", "testApp",
           "--master", "local",
           "--properties-file", propsFile,
-          "--extra-properties-files",
+          "--load-spark-defaults",
           unusedJar.toString)
         val appArgs = new SparkSubmitArguments(args, env = Map("SPARK_CONF_DIR" -> path))
         appArgs.executorCores should be("16")
@@ -1133,7 +1133,7 @@ class SparkSubmitSuite
     }
   }
 
-  test("SPARK-48392: should skip spark-defaults.conf when --extra-properties-files is not set") {
+  test("SPARK-48392: should skip spark-defaults.conf when --load-spark-defaults is not set") {
     forConfDir(Map("spark.executor.memory" -> "3g", "spark.driver.memory" -> "3g")) { path =>
       withPropertyFile("spark-conf.properties",
         Map("spark.executor.cores" -> "16", "spark.driver.memory" -> "4g")) { propsFile =>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,8 +103,9 @@ such as `--master`, as shown above. `spark-submit` can accept any Spark property
 flag, but uses special flags for properties that play a part in launching the Spark application.
 Running `./bin/spark-submit --help` will show the entire list of these options.
 
-`bin/spark-submit` will also read configuration options from `conf/spark-defaults.conf`, in which
-each line consists of a key and a value separated by whitespace. For example:
+When configurations are specified via the `--conf/-c` flags, `bin/spark-submit` will also read
+configuration options from `conf/spark-defaults.conf`, in which each line consists of a key and
+a value separated by whitespace. For example:
 
     spark.master            spark://5.6.7.8:7077
     spark.executor.memory   4g
@@ -112,7 +113,8 @@ each line consists of a key and a value separated by whitespace. For example:
     spark.serializer        org.apache.spark.serializer.KryoSerializer
 
 In addition, a property file with Spark configurations can be passed to `bin/spark-submit` via
-the `--properties-file` parameter.
+`--properties-file` parameter. When this is set, Spark will no longer load configurations from
+`conf/spark-defaults.conf` unless another parameter `--load-spark-defaults` is provided.
 
 Any values specified as flags or in the properties file will be passed on to the application
 and merged with those specified through SparkConf. Properties set directly on the SparkConf

--- a/docs/submitting-applications.md
+++ b/docs/submitting-applications.md
@@ -178,8 +178,13 @@ The master URL passed to Spark can be in one of the following formats:
 # Loading Configuration from a File
 
 The `spark-submit` script can load default [Spark configuration values](configuration.html) from a
-properties file and pass them on to your application. By default, it will read options
-from `conf/spark-defaults.conf` in the `SPARK_HOME` directory.
+properties file and pass them on to your application. The file can be specified via the `--properties-file`
+parameter. When this is not specified, by default Spark will read options from `conf/spark-defaults.conf`
+in the `SPARK_HOME` directory.
+
+An additional flag `--load-spark-defaults` can be used to tell Spark to load configurations from `conf/spark-defaults.conf`
+even when a property file is provided via `--properties-file`. This is useful, for instance, when users
+want to put system-wide default settings in the former while user/cluster specific settings in the latter.
 
 Loading default Spark configurations this way can obviate the need for certain flags to
 `spark-submit`. For instance, if the `spark.master` property is set, you can safely omit the

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitOptionParser.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitOptionParser.java
@@ -55,7 +55,7 @@ class SparkSubmitOptionParser {
   protected final String PACKAGES = "--packages";
   protected final String PACKAGES_EXCLUDE = "--exclude-packages";
   protected final String PROPERTIES_FILE = "--properties-file";
-  protected final String EXTRA_PROPERTIES_FILES = "--extra-properties-files";
+  protected final String LOAD_SPARK_DEFAULTS = "--load-spark-defaults";
   protected final String PROXY_USER = "--proxy-user";
   protected final String PY_FILES = "--py-files";
   protected final String REPOSITORIES = "--repositories";
@@ -131,7 +131,7 @@ class SparkSubmitOptionParser {
     { USAGE_ERROR },
     { VERBOSE, "-v" },
     { VERSION },
-    { EXTRA_PROPERTIES_FILES },
+    { LOAD_SPARK_DEFAULTS },
   };
 
   /**

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitOptionParser.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitOptionParser.java
@@ -55,6 +55,7 @@ class SparkSubmitOptionParser {
   protected final String PACKAGES = "--packages";
   protected final String PACKAGES_EXCLUDE = "--exclude-packages";
   protected final String PROPERTIES_FILE = "--properties-file";
+  protected final String EXTRA_PROPERTIES_FILES = "--extra-properties-files";
   protected final String PROXY_USER = "--proxy-user";
   protected final String PY_FILES = "--py-files";
   protected final String REPOSITORIES = "--repositories";
@@ -130,6 +131,7 @@ class SparkSubmitOptionParser {
     { USAGE_ERROR },
     { VERBOSE, "-v" },
     { VERSION },
+    { EXTRA_PROPERTIES_FILES },
   };
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Following the discussions in #46709, this PR adds a flag `--load-spark-defaults` to control whether `spark-defaults.conf` should be loaded when `--properties-file` is specified. By default, the flag is turned off.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Ideally we should avoid behavior change and reduce user disruptions. For this reason, a flag is preferred.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

N/A

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No