### PR TITLE
[SPARK-48656][CORE] Do a length check and throw COLLECTION_SIZE_LIMIT_EXCEEDED error in `CartesianRDD.getPartitions`

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -405,12 +405,6 @@
     },
     "sqlState" : "58030"
   },
-  "CARTESIAN_PARTITION_NUM_ARITHMETIC_OVERFLOW" : {
-    "message" : [
-      "The number of partitions in rdd1 (<value1>) multiplied by the number of partitions in rdd2 (<value2>) exceeds `Int.MaxValue` when performing a Cartesian product."
-    ],
-    "sqlState" : "22003"
-  },
   "CAST_INVALID_INPUT" : {
     "message" : [
       "The value <expression> of the type <sourceType> cannot be cast to <targetType> because it is malformed. Correct the value as per the syntax, or change its target type. Use `try_cast` to tolerate malformed input and return NULL instead. If necessary set <ansiConfig> to \"false\" to bypass this error."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -405,6 +405,12 @@
     },
     "sqlState" : "58030"
   },
+  "CARTESIAN_PARTITION_NUM_ARITHMETIC_OVERFLOW" : {
+    "message" : [
+      "The number of partitions in rdd1 (<value1>) multiplied by the number of partitions in rdd2 (<value2>) exceeds `Int.MaxValue` when performing a Cartesian product."
+    ],
+    "sqlState" : "22003"
+  },
   "CAST_INVALID_INPUT" : {
     "message" : [
       "The value <expression> of the type <sourceType> cannot be cast to <targetType> because it is malformed. Correct the value as per the syntax, or change its target type. Use `try_cast` to tolerate malformed input and return NULL instead. If necessary set <ansiConfig> to \"false\" to bypass this error."

--- a/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
+++ b/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
@@ -24,7 +24,7 @@ import scala.jdk.CollectionConverters._
 
 import org.apache.hadoop.fs.Path
 
-import org.apache.spark.{SparkArithmeticException, SparkException, SparkIllegalArgumentException, SparkRuntimeException, SparkUnsupportedOperationException, TaskNotSerializableException}
+import org.apache.spark.{SparkException, SparkIllegalArgumentException, SparkRuntimeException, SparkUnsupportedOperationException, TaskNotSerializableException}
 import org.apache.spark.internal.config.IO_COMPRESSION_CODEC
 import org.apache.spark.io.CompressionCodec.FALLBACK_COMPRESSION_CODEC
 import org.apache.spark.memory.SparkOutOfMemoryError
@@ -501,13 +501,12 @@ private[spark] object SparkCoreErrors {
         "configVal" -> toConfVal(FALLBACK_COMPRESSION_CODEC)))
   }
 
-  def cartesianPartitionNumOverflow(rdd1PartitionNum: Int, rdd1PartitionNum2: Int): Throwable = {
-    new SparkArithmeticException(
-      errorClass = "CARTESIAN_PARTITION_NUM_ARITHMETIC_OVERFLOW",
+  def tooManyArrayElementsError(numElements: Long, maxRoundedArrayLength: Int): Throwable = {
+    new SparkIllegalArgumentException(
+      errorClass = "COLLECTION_SIZE_LIMIT_EXCEEDED.INITIALIZE",
       messageParameters = Map(
-        "value1" -> rdd1PartitionNum.toString,
-        "value2" -> rdd1PartitionNum2.toString),
-      context = Array.empty
+        "numberOfElements" -> numElements.toString,
+        "maxRoundedArrayLength" -> maxRoundedArrayLength.toString)
     )
   }
 

--- a/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
+++ b/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
@@ -19,8 +19,11 @@ package org.apache.spark.errors
 
 import java.io.{File, IOException}
 import java.util.concurrent.TimeoutException
+
 import scala.jdk.CollectionConverters._
+
 import org.apache.hadoop.fs.Path
+
 import org.apache.spark.{SparkArithmeticException, SparkException, SparkIllegalArgumentException, SparkRuntimeException, SparkUnsupportedOperationException, TaskNotSerializableException}
 import org.apache.spark.internal.config.IO_COMPRESSION_CODEC
 import org.apache.spark.io.CompressionCodec.FALLBACK_COMPRESSION_CODEC

--- a/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
+++ b/core/src/main/scala/org/apache/spark/errors/SparkCoreErrors.scala
@@ -19,12 +19,9 @@ package org.apache.spark.errors
 
 import java.io.{File, IOException}
 import java.util.concurrent.TimeoutException
-
 import scala.jdk.CollectionConverters._
-
 import org.apache.hadoop.fs.Path
-
-import org.apache.spark.{SparkException, SparkIllegalArgumentException, SparkRuntimeException, SparkUnsupportedOperationException, TaskNotSerializableException}
+import org.apache.spark.{SparkArithmeticException, SparkException, SparkIllegalArgumentException, SparkRuntimeException, SparkUnsupportedOperationException, TaskNotSerializableException}
 import org.apache.spark.internal.config.IO_COMPRESSION_CODEC
 import org.apache.spark.io.CompressionCodec.FALLBACK_COMPRESSION_CODEC
 import org.apache.spark.memory.SparkOutOfMemoryError
@@ -499,6 +496,16 @@ private[spark] object SparkCoreErrors {
         "codecName" -> codecName,
         "configKey" -> toConf(IO_COMPRESSION_CODEC.key),
         "configVal" -> toConfVal(FALLBACK_COMPRESSION_CODEC)))
