### PR TITLE
[SPARK-48670][SQL] Providing suggestion as part of error message when invalid collation name is given

### DIFF
--- a/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
+++ b/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
@@ -417,15 +417,15 @@ class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ig
       ("UTF8_LCASE_LCASE", "UTF8_LCASE"),
       ("UNICODE_CS_CS", "UNICODE_CS"),
       ("UNICODE_CI_CI", "UNICODE_CI"),
-      // ("UNICODE_CI_CS", ""), // error message for invalid combination...
-      // ("UNICODE_CS_CI", ""),
+      ("UNICODE_CI_CS", "UNICODE_CS"),
+      ("UNICODE_CS_CI", "UNICODE_CS"),
       ("UNICODE_AS_AS", "UNICODE_AS"),
       ("UNICODE_AI_AI", "UNICODE_AI"),
-      // ("UNICODE_AS_AI", ""),
-      // ("UNICODE_AI_AS", ""),
-      // ("UNICODE_AS_CS_AI", ""),
-      // ("UNICODE_CS_AI_CI", ""),
-      // ("UNICODE_CS_AS_CI_AI", "")
+      ("UNICODE_AS_AI", "UNICODE_AS"),
+      ("UNICODE_AI_AS", "UNICODE_AS"),
+      ("UNICODE_AS_CS_AI", "UNICODE_AS_CS"),
+      ("UNICODE_CS_AI_CI", "UNICODE_CS_AI"),
+      ("UNICODE_CS_AS_CI_AI", "UNICODE_CS_AS")
     ).foreach { case (collationName, proposal) =>
       val error = intercept[SparkException] {
         fetchCollation(collationName)

--- a/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
+++ b/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
@@ -114,11 +114,11 @@ class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ig
       ("UNICODE_UNSPECIFIED_CI_UNSPECIFIED", "UNICODE"),
       ("UNICODE_INDETERMINATE", "UNICODE"),
       ("UNICODE_CI_INDETERMINATE", "UNICODE")
-    ).foreach{case (collationName, proposal) =>
+    ).foreach{case (collationName, proposals) =>
       val error = intercept[SparkException] { fetchCollation(collationName) }
       assert(error.getErrorClass === "COLLATION_INVALID_NAME")
       assert(error.getMessageParameters.asScala === Map(
-        "collationName" -> collationName, "proposal" -> proposal))
+        "collationName" -> collationName, "proposals" -> proposals))
     }
   }
 
@@ -276,8 +276,8 @@ class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ig
     Seq(
       ("en_US", "en_USA"), // Must use 3-letter country code
       ("eN_US", "en_USA"), // verify that proper casing is captured in error.
-      ("enn", "en"),
-      ("en_AAA","en_USA"),
+      ("enn", "en, nn, bn"),
+      ("en_AAA", "en_USA"),
       ("en_Something", "UNICODE"),
       ("en_Something_USA", "en_USA"),
       ("en_LCASE", "en_USA"),
@@ -314,12 +314,14 @@ class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ig
       ("Cyrl_CI_sr_SRB", "sr_Cyrl_SRB"),
       ("Cyrl_sr_CI_SRB", "sr_Cyrl_SRB"),
       // no locale specified
-      ("_CI_AI", "af_CI_AI")
-    ).foreach { case (collationName, proposal) => {
+      ("_CI_AI", "af_CI_AI, am_CI_AI, ar_CI_AI"),
+      ("", "af, am, ar")
+    ).foreach { case (collationName, proposals) => {
       val error = intercept[SparkException] { fetchCollation(collationName) }
       assert(error.getErrorClass === "COLLATION_INVALID_NAME")
+
       assert(error.getMessageParameters.asScala === Map(
-        "collationName" -> collationName, "proposal" -> proposal))
+        "collationName" -> collationName, "proposals" -> proposals))
     }}
   }
 
@@ -424,14 +426,14 @@ class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ig
       ("UNICODE-CS-AS", "UNICODE"),
       ("UNICODECSAS", "UNICODE"),
       ("_CS_AS_UNICODE", "UNICODE")
