### PR TITLE
[SPARK-48621][SQL] Fix Like simplification in Optimizer for collated strings

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSQLRegexpSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSQLRegexpSuite.scala
@@ -18,6 +18,8 @@
 package org.apache.spark.sql
 
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.logical.Project
+import org.apache.spark.sql.internal.SqlApiConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{ArrayType, BooleanType, IntegerType, StringType}
 
@@ -53,6 +55,57 @@ class CollationSQLRegexpSuite
       }
       assert(unsupportedCollation.getErrorClass === "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE")
     })
+  }
+
+  test("Like simplification should work with collated strings") {
+    case class SimplifyLikeTestCase[R](collation: String, str: String, cls: Class[_], result: R)
+    val testCases = Seq(
+      SimplifyLikeTestCase("UTF8_BINARY", "ab%", classOf[StartsWith], false),
+      SimplifyLikeTestCase("UTF8_BINARY", "%bc", classOf[EndsWith], false),
+      SimplifyLikeTestCase("UTF8_BINARY", "a%c", classOf[And], false),
+      SimplifyLikeTestCase("UTF8_BINARY", "%b%", classOf[Contains], false),
+      SimplifyLikeTestCase("UTF8_BINARY", "abc", classOf[EqualTo], false),
+      SimplifyLikeTestCase("UTF8_LCASE", "ab%", classOf[StartsWith], true),
+      SimplifyLikeTestCase("UTF8_LCASE", "%bc", classOf[EndsWith], true),
+      SimplifyLikeTestCase("UTF8_LCASE", "a%c", classOf[And], true),
+      SimplifyLikeTestCase("UTF8_LCASE", "%b%", classOf[Contains], true),
+      SimplifyLikeTestCase("UTF8_LCASE", "abc", classOf[EqualTo], true)
+    )
+    sql("CREATE TABLE IF NOT EXISTS t(c STRING) using PARQUET")
+    sql("INSERT INTO t(c) VALUES('ABC')")
+    testCases.foreach(t => {
+      val query = sql(s"select c collate ${t.collation} like '${t.str}' FROM t")
+      checkAnswer(query, Row(t.result))
+      val optimizedPlan = query.queryExecution.optimizedPlan.asInstanceOf[Project]
+      assert(optimizedPlan.projectList.head.asInstanceOf[Alias].child.getClass == t.cls)
+    })
+  }
+
+  test("Like simplification should work with collated strings (for default collation)") {
+    val tableNameBinary = "T_BINARY"
+    withTable(tableNameBinary) {
+      withSQLConf(SqlApiConf.DEFAULT_COLLATION -> "UTF8_BINARY") {
+        sql(s"CREATE TABLE IF NOT EXISTS $tableNameBinary(c STRING) using PARQUET")
+        sql(s"INSERT INTO $tableNameBinary(c) VALUES('ABC')")
+        checkAnswer(sql(s"select c like 'ab%' FROM $tableNameBinary"), Row(false))
+        checkAnswer(sql(s"select c like '%bc' FROM $tableNameBinary"), Row(false))
+        checkAnswer(sql(s"select c like 'a%c' FROM $tableNameBinary"), Row(false))
+        checkAnswer(sql(s"select c like '%b%' FROM $tableNameBinary"), Row(false))
+        checkAnswer(sql(s"select c like 'abc' FROM $tableNameBinary"), Row(false))
+      }
+    }
+    val tableNameLcase = "T_LCASE"
+    withTable(tableNameLcase) {
+      withSQLConf(SqlApiConf.DEFAULT_COLLATION -> "UTF8_LCASE") {
+        sql(s"CREATE TABLE IF NOT EXISTS $tableNameLcase(c STRING) using PARQUET")
+        sql(s"INSERT INTO $tableNameLcase(c) VALUES('ABC')")
+        checkAnswer(sql(s"select c like 'ab%' FROM $tableNameLcase"), Row(true))
+        checkAnswer(sql(s"select c like '%bc' FROM $tableNameLcase"), Row(true))
+        checkAnswer(sql(s"select c like 'a%c' FROM $tableNameLcase"), Row(true))
+        checkAnswer(sql(s"select c like '%b%' FROM $tableNameLcase"), Row(true))
+        checkAnswer(sql(s"select c like 'abc' FROM $tableNameLcase"), Row(true))
+      }
+    }
   }
 
   test("Support ILike string expression with collation") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Enable `LikeSimplification` optimizer rule for collated strings.


### Why are the changes needed?
Optimize how `Like` expression works with collated strings and ensure collation awareness when replacing `Like` expressions with `StartsWith` / `EndsWith` / `Contains` / `EqualTo` under special conditions.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
New e2e sql tests in `CollationSQLRegexpSuite`.


### Was this patch authored or co-authored using generative AI tooling?
No.
