### PR TITLE
[SPARK-48564][PYTHON][CONNECT] Propagate cached schema in set operations

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1132,6 +1132,8 @@ class DataFrame(ParentDataFrame):
         print(self._show_string(n, truncate, vertical))
 
     def _merge_cached_schema(self, other: ParentDataFrame) -> Optional[StructType]:
+        # to avoid type coercion, only propagate the schema
+        # when the cached schemas are exactly the same
         if self._cached_schema is not None and self._cached_schema == other._cached_schema:  # type: ignore[arg-type]
             return self.schema
         return None

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1134,7 +1134,7 @@ class DataFrame(ParentDataFrame):
     def _merge_cached_schema(self, other: ParentDataFrame) -> Optional[StructType]:
         # to avoid type coercion, only propagate the schema
         # when the cached schemas are exactly the same
-        if self._cached_schema is not None and self._cached_schema == other._cached_schema:  # type: ignore[arg-type]
+        if self._cached_schema is not None and self._cached_schema == other._cached_schema:
             return self.schema
         return None
 

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1131,24 +1131,31 @@ class DataFrame(ParentDataFrame):
     def show(self, n: int = 20, truncate: Union[bool, int] = True, vertical: bool = False) -> None:
         print(self._show_string(n, truncate, vertical))
 
+    def _merge_cached_schema(self, other: ParentDataFrame) -> Optional[StructType]:
+        if self._cached_schema is not None and self._cached_schema == other._cached_schema:  # type: ignore[arg-type]
+            return self.schema
+        return None
+
     def union(self, other: ParentDataFrame) -> ParentDataFrame:
         self._check_same_session(other)
         return self.unionAll(other)
 
     def unionAll(self, other: ParentDataFrame) -> ParentDataFrame:
         self._check_same_session(other)
-        return DataFrame(
+        res = DataFrame(
             plan.SetOperation(
                 self._plan, other._plan, "union", is_all=True  # type: ignore[arg-type]
             ),
             session=self._session,
         )
+        res._cached_schema = self._merge_cached_schema(other)
+        return res
 
     def unionByName(
         self, other: ParentDataFrame, allowMissingColumns: bool = False
     ) -> ParentDataFrame:
         self._check_same_session(other)
-        return DataFrame(
+        res = DataFrame(
             plan.SetOperation(
                 self._plan,
                 other._plan,  # type: ignore[arg-type]
@@ -1158,42 +1165,52 @@ class DataFrame(ParentDataFrame):
             ),
             session=self._session,
         )
+        res._cached_schema = self._merge_cached_schema(other)
+        return res
 
     def subtract(self, other: ParentDataFrame) -> ParentDataFrame:
         self._check_same_session(other)
-        return DataFrame(
+        res = DataFrame(
             plan.SetOperation(
                 self._plan, other._plan, "except", is_all=False  # type: ignore[arg-type]
             ),
             session=self._session,
         )
+        res._cached_schema = self._merge_cached_schema(other)
+        return res
 
     def exceptAll(self, other: ParentDataFrame) -> ParentDataFrame:
         self._check_same_session(other)
-        return DataFrame(
+        res = DataFrame(
             plan.SetOperation(
                 self._plan, other._plan, "except", is_all=True  # type: ignore[arg-type]
             ),
             session=self._session,
         )
+        res._cached_schema = self._merge_cached_schema(other)
+        return res
 
     def intersect(self, other: ParentDataFrame) -> ParentDataFrame:
         self._check_same_session(other)
-        return DataFrame(
+        res = DataFrame(
             plan.SetOperation(
                 self._plan, other._plan, "intersect", is_all=False  # type: ignore[arg-type]
             ),
             session=self._session,
         )
+        res._cached_schema = self._merge_cached_schema(other)
+        return res
 
     def intersectAll(self, other: ParentDataFrame) -> ParentDataFrame:
         self._check_same_session(other)
-        return DataFrame(
+        res = DataFrame(
             plan.SetOperation(
                 self._plan, other._plan, "intersect", is_all=True  # type: ignore[arg-type]
             ),
             session=self._session,
         )
+        res._cached_schema = self._merge_cached_schema(other)
+        return res
 
     def where(self, condition: Union[Column, str]) -> ParentDataFrame:
         if not isinstance(condition, (str, Column)):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Propagate cached schema in set operations


### Why are the changes needed?
to avoid extra RPC to get the schema of result data frame


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
added tests


### Was this patch authored or co-authored using generative AI tooling?
No