### PR TITLE
[SPARK-48731][INFRA] Upgrade `docker/build-push-action` to v6

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -341,7 +341,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./dev/infra/
           push: true

--- a/.github/workflows/build_infra_images_cache.yml
+++ b/.github/workflows/build_infra_images_cache.yml
@@ -51,7 +51,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./dev/infra/
           push: true


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `docker/build-push-action` from `v5` to `v6`.


### Why are the changes needed?
https://github.com/docker/build-push-action/releases/tag/v6.5.0
...
https://github.com/docker/build-push-action/releases/tag/v6.0.0
<img width="1097" alt="image" src="https://github.com/apache/spark/assets/15246973/136a0257-6a94-4771-a97c-3f703925b269">
https://docs.docker.com/build/ci/github-actions/build-summary/

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.
Manual observation as following:
https://github.com/panbingkun/spark/actions/runs/9689581212
<img width="1003" alt="image" src="https://github.com/apache/spark/assets/15246973/43af8e42-32d3-463c-9bbf-33cf9817bc1f">


### Was this patch authored or co-authored using generative AI tooling?
No.
