### PR TITLE
[SPARK-46124][FOLLOWUP][3.5][CONNECT][SS] Send missing fields in StreamingQueryProgress to client

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/progress.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/streaming/progress.scala
@@ -202,7 +202,7 @@ private[spark] object StreamingQueryProgress {
   }
 
   private[spark] def jsonString(progress: StreamingQueryProgress): String =
-    mapper.writeValueAsString(progress)
+    progress.json
 
   private[spark] def fromJson(json: String): StreamingQueryProgress =
     mapper.readValue[StreamingQueryProgress](json)

--- a/python/pyspark/sql/tests/streaming/test_streaming.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming.py
@@ -29,7 +29,7 @@ from pyspark.errors.exceptions.connect import SparkConnectException
 
 class StreamingTestsMixin:
     def test_streaming_query_functions_basic(self):
-        df = self.spark.readStream.format("rate").option("rowsPerSecond", 10).load()
+        df = self.spark.readStream.format("text").load("python/test_support/sql/streaming")
         query = (
             df.writeStream.format("memory")
             .queryName("test_streaming_query_functions_basic")

--- a/python/pyspark/sql/tests/streaming/test_streaming_listener.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_listener.py
@@ -192,6 +192,17 @@ class StreamingListenerTestsMixin:
         self.assertTrue(isinstance(progress.numOutputRows, int))
         self.assertTrue(isinstance(progress.metrics, dict))
 
+    def test_streaming_last_progress(self):
+        try:
+            df = self.spark.readStream.format("text").load("python/test_support/sql/streaming")
+            query = df.writeStream.format("noop").queryName("test_streaming_progress").start()
+            query.processAllAvailable()
+
+            progress = StreamingQueryProgress.fromJson(query.lastProgress)
+            self.check_streaming_query_progress(progress, False)
+        finally:
+            query.stop()
+
 
 class StreamingListenerTests(StreamingListenerTestsMixin, ReusedSQLTestCase):
     def test_number_of_public_methods(self):

--- a/sql/core/src/main/scala/org/apache/spark/sql/streaming/progress.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/streaming/progress.scala
@@ -186,7 +186,7 @@ private[spark] object StreamingQueryProgress {
   }
 
   private[spark] def jsonString(progress: StreamingQueryProgress): String =
-    mapper.writeValueAsString(progress)
+    progress.json
 
   private[spark] def fromJson(json: String): StreamingQueryProgress =
     mapper.readValue[StreamingQueryProgress](json)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Currently in PySpark Client, calling `query.lastProgress` won't return you three fields: 
https://github.com/apache/spark/blob/0bc2c69d3646b77e5e5e038a9828a1937a419f26/sql/core/src/main/scala/org/apache/spark/sql/streaming/progress.scala#L145-L152

This is because these three fields aren't native fields and is supposed to be reconstructed when rebuilding the client side `StreamingQueryProgress`. But this brings a bug only in Python Spark Connect.

This is not an issue for scala connect client, because the client side reconstruct the StreamingQueryProgress using the same way it's constructed in the server side.

The problem with python is the return type is a dict, so there is no such reconstruction, and therefor these fields are not there.
https://github.com/apache/spark/blob/d6fcba0d4ae73bc65022355b7c8da90ccae68213/python/pyspark/sql/connect/streaming/query.py#L122

This is not an issue in classic pyspark also, because classic pyspark calls the `jsonValue` of `StreamingQueryProgress`, which has all fields defined:
https://github.com/apache/spark/blob/0bc2c69d3646b77e5e5e038a9828a1937a419f26/sql/core/src/main/scala/org/apache/spark/sql/streaming/progress.scala#L162-L178

In this PR we send all such fields to the client to fix this issue. This won't cause backward compatibility issue because that field is a map anyways.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Bug fix

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added unit test, passed locally. Before the fix, the test would fail with:
```
======================================================================
ERROR: test_streaming_last_progress (pyspark.sql.tests.connect.streaming.test_parity_streaming.StreamingParityTests.test_streaming_last_progress)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/wei.liu/oss-spark/python/pyspark/sql/tests/streaming/test_streaming.py", line 68, in test_streaming_last_progress
    progress = StreamingQueryProgress.fromJson(query.lastProgress)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/wei.liu/oss-spark/python/pyspark/sql/streaming/listener.py", line 489, in fromJson
    numInputRows=j["numInputRows"],
                 ~^^^^^^^^^^^^^^^^
KeyError: 'numInputRows'
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No