### PR TITLE
[SPARK-48475][PYTHON] Optimize _get_jvm_function in PySpark.

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -86,7 +86,7 @@ def _get_jvm_function(name: str, sc: "SparkContext") -> Callable:
     Java gateway associated with sc.
     """
     assert sc._jvm is not None
-    return getattr(sc._jvm.functions, name)
+    return getattr(getattr(sc._jvm, "org.apache.spark.sql.functions"), name)
 
 
 def _invoke_function(name: str, *args: Any) -> Column:


### PR DESCRIPTION
### What changes were proposed in this pull request?

It is a performance optimization for PySpark. For the context, `sc._jvm` is a `JVMView` object in Py4J. It has an overloaded `__getattr__` implementation ([source](https://github.com/py4j/py4j/blob/master/py4j-python/src/py4j/java_gateway.py#L1741)). Accessing `.functions` internally sends a command to the Py4J server. The server then searches through a list of imports to find a package that contains the `functions` class ([source](https://github.com/py4j/py4j/blob/master/py4j-java/src/main/java/py4j/reflection/TypeUtil.java#L249)), and will eventually find `org.apache.spark.sql.functions`. The failed reflection attempts are much more expensive than the last successful reflection. Instead, we can directly use this fully qualified class name and prevent all failed reflection attempts.

### Why are the changes needed?

It improves the performance in PySpark when building large `DataFrame`.

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Existing tests.

The following code can verify the performance improvement:

```
import pyspark.sql.functions as F
from datetime import datetime

for i in range(5):
  T = datetime.now()
  df = spark.range(0, 10).agg(F.array([F.sum(F.col("id")) for i in range(0, 500)]))
  print(datetime.now() - T)
```

On local PySpark shell, the time consumption before/after the optimization is about 1s/0.5s.


### Was this patch authored or co-authored using generative AI tooling?

No.
