### PR TITLE
[SPARK-48645][BUILD] Upgrade Maven to 3.9.8

### DIFF
--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -27,7 +27,7 @@ license: |
 ## Apache Maven
 
 The Maven-based build is the build of reference for Apache Spark.
-Building Spark using Maven requires Maven 3.9.7 and Java 17/21.
+Building Spark using Maven requires Maven 3.9.8 and Java 17/21.
 Spark requires Scala 2.13; support for Scala 2.12 was removed in Spark 4.0.0.
 
 ### Setting up Maven's Memory Usage

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>17</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
-    <maven.version>3.9.7</maven.version>
+    <maven.version>3.9.8</maven.version>
     <exec-maven-plugin.version>3.2.0</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
     <asm.version>9.7</asm.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Maven to 3.9.8.

### Why are the changes needed?

Release Note:
- https://maven.apache.org/docs/3.9.8/release-notes.html

    > Bug fixes ranges from restored ability (lost in 3.9.7) to build some project that depends on artifact with invalid POMs, OS profile activation issues and many other minor but annoying bugs. The “known issue” (bug) from 3.9.7, [MNG-8116](https://issues.apache.org/jira/browse/MNG-8116) was fixed as well. As part of fix Eclipse Sisu is updated to version 0.9.0.M3, that carries ASM 9.7 (Java 23).


Bug Fixes:
- [MNG-7758](https://issues.apache.org/jira/browse/MNG-7758): o.e.aether.resolution.ArtifactResolutionException incorrectly examined when multiple repositories are involved
- [MNG-8066](https://issues.apache.org/jira/browse/MNG-8066): Maven hangs on self-referencing exceptions
- [MNG-8116](https://issues.apache.org/jira/browse/MNG-8116): Plugin configuration can randomly fail in case of method overloading as it doesn't take into account implementation attribute
- [MNG-8131](https://issues.apache.org/jira/browse/MNG-8131): Property replacement in dependency pom no longer works
- [MNG-8135](https://issues.apache.org/jira/browse/MNG-8135): Profile activation based on OS properties is no longer case insensitive
- [MNG-8142](https://issues.apache.org/jira/browse/MNG-8142): If JDK profile activator gets "invalid" JDK version for whatever reason, it chokes but does not tell why
- [MNG-8147](https://issues.apache.org/jira/browse/MNG-8147): Profile interpolation broke their evaluation in case of duplicate IDs

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.