### PR TITLE
[PYTHON] Fix `assertDataFrameEqual` behavior with mixed DataFrame types

### DIFF
--- a/python/pyspark/pandas/tests/indexes/test_indexing_adv.py
+++ b/python/pyspark/pandas/tests/indexes/test_indexing_adv.py
@@ -69,7 +69,7 @@ class IndexingAdvMixin:
         self.assertEqual(psdf.at[3, "b"], 6)
         self.assertEqual(psdf.at[3, "b"], pdf.at[3, "b"])
         self.assert_eq(psdf.at[9, "b"], np.array([0, 0, 0]))
-        self.assert_eq(psdf.at[9, "b"], pdf.at[9, "b"])
+        self.assert_eq(psdf.at[9, "b"], pdf.at[9, "b"].to_numpy())
 
         # Assert .at for Series
         self.assertEqual(test_series.at["b"], 6)
@@ -104,7 +104,7 @@ class IndexingAdvMixin:
         self.assertEqual(psdf.at[3, 1], 6)
         self.assertEqual(psdf.at[3, 1], pdf.at[3, 1])
         self.assert_eq(psdf.at[9, 1], np.array([0, 0, 0]))
-        self.assert_eq(psdf.at[9, 1], pdf.at[9, 1])
+        self.assert_eq(psdf.at[9, 1], pdf.at[9, 1].to_numpy())
 
     def test_at_multiindex(self):
         psdf = self.psdf.set_index("b", append=True)

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -955,13 +955,8 @@ class UtilsTestsMixin:
             exception=pe.exception,
             error_class="INVALID_TYPE_DF_EQUALITY_ARG",
             message_parameters={
-                "expected_type": f"{ps.DataFrame.__name__}, "
-                f"{pd.DataFrame.__name__}, "
-                f"{ps.Series.__name__}, "
-                f"{pd.Series.__name__}, "
-                f"{ps.Index.__name__}"
-                f"{pd.Index.__name__}, ",
-                "arg_name": "expected",
+                "expected_type": "Pandas or Pandas-on-Spark DataFrame, Series, or Index",
+                "arg_name": "right",
                 "actual_type": type(df2),
             },
         )
@@ -973,13 +968,8 @@ class UtilsTestsMixin:
             exception=pe.exception,
             error_class="INVALID_TYPE_DF_EQUALITY_ARG",
             message_parameters={
-                "expected_type": f"{ps.DataFrame.__name__}, "
-                f"{pd.DataFrame.__name__}, "
-                f"{ps.Series.__name__}, "
-                f"{pd.Series.__name__}, "
-                f"{ps.Index.__name__}"
-                f"{pd.Index.__name__}, ",
-                "arg_name": "expected",
+                "expected_type": "Pandas or Pandas-on-Spark DataFrame, Series, or Index",
+                "arg_name": "right",
                 "actual_type": type(df2),
             },
         )
@@ -991,14 +981,9 @@ class UtilsTestsMixin:
             exception=pe.exception,
             error_class="INVALID_TYPE_DF_EQUALITY_ARG",
             message_parameters={
-                "expected_type": f"{ps.DataFrame.__name__}, "
-                f"{pd.DataFrame.__name__}, "
-                f"{ps.Series.__name__}, "
-                f"{pd.Series.__name__}, "
-                f"{ps.Index.__name__}"
-                f"{pd.Index.__name__}, ",
-                "arg_name": "expected",
-                "actual_type": type(df1),
+                "expected_type": "Pandas or Pandas-on-Spark DataFrame, Series, or Index",
+                "arg_name": "left",
+                "actual_type": type(df2),
             },
         )
 
@@ -1009,14 +994,9 @@ class UtilsTestsMixin:
             exception=pe.exception,
             error_class="INVALID_TYPE_DF_EQUALITY_ARG",
             message_parameters={
-                "expected_type": f"{ps.DataFrame.__name__}, "
-                f"{pd.DataFrame.__name__}, "
-                f"{ps.Series.__name__}, "
-                f"{pd.Series.__name__}, "
-                f"{ps.Index.__name__}"
-                f"{pd.Index.__name__}, ",
-                "arg_name": "expected",
-                "actual_type": type(df1),
+                "expected_type": "Pandas or Pandas-on-Spark DataFrame, Series, or Index",
+                "arg_name": "left",
+                "actual_type": type(df2),
             },
         )
 
@@ -1049,10 +1029,9 @@ class UtilsTestsMixin:
             message_parameters={
                 "expected_type": "DataFrame, Series, Index, ",
                 "arg_name": "right",
-                "actual_type": type(df2),
+                "actual_type": type(df1),
             },
         )
-
 
     def test_assert_error_non_pyspark_df(self):
         dict1 = {"a": 1, "b": 2}

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -943,7 +943,6 @@ class UtilsTestsMixin:
     @unittest.skipIf(not have_pandas or not have_pyarrow, "no pandas or pyarrow dependency")
     def test_assert_error_pandas_pyspark_df(self):
         import pyspark.pandas as ps
