### PR TITLE
[SPARK-48465][SQL] Avoid no-op empty relation propagation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PropagateEmptyRelation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PropagateEmptyRelation.scala
@@ -133,8 +133,8 @@ abstract class PropagateEmptyRelationBase extends Rule[LogicalPlan] with CastSup
         p
       }
 
-    // the only case can be matched here is that LogicalQueryStage is empty
-    case p: LeafNode if !p.isInstanceOf[LocalRelation] && isEmpty(p) => empty(p)
+    // Only replace a query stage if it would lead to a reduction of operators
+    case p: LogicalQueryStage if isEmpty(p) && !p.isDirectStage => empty(p)
 
     case p: UnaryNode if p.children.nonEmpty && p.children.forall(isEmpty) => p match {
       case _: Project => empty(p)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PropagateEmptyRelation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PropagateEmptyRelation.scala
@@ -133,7 +133,9 @@ abstract class PropagateEmptyRelationBase extends Rule[LogicalPlan] with CastSup
         p
       }
 
-    // Only replace a query stage if it would lead to a reduction of operators
+    // Only replace a query stage if it would lead to a reduction of operators. !p.isDirectStage
+    // means the physical node it contains is partial aggregate instead of QueryStageExec, which
+    // is exactly what we want to propagate empty relation.
     case p: LogicalQueryStage if isEmpty(p) && !p.isDirectStage => empty(p)
 
     case p: UnaryNode if p.children.nonEmpty && p.children.forall(isEmpty) => p match {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -2853,7 +2853,7 @@ class AdaptiveQueryExecSuite
       // shuffleOrigin: REPARTITION_BY_NUM
       assert(spark.range(0).repartition(5).rdd.getNumPartitions == 5)
       // shuffleOrigin: REBALANCE_PARTITIONS_BY_NONE
-      assert(spark.range(0).repartition().rdd.getNumPartitions == 0)
+      assert(spark.range(0).repartition().rdd.getNumPartitions == 1)
       // through project
       assert(spark.range(0).selectExpr("id % 3 as c1", "id % 7 as c2")
         .repartition(5).select($"c2").rdd.getNumPartitions == 5)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Narrow down `PropagationEmptyRelation` matching pattern from "non `LocalRelation` `LeafNode`" to "`LogicalQueryStage` that contains direct `QueryStageExec`", which still allows partial aggregate empty relation to be propagated.

### Why are the changes needed?

We should avoid no-op empty relation propagation in AQE: if we convert an empty QueryStageExec to empty relation, it will further wrapped into a new query stage and execute -> produce empty result -> empty relation propagation again. This issue is currently not exposed because AQE will try to reuse shuffle.


### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
Existing test.



### Was this patch authored or co-authored using generative AI tooling?
NO