### PR TITLE
[SPARK-48667][PYTHON] Arrow python UDFS didn't support UDT as outputType

### DIFF
--- a/python/pyspark/sql/tests/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/test_arrow_python_udf.py
@@ -33,6 +33,7 @@ from pyspark.testing.sqlutils import (
 )
 from pyspark.util import PythonEvalType
 
+
 @unittest.skipIf(
     not have_pandas or not have_pyarrow, pandas_requirement_message or pyarrow_requirement_message
 )

--- a/python/pyspark/sql/tests/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/test_arrow_python_udf.py
@@ -29,7 +29,7 @@ from pyspark.testing.sqlutils import (
     pyarrow_requirement_message,
     ReusedSQLTestCase,
     ExamplePoint,
-    ExamplePointUDT
+    ExamplePointUDT,
 )
 from pyspark.util import PythonEvalType
 
@@ -221,10 +221,8 @@ class PythonUDFArrowTestsMixin(BaseUDFTestsMixin):
         with self.assertRaises(PythonException):
             self.spark.sql("SELECT test_udf(id, a => id * 10) FROM range(2)").show()
 
-    def test_udt_as_return_type(self):
-        data = [
-            ExamplePoint(1.0, 2.0),
-        ]
+    def test_udt_as_udf_return_type(self):
+        data = [ExamplePoint(1.0, 2.0)]
         schema = StructType().add("point", ExamplePointUDT())
         df = self.spark.createDataFrame([data], schema=schema)
         [row] = df.select(

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -2814,7 +2814,7 @@ class UDTFArrowTestsMixin(BaseUDTFTestsMixin):
                 with self.assertRaisesRegex(PythonException, "UDTF_ARROW_TYPE_CAST_ERROR"):
                     udtf(TestUDTF, returnType=ret_type)().collect()
 
-    def test_udt_as_return_type(self):
+    def test_udtf_as_return_type(self):
         class TestUDTF:
             def eval(self):
                 yield ExamplePoint(0, 1),
@@ -2825,7 +2825,7 @@ class UDTFArrowTestsMixin(BaseUDTFTestsMixin):
         schema = StructType().add("point", ExamplePointUDT())
         df = self.spark.createDataFrame([data], schema=schema)
         [row] = df.select(
-            udtf(TestUDTF, returnType=ExamplePointUDT(), useArrow=True)("point"),
+            udtf(TestUDTF, returnType=schema, useArrow=True)("point"),
         ).collect()
         self.assertEqual(row[0], ExamplePoint(1.0, 2.0))
 

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -2819,12 +2819,8 @@ class UDTFArrowTestsMixin(BaseUDTFTestsMixin):
             def eval(self):
                 yield ExamplePoint(0, 1),
 
-        data = [ExamplePoint(1.0, 2.0),]
         schema = StructType().add("point", ExamplePointUDT())
-        df = self.spark.createDataFrame([data], schema=schema)
-        [row] = df.select(
-            udtf(TestUDTF, returnType=schema, useArrow=True)("point"),
-        ).collect()
+        [row] =udtf(TestUDTF, returnType=schema, useArrow=True)(lit()).collect()
         self.assertEqual(row[0], ExamplePoint(1.0, 2.0))
 
 

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -2820,7 +2820,7 @@ class UDTFArrowTestsMixin(BaseUDTFTestsMixin):
                 yield ExamplePoint(0, 1),
 
         schema = StructType().add("point", ExamplePointUDT())
-        [row] =udtf(TestUDTF, returnType=schema, useArrow=True)(lit()).collect()
+        [row] = udtf(TestUDTF, returnType=schema, useArrow=True)().collect()
         self.assertEqual(row[0], ExamplePoint(1.0, 2.0))
 
 

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -2817,7 +2817,7 @@ class UDTFArrowTestsMixin(BaseUDTFTestsMixin):
     def test_udt_as_udtf_return_type(self):
         class TestUDTF:
             def eval(self):
-                yield Row(point=ExamplePoint(0, 1)),
+                yield ExamplePoint(0, 1),
 
         schema = StructType().add("point", ExamplePointUDT())
         self._check_result_or_exception(TestUDTF, schema, [Row(point=ExamplePoint(1.0, 2.0))])

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -2820,10 +2820,10 @@ class UDTFArrowTestsMixin(BaseUDTFTestsMixin):
                 yield ExamplePoint(0, 1),
 
         schema = StructType().add("point", ExamplePointUDT())
-        [row] = udtf(TestUDTF, returnType=schema, useArrow=False).collect()
+        [row] = udtf(TestUDTF, returnType=schema, useArrow=False)().collect()
         self.assertEqual(row[0], ExamplePoint(1.0, 2.0))
         with self.assertRaisesRegex(PythonException, "UDTF_ARROW_TYPE_CAST_ERROR"):
-            udtf(TestUDTF, returnType=schema, useArrow=True).collect()
+            udtf(TestUDTF, returnType=schema, useArrow=True)().collect()
 
 
 class UDTFArrowTests(UDTFArrowTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -2817,7 +2817,7 @@ class UDTFArrowTestsMixin(BaseUDTFTestsMixin):
     def test_udt_as_udtf_return_type(self):
         class TestUDTF:
             def eval(self):
-                yield ExamplePoint(0, 1),
+                yield ExamplePoint(1.0, 2.0),
 
         schema = StructType().add("point", ExamplePointUDT())
         [row] = udtf(TestUDTF, returnType=schema, useArrow=False)().collect()

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -2817,12 +2817,10 @@ class UDTFArrowTestsMixin(BaseUDTFTestsMixin):
     def test_udt_as_udtf_return_type(self):
         class TestUDTF:
             def eval(self):
-                yield ExamplePoint(0, 1),
+                yield Row(point=ExamplePoint(0, 1)),
 
         schema = StructType().add("point", ExamplePointUDT())
-        func = udtf(TestUDTF, returnType=schema, useArrow=True)
-        [row] = func().collect()
-        self.assertEqual(row[0], ExamplePoint(1.0, 2.0))
+        self._check_result_or_exception(TestUDTF, schema, [Row(point=ExamplePoint(1.0, 2.0))])
 
 
 class UDTFArrowTests(UDTFArrowTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -64,7 +64,7 @@ from pyspark.testing.sqlutils import (
     pyarrow_requirement_message,
     ReusedSQLTestCase,
     ExamplePoint,
-    ExamplePointUDT
+    ExamplePointUDT,
 )
 
 
@@ -2814,14 +2814,12 @@ class UDTFArrowTestsMixin(BaseUDTFTestsMixin):
                 with self.assertRaisesRegex(PythonException, "UDTF_ARROW_TYPE_CAST_ERROR"):
                     udtf(TestUDTF, returnType=ret_type)().collect()
 
-    def test_udtf_as_return_type(self):
+    def test_udt_as_udtf_return_type(self):
         class TestUDTF:
             def eval(self):
                 yield ExamplePoint(0, 1),
 
-        data = [
-            ExamplePoint(1.0, 2.0),
-        ]
+        data = [ExamplePoint(1.0, 2.0),]
         schema = StructType().add("point", ExamplePointUDT())
         df = self.spark.createDataFrame([data], schema=schema)
         [row] = df.select(

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -2820,7 +2820,10 @@ class UDTFArrowTestsMixin(BaseUDTFTestsMixin):
                 yield ExamplePoint(0, 1),
 
         schema = StructType().add("point", ExamplePointUDT())
-        self._check_result_or_exception(TestUDTF, schema, [Row(point=ExamplePoint(1.0, 2.0))])
+        [row] = udtf(TestUDTF, returnType=schema, useArrow=False).collect()
+        self.assertEqual(row[0], ExamplePoint(1.0, 2.0))
+        with self.assertRaisesRegex(PythonException, "UDTF_ARROW_TYPE_CAST_ERROR"):
+            udtf(TestUDTF, returnType=schema, useArrow=True).collect()
 
 
 class UDTFArrowTests(UDTFArrowTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -2820,7 +2820,8 @@ class UDTFArrowTestsMixin(BaseUDTFTestsMixin):
                 yield ExamplePoint(0, 1),
 
         schema = StructType().add("point", ExamplePointUDT())
-        [row] = udtf(TestUDTF, returnType=schema, useArrow=True)().collect()
+        func = udtf(TestUDTF, returnType=schema, useArrow=True)
+        [row] = func().collect()
         self.assertEqual(row[0], ExamplePoint(1.0, 2.0))
 
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
@@ -219,4 +219,18 @@ private[sql] object ArrowUtils {
         valueContainsNull)
     case _ => dt
   }
+
+  def toArrowOutputSchema(dt: DataType): DataType = {
+    dt match {
+      case udt: UserDefinedType[_] => toArrowOutputSchema(udt.sqlType)
+      case arr@ArrayType(elementType, _) =>
+        arr.copy(elementType = toArrowOutputSchema(elementType))
+      case struct@StructType(fields) =>
+        struct.copy(fields.map(field => field.copy(dataType = toArrowOutputSchema(field.dataType))))
+      case map@MapType(keyType, valueType, _) =>
+        map.copy(keyType = toArrowOutputSchema(keyType), valueType = toArrowOutputSchema(valueType))
+      case _ =>
+        dt
+    }
+  }
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
@@ -220,14 +220,19 @@ private[sql] object ArrowUtils {
     case _ => dt
   }
 
+  /**
+   * Convert from spark sql types to arrow field can't support UserDefinedType yet.
+   * Arrow support UserDefinedType by read/write it's serialized/deserialized data.
+   * When compare output types should convert UserDefinedType to it's sqlType too.
+   */
   def toArrowOutputSchema(dt: DataType): DataType = {
     dt match {
       case udt: UserDefinedType[_] => toArrowOutputSchema(udt.sqlType)
-      case arr@ArrayType(elementType, _) =>
+      case arr @ ArrayType(elementType, _) =>
         arr.copy(elementType = toArrowOutputSchema(elementType))
-      case struct@StructType(fields) =>
+      case struct @ StructType(fields) =>
         struct.copy(fields.map(field => field.copy(dataType = toArrowOutputSchema(field.dataType))))
-      case map@MapType(keyType, valueType, _) =>
+      case map @ MapType(keyType, valueType, _) =>
         map.copy(keyType = toArrowOutputSchema(keyType), valueType = toArrowOutputSchema(valueType))
       case _ =>
         dt

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/objects.scala
@@ -42,6 +42,7 @@ import org.apache.spark.sql.execution.streaming.GroupStateImpl
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.GroupStateTimeout
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.util.ArrowUtils
 
 /**
  * Physical version of `ObjectProducer`.
@@ -252,7 +253,8 @@ case class MapPartitionsInRWithArrowExec(
       val outputProject = UnsafeProjection.create(output, output)
       columnarBatchIter.flatMap { batch =>
         val actualDataTypes = (0 until batch.numCols()).map(i => batch.column(i).dataType())
-        assert(outputTypes == actualDataTypes, "Invalid schema from dapply(): " +
+        val arrowOutputTypes = outputTypes.map(ArrowUtils.toArrowOutputSchema)
+        assert(arrowOutputTypes == actualDataTypes, "Invalid schema from dapply(): " +
           s"expected ${outputTypes.mkString(", ")}, got ${actualDataTypes.mkString(", ")}")
         batch.rowIterator.asScala
       }.map(outputProject)
@@ -598,7 +600,8 @@ case class FlatMapGroupsInRWithArrowExec(
 
       columnarBatchIter.flatMap { batch =>
         val actualDataTypes = (0 until batch.numCols()).map(i => batch.column(i).dataType())
-        assert(outputTypes == actualDataTypes, "Invalid schema from gapply(): " +
+        val arrowOutputTypes = outputTypes.map(ArrowUtils.toArrowOutputSchema)
+        assert(arrowOutputTypes == actualDataTypes, "Invalid schema from gapply(): " +
           s"expected ${outputTypes.mkString(", ")}, got ${actualDataTypes.mkString(", ")}")
         batch.rowIterator().asScala
       }.map(outputProject)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonExec.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.metric.SQLMetric
 import org.apache.spark.sql.execution.python.EvalPythonExec.ArgumentMetadata
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.ArrowUtils
 
 /**
  * Grouped a iterator into batches.
@@ -125,7 +126,8 @@ class ArrowEvalPythonEvaluatorFactory(
 
     columnarBatchIter.flatMap { batch =>
       val actualDataTypes = (0 until batch.numCols()).map(i => batch.column(i).dataType())
-      assert(outputTypes == actualDataTypes, "Invalid schema from pandas_udf: " +
+      val arrowOutputTypes = outputTypes.map(ArrowUtils.toArrowOutputSchema)
+      assert(arrowOutputTypes == actualDataTypes, "Invalid schema from pandas_udf: " +
         s"expected ${outputTypes.mkString(", ")}, got ${actualDataTypes.mkString(", ")}")
       batch.rowIterator.asScala
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonUDTFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonUDTFExec.scala
@@ -83,7 +83,8 @@ case class ArrowEvalPythonUDTFExec(
       val actualDataTypes = (0 until flattenedBatch.numCols()).map(
         i => flattenedBatch.column(i).dataType())
       val arrowOutputTypes = outputTypes.map(ArrowUtils.toArrowOutputSchema)
-      assert(arrowOutputTypes == actualDataTypes, "Invalid schema from arrow-enabled Python UDTF: " +
+      assert(arrowOutputTypes == actualDataTypes,
+        "Invalid schema from arrow-enabled Python UDTF: " +
         s"expected ${outputTypes.mkString(", ")}, got ${actualDataTypes.mkString(", ")}")
 
       flattenedBatch.setNumRows(batch.numRows())

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonUDTFExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/ArrowEvalPythonUDTFExec.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.python.EvalPythonExec.ArgumentMetadata
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.ArrowUtils
 import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch}
 
 /**
@@ -81,7 +82,8 @@ case class ArrowEvalPythonUDTFExec(
 
       val actualDataTypes = (0 until flattenedBatch.numCols()).map(
         i => flattenedBatch.column(i).dataType())
-      assert(outputTypes == actualDataTypes, "Invalid schema from arrow-enabled Python UDTF: " +
+      val arrowOutputTypes = outputTypes.map(ArrowUtils.toArrowOutputSchema)
+      assert(arrowOutputTypes == actualDataTypes, "Invalid schema from arrow-enabled Python UDTF: " +
         s"expected ${outputTypes.mkString(", ")}, got ${actualDataTypes.mkString(", ")}")
 
       flattenedBatch.setNumRows(batch.numRows())


### PR DESCRIPTION
### What changes were proposed in this pull request?
Arrow Python UDF didn't support  UDT as return type 
```
df.select(udf(lambda x: x, returnType=ExamplePointUDT(), useArrow=useArrow)("point")), 
 ```
```
 java.lang.AssertionError: assertion failed: Invalid schema from pandas_udf: expected org.apache.spark.sql.test.ExamplePointUDT@49ccc723, StructType(StructField(st,StructType(StructField(tt,TimestampType,true)),true)), got ArrayType(DoubleType,false)
 ```
Since Arrow Field didn't support UDT type,  UDT will convert to it's sqlType() in ArrowField, I think here we should convert it when compare output schema.

### Why are the changes needed?
Support Arrow python UDFs UDT as outputType


### Does this PR introduce _any_ user-facing change?
Support Arrow python UDFs UDT as outputType


### How was this patch tested?
Added UT

### Was this patch authored or co-authored using generative AI tooling?
No
