### PR TITLE
[SPARK-48493][PYTHON] Enhance Python Datasource Reader with direct Arrow Batch support for improved performance

### DIFF
--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -25,7 +25,6 @@ from pyspark.errors import PySparkNotImplementedError
 if TYPE_CHECKING:
     from pyspark.sql.session import SparkSession
 
-
 __all__ = [
     "DataSource",
     "DataSourceReader",
@@ -332,8 +331,17 @@ class DataSourceReader(ABC):
             messageParameters={"feature": "partitions"},
         )
 
+    if TYPE_CHECKING:
+        import pyarrow as pa
+
+        RecordBatchType = pa.RecordBatch
+    else:
+        RecordBatchType = None
+
     @abstractmethod
-    def read(self, partition: InputPartition) -> Iterator[Tuple]:
+    def read(
+        self, partition: InputPartition
+    ) -> Union[Iterator[Tuple], Iterator["RecordBatchType"]]:
         """
         Generates data for a given partition and returns an iterator of tuples or rows.
 

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -23,6 +23,7 @@ from pyspark.sql.types import StructType
 from pyspark.errors import PySparkNotImplementedError
 
 if TYPE_CHECKING:
+    from pyarrow import RecordBatch
     from pyspark.sql.session import SparkSession
 
 __all__ = [
@@ -331,17 +332,8 @@ class DataSourceReader(ABC):
             messageParameters={"feature": "partitions"},
         )
 
-    if TYPE_CHECKING:
-        import pyarrow as pa
-
-        RecordBatchType = pa.RecordBatch
-    else:
-        RecordBatchType = None
-
     @abstractmethod
-    def read(
-        self, partition: InputPartition
-    ) -> Union[Iterator[Tuple], Iterator["RecordBatchType"]]:
+    def read(self, partition: InputPartition) -> Union[Iterator[Tuple], Iterator["RecordBatch"]]:
         """
         Generates data for a given partition and returns an iterator of tuples or rows.
 
@@ -358,9 +350,10 @@ class DataSourceReader(ABC):
 
         Returns
         -------
-        iterator of tuples or :class:`Row`\\s
+        iterator of tuples or pyarrow RecordBatch
             An iterator of tuples or rows. Each tuple or row will be converted to a row
             in the final DataFrame.
+            It can also return an iterator of pyarrow RecordBatch if the data source supports it.
 
         Examples
         --------
@@ -456,7 +449,7 @@ class DataSourceStreamReader(ABC):
         )
 
     @abstractmethod