-    ).foreach { case (collationName, proposal) =>
+    ).foreach { case (collationName, proposals) =>
       val error = intercept[SparkException] {
         fetchCollation(collationName)
       }
 
       assert(error.getErrorClass === "COLLATION_INVALID_NAME")
       assert(error.getMessageParameters.asScala === Map(
-        "collationName" -> collationName, "proposal" -> proposal))
+        "collationName" -> collationName, "proposals" -> proposals))
     }
   }
 

--- a/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
+++ b/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
@@ -277,47 +277,46 @@ class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ig
 
 
   test("invalid names of collations with ICU non-root localization") {
-    case class TestCase(collationName: String, proposal: String)
     Seq(
-      TestCase("en_US", "en_USA"), // Must use 3-letter country code
-      TestCase("enn", "en"),
-      TestCase("en_AAA","en_USA"),
-      TestCase("en_Something", "UNICODE"),
-      TestCase("en_Something_USA", "en_USA"),
-      TestCase("en_LCASE", "en_USA"),
-      TestCase("en_UCASE", "en_USA"),
-      TestCase("en_CI_LCASE", "UNICODE"),
-      TestCase("en_CI_UCASE", "en_USA"),
-      TestCase("en_CI_UNSPECIFIED", "en_USA"),
-      TestCase("en_USA_UNSPECIFIED", "en_USA"),
-      TestCase("en_USA_UNSPECIFIED_CI", "en_USA_CI"),
-      TestCase("en_INDETERMINATE", "en_USA"),
-      TestCase("en_USA_INDETERMINATE", "en_USA"),
-      TestCase("en_Latn_USA", "en_USA"),
-      TestCase("en_Cyrl_USA", "en_USA"),
-      TestCase("en_USA_AAA", "en_USA"),
-      TestCase("sr_Cyrl_SRB_AAA", "sr_Cyrl_SRB"),
-      // // Invalid ordering of language, script and country code.
-      TestCase("USA_en", "en"),
-      TestCase("sr_SRB_Cyrl", "sr_Cyrl"),
-      TestCase("SRB_sr", "ar_SAU"),
-      TestCase("SRB_sr_Cyrl", "bs_Cyrl"),
-      TestCase("SRB_Cyrl_sr", "sr_Cyrl_SRB"),
-      TestCase("Cyrl_sr", "sr_Cyrl_SRB"),
-      TestCase("Cyrl_sr_SRB", "sr_Cyrl_SRB"),
-      TestCase("Cyrl_SRB_sr", "sr_Cyrl_SRB"),
-      // // Collation specifiers in the middle of locale.
-      TestCase("CI_en", "ceb"),
-      TestCase("USA_CI_en", "UNICODE"),
-      TestCase("en_CI_USA", "en_USA"),
-      TestCase("CI_sr_Cyrl_SRB", "sr_Cyrl_SRB"),
-      TestCase("sr_CI_Cyrl_SRB", "sr_Cyrl_SRB"),
-      TestCase("sr_Cyrl_CI_SRB", "sr_Cyrl_SRB"),
-      TestCase("CI_Cyrl_sr", "sr_Cyrl_SRB"),
-      TestCase("Cyrl_CI_sr", "he_ISR"),
-      TestCase("Cyrl_CI_sr_SRB", "sr_Cyrl_SRB"),
-      TestCase("Cyrl_sr_CI_SRB", "sr_Cyrl_SRB"),
-    ).foreach { case TestCase(collationName, proposal) => {
+      ("en_US", "en_USA"), // Must use 3-letter country code
+      ("enn", "en"),
+      ("en_AAA","en_USA"),
+      ("en_Something", "UNICODE"),
+      ("en_Something_USA", "en_USA"),
+      ("en_LCASE", "en_USA"),
+      ("en_UCASE", "en_USA"),
+      ("en_CI_LCASE", "UNICODE"),
+      ("en_CI_UCASE", "en_USA"),
+      ("en_CI_UNSPECIFIED", "en_USA"),
+      ("en_USA_UNSPECIFIED", "en_USA"),
+      ("en_USA_UNSPECIFIED_CI", "en_USA_CI"),
+      ("en_INDETERMINATE", "en_USA"),
+      ("en_USA_INDETERMINATE", "en_USA"),
+      ("en_Latn_USA", "en_USA"),
+      ("en_Cyrl_USA", "en_USA"),
+      ("en_USA_AAA", "en_USA"),
+      ("sr_Cyrl_SRB_AAA", "sr_Cyrl_SRB"),
+      // Invalid ordering of language, script and country code.
+      ("USA_en", "en"),
+      ("sr_SRB_Cyrl", "sr_Cyrl"),
+      ("SRB_sr", "ar_SAU"),
+      ("SRB_sr_Cyrl", "bs_Cyrl"),
+      ("SRB_Cyrl_sr", "sr_Cyrl_SRB"),
+      ("Cyrl_sr", "sr_Cyrl_SRB"),
+      ("Cyrl_sr_SRB", "sr_Cyrl_SRB"),
+      ("Cyrl_SRB_sr", "sr_Cyrl_SRB"),
+      // Collation specifiers in the middle of locale.
+      ("CI_en", "ceb"),
+      ("USA_CI_en", "UNICODE"),
+      ("en_CI_USA", "en_USA"),
+      ("CI_sr_Cyrl_SRB", "sr_Cyrl_SRB"),
+      ("sr_CI_Cyrl_SRB", "sr_Cyrl_SRB"),
+      ("sr_Cyrl_CI_SRB", "sr_Cyrl_SRB"),
+      ("CI_Cyrl_sr", "sr_Cyrl_SRB"),
+      ("Cyrl_CI_sr", "he_ISR"),
+      ("Cyrl_CI_sr_SRB", "sr_Cyrl_SRB"),
+      ("Cyrl_sr_CI_SRB", "sr_Cyrl_SRB"),
+    ).foreach { case (collationName, proposal) => {
       val error = intercept[SparkException] {
         fetchCollation(collationName)
       }

--- a/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
+++ b/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
@@ -278,6 +278,7 @@ class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ig
   test("invalid names of collations with ICU non-root localization") {
     Seq(
       ("en_US", "en_USA"), // Must use 3-letter country code
+      ("eN_US", "en_USA"), // verify that proper casing is captured in error.
       ("enn", "en"),
       ("en_AAA","en_USA"),
       ("en_Something", "UNICODE"),
@@ -315,6 +316,8 @@ class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ig
       ("Cyrl_CI_sr", "he_ISR"),
       ("Cyrl_CI_sr_SRB", "sr_Cyrl_SRB"),
       ("Cyrl_sr_CI_SRB", "sr_Cyrl_SRB"),
+      // no locale specified
+      ("_CI_AI", "af_CI_AI")
     ).foreach { case (collationName, proposal) => {
       val error = intercept[SparkException] {
         fetchCollation(collationName)
@@ -409,7 +412,7 @@ class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ig
     })
   }
 
-  test("repeated and/or incompatible specifiers in collation name") {
+  test("repeated and/or incompatible and/or misplaced specifiers in collation name") {
     Seq(
       ("UTF8_LCASE_LCASE", "UTF8_LCASE"),
       ("UNICODE_CS_CS", "UNICODE_CS"),
@@ -422,7 +425,11 @@ class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ig
       ("UNICODE_AI_AS", "UNICODE_AS"),
       ("UNICODE_AS_CS_AI", "UNICODE_AS_CS"),
       ("UNICODE_CS_AI_CI", "UNICODE_CS_AI"),
-      ("UNICODE_CS_AS_CI_AI", "UNICODE_CS_AS")
+      ("UNICODE_CS_AS_CI_AI", "UNICODE_CS_AS"),
+      ("UNICODE__CS__AS", "UNICODE_AS"),
+      ("UNICODE-CS-AS", "UNICODE"),
+      ("UNICODECSAS", "UNICODE"),
+      ("_CS_AS_UNICODE", "UNICODE"),
     ).foreach { case (collationName, proposal) =>
       val error = intercept[SparkException] {
         fetchCollation(collationName)

--- a/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
+++ b/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
@@ -113,12 +113,9 @@ class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ig
       ("UNICODE_CI_UNSPECIFIED", "UNICODE"),
       ("UNICODE_UNSPECIFIED_CI_UNSPECIFIED", "UNICODE"),
       ("UNICODE_INDETERMINATE", "UNICODE"),
-      ("UNICODE_CI_INDETERMINATE", "UNICODE"),
-    ).foreach {case (collationName, proposal) =>
-      val error = intercept[SparkException] {
-        fetchCollation(collationName)
-      }
-
+      ("UNICODE_CI_INDETERMINATE", "UNICODE")
+    ).foreach{case (collationName, proposal) =>
+      val error = intercept[SparkException] { fetchCollation(collationName) }
       assert(error.getErrorClass === "COLLATION_INVALID_NAME")
       assert(error.getMessageParameters.asScala === Map(
         "collationName" -> collationName, "proposal" -> proposal))
@@ -319,10 +316,7 @@ class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ig
       // no locale specified
       ("_CI_AI", "af_CI_AI")
     ).foreach { case (collationName, proposal) => {
-      val error = intercept[SparkException] {
-        fetchCollation(collationName)
-      }
-
+      val error = intercept[SparkException] { fetchCollation(collationName) }
       assert(error.getErrorClass === "COLLATION_INVALID_NAME")
       assert(error.getMessageParameters.asScala === Map(
         "collationName" -> collationName, "proposal" -> proposal))
@@ -429,7 +423,7 @@ class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ig
       ("UNICODE__CS__AS", "UNICODE_AS"),
       ("UNICODE-CS-AS", "UNICODE"),
       ("UNICODECSAS", "UNICODE"),
-      ("_CS_AS_UNICODE", "UNICODE"),
+      ("_CS_AS_UNICODE", "UNICODE")
     ).foreach { case (collationName, proposal) =>
       val error = intercept[SparkException] {
         fetchCollation(collationName)

--- a/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
+++ b/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
@@ -275,7 +275,6 @@ class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ig
     })
   }
 
-
   test("invalid names of collations with ICU non-root localization") {
     Seq(
       ("en_US", "en_USA"), // Must use 3-letter country code
@@ -406,8 +405,7 @@ class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ig
     )
     badCollationIds.foreach(collationId => {
       // Assumptions about collation id will break and assert statement will fail.
-      // intercept[AssertionError](fetchCollation(collationId))
-      fetchCollation(collationId)
+      intercept[AssertionError](fetchCollation(collationId))
     })
   }
 

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -475,7 +475,7 @@
   },
   "COLLATION_INVALID_NAME" : {
     "message" : [
-      "The value <collationName> does not represent a correct collation name. Suggested valid collation name: [<proposal>]."
+      "The value <collationName> does not represent a correct collation name. Suggested valid collation names: [<proposals>]."
     ],
     "sqlState" : "42704"
   },
@@ -1932,7 +1932,7 @@
     "subClass" : {
       "DEFAULT_COLLATION" : {
         "message" : [
-          "Cannot resolve the given default collation. Did you mean '<proposal>'?"
+          "Cannot resolve the given default collation. Suggested valid collation names: ['<proposals>']?"
         ]
       },
       "TIME_ZONE" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -475,7 +475,7 @@
   },
   "COLLATION_INVALID_NAME" : {
     "message" : [
-      "The value <collationName> does not represent a correct collation name."
+      "The value <collationName> does not represent a correct collation name. Suggested valid collation name: [<proposal>]."
     ],
     "sqlState" : "42704"
   },
@@ -1932,7 +1932,7 @@
     "subClass" : {
       "DEFAULT_COLLATION" : {
         "message" : [
-          "Cannot resolve the given default collation."
+          "Cannot resolve the given default collation. Did you mean '<proposal>'?"
         ]
       },
       "TIME_ZONE" : {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -782,7 +782,8 @@ object SQLConf {
           }
         },
         "DEFAULT_COLLATION",
-        _ => Map())
+        collationName => Map(
+          "proposal" -> CollationFactory.getClosestSuggestionOnInvalidName(collationName)))
       .createWithDefault("UTF8_BINARY")
 
   val FETCH_SHUFFLE_BLOCKS_IN_BATCH =

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -783,7 +783,7 @@ object SQLConf {
         },
         "DEFAULT_COLLATION",
         collationName => Map(
-          "proposal" -> CollationFactory.getClosestSuggestionOnInvalidName(collationName)))
+          "proposals" -> CollationFactory.getClosestSuggestionsOnInvalidName(collationName, 3)))
       .createWithDefault("UTF8_BINARY")
 
   val FETCH_SHUFFLE_BLOCKS_IN_BATCH =

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollationExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollationExpressionSuite.scala
@@ -63,7 +63,7 @@ class CollationExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
       exception = intercept[SparkException] { Collate(Literal("abc"), "UTF8_BS") },
       errorClass = "COLLATION_INVALID_NAME",
       sqlState = "42704",
-      parameters = Map("collationName" -> "UTF8_BS"))
+      parameters = Map("collationName" -> "UTF8_BS", "proposal" -> "UTF8_LCASE"))
   }
 
   test("collation on non-explicit default collation") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollationExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollationExpressionSuite.scala
