### PR TITLE
[MINOR][TESTS] Always remove spark.master in ReusedConnectTestCase

### DIFF
--- a/python/pyspark/testing/connectutils.py
+++ b/python/pyspark/testing/connectutils.py
@@ -170,6 +170,8 @@ class ReusedConnectTestCase(unittest.TestCase, SQLTestUtils, PySparkErrorTestUti
         conf = SparkConf(loadDefaults=False)
         # Make the server terminate reattachable streams every 1 second and 123 bytes,
         # to make the tests exercise reattach.
+        if conf._jconf is not None:
+            conf._jconf.remove("spark.master")
         conf.set("spark.connect.execute.reattachable.senderMaxStreamDuration", "1s")
         conf.set("spark.connect.execute.reattachable.senderMaxStreamSize", "123")
         return conf


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to always remove `spark.master` in `ReusedConnectTestCase`.

### Why are the changes needed?

More just for sanity. The tests should only run with `spark.remote`

### Does this PR introduce _any_ user-facing change?

No, test-only

### How was this patch tested?

Fixed unittest

### Was this patch authored or co-authored using generative AI tooling?

No.
