### PR TITLE
[SPARK-48584][SQL][FOLLOWUP] Improve the unescapePathName.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtils.scala
@@ -103,7 +103,7 @@ object ExternalCatalogUtils {
     }
     var plaintextEndIdx = path.indexOf('%')
     val length = path.length
-    if (plaintextEndIdx == -1 || plaintextEndIdx + 2 > length) {
+    if (plaintextEndIdx == -1 || plaintextEndIdx + 2 >= length) {
       // fast path, no %xx encoding found then return the string identity
       path
     } else {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/ExternalCatalogUtilsSuite.scala
@@ -59,6 +59,8 @@ class ExternalCatalogUtilsSuite extends SparkFunSuite {
     assert(unescapePathName("a%2Fb") === "a/b")
     assert(unescapePathName("a%2") === "a%2")
     assert(unescapePathName("a%F ") === "a%F ")
+    assert(unescapePathName("%0") === "%0")
+    assert(unescapePathName("0%") === "0%")
     // scalastyle:off nonascii
     assert(unescapePathName("a\u00FF") === "a\u00FF")
     // scalastyle:on nonascii


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR follows up https://github.com/apache/spark/pull/46938 and improve the `unescapePathName`.


### Why are the changes needed?
Improve the `unescapePathName` by cut off slow path.


### Does this PR introduce _any_ user-facing change?
'No'.


### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
