### PR TITLE
[SPARK-39901][CORE][SQL] Redesign `ignoreCorruptFiles` to make it more accurate by adding a new config `spark.files.ignoreCorruptFiles.errorClasses`

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1181,6 +1181,19 @@ package object config {
     .booleanConf
     .createWithDefault(false)
 
+  private[spark] val IGNORE_CORRUPT_FILES_ERROR_CLASSES =
+    ConfigBuilder("spark.files.ignoreCorruptFiles.errorClasses")
+      .doc("A comma-separated list of error classes used to determine which exceptions can be " +
+        "ignored, allowing Spark jobs to continue running when encountering corrupted files. " +
+        "You can specify the key message of an exception by adding a colon (:) after the " +
+        "class name, for example: `java.lang.IOException:not a SequenceFile file`. " +
+        s"This configuration is effective only when ${IGNORE_CORRUPT_FILES.key} is " +
+        "set to true. If this configuration is not set, the behavior of Spark handling " +
+        "corrupted files is the same as before.")
+      .version("4.0.0")
+      .stringConf
+      .createWithDefault("")
+
   private[spark] val IGNORE_MISSING_FILES = ConfigBuilder("spark.files.ignoreMissingFiles")
     .doc("Whether to ignore missing files. If true, the Spark jobs will continue to run when " +
       "encountering missing files and the contents that have been read will still be returned.")

--- a/core/src/main/scala/org/apache/spark/util/IgnoreCorruptFilesUtils.scala
+++ b/core/src/main/scala/org/apache/spark/util/IgnoreCorruptFilesUtils.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+
+private[spark] case class IgnoreCorruptFilesError(errorClassName: String, errorKeyMsg: String)
+
+/**
+ * Ignore corrupt files utility methods.
+ */
+private[spark] object IgnoreCorruptFilesUtils {
+
+  def errorClassesStrToSeq(str: String): Seq[IgnoreCorruptFilesError] = {
+    Option(str).filter(_.trim.nonEmpty).map { s =>
+      s.split(",").map(_.trim).map {
+        case each if each.nonEmpty =>
+          val classInfo = each.split(":", 2).map(_.trim)
+          val className = classInfo(0)
+          val classValue = if (classInfo.length > 1) classInfo(1) else ""
+          IgnoreCorruptFilesError(className, classValue)
+      }.filter(_.errorClassName != "").toSeq
+    }.getOrElse(Seq.empty)
+  }
+
+  private def containsErrorClass(
+      errorClasses: Seq[IgnoreCorruptFilesError],
+      error: Exception): Boolean = {
+    Option(errorClasses).exists(_.exists { errorClass =>
+      val classNameMatch = error.getClass.getName == errorClass.errorClassName
+      classNameMatch && Option(error.getMessage).exists(_.contains(errorClass.errorKeyMsg))
+    })
+  }
+
+  def ignoreCorruptFiles(
+      ignoreCorruptFilesFlag: Boolean,
+      errorClasses: Seq[IgnoreCorruptFilesError],
+      error: Exception): Boolean = {
+    if (ignoreCorruptFilesFlag) {
+      errorClasses.isEmpty || containsErrorClass(errorClasses, error)
+    } else {
+      false
+    }
+  }
+}

--- a/core/src/test/scala/org/apache/spark/FileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FileSuite.scala
@@ -627,7 +627,8 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
 
       // ignoreCorrupt set true, ignoreCorruptFilesErrorClasses set with right error classes
       conf = new SparkConf().set(IGNORE_CORRUPT_FILES, true)
-        .set(IGNORE_CORRUPT_FILES_ERROR_CLASSES, "java.io.EOFException:Unexpected end of input stream")
+        .set(IGNORE_CORRUPT_FILES_ERROR_CLASSES,
+          "java.io.EOFException:Unexpected end of input stream")
       sc = new SparkContext("local", "test", conf)
       // Test HadoopRDD
       assert(sc.textFile(inputFile.toURI.toString).collect().isEmpty)

--- a/core/src/test/scala/org/apache/spark/FileSuite.scala
+++ b/core/src/test/scala/org/apache/spark/FileSuite.scala
@@ -540,106 +540,71 @@ class FileSuite extends SparkFunSuite with LocalSparkContext {
     }
   }
 
