### PR TITLE
[SPARK-48677][BUILD] Upgrade `scalafmt` to 3.8.2

### DIFF
--- a/dev/.scalafmt.conf
+++ b/dev/.scalafmt.conf
@@ -27,4 +27,4 @@ danglingParentheses.preset = false
 docstrings.style = Asterisk
 maxColumn = 98
 runner.dialect = scala213
-version = 3.8.1
+version = 3.8.2


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `scalafmt` to 3.8.2.


### Why are the changes needed?
- The full release notes: https://github.com/scalameta/scalafmt/releases/tag/v3.8.2
The last upgrade occurred 2 months ago.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.
Manually test:
```
sh dev/scalastyle
-e Scalastyle checks passed.
```


### Was this patch authored or co-authored using generative AI tooling?
No.
