### PR TITLE
[SPARK-48718][SQL] Handle and fix the case when deserializer in cogroup is resolved during application of DeduplicateRelation rule

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -21,6 +21,7 @@ import java.io.{Externalizable, ObjectInput, ObjectOutput}
 import java.sql.{Date, Timestamp}
 
 import scala.collection.immutable.HashSet
+import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 import scala.util.Random
 
@@ -950,6 +951,25 @@ class DatasetSuite extends QueryTest
       case (row, iterator, iterator1) => iterator.toSeq ++ iterator1.toSeq
     }(ExpressionEncoder(inputType)).collect()
     assert(result2.length == 3)
+  }
+
+  test("correctly handle when deserializer in cogroup is resolved in dedup relation") {
+    val lhs = spark.createDataFrame(
+      List(Row(123L)).asJava,
+      StructType(Seq(StructField("GROUPING_KEY", LongType)))
+    )
+    val rhs = spark.createDataFrame(
+      List(Row(0L, 123L)).asJava,
+      StructType(Seq(StructField("ID", LongType), StructField("GROUPING_KEY", LongType)))
+    )
+
+    val lhsKV = lhs.groupByKey((r: Row) => r.getAs[Long]("GROUPING_KEY"))
+    val rhsKV = rhs.groupByKey((r: Row) => r.getAs[Long]("GROUPING_KEY"))
+    val cogrouped = lhsKV.cogroup(rhsKV)(
+      (a: Long, b: Iterator[Row], c: Iterator[Row]) => Iterator(0L)
+    )
+    val joined = rhs.join(cogrouped, col("ID") === col("value"), "left")
+    checkAnswer(joined, Row(0L, 123L, 0L) :: Nil)
   }
 
   test("SPARK-34806: observation on datasets") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DatasetSuite.scala
@@ -953,7 +953,7 @@ class DatasetSuite extends QueryTest
     assert(result2.length == 3)
   }
 
-  test("correctly handle when deserializer in cogroup is resolved in dedup relation") {
+  test("SPARK-48718: cogroup deserializer expr is resolved before dedup relation") {
     val lhs = spark.createDataFrame(
       List(Row(123L)).asJava,
       StructType(Seq(StructField("GROUPING_KEY", LongType)))


### PR DESCRIPTION
### What changes were proposed in this pull request?
A followup for https://github.com/apache/spark/pull/41554/files.
Handle the case when the deserializer in cogroup is resolved when applying DeduplicateRelation rule. Otherwise, it will throw an uncastable error.
See the added test case as an example.


### Why are the changes needed?
Fix a bug introduced in a previous commit.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Add a new test case.


### Was this patch authored or co-authored using generative AI tooling?
No.
