### PR TITLE
[SPARK-48694][CORE]Manage memory used by external cache

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -450,6 +450,26 @@ package object config {
     .checkValue(v => v >= 0.0 && v < 1.0, "Storage fraction must be in [0,1)")
     .createWithDefault(0.5)
 
+  private[spark] val EXTERNAL_MEMORY_CACHE_ENABLED =
+    ConfigBuilder("spark.memory.external.cache.enabled")
+      .doc("Enable external file cache or not")
+      .booleanConf
+      .createWithDefault(false)
+
+  private[spark] val EXTERNAL_MEMORY_STORAGE_FRACTION =
+    ConfigBuilder("spark.memory.external.storageFraction")
+    .doc("Amount of external storage memory used like file cache, expressed as a fraction of " +
+      "spark storage memory.")
+    .doubleConf
+    .checkValue(v => v >= 0.0 && v < 1.0, "External storage fraction must be in [0,1)")
+    .createWithDefault(0.5)
+
+  private[spark] val STORAGE_MEMORY_EVICT_PREFERENCE =
+    ConfigBuilder("spark.memory.storage.preferEvictExtCache")
+    .doc("Preference to evict RDD cache or external file cache when storage memory is not enough.")
+    .booleanConf
+    .createWithDefault(true)
+
   private[spark] val MEMORY_FRACTION = ConfigBuilder("spark.memory.fraction")
     .doc("Fraction of (heap space - 300MB) used for execution and storage. The " +
       "lower this is, the more frequently spills and cached data eviction occur. " +

--- a/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
+++ b/core/src/main/scala/org/apache/spark/memory/UnifiedMemoryManager.scala
@@ -121,7 +121,7 @@ private[spark] class UnifiedMemoryManager(
         if (memoryReclaimableFromStorage > 0) {
           // Only reclaim as much space as is necessary and available:
           val spaceToReclaim = storagePool.freeSpaceToShrinkPool(
-            math.min(extraMemoryNeeded, memoryReclaimableFromStorage))
+            math.min(extraMemoryNeeded, memoryReclaimableFromStorage), conf)
           storagePool.decrementPoolSize(spaceToReclaim)
           executionPool.incrementPoolSize(spaceToReclaim)
         }
@@ -180,7 +180,7 @@ private[spark] class UnifiedMemoryManager(
       executionPool.decrementPoolSize(memoryBorrowedFromExecution)
       storagePool.incrementPoolSize(memoryBorrowedFromExecution)
     }
-    storagePool.acquireMemory(blockId, numBytes)
+    storagePool.acquireMemory(blockId, numBytes, conf)
   }
 
   override def acquireUnrollMemory(

--- a/core/src/main/scala/org/apache/spark/storage/memory/ExternalMemoryStore.scala
+++ b/core/src/main/scala/org/apache/spark/storage/memory/ExternalMemoryStore.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.storage.memory
+
+import org.apache.spark.SparkConf
+import org.apache.spark.internal.Logging
+import org.apache.spark.memory.{MemoryManager, MemoryMode}
+import org.apache.spark.storage.BlockId
+
+/**
+ * Interfaces provided in this class will be wrapped together with external cache APIs, like
+ * createEntry(), evict(), remove(), etc.
+ * @param conf
+ * @param memoryManager
+ */
+private[spark] class ExternalMemoryStore(
+    conf: SparkConf,
+    memoryManager: MemoryManager)
+  extends Logging {
+
+  // Note: all changes to memory allocations, notably evicting entries and
+  // acquiring memory, must be synchronized on `memoryManager`!
+
+  private[spark] def initExternalCache(conf: SparkConf): Unit = {}
+
+  /**
+   * call before API createEntry()
+   * @param numBytes
+   * @return whether all numBytes bytes were successfully granted.
+   */
+  private[spark] def acquireStorageMemory(numBytes: Long): Boolean = {
+    memoryManager.acquireStorageMemory(BlockId("file_cache"), numBytes, MemoryMode.OFF_HEAP)
+  }
+
+  /**
+   * work together with evictEntries() in external cache
+   * @param spaceToFree
+   * @return actual bytes returned by evictEntries
+   */
+  private[spark] def evictEntriesToFreeSpace(spaceToFree: Long): Long = {
+    spaceToFree
+  }
+
+  /**
+   * call after API remove entry
+   * free numBytes bytes memory in StorageMemoryPool
+   * @param numBytes
+   */
+  private[spark] def releaseStorageMemory(numBytes: Long): Unit = {
+    memoryManager.releaseStorageMemory(numBytes, MemoryMode.OFF_HEAP)
+  }
+}
+


### PR DESCRIPTION

### What changes were proposed in this pull request?
This PR proposes changes to count memory used by external cache in storage memory and include it in overall spill logic.


### Why are the changes needed?
We have a scenario that use Spark together with a 3rd party file source cache, which is an independent lib and has its internal logic for cache entry creation, eviction and remove. Currently we allocate dedicated memory for this cache but the problem is that the memory can't be shared along with Spark execution/storage memory. It will be more effective for memory usage if we can count it in the UnifiedMemoryManager and include it in memory spill logic.

We also have a requirement of memory management for a native RDD cache implementation. The existing interfaces in MemoryStore is generally bound with Spark SerializerManager and BlockEvictionHandler. It's not easy to extend for such customized RDD cache.


### Does this PR introduce _any_ user-facing change?
Yes. It introduces some configurations for memory management: `spark.memory.external.cache.enabled`, `spark.memory.external.storageFraction` and `spark.memory.storage.preferEvictExtCache`.



### How was this patch tested?
It's tested by tpcds workload with external file source cache.


### Was this patch authored or co-authored using generative AI tooling?
No
