### PR TITLE
[SPARK-48601][SQL] Give a more user friendly error message when setting a null value for JDBC Option

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2597,6 +2597,12 @@
     },
     "sqlState" : "22023"
   },
+  "NULL_DATA_SOURCE_OPTION" : {
+    "message" : [
+      "JDBC Option value <option> cannot have null value."
+    ],
+    "sqlState" : "22024"
+  },
   "INVALID_PARTITION_COLUMN_DATA_TYPE" : {
     "message" : [
       "Cannot use <type> for partition column."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2597,12 +2597,6 @@
     },
     "sqlState" : "22023"
   },
-  "NULL_DATA_SOURCE_OPTION" : {
-    "message" : [
-      "JDBC Option value <option> cannot have null value."
-    ],
-    "sqlState" : "22024"
-  },
   "INVALID_PARTITION_COLUMN_DATA_TYPE" : {
     "message" : [
       "Cannot use <type> for partition column."
@@ -3333,6 +3327,12 @@
       "Row ID attributes cannot be nullable: <nullableRowIdAttrs>."
     ],
     "sqlState" : "42000"
+  },
+  "NULL_DATA_SOURCE_OPTION" : {
+    "message" : [
+      "JDBC Option value <option> cannot have null value."
+    ],
+    "sqlState" : "22024"
   },
   "NULL_MAP_KEY" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3330,7 +3330,7 @@
   },
   "NULL_DATA_SOURCE_OPTION" : {
     "message" : [
-      "JDBC Option value <option> cannot have null value."
+      "Data source read/write option <option> cannot have null value."
     ],
     "sqlState" : "22024"
   },

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -175,6 +175,13 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
         "functionName" -> toSQLId(funcName)))
   }
 
+  def nullDataSourceOption(option: String): Throwable = {
+    new AnalysisException(
+      errorClass = "NULL_DATA_SOURCE_OPTION",
+      messageParameters = Map("option" -> option)
+    )
+  }
+
   def unorderablePivotColError(pivotCol: Expression): Throwable = {
     new AnalysisException(
       errorClass = "INCOMPARABLE_PIVOT_COLUMN",

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -54,7 +54,7 @@ class JDBCOptions(
       // If an option value is `null`, throw a user-friendly error. Keys here cannot be null, as
       // scala's implementation of Maps prohibits null keys.
       if (v == null) {
-        throw QueryCompilationErrors.nullArgumentError("JDBCOptions.asProperties", k)
+        throw QueryCompilationErrors.nullArgumentError("JDBC Options", k)
       }
       properties.setProperty(k, v)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -19,7 +19,9 @@ package org.apache.spark.sql.execution.datasources.jdbc
 
 import java.sql.{Connection, DriverManager}
 import java.util.{Locale, Properties}
+
 import org.apache.commons.io.FilenameUtils
+
 import org.apache.spark.SparkFiles
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -19,13 +19,11 @@ package org.apache.spark.sql.execution.datasources.jdbc
 
 import java.sql.{Connection, DriverManager}
 import java.util.{Locale, Properties}
-
 import org.apache.commons.io.FilenameUtils
-
 import org.apache.spark.SparkFiles
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
-import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.TimestampNTZType
 import org.apache.spark.util.Utils
@@ -52,7 +50,14 @@ class JDBCOptions(
    */
   val asProperties: Properties = {
     val properties = new Properties()
-    parameters.originalMap.foreach { case (k, v) => properties.setProperty(k, v) }
+    parameters.originalMap.foreach { case (k, v) =>
+      // If an option value is `null`, throw a user-friendly error. Keys here cannot be null, as
+      // scala's implementation of Maps prohibits null keys.
+      if (v == null) {
+        throw QueryCompilationErrors.nullArgumentError("JDBCOptions.asProperties", k)
+      }
+      properties.setProperty(k, v)
+    }
     properties
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -56,7 +56,7 @@ class JDBCOptions(
       // If an option value is `null`, throw a user-friendly error. Keys here cannot be null, as
       // scala's implementation of Maps prohibits null keys.
       if (v == null) {
-        throw QueryCompilationErrors.nullArgumentError("JDBC Options", k)
+        throw QueryCompilationErrors.nullDataSourceOption(k)
       }
       properties.setProperty(k, v)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -377,10 +377,9 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       exception = intercept[AnalysisException] {
         df.collect()
       },
-      errorClass = "INVALID_PARAMETER_VALUE.NULL",
+      errorClass = "NULL_DATA_SOURCE_OPTION",
       parameters = Map(
-        "parameter" -> "`pushDownOffset`",
-        "functionName" -> "`JDBC Options`")
+        "option" -> "pushDownOffset")
     )
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -369,6 +369,21 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
     }
   }
 
+  test("null value for option exception") {
+    val df = spark.read
+      .option("pushDownOffset", null)
+      .table("h2.test.employee")
+    checkError(
+      exception = intercept[AnalysisException] {
+        df.collect()
+      },
+      errorClass = "INVALID_PARAMETER_VALUE.NULL",
+      parameters = Map(
+        "parameter" -> "`pushDownOffset`",
+        "functionName" -> "`JDBCOptions`.`asProperties`")
+    )
+  }
+
   test("simple scan with OFFSET") {
     val df1 = spark.read
       .table("h2.test.employee")

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -380,7 +380,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       errorClass = "INVALID_PARAMETER_VALUE.NULL",
       parameters = Map(
         "parameter" -> "`pushDownOffset`",
-        "functionName" -> "`JDBCOptions`.`asProperties`")
+        "functionName" -> "`JDBC Options`")
     )
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR, proposed changes add a check for validating that JDBC Option values are not null, and throw a user-friendly error in case that they are.


### Why are the changes needed?
When setting a `null` value for JDBC Option, a spark internal exception is thrown due to java.lang.NullPointerException. A more user-friendly message should be thrown in such cases.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
A new test in this PR.


### Was this patch authored or co-authored using generative AI tooling?
No
