### PR TITLE
[SPARK-48619] Fix reference error when grouping by MapType

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InsertMapSortInGroupingExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InsertMapSortInGroupingExpressions.scala
@@ -43,7 +43,7 @@ object InsertMapSortInGroupingExpressions extends Rule[LogicalPlan] with AliasHe
         !expr.isInstanceOf[MapSort] && expr.dataType.isInstanceOf[MapType]
       )
       val newChild = Project(toSort.map( expr =>
-        Alias(MapSort(expr), "map_sorted")()
+        Alias(MapSort(expr), s"map_sorted_${expr.prettyName}")()
       ), child)
       val sortedAliasMap = getAliasMap(newChild)
       val newGroupingExpr = groupingExpr.map(expr => replaceAlias(expr, sortedAliasMap))

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -2202,6 +2202,36 @@ class DataFrameAggregateSuite extends QueryTest
     assertAggregateOnDataframe(dfDifferent, numRows, "m0")
   }
 
+  test("Fix reference error when grouping by MapType") {
+    val numRows = 50
+
+    val dfSingleColumn = (0 until numRows)
+      .map(_ => Tuple1(Map(1 -> 1)))
+      .toDF("m")
+    val resultSingleColumn = dfSingleColumn.groupBy("m")
+      .agg(count("*")).select("m", "count(1)")
+    checkAnswer(
+      resultSingleColumn,
+      Seq[Row](
+        Row(Map(1 -> 1), numRows)
+      )
+    )
+
+    val dfMultiColumn = (0 until numRows)
+      .map(_ => Tuple2(Map(1 -> 1), Map(2 -> 2)))
+      .toDF("m0", "m1")
+
+    val resultMultiColumn = dfMultiColumn.groupBy("m0", "m1")
+      .agg(count("*")).select("m0", "m1", "count(1)")
+    checkAnswer(
+      resultMultiColumn,
+      Seq[Row](
+        Row(Map(1 -> 1), Map(2 -> 2), numRows)
+      )
+    )
+
+  }
+
   test("SPARK-46536 Support GROUP BY CalendarIntervalType") {
     val numRows = 50
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR, rule `InsertMapSortInGroupingExpressions` was modified to add an alias for `map_sort(col)` . Grouping and aggregate expressions are then modified to use this alias.

### Why are the changes needed?
Currently, trying to reference a map column that is being grouped by, causes reference errors because we are only replacing the grouping expression `m` with `map_sort(m)`. The following query fails:

```sql
SELECT m FROM table GROUP BY m
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
New Tests in this PR, and existing tests regarding grouping of map types.


### Was this patch authored or co-authored using generative AI tooling?
No
