### PR TITLE
[SPARK-48594][PYTHON][CONNECT] Rename `parent` field to `child` in `ColumnAlias`

### DIFF
--- a/python/pyspark/sql/connect/expressions.py
+++ b/python/pyspark/sql/connect/expressions.py
@@ -153,18 +153,18 @@ class CaseWhen(Expression):
 
 
 class ColumnAlias(Expression):
-    def __init__(self, parent: Expression, alias: Sequence[str], metadata: Any):
+    def __init__(self, child: Expression, alias: Sequence[str], metadata: Any):
         super().__init__()
 
         self._alias = alias
         self._metadata = metadata
-        self._parent = parent
+        self._child = child
 
     def to_plan(self, session: "SparkConnectClient") -> "proto.Expression":
         if len(self._alias) == 1:
             exp = proto.Expression()
             exp.alias.name.append(self._alias[0])
-            exp.alias.expr.CopyFrom(self._parent.to_plan(session))
+            exp.alias.expr.CopyFrom(self._child.to_plan(session))
 
             if self._metadata:
                 exp.alias.metadata = json.dumps(self._metadata)
@@ -177,11 +177,11 @@ class ColumnAlias(Expression):
                 )
             exp = proto.Expression()
             exp.alias.name.extend(self._alias)
-            exp.alias.expr.CopyFrom(self._parent.to_plan(session))
+            exp.alias.expr.CopyFrom(self._child.to_plan(session))
             return exp
 
     def __repr__(self) -> str:
-        return f"{self._parent} AS {','.join(self._alias)}"
+        return f"{self._child} AS {','.join(self._alias)}"
 
 
 class LiteralExpression(Expression):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Rename `parent` field to `child` in `ColumnAlias`

### Why are the changes needed?
it should be `child` other than `parent`, to be consistent with both other expressions in `expressions.py` and the Scala side.


### Does this PR introduce _any_ user-facing change?
No, it is just an internal change


### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
No
