### PR TITLE
[SPARK-48630][INFRA] Make `merge_spark_pr` keep the format of revert PR

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -501,15 +501,23 @@ def standardize_jira_ref(text):
     >>> standardize_jira_ref(
     ...     "[SPARK-6250][SPARK-6146][SPARK-5911][SQL] Types are now reserved words in DDL parser.")
     '[SPARK-6250][SPARK-6146][SPARK-5911][SQL] Types are now reserved words in DDL parser.'
+    >>> standardize_jira_ref(
+    ...     'Revert "[SPARK-48591][PYTHON] Simplify the if-else branches with F.lit"')
+    'Revert "[SPARK-48591][PYTHON] Simplify the if-else branches with F.lit"'
     >>> standardize_jira_ref("Additional information for users building from source code")
     'Additional information for users building from source code'
     """
     jira_refs = []
     components = []
 
+    is_revert = False
+    if text.startswith('Revert "') and text.endswith('"'):
+        is_revert = True
+        text = text[8:-1]
+
     # If the string is compliant, no need to process any further
     if re.search(r"^\[SPARK-[0-9]{3,6}\](\[[A-Z0-9_\s,]+\] )+\S+", text):
-        return text
+        return f'Revert "{text}"' if is_revert else text
 
     # Extract JIRA ref(s):
     pattern = re.compile(r"(SPARK[-\s]*[0-9]{3,6})+", re.IGNORECASE)
@@ -537,7 +545,7 @@ def standardize_jira_ref(text):
     # included
     clean_text = re.sub(r"\s+", " ", clean_text.strip())
 
-    return clean_text
+    return f'Revert "{clean_text}"' if is_revert else clean_text
 
 
 def get_current_ref():

--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -510,14 +510,13 @@ def standardize_jira_ref(text):
     jira_refs = []
     components = []
 
-    is_revert = False
+    # If this is a Revert PR, no need to process any further
     if text.startswith('Revert "') and text.endswith('"'):
-        is_revert = True
-        text = text[8:-1]
+        return text
 
     # If the string is compliant, no need to process any further
     if re.search(r"^\[SPARK-[0-9]{3,6}\](\[[A-Z0-9_\s,]+\] )+\S+", text):
-        return f'Revert "{text}"' if is_revert else text
+        return text
 
     # Extract JIRA ref(s):
     pattern = re.compile(r"(SPARK[-\s]*[0-9]{3,6})+", re.IGNORECASE)
@@ -545,7 +544,7 @@ def standardize_jira_ref(text):
     # included
     clean_text = re.sub(r"\s+", " ", clean_text.strip())
 
-    return f'Revert "{clean_text}"' if is_revert else clean_text
+    return clean_text
 
 
 def get_current_ref():


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `merge_spark_pr` keep the format of revert PR


### Why are the changes needed?
existing script format revert PR in this way:
```
Original: Revert "[SPARK-48591][PYTHON] Simplify the if-else branches with `F.lit`"
Modified: [SPARK-48591][PYTHON] Revert "[] Simplify the if-else branches with `F.lit`"
```

another example:
```
Revert "[SPARK-46937][SQL] Improve concurrency performance for FunctionRegistry"
```
was modified to
```
[SPARK-46937][SQL] Revert "[] Improve concurrency performance for FunctionRegistry"
```
see https://github.com/apache/spark/commit/82a84ede6a47232fe3af86672ceea97f703b3e8a


### Does this PR introduce _any_ user-facing change?
no, infra-only

### How was this patch tested?
manually test, let me use this script to merge some PR to check

### Was this patch authored or co-authored using generative AI tooling?
No