### PR TITLE
[SPARK-48494][BUILD] Update `airlift:aircompressor` to 0.27

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -4,7 +4,7 @@ JTransforms/3.1//JTransforms-3.1.jar
 RoaringBitmap/1.0.6//RoaringBitmap-1.0.6.jar
 ST4/4.0.4//ST4-4.0.4.jar
 activation/1.1.1//activation-1.1.1.jar
-aircompressor/0.26//aircompressor-0.26.jar
+aircompressor/0.27//aircompressor-0.27.jar
 algebra_2.13/2.8.0//algebra_2.13-2.8.0.jar
 aliyun-java-sdk-core/4.5.10//aliyun-java-sdk-core-4.5.10.jar
 aliyun-java-sdk-kms/2.11.0//aliyun-java-sdk-kms-2.11.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -2606,7 +2606,7 @@
       <dependency>
         <groupId>io.airlift</groupId>
         <artifactId>aircompressor</artifactId>
-        <version>0.26</version>
+        <version>0.27</version>
       </dependency>
       <dependency>
         <groupId>org.apache.orc</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
upgrade airlift:aircompressor from 0.26 to 0.27

### Why are the changes needed?
[CVE-2024-36114](https://www.cve.org/CVERecord?id=CVE-2024-36114)

[Decompressors can crash the JVM and leak memory content](https://github.com/airlift/aircompressor/security/advisories/GHSA-973x-65j7-xcf4)

The fix https://github.com/airlift/aircompressor/commit/d01ecb779375a092d00e224abe7869cdf49ddc3e

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
pass GA

### Was this patch authored or co-authored using generative AI tooling?
No.