### PR TITLE
[SPARK-48739][SQL] Disable writing collated data to file formats that don't support them in non managed tables

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4303,6 +4303,12 @@
     },
     "sqlState" : "0A000"
   },
+  "UNSUPPORTED_COLLATIONS_FOR_DATASOURCE" : {
+    "message" : [
+      "The <format> datasource doesn't support collations on the column <columnName>."
+    ],
+    "sqlState" : "0A000"
+  },
   "UNSUPPORTED_DATASOURCE_FOR_DIRECT_QUERY" : {
     "message" : [
       "Unsupported data source type for direct query on files: <dataSourceType>"

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1752,6 +1752,14 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
         "format" -> format))
   }
 
+  def collationsUnsupportedByDataSourceError(format: String, column: StructField): Throwable = {
+    new AnalysisException(
+      errorClass = "UNSUPPORTED_COLLATIONS_FOR_DATASOURCE",
+      messageParameters = Map(
+        "columnName" -> toSQLId(column.name),
+        "format" -> format))
+  }
+
   def failToResolveDataSourceForTableError(table: CatalogTable, key: String): Throwable = {
     new AnalysisException(
       errorClass = "_LEGACY_ERROR_TEMP_1151",

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -536,6 +536,7 @@ case class DataSource(
               dataSource.toString, field)
           }
         }
+        DataSourceUtils.verifyCollations(dataSource, data.schema)
         SaveIntoDataSourceCommand(data, dataSource, caseInsensitiveOptions, mode)
       case format: FileFormat =>
         disallowWritingIntervals(data.schema.map(_.dataType), forbidAnsiIntervals = false)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -536,7 +536,6 @@ case class DataSource(
               dataSource.toString, field)
           }
         }
