### PR TITLE
[SPARK-48757][CORE] Make `IndexShuffleBlockResolver` have explicit constructors

### DIFF
--- a/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/IndexShuffleBlockResolver.scala
@@ -57,10 +57,22 @@ import org.apache.spark.util.collection.OpenHashSet
 private[spark] class IndexShuffleBlockResolver(
     conf: SparkConf,
     // var for testing
-    var _blockManager: BlockManager = null,
-    val taskIdMapsForShuffle: JMap[Int, OpenHashSet[Long]] = Collections.emptyMap())
+    var _blockManager: BlockManager,
+    val taskIdMapsForShuffle: JMap[Int, OpenHashSet[Long]])
   extends ShuffleBlockResolver
   with Logging with MigratableResolver {
+
+  def this(conf: SparkConf) = {
+    this(conf, null, Collections.emptyMap())
+  }
+
+  def this(conf: SparkConf, _blockManager: BlockManager) = {
+    this(conf, _blockManager, Collections.emptyMap())
+  }
+
+  def this(conf: SparkConf, taskIdMapsForShuffle: JMap[Int, OpenHashSet[Long]]) = {
+    this(conf, null, taskIdMapsForShuffle)
+  }
 
   private lazy val blockManager = Option(_blockManager).getOrElse(SparkEnv.get.blockManager)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `IndexShuffleBlockResolver` have explicit constructors from Apache Spark 4.0.0.

### Why are the changes needed?

Although `IndexShuffleBlockResolver` is `private` and there is no contract to keep class constructor signatures, from Apache Spark 4.0.0, we had better reduce the following situations with the old libraries built against old Spark versions.

```
Cause: java.lang.NoSuchMethodError: 'void org.apache.spark.shuffle.IndexShuffleBlockResolver.<init>(org.apache.spark.SparkConf, org.apache.spark.storage.BlockManager)'
[info] at org.apache.spark.sql.comet.execution.shuffle.CometShuffleManager.<init>(CometShuffleManager.scala:64)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.