@@ -63,7 +63,7 @@ class CollationExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
       exception = intercept[SparkException] { Collate(Literal("abc"), "UTF8_BS") },
       errorClass = "COLLATION_INVALID_NAME",
       sqlState = "42704",
-      parameters = Map("collationName" -> "UTF8_BS", "proposal" -> "UTF8_LCASE"))
+      parameters = Map("collationName" -> "UTF8_BS", "proposals" -> "UTF8_LCASE"))
   }
 
   test("collation on non-explicit default collation") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
@@ -152,7 +152,7 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
       exception = intercept[SparkException] { sql("select 'aaa' collate UTF8_BS") },
       errorClass = "COLLATION_INVALID_NAME",
       sqlState = "42704",
-      parameters = Map("collationName" -> "UTF8_BS"))
+      parameters = Map("collationName" -> "UTF8_BS", "proposal" -> "UTF8_LCASE"))
   }
 
   test("disable bucketing on collated string column") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
@@ -152,7 +152,7 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
       exception = intercept[SparkException] { sql("select 'aaa' collate UTF8_BS") },
       errorClass = "COLLATION_INVALID_NAME",
       sqlState = "42704",
-      parameters = Map("collationName" -> "UTF8_BS", "proposal" -> "UTF8_LCASE"))
+      parameters = Map("collationName" -> "UTF8_BS", "proposals" -> "UTF8_LCASE"))
   }
 
   test("disable bucketing on collated string column") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -514,7 +514,8 @@ class SQLConfSuite extends QueryTest with SharedSparkSession {
       errorClass = "INVALID_CONF_VALUE.DEFAULT_COLLATION",
       parameters = Map(
         "confValue" -> "UNICODE_C",
-        "confName" -> "spark.sql.session.collation.default"
+        "confName" -> "spark.sql.session.collation.default",
+        "proposal" -> "UNICODE"
       ))
 
     withSQLConf(SQLConf.COLLATION_ENABLED.key -> "false") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/SQLConfSuite.scala
@@ -515,7 +515,7 @@ class SQLConfSuite extends QueryTest with SharedSparkSession {
       parameters = Map(
         "confValue" -> "UNICODE_C",
         "confName" -> "spark.sql.session.collation.default",
-        "proposal" -> "UNICODE"
+        "proposals" -> "UNICODE"
       ))
 
     withSQLConf(SQLConf.COLLATION_ENABLED.key -> "false") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR improves error reporting in collation space. Currently, when invalid collation name is provided, caller just gets information that collation name can't be accepted. This PR will also return a suggestion on valid collation name that is similar to invalid one that was provided.

We propose following rules on generating the suggestion:
1) Find locale that is the closest valid locale measured by Levenshtein distance.
2) Remove duplicate modifiers (e.g. CS_AI_AI_CS becomes CS_AI).
3) Remove invalid combinations (e.g. CS_CI becomes CS).


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests for invalid collation names are extended to also cover suggestion checks.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