-    def read(self, partition: InputPartition) -> Iterator[Tuple]:
+    def read(self, partition: InputPartition) -> Union[Iterator[Tuple], Iterator["RecordBatch"]]:
         """
         Generates data for a given partition and returns an iterator of tuples or rows.
 
@@ -478,9 +471,10 @@ class DataSourceStreamReader(ABC):
 
         Returns
         -------
-        iterator of tuples or :class:`Row`\\s
+        iterator of tuples or pyarrow RecordBatch
             An iterator of tuples or rows. Each tuple or row will be converted to a row
             in the final DataFrame.
+            It can also return an iterator of pyarrow RecordBatch if the data source supports it.
         """
         raise PySparkNotImplementedError(
             errorClass="NOT_IMPLEMENTED",

--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -374,6 +374,77 @@ class BasePythonDataSourceTestsMixin:
         self.assertEqual(d2["BaR"], 3)
         self.assertEqual(d2["baz"], 3)
 
+    def test_arrow_batch_data_source(self):
+        import pyarrow as pa
+
+        class ArrowBatchDataSource(DataSource):
+            """
+            A data source for testing Arrow Batch Serialization
+            """
+
+            @classmethod
+            def name(cls):
+                return "arrowbatch"
+
+            def schema(self):
+                return "key int, value string"
+
+            def reader(self, schema: str):
+                return ArrowBatchDataSourceReader(schema, self.options)
+
+        class ArrowBatchDataSourceReader(DataSourceReader):
+            def __init__(self, schema, options):
+                self.schema: str = schema
+                self.options = options
+
+            def read(self, partition):
+                # Create Arrow Record Batch
+                keys = pa.array([1, 2, 3, 4, 5], type=pa.int32())
+                values = pa.array(["one", "two", "three", "four", "five"], type=pa.string())
+                schema = pa.schema([("key", pa.int32()), ("value", pa.string())])
+
+            def __init__(self, schema, options):
+                self.schema: str = schema
+                self.options = options
+
+            def read(self, partition):
+                # Create Arrow Record Batch
+                keys = pa.array([1, 2, 3, 4, 5], type=pa.int32())
+                values = pa.array(["one", "two", "three", "four", "five"], type=pa.string())
+                schema = pa.schema([("key", pa.int32()), ("value", pa.string())])
+                record_batch = pa.RecordBatch.from_arrays([keys, values], schema=schema)
+                yield record_batch
+
+            def partitions(self):
+                # hardcoded number of partitions
+                num_part = 1
+                return [InputPartition(i) for i in range(num_part)]
+
+        self.spark.dataSource.register(ArrowBatchDataSource)
+        df = self.spark.read.format("arrowbatch").load()
+        expected_data = [
+            Row(key=1, value="one"),
+            Row(key=2, value="two"),
+            Row(key=3, value="three"),
+            Row(key=4, value="four"),
+            Row(key=5, value="five"),
+        ]
+        assertDataFrameEqual(df, expected_data)
+
+        with self.assertRaisesRegex(
+            PythonException,
+            "PySparkRuntimeError: \\[DATA_SOURCE_RETURN_SCHEMA_MISMATCH\\] Return schema mismatch in the "
+            "result from 'read' method\. Expected: 1 columns, Found: 2 columns",
+        ):
+            self.spark.read.format("arrowbatch").schema("dummy int").load().show()
+
+        with self.assertRaisesRegex(
+            PythonException,
+            "PySparkRuntimeError: \\[DATA_SOURCE_RETURN_SCHEMA_MISMATCH\\] Return schema mismatch in the "
+            "result from 'read' method\. Expected: \['key', 'dummy'\] columns, Found: \['key', 'value'\] columns",
+        ):
+            self.spark.read.format("arrowbatch").schema("key int, dummy string").load().show()
+
     def test_data_source_type_mismatch(self):
         class TestDataSource(DataSource):
             @classmethod

--- a/python/pyspark/sql/tests/test_python_datasource.py
+++ b/python/pyspark/sql/tests/test_python_datasource.py
@@ -402,16 +402,6 @@ class BasePythonDataSourceTestsMixin:
                 keys = pa.array([1, 2, 3, 4, 5], type=pa.int32())
                 values = pa.array(["one", "two", "three", "four", "five"], type=pa.string())
                 schema = pa.schema([("key", pa.int32()), ("value", pa.string())])
-
-            def __init__(self, schema, options):
-                self.schema: str = schema
-                self.options = options
-
-            def read(self, partition):
-                # Create Arrow Record Batch
-                keys = pa.array([1, 2, 3, 4, 5], type=pa.int32())
-                values = pa.array(["one", "two", "three", "four", "five"], type=pa.string())
-                schema = pa.schema([("key", pa.int32()), ("value", pa.string())])
                 record_batch = pa.RecordBatch.from_arrays([keys, values], schema=schema)
                 yield record_batch
 
@@ -433,15 +423,16 @@ class BasePythonDataSourceTestsMixin:
 
         with self.assertRaisesRegex(
             PythonException,
-            "PySparkRuntimeError: \\[DATA_SOURCE_RETURN_SCHEMA_MISMATCH\\] Return schema mismatch in the "
-            "result from 'read' method\. Expected: 1 columns, Found: 2 columns",
+            "PySparkRuntimeError: \\[DATA_SOURCE_RETURN_SCHEMA_MISMATCH\\] Return schema"
+            " mismatch in the result from 'read' method\\. Expected: 1 columns, Found: 2 columns",
         ):
             self.spark.read.format("arrowbatch").schema("dummy int").load().show()
 
         with self.assertRaisesRegex(
             PythonException,
-            "PySparkRuntimeError: \\[DATA_SOURCE_RETURN_SCHEMA_MISMATCH\\] Return schema mismatch in the "
-            "result from 'read' method\. Expected: \['key', 'dummy'\] columns, Found: \['key', 'value'\] columns",
+            "PySparkRuntimeError: \\[DATA_SOURCE_RETURN_SCHEMA_MISMATCH\\] Return schema mismatch"
+            " in the result from 'read' method\\. Expected: \\['key', 'dummy'\\] columns, Found:"
+            " \\['key', 'value'\\] columns",
         ):
             self.spark.read.format("arrowbatch").schema("key int, dummy string").load().show()
 

--- a/python/pyspark/sql/tests/test_python_streaming_datasource.py
+++ b/python/pyspark/sql/tests/test_python_streaming_datasource.py
@@ -152,6 +152,66 @@ class BasePythonStreamingDataSourceTestsMixin:
         q.awaitTermination()
         self.assertIsNone(q.exception(), "No exception has to be propagated.")
 
+    def test_stream_reader_pyarrow(self):
+        import pyarrow as pa
+
+        class TestStreamReader(DataSourceStreamReader):
+            def initialOffset(self):
+                return {"offset": 0}
+
+            def latestOffset(self):
+                return {"offset": 2}
+
+            def partitions(self, start, end):
+                # hardcoded number of partitions
+                num_part = 1
+                return [InputPartition(i) for i in range(num_part)]
+
+            def read(self, partition):
+                keys = pa.array([1, 2, 3, 4, 5], type=pa.int32())
+                values = pa.array(["one", "two", "three", "four", "five"], type=pa.string())
+                schema = pa.schema([("key", pa.int32()), ("value", pa.string())])
+                record_batch = pa.RecordBatch.from_arrays([keys, values], schema=schema)
+                yield record_batch
+
+        class TestDataSourcePyarrow(DataSource):
+            @classmethod
+            def name(cls):
+                return "testdatasourcepyarrow"
+
+            def schema(self):
+                return "key int, value string"
+
+            def streamReader(self, schema):
+                return TestStreamReader()
+
+        self.spark.dataSource.register(TestDataSourcePyarrow)
+        df = self.spark.readStream.format("testdatasourcepyarrow").load()
+
+        output_dir = tempfile.TemporaryDirectory(prefix="test_data_stream_write_output")
+        checkpoint_dir = tempfile.TemporaryDirectory(prefix="test_data_stream_write_checkpoint")
+
+        q = (
+            df.writeStream.format("json")
+            .option("checkpointLocation", checkpoint_dir.name)
+            .start(output_dir.name)
+        )
+        while not q.recentProgress:
+            time.sleep(0.2)
+        q.stop()
+        q.awaitTermination()
+
+        expected_data = [
+            Row(key=1, value="one"),
+            Row(key=2, value="two"),
+            Row(key=3, value="three"),
+            Row(key=4, value="four"),
+            Row(key=5, value="five"),
+        ]
+        df = self.spark.read.json(output_dir.name)
+
+        assertDataFrameEqual(df, expected_data)
+
     def test_simple_stream_reader(self):
         class SimpleStreamReader(SimpleDataSourceStreamReader):
             def initialOffset(self):

--- a/python/pyspark/sql/worker/plan_data_source_read.py
+++ b/python/pyspark/sql/worker/plan_data_source_read.py
@@ -19,7 +19,7 @@ import os
 import sys
 import functools
 import pyarrow as pa
-from itertools import islice
+from itertools import islice, tee
 from typing import IO, List, Iterator, Iterable, Tuple, Union
 
 from pyspark.accumulators import _accumulatorRegistry
@@ -59,20 +59,16 @@ from pyspark.worker_util import (
 
 
 def records_to_arrow_batches(
-    output_iter: Iterator[Tuple],
+    output_iter: Union[Iterator[Tuple], Iterator[pa.RecordBatch]],
     max_arrow_batch_size: int,
     return_type: StructType,
     data_source: DataSource,
 ) -> Iterable[pa.RecordBatch]:
     """
-    Convert an iterator of Python tuples to an iterator of pyarrow record batches.
-
-    For each python tuple, check the types of each field and append it to the records batch.
-
+    First check if the iterator yields pyarrow record batched, if so, yield them directly.
+    Otherwise, convert an iterator of Python tuples to an iterator of pyarrow record batches.
+    For each Python tuple, check the types of each field and append it to the records batch.
     """
-
-    def batched(iterator: Iterator, n: int) -> Iterator:
-        return iter(functools.partial(lambda it: list(islice(it, n)), iterator), [])
 
     pa_schema = to_arrow_schema(return_type)
     column_names = return_type.fieldNames()
@@ -83,6 +79,46 @@ def records_to_arrow_batches(
     num_cols = len(column_names)
     col_mapping = {name: i for i, name in enumerate(column_names)}
     col_name_set = set(column_names)
+
+    # Create a copy of the iterator using itertools.tee
+    output_iter, output_iter_copy = tee(output_iter)
+    try:
+        # Check if the first element is of type pa.RecordBatch
+        # In that case, yield all elements and return
+        first_element = next(output_iter_copy)
+        if isinstance(first_element, pa.RecordBatch):
+            print(pa_schema)
+            print(first_element.schema)
+            # Validate the schema, check the RecordBatch column count
+            num_columns = first_element.num_columns
+            if num_columns != num_cols:
+                raise PySparkRuntimeError(
+                    error_class="DATA_SOURCE_RETURN_SCHEMA_MISMATCH",
+                    message_parameters={
+                        "expected": str(num_cols),
+                        "actual": str(num_columns),
+                    },
+                )
+            for name in column_names:
+                if name not in first_element.schema.names:
+                    raise PySparkRuntimeError(
+                        error_class="DATA_SOURCE_RETURN_SCHEMA_MISMATCH",
+                        message_parameters={
+                            "expected": str(column_names),
+                            "actual": str(first_element.schema.names),
+                        },
+                    )
+
+            yield first_element
+            for element in output_iter_copy:
+                yield element
+            return
+    except StopIteration:
+        pass
+
+    def batched(iterator: Iterator, n: int) -> Iterator:
+        return iter(functools.partial(lambda it: list(islice(it, n)), iterator), [])
+
     for batch in batched(output_iter, max_arrow_batch_size):
         pylist: List[List] = [[] for _ in range(num_cols)]
         for result in batch:
@@ -103,7 +139,7 @@ def records_to_arrow_batches(
                     messageParameters={
                         "type": type(result).__name__,
                         "name": data_source.name(),
-                        "supported_types": "tuple, list, `pyspark.sql.types.Row`",
+                        "supported_types": "tuple, list, `pyspark.sql.types.Row`, pyarrow RecordBatch",
                     },
                 )
 
@@ -145,9 +181,10 @@ def main(infile: IO, outfile: IO) -> None:
 
     This process then creates a `DataSourceReader` instance by calling the `reader` method
     on the `DataSource` instance. Then it calls the `partitions()` method of the reader and
-    constructs a Python UDTF using the `read()` method of the reader.
+    constructs a Python Arrow Batch with the data using the `read()` method of the reader.
 
-    The partition values and the UDTF are then serialized and sent back to the JVM via the socket.
+    The partition values and the Arrow Batch are then serialized and sent back to the JVM
+    via the socket.
     """
     try:
         check_python_version(infile)

--- a/python/pyspark/sql/worker/plan_data_source_read.py
+++ b/python/pyspark/sql/worker/plan_data_source_read.py
@@ -91,7 +91,7 @@ def records_to_arrow_batches(
         num_columns = first_element.num_columns
         if num_columns != num_cols:
             raise PySparkRuntimeError(
-                error_class="DATA_SOURCE_RETURN_SCHEMA_MISMATCH",
+                errorClass="DATA_SOURCE_RETURN_SCHEMA_MISMATCH",
                 message_parameters={
                     "expected": str(num_cols),
                     "actual": str(num_columns),
@@ -100,7 +100,7 @@ def records_to_arrow_batches(
         for name in column_names:
             if name not in first_element.schema.names:
                 raise PySparkRuntimeError(
-                    error_class="DATA_SOURCE_RETURN_SCHEMA_MISMATCH",
+                    errorClass="DATA_SOURCE_RETURN_SCHEMA_MISMATCH",
                     message_parameters={
                         "expected": str(column_names),
                         "actual": str(first_element.schema.names),

--- a/python/pyspark/sql/worker/plan_data_source_read.py
+++ b/python/pyspark/sql/worker/plan_data_source_read.py
@@ -139,7 +139,8 @@ def records_to_arrow_batches(
                     messageParameters={
                         "type": type(result).__name__,
                         "name": data_source.name(),
-                        "supported_types": "tuple, list, `pyspark.sql.types.Row`, pyarrow RecordBatch",
+                        "supported_types": "tuple, list, `pyspark.sql.types.Row`,"
+                        " pyarrow RecordBatch",
                     },
                 )
 

--- a/python/pyspark/sql/worker/plan_data_source_read.py
+++ b/python/pyspark/sql/worker/plan_data_source_read.py
@@ -92,7 +92,7 @@ def records_to_arrow_batches(
         if num_columns != num_cols:
             raise PySparkRuntimeError(
                 errorClass="DATA_SOURCE_RETURN_SCHEMA_MISMATCH",
-                message_parameters={
+                messageParameters={
                     "expected": str(num_cols),
                     "actual": str(num_columns),
                 },
@@ -101,7 +101,7 @@ def records_to_arrow_batches(
             if name not in first_element.schema.names:
                 raise PySparkRuntimeError(
                     errorClass="DATA_SOURCE_RETURN_SCHEMA_MISMATCH",
-                    message_parameters={
+                    messageParameters={
                         "expected": str(column_names),
                         "actual": str(first_element.schema.names),
                     },


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pull request proposes enhancing the Python Datasource Reader by adding an option to yield Arrow batches directly. This change aims to significantly improve performance compared to the existing approach of using tuples or Rows. The implementation takes advantage of the existing work with MapInArrow (referenced in SPARK-46253).

### Why are the changes needed?
The changes are needed to address performance issues in the Python Datasource Reader. The current method of sending data as tuples or Rows is inefficient, leading to slower data processing times. By allowing the Datasource Reader to yield Arrow batches directly, we can use the more efficient Arrow format, significantly speeding up data processing. Tests have shown this approach to be up to 8x faster (in a preliminary test with a High Energy Physics Datasource reader for the ROOT data format), particularly benefiting use cases involving large datasets.

### Does this PR introduce _any_ user-facing change?
Yes, this PR introduces a user-facing change by adding an option to the Python Datasource Reader that allows users to yield Arrow batches directly.

### How was this patch tested?
A new test was added to the Python Datasource test suite. Additionally, it was manually tested using a custom Python datasource for performance testing.

### Was this patch authored or co-authored using generative AI tooling?
No