### PR TITLE
[SPARK-48768][PYTHON][CONNECT] Should not cache `explain`

### DIFF
--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1975,7 +1975,6 @@ class DataFrame(ParentDataFrame):
         query = self._plan.to_proto(self._session.client)
         return self._session.client.explain_string(query, explain_mode)
 
-    @functools.cache
     def explain(
         self, extended: Optional[Union[bool, str]] = None, mode: Optional[str] = None
     ) -> None:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Should not cache `explain`


### Why are the changes needed?
the plans can be affected by `dataframe.cache`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
No