### PR TITLE
[SPARK-48372][SPARK-45716][PYTHON][FOLLOW-UP] Remove unused helper method

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1844,14 +1844,6 @@ class DataFrame(ParentDataFrame):
         assert result is not None
         return result
 
-    def _tree_string(self, level: Optional[int] = None) -> str:
-        query = self._plan.to_proto(self._session.client)
-        result = self._session.client._analyze(
-            method="tree_string", plan=query, level=level
-        ).tree_string
-        assert result is not None
-        return result
-
     def printSchema(self, level: Optional[int] = None) -> None:
         if level:
             print(self.schema.treeString(level))

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -568,7 +568,7 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
 
     def test_print_schema(self):
         # SPARK-41216: Test print schema
-        tree_str = self.connect.sql("SELECT 1 AS X, 2 AS Y")._tree_string()
+        tree_str = self.connect.sql("SELECT 1 AS X, 2 AS Y").schema.treeString()
         # root
         #  |-- X: integer (nullable = false)
         #  |-- Y: integer (nullable = false)


### PR DESCRIPTION
### What changes were proposed in this pull request?
followup of https://github.com/apache/spark/pull/46685, to remove unused helper method


### Why are the changes needed?
method `_tree_string` is no longer needed


### Does this PR introduce _any_ user-facing change?
No, internal change only

### How was this patch tested?
CI

### Was this patch authored or co-authored using generative AI tooling?
No