### PR TITLE
[SPARK-48756][CONNECT][PYTHON]Support for `df.debug()` in Connect Mode

### DIFF
--- a/python/docs/source/reference/pyspark.sql/dataframe.rst
+++ b/python/docs/source/reference/pyspark.sql/dataframe.rst
@@ -46,6 +46,7 @@ DataFrame
     DataFrame.crossJoin
     DataFrame.crosstab
     DataFrame.cube
+    DataFrame.debug
     DataFrame.describe
     DataFrame.distinct
     DataFrame.drop

--- a/python/docs/source/user_guide/connect_execution_info_and_debug.rst
+++ b/python/docs/source/user_guide/connect_execution_info_and_debug.rst
@@ -1,0 +1,60 @@
+..  Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+..    http://www.apache.org/licenses/LICENSE-2.0
+
+..  Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+===========
+Spark Connect - Execution Info and Debug
+===========
+
+
+Execution Info
+--------------
+
+The ``executionInfo`` property of the DataFrame allows users to access execution
+metrics about a previously executed operation. In Spark Connect mode, the
+plan metrics of the execution are always submitted as the last elements of the
+response allowing users an easy way to present this information.
+
+.. code-block:: python
+    df = spark.range(100)
+    df.collect()
+    ei = df.executionInfo
+
+    # Access the execution metrics:
+    metrics = ei.metrics
+    print(metrics.toText())
+
+Debugging DataFrame Data Flows
+-------------------------------
+Sometimes it is useful to understand the data flow of a DataFrame operation. Whereas
+metrics allow to track row counts between different operators, the execution plan
+does not always resemble the semantic execution.
+
+The ``debug`` method allows users to inject predefiend observation points into the
+query execution. After execution the user can access the observations and access
+the associated metrics.
+
+By default, calling ``debug()`` will inject a single observation that counts the number
+of rows flowing out of the DataFrame.
+
+
+.. code-block:: python
+    df = spark.range(100).debug()
+    filtered = df.where(df.id < 10).debug()
+    filtered.collect()
+    ei = df.executionInfo
+    for op in ei.observations:
+        print(op.debugString())

--- a/python/docs/source/user_guide/index.rst
+++ b/python/docs/source/user_guide/index.rst
@@ -28,6 +28,7 @@ PySpark specific user guides are available here:
    python_packaging
    sql/index
    pandas_on_spark/index
+   connect_execution_info_and_debug
 
 There are also basic programming guides covering multiple languages available in
 `the Spark documentation <https://spark.apache.org/docs/latest/index.html#where-to-go-from-here>`_, including these:

--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -1028,6 +1028,11 @@
       "Unknown value for `<var>`."
     ]
   },
