### PR TITLE
[SPARK-48643][SQL] Narrow down default regex of sql options redaction

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3293,7 +3293,7 @@ object SQLConf {
       s"configuration defined by ${SECRET_REDACTION_PATTERN.key}.")
     .version("2.2.2")
     .regexConf
-    .createWithDefault("(?i)url".r)
+    .createWithDefault("(?i)^url$".r)
 
   val SQL_STRING_REDACTION_PATTERN =
     buildConf("spark.sql.redaction.string.regex")

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCSuite.scala
@@ -1255,6 +1255,7 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
     val password = "testPass"
     val tableName = "tab1"
     val dbTable = "TEST.PEOPLE"
+    val testOpt = "hourly"
     withTable(tableName) {
       sql(
         s"""
@@ -1264,7 +1265,8 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
            | url '$urlWithUserAndPass',
            | dbtable '$dbTable',
            | user '$userName',
-           | password '$password')
+           | password '$password',
+           | testOpt '$testOpt')
          """.stripMargin)
 
       val show = ShowCreateTableCommand(TableIdentifier(tableName), ShowCreateTable.getoutputAttrs)
@@ -1272,6 +1274,8 @@ class JDBCSuite extends QueryTest with SharedSparkSession {
         assert(!r.toString.contains(password))
         assert(r.toString.contains(dbTable))
         assert(r.toString.contains(userName))
+        assert(r.toString.contains(userName))
+        assert(r.toString.contains(testOpt))
       }
 
       sql(s"SHOW CREATE TABLE $tableName").collect().foreach { r =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Narrow down default regex of sql options redaction.


### Why are the changes needed?
The current `spark.sql.redaction.options.regex` configuration is too loose, resulting in masking of some insensitive options.

Like ['tag.creation-period'='hourly'](https://paimon.apache.org/docs/master/maintenance/manage-tags/) option in Paimon,

Original option:

```
'tag.creation-period' = 'hourly' 
```

Redacted:

```
'tag.creation-period' = '*********(redacted)'
```


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, affects behavior of sql options redaction.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
added unit test


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No