### PR TITLE
[SPARK-48505][CORE] Simplify the implementation of `Utils#isG1GC`

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -19,7 +19,7 @@ package org.apache.spark.util
 
 import java.io._
 import java.lang.{Byte => JByte}
-import java.lang.management.{LockInfo, ManagementFactory, MonitorInfo, PlatformManagedObject, ThreadInfo}
+import java.lang.management.{LockInfo, ManagementFactory, MonitorInfo, ThreadInfo}
 import java.lang.reflect.InvocationTargetException
 import java.math.{MathContext, RoundingMode}
 import java.net._

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -3057,16 +3057,8 @@ private[spark] object Utils
    */
   lazy val isG1GC: Boolean = {
     Try {
-      val clazz = Utils.classForName("com.sun.management.HotSpotDiagnosticMXBean")
-        .asInstanceOf[Class[_ <: PlatformManagedObject]]
-      val vmOptionClazz = Utils.classForName("com.sun.management.VMOption")
-      val hotSpotDiagnosticMXBean = ManagementFactory.getPlatformMXBean(clazz)
-      val vmOptionMethod = clazz.getMethod("getVMOption", classOf[String])
-      val valueMethod = vmOptionClazz.getMethod("getValue")
-
-      val useG1GCObject = vmOptionMethod.invoke(hotSpotDiagnosticMXBean, "UseG1GC")
-      val useG1GC = valueMethod.invoke(useG1GCObject).asInstanceOf[String]
-      "true".equals(useG1GC)
+      ManagementFactory.getGarbageCollectorMXBeans.asScala
+        .exists(_.getName.contains("G1"))
     }.getOrElse(false)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR changes to use the result of `ManagementFactory.getGarbageCollectorMXBeans` to determine whether G1GC is used. When G1GC is used, `ManagementFactory.getGarbageCollectorMXBeans` will return two instances of `GarbageCollectorExtImpl`, their names are `G1 Young Generation` and `G1 Old Generation` respectively.

### Why are the changes needed?
Simplify the implementation.



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
