### PR TITLE
[MINOR][PYTHON][DOCS] Fix pyspark.sql.functions.reduce docstring typo

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -18389,7 +18389,7 @@ def aggregate(
         initial value. Name of column or expression
     merge : function
         a binary function ``(acc: Column, x: Column) -> Column...`` returning expression
-        of the same type as ``zero``
+        of the same type as ``initialValue``
     finish : function, optional
         an optional unary function ``(x: Column) -> Column: ...``
         used to convert accumulated value.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes a mistake in the docstring for `pyspark.sql.functions.reduce`. The parameter to the function is called `initialValue` not `zero` - there is no other mention of `zero` on the page, so it must be a mistake and should be `initialValue`.

### Why are the changes needed?

The docstring is incorrect.

### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

N/A


### Was this patch authored or co-authored using generative AI tooling?

No
