### PR TITLE
[SPARK-48717][Python][SS] Catch ForeachBatch py4j InterruptedException better in classic PySpark

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -689,7 +689,7 @@ object StreamExecution {
     classOf[ClosedByInterruptException].getName)
   val PROXY_ERROR = (
     "py4j.protocol.Py4JJavaError: An error occurred while calling" +
-      s".+(\\r\\n|\\r|\\n)((.|\\r\\n|\\r|\\n)*)(${IO_EXCEPTION_NAMES.mkString("|")})").r
+      s"((.|\\r\\n|\\r|\\n)*)(${IO_EXCEPTION_NAMES.mkString("|")})").r
 
   @scala.annotation.tailrec
   def isInterruptionException(e: Throwable, sc: SparkContext): Boolean = e match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -689,7 +689,7 @@ object StreamExecution {
     classOf[ClosedByInterruptException].getName)
   val PROXY_ERROR = (
     "py4j.protocol.Py4JJavaError: An error occurred while calling" +
-    s".+(\\r\\n|\\r|\\n): (${IO_EXCEPTION_NAMES.mkString("|")})").r
+      s".+(\\r\\n|\\r|\\n)((.|\\r\\n|\\r|\\n)*)(${IO_EXCEPTION_NAMES.mkString("|")})").r
 
   @scala.annotation.tailrec
   def isInterruptionException(e: Throwable, sc: SparkContext): Boolean = e match {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -1334,7 +1334,7 @@ class StreamSuite extends StreamTest {
         |: java.util.concurrent.ExecutionException: java.lang.InterruptedException
         |""".stripMargin)
     val febError1 = ForeachBatchUserFuncException(e1)
-    assert(StreamExecution.isInterruptionException(feb_error1, spark.sparkContext))
+    assert(StreamExecution.isInterruptionException(febError1, spark.sparkContext))
 
     // scalastyle:off line.size.limit
     val e2 = new py4j.Py4JException(
@@ -1354,7 +1354,7 @@ class StreamSuite extends StreamTest {
         |""".stripMargin)
     // scalastyle:on line.size.limit
     val febError2 = ForeachBatchUserFuncException(e2)
-    assert(StreamExecution.isInterruptionException(feb_error2, spark.sparkContext))
+    assert(StreamExecution.isInterruptionException(febError2, spark.sparkContext))
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -1333,7 +1333,7 @@ class StreamSuite extends StreamTest {
         |py4j.protocol.Py4JJavaError: An error occurred while calling o1073599.sql.
         |: java.util.concurrent.ExecutionException: java.lang.InterruptedException
         |""".stripMargin)
-    val feb_error1 = ForeachBatchUserFuncException(e1)
+    val febError1 = ForeachBatchUserFuncException(e1)
     assert(StreamExecution.isInterruptionException(feb_error1, spark.sparkContext))
 
     // scalastyle:off line.size.limit
@@ -1353,7 +1353,7 @@ class StreamSuite extends StreamTest {
         |at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1000)*
         |""".stripMargin)
     // scalastyle:on line.size.limit
-    val feb_error2 = ForeachBatchUserFuncException(e2)
+    val febError2 = ForeachBatchUserFuncException(e2)
     assert(StreamExecution.isInterruptionException(feb_error2, spark.sparkContext))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -1336,6 +1336,7 @@ class StreamSuite extends StreamTest {
     val feb_error1 = ForeachBatchUserFuncException(e1)
     assert(StreamExecution.isInterruptionException(feb_error1, spark.sparkContext))
 
+    // scalastyle:off line.size.limit
     val e2 = new py4j.Py4JException(
       """
         |py4j.protocol.Py4JJavaError: An error occurred while calling o2141502.saveAsTable.
@@ -1351,6 +1352,7 @@ class StreamSuite extends StreamTest {
         |*Caused by: java.lang.InterruptedException
         |at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1000)*
         |""".stripMargin)
+    // scalastyle:on line.size.limit
     val feb_error2 = ForeachBatchUserFuncException(e2)
     assert(StreamExecution.isInterruptionException(feb_error2, spark.sparkContext))
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -1326,6 +1326,34 @@ class StreamSuite extends StreamTest {
       }
     }
   }
