### PR TITLE
[SPARK-48704][INFRA] Update `build_sparkr_window.yml` to use `windows-2022`

### DIFF
--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-name: "Build / SparkR-only (master, 4.4.0, windows-2019)"
+name: "Build / SparkR-only (master, 4.4.0, windows-2022)"
 
 on:
   schedule:
@@ -25,7 +25,7 @@ on:
 jobs:
   build:
     name: "Build module: sparkr"
-    runs-on: windows-2019
+    runs-on: windows-2022
     timeout-minutes: 300
     if: github.repository == 'apache/spark'
     steps:


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to update `build_sparkr_window.yml` to use `windows-2022` (from `windows-2019`)


### Why are the changes needed?
- `windows-latest` now points to `windows-2022`.
  Because `windows-2019` has already exceeded `Mainstream End Date` (Jan 9, 2024).
  https://github.com/actions/runner-images?tab=readme-ov-file#available-images
  <img width="842" alt="image" src="https://github.com/apache/spark/assets/15246973/cd2f936b-9488-46d1-b27e-402b6601df0c">

- windows-server-2019
  https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2019
  <img width="980" alt="image" src="https://github.com/apache/spark/assets/15246973/3a7fc03f-8583-4c33-abeb-b23b70d6df8b">

- windows-server-2022
  https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2022
  <img width="981" alt="image" src="https://github.com/apache/spark/assets/15246973/271a3fc6-0229-4a24-9113-45a97c9f96de">

- `Mainstream End Date` & `Extended End Date`
  Mainstream End Date: Date the product ceases to receive enhancements or new features. 
  Extended End Date: After this date, these products will no longer receive security updates, non-security updates, bug fixes, technical support or online technical content updates.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.



### Was this patch authored or co-authored using generative AI tooling?
No.
