### PR TITLE
[SPARK-48490][CORE] Unescapes any literals for message of MessageWithContext

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
@@ -19,6 +19,7 @@ package org.apache.spark.internal
 
 import scala.jdk.CollectionConverters._
 
+import org.apache.commons.text.StringEscapeUtils
 import org.apache.logging.log4j.{CloseableThreadContext, Level, LogManager}
 import org.apache.logging.log4j.core.{Filter, LifeCycle, LogEvent, Logger => Log4jLogger, LoggerContext}
 import org.apache.logging.log4j.core.appender.ConsoleAppender
@@ -158,7 +159,7 @@ trait Logging {
         }
       }
 
-      MessageWithContext(sb.toString(), context)
+      MessageWithContext(StringEscapeUtils.unescapeJava(sb.toString()), context)
     }
   }
 

--- a/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
@@ -100,7 +100,7 @@ case class MessageWithContext(message: String, context: java.util.HashMap[String
  * Companion class for lazy evaluation of the MessageWithContext instance.
  */
 class LogEntry(messageWithContext: => MessageWithContext) {
-  def message: String = messageWithContext.message
+  def message: String = StringEscapeUtils.unescapeJava(messageWithContext.message)
 
   def context: java.util.HashMap[String, String] = messageWithContext.context
 }
@@ -159,7 +159,7 @@ trait Logging {
         }
       }
 
-      MessageWithContext(StringEscapeUtils.unescapeJava(sb.toString()), context)
+      MessageWithContext(sb.toString(), context)
     }
   }
 

--- a/common/utils/src/test/java/org/apache/spark/util/PatternSparkLoggerSuite.java
+++ b/common/utils/src/test/java/org/apache/spark/util/PatternSparkLoggerSuite.java
@@ -54,6 +54,12 @@ public class PatternSparkLoggerSuite extends SparkLoggerSuiteBase {
   }
 
   @Override