-        import pandas as pd
 
         df1 = ps.DataFrame(data=[10, 20, 30], columns=["Numbers"])
         df2 = self.spark.createDataFrame([(10,), (11,), (13,)], ["Numbers"])

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -984,6 +984,76 @@ class UtilsTestsMixin:
             },
         )
 
+        with self.assertRaises(PySparkAssertionError) as pe:
+            assertDataFrameEqual(df2, df1, checkRowOrder=False)
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
+            message_parameters={
+                "expected_type": f"{ps.DataFrame.__name__}, "
+                f"{pd.DataFrame.__name__}, "
+                f"{ps.Series.__name__}, "
+                f"{pd.Series.__name__}, "
+                f"{ps.Index.__name__}"
+                f"{pd.Index.__name__}, ",
+                "arg_name": "expected",
+                "actual_type": type(df1),
+            },
+        )
+
+        with self.assertRaises(PySparkAssertionError) as pe:
+            assertDataFrameEqual(df2, df1, checkRowOrder=True)
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
+            message_parameters={
+                "expected_type": f"{ps.DataFrame.__name__}, "
+                f"{pd.DataFrame.__name__}, "
+                f"{ps.Series.__name__}, "
+                f"{pd.Series.__name__}, "
+                f"{ps.Index.__name__}"
+                f"{pd.Index.__name__}, ",
+                "arg_name": "expected",
+                "actual_type": type(df1),
+            },
+        )
+
+    @unittest.skipIf(not have_pandas or not have_pyarrow, "no pandas or pyarrow dependency")
+    def test_assert_error_spark_and_pandas_df(self):
+        import pandas as pd
+
+        df1 = self.spark.createDataFrame([(10,), (20,), (30,)], ["Numbers"])
+        df2 = pd.DataFrame(data=[10, 11, 13], columns=["Numbers"])
+
+        with self.assertRaises(PySparkAssertionError) as pe:
+            assertDataFrameEqual(df1, df2)
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
+            message_parameters={
+                "expected_type": "DataFrame, Series, Index, ",
+                "arg_name": "left",
+                "actual_type": type(df1),
+            },
+        )
+
+        with self.assertRaises(PySparkAssertionError) as pe:
+            assertDataFrameEqual(df2, df1)
+
+        self.check_error(
+            exception=pe.exception,
+            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
+            message_parameters={
+                "expected_type": "DataFrame, Series, Index, ",
+                "arg_name": "right",
+                "actual_type": type(df2),
+            },
+        )
+
+
     def test_assert_error_non_pyspark_df(self):
         dict1 = {"a": 1, "b": 2}
         dict2 = {"a": 1, "b": 2}


### PR DESCRIPTION
### What changes were proposed in this pull request?
* Avoid `AttributeError` (see examples below) when mixing Spark DataFrame & Pandas or Pandas-on-Spark DataFrame in `assertDataFrameEqual` by flowing into `_assert_pandas_almost_equal`/`_assert_pandas_equal` instead of `assertAlmostEqual`/`assertEqual`.
* In `PandasOnSparkTestUtils.assert_eq`, applied the Pandas-on-Spark flow for both params `left` and `right`, instead of only `left`, and clarified the error to specify that a Pandas or Pandas-on-Spark object is expected, since which is not immediately obvious from the current error: `DataFrame, DataFrame, Series, Series, IndexIndex`

### Why are the changes needed?
* `assertDataFrameEqual` results in `AttributeError` when providing a Spark DataFrame as the first argument and a Pandas DataFrame or a Pandas-on-Spark DataFrame as the second argument (when not inheriting from unittest).

### Does this PR introduce _any_ user-facing change?
* Better errors will be raised in the situation described above:
  * `PySparkAssertionError` with a message is raised instead of `AttributeError`.
  * `PySparkAssertionError` error when mixing Spark & Pandas-on-Spark DataFrames is consistently raised in `PandasOnSparkTestUtils.assert_eq`, regardless of which one is left or right.
  * Clarified error message `Expected type DataFrame, DataFrame, Series, Series, IndexIndex,  for ...` -> `Expected type Pandas or Pandas-on-Spark DataFrame, Series, or Index for ...`

#### Setup:

```
import pandas as pd
import pyspark.pandas as ps
from pyspark.testing import assertDataFrameEqual

df1 = spark.createDataFrame([(10,), (20,), (30,)], ["Numbers"])
df2 = pd.DataFrame(data=[10, 11, 13], columns=["Numbers"])
df3 = ps.DataFrame(data=[10, 11, 13], columns=["Numbers"])
```

#### Before:

