### PR TITLE
[SPARK-47910][CORE][3.5][FOLLOWUP] Remove the use of MDC

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/DiskBlockObjectWriter.scala
+++ b/core/src/main/scala/org/apache/spark/storage/DiskBlockObjectWriter.scala
@@ -192,8 +192,7 @@ private[spark] class DiskBlockObjectWriter(
       }
     } catch {
       case e: IOException =>
-        logInfo(log"Exception occurred while closing the output stream" +
-          log"${MDC(ERROR, e.getMessage)}")
+        logInfo("Exception occurred while closing the output stream: " + e.getMessage)
     } finally {
       if (initialized) {
         Utils.tryWithSafeFinally {


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pull request https://github.com/apache/spark/pull/46131 was merged into the 3.5 branch. The log output in this PR uses MDC, which is not yet supported in version 3.5.


### Why are the changes needed?
Remove the use of MDC.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
No need.


### Was this patch authored or co-authored using generative AI tooling?
No.
