### PR TITLE
[SPARK-48631][CORE][TEST] Fix test "error during accessing host local dirs for executors"

### DIFF
--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -374,7 +374,6 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
         .when(blockManager)
         .getHostLocalShuffleData(meq(blockId.asInstanceOf[ShuffleBlockId]), any())
     }
-    val hostLocalBmId = BlockManagerId("test-host-local-client-1", "test-local-host", 3)
 
     val mockExternalBlockStoreClient = mock(classOf[ExternalBlockStoreClient])
     val hostLocalDirManager = new HostLocalDirManager(
@@ -392,7 +391,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
 
     configureMockTransfer(Map())
     val iterator = createShuffleBlockIteratorWithDefaults(
-      Map(hostLocalBmId -> toBlockList(hostLocalBlocks.keys, 1L, 1))
+      Map(blockManager.blockManagerId -> toBlockList(hostLocalBlocks.keys, 1L, 1))
     )
     intercept[FetchFailedException] { iterator.next() }
   }

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -396,6 +396,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
       blockManager = Some(blockManager)
     )
     intercept[FetchFailedException] { iterator.next() }
+    verify(mockExternalBlockStoreClient, times(1)).getHostLocalDirs(any(), any(), any(), any())
   }
 
   test("Hit maxBytesInFlight limitation before maxBlocksInFlightPerAddress") {

--- a/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/ShuffleBlockFetcherIteratorSuite.scala
@@ -374,6 +374,7 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
         .when(blockManager)
         .getHostLocalShuffleData(meq(blockId.asInstanceOf[ShuffleBlockId]), any())
     }
+    val hostLocalBmId = BlockManagerId("test-host-local-client-1", "test-local-host", 3)
 
     val mockExternalBlockStoreClient = mock(classOf[ExternalBlockStoreClient])
     val hostLocalDirManager = new HostLocalDirManager(
@@ -391,7 +392,8 @@ class ShuffleBlockFetcherIteratorSuite extends SparkFunSuite with PrivateMethodT
 
     configureMockTransfer(Map())
     val iterator = createShuffleBlockIteratorWithDefaults(
-      Map(blockManager.blockManagerId -> toBlockList(hostLocalBlocks.keys, 1L, 1))
+      Map(hostLocalBmId -> toBlockList(hostLocalBlocks.keys, 1L, 1)),
+      blockManager = Some(blockManager)
     )
     intercept[FetchFailedException] { iterator.next() }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This change fixes test "error during accessing host local dirs for executors" in ShuffleBlockFetcherIteratorSuite, by setting up `blocksByAddress` correctly for the `ShuffleBlockFetcherIterator` used in the test.

### Why are the changes needed?
The test is for host local blocks, but the `BlockManagerId` was not set up correctly, so `ShuffleBlockFetcherIterator` would treat those blocks as remote blocks instead.

This change is to make the test valid to prevent further breaking changes.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Added an additional check in the test. Also tested locally and verified that the correct code path was reached.

### Was this patch authored or co-authored using generative AI tooling?
No.