### PR TITLE
[SPARK-48512][PYTHON][TESTS] Refactor Python tests

### DIFF
--- a/python/pyspark/sql/tests/test_context.py
+++ b/python/pyspark/sql/tests/test_context.py
@@ -26,10 +26,10 @@ import py4j
 from pyspark import SparkContext, SQLContext
 from pyspark.sql import Row, SparkSession
 from pyspark.sql.types import StructType, StringType, StructField
-from pyspark.testing.utils import ReusedPySparkTestCase
+from pyspark.testing.utils import ReusedSQLTestCase, ReusedPySparkTestCase
 
 
-class HiveContextSQLTests(ReusedPySparkTestCase):
+class HiveContextSQLTests(ReusedPySparkTestCase, ReusedSQLTestCase):
     @classmethod
     def setUpClass(cls):
         ReusedPySparkTestCase.setUpClass()

--- a/python/pyspark/sql/tests/test_context.py
+++ b/python/pyspark/sql/tests/test_context.py
@@ -100,23 +100,19 @@ class HiveContextSQLTests(ReusedPySparkTestCase):
         self.spark.sql("DROP TABLE savedJsonTable")
         self.spark.sql("DROP TABLE externalJsonTable")
 
-        defaultDataSourceName = self.spark.conf.get(
-            "spark.sql.sources.default", "org.apache.spark.sql.parquet"
-        )
-        self.spark.sql("SET spark.sql.sources.default=org.apache.spark.sql.json")
-        df.write.saveAsTable("savedJsonTable", path=tmpPath, mode="overwrite")
-        actual = self.spark.catalog.createTable("externalJsonTable", path=tmpPath)
-        self.assertEqual(
-            sorted(df.collect()), sorted(self.spark.sql("SELECT * FROM savedJsonTable").collect())
-        )
-        self.assertEqual(
-            sorted(df.collect()),
-            sorted(self.spark.sql("SELECT * FROM externalJsonTable").collect()),
-        )
-        self.assertEqual(sorted(df.collect()), sorted(actual.collect()))
-        self.spark.sql("DROP TABLE savedJsonTable")
-        self.spark.sql("DROP TABLE externalJsonTable")
-        self.spark.sql("SET spark.sql.sources.default=" + defaultDataSourceName)
+        with self.sql_conf({"spark.sql.sources.default": "org.apache.spark.sql.json"}):
+            df.write.saveAsTable("savedJsonTable", path=tmpPath, mode="overwrite")
+            actual = self.spark.catalog.createTable("externalJsonTable", path=tmpPath)
+            self.assertEqual(
+                sorted(df.collect()), sorted(self.spark.sql("SELECT * FROM savedJsonTable").collect())
+            )
+            self.assertEqual(
+                sorted(df.collect()),
+                sorted(self.spark.sql("SELECT * FROM externalJsonTable").collect()),
+            )
+            self.assertEqual(sorted(df.collect()), sorted(actual.collect()))
+            self.spark.sql("DROP TABLE savedJsonTable")
+            self.spark.sql("DROP TABLE externalJsonTable")
 
         shutil.rmtree(tmpPath)
 

--- a/python/pyspark/sql/tests/test_context.py
+++ b/python/pyspark/sql/tests/test_context.py
@@ -26,7 +26,8 @@ import py4j
 from pyspark import SparkContext, SQLContext
 from pyspark.sql import Row, SparkSession
 from pyspark.sql.types import StructType, StringType, StructField
