### PR TITLE
[SPARK-48578][SQL][FOLLOWUP] Fix  `dev/scalastyle` error for `ExpressionImplUtilsSuite`

### DIFF
--- a/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtilsSuite.scala
+++ b/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtilsSuite.scala
@@ -390,10 +390,12 @@ class ExpressionImplUtilsSuite extends SparkFunSuite {
       UTF8String.fromString("A"), except = false)
     validateUTF8(UTF8String.fromBytes(Array[Byte](0x61)),
       UTF8String.fromString("a"), except = false)
+    // scalastyle:off nonascii
     validateUTF8(UTF8String.fromBytes(Array[Byte](0x80.toByte)),
       UTF8String.fromString("\uFFFD"), except = true)
     validateUTF8(UTF8String.fromBytes(Array[Byte](0xFF.toByte)),
       UTF8String.fromString("\uFFFD"), except = true)
+    // scalastyle:on nonascii
   }
 
   test("TryValidate UTF8 string") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr is following up https://github.com/apache/spark/pull/46845, to fix ` dev/scalastyle` check error.


### Why are the changes needed?
Make `sh dev/scalastyle` happy.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manually test
```
sh dev/scakastyle
```

Before:
```
(base) ➜  spark-community git:(master) ✗ sh dev/scalastyle
-e Scalastyle checks failed at following occurrences:
[error] /Users/panbingkun/Developer/spark/spark-community/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtilsSuite.scala:394:28: nonascii.message
[error] /Users/panbingkun/Developer/spark/spark-community/sql/catalyst/src/test/java/org/apache/spark/sql/catalyst/expressions/ExpressionImplUtilsSuite.scala:396:28: nonascii.message
[error] Total time: 23 s, completed Jun 26, 2024, 9:49:06 AM

```

After:
```
(base) ➜  spark-community git:(fix_scalastyle) ✗ sh dev/scalastyle
-e Scalastyle checks passed.
```


### Was this patch authored or co-authored using generative AI tooling?
No.
