### PR TITLE
[SPARK-48508][CONNECT][PYTHON] Cache user specified schema in `DataFrame.{to, mapInPandas, mapInArrow}`

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1825,10 +1825,12 @@ class DataFrame(ParentDataFrame):
 
     def to(self, schema: StructType) -> ParentDataFrame:
         assert schema is not None
-        return DataFrame(
+        res = DataFrame(
             plan.ToSchema(child=self._plan, schema=schema),
             session=self._session,
         )
+        res._cached_schema = schema
+        return res
 
     def toDF(self, *cols: str) -> ParentDataFrame:
         for col_ in cols:
@@ -2009,7 +2011,7 @@ class DataFrame(ParentDataFrame):
             evalType=evalType,
         )
 
-        return DataFrame(
+        res = DataFrame(
             plan.MapPartitions(
                 child=self._plan,
                 function=udf_obj,
@@ -2019,6 +2021,9 @@ class DataFrame(ParentDataFrame):
             ),
             session=self._session,
         )
+        if isinstance(schema, StructType):
+            res._cached_schema = schema
+        return res
 
     def mapInPandas(
         self,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Cache user specified schema in `DataFrame.{to, mapInPandas, mapInArrow}`

### Why are the changes needed?
to avoid extra RPC to get the schema


### Does this PR introduce _any_ user-facing change?
no, it should only be an optimization


### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
No