+  "UNSUPPORTED_DATADEBUGOP": {
+    "message": [
+      "Argument `<arg_name>` should be a DataDebugOp, got <arg_type>."
+    ]
+  },
   "UNSUPPORTED_DATA_TYPE": {
     "message": [
       "Unsupported DataType `<data_type>`."

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1843,6 +1843,12 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             message_parameters={"member": "queryExecution"},
         )
 
+    def debug(self) -> "DataFrame":
+        raise PySparkValueError(
+            error_class="CLASSIC_OPERATION_NOT_SUPPORTED_ON_DF",
+            message_parameters={"member": "debug"},
+        )
+
 
 def _to_scala_map(sc: "SparkContext", jm: Dict) -> "JavaObject":
     """

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -87,6 +87,10 @@ class LogicalPlan:
         assert plan_id is not None
         return plan_id
 
+    @property
+    def plan_id(self) -> int:
+        return self._plan_id
+
     def _create_proto_relation(self) -> proto.Relation:
         plan = proto.Relation()
         plan.common.plan_id = self._plan_id

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -6307,6 +6307,21 @@ class DataFrame:
         """
         ...
 
+    def debug(self) -> "DataFrame":
+        """
+        Helper function that allows to debug the query execution with customer observations.
+
+        Essentially, this method is a wrapper around the `observe()` method, but simplifies
+        the usage. In addition, it makes sure that the captured metrics are properly collected
+        as part of the execution info.
+
+        .. versionadded:: 4.0.0
+        Returns
+        -------
+        DataFrame instance with the observations added
+        """
+        ...
+
 
 class DataFrameNaFunctions:
     """Functionality for working with missing data in :class:`DataFrame`.

--- a/python/pyspark/sql/observation.py
+++ b/python/pyspark/sql/observation.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 import os
-from typing import Any, Dict, Optional, TYPE_CHECKING
+from typing import Any, Dict, Optional, TYPE_CHECKING, List
 
 from pyspark.errors import PySparkTypeError, PySparkValueError, PySparkAssertionError
 from pyspark.sql.column import Column
@@ -77,7 +77,7 @@ class Observation:
             return ConnectObservation(*args, **kwargs)
         return super().__new__(cls)
 
-    def __init__(self, name: Optional[str] = None) -> None:
+    def __init__(self, name: Optional[str] = None, call_site: Optional[List[str]] = None) -> None:
         """Constructs a named or unnamed Observation instance.
 
         Parameters
@@ -99,6 +99,8 @@ class Observation:
         self._name = name
         self._jvm: Optional[JVMView] = None
         self._jo: Optional["JavaObject"] = None
+        self._call_site = call_site
+        self._plan_id = -1
 
     def _on(self, df: DataFrame, *exprs: Column) -> DataFrame:
         """Attaches this observation to the given :class:`DataFrame` to observe aggregations.

--- a/python/pyspark/sql/tests/connect/test_df_debug.py
+++ b/python/pyspark/sql/tests/connect/test_df_debug.py
@@ -14,23 +14,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+import os
 import unittest
 
+from pyspark.sql.metrics import DataDebugOp
 from pyspark.testing.connectutils import (
     should_test_connect,
     have_graphviz,
     graphviz_requirement_message,
+    ReusedConnectTestCase,
 )
-from pyspark.sql.tests.connect.test_connect_basic import SparkConnectSQLTestCase
 
 if should_test_connect:
     from pyspark.sql.connect.dataframe import DataFrame
 
 
-class SparkConnectDataFrameDebug(SparkConnectSQLTestCase):
+class SparkConnectDataFrameDebug(ReusedConnectTestCase):
     def test_df_debug_basics(self):
-        df: DataFrame = self.connect.range(100).repartition(10).groupBy("id").count()
+        df: DataFrame = self.spark.range(100).repartition(10).groupBy("id").count()
         x = df.collect()  # noqa: F841
         ei = df.executionInfo
 
@@ -38,12 +39,12 @@ class SparkConnectDataFrameDebug(SparkConnectSQLTestCase):
         self.assertIn(root, graph, "The root must be rooted in the graph")
 
     def test_df_quey_execution_empty_before_execution(self):
-        df: DataFrame = self.connect.range(100).repartition(10).groupBy("id").count()
+        df: DataFrame = self.spark.range(100).repartition(10).groupBy("id").count()
         ei = df.executionInfo
         self.assertIsNone(ei, "The query execution must be None before the action is executed")
 
     def test_df_query_execution_with_writes(self):
-        df: DataFrame = self.connect.range(100).repartition(10).groupBy("id").count()
+        df: DataFrame = self.spark.range(100).repartition(10).groupBy("id").count()
         df.write.save("/tmp/test_df_query_execution_with_writes", format="json", mode="overwrite")
         ei = df.executionInfo
         self.assertIsNotNone(
@@ -51,19 +52,19 @@ class SparkConnectDataFrameDebug(SparkConnectSQLTestCase):
         )
 
     def test_query_execution_text_format(self):
-        df: DataFrame = self.connect.range(100).repartition(10).groupBy("id").count()
+        df: DataFrame = self.spark.range(100).repartition(10).groupBy("id").count()
         df.collect()
         self.assertIn("HashAggregate", df.executionInfo.metrics.toText())
 
         # Different execution mode.
-        df: DataFrame = self.connect.range(100).repartition(10).groupBy("id").count()
+        df: DataFrame = self.spark.range(100).repartition(10).groupBy("id").count()
         df.toPandas()
         self.assertIn("HashAggregate", df.executionInfo.metrics.toText())
 
     @unittest.skipIf(not have_graphviz, graphviz_requirement_message)
     def test_df_query_execution_metrics_to_dot(self):
-        df: DataFrame = self.connect.range(100).repartition(10).groupBy("id").count()
-        x = df.collect()  # noqa: F841
+        df: DataFrame = self.spark.range(100).repartition(10).groupBy("id").count()
+        df.collect()
         ei = df.executionInfo
 
         dot = ei.metrics.toDot()
@@ -72,6 +73,78 @@ class SparkConnectDataFrameDebug(SparkConnectSQLTestCase):
         self.assertGreater(len(source), 0, "The dot representation must not be empty")
         self.assertIn("digraph", source, "The dot representation must contain the digraph keyword")
         self.assertIn("Metrics", source, "The dot representation must contain the Metrics keyword")
+
+    def test_query_with_debug(self):
+        self.assertIn("SPARK_TESTING", os.environ, "SPARK_TESTING must be set to run this test")
+
+        df: DataFrame = self.spark.range(100).repartition(10).groupBy("id").count()
+        df = df.debug()
+        df.collect()
+        ei = df.executionInfo
+        self.assertIsNotNone(
+            ei.observations, "Observations must be present when debug has been used"
+        )
+
+        # Check that the call site contains this function in the top stack element
+        observations = ei.observations
+
+        # THe stack should contain call_site_stack (0), df.debug() (1), test_query_with_debug (2)
+        stack = observations[0]._call_site[2]
+        self.assertIn(
+            "test_query_with_debug",
+            stack,
+            (
+                "The call site must contain this function: stack "
+                ";".join(observations[0]._call_site)
+            ),
+        )
+
+    def test_query_with_debug_and_plan_id_order(self):
+        a: DataFrame = self.spark.range(100).repartition(10).groupBy("id").count()
+        a = a.debug()
+        b: DataFrame = self.spark.range(1000)
+        b = b.filter(b.id < 10).debug()
+        c: DataFrame = a.join(b, "id")
+        c = c.debug()
+        c.collect()
+
+        ei = c.executionInfo
+        self.assertIsNotNone(ei, "The query execution must be set after the action is executed")
+        self.assertEqual(
+            len(ei.observations),
+            3,
+            "The number of observations must be equal to the number of debug",
+        )
+
+        # Check the count values for all observations
+        o1 = ei.observations[0]
+        o2 = ei.observations[1]
+        o3 = ei.observations[2]
+
+        self.assertEqual(o1.get["count_values"], 100, "The count values must be 100")
+        self.assertEqual(o2.get["count_values"], 10, "The count values must be 10 after filter")
+        self.assertEqual(o3.get["count_values"], 10, "The count values must be 10 after join")
+
+    def test_query_with_debug_and_other_ops(self):
+        a: DataFrame = self.spark.range(100).repartition(10).groupBy("id").count()
+        b = a.debug(DataDebugOp.count_distinct_values("id"))
+        b.collect()
+        ei = b.executionInfo
+        self.assertIsNotNone(ei, "The query execution must be set after the action is executed")
+        self.assertEqual(
+            len(ei.observations),
+            1,
+            "The number of observations must be equal to the number of debug observations",
+        )
+
+        o1 = ei.observations[0]  # count_values
+        self.assertEqual(2, len(o1.get.values()), "Two metrics were collected")
+        self.assertEqual(o1.get["count_values"], 100, "The count values must be 100")
+        self.assertGreater(
+            o1.get["count_distinct_values_id"],
+            90,
+            "The approx count distinct values must be roughly",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?

At times users want to evaluate the properties of their data flow graph and understand how certain transformations behave. Today this is more complex than necessary. Even though the `df.observe()` API has been around in Spark since Spark 3.3, it's usage is not widespread.

To give users a more visible API for understanding the data flow execution in Spark, this patch adds a new method to the DataFrame API called `df.debug()`. Debug will by default do the following:

  1. Create a new observation with the name `debug:<uuid>`
  2. Add a `count(1)` observation to it
  3. Capture the call stack and attach it to the observation.

After the execution, users can now access the observation using the execution info property of the DataFrame.

```python
df = spark.range(100).debug()
df = df.filter(df.id < 10).debug()
df.collect()
ei = df.executionInfo
for o in ei.observations:
    print(o.debugString())
```

The debug String contains the reference to the observation, the call site and the values.

```
Observation(name=debug:945125d7-2c0b-495c-a94b-3fdd56560b2f, planId=0, metrics=count_values=100, callSite=<ipython-input-1-df562d17bba7>:1@<module>)
Observation(name=debug:d8a11a55-58ed-4b62-80ef-14a862c1f446, planId=2, metrics=count_values=10, callSite=<ipython-input-2-4a176498c5c4>:1@<module>)
```

<img width="1200" alt="image" src="https://github.com/apache/spark/assets/3421/736e59b2-ae08-4c2b-862f-5f82b7d8f323">

In addition to the count, we have defined several useful additional debug observations that can be easily injected.

```python
from pyspark.sql.metrics import DataDebugOp
df = spark.range(100).debug(DataDebugOp.max_value("id"))
df = df.filter(df.id < 10).debug(DataDebugOp.max_value("id"))
df.collect()
ei = df.executionInfo
for o in ei.observations:
     print(o.debugString())
```

Produces the following output:

```
Observation(name=debug:a682f617-ddde-45bc-8263-8c3220cf9887, planId=4, metrics=count_values=100, max_value_id=99, callSite=<ipython-input-7-a374a4f978f1>:2@<module>)
Observation(name=debug:a82808b6-039e-406d-acc5-c9922be84893, planId=6, metrics=count_values=10, max_value_id=9, callSite=<ipython-input-7-a374a4f978f1>:3@<module>)
```


<img width="1210" alt="image" src="https://github.com/apache/spark/assets/3421/2a6c85f3-3a3b-47dd-8ba5-d47cf3ef5660">


### Why are the changes needed?
User-support


### Does this PR introduce _any_ user-facing change?
Adds new method.



### How was this patch tested?
New UT


### Was this patch authored or co-authored using generative AI tooling?
No