### PR TITLE
[SPARK-48519][BUILD] Upgrade jetty to 11.0.21

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -137,8 +137,8 @@ jersey-container-servlet/3.0.12//jersey-container-servlet-3.0.12.jar
 jersey-hk2/3.0.12//jersey-hk2-3.0.12.jar
 jersey-server/3.0.12//jersey-server-3.0.12.jar
 jettison/1.5.4//jettison-1.5.4.jar
-jetty-util-ajax/11.0.20//jetty-util-ajax-11.0.20.jar
-jetty-util/11.0.20//jetty-util-11.0.20.jar
+jetty-util-ajax/11.0.21//jetty-util-ajax-11.0.21.jar
+jetty-util/11.0.21//jetty-util-11.0.21.jar
 jline/2.14.6//jline-2.14.6.jar
 jline/3.25.1//jline-3.25.1.jar
 jna/5.14.0//jna-5.14.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
     <parquet.version>1.13.1</parquet.version>
     <orc.version>2.0.1</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>
-    <jetty.version>11.0.20</jetty.version>
+    <jetty.version>11.0.21</jetty.version>
     <jakartaservlet.version>5.0.0</jakartaservlet.version>
     <!-- SPARK-46938: Required by Hive / LibThrift libs -->
     <javaxservlet.version>4.0.1</javaxservlet.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade jetty from 11.0.20 to 11.0.21.

### Why are the changes needed?
The new version bring some bug fix like [Reduce ByteBuffer churning in HttpOutput](https://github.com/jetty/jetty.project/commit/fe94c9f8a40df49021b28280f708448870c5b420). The full release notes as follows:
- https://github.com/jetty/jetty.project/releases/tag/jetty-11.0.21


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No