### PR TITLE
[SPARK-48723][INFRA] Run `git cherry-pick --abort` if backporting is denied by committer

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -118,9 +118,14 @@ def run_cmd(cmd):
         return subprocess.check_output(cmd.split(" ")).decode("utf-8")
 
 
-def continue_maybe(prompt):
+def continue_maybe(prompt, cherry=False):
     result = bold_input("%s (y/N): " % prompt)
     if result.lower() != "y":
+        if cherry:
+            try:
+                run_cmd("git cherry-pick --abort")
+            except Exception:
+                print_error("Unable to abort and get back to the state before cherry-pick")
         fail("Okay, exiting")
 
 
@@ -234,9 +239,9 @@ def cherry_pick(pr_num, merge_hash, default_branch):
         run_cmd("git cherry-pick -sx %s" % merge_hash)
     except Exception as e:
         msg = "Error cherry-picking: %s\nWould you like to manually fix-up this merge?" % e
-        continue_maybe(msg)
+        continue_maybe(msg, True)
         msg = "Okay, please fix any conflicts and finish the cherry-pick. Finished?"
-        continue_maybe(msg)
+        continue_maybe(msg, True)
 
     continue_maybe(
         "Pick complete (local ref %s). Push to %s?" % (pick_branch_name, PUSH_REMOTE_NAME)


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


This pull request includes the addition of `git cherry-pick --abort` to run if backporting is denied by committers.

Otherwise, the unresolved cherry-pick context will block following command to be run properly

```python
Error cherry-picking: Command '['git', 'cherry-pick', '-sx', 'e23d69b0']' returned non-zero exit status 1.
y fix-up this merge? (y/N): n
Okay, exiting
Restoring head pointer to master
git checkout master
error: you need to resolve your current index first
Restoring head pointer to master
git checkout master
error: you need to resolve your current index first
Traceback (most recent call last):
  File "/Users/hzyaoqin/spark/./dev/merge_spark_pr.py", line 234, in cherry_pick

  File "/Users/hzyaoqin/spark/./dev/merge_spark_pr.py", line 118, in run_cmd

  File "/opt/homebrew/Cellar/python@3.11/3.11.8/Frameworks/Python.framework/Versions/3.11/lib/python3.11/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

improve merge PR progress

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

no
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Locally with python interpreter:
```python
>>> cherry_pick(47082, "e23d69b", "branch-3.5")
Enter a branch name [branch-3.5]:
git fetch apache branch-3.5:PR_TOOL_PICK_PR_47082_BRANCH-3.5
From github.com:apache/spark
 * [new branch]              branch-3.5 -> PR_TOOL_PICK_PR_47082_BRANCH-3.5
git checkout PR_TOOL_PICK_PR_47082_BRANCH-3.5
Updating files: 100% (6027/6027), done.
Switched to branch 'PR_TOOL_PICK_PR_47082_BRANCH-3.5'
git cherry-pick -sx e23d69b
error: could not apply e23d69b0f1d... [SPARK-48709][SQL] Fix varchar type resolution mismatch for DataSourceV2 CTAS
hint: After resolving the conflicts, mark them with
hint: "git add/rm <pathspec>", then run
hint: "git cherry-pick --continue".
hint: You can instead skip this commit with "git cherry-pick --skip".
hint: To abort and get back to the state before "git cherry-pick",
hint: run "git cherry-pick --abort".
Error cherry-picking: Command '['git', 'cherry-pick', '-sx', 'e23d69b']' returned non-zero exit status 1.
 fix-up this merge? (y/N): n
git cherry-pick --abort
Okay, exiting
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no