### PR TITLE
[SPARK-48737] Perf improvement during analysis - Create exception only when it is necessary for default expression resolving

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -165,10 +165,6 @@ object ResolveDefaultColumns extends QueryErrorsBase
    *
    * The column "DEFAULT" will be resolved to the default value expression defined for the column of
    * the assignment key.
-   *
-   * IMPORTANT: The 'invalidColumnDefaultException' argument must be lazy until the exception
-   * is actually thrown, because the instantiation of SparkThrowable exception results in
-   * reading the file error-classes to format exception message.
    */
   def resolveColumnDefaultInAssignmentValue(
       key: Expression,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/ResolveDefaultColumnsUtil.scala
@@ -165,11 +165,15 @@ object ResolveDefaultColumns extends QueryErrorsBase
    *
    * The column "DEFAULT" will be resolved to the default value expression defined for the column of
    * the assignment key.
+   *
+   * IMPORTANT: The 'invalidColumnDefaultException' argument must be lazy until the exception
+   * is actually thrown, because the instantiation of SparkThrowable exception results in
+   * reading the file error-classes to format exception message.
    */
   def resolveColumnDefaultInAssignmentValue(
       key: Expression,
       value: Expression,
-      invalidColumnDefaultException: Throwable): Expression = {
+      invalidColumnDefaultException: => Throwable): Expression = {
     key match {
       case attr: AttributeReference =>
         value match {


### PR DESCRIPTION
### What changes were proposed in this pull request?
When resolving of default value being done in method resolveColumnDefaultInAssignmentValue, exception that should be thrown in case default value is not resolvable is created in any case (positive or negative outcome), but exception creation can be expensive (because reading error-classes file to get exception message) we should avoid it and create exception only when it is needed.

### Why are the changes needed?
Perf improvement (less file reads)

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
No tests yet

### Was this patch authored or co-authored using generative AI tooling?
No
