### PR TITLE
[SPARK-48558][CORE] Improve accumulator V2 error message

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
+++ b/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
@@ -166,7 +166,7 @@ abstract class AccumulatorV2[IN, OUT] extends Serializable {
     if (atDriverSide) {
       if (!isRegistered) {
         throw new UnsupportedOperationException(
-          "Accumulator must be registered before send to executor")
+          s"Accumulator '${this.name.get}' must be registered before send to executor")
       }
       val copyAcc = copyAndReset()
       assert(copyAcc.isZero, "copyAndReset must return a zero value copy")

--- a/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
+++ b/core/src/main/scala/org/apache/spark/util/AccumulatorV2.scala
@@ -165,8 +165,13 @@ abstract class AccumulatorV2[IN, OUT] extends Serializable {
   final protected def writeReplace(): Any = {
     if (atDriverSide) {
       if (!isRegistered) {
+        val printName = if (this.name.isDefined) {
+          s" '${this.name.get}' "
+        } else {
+          " "
+        }
         throw new UnsupportedOperationException(
-          s"Accumulator '${this.name.get}' must be registered before send to executor")
+          s"Accumulator${printName}must be registered before send to executor")
       }
       val copyAcc = copyAndReset()
       assert(copyAcc.isZero, "copyAndReset must return a zero value copy")


### PR DESCRIPTION

### What changes were proposed in this pull request?
Improves the error message for when an accumulator V2 is used before registering.

### Why are the changes needed?
More user friendly. The change makes it easier to identify the accumulator that caused the problem.

### Does this PR introduce _any_ user-facing change?
Yes the error message is more informative.

### How was this patch tested?
Existing tests

### Was this patch authored or co-authored using generative AI tooling?
NO
