### PR TITLE
[SPARK-43301][CORE][SHUFFLE] BlockStoreClient getHostLocalDirs RPC supports IOException retry

### DIFF
--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
@@ -236,6 +236,7 @@ public abstract class BlockStoreClient implements Closeable {
               if (!isSaslTimeout && saslRetryCount > 0) {
                 Preconditions.checkState(retryCount >= saslRetryCount,
                         "retryCount must be greater than or equal to saslRetryCount");
+                // Consistent with the retry logic of the RetryingBlockTransferor.shouldRetry method
                 retryCount -= saslRetryCount;
                 saslRetryCount = 0;
               }

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
@@ -230,8 +230,8 @@ public abstract class BlockStoreClient implements Closeable {
             .exceptionally(e -> {
               int retryCount = retryCountValue;
               int saslRetryCount = saslRetryCountValue;
-              boolean isIOException = e instanceof IOException
-                      || (e.getCause() != null && e.getCause() instanceof IOException);
+              boolean isIOException = e instanceof IOException ||
+                      e.getCause() instanceof IOException;
               boolean isSaslTimeout = enableSaslRetries && e instanceof SaslTimeoutException;
               if (!isSaslTimeout && saslRetryCount > 0) {
                 Preconditions.checkState(retryCount >= saslRetryCount,
@@ -245,12 +245,12 @@ public abstract class BlockStoreClient implements Closeable {
               if (!shouldRetry) {
                 future.completeExceptionally(e);
               } else {
-                if (enableSaslRetries && e instanceof SaslTimeoutException) {
+                if (isSaslTimeout) {
                   saslRetryCount += 1;
                 }
                 retryCount += 1;
-                int finalRetryCount = retryCount;
-                int finalSaslRetryCount = saslRetryCount;
+                final int finalRetryCount = retryCount;
+                final int finalSaslRetryCount = saslRetryCount;
                 logger.info("Retrying ({}/{}) for getting host local dirs after {} ms",
                         MDC.of(LogKeys.NUM_RETRY$.MODULE$, finalRetryCount),
                         MDC.of(LogKeys.MAX_ATTEMPTS$.MODULE$, maxRetries),

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
@@ -54,7 +54,7 @@ public abstract class BlockStoreClient implements Closeable {
   protected final SparkLogger logger = SparkLoggerFactory.getLogger(this.getClass());
 
   private static final ScheduledExecutorService scheduledExecutor =
-          Executors.newScheduledThreadPool(16,
+          Executors.newSingleThreadScheduledExecutor(
                   NettyUtils.createThreadFactory("Block Store Client Retry"));
 
   protected volatile TransportClientFactory clientFactory;

--- a/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
+++ b/common/network-shuffle/src/main/java/org/apache/spark/network/shuffle/BlockStoreClient.java
@@ -252,6 +252,7 @@ public abstract class BlockStoreClient implements Closeable {
                 final int finalRetryCount = retryCount;
                 final int finalSaslRetryCount = saslRetryCount;
                 logger.info("Retrying ({}/{}) for getting host local dirs after {} ms",
+                        e,
                         MDC.of(LogKeys.NUM_RETRY$.MODULE$, finalRetryCount),
                         MDC.of(LogKeys.MAX_ATTEMPTS$.MODULE$, maxRetries),
                         MDC.of(LogKeys.RETRY_WAIT_TIME$.MODULE$, delayMs));

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.storage
 import java.io._
 import java.nio.ByteBuffer
 import java.util.UUID
-import java.util.concurrent.{CompletableFuture, Semaphore}
+import java.util.concurrent.{CompletableFuture, ExecutionException, Semaphore}
 import java.util.zip.CheckedInputStream
 
 import scala.collection.mutable
@@ -28,6 +28,7 @@ import scala.collection.mutable
 import scala.concurrent.ExecutionContext.Implicits.global
 // scalastyle:on executioncontextglobal
 import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
 
 import com.google.common.io.ByteStreams
 import io.netty.util.internal.OutOfDirectMemoryError
@@ -42,8 +43,11 @@ import org.apache.spark.{MapOutputTracker, SparkFunSuite, TaskContext}
 import org.apache.spark.MapOutputTracker.SHUFFLE_PUSH_MAP_ID
 import org.apache.spark.network._
 import org.apache.spark.network.buffer.{FileSegmentManagedBuffer, ManagedBuffer}
+import org.apache.spark.network.client.{RpcResponseCallback, TransportClient, TransportClientFactory}
+import org.apache.spark.network.sasl.SecretKeyHolder
 import org.apache.spark.network.shuffle.{BlockFetchingListener, DownloadFileManager, ExternalBlockStoreClient, MergedBlockMeta, MergedBlocksMetaListener}
-import org.apache.spark.network.util.LimitedInputStream
+import org.apache.spark.network.shuffle.protocol.LocalDirsForExecutors
+import org.apache.spark.network.util.{LimitedInputStream, MapConfigProvider, TransportConf}
 import org.apache.spark.shuffle.{FetchFailedException, ShuffleReadMetricsReporter}
 import org.apache.spark.storage.BlockManagerId.SHUFFLE_MERGER_IDENTIFIER
 import org.apache.spark.storage.ShuffleBlockFetcherIterator._
@@ -360,6 +364,72 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite {
     // 2 remote blocks are read from the same block manager
     verifyFetchBlocksInvocationCount(1)
     assert(blockManager.hostLocalDirManager.get.getCachedHostLocalDirs.size === 1)
+  }
+
+  test("BlockStoreClient getHostLocalDirs RPC supports IOException retry") {
+    val mockClientFactory = mock(classOf[TransportClientFactory])
+    val mockTransportClient = mock(classOf[TransportClient])
+    val execToDirs = Map("exec-1" ->
+      Array("loc2.1", "loc2.2"))
+
+    var sendRpcThrowIOExceptionIdx = 0
+    var sendRpcThrowIOExceptionMaxCnt = 2
+    when(mockClientFactory.createClient(any(), any())).thenAnswer(_ => {
+      mockTransportClient
+    })
+    when(mockTransportClient.sendRpc(any(), any())).thenAnswer(invocationOnMock => {
+      if (sendRpcThrowIOExceptionIdx < sendRpcThrowIOExceptionMaxCnt) {
+        sendRpcThrowIOExceptionIdx += 1
+        throw new IOException("sendRpc failed " + sendRpcThrowIOExceptionIdx + " times")
+      }
+      val callback = invocationOnMock.getArgument(1).asInstanceOf[RpcResponseCallback]
+      callback.onSuccess(new LocalDirsForExecutors(execToDirs.asJava).toByteBuffer)
+      null
+    })
+
+    class TestExternalBlockStoreClient(
+      conf: TransportConf,
+      secretKeyHolder: SecretKeyHolder,
+      authEnabled: Boolean,
+      registrationTimeoutMs: Long) extends ExternalBlockStoreClient(
+      conf, secretKeyHolder, authEnabled, registrationTimeoutMs) {
+      override def init(appId: String): Unit = {
+        super.init(appId)
+        this.clientFactory = mockClientFactory
+      }
+    }
+
+    val config = new java.util.HashMap[String, String]
+    config.put("spark.shuffle.io.maxRetries", "3")
+    val clientConf: TransportConf = new TransportConf("shuffle", new MapConfigProvider(config))
+    val testExternalBlockStoreClient = new TestExternalBlockStoreClient(
+      clientConf, null, false, 5000)
+    try {
+      testExternalBlockStoreClient.init("APP_ID")
+      Seq((0, true), (2, true), (3, true), (4, false)).foreach { case (maxCnt, success) =>
+        sendRpcThrowIOExceptionIdx = 0
+        sendRpcThrowIOExceptionMaxCnt = maxCnt
+        val hostLocalDirsCompletable = new CompletableFuture[java.util.Map[String, Array[String]]]
+        testExternalBlockStoreClient.getHostLocalDirs("exec-1", 1,
+          Array("exec-1"), hostLocalDirsCompletable)
+        try {
+          val result = hostLocalDirsCompletable.get()
+          assert(success)
+          assert(result.size() == 1)
+          assert(result.keySet() == execToDirs.asJava.keySet())
+          assert(result.values().iterator().next() sameElements
+            execToDirs.asJava.values().iterator().next())
+        } catch {
+          case e: ExecutionException =>
+            assert(e.getCause.isInstanceOf[IOException])
+            assert(!success)
+        }
+      }
+    } finally {
+      if (testExternalBlockStoreClient != null) {
+        testExternalBlockStoreClient.close()
+      }
+    }
   }
 
   test("error during accessing host local dirs for executors") {

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -373,7 +373,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite {
       Array("loc2.1", "loc2.2"))
 
     var sendRpcThrowIOExceptionIdx = 0
-    var sendRpcThrowIOExceptionMaxCnt = 2
+    var sendRpcThrowIOExceptionMaxCnt = 0
     when(mockClientFactory.createClient(any(), any())).thenAnswer(_ => {
       mockTransportClient
     })
@@ -400,13 +400,15 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite {
     }
 
     val config = new java.util.HashMap[String, String]
-    config.put("spark.shuffle.io.maxRetries", "3")
+    val maxRetries = 3
+    config.put("spark.shuffle.io.maxRetries", maxRetries.toString)
     val clientConf: TransportConf = new TransportConf("shuffle", new MapConfigProvider(config))
     val testExternalBlockStoreClient = new TestExternalBlockStoreClient(
       clientConf, null, false, 5000)
     try {
       testExternalBlockStoreClient.init("APP_ID")
-      Seq((0, true), (2, true), (3, true), (4, false)).foreach { case (maxCnt, success) =>
+      ((0 to maxRetries).map((_, true)) ++ Seq((maxRetries + 1, false))).foreach {
+        case (maxCnt, success) =>
         sendRpcThrowIOExceptionIdx = 0
         sendRpcThrowIOExceptionMaxCnt = maxCnt
         val hostLocalDirsCompletable = new CompletableFuture[java.util.Map[String, Array[String]]]

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -425,6 +425,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite {
           case e: ExecutionException =>
             assert(e.getCause.isInstanceOf[IOException])
             assert(!success)
+            assert(sendRpcThrowIOExceptionIdx == sendRpcThrowIOExceptionMaxCnt)
         }
       }
     } finally {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use `CompletableFuture` to implement retry logic, and retry operations are performed asynchronously.

### Why are the changes needed?
`BlockStoreClient#getHostLocalDirs` RPC did not retry when `IOexception` occurred, and then `FetchFailedException` was thrown.

```java
23/04/24 01:24:55,158 [shuffle-client-7-1] WARN ExternalBlockStoreClient: Error while trying to get the host local dirs for [148]
23/04/24 01:24:55,158 [shuffle-client-7-1] ERROR ShuffleBlockFetcherIterator: Error occurred while fetching host local blocks
java.io.IOException: Connection reset by peer
	at sun.nio.ch.FileDispatcherImpl.read0(Native Method)
	at sun.nio.ch.SocketDispatcher.read(SocketDispatcher.java:39)
	at sun.nio.ch.IOUtil.readIntoNativeBuffer(IOUtil.java:223)
	at sun.nio.ch.IOUtil.read(IOUtil.java:192)
	at sun.nio.ch.SocketChannelImpl.read(SocketChannelImpl.java:380)
	at io.netty.buffer.PooledByteBuf.setBytes(PooledByteBuf.java:253)
	at io.netty.buffer.AbstractByteBuf.writeBytes(AbstractByteBuf.java:1132)
	at io.netty.channel.socket.nio.NioSocketChannel.doReadBytes(NioSocketChannel.java:350)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:151)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:719)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:655)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:581)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:493)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:745) 
```

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
local test / add UT

### Was this patch authored or co-authored using generative AI tooling?
No