### PR TITLE
[SPARK-48469][SQL][TESTS] Replace `deprecated` method in `integrationtest`

### DIFF
--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/ClientModeTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/ClientModeTestsSuite.scala
@@ -34,7 +34,7 @@ private[spark] trait ClientModeTestsSuite { k8sSuite: KubernetesSuite =>
       .getKubernetesClient
       .services()
       .inNamespace(kubernetesTestComponents.namespace)
-      .create(new ServiceBuilder()
+      .resource(new ServiceBuilder()
         .withNewMetadata()
           .withName(s"$driverPodName-svc")
           .endMetadata()
@@ -52,12 +52,12 @@ private[spark] trait ClientModeTestsSuite { k8sSuite: KubernetesSuite =>
             .withNewTargetPort(blockManagerPort)
             .endPort()
           .endSpec()
-        .build())
+        .build()).create()
     try {
       val driverPod = testBackend.getKubernetesClient
         .pods()
         .inNamespace(kubernetesTestComponents.namespace)
-        .create(new PodBuilder()
+        .resource(new PodBuilder()
           .withNewMetadata()
           .withName(driverPodName)
           .withLabels(labels.asJava)
@@ -94,7 +94,7 @@ private[spark] trait ClientModeTestsSuite { k8sSuite: KubernetesSuite =>
             .addToArgs("10")
             .endContainer()
           .endSpec()
-        .build())
+        .build()).create()
       Eventually.eventually(TIMEOUT, INTERVAL) {
         assert(kubernetesTestComponents.kubernetesClient
           .pods()

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DepsTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/DepsTestsSuite.scala
@@ -135,7 +135,7 @@ private[spark] trait DepsTestsSuite { k8sSuite: KubernetesSuite =>
       .kubernetesClient
       .services()
       .inNamespace(kubernetesTestComponents.namespace)
-      .create(minioService))
+      .resource(minioService).create())
 
     // try until the stateful set of a previous test is deleted
     Eventually.eventually(TIMEOUT, INTERVAL) (kubernetesTestComponents
@@ -143,7 +143,7 @@ private[spark] trait DepsTestsSuite { k8sSuite: KubernetesSuite =>
       .apps()
       .statefulSets()
       .inNamespace(kubernetesTestComponents.namespace)
-      .create(minioStatefulSet))
+      .resource(minioStatefulSet).create())
   }
 
   private def deleteMinioStorage(): Unit = {

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesTestComponents.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesTestComponents.scala
@@ -45,11 +45,11 @@ private[spark] class KubernetesTestComponents(val kubernetesClient: KubernetesCl
   val clientConfig = kubernetesClient.getConfiguration
 
   def createNamespace(): Unit = {
-    kubernetesClient.namespaces.create(new NamespaceBuilder()
+    kubernetesClient.namespaces.resource(new NamespaceBuilder()
       .withNewMetadata()
       .withName(namespace)
       .endMetadata()
-      .build())
+      .build()).create()
   }
 
   def deleteNamespace(): Unit = {

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/PVTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/PVTestsSuite.scala
@@ -71,13 +71,13 @@ private[spark] trait PVTestsSuite { k8sSuite: KubernetesSuite =>
     kubernetesTestComponents
       .kubernetesClient
       .persistentVolumes()
-      .create(pvBuilder.build())
+      .resource(pvBuilder.build()).create()
 
     kubernetesTestComponents
       .kubernetesClient
       .persistentVolumeClaims()
       .inNamespace(kubernetesTestComponents.namespace)
-      .create(pvcBuilder.build())
+      .resource(pvcBuilder.build()).create()
   }
 
   private def deleteLocalStorage(): Unit = {

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SecretsTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/SecretsTestsSuite.scala
@@ -45,7 +45,7 @@ private[spark] trait SecretsTestsSuite { k8sSuite: KubernetesSuite =>
       .kubernetesClient
       .secrets()
       .inNamespace(kubernetesTestComponents.namespace)
-      .createOrReplace(envSecret)
+      .resource(envSecret).serverSideApply()
   }
 
   private def deleteTestSecret(): Unit = {

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/Utils.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/Utils.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.deploy.k8s.integrationtest
 
 import java.io.{Closeable, File, FileInputStream, FileOutputStream, PrintWriter}
+import java.nio.charset.Charset
 import java.nio.file.{Files, Path}
 import java.util.concurrent.CountDownLatch
 import java.util.zip.{ZipEntry, ZipOutputStream}
@@ -27,7 +28,7 @@ import io.fabric8.kubernetes.client.dsl.ExecListener
 import io.fabric8.kubernetes.client.dsl.ExecListener.Response
 import org.apache.commons.compress.archivers.tar.{TarArchiveEntry, TarArchiveOutputStream}
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream
-import org.apache.commons.compress.utils.IOUtils
+import org.apache.commons.io.IOUtils
 import org.apache.commons.io.output.ByteArrayOutputStream
 
 import org.apache.spark.{SPARK_VERSION, SparkException}
@@ -83,7 +84,7 @@ object Utils extends Logging {
     }
     val listener = new ReadyListener()
     val watch = pod
-      .readingInput(System.in)
+      .redirectingInput()
       .writingOutput(out)
       .writingError(System.err)
       .withTTY()
@@ -94,7 +95,7 @@ object Utils extends Logging {
     listener.waitForClose()
     watch.close()
     out.flush()
-    val result = out.toString()
+    val result = out.toString(Charset.defaultCharset())
     result
   }
 

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/VolcanoTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/VolcanoTestsSuite.scala
@@ -150,7 +150,7 @@ private[spark] trait VolcanoTestsSuite extends BeforeAndAfterEach { k8sSuite: Ku
     kubernetesTestComponents.kubernetesClient.adapt(classOf[VolcanoClient])
       .queues()
       .inNamespace(kubernetesTestComponents.namespace)
-      .createOrReplace(resource)
+      .resource(resource).serverSideApply()
     testResources += resource
   }
 
@@ -177,7 +177,7 @@ private[spark] trait VolcanoTestsSuite extends BeforeAndAfterEach { k8sSuite: Ku
     kubernetesTestComponents.kubernetesClient
       .load(new FileInputStream(yamlPath))
       .inNamespace(kubernetesTestComponents.namespace)
-      .createOrReplace()
+      .serverSideApply()
     testYAMLPaths += yamlPath
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to replace `deprecated` method in `integrationtest`.

### Why are the changes needed?
In the UT of `integrationtest`, some methods have already been deprecated, let's avoid using it.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
