### PR TITLE
[SPARK-48524][SQL] Make Not IsNull semantically equal to IsNotNull and vice versa

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -328,6 +328,8 @@ case class Not(child: Expression)
       case Not(LessThan(l, r)) => GreaterThanOrEqual(l, r)
       case Not(GreaterThanOrEqual(l, r)) => LessThan(l, r)
       case Not(LessThanOrEqual(l, r)) => GreaterThan(l, r)
+      case Not(IsNull(c)) => IsNotNull(c)
+      case Not(IsNotNull(c)) => IsNull(c)
       case other => other
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CanonicalizeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CanonicalizeSuite.scala
@@ -479,4 +479,13 @@ class CanonicalizeSuite extends SparkFunSuite {
         }
     }
   }
+
+  test("canonicalization of IsNull and IsNotNull") {
+    val attr = AttributeReference("a", BooleanType)()
+    assert(Not(IsNull(attr)).semanticEquals(IsNotNull(attr)))
+    assert(Not(IsNull(attr)).canonicalized.isInstanceOf[IsNotNull])
+
+    assert(Not(IsNotNull(attr)).semanticEquals(IsNull(attr)))
+    assert(Not(IsNotNull(attr)).canonicalized.isInstanceOf[IsNull])
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CanonicalizeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CanonicalizeSuite.scala
@@ -480,7 +480,7 @@ class CanonicalizeSuite extends SparkFunSuite {
     }
   }
 
-  test("canonicalization of IsNull and IsNotNull") {
+  test("SPARK-48524: canonicalization of IsNull and IsNotNull") {
     val attr = AttributeReference("a", BooleanType)()
     assert(Not(IsNull(attr)).semanticEquals(IsNotNull(attr)))
     assert(Not(IsNull(attr)).canonicalized.isInstanceOf[IsNotNull])


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
`Not(IsNull(x))` is made semantically equivalent to `IsNotNull(x)` and vice versa. 


### Why are the changes needed?
The following would return `false` whereas it should really be `true`:
```
case a And b if Not(a).semanticEquals(b) =>
    If(IsNull(a), Literal.create(null, a.dataType), FalseLiteral)
```
If `a` were `IsNull(x)` and `b` were `IsNotNull(x)`.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Unit tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
