### PR TITLE
[SPARK-48634][PYTHON][CONNECT][FOLLOW-UP] Do not make a request if threadpool is not initialized

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1108,7 +1108,7 @@ class SparkConnectClient(object):
         """
         Close the channel.
         """
-        ExecutePlanResponseReattachableIterator.shutdown_threadpool()
+        ExecutePlanResponseReattachableIterator.shutdown()
         self._channel.close()
         self._closed = True
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to not make a request if threadpool is not initialized to keep the same behaviour before https://github.com/apache/spark/pull/46993.

### Why are the changes needed?

To make Python exit slient.

### Does this PR introduce _any_ user-facing change?

Virtually no.

### How was this patch tested?

Manually tested, with long running Python job and exiting it.

### Was this patch authored or co-authored using generative AI tooling?

No.
