### PR TITLE
 [SPARK-48580][CORE] Add consistency check and fallback for mapIds in push-merged block meta

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -1018,6 +1018,8 @@ final class ShuffleBlockFetcherIterator(
             shuffleId, shuffleMergeId, reduceId, bitmaps, localDirs) =>
             // Fetch push-merged-local shuffle block data as multiple shuffle chunks
             val shuffleBlockId = ShuffleMergedBlockId(shuffleId, shuffleMergeId, reduceId)
+            pushBasedFetchHelper.checkPushMergedBlockMetaConsistency(
+              shuffleBlockId, blockManager.blockManagerId, bitmaps)
             try {
               val bufs: Seq[ManagedBuffer] = blockManager.getLocalMergedBlockData(shuffleBlockId,
                 localDirs)
@@ -1055,6 +1057,8 @@ final class ShuffleBlockFetcherIterator(
           // count of this is added to numBlocksToFetch in collectFetchReqsFromMergedBlocks.
           numBlocksInFlightPerAddress(address) -= 1
           numBlocksToFetch -= 1
+          pushBasedFetchHelper.checkPushMergedBlockMetaConsistency(
+            ShuffleMergedBlockId(shuffleId, shuffleMergeId, reduceId), address, bitmaps)
           val blocksToFetch = pushBasedFetchHelper.createChunkBlockInfosFromMetaResponse(
             shuffleId, shuffleMergeId, reduceId, blockSize, bitmaps)
           val additionalRemoteReqs = new ArrayBuffer[FetchRequest]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add consistency check for mapIds between the push-merged block meta from the server side and the mapTracker on the driver side for reduce tasks. If any mapIds is found missing in the chunk meta, fallback to fetching original shuffle blocks.
This end-to-end check helps to avoid issues of data loss during the shuffle read phase when reduce tasks fetch merged data.

### Why are the changes needed?

ShuffleBlockFetcherIterator initializes requests based on the mergeStatus and mapStatus from the driver side, where the mergeStatus's mapTracker (partition level bitmap) comes from the mapTracker maintained in the shuffle service's memory. but the actual mapIds for fetching chunk data come from the shuffle service's metaFile. There is no consistency check between the two. 
When the server encounters issues such as disk failures, it may cause inconsistencies in mapIds between the mapTracker and the metaFile. This ultimately results in data loss when reduce tasks fetch merged data.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UT

### Was this patch authored or co-authored using generative AI tooling?
No