### PR TITLE
[SPARK-48669][K8S] K8s resource name prefix follows `DNS Subdomain Names` rule

### DIFF
--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/KubernetesConfSuite.scala
@@ -276,4 +276,16 @@ class KubernetesConfSuite extends SparkFunSuite {
       assert(KubernetesConf.getResourceNamePrefix(appName).matches("[a-z]([-a-z0-9]*[a-z0-9])?"))
     }
   }
+
+  test("SPARK-48699: Resource name prefix should be truncated if app name is too long") {
+    // An app name of 330 characters
+    val longAppName = "foo-123-bar" * 30
+    val id = KubernetesUtils.uniqueID()
+    val resourceNamePrefix = KubernetesConf.getResourceNamePrefix(longAppName, id)
+    // We are at allowed max length
+    assert(resourceNamePrefix.length === KUBERNETES_DNS_SUBDOMAIN_NAME_MAX_LENGTH - 24)
+    assert(resourceNamePrefix.matches("[a-z]([-a-z0-9]*[a-z0-9])?"))
+    // We don't truncate the unique ID
+    assert(resourceNamePrefix.endsWith(id))
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR aims to support jobs with long `spark.app.name` in K8s. The resource name prefix should be truncated for the resource names to follow [DNS Subdomain Names](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names).

The current used resource suffixes are as follows:

- `-driver`
- `-driver-podspec-conf-map`
- `-driver-pvc-$i`
- `-driver-svc`
- `-exec-${executorId}`
- `-exec-${executorId}-pvc-$i`
- `-hadoop-config`
- `-kubernetes-credentials`
- `-delegation-tokens`
- `-kerberos-keytab`
- `-krb5-file`

Among them, the longest one is `-driver-podspec-conf-map` of length 24.
The max length of `-exec-${executorId}-pvc-$i` is also 24, as the max length of `executorId` is 10 (length of Integer.MAX_VALUE) and the max allowed PVC specs is 128 of length 3.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, when a job with long `spark.app.name` is submitted, K8s will reject the creation of driver pod due to the pod name is exceeded 253.

Error example:
```
Caused by: io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: POST at: https://kubernetes.default.svc.cluster.local:443/api/v1/namespaces/foo/pods. Message: Pod "some-super-long-spark-pod-name-exceeded-length-253-driver" is invalid: metadata.name: Invalid value: "some-super-long-spark-pod-name-exceeded-length-253-driver": must be no more than 253 characters. 
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, users can run jobs on K8s with longer `spark.app.name`.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Pass the CIs with the updated unit tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.