### PR TITLE
[SPARK-48671][SQL][TESTS] Add test cases for `Hex.hex`

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HexSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HexSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
-import org.apache.spark.{SparkFunSuite, SparkIllegalArgumentException}
+import org.apache.spark.SparkFunSuite
 
 class HexSuite extends SparkFunSuite {
   test("SPARK-48596: hex long values") {
@@ -38,23 +38,9 @@ class HexSuite extends SparkFunSuite {
     assert(Hex.hex(Long.MaxValue).toString === "7FFFFFFFFFFFFFFF")
   }
 
-  test("SPARK-48644: hex bytes values") {
+  test("SPARK-48671: hex bytes values") {
     assert(Hex.hex(Array[Byte]()).toString === "")
     assert(Hex.hex(Array[Byte](0, 1, 15, 16, 17, Byte.MaxValue)).toString === "00010F10117F")
     assert(Hex.hex(Array[Byte](-1, -15, -16, -17, Byte.MinValue)).toString === "FFF1F0EF80")
-  }
-
-  test("SPARK-48644: bytes length check in hex") {
-    val bytes = new Array[Byte](1073741824)
-    checkError(
-      exception = intercept[SparkIllegalArgumentException] {
-        Hex.hex(bytes)
-      },
-      errorClass = "COLLECTION_SIZE_LIMIT_EXCEEDED.INITIALIZE",
-      sqlState = "54000",
-      parameters = Map(
-        "numberOfElements" -> (bytes.length.toLong * 2).toString,
-        "maxRoundedArrayLength" -> Int.MaxValue.toString)
-    )
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HexSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/HexSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkFunSuite, SparkIllegalArgumentException}
 
 class HexSuite extends SparkFunSuite {
   test("SPARK-48596: hex long values") {
@@ -36,5 +36,25 @@ class HexSuite extends SparkFunSuite {
     assert(Hex.hex(-1).toString === "FFFFFFFFFFFFFFFF")
     assert(Hex.hex(Long.MinValue).toString === "8000000000000000")
     assert(Hex.hex(Long.MaxValue).toString === "7FFFFFFFFFFFFFFF")
+  }
+
+  test("SPARK-48644: hex bytes values") {
+    assert(Hex.hex(Array[Byte]()).toString === "")
+    assert(Hex.hex(Array[Byte](0, 1, 15, 16, 17, Byte.MaxValue)).toString === "00010F10117F")
+    assert(Hex.hex(Array[Byte](-1, -15, -16, -17, Byte.MinValue)).toString === "FFF1F0EF80")
+  }
+
+  test("SPARK-48644: bytes length check in hex") {
+    val bytes = new Array[Byte](1073741824)
+    checkError(
+      exception = intercept[SparkIllegalArgumentException] {
+        Hex.hex(bytes)
+      },
+      errorClass = "COLLECTION_SIZE_LIMIT_EXCEEDED.INITIALIZE",
+      sqlState = "54000",
+      parameters = Map(
+        "numberOfElements" -> (bytes.length.toLong * 2).toString,
+        "maxRoundedArrayLength" -> Int.MaxValue.toString)
+    )
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR aims  to add some test cases  for function `Hex.hex(bytes: Array[Byte])`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Supplement test cases to make the code more robust.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Passed new test cases added in `HexSuite`.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.