+  }
+
+  def cartesianPartitionNumOverflow(rdd1PartitionNum: Int, rdd1PartitionNum2: Int): Throwable = {
+    new SparkArithmeticException(
+      errorClass = "CARTESIAN_PARTITION_NUM_ARITHMETIC_OVERFLOW",
+      messageParameters = Map(
+        "value1" -> rdd1PartitionNum.toString,
+        "value2" -> rdd1PartitionNum2.toString),
+      context = Array.empty
+    )
   }
 
   private def quoteByDefault(elem: String): String = {

--- a/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
@@ -58,8 +58,7 @@ class CartesianRDD[T: ClassTag, U: ClassTag](
 
   override def getPartitions: Array[Partition] = {
     // create the cross product split
-    val numPartitionsInRdd1 = rdd1.partitions.length
-    val partitionNum: Long = numPartitionsInRdd1.toLong * numPartitionsInRdd2.toLong
+    val partitionNum: Long = numPartitionsInRdd2.toLong * rdd1.partitions.length
     if (partitionNum > Int.MaxValue) {
       throw SparkCoreErrors.tooManyArrayElementsError(partitionNum, Int.MaxValue)
     }

--- a/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
@@ -18,7 +18,9 @@
 package org.apache.spark.rdd
 
 import java.io.{IOException, ObjectOutputStream}
+
 import scala.reflect.ClassTag
+
 import org.apache.spark._
 import org.apache.spark.errors.SparkCoreErrors
 import org.apache.spark.util.Utils

--- a/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
@@ -61,7 +61,7 @@ class CartesianRDD[T: ClassTag, U: ClassTag](
     val numPartitionsInRdd1 = rdd1.partitions.length
     val partitionNum: Long = numPartitionsInRdd1.toLong * numPartitionsInRdd2.toLong
     if (partitionNum > Int.MaxValue) {
-      throw SparkCoreErrors.cartesianPartitionNumOverflow(numPartitionsInRdd1, numPartitionsInRdd2)
+      throw SparkCoreErrors.tooManyArrayElementsError(partitionNum, Int.MaxValue)
     }
     val array = new Array[Partition](partitionNum.toInt)
     for (s1 <- rdd1.partitions; s2 <- rdd2.partitions) {

--- a/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
@@ -54,11 +54,11 @@ class CartesianRDD[T: ClassTag, U: ClassTag](
   extends RDD[(T, U)](sc, Nil)
   with Serializable {
 
-  val numPartitionsInRdd1 = rdd1.partitions.length
   val numPartitionsInRdd2 = rdd2.partitions.length
 
   override def getPartitions: Array[Partition] = {
     // create the cross product split
+    val numPartitionsInRdd1 = rdd1.partitions.length
     val partitionNum: Long = numPartitionsInRdd1.toLong * numPartitionsInRdd2.toLong
     if (partitionNum > Int.MaxValue) {
       throw SparkCoreErrors.cartesianPartitionNumOverflow(numPartitionsInRdd1, numPartitionsInRdd2)

--- a/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/RDDSuite.scala
@@ -925,8 +925,7 @@ class RDDSuite extends SparkFunSuite with SharedSparkContext with Eventually {
       sqlState = "22003",
       parameters = Map(
         "value1" -> rdd1.partitions.length.toString,
-        "value2" -> rdd2.partitions.length.toString,
-      )
+        "value2" -> rdd2.partitions.length.toString)
     )
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This pr aims to optimize the error message by doing a length check and throw `COLLECTION_SIZE_LIMIT_EXCEEDED.INITIALIZE` error in `CartesianRDD.getPartitions`.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Optimize the error prompts for Spark users.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, this PR changes user-facing error class and message.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Add a new test case in `RDDSuite`.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.