### PR TITLE
[MINOR][PYTHON][TESTS] Remove duplicate schema checking

### DIFF
--- a/python/pyspark/sql/tests/test_group.py
+++ b/python/pyspark/sql/tests/test_group.py
@@ -26,7 +26,7 @@ from pyspark.testing.sqlutils import (
     pandas_requirement_message,
     pyarrow_requirement_message,
 )
-from pyspark.testing import assertDataFrameEqual, assertSchemaEqual
+from pyspark.testing import assertDataFrameEqual
 
 
 class GroupTestsMixin:
@@ -92,30 +92,25 @@ class GroupTestsMixin:
             # basic case
             df1 = spark.sql("select a, sum(b) from v group by 1;")
             df2 = df.groupBy(1).agg(sf.sum("b"))
-            assertSchemaEqual(df1.schema, df2.schema)
             assertDataFrameEqual(df1, df2)
 
             # constant case
             df1 = spark.sql("select 1, 2, sum(b) from v group by 1, 2;")
             df2 = df.select(sf.lit(1), sf.lit(2), "b").groupBy(1, 2).agg(sf.sum("b"))
-            assertSchemaEqual(df1.schema, df2.schema)
             assertDataFrameEqual(df1, df2)
 
             # duplicate group by column
             df1 = spark.sql("select a, 1, sum(b) from v group by a, 1;")
             df2 = df.select("a", sf.lit(1), "b").groupBy("a", 2).agg(sf.sum("b"))
-            assertSchemaEqual(df1.schema, df2.schema)
             assertDataFrameEqual(df1, df2)
 
             df1 = spark.sql("select a, 1, sum(b) from v group by 1, 2;")
             df2 = df.select("a", sf.lit(1), "b").groupBy(1, 2).agg(sf.sum("b"))
-            assertSchemaEqual(df1.schema, df2.schema)
             assertDataFrameEqual(df1, df2)
 
             # group by a non-aggregate expression's ordinal
             df1 = spark.sql("select a, b + 2, count(2) from v group by a, 2;")
             df2 = df.select("a", df.b + 2).groupBy(1, 2).agg(sf.count(sf.lit(2)))
-            assertSchemaEqual(df1.schema, df2.schema)
             assertDataFrameEqual(df1, df2)
 
             # negative cases: ordinal out of range
@@ -152,28 +147,23 @@ class GroupTestsMixin:
 
             df1 = spark.sql("select * from v order by 1 desc;")
             df2 = df.orderBy(-1)
-            assertSchemaEqual(df1.schema, df2.schema)
             assertDataFrameEqual(df1, df2)
 
             df1 = spark.sql("select * from v order by 1 desc, b desc;")
             df2 = df.orderBy(-1, df.b.desc())
-            assertSchemaEqual(df1.schema, df2.schema)
             assertDataFrameEqual(df1, df2)
 
             df1 = spark.sql("select * from v order by 1 desc, 2 desc;")
             df2 = df.orderBy(-1, -2)
-            assertSchemaEqual(df1.schema, df2.schema)
             assertDataFrameEqual(df1, df2)
 
             # groupby ordinal with orderby ordinal
             df1 = spark.sql("select a, 1, sum(b) from v group by 1, 2 order by 1;")
             df2 = df.select("a", sf.lit(1), "b").groupBy(1, 2).agg(sf.sum("b")).sort(1)
-            assertSchemaEqual(df1.schema, df2.schema)
             assertDataFrameEqual(df1, df2)
 
             df1 = spark.sql("select a, 1, sum(b) from v group by 1, 2 order by 3, 1;")
             df2 = df.select("a", sf.lit(1), "b").groupBy(1, 2).agg(sf.sum("b")).sort(3, 1)
-            assertSchemaEqual(df1.schema, df2.schema)
             assertDataFrameEqual(df1, df2)
 
             # negative cases: ordinal out of range


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to remove duplicated schema checking. `assertDataFrameEqual` already checks it

### Why are the changes needed?

To remove duplicate schema comparison

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Manually

### Was this patch authored or co-authored using generative AI tooling?

No.
