### PR TITLE
[SPARK-48496][CORE] Use static regex Pattern instances in JavaUtils.timeStringAs and JavaUtils.byteStringAs

### DIFF
--- a/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java
+++ b/common/utils/src/main/java/org/apache/spark/network/util/JavaUtils.java
@@ -228,6 +228,8 @@ public class JavaUtils {
       Map.entry("pb", ByteUnit.PiB));
   }
 
+  private static final Pattern TIME_STRING_PATTERN = Pattern.compile("(-?[0-9]+)([a-z]+)?");
+
   /**
    * Convert a passed time string (e.g. 50s, 100ms, or 250us) to a time count in the given unit.
    * The unit is also considered the default if the given string does not specify a unit.
@@ -236,7 +238,7 @@ public class JavaUtils {
     String lower = str.toLowerCase(Locale.ROOT).trim();
 
     try {
-      Matcher m = Pattern.compile("(-?[0-9]+)([a-z]+)?").matcher(lower);
+      Matcher m = TIME_STRING_PATTERN.matcher(lower);
       if (!m.matches()) {
         throw new NumberFormatException("Failed to parse time string: " + str);
       }
@@ -276,6 +278,11 @@ public class JavaUtils {
     return timeStringAs(str, TimeUnit.SECONDS);
   }
 
+  private static final Pattern BYTE_STRING_PATTERN =
+    Pattern.compile("([0-9]+)([a-z]+)?");
+  private static final Pattern BYTE_STRING_FRACTION_PATTERN =
+    Pattern.compile("([0-9]+\\.[0-9]+)([a-z]+)?");
+
   /**
    * Convert a passed byte string (e.g. 50b, 100kb, or 250mb) to the given. If no suffix is
    * provided, a direct conversion to the provided unit is attempted.
@@ -284,8 +291,8 @@ public class JavaUtils {
     String lower = str.toLowerCase(Locale.ROOT).trim();
 
     try {
-      Matcher m = Pattern.compile("([0-9]+)([a-z]+)?").matcher(lower);
-      Matcher fractionMatcher = Pattern.compile("([0-9]+\\.[0-9]+)([a-z]+)?").matcher(lower);
+      Matcher m = BYTE_STRING_PATTERN.matcher(lower);
+      Matcher fractionMatcher = BYTE_STRING_FRACTION_PATTERN.matcher(lower);
 
       if (m.matches()) {
         long val = Long.parseLong(m.group(1));


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates `JavaUtils.timeStringAs` and `JavaUtils.byteStringAs` to use static `Pattern` instances instead of recompiling the regexes on every call.

### Why are the changes needed?

Tiny perf. optimization. This isn't a huge overhead in the grand scheme of things, but it surfaced during some other profiling work and is straightforward to address via static Pattern instances.

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Existing tests.


### Was this patch authored or co-authored using generative AI tooling?

No.
