### PR TITLE
[MINOR][DOCS] Fix the type hints of `functions.first(..., ignorenulls)` and `functions.last(..., ignorenulls)`

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -5474,8 +5474,8 @@ def first(col: "ColumnOrName", ignorenulls: bool = False) -> Column:
     ----------
     col : :class:`~pyspark.sql.Column` or str
         column to fetch first value for.
-    ignorenulls : :class:`~pyspark.sql.Column` or str
-        if first value is null then look for first non-null value.
+    ignorenulls : bool
+        if first value is null then look for first non-null value. ``False``` by default.
 
     Returns
     -------
@@ -5747,8 +5747,8 @@ def last(col: "ColumnOrName", ignorenulls: bool = False) -> Column:
     ----------
     col : :class:`~pyspark.sql.Column` or str
         column to fetch last value for.
-    ignorenulls : :class:`~pyspark.sql.Column` or str
-        if last value is null then look for non-null value.
+    ignorenulls : bool
+        if last value is null then look for non-null value. ``False``` by default.
 
     Returns
     -------


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix the type hints of `functions.first(..., ignorenulls)` and `functions.last(..., ignorenulls)` to be properly `bool`s.

### Why are the changes needed?

To guide users about the correct types

### Does this PR introduce _any_ user-facing change?

Yes, it changes the user-facing documentation.

### How was this patch tested?

CI in this PR should verify them.

### Was this patch authored or co-authored using generative AI tooling?

No.