### PR TITLE
[SPARK-48644][SQL] Do a length check and throw COLLECTION_SIZE_LIMIT_EXCEEDED error in Hex.hex

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
@@ -1032,9 +1032,19 @@ object Hex {
     array
   }
 
+  private def maxArraySize(length: Long): Int = {
+    if (length > Int.MaxValue) {
+      throw QueryExecutionErrors.tooManyArrayElementsError(length, Int.MaxValue)
+    }
+    length.toInt
+  }
+
   def hex(bytes: Array[Byte]): UTF8String = {
     val length = bytes.length
-    val value = new Array[Byte](length * 2)
+    if (length == 0) {
+      return UTF8String.EMPTY_UTF8
+    }
+    val value = new Array[Byte](maxArraySize(length * 2L))
     var i = 0
     while (i < length) {
       value(i * 2) = hexDigits((bytes(i) & 0xF0) >> 4)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala
@@ -1032,19 +1032,16 @@ object Hex {
     array
   }
 
-  private def maxArraySize(length: Long): Int = {
-    if (length > Int.MaxValue) {
-      throw QueryExecutionErrors.tooManyArrayElementsError(length, Int.MaxValue)
-    }
-    length.toInt
-  }
-
   def hex(bytes: Array[Byte]): UTF8String = {
     val length = bytes.length
     if (length == 0) {
       return UTF8String.EMPTY_UTF8
     }
-    val value = new Array[Byte](maxArraySize(length * 2L))
+    val targetLength = length * 2L
+    if (targetLength > Int.MaxValue) {
+      throw QueryExecutionErrors.tooManyArrayElementsError(targetLength, Int.MaxValue)
+    }
+    val value = new Array[Byte](targetLength.toInt)
     var i = 0
     while (i < length) {
       value(i * 2) = hexDigits((bytes(i) & 0xF0) >> 4)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

A length check is necessary for heximalising the byte array as the new array size is 2x the original. If the length of the new byte array exceeds Int.MaxValue, we shall report the actual length and the threshold instead of NegativeArraySizeException

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

improve error handling

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, we convert large strings or binary values to hex strings, if the max length exceeds, the raised error is changed

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
test manually without adding unit test because such a test case is quite memory consuming.
```
 org.apache.spark.sql.catalyst.expressions.Hex.hex((" " * (Int.MaxValue / 2 + 1)).getBytes)
org.apache.spark.SparkIllegalArgumentException: [COLLECTION_SIZE_LIMIT_EXCEEDED.INITIALIZE] Can't create array with 2147483648 elements which exceeding the array size limit 2147483647, cannot initialize an array with specified parameters. SQLSTATE: 54000
  at org.apache.spark.sql.errors.QueryExecutionErrors$.tooManyArrayElementsError(QueryExecutionErrors.scala:2517)
  at org.apache.spark.sql.catalyst.expressions.Hex$.hex(mathExpressions.scala:1042)
  ... 42 elided
```
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->no
