### PR TITLE
[SPARK-48172][SQL][FOLLOWUP] Fix escaping issues in JDBCDialects

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DockerJDBCIntegrationV2Suite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/DockerJDBCIntegrationV2Suite.scala
@@ -39,16 +39,24 @@ abstract class DockerJDBCIntegrationV2Suite extends DockerJDBCIntegrationSuite {
     connection.prepareStatement("INSERT INTO employee VALUES (6, 'jen', 12000, 1200)")
       .executeUpdate()
 
-    connection.prepareStatement(
-      s"""
-         |INSERT INTO pattern_testing_table VALUES
-         |('special_character_quote''_present'),
-         |('special_character_quote_not_present'),
-         |('special_character_percent%_present'),
-         |('special_character_percent_not_present'),
-         |('special_character_underscore_present'),
-         |('special_character_underscorenot_present')
-             """.stripMargin).executeUpdate()
+    connection.prepareStatement("INSERT INTO pattern_testing_table "
+        + "VALUES ('special_character_quote''_present')")
+      .executeUpdate()
+    connection.prepareStatement("INSERT INTO pattern_testing_table "
+        + "VALUES ('special_character_quote_not_present')")
+      .executeUpdate()
+    connection.prepareStatement("INSERT INTO pattern_testing_table "
+        + "VALUES ('special_character_percent%_present')")
+      .executeUpdate()
+    connection.prepareStatement("INSERT INTO pattern_testing_table "
+        + "VALUES ('special_character_percent_not_present')")
+      .executeUpdate()
+    connection.prepareStatement("INSERT INTO pattern_testing_table "
+        + "VALUES ('special_character_underscore_present')")
+      .executeUpdate()
+    connection.prepareStatement("INSERT INTO pattern_testing_table "
+        + "VALUES ('special_character_underscorenot_present')")
+      .executeUpdate()
   }
 
   def tablePreparation(connection: Connection): Unit

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
@@ -95,7 +95,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
         " bonus BINARY_DOUBLE)").executeUpdate()
     connection.prepareStatement(
       s"""CREATE TABLE pattern_testing_table (
-         |pattern_testing_col VARCHAR(50)
+         |pattern_testing_col VARCHAR2(50)
          |)
                    """.stripMargin
     ).executeUpdate()

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
@@ -95,7 +95,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
         " bonus BINARY_DOUBLE)").executeUpdate()
     connection.prepareStatement(
       s"""CREATE TABLE pattern_testing_table (
-         |pattern_testing_col VARCHAR2(50)
+         |pattern_testing_col VARCHAR(50)
          |)
                    """.stripMargin
     ).executeUpdate()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Removal of stripMargin from the code in `DockerJDBCIntegrationV2Suite`.


### Why are the changes needed?
https://github.com/apache/spark/pull/46588
Given PR was merged to master/3.5/3.4. This PR broke daily jobs for `OracleIntegrationSuite`. Upon inspection, it was noted that 3.4 and 3.5 are run with JDK8 while master is run with JDK21 and stripMargin was behaving differently in those cases. Upon removing stripMargin and spliting `INSERT INTO` statements into multiple lines, all integration tests have passed.


### Does this PR introduce _any_ user-facing change?
No, only loading of the test data was changed to follow language requirements.


### How was this patch tested?
Existing suite was aborted in the job and now it is running.


### Was this patch authored or co-authored using generative AI tooling?
No

Closes #46806 