### PR TITLE
[SPARK-48446][SS][DOCS] Update SS doc of dropDuplicates to use the right syntax

### DIFF
--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -2082,12 +2082,12 @@ You can deduplicate records in data streams using a unique identifier in the eve
 streamingDf = spark.readStream. ...
 
 # Without watermark using guid column
-streamingDf.dropDuplicates("guid")
+streamingDf.dropDuplicates(["guid"])
 
 # With watermark using guid and eventTime columns
 streamingDf \
   .withWatermark("eventTime", "10 seconds") \
-  .dropDuplicates("guid", "eventTime")
+  .dropDuplicates(["guid", "eventTime"])
 {% endhighlight %}
 
 </div>
@@ -2103,7 +2103,7 @@ streamingDf.dropDuplicates("guid")
 // With watermark using guid and eventTime columns
 streamingDf
   .withWatermark("eventTime", "10 seconds")
-  .dropDuplicates("guid", "eventTime")
+  .dropDuplicates(Vector("guid", "eventTime"))
 {% endhighlight %}
 
 </div>
@@ -2119,7 +2119,7 @@ streamingDf.dropDuplicates("guid");
 // With watermark using guid and eventTime columns
 streamingDf
   .withWatermark("eventTime", "10 seconds")
-  .dropDuplicates("guid", "eventTime");
+  .dropDuplicates({"guid", "eventTime"});
 {% endhighlight %}
 
 
@@ -2163,7 +2163,7 @@ streamingDf = spark.readStream. ...
 # deduplicate using guid column with watermark based on eventTime column
 streamingDf \
   .withWatermark("eventTime", "10 hours") \
-  .dropDuplicatesWithinWatermark("guid")
+  .dropDuplicatesWithinWatermark(["guid"])
 {% endhighlight %}
 
 </div>

--- a/docs/structured-streaming-programming-guide.md
+++ b/docs/structured-streaming-programming-guide.md
@@ -2103,7 +2103,7 @@ streamingDf.dropDuplicates("guid")
 // With watermark using guid and eventTime columns
 streamingDf
   .withWatermark("eventTime", "10 seconds")
-  .dropDuplicates(Vector("guid", "eventTime"))
+  .dropDuplicates("guid", "eventTime")
 {% endhighlight %}
 
 </div>
@@ -2119,7 +2119,7 @@ streamingDf.dropDuplicates("guid");
 // With watermark using guid and eventTime columns
 streamingDf
   .withWatermark("eventTime", "10 seconds")
-  .dropDuplicates({"guid", "eventTime"});
+  .dropDuplicates("guid", "eventTime");
 {% endhighlight %}
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR fixes the wrong usage of `dropDuplicates` and `dropDuplicatesWithinWatermark` in the Structured Streaming Programming Guide.


### Why are the changes needed?
Previously the syntax in the guide was wrong, so users will see an error if directly using the example.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Made sure that the updated examples conform to the API doc, and can run out of the box.


### Was this patch authored or co-authored using generative AI tooling?
No.