-from pyspark.testing.utils import ReusedSQLTestCase, ReusedPySparkTestCase
+from pyspark.testing.sqlutils import ReusedSQLTestCase
+from pyspark.testing.utils import ReusedPySparkTestCase
 
 
 class HiveContextSQLTests(ReusedPySparkTestCase, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/test_context.py
+++ b/python/pyspark/sql/tests/test_context.py
@@ -104,7 +104,8 @@ class HiveContextSQLTests(ReusedPySparkTestCase):
             df.write.saveAsTable("savedJsonTable", path=tmpPath, mode="overwrite")
             actual = self.spark.catalog.createTable("externalJsonTable", path=tmpPath)
             self.assertEqual(
-                sorted(df.collect()), sorted(self.spark.sql("SELECT * FROM savedJsonTable").collect())
+                sorted(df.collect()),
+                sorted(self.spark.sql("SELECT * FROM savedJsonTable").collect()),
             )
             self.assertEqual(
                 sorted(df.collect()),

--- a/python/pyspark/sql/tests/test_context.py
+++ b/python/pyspark/sql/tests/test_context.py
@@ -27,13 +27,12 @@ from pyspark import SparkContext, SQLContext
 from pyspark.sql import Row, SparkSession
 from pyspark.sql.types import StructType, StringType, StructField
 from pyspark.testing.sqlutils import ReusedSQLTestCase
-from pyspark.testing.utils import ReusedPySparkTestCase
 
 
-class HiveContextSQLTests(ReusedPySparkTestCase, ReusedSQLTestCase):
+class HiveContextSQLTests(ReusedSQLTestCase):
     @classmethod
     def setUpClass(cls):
-        ReusedPySparkTestCase.setUpClass()
+        ReusedSQLTestCase.setUpClass()
         cls.tempdir = tempfile.NamedTemporaryFile(delete=False)
         cls.hive_available = True
         cls.spark = None
@@ -59,7 +58,7 @@ class HiveContextSQLTests(ReusedPySparkTestCase, ReusedSQLTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        ReusedPySparkTestCase.tearDownClass()
+        ReusedSQLTestCase.tearDownClass()
         shutil.rmtree(cls.tempdir.name, ignore_errors=True)
         if cls.spark is not None:
             cls.spark.stop()

--- a/python/pyspark/sql/tests/test_readwriter.py
+++ b/python/pyspark/sql/tests/test_readwriter.py
@@ -55,12 +55,9 @@ class ReadwriterTestsMixin:
             )
             self.assertEqual(sorted(df.collect()), sorted(actual.collect()))
 
-            try:
-                self.spark.sql("SET spark.sql.sources.default=org.apache.spark.sql.json")
+            with self.sql_conf({"spark.sql.sources.default": "org.apache.spark.sql.json"}):
                 actual = self.spark.read.load(path=tmpPath)
                 self.assertEqual(sorted(df.collect()), sorted(actual.collect()))
-            finally:
-                self.spark.sql("RESET spark.sql.sources.default")
 
             csvpath = os.path.join(tempfile.mkdtemp(), "data")
             df.write.option("quote", None).format("csv").save(csvpath)
@@ -94,12 +91,9 @@ class ReadwriterTestsMixin:
             )
             self.assertEqual(sorted(df.collect()), sorted(actual.collect()))
 
-            try:
-                self.spark.sql("SET spark.sql.sources.default=org.apache.spark.sql.json")
+            with self.sql_conf({"spark.sql.sources.default": "org.apache.spark.sql.json"}):
                 actual = self.spark.read.load(path=tmpPath)
                 self.assertEqual(sorted(df.collect()), sorted(actual.collect()))
-            finally:
-                self.spark.sql("RESET spark.sql.sources.default")
         finally:
             shutil.rmtree(tmpPath)
 

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -491,9 +491,7 @@ class TypesTestsMixin:
         self.assertEqual(asdict(user), r.asDict())
 
     def test_negative_decimal(self):
-        with self.sql_conf(
-                {"spark.sql.legacy.allowNegativeScaleOfDecimal": True}
-        ):
+        with self.sql_conf({"spark.sql.legacy.allowNegativeScaleOfDecimal": True}):
             df = self.spark.createDataFrame([(1,), (11,)], ["value"])
             ret = df.select(F.col("value").cast(DecimalType(1, -1))).collect()
             actual = list(map(lambda r: int(r.value), ret))

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -491,14 +491,13 @@ class TypesTestsMixin:
         self.assertEqual(asdict(user), r.asDict())
 
     def test_negative_decimal(self):
-        try:
-            self.spark.sql("set spark.sql.legacy.allowNegativeScaleOfDecimal=true")
+        with self.sql_conf(
+                {"spark.sql.legacy.allowNegativeScaleOfDecimal": True}
+        ):
             df = self.spark.createDataFrame([(1,), (11,)], ["value"])
             ret = df.select(F.col("value").cast(DecimalType(1, -1))).collect()
             actual = list(map(lambda r: int(r.value), ret))
             self.assertEqual(actual, [0, 10])
-        finally:
-            self.spark.sql("set spark.sql.legacy.allowNegativeScaleOfDecimal=false")
 
     def test_create_dataframe_from_objects(self):
         data = [MyObject(1, "1"), MyObject(2, "2")]

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -1742,7 +1742,7 @@ class UtilsTestsMixin:
         self.assertRaisesRegex(
             IllegalArgumentException,
             "Setting negative mapred.reduce.tasks",
-            lambda: self.spark.conf.set("mapred.reduce.tasks", "-1"),
+            lambda: self.spark.sql("SET mapred.reduce.tasks=-1"),
         )
 
     def test_capture_pyspark_value_exception(self):

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -1742,7 +1742,7 @@ class UtilsTestsMixin:
         self.assertRaisesRegex(
             IllegalArgumentException,
             "Setting negative mapred.reduce.tasks",
-            lambda: self.spark.sql("SET mapred.reduce.tasks=-1"),
+            lambda: self.spark.conf.set("mapred.reduce.tasks", "-1"),
         )
 
     def test_capture_pyspark_value_exception(self):


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


Use withSQLConf in tests when it is appropriate.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Enforce good practice for setting config in test cases.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
NO

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
existing UT

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
NO