### PR TITLE
[SPARK-48474][CORE] Fix the class name of the log in `SparkSubmitArguments` & `SparkSubmit`

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -64,6 +64,8 @@ private[deploy] object SparkSubmitAction extends Enumeration {
  */
 private[spark] class SparkSubmit extends Logging {
 
+  override protected def logName: String = classOf[SparkSubmit].getName
+
   import DependencyUtils._
   import SparkSubmit._
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -85,6 +85,8 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
   var submissionToRequestStatusFor: String = null
   var useRest: Boolean = false // used internally
 
+  override protected def logName: String = classOf[SparkSubmitArguments].getName
+
   /** Default properties present in the currently defined defaults file. */
   lazy val defaultSparkProperties: HashMap[String, String] = {
     val defaultProperties = new HashMap[String, String]()


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix `the class name` of the log in `SparkSubmitArguments` & `SparkSubmit`.


### Why are the changes needed?
We should display the class names that `match our understanding` in the logs, rather than the `anonymous class names` automatically generated by Scala.

```
sh bin/spark-shell --verbose
```

Before:
<img width="835" alt="image" src="https://github.com/apache/spark/assets/15246973/30843cb5-7a0e-4ec9-998a-36e9cbe09c33">


After:
<img width="840" alt="image" src="https://github.com/apache/spark/assets/15246973/94c526c7-3409-471a-bb89-b9c08f2a8d2d">


### Does this PR introduce _any_ user-facing change?
Yes, only for log.


### How was this patch tested?
Manually test.


### Was this patch authored or co-authored using generative AI tooling?
No.