+  protected def ignoreCorruptFilesError(conf: SparkConf, inputFile: File): Unit = {
+    // Reading a corrupt gzip file should throw EOFException
+    sc = new SparkContext("local", "test", conf)
+    // Test HadoopRDD
+    var e = intercept[SparkException] {
+      sc.textFile(inputFile.toURI.toString).collect()
+    }
+    assert(e.getCause.isInstanceOf[EOFException])
+    assert(e.getCause.getMessage === "Unexpected end of input stream")
+    // Test NewHadoopRDD
+    e = intercept[SparkException] {
+      sc.newAPIHadoopFile(
+        inputFile.toURI.toString,
+        classOf[NewTextInputFormat],
+        classOf[LongWritable],
+        classOf[Text]).collect()
+    }
+    assert(e.getCause.isInstanceOf[EOFException])
+    assert(e.getCause.getMessage === "Unexpected end of input stream")
+    sc.stop()
+  }
+
+  protected def ignoreCorruptFilesSuccess(conf: SparkConf, inputFile: File): Unit = {
+    sc = new SparkContext("local", "test", conf)
+    // Test HadoopRDD
+    assert(sc.textFile(inputFile.toURI.toString).collect().isEmpty)
+    // Test NewHadoopRDD
+    assert {
+      sc.newAPIHadoopFile(
+        inputFile.toURI.toString,
+        classOf[NewTextInputFormat],
+        classOf[LongWritable],
+        classOf[Text]).collect().isEmpty
+    }
+  }
+
   test("spark.files.ignoreCorruptFiles should work both HadoopRDD and NewHadoopRDD") {
     withCorruptFile(inputFile => {
-      // Reading a corrupt gzip file should throw EOFException
-      sc = new SparkContext("local", "test")
-      // Test HadoopRDD
-      var e = intercept[SparkException] {
-        sc.textFile(inputFile.toURI.toString).collect()
-      }
-      assert(e.getCause.isInstanceOf[EOFException])
-      assert(e.getCause.getMessage === "Unexpected end of input stream")
-      // Test NewHadoopRDD
-      e = intercept[SparkException] {
-        sc.newAPIHadoopFile(
-          inputFile.toURI.toString,
-          classOf[NewTextInputFormat],
-          classOf[LongWritable],
-          classOf[Text]).collect()
-      }
-      assert(e.getCause.isInstanceOf[EOFException])
-      assert(e.getCause.getMessage === "Unexpected end of input stream")
-      sc.stop()
+      var conf = new SparkConf().set(IGNORE_CORRUPT_FILES, false)
+      ignoreCorruptFilesError(conf, inputFile)
 
-      val conf = new SparkConf().set(IGNORE_CORRUPT_FILES, true)
-      sc = new SparkContext("local", "test", conf)
-      // Test HadoopRDD
-      assert(sc.textFile(inputFile.toURI.toString).collect().isEmpty)
-      // Test NewHadoopRDD
-      assert {
-        sc.newAPIHadoopFile(
-          inputFile.toURI.toString,
-          classOf[NewTextInputFormat],
-          classOf[LongWritable],
-          classOf[Text]).collect().isEmpty
-      }
+      conf = new SparkConf().set(IGNORE_CORRUPT_FILES, true)
+      ignoreCorruptFilesSuccess(conf, inputFile)
     })
   }
 
   test("SPARK-39901: spark.files.ignoreCorruptFilesErrorClasses should work both " +
     "HadoopRDD and NewHadoopRDD") {
     withCorruptFile(inputFile => {
-      // ignoreCorrupt set false, ignoreCorruptFilesErrorClasses set with right error classes
+      // ignoreCorruptFiles: false, ignoreCorruptFilesErrorClasses: right error classes
       var conf = new SparkConf().set(
         IGNORE_CORRUPT_FILES_ERROR_CLASSES, "java.io.EOFException:Unexpected end of input stream")
-      sc = new SparkContext("local", "test")
-      // Test HadoopRDD
-      var e = intercept[SparkException] {
-        sc.textFile(inputFile.toURI.toString).collect()
-      }
-      assert(e.getCause.isInstanceOf[EOFException])
-      assert(e.getCause.getMessage === "Unexpected end of input stream")
-      // Test NewHadoopRDD
-      e = intercept[SparkException] {
-        sc.newAPIHadoopFile(
-          inputFile.toURI.toString,
-          classOf[NewTextInputFormat],
-          classOf[LongWritable],
-          classOf[Text]).collect()
-      }
-      assert(e.getCause.isInstanceOf[EOFException])
-      assert(e.getCause.getMessage === "Unexpected end of input stream")
-      sc.stop()
+      ignoreCorruptFilesError(conf, inputFile)
 
-      // ignoreCorrupt set true, ignoreCorruptFilesErrorClasses set with wrong error classes
+      // ignoreCorruptFiles: true, ignoreCorruptFilesErrorClasses: wrong error classes
       conf = new SparkConf().set(IGNORE_CORRUPT_FILES, true)
         .set(IGNORE_CORRUPT_FILES_ERROR_CLASSES,
           "java.io.RuntimeException:Unexpected end of input stream")
-      sc = new SparkContext("local", "test", conf)
-      // Test HadoopRDD
-      e = intercept[SparkException] {
-        sc.textFile(inputFile.toURI.toString).collect()
-      }
-      assert(e.getCause.isInstanceOf[EOFException])
-      assert(e.getCause.getMessage === "Unexpected end of input stream")
-      // Test NewHadoopRDD
-      e = intercept[SparkException] {
-        sc.newAPIHadoopFile(
-          inputFile.toURI.toString,
-          classOf[NewTextInputFormat],
-          classOf[LongWritable],
-          classOf[Text]).collect()
-      }
-      assert(e.getCause.isInstanceOf[EOFException])
-      assert(e.getCause.getMessage === "Unexpected end of input stream")
-      sc.stop()
+      ignoreCorruptFilesError(conf, inputFile)
 
-      // ignoreCorrupt set true, ignoreCorruptFilesErrorClasses set with right error classes
+      // ignoreCorruptFiles: true, ignoreCorruptFilesErrorClasses: right error classes
       conf = new SparkConf().set(IGNORE_CORRUPT_FILES, true)
         .set(IGNORE_CORRUPT_FILES_ERROR_CLASSES,
           "java.io.EOFException:Unexpected end of input stream")
-      sc = new SparkContext("local", "test", conf)
-      // Test HadoopRDD
-      assert(sc.textFile(inputFile.toURI.toString).collect().isEmpty)
-      // Test NewHadoopRDD
-      assert {
-        sc.newAPIHadoopFile(
-          inputFile.toURI.toString,
-          classOf[NewTextInputFormat],
-          classOf[LongWritable],
-          classOf[Text]).collect().isEmpty
-      }
+      ignoreCorruptFilesSuccess(conf, inputFile)
     })
   }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2266,6 +2266,18 @@ Apart from these, the following properties are also available, and may be useful
   <td>2.1.0</td>
 </tr>
 <tr>