-        DataSourceUtils.verifyCollations(dataSource, data.schema)
         SaveIntoDataSourceCommand(data, dataSource, caseInsensitiveOptions, mode)
       case format: FileFormat =>
         disallowWritingIntervals(data.schema.map(_.dataType), forbidAnsiIntervals = false)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -540,6 +540,7 @@ case class DataSource(
       case format: FileFormat =>
         disallowWritingIntervals(data.schema.map(_.dataType), forbidAnsiIntervals = false)
         DataSource.validateSchema(data.schema, sparkSession.sessionState.conf)
+        DataSourceUtils.verifyCollations(format, data.schema)
         planForWritingFileFormat(format, mode, data)
       case _ => throw SparkException.internalError(
         s"${providingClass.getCanonicalName} does not allow create table as select.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
@@ -99,8 +99,7 @@ object DataSourceUtils extends PredicateHelper {
    */
   def verifyCollations(format: FileFormat, schema: StructType): Unit = {
     schema.foreach { field =>
-      if (SchemaUtils.hasNonUTF8BinaryCollation(schema)
-        && !format.supportCollations) {
+      if (SchemaUtils.hasNonUTF8BinaryCollation(schema) && !format.supportCollations) {
         throw QueryCompilationErrors.collationsUnsupportedByDataSourceError(
           format.toString, field)
       }
@@ -112,8 +111,7 @@ object DataSourceUtils extends PredicateHelper {
    */
   def verifyCollations(relation: CreatableRelationProvider, schema: StructType): Unit = {
     schema.foreach { field =>
-      if (SchemaUtils.hasNonUTF8BinaryCollation(schema)
-        && !relation.supportCollations) {
+      if (SchemaUtils.hasNonUTF8BinaryCollation(schema) && !relation.supportCollations) {
         throw QueryCompilationErrors.collationsUnsupportedByDataSourceError(
           relation.toString, field)
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.catalyst.util.RebaseDateTime.RebaseSpec
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.datasources.parquet.ParquetOptions
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
-import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider}
+import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.{CaseInsensitiveStringMap, SchemaUtils}
 import org.apache.spark.util.Utils

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceUtils.scala
@@ -106,19 +106,6 @@ object DataSourceUtils extends PredicateHelper {
     }
   }
 
-  /**
-   * Verify that if the schema has collated types the relation supports them.
-   */
-  def verifyCollations(relation: CreatableRelationProvider, schema: StructType): Unit = {
-    schema.foreach { field =>
-      if (SchemaUtils.hasNonUTF8BinaryCollation(schema) && !relation.supportCollations) {
-        throw QueryCompilationErrors.collationsUnsupportedByDataSourceError(
-          relation.toString, field)
-      }
-    }
-  }
-
-
   // SPARK-24626: Metadata files and temporary files should not be
   // counted as data files, so that they shouldn't participate in tasks like
   // location size calculation.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormat.scala
@@ -189,6 +189,11 @@ trait FileFormat {
   def supportFieldName(name: String): Boolean = true
 
   /**
+   * Returns whether the file format supports non-default collated data types.
+   */
+  def supportCollations: Boolean = false
+
+  /**
    * All fields the file format's _metadata struct defines.
    *
    * Each metadata struct field is either "constant" or "generated" (respectively defined/matched by

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -117,7 +117,6 @@ object FileFormatWriter extends Logging {
     val dataSchema = dataColumns.toStructType
     DataSourceUtils.verifySchema(fileFormat, dataSchema)
     DataSourceUtils.checkFieldNames(fileFormat, dataSchema)
-//    DataSourceUtils.verifyCollations(fileFormat, dataSchema)
     // Note: prepareWrite has side effect. It sets "job".
     val outputWriterFactory =
       fileFormat.prepareWrite(sparkSession, job, caseInsensitiveOptions, dataSchema)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -117,6 +117,7 @@ object FileFormatWriter extends Logging {
     val dataSchema = dataColumns.toStructType
     DataSourceUtils.verifySchema(fileFormat, dataSchema)
     DataSourceUtils.checkFieldNames(fileFormat, dataSchema)
+//    DataSourceUtils.verifyCollations(fileFormat, dataSchema)
     // Note: prepareWrite has side effect. It sets "job".
     val outputWriterFactory =
       fileFormat.prepareWrite(sparkSession, job, caseInsensitiveOptions, dataSchema)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/orc/OrcUtils.scala
@@ -284,6 +284,7 @@ object OrcUtils extends Logging {
       s"map<${getOrcSchemaString(m.keyType)},${getOrcSchemaString(m.valueType)}>"
     case _: DayTimeIntervalType | _: TimestampNTZType => LongType.catalogString
     case _: YearMonthIntervalType => IntegerType.catalogString
+    case _: StringType => StringType.catalogString
     case _ => dt.catalogString
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetFileFormat.scala
@@ -361,6 +361,8 @@ class ParquetFileFormat
     case _ => false
   }
 
+  override def supportCollations: Boolean = true
+
   override def metadataSchemaFields: Seq[StructField] = {
     super.metadataSchemaFields :+ ParquetFileFormat.ROW_INDEX_FIELD
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -196,6 +196,11 @@ trait CreatableRelationProvider {
       case _ => false
     }
   }
+
+  /**
+   * Returns whether the data source supports non-default collated data types.
+   */
+  def supportCollations: Boolean = false
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -192,7 +192,7 @@ trait CreatableRelationProvider {
       case udt: UserDefinedType[_] => supportsDataType(udt.sqlType)
       case BinaryType | BooleanType | ByteType | CharType(_) | DateType | _ : DecimalType |
            DoubleType | FloatType | IntegerType | LongType | NullType | ObjectType(_) | ShortType |
-           _: StringType | TimestampNTZType | TimestampType | VarcharType(_) => true
+           StringType | TimestampNTZType | TimestampType | VarcharType(_) => true
       case _ => false
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/sources/interfaces.scala
@@ -200,7 +200,7 @@ trait CreatableRelationProvider {
   /**
    * Returns whether the data source supports non-default collated data types.
    */
-  def supportCollations: Boolean = false
+  def supportCollations: Boolean = true
 }
 
 /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
@@ -39,10 +39,6 @@ import org.apache.spark.sql.types.{MapType, StringType, StructField, StructType}
 class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
   protected val v2Source = classOf[FakeV2ProviderWithCustomSchema].getName
 
-  private val collationPreservingSources = Seq("parquet")
-  private val collationNonPreservingSources = Seq("orc", "csv", "json", "text")
-  private val allFileBasedDataSources = collationPreservingSources ++  collationNonPreservingSources
-
   test("collate returns proper type") {
     Seq("utf8_binary", "utf8_lcase", "unicode", "unicode_ci").foreach { collationName =>
       checkAnswer(sql(s"select 'aaa' collate $collationName"), Row("aaa"))
@@ -341,53 +337,6 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
       checkAnswer(
         spark.read.parquet(path.getAbsolutePath),
         Row("a"))
-    }
-  }
-
-  test("create table with collation") {
-    val tableName = "dummy_tbl"
-    val collationName = "UTF8_LCASE"
-    val collationId = CollationFactory.collationNameToId(collationName)
-
-    allFileBasedDataSources.foreach { format =>
-      withTable(tableName) {
-        sql(
-        s"""
-           |CREATE TABLE $tableName (
-           |  c1 STRING COLLATE $collationName
-           |)
-           |USING $format
-           |""".stripMargin)
-
-        sql(s"INSERT INTO $tableName VALUES ('aaa')")
-        sql(s"INSERT INTO $tableName VALUES ('AAA')")
-
-        checkAnswer(sql(s"SELECT DISTINCT COLLATION(c1) FROM $tableName"), Seq(Row(collationName)))
-        assert(sql(s"select c1 FROM $tableName").schema.head.dataType == StringType(collationId))
-      }
-    }
-  }
-
-  test("write collated data to different data sources with dataframe api") {
-    val collationName = "UNICODE_CI"
-
-    allFileBasedDataSources.foreach { format =>
-      withTempPath { path =>
-        val df = sql(s"SELECT c COLLATE $collationName AS c FROM VALUES ('aaa') AS data(c)")
-        df.write.format(format).save(path.getAbsolutePath)
-
-        val readback = spark.read.format(format).load(path.getAbsolutePath)
-        val readbackCollation = if (collationPreservingSources.contains(format)) {
-          collationName
-        } else {
-          "UTF8_BINARY"
-        }
-
-        checkAnswer(readback, Row("aaa"))
-        checkAnswer(
-          readback.selectExpr(s"collation(${readback.columns.head})"),
-          Row(readbackCollation))
-      }
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/DataSourceCollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/DataSourceCollationSuite.scala
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.collation
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{AnalysisException, QueryTest}
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.datasources.csv.CSVFileFormat
+import org.apache.spark.sql.execution.datasources.json.JsonFileFormat
+import org.apache.spark.sql.execution.datasources.orc.OrcFileFormat
+import org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat
+import org.apache.spark.sql.execution.datasources.text.TextFileFormat
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+abstract class DataSourceCollationSuite extends QueryTest
+  with SharedSparkSession
+  with AdaptiveSparkPlanHelper {
+
+  protected val lcaseCollation = "UNICODE_CI"
+
+  protected val dataSourceMap = Map(
+    "parquet" -> new ParquetFileFormat,
+    "orc" -> new OrcFileFormat,
+    "json" -> new JsonFileFormat,
+    "csv" -> new CSVFileFormat,
+    "text" -> new TextFileFormat
+  )
+
+  def testDataSourceWrite(dataSource: String, useCollations: Boolean): Unit = {
+    withTempDir { dir =>
+      val stringType = if (useCollations) s"COLLATE(c, '$lcaseCollation')" else "c"
+      val fileFormat = dataSourceMap(dataSource)
+
+      val df = sql(
+        s"""
+           |SELECT
+           |  $stringType as c1
+           |FROM VALUES ('a'), ('b'), ('A')
+           |AS data(c)
+           |""".stripMargin)
+
+      val action = () => df.write
+        .format(dataSource)
+        .mode("overwrite")
+        .save(dir.getAbsolutePath)
+
+      if (!useCollations || fileFormat.supportCollations) {
+        action()
+      } else {
+        checkError(
+          exception = intercept[AnalysisException] {
+            action()
+          },
+          errorClass = "UNSUPPORTED_COLLATIONS_FOR_DATASOURCE",
+          sqlState = "0A000",
+          Map("columnName" -> "`c1`", "format" -> fileFormat.toString)
+        )
+      }
+    }
+  }
+
+  def testDataSourceSaveAsTable(dataSource: String, useCollations: Boolean): Unit = {
+    val tableName = s"t2$dataSource$useCollations"
+    withTable("tbl") {
+      val stringType = if (useCollations) s"COLLATE(c, '$lcaseCollation')" else "c"
+
+      val df = sql(
+        s"""
+           |SELECT
+           |  $stringType as c1
+           |FROM VALUES ('a'), ('b'), ('A')
+           |AS data(c)
+           |""".stripMargin)
+
+      // should always work
+      df.write
+        .format(dataSource)
+        .mode("overwrite")
+        .saveAsTable(tableName)
+
+      val expectedRowCnt = if (useCollations) 2 else 1
+      assert(
+        spark.read.table(tableName).where("c1 = 'a'").count()
+          === expectedRowCnt)
+    }
+  }
+
+  def testManagedTableInsert(dataSource: String, useCollations: Boolean): Unit = {
+    val tableName = s"tbl$dataSource$useCollations"
+    withTable(tableName) {
+      val stringType = if (useCollations) s"STRING COLLATE $lcaseCollation" else "STRING"
+
+      // should always work
+      sql(
+        s"""
+           |CREATE TABLE $tableName (c $stringType)
+           |USING $dataSource
+           |""".stripMargin)
+
+      sql(s"INSERT INTO $tableName VALUES ('a'), ('b'), ('A')")
+
+      val expectedRowCnt = if (useCollations) 2 else 1
+      assert(sql(s"SELECT * FROM $tableName WHERE c = 'a'").collect().length === expectedRowCnt)
+    }
+  }
+
+  dataSourceMap.keys.foreach { source =>
+    Seq(true, false).foreach { useCollations =>
+      test(s"data source write $source with collations: $useCollations") {
+        testDataSourceWrite(source, useCollations)
+      }
+
+      test(s"data source save as table $source with collations: $useCollations") {
+        testDataSourceSaveAsTable(source, useCollations)
+      }
+
+      test(s"managed table insert $source with collations: $useCollations") {
+          testManagedTableInsert(source, useCollations)
+      }
+    }
+  }
+}
+
+
+class V1DataSourceCollationSuite extends DataSourceCollationSuite {
+  override protected def sparkConf: SparkConf =
+    super
+      .sparkConf
+      .set(SQLConf.USE_V1_SOURCE_LIST, dataSourceMap.keys.mkString(","))
+}
+
+class V2DataSourceCollationSuite extends DataSourceCollationSuite {
+  override protected def sparkConf: SparkConf =
+    super
+      .sparkConf
+      .set(SQLConf.USE_V1_SOURCE_LIST, "")
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/collation/DataSourceCollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/collation/DataSourceCollationSuite.scala
@@ -157,14 +157,14 @@ abstract class DataSourceCollationSuite extends QueryTest
   }
 }
 
-class V1DataSourceCollationSuite extends DataSourceCollationSuite {
+class DataSourceCollationV1Suite extends DataSourceCollationSuite {
   override protected def sparkConf: SparkConf =
     super
       .sparkConf
       .set(SQLConf.USE_V1_SOURCE_LIST, dataSourceMap.keys.mkString(","))
 }
 
-class V2DataSourceCollationSuite extends DataSourceCollationSuite {
+class DataSourceCollationV2Suite extends DataSourceCollationSuite {
   override protected def sparkConf: SparkConf =
     super
       .sparkConf

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommandSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommandSuite.scala
@@ -81,8 +81,7 @@ class SaveIntoDataSourceCommandSuite extends QueryTest with SharedSparkSession {
       options = Map())
 
     val df = spark.range(1).selectExpr(
-        "cast('a' as binary) a", "true b", "cast(1 as byte) c", "1.23 d", "'abc'",
-        "'abc' COLLATE UTF8_LCASE")
+        "cast('a' as binary) a", "true b", "cast(1 as byte) c", "1.23 d", "'abc'")
     dataSource.planForWriting(SaveMode.ErrorIfExists, df.logicalPlan)
 
     // Variant and Interval types are disallowed by default.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Disable writing collated types to data sources that don't support them. However, spark managed tables should still work as the schema is in HMS and not in the file itself.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Right now, when users write a collated type directly to json, text, orc.. they will not see that collation when reading back.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added new UTs

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.