### PR TITLE
[SPARK-48488][CORE] Fix methods `log[info|warning|error]` in `SparkSubmit`

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -39,8 +39,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.spark._
 import org.apache.spark.api.r.RUtils
 import org.apache.spark.deploy.rest._
-import org.apache.spark.internal.{Logging, MDC}
-import org.apache.spark.internal.LogKeys
+import org.apache.spark.internal.{LogEntry, Logging, LogKeys, MDC}
 import org.apache.spark.internal.config._
 import org.apache.spark.internal.config.UI._
 import org.apache.spark.launcher.SparkLauncher
@@ -1099,17 +1098,31 @@ object SparkSubmit extends CommandLineUtils with Logging {
         new SparkSubmitArguments(args.toImmutableArraySeq) {
           override protected def logInfo(msg: => String): Unit = self.logInfo(msg)
 
+          override protected def logInfo(entry: LogEntry): Unit = self.logInfo(entry)
+
           override protected def logWarning(msg: => String): Unit = self.logWarning(msg)
 
+          override protected def logWarning(entry: LogEntry): Unit = self.logWarning(entry)
+
           override protected def logError(msg: => String): Unit = self.logError(msg)
+
+          override protected def logError(entry: LogEntry): Unit = self.logError(entry)
         }
       }
 
       override protected def logInfo(msg: => String): Unit = printMessage(msg)
 
+      override protected def logInfo(entry: LogEntry): Unit = printMessage(entry.message)
+
       override protected def logWarning(msg: => String): Unit = printMessage(s"Warning: $msg")
 
+      override protected def logWarning(entry: LogEntry): Unit =
+        printMessage(s"Warning: ${entry.message}")
+
       override protected def logError(msg: => String): Unit = printMessage(s"Error: $msg")
+
+      override protected def logError(entry: LogEntry): Unit =
+        printMessage(s"Error: ${entry.message}")
 
       override def doSubmit(args: Array[String]): Unit = {
         try {


### PR DESCRIPTION
### What changes were proposed in this pull request?
The PR aims to use the method `A` (see below) to output the parameters when we execute a command similar to `sh bin/spark-shell --verbose`, rather than using the method `B` (see below) to output them. (When doing structured log migration, we `ignored` this special logic and broke the `original` logic. Now we need to fix it.)

Method A:
https://github.com/apache/spark/blob/4360ec733d248b62798a191301e2b671f7bcfbd5/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala#L1108-L1112

https://github.com/apache/spark/blob/114164bd3f6bfb67e58f8ead93c5bba0d08b8a0a/core/src/main/scala/org/apache/spark/util/CommandLineUtils.scala#L38

Method B:
https://github.com/apache/spark/blob/114164bd3f6bfb67e58f8ead93c5bba0d08b8a0a/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala#L180

https://github.com/apache/spark/blob/114164bd3f6bfb67e58f8ead93c5bba0d08b8a0a/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala#L240

https://github.com/apache/spark/blob/114164bd3f6bfb67e58f8ead93c5bba0d08b8a0a/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala#L260

### Why are the changes needed?
- In our structured log migration of the `SparkSubmit` class, we `overlooked` the `special logic of this class`, which overloads `logInfo`, `logWarning` and `logError`. 
https://github.com/apache/spark/blob/4360ec733d248b62798a191301e2b671f7bcfbd5/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala#L1100-L1112

Their `real purpose` is to print message to `System.err` (`CommandLineLoggingUtils#printMessage`), as follows:
https://github.com/apache/spark/blob/114164bd3f6bfb67e58f8ead93c5bba0d08b8a0a/core/src/main/scala/org/apache/spark/util/CommandLineUtils.scala#L35-L38

```
./build/sbt -Phadoop-3 -Pkubernetes -Pkinesis-asl -Phive-thriftserver -Pdocker-integration-tests -Pyarn -Phadoop-cloud -Pspark-ganglia-lgpl -Phive -Pjvm-profiler clean package
sh bin/spark-shell --verbose
```

Before:
<img width="395" alt="image" src="https://github.com/apache/spark/assets/15246973/0ccfff89-2061-4ae3-b189-41a40d50bccd">

After:
<img width="979" alt="image" src="https://github.com/apache/spark/assets/15246973/63087251-5500-4155-bf47-330a1c20921f">


### Does this PR introduce _any_ user-facing change?
Yes, only restore to the original logic.

### How was this patch tested?
- Manually test.
- Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
No.