### PR TITLE
Revert "[SPARK-46937][SQL] Improve concurrency performance for FunctionRegistry"

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -18,9 +18,9 @@
 package org.apache.spark.sql.catalyst.analysis
 
 import java.util.Locale
-import java.util.concurrent.ConcurrentHashMap
+import javax.annotation.concurrent.GuardedBy
 
-import scala.jdk.CollectionConverters._
+import scala.collection.mutable
 import scala.reflect.ClassTag
 
 import org.apache.spark.SparkUnsupportedOperationException
@@ -195,8 +195,9 @@ object FunctionRegistryBase {
 
 trait SimpleFunctionRegistryBase[T] extends FunctionRegistryBase[T] with Logging {
 
+  @GuardedBy("this")
   protected val functionBuilders =
-    new ConcurrentHashMap[FunctionIdentifier, (ExpressionInfo, FunctionBuilder)]
+    new mutable.HashMap[FunctionIdentifier, (ExpressionInfo, FunctionBuilder)]
 
   // Resolution of the function name is always case insensitive, but the database name
   // depends on the caller
@@ -219,10 +220,10 @@ trait SimpleFunctionRegistryBase[T] extends FunctionRegistryBase[T] with Logging
   def internalRegisterFunction(
       name: FunctionIdentifier,
       info: ExpressionInfo,
-      builder: FunctionBuilder): Unit = {
+      builder: FunctionBuilder): Unit = synchronized {
     val newFunction = (info, builder)
     functionBuilders.put(name, newFunction) match {
-      case previousFunction if previousFunction != newFunction =>
+      case Some(previousFunction) if previousFunction != newFunction =>
         logWarning(log"The function ${MDC(FUNCTION_NAME, name)} replaced a " +
           log"previously registered function.")
       case _ =>
@@ -230,25 +231,34 @@ trait SimpleFunctionRegistryBase[T] extends FunctionRegistryBase[T] with Logging
   }
 
   override def lookupFunction(name: FunctionIdentifier, children: Seq[Expression]): T = {
-    val func = Option(functionBuilders.get(normalizeFuncName(name))).map(_._2).getOrElse {
-      throw QueryCompilationErrors.unresolvedRoutineError(name, Seq("system.builtin"))
+    val func = synchronized {
+      functionBuilders.get(normalizeFuncName(name)).map(_._2).getOrElse {
+        throw QueryCompilationErrors.unresolvedRoutineError(name, Seq("system.builtin"))
+      }
     }
     func(children)
   }
 
-  override def listFunction(): Seq[FunctionIdentifier] =
-    functionBuilders.keys().asScala.toSeq
+  override def listFunction(): Seq[FunctionIdentifier] = synchronized {
+    functionBuilders.iterator.map(_._1).toList
+  }
 
-  override def lookupFunction(name: FunctionIdentifier): Option[ExpressionInfo] =
-    Option(functionBuilders.get(normalizeFuncName(name))).map(_._1)
+  override def lookupFunction(name: FunctionIdentifier): Option[ExpressionInfo] = synchronized {
+    functionBuilders.get(normalizeFuncName(name)).map(_._1)
+  }
 
-  override def lookupFunctionBuilder(name: FunctionIdentifier): Option[FunctionBuilder] =
-    Option(functionBuilders.get(normalizeFuncName(name))).map(_._2)
+  override def lookupFunctionBuilder(
+      name: FunctionIdentifier): Option[FunctionBuilder] = synchronized {
+    functionBuilders.get(normalizeFuncName(name)).map(_._2)
+  }
 
-  override def dropFunction(name: FunctionIdentifier): Boolean =
-    Option(functionBuilders.remove(normalizeFuncName(name))).isDefined
+  override def dropFunction(name: FunctionIdentifier): Boolean = synchronized {
+    functionBuilders.remove(normalizeFuncName(name)).isDefined
+  }
 
-  override def clear(): Unit = functionBuilders.clear()
+  override def clear(): Unit = synchronized {
+    functionBuilders.clear()
+  }
 }
 
 /**
@@ -298,11 +308,7 @@ class SimpleFunctionRegistry
 
   override def clone(): SimpleFunctionRegistry = synchronized {
     val registry = new SimpleFunctionRegistry
-    val iterator = functionBuilders.entrySet().iterator()
-    while (iterator.hasNext) {
-      val entry = iterator.next()
-      val name = entry.getKey
-      val (info, builder) = entry.getValue
+    functionBuilders.iterator.foreach { case (name, (info, builder)) =>
       registry.internalRegisterFunction(name, info, builder)
     }
     registry
@@ -1030,11 +1036,7 @@ class SimpleTableFunctionRegistry extends SimpleFunctionRegistryBase[LogicalPlan
 
   override def clone(): SimpleTableFunctionRegistry = synchronized {
     val registry = new SimpleTableFunctionRegistry
-    val iterator = functionBuilders.entrySet().iterator()
-    while (iterator.hasNext) {
-      val entry = iterator.next()
-      val name = entry.getKey
-      val (info, builder) = entry.getValue
+    functionBuilders.iterator.foreach { case (name, (info, builder)) =>
       registry.internalRegisterFunction(name, info, builder)
     }
     registry

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -222,7 +222,7 @@ trait SimpleFunctionRegistryBase[T] extends FunctionRegistryBase[T] with Logging
       builder: FunctionBuilder): Unit = {
     val newFunction = (info, builder)
     functionBuilders.put(name, newFunction) match {
-      case previousFunction if previousFunction != null =>
+      case previousFunction if previousFunction != newFunction =>
         logWarning(log"The function ${MDC(FUNCTION_NAME, name)} replaced a " +
           log"previously registered function.")
       case _ =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Reverts https://github.com/apache/spark/pull/44976 as it breaks thread-safety

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix thread-safety

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
N/A

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no