### PR TITLE
[SPARK-48721][SQL][DOCS] Fix the doc of `decode` function in SQL API page

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -2842,7 +2842,7 @@ object Decode {
 // scalastyle:off line.size.limit
 @ExpressionDescription(
   usage = """
-    _FUNC_(bin, charset) - Decodes the first argument using the second argument character set.
+    _FUNC_(bin, charset) - Decodes the first argument using the second argument character set. If either argument is null, the result will also be null.
 
     _FUNC_(expr, search, result [, search, result ] ... [, default]) - Compares expr
       to each search value in order. If expr is equal to a search value, _FUNC_ returns
@@ -2867,7 +2867,10 @@ object Decode {
       > SELECT _FUNC_(null, 6, 'Spark', NULL, 'SQL', 4, 'rocks');
        SQL
   """,
-  since = "3.2.0",
+  since = "1.5.0",
+  note = """
+    _FUNC_(expr, search, result [, search, result ] ... [, default]) is supported since 3.2.0
+  """,
   group = "string_funcs")
 // scalastyle:on line.size.limit
 case class Decode(params: Seq[Expression], replacement: Expression)
@@ -2882,25 +2885,6 @@ case class Decode(params: Seq[Expression], replacement: Expression)
   }
 }
 
-/**
- * Decodes the first argument into a String using the provided character set.
- */
-// scalastyle:off line.size.limit
-@ExpressionDescription(
-  usage = "_FUNC_(bin, charset) - Decodes the first argument using the second argument character set. If either argument is null, the result will also be null.",
-  examples = """
-    Examples:
-      > SELECT _FUNC_(encode('abc', 'utf-8'), 'utf-8');
-       abc
-  """,
-  arguments = """
-    Arguments:
-      * bin - a binary expression to decode
-      * charset - one of the charsets 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16', 'UTF-32' to decode `bin` into a STRING. It is case insensitive.
-  """,
-  since = "1.5.0",
-  group = "string_funcs")
-// scalastyle:on line.size.limit
 case class StringDecode(
     bin: Expression,
     charset: Expression,


### PR DESCRIPTION


### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
There are some documentation errors in https://spark.apache.org/docs/4.0.0-preview1/api/sql/index.html#decode

This PR fixes the doc of the `decode` function in the SQL API page
- correct since version
- add back missing null semantics
- clean stale annotations in StringDecode


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

doc build

![image](https://github.com/apache/spark/assets/8326978/3f040308-ea4a-41c5-b354-336be028e983)

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no