### PR TITLE
[SPARK-48342][FOLLOWUP][SQL] Remove unnecessary import in AstBuilder

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -20,7 +20,6 @@ package org.apache.spark.sql.catalyst.parser
 import java.util.Locale
 import java.util.concurrent.TimeUnit
 
-import scala.collection.immutable.Seq
 import scala.collection.mutable.{ArrayBuffer, ListBuffer, Set}
 import scala.jdk.CollectionConverters._
 import scala.util.{Left, Right}


### PR DESCRIPTION
### What changes were proposed in this pull request?
In [SQL Scripting parser PR](https://github.com/apache/spark/pull/46665) we didn't notice that import for `scala.collection.immutable.Seq` was added to `AstBuilder` (probably accidentally by IntelliJ). While this import is not unused per se, it is logically not needed (since Scala 2.13, `scala.Seq` is an alias for `scala.collection.immutable.Seq`).

Anyways, no enforcement was there before and it makes sense to leave it as such. It's not in any way required for SQL Scripting parser change.

### Why are the changes needed?
To remove accidentally added package enforcement that's not needed and wasn't used before.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Already existing tests cover this change.

### Was this patch authored or co-authored using generative AI tooling?
No.