### PR TITLE
[SPARK-48447][SS] Check state store provider class before invoking the constructor

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2798,10 +2798,11 @@
     ],
     "sqlState" : "42601"
   },
-  "INVALID_STATE_STORE_PROVIDER" : {
+  "STATE_STORE_INVALID_PROVIDER" : {
     "message" : [
       "The given State Store Provider <inputClass> does not extend org.apache.spark.sql.execution.streaming.state.StateStoreProvider."
-    ]
+    ],
+    "sqlState" : "42K06"
   },
   "INVALID_SUBQUERY_EXPRESSION" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2798,12 +2798,6 @@
     ],
     "sqlState" : "42601"
   },
-  "STATE_STORE_INVALID_PROVIDER" : {
-    "message" : [
-      "The given State Store Provider <inputClass> does not extend org.apache.spark.sql.execution.streaming.state.StateStoreProvider."
-    ],
-    "sqlState" : "42K06"
-  },
   "INVALID_SUBQUERY_EXPRESSION" : {
     "message" : [
       "Invalid subquery:"
@@ -3712,6 +3706,12 @@
       "Incorrect number of prefix columns=<numPrefixCols> for prefix scan encoder. Prefix columns cannot be zero or greater than or equal to num of schema columns."
     ],
     "sqlState" : "42802"
+  },
+  "STATE_STORE_INVALID_PROVIDER" : {
+    "message" : [
+      "The given State Store Provider <inputClass> does not extend org.apache.spark.sql.execution.streaming.state.StateStoreProvider."
+    ],
+    "sqlState" : "42K06"
   },
   "STATE_STORE_NULL_TYPE_ORDERING_COLS_NOT_SUPPORTED" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2798,6 +2798,11 @@
     ],
     "sqlState" : "42601"
   },
+  "INVALID_STATE_STORE_PROVIDER" : {
+    "message" : [
+      "The given State Store Provider <inputClass> does not extend org.apache.spark.sql.execution.streaming.state.StateStoreProvider."
+    ]
+  },
   "INVALID_SUBQUERY_EXPRESSION" : {
     "message" : [
       "Invalid subquery:"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -398,7 +398,7 @@ object StateStoreProvider {
     val providerClass = Utils.classForName(providerClassName)
     if (!classOf[StateStoreProvider].isAssignableFrom(providerClass)) {
       throw new SparkException(
-        errorClass = "INVALID_STATE_STORE_PROVIDER",
+        errorClass = "STATE_STORE_INVALID_PROVIDER",
         messageParameters = Map("inputClass" -> providerClassName),
         cause = null)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -1443,9 +1443,9 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
       val ex = intercept[StreamingQueryException] {
         query.processAllAvailable()
       }
-      assert(ex.getMessage.contains("The streaming query failed because the given " +
-        "StateStoreProvider does not extend org.apache.spark.sql.execution.streaming.state." +
-        "StateStoreProvider"))
+      assert(ex.getMessage.contains(
+        s"The given State Store Provider ${classOf[Object].getCanonicalName} does not " +
+          "extend org.apache.spark.sql.execution.streaming.state.StateStoreProvider."))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -1432,6 +1432,20 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
     }
   }
 
+  test("StateStoreProvider integrity check") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[StreamTest].getCanonicalName) {
+      val input = MemoryStream[Int]
+      input.addData(1)
+      val query = input.toDF().limit(1).writeStream
+        .trigger(Trigger.AvailableNow())
+        .format("console")
+        .start()
+      failAfter(streamingTimeout) {
+        query.processAllAvailable()
+      }
+    }
+  }
+
   private def checkExceptionMessage(df: DataFrame): Unit = {
     withTempDir { outputDir =>
       withTempDir { checkpointDir =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds a validity check to the StateStoreProvider class before calling its constructor. A new runtime exception was created to report this issue.


### Why are the changes needed?
This is a security improvement to a user-facing API. Users are only allowed to use class that extends `org.apache.spark.sql.execution.streaming.state.StateStoreProvider` as StateStoreProvider.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
This PR comes with a new test to test that invalid class cannot pass the security check. The fact that other tests in StreamingQuerySuite can pass implies that valid class can pass the check.


### Was this patch authored or co-authored using generative AI tooling?
No.
