### PR TITLE
[SPARK-48665][PYTHON][CONNECT] Support providing a dict in pyspark lit to create a map.

### DIFF
--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -154,14 +154,14 @@
       "The value <provider> does not represent a correct collation provider. Supported providers are: [<supportedProviders>]."
     ]
   },
-  "COLUMN_IN_LIST": {
-    "message": [
-      "`<func_name>` does not allow a Column in a list."
-    ]
-  },
   "COLUMN_IN_DICT": {
     "message": [
       "`<func_name>` does not allow a Column in a dict."
+    ]
+  },
+  "COLUMN_IN_LIST": {
+    "message": [
+      "`<func_name>` does not allow a Column in a list."
     ]
   },
   "CONNECT_URL_ALREADY_DEFINED": {

--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -159,6 +159,11 @@
       "`<func_name>` does not allow a Column in a list."
     ]
   },
+  "COLUMN_IN_DICT": {
+    "message": [
+      "`<func_name>` does not allow a Column in a dict."
+    ]
+  },
   "CONNECT_URL_ALREADY_DEFINED": {
     "message": [
       "Only one Spark Connect client URL can be set; however, got a different URL [<new_url>] from the existing [<existing_url>]."

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -255,6 +255,7 @@ column = col
 
 
 def lit(col: Any) -> Column:
+    from itertools import chain
     from pyspark.sql.connect.column import Column as ConnectColumn
 
     if isinstance(col, Column):
@@ -265,6 +266,8 @@ def lit(col: Any) -> Column:
                 error_class="COLUMN_IN_LIST", message_parameters={"func_name": "lit"}
             )
         return array(*[lit(c) for c in col])
+    elif isinstance(col, dict):
+        return create_map(*[lit(x) for x in chain(*col.items())])
     elif isinstance(col, np.ndarray) and col.ndim == 1:
         if _from_numpy_type(col.dtype) is None:
             raise PySparkTypeError(

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -267,6 +267,12 @@ def lit(col: Any) -> Column:
             )
         return array(*[lit(c) for c in col])
     elif isinstance(col, dict):
+        # Skip checking if the keys are column as Columns are not hashable
+        # and cannot be used as dict keys in the first place.
+        if any(isinstance(value, Column) for value in col.values()):
+            raise PySparkValueError(
+                error_class="COLUMN_IN_DICT", message_parameters={"func_name": "lit"}
+            )
         return create_map(*[lit(x) for x in chain(*col.items())])
     elif isinstance(col, np.ndarray) and col.ndim == 1:
         if _from_numpy_type(col.dtype) is None:

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -155,7 +155,8 @@ def lit(col: Any) -> Column:
 
     Parameters
     ----------
-    col : :class:`~pyspark.sql.Column`, str, int, float, bool, list or dict, NumPy literals or ndarray.
+    col : :class:`~pyspark.sql.Column`, str, int, float, bool, list or dict,
+        NumPy literals or ndarray.
         the value to make it as a PySpark literal. If a column is passed,
         it returns the column as is.
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -238,6 +238,12 @@ def lit(col: Any) -> Column:
             )
         return array(*[lit(item) for item in col])
     elif isinstance(col, dict):
+        # Skip checking if the keys are column as Columns are not hashable
+        # and cannot be used as dict keys in the first place.
+        if any(isinstance(value, Column) for value in col.values()):
+            raise PySparkValueError(
+                error_class="COLUMN_IN_DICT", message_parameters={"func_name": "lit"}
+            )
         return create_map(*[lit(x) for x in chain(*col.items())])
     else:
         if _has_numpy and isinstance(col, np.generic):

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1183,6 +1183,16 @@ class FunctionsTestsMixin:
             message_parameters={"func_name": "lit"},
         )
 
+    def test_lit_dict(self):
+        # SPARK-48665: added support for dict type
+        test_dict = {"a": 1, "b": 2}
+        actual = self.spark.range(1).select(F.lit(test_dict)).first()[0]
+        self.assertEqual(actual, test_dict)
+
+        test_dict = {"a": {"1": 1}, "b": {"2": 2}}
+        actual = self.spark.range(1).select(F.lit(test_dict)).first()[0]
+        self.assertEqual(actual, test_dict)
+
     # Test added for SPARK-39832; change Python API to accept both col & str as input
     def test_regexp_replace(self):
         df = self.spark.createDataFrame(

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1193,6 +1193,12 @@ class FunctionsTestsMixin:
         actual = self.spark.range(1).select(F.lit(test_dict)).first()[0]
         self.assertEqual(actual, test_dict)
 
+        with self.sql_conf({"spark.sql.ansi.enabled": False}):
+            test_dict = {"a": 1, "b": "2", "c": None}
+            expected_dict = {"a": "1", "b": "2", "c": None}
+            actual = self.spark.range(1).select(F.lit(test_dict)).first()[0]
+            self.assertEqual(actual, expected_dict)
+
     # Test added for SPARK-39832; change Python API to accept both col & str as input
     def test_regexp_replace(self):
         df = self.spark.createDataFrame(

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1199,6 +1199,22 @@ class FunctionsTestsMixin:
             actual = self.spark.range(1).select(F.lit(test_dict)).first()[0]
             self.assertEqual(actual, expected_dict)
 
+        df = self.spark.range(10)
+        dicts = [
+            {"a": df.id},
+            {"a": {"b": df.id}},
+        ]
+
+        for d in dicts:
+            with self.assertRaises(PySparkValueError) as pe:
+                F.lit(d)
+
+            self.check_error(
+                exception=pe.exception,
+                error_class="COLUMN_IN_DICT",
+                message_parameters={"func_name": "lit"},
+            )
+
     # Test added for SPARK-39832; change Python API to accept both col & str as input
     def test_regexp_replace(self):
         df = self.spark.createDataFrame(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added the option to provide a dict to `pyspark.sql.functions.lit` in order to create a map


### Why are the changes needed?
To make it easier to create a map in pyspark.
Currently, it is only possible via `create_map` which requires a sequence of key,value,key,value... 
Scala already supports such functionality using `typedLit`

A [similar PR](https://github.com/apache/spark/pull/37722) was done in the past to add similar functionality for the creating of an array using a list, so I tried to follow all the changes done there as well.


### Does this PR introduce _any_ user-facing change?
Yes, docstring of `lit` was edited, and new functionality was added

Before:
```python
from pyspark.sql import functions as F
F.lit({"a":1})
# pyspark.errors.exceptions.captured.SparkRuntimeException: [UNSUPPORTED_FEATURE.LITERAL_TYPE] The feature is not supported: Literal for '{asd=2}' of class java.util.HashMap.
```
After:
```python
from pyspark.sql import functions as F
F.lit({"a":1, "b": 2})
# Column<'map(a, 1, b, 2)'>
```

### How was this patch tested?
Manual tests + unittest in CI


### Was this patch authored or co-authored using generative AI tooling?
No