```
>>> assertDataFrameEqual(df1, df2, ignoreColumnType=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "...spark/python/pyspark/testing/utils.py", line 828, in assertDataFrameEqual
    return PandasOnSparkTestUtils().assert_eq(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "...spark/python/pyspark/testing/pandasutils.py", line 483, in assert_eq
    self.assertAlmostEqual(lobj, robj)
    ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'PandasOnSparkTestUtils' object has no attribute 'assertAlmostEqual'. Did you mean: 'assertPandasEqual'?

>>> assertDataFrameEqual(df2, df1, ignoreColumnType=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "...spark/python/pyspark/testing/utils.py", line 828, in assertDataFrameEqual
    return PandasOnSparkTestUtils().assert_eq(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "...spark/python/pyspark/testing/pandasutils.py", line 472, in assert_eq
    _assert_pandas_almost_equal(lobj, robj, rtol=rtol, atol=atol)
  File "...spark/python/pyspark/testing/pandasutils.py", line 314, in _assert_pandas_almost_equal
    raise PySparkAssertionError(
pyspark.errors.exceptions.base.PySparkAssertionError: [INVALID_TYPE_DF_EQUALITY_ARG] Expected type DataFrame, Series, Index,  for `right` but got type <class 'pyspark.sql.classic.dataframe.DataFrame'>.
>>>

>>> assertDataFrameEqual(df1, df3, ignoreColumnType=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "...spark/python/pyspark/testing/utils.py", line 828, in assertDataFrameEqual
    return PandasOnSparkTestUtils().assert_eq(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "...spark/python/pyspark/testing/pandasutils.py", line 483, in assert_eq
    self.assertAlmostEqual(lobj, robj)
    ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'PandasOnSparkTestUtils' object has no attribute 'assertAlmostEqual'. Did you mean: 'assertPandasEqual'?

>>> assertDataFrameEqual(df3, df1, ignoreColumnType=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "...spark/python/pyspark/testing/utils.py", line 828, in assertDataFrameEqual
    return PandasOnSparkTestUtils().assert_eq(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "...spark/python/pyspark/testing/pandasutils.py", line 438, in assert_eq
    raise PySparkAssertionError(
pyspark.errors.exceptions.base.PySparkAssertionError: [INVALID_TYPE_DF_EQUALITY_ARG] Expected type DataFrame, DataFrame, Series, Series, IndexIndex,  for `expected` but got type <class 'pyspark.sql.classic.dataframe.DataFrame'>.
```

#### After

```
>>> assertDataFrameEqual(df1, df2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "...spark/python/pyspark/testing/utils.py", line 828, in assertDataFrameEqual
    return PandasOnSparkTestUtils().assert_eq(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "...spark/python/pyspark/testing/pandasutils.py", line 476, in assert_eq
    _assert_pandas_almost_equal(lobj, robj, rtol=rtol, atol=atol)
  File "...spark/python/pyspark/testing/pandasutils.py", line 300, in _assert_pandas_almost_equal
    raise PySparkAssertionError(
**pyspark.errors.exceptions.base.PySparkAssertionError: [INVALID_TYPE_DF_EQUALITY_ARG] Expected type DataFrame, Series, Index,  for `left` but got type <class 'pyspark.sql.classic.dataframe.DataFrame'>.**

>>> assertDataFrameEqual(df2, df1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "...spark/python/pyspark/testing/utils.py", line 828, in assertDataFrameEqual
    return PandasOnSparkTestUtils().assert_eq(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "...spark/python/pyspark/testing/pandasutils.py", line 465, in assert_eq
    _assert_pandas_almost_equal(lobj, robj, rtol=rtol, atol=atol)
  File "...spark/python/pyspark/testing/pandasutils.py", line 311, in _assert_pandas_almost_equal
    raise PySparkAssertionError(
pyspark.errors.exceptions.base.PySparkAssertionError: [INVALID_TYPE_DF_EQUALITY_ARG] Expected type DataFrame, Series, Index,  for `right` but got type <class 'pyspark.sql.classic.dataframe.DataFrame'>.

>>> assertDataFrameEqual(df1, df3)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "...spark/python/pyspark/testing/utils.py", line 828, in assertDataFrameEqual
    return PandasOnSparkTestUtils().assert_eq(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "...spark/python/pyspark/testing/pandasutils.py", line 426, in assert_eq
    raise PySparkAssertionError(
pyspark.errors.exceptions.base.PySparkAssertionError: [INVALID_TYPE_DF_EQUALITY_ARG] Expected type Pandas or Pandas-on-Spark DataFrame, Series, or Index for `left` but got type <class 'pyspark.sql.classic.dataframe.DataFrame'>.

>>> assertDataFrameEqual(df3, df1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "...spark/python/pyspark/testing/utils.py", line 828, in assertDataFrameEqual
    return PandasOnSparkTestUtils().assert_eq(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "...spark/python/pyspark/testing/pandasutils.py", line 438, in assert_eq
    raise PySparkAssertionError(
pyspark.errors.exceptions.base.PySparkAssertionError: [INVALID_TYPE_DF_EQUALITY_ARG] Expected type Pandas or Pandas-on-Spark DataFrame, Series, or Index for `right` but got type <class 'pyspark.sql.classic.dataframe.DataFrame'>.
```

### How was this patch tested?
* Manually tested new behavior in local SparkSession.
* Extended existing test case with Pandas-on-Spark DataFrame to confirm the correct error is raised when the parameters are flipped.
* Added test case with Spark DataFrame & Pandas DataFrame.

### Was this patch authored or co-authored using generative AI tooling?
No
