### PR TITLE
[SPARK-48286][SQL][3.5] Fix column default value check - Add error class

### DIFF
--- a/common/utils/src/main/resources/error/error-classes.json
+++ b/common/utils/src/main/resources/error/error-classes.json
@@ -1292,6 +1292,11 @@
           "which requires <expectedType> type, but the statement provided a value of incompatible <actualType> type."
         ]
       },
+      "NOT_CONSTANT" : {
+        "message" : [
+          "which is not a constant expression whose equivalent value is known at query planning time."
+        ]
+      },
       "SUBQUERY_EXPRESSION" : {
         "message" : [
           "which contains subquery expressions."

--- a/docs/sql-error-conditions-invalid-default-value-error-class.md
+++ b/docs/sql-error-conditions-invalid-default-value-error-class.md
@@ -29,6 +29,10 @@ This error class has the following derived error classes:
 
 which requires `<expectedType>` type, but the statement provided a value of incompatible `<actualType>` type.
 
+## NOT_CONSTANT
+
+which is not a constant expression whose equivalent value is known at query planning time.
+
 ## SUBQUERY_EXPRESSION
 
 which contains subquery expressions.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3406,6 +3406,19 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
         "defaultValue" -> defaultValue))
   }
 
+  def defaultValueNotConstantError(
+      statement: String,
+      colName: String,
+      defaultValue: String): Throwable = {
+    new AnalysisException(
+      errorClass = "INVALID_DEFAULT_VALUE.NOT_CONSTANT",
+      messageParameters = Map(
+        "statement" -> toSQLStmt(statement),
+        "colName" -> toSQLId(colName),
+        "defaultValue" -> defaultValue
+      ))
+  }
+
   def nullableColumnOrFieldError(name: Seq[String]): Throwable = {
     new AnalysisException(
       errorClass = "NULLABLE_COLUMN_OR_FIELD",

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -3315,7 +3315,6 @@ class DataSourceV2SQLSuiteV1Filter
           // Rand function is not foldable
           spark.sql(s"ALTER TABLE tab ADD COLUMN col2 DOUBLE DEFAULT rand()")
         }
-        assert(exception.getSqlState == "42623")
         assert(exception.errorClass.get == "INVALID_DEFAULT_VALUE.NOT_CONSTANT")
         assert(exception.messageParameters("colName") == "`col2`")
         assert(exception.messageParameters("defaultValue") == "rand()")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add error class INVALID_DEFAULT_VALUE.NOT_CONSTANT to fix compile issue we made by merging following PR https://github.com/apache/spark/pull/46594 into 3.5 branch

### Why are the changes needed?
To unblock compilation of branch 3.5

### Does this PR introduce _any_ user-facing change?
Same as original PR

### How was this patch tested?
Original PR had the tests


### Was this patch authored or co-authored using generative AI tooling?
No
