### PR TITLE
[SPARK-48535][SS] Update config docs to indicate possibility of data loss/corruption issue if skip nulls for stream-stream joins config is enabled

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2301,7 +2301,9 @@ object SQLConf {
   buildConf("spark.sql.streaming.stateStore.skipNullsForStreamStreamJoins.enabled")
     .internal()
     .doc("When true, this config will skip null values in hash based stream-stream joins. " +
-      "The number of skipped null values will be shown as custom metric of stream join operator.")
+      "The number of skipped null values will be shown as custom metric of stream join operator. " +
+      "If the streaming query was started with Spark 3.5 or above, please exercise caution " +
+      "before enabling this config since it may hide potential data loss/corruption issues.")
     .version("3.3.0")
     .booleanConf
     .createWithDefault(false)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update config docs to indicate possibility of data loss/corruption issue if skip nulls for stream-stream joins config is enabled

### Why are the changes needed?
Clarifying the implications of turning off this config after a certain Spark version


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
N/A - config doc only change


### Was this patch authored or co-authored using generative AI tooling?
No