+
+  test("isInterruptionException should correctly unwrap classic py4j InterruptedException") {
+    val e1 = new py4j.Py4JException(
+      """
+        |py4j.protocol.Py4JJavaError: An error occurred while calling o1073599.sql.
+        |: java.util.concurrent.ExecutionException: java.lang.InterruptedException
+        |""".stripMargin)
+    val feb_error1 = ForeachBatchUserFuncException(e1)
+    assert(StreamExecution.isInterruptionException(feb_error1, spark.sparkContext))
+
+    val e2 = new py4j.Py4JException(
+      """
+        |py4j.protocol.Py4JJavaError: An error occurred while calling o2141502.saveAsTable.
+        |: org.apache.spark.SparkException: Job aborted.
+        |at org.apache.spark.sql.errors.QueryExecutionErrors$.jobAbortedError(QueryExecutionErrors.scala:882)
+        |at org.apache.spark.sql.execution.datasources.FileFormatWriter$.$anonfun$write$1(FileFormatWriter.scala:334)
+        |<REDACTED STACK TRACE>
+        |org.apache.spark.sql.execution.streaming.StreamExecution.withAttributionTags(StreamExecution.scala:82)
+        |at org.apache.spark.sql.execution.streaming.StreamExecution.org$apache$spark$sql$execution$streaming$StreamExecution$$runStream(StreamExecution.scala:339)
+        |at org.apache.spark.sql.execution.streaming.StreamExecution$$anon$1.$anonfun$run$2(StreamExecution.scala:262)
+        |at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
+        |at org.apache.spark.sql.execution.streaming.StreamExecution$$anon$1.run(StreamExecution.scala:262)
+        |*Caused by: java.lang.InterruptedException
+        |at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1000)*
+        |""".stripMargin)
+    val feb_error2 = ForeachBatchUserFuncException(e2)
+    assert(StreamExecution.isInterruptionException(feb_error2, spark.sparkContext))
+  }
 }
 
 abstract class FakeSource extends StreamSourceProvider {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In https://issues.apache.org/jira/browse/SPARK-39218, there is a fix when python pinned thread mode is on, and `query.stop()` sends an interrupted signal, for example (from the original ticket):

```
import time

def func(batch_df, batch_id):
    time.sleep(10)
    print(batch_df.count())

q = spark.readStream.format("rate").load().writeStream.foreachBatch(func).start()
time.sleep(5)
q.stop()
```

Because all python errors are wrapped inside `PY4JJavaError`, the fix was to do reg-ex match on that error string:
https://github.com/apache/spark/blob/94763438943e21ee8156a4f1a3facddbf8d45797/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala#L690-L692

However, this regex only checks the case when the exception is thrown in `time.sleep(10)` (my understanding). So only errors like this would be captured:
```
py4j.protocol.Py4JJavaError: An error occurred while calling o44.count.
: java.lang.InterruptedException
```

But say the interrupted signal is sent when executing a spark query:

```
def func(batch_df, batch_id):
    batch_df.sparkSession.range(10000000).write.saveAsTable("oops")
    print(batch_df.count())
```

Then we would see such errors:
```
py4j.protocol.Py4JJavaError: An error occurred while calling o2141502.saveAsTable.  
: org.apache.spark.SparkException: Job aborted.  
<REDACTED>
<REDACTED>
<REDACTED>
...
at org.apache.spark.sql.execution.streaming.StreamExecution$$anon$1.$anonfun$run$2(StreamExecution.scala:262)  
at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)  
at org.apache.spark.sql.execution.streaming.StreamExecution$$anon$1.run(StreamExecution.scala:262)  
*Caused by: java.lang.InterruptedException  
at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1000)*  
at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1308)  
```

In such cases, query.stop() would actually cause the query to throw, although it shouldn't.

In this PR, we propose to relax the regex and match more InterruptedException.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Bug fix 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added unit test 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No