### PR TITLE
[SPARK-48374][PYTHON][TESTS][FOLLOW-UP] Explicitly enable ANSI mode for non-ANSI build

### DIFF
--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -1204,8 +1204,13 @@ class ArrowTestsMixin:
                 self.spark.sql("select 1/0").toPandas()
 
     def test_toArrow_error(self):
-        with self.assertRaises(ArithmeticException):
-            self.spark.sql("select 1/0").toArrow()
+        with self.sql_conf(
+            {
+                "spark.sql.ansi.enabled": True,
+            }
+        ):
+            with self.assertRaises(ArithmeticException):
+                self.spark.sql("select 1/0").toArrow()
 
     def test_toPandas_duplicate_field_names(self):
         for arrow_enabled in [True, False]:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to explicitly set ANSI mode in `test_toArrow_error` test.

### Why are the changes needed?

To make non-ANSI build passing https://github.com/apache/spark/actions/runs/9342888897/job/25711689943:

```

======================================================================
FAIL [0.180s]: test_toArrow_error (pyspark.sql.tests.connect.test_parity_arrow.ArrowParityTests.test_toArrow_error)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/spark/spark/python/pyspark/sql/tests/test_arrow.py", line 1207, in test_toArrow_error
    with self.assertRaises(ArithmeticException):
AssertionError: ArithmeticException not raised

----------------------------------------------------------------------
Ran 88 tests in 17.797s
```

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.