### PR TITLE
[SPARK-48531][INFRA] Fix `Black` target version to Python 3.9

### DIFF
--- a/dev/pyproject.toml
+++ b/dev/pyproject.toml
@@ -29,6 +29,6 @@ testpaths = [
 # GitHub workflow version and dev/reformat-python
 required-version = "23.9.1"
 line-length = 100
-target-version = ['py38']
+target-version = ['py39']
 include = '\.pyi?$'
 extend-exclude = 'cloudpickle|error_classes.py'


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `Black` target version to `Python 3.9`.

### Why are the changes needed?

Since SPARK-47993 dropped Python 3.8 support officially at Apache Spark 4.0.0, we had better update target version to `Python 3.9`.

- #46228

`py39` is the version for `Python 3.9`.
```
$ black --help  | grep target
  -t, --target-version [py33|py34|py35|py36|py37|py38|py39|py310|py311|py312]
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with Python linter.

### Was this patch authored or co-authored using generative AI tooling?

No.