### PR TITLE
[SPARK-48546][SQL] Fix ExpressionEncoder after replacing NullPointerExceptions with proper error classes in AssertNotNull expression

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/encoders/ExpressionEncoder.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.encoders
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 
+import org.apache.spark.SparkRuntimeException
 import org.apache.spark.sql.{Encoder, Row}
 import org.apache.spark.sql.catalyst.{DeserializerBuildHelper, InternalRow, JavaTypeInference, ScalaReflection, SerializerBuildHelper}
 import org.apache.spark.sql.catalyst.analysis.{Analyzer, GetColumnByOrdinal, SimpleAnalyzer, UnresolvedAttribute, UnresolvedExtractValue}
@@ -187,6 +188,8 @@ object ExpressionEncoder {
       }
       constructProjection(row).get(0, anyObjectType).asInstanceOf[T]
     } catch {
+      case e: SparkRuntimeException if e.getErrorClass == "NOT_NULL_ASSERT_VIOLATION" =>
+        throw e
       case e: Exception =>
         throw QueryExecutionErrors.expressionDecodingError(e, expressions)
     }
@@ -213,6 +216,8 @@ object ExpressionEncoder {
       inputRow(0) = t
       extractProjection(inputRow)
     } catch {
+      case e: SparkRuntimeException if e.getErrorClass == "NOT_NULL_ASSERT_VIOLATION" =>
+        throw e
       case e: Exception =>
         throw QueryExecutionErrors.expressionEncodingError(e, expressions)
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderResolutionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderResolutionSuite.scala
@@ -173,7 +173,7 @@ class EncoderResolutionSuite extends PlanTest {
     val exception = intercept[SparkRuntimeException] {
       fromRow(InternalRow(new GenericArrayData(Array(1, null))))
     }
-    assert(exception.getErrorClass == NOT_NULL_ASSERT_VIOLATION")
+    assert(exception.getErrorClass == "NOT_NULL_ASSERT_VIOLATION")
   }
 
   test("the real number of fields doesn't match encoder schema: tuple encoder") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderResolutionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderResolutionSuite.scala
@@ -170,17 +170,10 @@ class EncoderResolutionSuite extends PlanTest {
     fromRow(InternalRow(new GenericArrayData(Array(1, 2))))
 
     // If there is null value, it should throw runtime exception
-    checkError(
-      exception = intercept[SparkRuntimeException] {
-        fromRow(InternalRow(new GenericArrayData(Array(1, null))))
-      },
-      errorClass = "EXPRESSION_DECODING_FAILED",
-      sqlState = "42846",
-      parameters = Map(
-        "expressions" ->
-          ("mapobjects(lambdavariable(MapObject, IntegerType, true, -1), " +
-          "assertnotnull(lambdavariable(MapObject, IntegerType, true, -1)), " +
-          "input[0, array<int>, true], Some(interface scala.collection.immutable.Seq))")))
+    val exception = intercept[SparkRuntimeException] {
+      fromRow(InternalRow(new GenericArrayData(Array(1, null))))
+    }
+    assert(exception.getErrorClass = NOT_NULL_ASSERT_VIOLATION")
   }
 
   test("the real number of fields doesn't match encoder schema: tuple encoder") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderResolutionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/EncoderResolutionSuite.scala
@@ -173,7 +173,7 @@ class EncoderResolutionSuite extends PlanTest {
     val exception = intercept[SparkRuntimeException] {
       fromRow(InternalRow(new GenericArrayData(Array(1, null))))
     }
-    assert(exception.getErrorClass = NOT_NULL_ASSERT_VIOLATION")
+    assert(exception.getErrorClass == NOT_NULL_ASSERT_VIOLATION")
   }
 
   test("the real number of fields doesn't match encoder schema: tuple encoder") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
@@ -279,7 +279,7 @@ class RowEncoderSuite extends CodegenInterpretedPlanTest {
     // Check the error class only since the parameters may change depending on how we are running
     // this test case.
     val exception = intercept[SparkRuntimeException](toRow(encoder, null))
-    assert(exception.getErrorClass == "EXPRESSION_ENCODING_FAILED")
+    assert(exception.getErrorClass == "NOT_NULL_ASSERT_VIOLATION")
   }
 
   test("RowEncoder should validate external type") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -2081,11 +2081,8 @@ class DatasetSuite extends QueryTest
 
   test("SPARK-23835: null primitive data type should throw NullPointerException") {
     val ds = Seq[(Option[Int], Option[Int])]((Some(1), None)).toDS()
-    checkError(
-      exception = intercept[SparkRuntimeException](ds.as[(Int, Int)].collect()),
-      errorClass = "EXPRESSION_DECODING_FAILED",
-      sqlState = "42846",
-      parameters = Map("expressions" -> "newInstance(class scala.Tuple2)"))
+    val exception = intercept[SparkRuntimeException](ds.as[(Int, Int)].collect())
+    assert(exception.getErrorClass == "NOT_NULL_ASSERT_VIOLATION")
   }
 
   test("SPARK-24569: Option of primitive types are mistakenly mapped to struct type") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -1254,7 +1254,7 @@ class DatasetSuite extends QueryTest
     // Just check the error class here to avoid flakiness due to different parameters.
     assert(intercept[SparkRuntimeException] {
       buildDataset(Row(Row("hello", null))).collect()
-    }.getErrorClass == "EXPRESSION_DECODING_FAILED")
+    }.getErrorClass == "NOT_NULL_ASSERT_VIOLATION")
   }
 
   test("SPARK-12478: top level null field") {
@@ -1593,7 +1593,7 @@ class DatasetSuite extends QueryTest
 
   test("Dataset should throw RuntimeException if top-level product input object is null") {
     val e = intercept[SparkRuntimeException](Seq(ClassData("a", 1), null).toDS())
-    assert(e.getErrorClass == "EXPRESSION_ENCODING_FAILED")
+    assert(e.getErrorClass == "NOT_NULL_ASSERT_VIOLATION")
   }
 
   test("dropDuplicates") {
@@ -2036,18 +2036,19 @@ class DatasetSuite extends QueryTest
   test("SPARK-22472: add null check for top-level primitive values") {
     // If the primitive values are from Option, we need to do runtime null check.
     val ds = Seq(Some(1), None).toDS().as[Int]
-    val errorClass = "EXPRESSION_DECODING_FAILED"
-    val sqlState = "42846"
+    val errorClass = "NOT_NULL_ASSERT_VIOLATION"
+    val sqlState = "42000"
+    val parameters = Map("walkedTypePath" -> "\n- root class: \"int\"\n")
     checkError(
       exception = intercept[SparkRuntimeException](ds.collect()),
-      errorClass = "EXPRESSION_DECODING_FAILED",
-      sqlState = "42846",
-      parameters = Map("expressions" -> "assertnotnull(input[0, int, true])"))
+      errorClass = errorClass,
+      sqlState = sqlState,
+      parameters = parameters)
     checkError(
       exception = intercept[SparkRuntimeException](ds.map(_ * 2).collect()),
-      errorClass = "NOT_NULL_ASSERT_VIOLATION",
-      sqlState = "42000",
-      parameters = Map("walkedTypePath" -> "\n- root class: \"int\"\n"))
+      errorClass = errorClass,
+      sqlState = sqlState,
+      parameters = parameters)
 
     withTempPath { path =>
       Seq(Integer.valueOf(1), null).toDF("i").write.parquet(path.getCanonicalPath)
@@ -2055,14 +2056,14 @@ class DatasetSuite extends QueryTest
       val ds = spark.read.parquet(path.getCanonicalPath).as[Int]
       checkError(
         exception = intercept[SparkRuntimeException](ds.collect()),
-        errorClass = "EXPRESSION_DECODING_FAILED",
-        sqlState = "42846",
-        parameters = Map("expressions" -> "assertnotnull(input[0, int, true])"))
+        errorClass = errorClass,
+        sqlState = sqlState,
+        parameters = parameters)
       checkError(
         exception = intercept[SparkRuntimeException](ds.map(_ * 2).collect()),
-        errorClass = "NOT_NULL_ASSERT_VIOLATION",
-        sqlState = "42000",
-        parameters = Map("walkedTypePath" -> "\n- root class: \"int\"\n"))
+        errorClass = errorClass,
+        sqlState = sqlState,
+        parameters = parameters)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

In https://github.com/apache/spark/pull/46793, we replaced NullPointerExceptions with proper error classes in AssertNotNull expression. However, that PR forgot to update the `ExpressionEncoder` to check for these new error classes. This PR fixes it to make sure we use the new error classes in all cases.

### Why are the changes needed?

See above

### Does this PR introduce _any_ user-facing change?

Yes, see above

### How was this patch tested?

This PR updates tests with the new error classes

### Was this patch authored or co-authored using generative AI tooling?

No