### PR TITLE
[SPARK-47500][PYTHON][CONNECT][FOLLOWUP] Restore error message for `DataFrame.select(None)`

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -223,6 +223,11 @@ class DataFrame(ParentDataFrame):
     def select(self, *cols: "ColumnOrName") -> ParentDataFrame:  # type: ignore[misc]
         if len(cols) == 1 and isinstance(cols[0], list):
             cols = cols[0]
+        if any(not isinstance(c, (str, Column)) for c in cols):
+            raise PySparkTypeError(
+                error_class="NOT_LIST_OF_COLUMN_OR_STR",
+                message_parameters={"arg_name": "columns"},
+            )
         return DataFrame(
             plan.Project(self._plan, [F._to_col(c) for c in cols]),
             session=self._session,

--- a/python/pyspark/sql/tests/connect/test_connect_error.py
+++ b/python/pyspark/sql/tests/connect/test_connect_error.py
@@ -21,6 +21,7 @@ from pyspark.errors import PySparkAttributeError
 from pyspark.errors.exceptions.base import SessionNotSameException
 from pyspark.sql.types import Row
 from pyspark.testing.connectutils import should_test_connect
+from pyspark.errors import PySparkTypeError
 from pyspark.errors.exceptions.connect import AnalysisException
 from pyspark.sql.tests.connect.test_connect_basic import SparkConnectSQLTestCase
 
@@ -213,6 +214,16 @@ class SparkConnectErrorTests(SparkConnectSQLTestCase):
     def test_column_cannot_be_constructed_from_string(self):
         with self.assertRaises(TypeError):
             Column("col")
+
+    def test_select_none(self):
+        with self.assertRaises(PySparkTypeError) as e1:
+            self.connect.range(1).select(None)
+
+        self.check_error(
+            exception=e1.exception,
+            error_class="NOT_LIST_OF_COLUMN_OR_STR",
+            message_parameters={"arg_name": "columns"},
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?
the refactor PR https://github.com/apache/spark/pull/45636 changed the error message of `DataFrame.select(None)` from `PySparkTypeError` to `AssertionError`, this PR restore the previous error message


### Why are the changes needed?
error message improvement


### Does this PR introduce _any_ user-facing change?
yes, error message improvement


### How was this patch tested?
added test


### Was this patch authored or co-authored using generative AI tooling?
no