### PR TITLE
[SPARK-48648][PYTHON][CONNECT] Make SparkConnectClient.tags properly threadlocal

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -659,12 +659,7 @@ class SparkConnectClient(object):
         use_reattachable_execute: bool
             Enable reattachable execution.
         """
-
-        class ClientThreadLocals(threading.local):
-            tags: set = set()
-            inside_error_handling: bool = False
-
-        self.thread_local = ClientThreadLocals()
+        self.thread_local = threading.local()
 
         # Parse the connection string.
         self._builder = (
@@ -1693,7 +1688,7 @@ class SparkConnectClient(object):
         Throws the appropriate internal Python exception.
         """
 
-        if self.thread_local.inside_error_handling:
+        if getattr(self.thread_local, "inside_error_handling", False):
             # We are already inside error handling routine,
             # avoid recursive error processing (with potentially infinite recursion)
             raise error


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR changes the `thread.local` in `SparkConnectClient` to be used properly to fix the bug caused by https://github.com/apache/spark/pull/44210. It mistakenly used `thread.local` wrongly by inheriting `thread.local` and setting the class-level variables which always exist.

### Why are the changes needed?

So users can properly use thread-based `interruptTag`. Now the code below cancels both queries:

```python
import concurrent.futures
import time
import threading
from pyspark.sql.functions import udf

def run_query_with_tag(query, tag):
    try:
        spark.addTag(tag)
        print(f"starting query {tag}")
        df = spark.sql(query).select(udf(lambda: time.sleep(10))())
        print(f"collecting query {tag}")
        res = df.collect()
        print(f"done with query {tag}")
    finally:
        spark.removeTag(tag)

queries_with_tags = [
    ("SELECT * FROM range(100)", "tag1"),
    ("SELECT * FROM range(100)", "tag2"),
]

with concurrent.futures.ThreadPoolExecutor() as executor:
    futures = {executor.submit(run_query_with_tag, query, tag): (query, tag) for query, tag in queries_with_tags}
    time.sleep(5)
    print("Interrupting tag1")
    print(spark.interruptTag("tag1"))
    for f in futures:
        try:
            f.result()
            print(f"done with {f.result()}")
        except:
            print(f"failed with {f.exception()}")
```

### Does this PR introduce _any_ user-facing change?

No, this was caused by https://github.com/apache/spark/pull/44210 but the change has not been released out.

### How was this patch tested?

Unittest was added.

### Was this patch authored or co-authored using generative AI tooling?

No.