+  <td><code>spark.files.ignoreCorruptFiles.errorClasses</code></td>
+  <td>false</td>
+  <td>
+    A comma-separated list of error classes used to determine which exceptions can be ignored, allowing Spark jobs to 
+    continue running when encountering corrupted files. You can specify the key message of an exception by adding a 
+    colon (:) after the class name, for example: `java.lang.IOException:not a SequenceFile file`. This configuration 
+    is effective only when `spark.files.ignoreCorruptFiles` is set to true. If this configuration is not set, the 
+    behavior of Spark handling corrupted files is the same as before.
+  </td>
+  <td>4.0.0</td>
+</tr>
+<tr>
   <td><code>spark.files.ignoreMissingFiles</code></td>
   <td>false</td>
   <td>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/FileSourceOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/FileSourceOptions.scala
@@ -16,9 +16,10 @@
  */
 package org.apache.spark.sql.catalyst
 
-import org.apache.spark.sql.catalyst.FileSourceOptions.{IGNORE_CORRUPT_FILES, IGNORE_MISSING_FILES}
+import org.apache.spark.sql.catalyst.FileSourceOptions.{IGNORE_CORRUPT_FILES, IGNORE_CORRUPT_FILES_ERROR_CLASSES, IGNORE_MISSING_FILES}
 import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.util.{IgnoreCorruptFilesError, IgnoreCorruptFilesUtils}
 
 /**
  * Common options for the file-based data source.
@@ -32,11 +33,17 @@ class FileSourceOptions(
   val ignoreCorruptFiles: Boolean = parameters.get(IGNORE_CORRUPT_FILES).map(_.toBoolean)
     .getOrElse(SQLConf.get.ignoreCorruptFiles)
 
+  val ignoreCorruptFilesErrorClasses: Seq[IgnoreCorruptFilesError] =
+    IgnoreCorruptFilesUtils.errorClassesStrToSeq(parameters.get(
+      IGNORE_CORRUPT_FILES_ERROR_CLASSES).getOrElse(SQLConf.get.ignoreCorruptFilesErrorClasses)
+    )
+
   val ignoreMissingFiles: Boolean = parameters.get(IGNORE_MISSING_FILES).map(_.toBoolean)
     .getOrElse(SQLConf.get.ignoreMissingFiles)
 }
 
 object FileSourceOptions {
   val IGNORE_CORRUPT_FILES = "ignoreCorruptFiles"
+  val IGNORE_CORRUPT_FILES_ERROR_CLASSES = "ignoreCorruptFilesErrorClasses"
   val IGNORE_MISSING_FILES = "ignoreMissingFiles"
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/xml/StaxXmlParser.scala
@@ -44,6 +44,7 @@ import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
+import org.apache.spark.util.IgnoreCorruptFilesUtils
 
 class StaxXmlParser(
     schema: StructType,
@@ -655,7 +656,10 @@ class XmlTokenizer(
             e)
         case NonFatal(e) =>
           ExceptionUtils.getRootCause(e) match {
-            case _: RuntimeException | _: IOException if options.ignoreCorruptFiles =>
+            case _: RuntimeException | _: IOException if IgnoreCorruptFilesUtils.ignoreCorruptFiles(
+              options.ignoreCorruptFiles,
+              options.ignoreCorruptFilesErrorClasses,
+              e.asInstanceOf[Exception]) =>
               logWarning(
                 "Skipping the rest of" +
                   " the content in the corrupted file during schema inference",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1977,6 +1977,19 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val IGNORE_CORRUPT_FILES_ERROR_CLASSES =
+    buildConf("spark.sql.files.ignoreCorruptFiles.errorClasses")
+      .doc("A comma-separated list of error classes used to determine which exceptions can be " +
+        "ignored, allowing Spark jobs to continue running when encountering corrupted files. " +
+        "You can specify the key message of an exception by adding a colon (:) after the " +
+        "class name, for example: `java.lang.IOException:not a SequenceFile file`. " +
+        s"This configuration is effective only when ${IGNORE_CORRUPT_FILES.key} is " +
+        "set to true. If this configuration is not set, the behavior of Spark handling " +
+        "corrupted files is the same as before.")
+      .version("4.0.0")
+      .stringConf
+      .createWithDefault("")
+
   val IGNORE_MISSING_FILES = buildConf("spark.sql.files.ignoreMissingFiles")
     .doc("Whether to ignore missing files. If true, the Spark jobs will continue to run when " +
       "encountering missing files and the contents that have been read will still be returned. " +
@@ -5297,6 +5310,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def filesMaxPartitionNum: Option[Int] = getConf(FILES_MAX_PARTITION_NUM)
 
   def ignoreCorruptFiles: Boolean = getConf(IGNORE_CORRUPT_FILES)
+
+  def ignoreCorruptFilesErrorClasses: String = getConf(IGNORE_CORRUPT_FILES_ERROR_CLASSES)
 
   def ignoreMissingFiles: Boolean = getConf(IGNORE_MISSING_FILES)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XmlDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/xml/XmlDataSource.scala
@@ -40,6 +40,7 @@ import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.datasources.text.TextFileFormat
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.util.IgnoreCorruptFilesUtils
 
 /**
  * Common functions for parsing XML files
@@ -190,7 +191,11 @@ object MultiLineXmlDataSource extends XmlDataSource {
             Iterator.empty[String]
           case NonFatal(e) =>
             ExceptionUtils.getRootCause(e) match {
-              case _: RuntimeException | _: IOException if parsedOptions.ignoreCorruptFiles =>
+              case _: RuntimeException | _: IOException
+                if IgnoreCorruptFilesUtils.ignoreCorruptFiles(
+                  parsedOptions.ignoreCorruptFiles,
+                  parsedOptions.ignoreCorruptFilesErrorClasses,
+                  e.asInstanceOf[Exception]) =>
                 logWarning("Skipped the rest of the content in the corrupted file", e)
                 Iterator.empty[String]
               case o => throw o

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -1482,34 +1482,42 @@ abstract class CSVSuite
     }
   }
 
+  protected def ignoreCorruptFilesError(inputFile: File): Unit = {
+    val e = intercept[SparkException] {
+      spark.read.csv(inputFile.toURI.toString).collect()
+    }
+    checkErrorMatchPVals(
+      exception = e,
+      errorClass = "FAILED_READ_FILE.NO_HINT",
+      parameters = Map("path" -> s".*${inputFile.getName}.*")
+    )
+    assert(e.getCause.isInstanceOf[EOFException])
+    assert(e.getCause.getMessage === "Unexpected end of input stream")
+    val e2 = intercept[SparkException] {
+      spark.read.option("multiLine", true).csv(inputFile.toURI.toString).collect()
+    }
+    checkErrorMatchPVals(
+      exception = e2,
+      errorClass = "FAILED_READ_FILE.NO_HINT",
+      parameters = Map("path" -> s".*${inputFile.getName}.*")
+    )
+    assert(e2.getCause.getCause.getCause.isInstanceOf[EOFException])
+    assert(e2.getCause.getCause.getCause.getMessage === "Unexpected end of input stream")
+  }
+
+  protected def ignoreCorruptFilesSuccess(inputFile: File): Unit = {
+    assert(spark.read.csv(inputFile.toURI.toString).collect().isEmpty)
+    assert(spark.read.option("multiLine", true).csv(inputFile.toURI.toString).collect()
+      .isEmpty)
+  }
+
   test("Enabling/disabling ignoreCorruptFiles/ignoreMissingFiles") {
     withCorruptFile(inputFile => {
       withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "false") {
-        val e = intercept[SparkException] {
-          spark.read.csv(inputFile.toURI.toString).collect()
-        }
-        checkErrorMatchPVals(
-          exception = e,
-          errorClass = "FAILED_READ_FILE.NO_HINT",
-          parameters = Map("path" -> s".*${inputFile.getName}.*")
-        )
-        assert(e.getCause.isInstanceOf[EOFException])
-        assert(e.getCause.getMessage === "Unexpected end of input stream")
-        val e2 = intercept[SparkException] {
-          spark.read.option("multiLine", true).csv(inputFile.toURI.toString).collect()
-        }
-        checkErrorMatchPVals(
-          exception = e2,
-          errorClass = "FAILED_READ_FILE.NO_HINT",
-          parameters = Map("path" -> s".*${inputFile.getName}.*")
-        )
-        assert(e2.getCause.getCause.getCause.isInstanceOf[EOFException])
-        assert(e2.getCause.getCause.getCause.getMessage === "Unexpected end of input stream")
+        ignoreCorruptFilesError(inputFile)
       }
       withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "true") {
-        assert(spark.read.csv(inputFile.toURI.toString).collect().isEmpty)
-        assert(spark.read.option("multiLine", true).csv(inputFile.toURI.toString).collect()
-          .isEmpty)
+        ignoreCorruptFilesSuccess(inputFile)
       }
     })
     withTempPath { dir =>
@@ -1538,43 +1546,22 @@ abstract class CSVSuite
     }
   }
 
-  test("SPARK-39901: Enabling/disabling ignoreCorruptFilesErrorClasses") {
+  test("SPARK-39901: Setting ignoreCorruptFilesErrorClasses") {
     withCorruptFile(inputFile => {
       withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "false",
         SQLConf.IGNORE_CORRUPT_FILES_ERROR_CLASSES.key ->
           "java.io.EOFException:Unexpected end of input stream") {
-        val e = intercept[SparkException] {
-          spark.read.csv(inputFile.toURI.toString).collect()
-        }
-        checkErrorMatchPVals(
-          exception = e,
-          errorClass = "FAILED_READ_FILE.NO_HINT",
-          parameters = Map("path" -> s".*${inputFile.getName}.*")
-        )
-        assert(e.getCause.isInstanceOf[EOFException])
-        assert(e.getCause.getMessage === "Unexpected end of input stream")
+        ignoreCorruptFilesError(inputFile)
       }
       withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "true") {
         withSQLConf(SQLConf.IGNORE_CORRUPT_FILES_ERROR_CLASSES.key ->
           "java.io.RuntimeException:Unexpected end of input stream") {
-          val e = intercept[SparkException] {
-            spark.read.csv(inputFile.toURI.toString).collect()
-          }
-          checkErrorMatchPVals(
-            exception = e,
-            errorClass = "FAILED_READ_FILE.NO_HINT",
-            parameters = Map("path" -> s".*${inputFile.getName}.*")
-          )
-          assert(e.getCause.isInstanceOf[EOFException])
-          assert(e.getCause.getMessage === "Unexpected end of input stream")
+          ignoreCorruptFilesError(inputFile)
         }
-
         val errorClasses = "java.io.EOFException:Unexpected end of input stream," +
           "com.univocity.parsers.common.TextParsingException:Error reading from input"
         withSQLConf(SQLConf.IGNORE_CORRUPT_FILES_ERROR_CLASSES.key -> errorClasses) {
-          assert(spark.read.csv(inputFile.toURI.toString).collect().isEmpty)
-          assert(spark.read.option("multiLine", true).csv(inputFile.toURI.toString).collect()
-            .isEmpty)
+          ignoreCorruptFilesSuccess(inputFile)
         }
       }
     })

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -1918,28 +1918,36 @@ abstract class JsonSuite
     }
   }
 
+  protected def ignoreCorruptFilesSuccess(inputFile: File): Unit = {
+    assert(spark.read.json(inputFile.toURI.toString).collect().isEmpty)
+    assert(spark.read.option("multiLine", true).json(inputFile.toURI.toString).collect()
+      .isEmpty)
+  }
+
+  protected def ignoreCorruptFilesError(inputFile: File): Unit = {
+    val e = intercept[SparkException] {
+      spark.read.json(inputFile.toURI.toString).collect()
+    }
+    checkErrorMatchPVals(
+      exception = e,
+      errorClass = "FAILED_READ_FILE.NO_HINT",
+      parameters = Map("path" -> s".*${inputFile.getName}.*"))
+    assert(e.getCause.isInstanceOf[EOFException])
+    assert(e.getCause.getMessage === "Unexpected end of input stream")
+    val e2 = intercept[SparkException] {
+      spark.read.option("multiLine", true).json(inputFile.toURI.toString).collect()
+    }
+    assert(e2.getCause.isInstanceOf[EOFException])
+    assert(e2.getCause.getMessage === "Unexpected end of input stream")
+  }
+
   test("SPARK-45035: json enable ignoreCorruptFiles/ignoreMissingFiles") {
     withCorruptFile(inputFile => {
       withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "false") {
-        val e = intercept[SparkException] {
-          spark.read.json(inputFile.toURI.toString).collect()
-        }
-        checkErrorMatchPVals(
-          exception = e,
-          errorClass = "FAILED_READ_FILE.NO_HINT",
-          parameters = Map("path" -> s".*${inputFile.getName}.*"))
-        assert(e.getCause.isInstanceOf[EOFException])
-        assert(e.getCause.getMessage === "Unexpected end of input stream")
-        val e2 = intercept[SparkException] {
-          spark.read.option("multiLine", true).json(inputFile.toURI.toString).collect()
-        }
-        assert(e2.getCause.isInstanceOf[EOFException])
-        assert(e2.getCause.getMessage === "Unexpected end of input stream")
+        ignoreCorruptFilesError(inputFile)
       }
       withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "true") {
-        assert(spark.read.json(inputFile.toURI.toString).collect().isEmpty)
-        assert(spark.read.option("multiLine", true).json(inputFile.toURI.toString).collect()
-          .isEmpty)
+        ignoreCorruptFilesSuccess(inputFile)
       }
     })
     withTempPath { dir =>
@@ -1968,39 +1976,21 @@ abstract class JsonSuite
     }
   }
 
-  test("SPARK-39901: json enable ignoreCorruptFilesErrorClasses") {
+  test("SPARK-39901: Setting ignoreCorruptFilesErrorClasses") {
     withCorruptFile(inputFile => {
       withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "false",
         SQLConf.IGNORE_CORRUPT_FILES_ERROR_CLASSES.key ->
           "java.io.EOFException:Unexpected end of input stream") {
-        val e = intercept[SparkException] {
-          spark.read.json(inputFile.toURI.toString).collect()
-        }
-        checkErrorMatchPVals(
-          exception = e,
-          errorClass = "FAILED_READ_FILE.NO_HINT",
-          parameters = Map("path" -> s".*${inputFile.getName}.*"))
-        assert(e.getCause.isInstanceOf[EOFException])
-        assert(e.getCause.getMessage === "Unexpected end of input stream")
+        ignoreCorruptFilesError(inputFile)
       }
       withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "true") {
         withSQLConf(SQLConf.IGNORE_CORRUPT_FILES_ERROR_CLASSES.key ->
           "java.io.RuntimeException:Unexpected end of input stream") {
-          val e = intercept[SparkException] {
-            spark.read.json(inputFile.toURI.toString).collect()
-          }
-          checkErrorMatchPVals(
-            exception = e,
-            errorClass = "FAILED_READ_FILE.NO_HINT",
-            parameters = Map("path" -> s".*${inputFile.getName}.*"))
-          assert(e.getCause.isInstanceOf[EOFException])
-          assert(e.getCause.getMessage === "Unexpected end of input stream")
+          ignoreCorruptFilesError(inputFile)
         }
         withSQLConf(SQLConf.IGNORE_CORRUPT_FILES_ERROR_CLASSES.key ->
           "java.io.EOFException:Unexpected end of input stream") {
-          assert(spark.read.json(inputFile.toURI.toString).collect().isEmpty)
-          assert(spark.read.option("multiLine", false).json(inputFile.toURI.toString).collect()
-            .isEmpty)
+          ignoreCorruptFilesSuccess(inputFile)
         }
       }
     })

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcQuerySuite.scala
@@ -640,7 +640,7 @@ abstract class OrcQueryTest extends OrcTest {
     }
   }
 
-  test("SPARK-39901: Enabling/disabling ignoreCorruptFilesErrorClasses") {
+  test("SPARK-39901: Setting ignoreCorruptFilesErrorClasses") {
     withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "true") {
       withSQLConf(SQLConf.IGNORE_CORRUPT_FILES_ERROR_CLASSES.key ->
         "org.apache.orc.FileFormatException:Malformed ORC file") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
@@ -241,7 +241,8 @@ abstract class OrcSuite
          => Seq[StructType]): Unit = {
       checkErrorMatchPVals(
         exception = intercept[SparkException] {
-          testMergeSchemasInParallel(ignoreCorruptFiles, ignoreCorruptFilesErrorClasses, schemaReader)
+          testMergeSchemasInParallel(ignoreCorruptFiles, ignoreCorruptFilesErrorClasses,
+            schemaReader)
         }.getCause.getCause.asInstanceOf[SparkException],
         errorClass = "FAILED_READ_FILE.CANNOT_READ_FILE_FOOTER",
         parameters = Map("path" -> "file:.*")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/orc/OrcSourceSuite.scala
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 import java.sql.{Date, Timestamp}
 import java.time.{Duration, Period}
 import java.util.Locale
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
 import org.apache.logging.log4j.Level
@@ -31,12 +32,13 @@ import org.apache.orc.OrcProto.ColumnEncoding.Kind.{DICTIONARY_V2, DIRECT, DIREC
 import org.apache.orc.OrcProto.Stream.Kind
 import org.apache.orc.impl.RecordReaderImpl
 import org.scalatest.BeforeAndAfterAll
+
 import org.apache.spark.{SPARK_VERSION_SHORT, SparkConf, SparkException}
 import org.apache.spark.sql.{Row, SPARK_VERSION_METADATA_KEY}
 import org.apache.spark.sql.execution.datasources.{CommonFileDataSourceSuite, SchemaMergeUtils}
 import org.apache.spark.sql.execution.datasources.orc.OrcCompressionCodec._
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.test.{SQLTestUtilsBase, SharedSparkSession}
+import org.apache.spark.sql.test.{SharedSparkSession, SQLTestUtilsBase}
 import org.apache.spark.sql.types._
 import org.apache.spark.util.{IgnoreCorruptFilesError, Utils}
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormatSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormatSuite.scala
@@ -18,7 +18,9 @@
 package org.apache.spark.sql.execution.datasources.parquet
 
 import java.time.{Duration, Period}
+
 import org.apache.hadoop.fs.{FileSystem, Path}
+
 import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.execution.datasources.CommonFileDataSourceSuite

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlSuite.scala
@@ -2828,37 +2828,46 @@ class XmlSuite
     )
   }
 
+  protected def ignoreCorruptFilesError(inputFile: File): Unit = {
+    val e = intercept[SparkException] {
+      spark.read
+        .option("rowTag", "ROW")
+        .option("multiLine", false)
+        .xml(inputFile.toURI.toString)
+        .collect()
+    }
+    assert(ExceptionUtils.getRootCause(e).isInstanceOf[EOFException])
+    assert(ExceptionUtils.getRootCause(e).getMessage === "Unexpected end of input stream")
+    val e2 = intercept[SparkException] {
+      spark.read
+        .option("rowTag", "ROW")
+        .option("multiLine", true)
+        .xml(inputFile.toURI.toString)
+        .collect()
+    }
+    assert(ExceptionUtils.getRootCause(e2).isInstanceOf[EOFException])
+    assert(ExceptionUtils.getRootCause(e2).getMessage === "Unexpected end of input stream")
+  }
+
+  protected def ignoreCorruptFilesSuccess(inputFile: File): Unit = {
+    val result = spark.read
+      .option("rowTag", "ROW")
+      .option("multiLine", false)
+      .xml(inputFile.toURI.toString)
+      .collect()
+    assert(result.isEmpty)
+  }
+
   test("SPARK-46248: Enabling/disabling ignoreCorruptFiles/ignoreMissingFiles") {
     withCorruptFile(inputFile => {
       withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "false") {
-        val e = intercept[SparkException] {
-          spark.read
-            .option("rowTag", "ROW")
-            .option("multiLine", false)
-            .xml(inputFile.toURI.toString)
-            .collect()
-        }
-        assert(ExceptionUtils.getRootCause(e).isInstanceOf[EOFException])
-        assert(ExceptionUtils.getRootCause(e).getMessage === "Unexpected end of input stream")
-        val e2 = intercept[SparkException] {
-          spark.read
-            .option("rowTag", "ROW")
-            .option("multiLine", true)
-            .xml(inputFile.toURI.toString)
-            .collect()
-        }
-        assert(ExceptionUtils.getRootCause(e2).isInstanceOf[EOFException])
-        assert(ExceptionUtils.getRootCause(e2).getMessage === "Unexpected end of input stream")
+        ignoreCorruptFilesError(inputFile)
       }
       withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "true") {
-        val result = spark.read
-           .option("rowTag", "ROW")
-           .option("multiLine", false)
-           .xml(inputFile.toURI.toString)
-           .collect()
-        assert(result.isEmpty)
+        ignoreCorruptFilesSuccess(inputFile)
       }
     })
+
     withTempPath { dir =>
       import org.apache.hadoop.fs.Path
       val xmlPath = new Path(dir.getCanonicalPath, "xml")
@@ -2886,43 +2895,25 @@ class XmlSuite
     }
   }
 
-  test("SPARK-39901: Enabling/disabling ignoreCorruptFilesErrorClasses") {
+  test("SPARK-39901: Setting ignoreCorruptFilesErrorClasses") {
+    // ignoreCorruptFiles: false, ignoreCorruptFilesErrorClasses: right classes
     withCorruptFile(inputFile => {
       withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "false",
         SQLConf.IGNORE_CORRUPT_FILES_ERROR_CLASSES.key ->
           "java.io.EOFException:Unexpected end of input stream") {
-        val e = intercept[SparkException] {
-          spark.read
-            .option("rowTag", "ROW")
-            .option("multiLine", false)
-            .xml(inputFile.toURI.toString)
-            .collect()
-        }
-        assert(ExceptionUtils.getRootCause(e).isInstanceOf[EOFException])
-        assert(ExceptionUtils.getRootCause(e).getMessage === "Unexpected end of input stream")
+        ignoreCorruptFilesError(inputFile)
       }
 
       withSQLConf(SQLConf.IGNORE_CORRUPT_FILES.key -> "true") {
+        // ignoreCorruptFiles: true, ignoreCorruptFilesErrorClasses: wrong classes
         withSQLConf(SQLConf.IGNORE_CORRUPT_FILES_ERROR_CLASSES.key ->
           "java.io.RuntimeException:Unexpected end of input stream") {
-          val e = intercept[SparkException] {
-            spark.read
-              .option("rowTag", "ROW")
-              .option("multiLine", false)
-              .xml(inputFile.toURI.toString)
-              .collect()
-          }
-          assert(ExceptionUtils.getRootCause(e).isInstanceOf[EOFException])
-          assert(ExceptionUtils.getRootCause(e).getMessage === "Unexpected end of input stream")
+          ignoreCorruptFilesError(inputFile)
         }
+        // ignoreCorruptFiles: true, ignoreCorruptFilesErrorClasses: right classes
         withSQLConf(SQLConf.IGNORE_CORRUPT_FILES_ERROR_CLASSES.key ->
           "java.io.EOFException:Unexpected end of input stream") {
-          val result = spark.read
-            .option("rowTag", "ROW")
-            .option("multiLine", false)
-            .xml(inputFile.toURI.toString)
-            .collect()
-          assert(result.isEmpty)
+          ignoreCorruptFilesSuccess(inputFile)
         }
       }
     })

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/TableReader.scala
@@ -46,7 +46,7 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.unsafe.types.UTF8String
-import org.apache.spark.util.{SerializableConfiguration, Utils}
+import org.apache.spark.util.{IgnoreCorruptFilesUtils, SerializableConfiguration, Utils}
 import org.apache.spark.util.ArrayImplicits._
 
 /**
@@ -331,7 +331,10 @@ class HadoopTableReader(
       classOf[Writable],
       _minSplitsPerRDD,
       ignoreCorruptFiles = conf.ignoreCorruptFiles,
-      ignoreMissingFiles = conf.ignoreMissingFiles)
+      ignoreMissingFiles = conf.ignoreMissingFiles,
+      ignoreCorruptFilesErrorClasses = IgnoreCorruptFilesUtils.errorClassesStrToSeq(
+        conf.ignoreCorruptFilesErrorClasses)
+    )
 
     // Only take the value (skip the key) because Hive works only with values.
     rdd.map(_._2)
@@ -367,7 +370,10 @@ class HadoopTableReader(
       classOf[Writable],
       jobConf,
       ignoreCorruptFiles = conf.ignoreCorruptFiles,
-      ignoreMissingFiles = conf.ignoreMissingFiles)
+      ignoreMissingFiles = conf.ignoreMissingFiles,
+      ignoreCorruptFilesErrorClasses = IgnoreCorruptFilesUtils.errorClassesStrToSeq(
+        conf.ignoreCorruptFilesErrorClasses)
+    )
 
     // Only take the value (skip the key) because Hive works only with values.
     rdd.map(_._2)

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileOperator.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/orc/OrcFileOperator.scala
@@ -118,7 +118,8 @@ private[hive] object OrcFileOperator extends Logging {
       : Seq[StructType] = {
     ThreadUtils.parmap(partFiles, "readingOrcSchemas", 8) { currentFile =>
       val file = currentFile.getPath.toString
-      getFileReader(file, Some(conf), ignoreCorruptFiles).map(reader => {
+      getFileReader(file, Some(conf), ignoreCorruptFiles,
+        ignoreCorruptFilesErrorClasses).map(reader => {
         val readerInspector = reader.getObjectInspector.asInstanceOf[StructObjectInspector]
         val schema = readerInspector.getTypeName
         logDebug(s"Reading schema from file $file., got Hive schema string: $schema")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
As described in issue [SPARK-39901](https://issues.apache.org/jira/browse/SPARK-39901) the design of the current `ignoreCorruptFiles` feature has certain flaws. It excessively matches `IOException`s, which may cause a file to be Ignored by mistake when encountering some transient and sporadic IO exceptions.

This PR proposes a new config `spark.files.ignoreCorruptFiles.errorClasses`. By setting this config, Spark users can accurately ignore corrupt files caused by specific exceptions. 

For example, if the config value is set as belows:

-   `java.lang.IOException:not a Sequence file,java.lang.EOFException`
(config format: className[:keyMsg],className[:keyMsg])

It means that when an `IOException` is encountered and the error message contains key information `not a Sequence file`, or when a `java.lang.EOFException` is encountered (note that only class needs to be judged here), corrupted files should be ignored.

The default value of this config is "", which means that the error class list for ignoring corrupt files has not been set. At this time, the behavior of `ignoreCorruptFiles` remains exactly the same as before.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Optimize the defects of the current `ignoreCorruptFiles` feature.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, Spark users can change the behavior of `ignoreCorruptFiles` by setting the new config; but by default, the behavior remains the same as before. So don't worry it's a breakchange for users.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Add some new test cases and Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.