+  String expectedPatternForBasicMsgWithEscapeChar(Level level) {
+    return toRegexPattern(level,
+      ".*<level> <className>: This is a log message\\nThis is a new line \\t other msg\\n");
+  }
+
+  @Override
   String expectedPatternForBasicMsgWithException(Level level) {
     return toRegexPattern(level, """
         .*<level> <className>: This is a log message

--- a/common/utils/src/test/java/org/apache/spark/util/SparkLoggerSuiteBase.java
+++ b/common/utils/src/test/java/org/apache/spark/util/SparkLoggerSuiteBase.java
@@ -68,16 +68,17 @@ public abstract class SparkLoggerSuiteBase {
     }
   }
 
-  private String basicMsg() {
-    return "This is a log message";
-  }
+  private final String basicMsg = "This is a log message";
+
+  private final String basicMsgWithEscapeChar =
+    "This is a log message\nThis is a new line \t other msg";
 
   private final MDC executorIDMDC = MDC.of(LogKeys.EXECUTOR_ID$.MODULE$, "1");
   private final String msgWithMDC = "Lost executor {}.";
 
   private final MDC[] mdcs = new MDC[] {
-      MDC.of(LogKeys.EXECUTOR_ID$.MODULE$, "1"),
-      MDC.of(LogKeys.REASON$.MODULE$, "the shuffle data is too large")};
+    MDC.of(LogKeys.EXECUTOR_ID$.MODULE$, "1"),
+    MDC.of(LogKeys.REASON$.MODULE$, "the shuffle data is too large")};
   private final String msgWithMDCs = "Lost executor {}, reason: {}";
 
   private final MDC executorIDMDCValueIsNull = MDC.of(LogKeys.EXECUTOR_ID$.MODULE$, null);
@@ -90,6 +91,9 @@ public abstract class SparkLoggerSuiteBase {
 
   // test for basic message (without any mdc)
   abstract String expectedPatternForBasicMsg(Level level);
+
+  // test for basic message (with escape char)
+  abstract String expectedPatternForBasicMsgWithEscapeChar(Level level);
 
   // test for basic message and exception
   abstract String expectedPatternForBasicMsgWithException(Level level);
@@ -113,12 +117,12 @@ public abstract class SparkLoggerSuiteBase {
   abstract String expectedPatternForJavaCustomLogKey(Level level);
 
   @Test
-  public void testBasicMsgLogger() {
-    Runnable errorFn = () -> logger().error(basicMsg());
-    Runnable warnFn = () -> logger().warn(basicMsg());
-    Runnable infoFn = () -> logger().info(basicMsg());
-    Runnable debugFn = () -> logger().debug(basicMsg());
-    Runnable traceFn = () -> logger().trace(basicMsg());
+  public void testBasicMsg() {
+    Runnable errorFn = () -> logger().error(basicMsg);
+    Runnable warnFn = () -> logger().warn(basicMsg);
+    Runnable infoFn = () -> logger().info(basicMsg);
+    Runnable debugFn = () -> logger().debug(basicMsg);
+    Runnable traceFn = () -> logger().trace(basicMsg);
     List.of(
         Pair.of(Level.ERROR, errorFn),
         Pair.of(Level.WARN, warnFn),
@@ -129,13 +133,30 @@ public abstract class SparkLoggerSuiteBase {
   }
 
   @Test
+  public void testBasicMsgWithEscapeChar() {
+    Runnable errorFn = () -> logger().error(basicMsgWithEscapeChar);
+    Runnable warnFn = () -> logger().warn(basicMsgWithEscapeChar);
+    Runnable infoFn = () -> logger().info(basicMsgWithEscapeChar);
+    Runnable debugFn = () -> logger().debug(basicMsgWithEscapeChar);
+    Runnable traceFn = () -> logger().trace(basicMsgWithEscapeChar);
+    List.of(
+        Pair.of(Level.ERROR, errorFn),
+        Pair.of(Level.WARN, warnFn),
+        Pair.of(Level.INFO, infoFn),
+        Pair.of(Level.DEBUG, debugFn),
+        Pair.of(Level.TRACE, traceFn)).forEach(pair ->
+      checkLogOutput(pair.getLeft(), pair.getRight(),
+        this::expectedPatternForBasicMsgWithEscapeChar));
+  }
+
+  @Test
   public void testBasicLoggerWithException() {
     Throwable exception = new RuntimeException("OOM");
-    Runnable errorFn = () -> logger().error(basicMsg(), exception);
-    Runnable warnFn = () -> logger().warn(basicMsg(), exception);
-    Runnable infoFn = () -> logger().info(basicMsg(), exception);
-    Runnable debugFn = () -> logger().debug(basicMsg(), exception);
-    Runnable traceFn = () -> logger().trace(basicMsg(), exception);
+    Runnable errorFn = () -> logger().error(basicMsg, exception);
+    Runnable warnFn = () -> logger().warn(basicMsg, exception);
+    Runnable infoFn = () -> logger().info(basicMsg, exception);
+    Runnable debugFn = () -> logger().debug(basicMsg, exception);
+    Runnable traceFn = () -> logger().trace(basicMsg, exception);
     List.of(
         Pair.of(Level.ERROR, errorFn),
         Pair.of(Level.WARN, warnFn),

--- a/common/utils/src/test/java/org/apache/spark/util/StructuredSparkLoggerSuite.java
+++ b/common/utils/src/test/java/org/apache/spark/util/StructuredSparkLoggerSuite.java
@@ -70,6 +70,17 @@ public class StructuredSparkLoggerSuite extends SparkLoggerSuiteBase {
   }
 
   @Override
+  String expectedPatternForBasicMsgWithEscapeChar(Level level) {
+    return compactAndToRegexPattern(level, """
+      {
+        "ts": "<timestamp>",
+        "level": "<level>",
+        "msg": "This is a log message\\\\nThis is a new line \\\\t other msg",
+        "logger": "<className>"
+      }""");
+  }
+
+  @Override
   String expectedPatternForBasicMsgWithException(Level level) {
     return compactAndToRegexPattern(level, """
       {

--- a/common/utils/src/test/scala/org/apache/spark/util/PatternLoggingSuite.scala
+++ b/common/utils/src/test/scala/org/apache/spark/util/PatternLoggingSuite.scala
@@ -34,6 +34,14 @@ class PatternLoggingSuite extends LoggingSuiteBase with BeforeAndAfterAll {
     s""".*$level $className: This is a log message\n"""
   }
 
+  override def expectedPatternForBasicMsgWithEscapeChar(level: Level): String = {
+    s""".*$level $className: This is a log message\nThis is a new line \t other msg\n"""
+  }
+
+  override def expectedPatternForBasicMsgWithEscapeCharMDC(level: Level): String = {
+    s""".*$level $className: This is a log message\nThis is a new line \t other msg\n"""
+  }
+
   override def expectedPatternForBasicMsgWithException(level: Level): String = {
     s""".*$level $className: This is a log message\n[\\s\\S]*"""
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to `unescapes` any literals for `message` of `MessageWithContext`


### Why are the changes needed?
- For example, before this PR
```
logInfo("This is a log message\nThis is a new line \t other msg")
```
It will output:
```
24/05/31 22:53:27 INFO PatternLoggingSuite: This is a log message
This is a new line 	 other msg
```

But:

```
logInfo(log"This is a log message\nThis is a new line \t other msg")
```
It will output:
```
24/05/31 22:53:59 ERROR PatternLoggingSuite: This is a log message\nThis is a new line \t other msg
```

Obviously, the latter is not the result we `expected`.

### Does this PR introduce _any_ user-facing change?
Yes, fix bug.


### How was this patch tested?
- Add new UT.
- Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
