### PR TITLE
[SPARK-48651][DOC] Configuring different JDK for Spark on YARN

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -1063,6 +1063,6 @@ then submit a Spark application:
     $ ./bin/spark-submit --class path.to.your.Class \
         --master yarn \
         --archives path/to/openjdk-21.tar.gz \
-        --conf spark.yarn.appMasterEnv.JAVA_HOME=./openjdk-21 \
-        --conf spark.executorEnv.JAVA_HOME=./openjdk-21 \
+        --conf spark.yarn.appMasterEnv.JAVA_HOME=./openjdk-21.tar.gz/openjdk-21 \
+        --conf spark.executorEnv.JAVA_HOME=./openjdk-21.tar.gz/openjdk-21 \
         <app jar> [app options]

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -34,7 +34,7 @@ Please see [Spark Security](security.html) and the specific security sections in
 # Launching Spark on YARN
 
 Apache Hadoop does not support Java 17 as of 3.4.0, while Apache Spark requires at least Java 17 since 4.0.0, so a different JDK should be configured for Spark applications.
-Please refer to [Configuring different JDK for Spark Applications](#configuring-different-jdk-for-spark-applications) for details.
+Please refer to [Configuring different JDKs for Spark Applications](#configuring-different-jdks-for-spark-applications) for details.
 
 Ensure that `HADOOP_CONF_DIR` or `YARN_CONF_DIR` points to the directory which contains the (client side) configuration files for the Hadoop cluster.
 These configs are used to write to HDFS and connect to the YARN ResourceManager. The

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -33,6 +33,9 @@ Please see [Spark Security](security.html) and the specific security sections in
 
 # Launching Spark on YARN
 
+Apache Hadoop does not support Java 17 as of 3.4.0, while Apache Spark requires at least Java 17 since 4.0.0, so a different JDK should be configured for Spark applications.
+Please refer to [Configuring different JDK for Spark Applications](#configuring-different-jdk-for-spark-applications) for details.
+
 Ensure that `HADOOP_CONF_DIR` or `YARN_CONF_DIR` points to the directory which contains the (client side) configuration files for the Hadoop cluster.
 These configs are used to write to HDFS and connect to the YARN ResourceManager. The
 configuration contained in this directory will be distributed to the YARN cluster so that all
@@ -1032,3 +1035,34 @@ and one should be configured with:
   spark.shuffle.service.name = spark_shuffle_y
   spark.shuffle.service.port = <other value>
 ```
+
+# Configuring different JDK for Spark Applications
+
+In some cases it may be desirable to use a different JDK from YARN node manager to run Spark applications,
+this can be achieved by setting the `JAVA_HOME` environment variable for YARN containers and the `spark-submit`
+process.
+
+Note that, Spark assumes that all JVM processes runs in one application use the same version of JDK, otherwise,
+you may encounter JDK serialization issues.
+
+To configure a Spark application to use a JDK which has been pre-installed on all nodes at `/opt/openjdk-17`:
+
+    $ export JAVA_HOME=/opt/openjdk-17
+    $ ./bin/spark-submit --class path.to.your.Class \
+        --master yarn \
+        --conf spark.yarn.appMasterEnv.JAVA_HOME=/opt/openjdk-17 \
+        --conf spark.executorEnv.JAVA_HOME=/opt/openjdk-17 \
+        <app jar> [app options]
+
+Optionally, the user may want to avoid installing a different JDK on the YARN cluster nodes, in such a case,
+it's also possible to distribute the JDK using YARN's Distributed Cache. For example, to use Java 21 to run
+a Spark application, prepare a JDK 21 tarball `openjdk-21.tar.gz` and untar it to `/opt` on the local node,
+then submit a Spark application:
+
+    $ export JAVA_HOME=/opt/openjdk-21
+    $ ./bin/spark-submit --class path.to.your.Class \
+        --master yarn \
+        --archives path/to/openjdk-21.tar.gz \
+        --conf spark.yarn.appMasterEnv.JAVA_HOME=./openjdk-21 \
+        --conf spark.executorEnv.JAVA_HOME=./openjdk-21 \
+        <app jar> [app options]

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -1036,7 +1036,7 @@ and one should be configured with:
   spark.shuffle.service.port = <other value>
 ```
 
-# Configuring different JDK for Spark Applications
+# Configuring different JDKs for Spark Applications
 
 In some cases it may be desirable to use a different JDK from YARN node manager to run Spark applications,
 this can be achieved by setting the `JAVA_HOME` environment variable for YARN containers and the `spark-submit`


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR updates the Spark on YARN docs to guide users to configure a different JDK for Spark Applications.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
As of today, the latest Apache Hadoop 3.4.0 does not support Java 17 yet, while Spark 4.0.0 requires at least Java 17, so users who want to use Spark on YARN must configure a different JDK for Spark applications run on YARN.

This is also asked in the mailing list https://lists.apache.org/thread/ply807h0hht1h8o7x7g1s3j51mnot5dr

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, it changes the user docs.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
I verified the command in a YARN cluster. 

The following command submits a Spark application with the distributed JDK 21
```
JAVA_HOME=/opt/openjdk-21 spark-submit \
  --master=yarn \
  --deploy-mode=cluster \
  --archives ./openjdk-21.tar.gz \
  --conf spark.yarn.appMasterEnv.JAVA_HOME=./openjdk-21.tar.gz/openjdk-21 \
  --conf spark.executorEnv.JAVA_HOME=./openjdk-21.tar.gz/openjdk-21 \
  --class org.apache.spark.examples.SparkPi \
  spark-examples*.jar 1
```

<img width="1678" alt="image" src="https://github.com/apache/spark/assets/26535726/363423a9-bbdf-460d-b6e4-72ab5d6a2e53">

<img width="1313" alt="image" src="https://github.com/apache/spark/assets/26535726/dd8dc1b1-bbe4-41cd-9e19-c8ed68b09f82">

<img width="1399" alt="image" src="https://github.com/apache/spark/assets/26535726/5bbebde6-dfbd-437f-8a44-7c23170911ac">

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.