### PR TITLE
[SPARK-48490][CORE][FOLLOWUP] Fix Unescape about MessageWithContext

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
@@ -19,7 +19,6 @@ package org.apache.spark.internal
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.commons.text.StringEscapeUtils
 import org.apache.logging.log4j.{CloseableThreadContext, Level, LogManager}
 import org.apache.logging.log4j.core.{Filter, LifeCycle, LogEvent, Logger => Log4jLogger, LoggerContext}
 import org.apache.logging.log4j.core.appender.ConsoleAppender
@@ -100,7 +99,7 @@ case class MessageWithContext(message: String, context: java.util.HashMap[String
  * Companion class for lazy evaluation of the MessageWithContext instance.
  */
 class LogEntry(messageWithContext: => MessageWithContext) {
-  def message: String = StringEscapeUtils.unescapeJava(messageWithContext.message)
+  def message: String = messageWithContext.message
 
   def context: java.util.HashMap[String, String] = messageWithContext.context
 }
@@ -161,7 +160,16 @@ trait Logging {
 
       MessageWithContext(sb.toString(), context)
     }
+
+    def log(c: Char): MessageWithContext = {
+      MessageWithContext(s"$c", new java.util.HashMap[String, String]())
+    }
   }
+
+  private final val LF_CHAR: Char = '\n'
+  private final val TAB_CHAR: Char = '\t'
+  final val LF = MessageWithContext(s"$LF_CHAR", new java.util.HashMap[String, String]())
+  final val TAB = MessageWithContext(s"$TAB_CHAR", new java.util.HashMap[String, String]())
 
   protected def withLogContext(context: java.util.HashMap[String, String])(body: => Unit): Unit = {
     val threadContext = CloseableThreadContext.putAll(context)

--- a/common/utils/src/test/scala/org/apache/spark/util/StructuredLoggingSuite.scala
+++ b/common/utils/src/test/scala/org/apache/spark/util/StructuredLoggingSuite.scala
@@ -56,7 +56,7 @@ trait LoggingSuiteBase
   def basicMsgWithEscapeChar: String = "This is a log message\nThis is a new line \t other msg"
 
   def basicMsgWithEscapeCharMDC: LogEntry =
-    log"This is a log message\nThis is a new line \t other msg"
+    log"This is a log message" + LF + log"This is a new line " + TAB + log" other msg"
 
   def msgWithMDC: LogEntry = log"Lost executor ${MDC(LogKeys.EXECUTOR_ID, "1")}."
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The PR aims to solve the issue encountered in the following scenarios:
https://github.com/apache/spark/pull/46897#issuecomment-2177869329
We force the execution of `StringEscapeUtils.unescapeJava` operation on `message` of `MessageWithContext`, which will result in unexpected behavior.


### Why are the changes needed?
Fix bug.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA
Existed UT


### Was this patch authored or co-authored using generative AI tooling?
No.
