### PR TITLE
[DRAFT] Virtual Column Family for RocksDB - StateStore API change

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2168,6 +2168,10 @@ object SQLConf {
       .checkValue(v => Set(1, 2).contains(v), "Valid versions are 1 and 2")
       .createWithDefault(2)
 
+<<<<<<< Updated upstream
+=======
+
+>>>>>>> Stashed changes
   val STREAMING_STOP_ACTIVE_RUN_ON_RESTART =
     buildConf("spark.sql.streaming.stopActiveRunOnRestart")
     .doc("Running multiple runs of the same streaming query concurrently is not supported. " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2168,15 +2168,6 @@ object SQLConf {
       .checkValue(v => Set(1, 2).contains(v), "Valid versions are 1 and 2")
       .createWithDefault(2)
 
-  val STREAMING_ROCKSDB_VIRTUAL_COL_FAMILY_ENABLED =
-    buildConf("spark.databricks.streaming.rocksDBVirtualColFamily.enabled")
-      .internal()
-      .doc("Whether structured streaming use virtual column family. Currently this is " +
-        "only supported with TransformWithState operator.")
-      .version("4.0.0")
-      .booleanConf
-      .createWithDefault(false)
-
   val STREAMING_STOP_ACTIVE_RUN_ON_RESTART =
     buildConf("spark.sql.streaming.stopActiveRunOnRestart")
     .doc("Running multiple runs of the same streaming query concurrently is not supported. " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2168,10 +2168,6 @@ object SQLConf {
       .checkValue(v => Set(1, 2).contains(v), "Valid versions are 1 and 2")
       .createWithDefault(2)
 
-<<<<<<< Updated upstream
-=======
-
->>>>>>> Stashed changes
   val STREAMING_STOP_ACTIVE_RUN_ON_RESTART =
     buildConf("spark.sql.streaming.stopActiveRunOnRestart")
     .doc("Running multiple runs of the same streaming query concurrently is not supported. " +

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2168,6 +2168,15 @@ object SQLConf {
       .checkValue(v => Set(1, 2).contains(v), "Valid versions are 1 and 2")
       .createWithDefault(2)
 
+  val STREAMING_ROCKSDB_VIRTUAL_COL_FAMILY_ENABLED =
+    buildConf("spark.databricks.streaming.rocksDBVirtualColFamily.enabled")
+      .internal()
+      .doc("Whether structured streaming use virtual column family. Currently this is " +
+        "only supported with TransformWithState operator.")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val STREAMING_STOP_ACTIVE_RUN_ON_RESTART =
     buildConf("spark.sql.streaming.stopActiveRunOnRestart")
     .doc("Running multiple runs of the same streaming query concurrently is not supported. " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StatePartitionReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StatePartitionReader.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeRow}
 import org.apache.spark.sql.connector.read.{InputPartition, PartitionReader, PartitionReaderFactory}
 import org.apache.spark.sql.execution.datasources.v2.state.metadata.StateMetadataPartitionReader
 import org.apache.spark.sql.execution.datasources.v2.state.utils.SchemaUtil
-import org.apache.spark.sql.execution.streaming.state.{NoPrefixKeyStateEncoderSpec, PrefixKeyScanStateEncoderSpec, ReadStateStore, StateStoreConf, StateStoreId, StateStoreProvider, StateStoreProviderId}
+import org.apache.spark.sql.execution.streaming.state.{ColumnFamilyType, NoPrefixKeyStateEncoderSpec, PrefixKeyScanStateEncoderSpec, ReadStateStore, StateStoreConf, StateStoreId, StateStoreProvider, StateStoreProviderId}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
 
@@ -88,7 +88,7 @@ class StatePartitionReader(
 
     StateStoreProvider.createAndInit(
       stateStoreProviderId, keySchema, valueSchema, keyStateEncoderType,
-      useColumnFamilies = false, storeConf, hadoopConf.value,
+      useColumnFamilies = ColumnFamilyType.None, storeConf, hadoopConf.value,
       useMultipleValuesPerKey = false)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/FlatMapGroupsWithStateExec.scala
@@ -228,7 +228,7 @@ trait FlatMapGroupsWithStateExecBase
             stateManager.stateSchema,
             NoPrefixKeyStateEncoderSpec(groupingAttributes.toStructType),
             stateInfo.get.storeVersion,
-            useColumnFamilies = false,
+            useColumnFamilies = ColumnFamilyType.None,
             storeConf, hadoopConfBroadcast.value.value)
           val processor = createInputProcessor(store)
           processDataWithPartition(childDataIterator, store, processor, Some(initStateIterator))

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -365,7 +365,7 @@ case class TransformWithStateExec(
               VALUE_ROW_SCHEMA,
               NoPrefixKeyStateEncoderSpec(KEY_ROW_SCHEMA),
               version = stateInfo.get.storeVersion,
-              useColumnFamilies = true,
+              useColumnFamilies = ColumnFamilyType.UseVirtualColFamily,
               storeConf = storeConf,
               hadoopConf = hadoopConfBroadcast.value.value
             )
@@ -434,7 +434,7 @@ case class TransformWithStateExec(
       KEY_ROW_SCHEMA,
       VALUE_ROW_SCHEMA,
       NoPrefixKeyStateEncoderSpec(KEY_ROW_SCHEMA),
-      useColumnFamilies = true,
+      useColumnFamilies = ColumnFamilyType.UseVirtualColFamily,
       storeConf = storeConf,
       hadoopConf = hadoopConfBroadcast.value.value,
       useMultipleValuesPerKey = true)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -126,6 +126,7 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
         valueSchema: StructType,
         keyStateEncoderSpec: KeyStateEncoderSpec,
         useMultipleValuesPerKey: Boolean = false,
+        useVirtualColFamily: Boolean = false,
         isInternal: Boolean = false): Unit = {
       throw StateStoreErrors.multipleColumnFamiliesNotSupported(providerName)
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.execution.streaming.state
 
 import java.io._
+
 import java.util
 import java.util.Locale
 import java.util.concurrent.atomic.LongAdder
@@ -30,14 +31,15 @@ import com.google.common.io.ByteStreams
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
-
 import org.apache.spark.{SparkConf, SparkEnv}
+
 import org.apache.spark.internal.{Logging, LogKeys, MDC, MessageWithContext}
 import org.apache.spark.io.CompressionCodec
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.streaming.CheckpointFileManager
 import org.apache.spark.sql.execution.streaming.CheckpointFileManager.CancellableFSDataOutputStream
+import org.apache.spark.sql.execution.streaming.state.ColumnFamilyType.ColumnFamilyType
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.{SizeEstimator, Utils}
 import org.apache.spark.util.ArrayImplicits._
@@ -288,11 +290,11 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
 
   // Run bunch of validations specific to HDFSBackedStateStoreProvider
   private def runValidation(
-      useColumnFamilies: Boolean,
+      useColumnFamilies: ColumnFamilyType,
       useMultipleValuesPerKey: Boolean,
       keyStateEncoderSpec: KeyStateEncoderSpec): Unit = {
     // TODO: add support for multiple col families with HDFSBackedStateStoreProvider
-    if (useColumnFamilies) {
+    if (!useColumnFamilies.equals(ColumnFamilyType.None)) {
       throw StateStoreErrors.multipleColumnFamiliesNotSupported(providerName)
     }
 
@@ -319,7 +321,7 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
       keySchema: StructType,
       valueSchema: StructType,
       keyStateEncoderSpec: KeyStateEncoderSpec,
-      useColumnFamilies: Boolean,
+      useColumnFamilies: ColumnFamilyType,
       storeConf: StateStoreConf,
       hadoopConf: Configuration,
       useMultipleValuesPerKey: Boolean = false): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
@@ -708,11 +708,11 @@ class NoPrefixKeyStateEncoder(keySchema: StructType)
       STATE_ENCODING_NUM_VERSION_BYTES + 8)
 
     Platform.putLong(encodedBytes, Platform.BYTE_ARRAY_OFFSET, colFamilyId)
-    Platform.putByte(encodedBytes, Platform.BYTE_ARRAY_OFFSET, STATE_ENCODING_VERSION)
+    Platform.putByte(encodedBytes, Platform.BYTE_ARRAY_OFFSET + 8, STATE_ENCODING_VERSION)
     // Platform.BYTE_ARRAY_OFFSET is the recommended way to memcopy b/w byte arrays. See Platform.
     Platform.copyMemory(
       bytesToEncode, Platform.BYTE_ARRAY_OFFSET,
-      encodedBytes, Platform.BYTE_ARRAY_OFFSET + STATE_ENCODING_NUM_VERSION_BYTES,
+      encodedBytes, Platform.BYTE_ARRAY_OFFSET + STATE_ENCODING_NUM_VERSION_BYTES + 8,
       bytesToEncode.length)
     encodedBytes
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
@@ -33,6 +33,7 @@ sealed trait RocksDBKeyStateEncoder {
 
   def encodePrefixKey(prefixKey: UnsafeRow): Array[Byte]
 
+  // TODO try change less of the API for key encoder
   def encodePrefixKey(prefixKey: UnsafeRow, colFamilyId: Long): Array[Byte] =
     throw new IllegalArgumentException(s"Unsupported encodePrefixKey with colFamilyId arg")
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -343,7 +343,6 @@ private[sql] class RocksDBStateStoreProvider
         )
         var colFamilyExists = false
         rocksDB.prefixScan(idPrefix).foreach { kv =>
-          logInfo("I am here inside remove col family")
           colFamilyExists = true
           rocksDB.remove(kv.key)
         }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -28,7 +28,6 @@ import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys._
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.errors.QueryExecutionErrors
-// import org.apache.spark.sql.internal.SQLConf.STREAMING_ROCKSDB_VIRTUAL_COL_FAMILY_ENABLED
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.util.Utils
@@ -79,6 +78,7 @@ private[sql] class RocksDBStateStoreProvider
 
     // TODO verify and throw error if colFamilyToLongMap does not have id
     // TODO check rocksDB.get function verify works for VCF
+    // TODO verify with changelog checkpoint
     override def get(key: UnsafeRow, colFamilyName: String): UnsafeRow = {
       verify(key != null, "Key cannot be null")
       val kvEncoder = keyValueEncoderMap.get(colFamilyName)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -64,11 +64,9 @@ private[sql] class RocksDBStateStoreProvider
       verify(useColumnFamilies, "Column families are not supported in this store")
 
       useVirtualColumnFamily = useVirtualColFamily
-      println("I am here inside using rocksdb state store provider: " + useVirtualColumnFamily)
       if (useVirtualColumnFamily) {
         // if use virtual column family, then use default col family, no need to create new
         // TODO avoid Id duplication
-        println("I am here inside using virtual col family")
         colFamilyToLongMap.putIfAbsent(colFamilyName, scala.util.Random.nextLong())
       } else {
         rocksDB.createColFamilyIfAbsent(colFamilyName, isInternal)
@@ -85,7 +83,6 @@ private[sql] class RocksDBStateStoreProvider
       verify(key != null, "Key cannot be null")
       val kvEncoder = keyValueEncoderMap.get(colFamilyName)
       val value = if (useVirtualColumnFamily) {
-        println("I am here inside use virtual col family")
         kvEncoder._2.decodeValue(
           rocksDB.get(kvEncoder._1.encodeKey(key,
             colFamilyToLongMap.get(colFamilyName))))
@@ -123,7 +120,6 @@ private[sql] class RocksDBStateStoreProvider
       "that supports multiple values for a single key.")
 
       val encodedValues = if (useVirtualColumnFamily) {
-        println("I am here inside virtual col family valuesIterator")
         rocksDB.get(keyEncoder.encodeKey(key, colFamilyToLongMap.get(colFamilyName)))
       } else {
         rocksDB.get(keyEncoder.encodeKey(key), colFamilyName)
@@ -142,7 +138,6 @@ private[sql] class RocksDBStateStoreProvider
       verify(key != null, "Key cannot be null")
       require(value != null, "Cannot merge a null value")
       val (encodedKey, physicalColFamilyName) = if (useVirtualColumnFamily) {
-        println("I am here inside virtual col family merge")
         (keyEncoder.encodeKey(key, colFamilyToLongMap.get(colFamilyName)),
           StateStore.DEFAULT_COL_FAMILY_NAME)
       } else {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -131,6 +131,7 @@ trait StateStore extends ReadStateStore {
       valueSchema: StructType,
       keyStateEncoderSpec: KeyStateEncoderSpec,
       useMultipleValuesPerKey: Boolean = false,
+      useVirtualColFamily: Boolean = false,
       isInternal: Boolean = false): Unit
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDD.scala
@@ -22,7 +22,9 @@ import java.util.UUID
 import scala.reflect.ClassTag
 
 import org.apache.spark.{Partition, TaskContext}
+
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.execution.streaming.state.ColumnFamilyType.ColumnFamilyType
 import org.apache.spark.sql.internal.SessionState
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.SerializableConfiguration
@@ -77,7 +79,7 @@ class ReadStateStoreRDD[T: ClassTag, U: ClassTag](
     keyStateEncoderSpec: KeyStateEncoderSpec,
     sessionState: SessionState,
     @transient private val storeCoordinator: Option[StateStoreCoordinatorRef],
-    useColumnFamilies: Boolean = false,
+    useColumnFamilies: ColumnFamilyType = ColumnFamilyType.None,
     extraOptions: Map[String, String] = Map.empty)
   extends BaseStateStoreRDD[T, U](dataRDD, checkpointLocation, queryRunId, operatorId,
     sessionState, storeCoordinator, extraOptions) {
@@ -112,7 +114,7 @@ class StateStoreRDD[T: ClassTag, U: ClassTag](
     keyStateEncoderSpec: KeyStateEncoderSpec,
     sessionState: SessionState,
     @transient private val storeCoordinator: Option[StateStoreCoordinatorRef],
-    useColumnFamilies: Boolean = false,
+    useColumnFamilies: ColumnFamilyType = ColumnFamilyType.None,
     extraOptions: Map[String, String] = Map.empty,
     useMultipleValuesPerKey: Boolean = false)
   extends BaseStateStoreRDD[T, U](dataRDD, checkpointLocation, queryRunId, operatorId,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/SymmetricHashJoinStateManager.scala
@@ -482,12 +482,12 @@ class SymmetricHashJoinStateManager(
       val store = if (useStateStoreCoordinator) {
         StateStore.get(
           storeProviderId, keySchema, valueSchema, NoPrefixKeyStateEncoderSpec(keySchema),
-          stateInfo.get.storeVersion, useColumnFamilies = false, storeConf, hadoopConf)
+          stateInfo.get.storeVersion, useColumnFamilies = ColumnFamilyType.None, storeConf, hadoopConf)
       } else {
         // This class will manage the state store provider by itself.
         stateStoreProvider = StateStoreProvider.createAndInit(
           storeProviderId, keySchema, valueSchema, NoPrefixKeyStateEncoderSpec(keySchema),
-          useColumnFamilies = false, storeConf, hadoopConf,
+          useColumnFamilies = ColumnFamilyType.None, storeConf, hadoopConf,
           useMultipleValuesPerKey = false)
         stateStoreProvider.getStore(stateInfo.get.storeVersion)
       }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/package.scala
@@ -20,8 +20,10 @@ package org.apache.spark.sql.execution.streaming
 import scala.reflect.ClassTag
 
 import org.apache.spark.TaskContext
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.execution.streaming.state.ColumnFamilyType.ColumnFamilyType
 import org.apache.spark.sql.internal.SessionState
 import org.apache.spark.sql.types.StructType
 
@@ -58,7 +60,7 @@ package object state {
         keyStateEncoderSpec: KeyStateEncoderSpec,
         sessionState: SessionState,
         storeCoordinator: Option[StateStoreCoordinatorRef],
-        useColumnFamilies: Boolean = false,
+        useColumnFamilies: ColumnFamilyType = ColumnFamilyType.None,
         extraOptions: Map[String, String] = Map.empty,
         useMultipleValuesPerKey: Boolean = false)(
         storeUpdateFunction: (StateStore, Iterator[T]) => Iterator[U]): StateStoreRDD[T, U] = {
@@ -98,7 +100,7 @@ package object state {
         keyStateEncoderSpec: KeyStateEncoderSpec,
         sessionState: SessionState,
         storeCoordinator: Option[StateStoreCoordinatorRef],
-        useColumnFamilies: Boolean = false,
+        useColumnFamilies: ColumnFamilyType = ColumnFamilyType.None,
         extraOptions: Map[String, String] = Map.empty)(
         storeReadFn: (ReadStateStore, Iterator[T]) => Iterator[U])
       : ReadStateStoreRDD[T, U] = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/MergingSortWithSessionWindowStateIteratorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/MergingSortWithSessionWindowStateIteratorSuite.scala
@@ -25,7 +25,7 @@ import org.scalatest.BeforeAndAfter
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils.toAttributes
-import org.apache.spark.sql.execution.streaming.state.{HDFSBackedStateStoreProvider, PrefixKeyScanStateEncoderSpec, RocksDBStateStoreProvider, StateStore, StateStoreConf, StateStoreId, StateStoreProviderId, StreamingSessionWindowStateManager}
+import org.apache.spark.sql.execution.streaming.state.{ColumnFamilyType, HDFSBackedStateStoreProvider, PrefixKeyScanStateEncoderSpec, RocksDBStateStoreProvider, StateStore, StateStoreConf, StateStoreId, StateStoreProviderId, StreamingSessionWindowStateManager}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.StreamTest
 import org.apache.spark.sql.types.{IntegerType, LongType, StringType, StructType}
@@ -221,7 +221,7 @@ class MergingSortWithSessionWindowStateIteratorSuite extends StreamTest with Bef
       val store = StateStore.get(
         storeProviderId, manager.getStateKeySchema, manager.getStateValueSchema,
         PrefixKeyScanStateEncoderSpec(manager.getStateKeySchema, manager.getNumColsForPrefixKey),
-        stateInfo.storeVersion, useColumnFamilies = false, storeConf, new Configuration)
+        stateInfo.storeVersion, useColumnFamilies = ColumnFamilyType.None, storeConf, new Configuration)
 
       try {
         f(manager, store)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/ListStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/ListStateSuite.scala
@@ -35,7 +35,7 @@ class ListStateSuite extends StateVariableSuiteBase {
   override def useMultipleValuesPerKey: Boolean = true
 
   private def testMapStateWithNullUserKey()(runListOps: ListState[Long] => Unit): Unit = {
-    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+    tryWithProviderResource(newStoreProviderWithStateVariable(ColumnFamilyType.UseVirtualColFamily)) { provider =>
       val store = provider.getStore(0)
       val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
         Encoders.STRING.asInstanceOf[ExpressionEncoder[Any]], TimeMode.None())
@@ -68,7 +68,7 @@ class ListStateSuite extends StateVariableSuiteBase {
   }
 
   test("List state operations for single instance") {
-    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+    tryWithProviderResource(newStoreProviderWithStateVariable(ColumnFamilyType.UseVirtualColFamily)) { provider =>
       val store = provider.getStore(0)
       val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
         Encoders.STRING.asInstanceOf[ExpressionEncoder[Any]], TimeMode.None())
@@ -96,7 +96,7 @@ class ListStateSuite extends StateVariableSuiteBase {
   }
 
   test("List state operations for multiple instance") {
-    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+    tryWithProviderResource(newStoreProviderWithStateVariable(ColumnFamilyType.UseVirtualColFamily)) { provider =>
       val store = provider.getStore(0)
       val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
         Encoders.STRING.asInstanceOf[ExpressionEncoder[Any]], TimeMode.None())
@@ -134,7 +134,7 @@ class ListStateSuite extends StateVariableSuiteBase {
   }
 
   test("List state operations with list, value, another list instances") {
-    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+    tryWithProviderResource(newStoreProviderWithStateVariable(ColumnFamilyType.UseVirtualColFamily)) { provider =>
       val store = provider.getStore(0)
       val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
         Encoders.STRING.asInstanceOf[ExpressionEncoder[Any]], TimeMode.None())
@@ -163,7 +163,7 @@ class ListStateSuite extends StateVariableSuiteBase {
   }
 
   test(s"test List state TTL") {
-    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+    tryWithProviderResource(newStoreProviderWithStateVariable(ColumnFamilyType.UseVirtualColFamily)) { provider =>
       val store = provider.getStore(0)
       val timestampMs = 10
       val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
@@ -219,7 +219,7 @@ class ListStateSuite extends StateVariableSuiteBase {
   }
 
   test("test negative or zero TTL duration throws error") {
-    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+    tryWithProviderResource(newStoreProviderWithStateVariable(ColumnFamilyType.UseVirtualColFamily)) { provider =>
       val store = provider.getStore(0)
       val batchTimestampMs = 10
       val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MapStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MapStateSuite.scala
@@ -38,7 +38,7 @@ class MapStateSuite extends StateVariableSuiteBase {
     .add("userKey", BinaryType)
 
   test("Map state operations for single instance") {
-    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+    tryWithProviderResource(newStoreProviderWithStateVariable(ColumnFamilyType.UseVirtualColFamily)) { provider =>
       val store = provider.getStore(0)
       val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
         Encoders.STRING.asInstanceOf[ExpressionEncoder[Any]], TimeMode.None())
@@ -72,7 +72,7 @@ class MapStateSuite extends StateVariableSuiteBase {
   }
 
   test("Map state operations for multiple map instances") {
-    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+    tryWithProviderResource(newStoreProviderWithStateVariable(ColumnFamilyType.UseVirtualColFamily)) { provider =>
       val store = provider.getStore(0)
       val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
         Encoders.STRING.asInstanceOf[ExpressionEncoder[Any]], TimeMode.None())
@@ -111,7 +111,7 @@ class MapStateSuite extends StateVariableSuiteBase {
   }
 
   test("Map state operations with list, value, another map instances") {
-    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+    tryWithProviderResource(newStoreProviderWithStateVariable(ColumnFamilyType.UseVirtualColFamily)) { provider =>
       val store = provider.getStore(0)
       val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
         Encoders.STRING.asInstanceOf[ExpressionEncoder[Any]], TimeMode.None())
@@ -171,7 +171,7 @@ class MapStateSuite extends StateVariableSuiteBase {
   }
 
   test("test Map state TTL") {
-    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+    tryWithProviderResource(newStoreProviderWithStateVariable(ColumnFamilyType.UseVirtualColFamily)) { provider =>
       val store = provider.getStore(0)
       val timestampMs = 10
       val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
@@ -229,7 +229,7 @@ class MapStateSuite extends StateVariableSuiteBase {
   }
 
   test("test negative or zero TTL duration throws error") {
-    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+    tryWithProviderResource(newStoreProviderWithStateVariable(ColumnFamilyType.UseVirtualColFamily)) { provider =>
       val store = provider.getStore(0)
       val batchTimestampMs = 10
       val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MemoryStateStore.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MemoryStateStore.scala
@@ -36,6 +36,7 @@ class MemoryStateStore extends StateStore() {
       valueSchema: StructType,
       keyStateEncoderSpec: KeyStateEncoderSpec,
       useMultipleValuesPerKey: Boolean = false,
+      useVirtualColFamily: Boolean = false,
       isInternal: Boolean = false): Unit = {
     throw StateStoreErrors.multipleColumnFamiliesNotSupported("MemoryStateStoreProvider")
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreIntegrationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreIntegrationSuite.scala
@@ -35,7 +35,7 @@ class RocksDBStateStoreIntegrationSuite extends StreamTest
   import testImplicits._
 
   testWithColumnFamilies("RocksDBStateStore",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
+    TestWithBothChangelogCheckpointingEnabledAndDisabled, false) { (_, _) =>
     withTempDir { dir =>
       val input = MemoryStream[Int]
       val conf = Map(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
@@ -62,7 +62,7 @@ class RocksDBStateStoreIntegrationSuite extends StreamTest
 
   testWithColumnFamilies("SPARK-36236: query progress contains only the " +
     s"expected RocksDB store custom metrics",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
+    TestWithBothChangelogCheckpointingEnabledAndDisabled, false) { (_, _) =>
     // fails if any new custom metrics are added to remind the author of API changes
     import testImplicits._
 
@@ -123,7 +123,7 @@ class RocksDBStateStoreIntegrationSuite extends StreamTest
   }
 
   testWithColumnFamilies("SPARK-36519: store RocksDB format version in the checkpoint",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
+    TestWithBothChangelogCheckpointingEnabledAndDisabled, false) { (_, _) =>
     withSQLConf(
       SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName) {
       withTempDir { dir =>
@@ -161,7 +161,7 @@ class RocksDBStateStoreIntegrationSuite extends StreamTest
   }
 
   testWithColumnFamilies("SPARK-36519: RocksDB format version can be set by the SQL conf",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
+    TestWithBothChangelogCheckpointingEnabledAndDisabled, false) { (_, _) =>
     withSQLConf(
       SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName,
       SQLConf.STATE_STORE_ROCKSDB_FORMAT_VERSION.key -> "100") {
@@ -183,7 +183,7 @@ class RocksDBStateStoreIntegrationSuite extends StreamTest
 
   testWithColumnFamilies("SPARK-37224: numRowsTotal = 0 when " +
     s"trackTotalNumberOfRows is turned off",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
+    TestWithBothChangelogCheckpointingEnabledAndDisabled, false) { (_, _) =>
     withTempDir { dir =>
       withSQLConf(
         (SQLConf.STATE_STORE_PROVIDER_CLASS.key -> classOf[RocksDBStateStoreProvider].getName),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -912,6 +912,74 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
     }
   }
 
+  // TODO This is the same as test("prefix scan") in StateStoreSuite without codec
+  testWithColumnFamilies("rocksdb prefix key encoder",
+    TestWithBothChangelogCheckpointingEnabledAndDisabled, true) {
+    (colFamiliesEnabled, virtualColFamilyEnabled) =>
+      tryWithProviderResource(newStoreProvider(
+        keySchema, PrefixKeyScanStateEncoderSpec(keySchema, 1),
+        colFamiliesEnabled)) { provider =>
+        var store = provider.getStore(0)
+
+        val testColFamily = "testState"
+        if (colFamiliesEnabled) {
+          store.createColFamilyIfAbsent(testColFamily,
+            keySchema, valueSchema, NoPrefixKeyStateEncoderSpec(keySchema),
+            useVirtualColFamily = virtualColFamilyEnabled)
+        }
+
+        def putCompositeKeys(keys: Seq[(String, Int)]): Unit = {
+          val randomizedKeys = scala.util.Random.shuffle(keys.toList)
+          randomizedKeys.foreach { case (key1, key2) =>
+            put(store, key1, key2, key2)
+          }
+        }
+
+        def verifyScan(key1: Seq[String], key2: Seq[Int]): Unit = {
+          key1.foreach { k1 =>
+            val keyValueSet = store.prefixScan(dataToPrefixKeyRow(k1)).map { pair =>
+              rowPairToDataPair(pair.withRows(pair.key.copy(), pair.value.copy()))
+            }.toSet
+
+            assert(keyValueSet === key2.map(k2 => ((k1, k2), k2)).toSet)
+          }
+        }
+
+        val key1AtVersion0 = Seq("a", "b", "c")
+        val key2AtVersion0 = Seq(1, 2, 3)
+        val keysAtVersion0 = for (k1 <- key1AtVersion0; k2 <- key2AtVersion0) yield (k1, k2)
+
+        putCompositeKeys(keysAtVersion0)
+        verifyScan(key1AtVersion0, key2AtVersion0)
+
+        assert(store.prefixScan(dataToPrefixKeyRow("non-exist")).isEmpty)
+
+        // committing and loading the version 1 (the version being committed)
+        store.commit()
+        store = provider.getStore(1)
+
+        // before putting the new key-value pairs, verify prefix scan works for existing keys
+        verifyScan(key1AtVersion0, key2AtVersion0)
+
+        val key1AtVersion1 = Seq("c", "d")
+        val key2AtVersion1 = Seq(4, 5, 6)
+        val keysAtVersion1 = for (k1 <- key1AtVersion1; k2 <- key2AtVersion1) yield (k1, k2)
+
+        // put a new key-value pairs, and verify that prefix scan reflects the changes
+        putCompositeKeys(keysAtVersion1)
+        verifyScan(Seq("c"), Seq(1, 2, 3, 4, 5, 6))
+        verifyScan(Seq("d"), Seq(4, 5, 6))
+
+        // aborting and loading the version 1 again (keysAtVersion1 should be rolled back)
+        store.abort()
+        store = provider.getStore(1)
+
+        // prefix scan should not reflect the uncommitted changes
+        verifyScan(key1AtVersion0, key2AtVersion0)
+        verifyScan(Seq("d"), Seq.empty)
+      }
+  }
+
   Seq(true, false).foreach { virtualColFamilyEnabled =>
     test(s"validate rocksdb values iterator correctness " +
       s"with virtualColFamilyEnabled=$virtualColFamilyEnabled") {
@@ -948,6 +1016,47 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
           assert(get(store, "a", 0).isEmpty)
         }
       }
+    }
+  }
+
+  Seq(true, false).foreach { virtualColFamilyEnabled =>
+    test(s"validate rocksdb removeColFamilyIfExists correctness " +
+      s"with virtualColFamilyEnabled=$virtualColFamilyEnabled") {
+      Seq(
+        // NoPrefixKeyStateEncoderSpec(keySchema)
+        PrefixKeyScanStateEncoderSpec(keySchema, 1)
+        // RangeKeyScanStateEncoderSpec(keySchema, Seq(1))
+      ).foreach { keyEncoder =>
+      tryWithProviderResource(newStoreProvider(keySchema, keyEncoder, true)) { provider =>
+        val store = provider.getStore(0)
+
+        val cfName = "testColFamily"
+        store.createColFamilyIfAbsent(cfName,
+          keySchema, valueSchema, keyEncoder,
+          useVirtualColFamily = virtualColFamilyEnabled)
+
+        // put some test data into state store
+        val timerTimestamps = Seq(931L, 8000L, 452300L, 4200L, -1L, 90L, 1L, 2L, 8L,
+          -230L, -14569L, -92L, -7434253L, 35L, 6L, 9L, -323L, 5L)
+        timerTimestamps.foreach { ts =>
+          val keyRow = dataToKeyRow(ts.toString, ts.toInt)
+          val valueRow = dataToValueRow(1)
+          store.put(keyRow, valueRow, cfName)
+        }
+        assert(store.iterator(cfName).toSeq.length == timerTimestamps.length)
+
+        store.removeColFamilyIfExists(cfName)
+
+        val e = intercept[Exception] {
+          store.iterator(cfName)
+        }
+        checkError(
+          exception = e.asInstanceOf[SparkUnsupportedOperationException],
+          errorClass = "STATEFUL_PROCESSOR_CANNOT_REINITIALIZE_STATE_ON_KEY",
+          sqlState = Some("42802"),
+          parameters = Map("groupingKey" -> "init_1")
+        )
+      }}
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -16,7 +16,7 @@
  */
 
 package org.apache.spark.sql.execution.streaming.state
-// scalastyle:off
+
 import java.util.UUID
 
 import scala.collection.immutable
@@ -39,7 +39,6 @@ import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.unsafe.Platform
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.Utils
-// scalastyle:on
 
 @ExtendedSQLTest
 class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvider]

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -295,7 +295,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
   }
 
   testWithColumnFamilies("rocksdb range scan - fixed size non-ordering columns",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled, false) {
+    TestWithBothChangelogCheckpointingEnabledAndDisabled, true) {
     (colFamiliesEnabled, virtualColFamilyEnabled) =>
 
     tryWithProviderResource(newStoreProvider(keySchemaWithRangeScan,
@@ -350,7 +350,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
 
   testWithColumnFamilies("rocksdb range scan - variable size non-ordering columns with " +
     "double type values are supported",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled, false) {
+    TestWithBothChangelogCheckpointingEnabledAndDisabled, true) {
     (colFamiliesEnabled, virtualColFamilyEnabled) =>
 
     val testSchema: StructType = StructType(
@@ -407,7 +407,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
   }
 
   testWithColumnFamilies("rocksdb range scan - variable size non-ordering columns",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled, false) {
+    TestWithBothChangelogCheckpointingEnabledAndDisabled, true) {
     (colFamiliesEnabled, virtualColFamilyEnabled) =>
 
     tryWithProviderResource(newStoreProvider(keySchemaWithRangeScan,
@@ -463,7 +463,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
 
   testWithColumnFamilies("rocksdb range scan multiple ordering columns - variable size " +
     s"non-ordering columns",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled, false) {
+    TestWithBothChangelogCheckpointingEnabledAndDisabled, true) {
     (colFamiliesEnabled, virtualColFamilyEnabled) =>
 
     val testSchema: StructType = StructType(
@@ -508,7 +508,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
   }
 
   testWithColumnFamilies("rocksdb range scan multiple non-contiguous ordering columns",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled, false) {
+    TestWithBothChangelogCheckpointingEnabledAndDisabled, true) {
     (colFamiliesEnabled, virtualColFamilyEnabled) =>
     val testSchema: StructType = StructType(
       Seq(
@@ -601,7 +601,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
 
   testWithColumnFamilies("rocksdb range scan multiple ordering columns - variable size " +
     s"non-ordering columns with null values in first ordering column",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled, false) {
+    TestWithBothChangelogCheckpointingEnabledAndDisabled, true) {
     (colFamiliesEnabled, virtualColFamilyEnabled) =>
 
     val testSchema: StructType = StructType(
@@ -704,7 +704,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
 
   testWithColumnFamilies("rocksdb range scan multiple ordering columns - variable size " +
     s"non-ordering columns with null values in second ordering column",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled, false) {
+    TestWithBothChangelogCheckpointingEnabledAndDisabled, true) {
     (colFamiliesEnabled, virtualColFamilyEnabled) =>
 
     val testSchema: StructType = StructType(
@@ -759,7 +759,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
 
   testWithColumnFamilies("rocksdb range scan byte ordering column - variable size " +
     s"non-ordering columns",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled, false) {
+    TestWithBothChangelogCheckpointingEnabledAndDisabled, true) {
     (colFamiliesEnabled, virtualColFamilyEnabled) =>
 
     val testSchema: StructType = StructType(
@@ -804,7 +804,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
   }
 
   testWithColumnFamilies("rocksdb range scan - ordering cols and key schema cols are same",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled, false) {
+    TestWithBothChangelogCheckpointingEnabledAndDisabled, true) {
     (colFamiliesEnabled, virtualColFamilyEnabled) =>
 
     // use the same schema as value schema for single col key schema
@@ -848,7 +848,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
   }
 
   testWithColumnFamilies("rocksdb range scan - with prefix scan",
-    TestWithBothChangelogCheckpointingEnabledAndDisabled, false) {
+    TestWithBothChangelogCheckpointingEnabledAndDisabled, true) {
     (colFamiliesEnabled, virtualColFamilyEnabled) =>
 
     tryWithProviderResource(newStoreProvider(keySchemaWithRangeScan,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -24,8 +24,8 @@ import scala.util.Random
 
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.BeforeAndAfter
-import org.apache.spark.{SparkConf, SparkUnsupportedOperationException}
 
+import org.apache.spark.{SparkConf, SparkUnsupportedOperationException}
 import org.apache.spark.io.CompressionCodec
 import org.apache.spark.sql.LocalSparkSession.withSparkSession
 import org.apache.spark.sql.SparkSession

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCompatibilitySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreCompatibilitySuite.scala
@@ -20,12 +20,13 @@ package org.apache.spark.sql.execution.streaming.state
 import java.io.File
 
 import org.apache.commons.io.FileUtils
-
 import org.apache.spark.SparkFunSuite
+
 import org.apache.spark.io.CompressionCodec
 import org.apache.spark.sql.catalyst.plans.PlanTestBase
 import org.apache.spark.sql.catalyst.streaming.InternalOutputModes.Update
 import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.apache.spark.sql.execution.streaming.state.ColumnFamilyType.ColumnFamilyType
 import org.apache.spark.sql.functions.count
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.StreamTest
@@ -64,20 +65,20 @@ trait StateStoreCodecsTest extends SparkFunSuite with PlanTestBase {
   protected val codecsInShortName =
     CompressionCodec.ALL_COMPRESSION_CODECS.map { c => CompressionCodec.getShortName(c) }
 
-  protected def testWithAllCodec(name: String)(func: Boolean => Any): Unit = {
-    Seq(true, false).foreach { colFamiliesEnabled =>
+  protected def testWithAllCodec(name: String)(func: ColumnFamilyType => Any): Unit = {
+    Seq(ColumnFamilyType.None, ColumnFamilyType.UsePhysicalColFamily).foreach { colFamilyType =>
       codecsInShortName.foreach { codecShortName =>
-        test(s"$name - with codec $codecShortName - with colFamiliesEnabled=$colFamiliesEnabled") {
+        test(s"$name - with codec $codecShortName - with colFamilyType=$colFamilyType") {
           withSQLConf(SQLConf.STATE_STORE_COMPRESSION_CODEC.key -> codecShortName) {
-            func(colFamiliesEnabled)
+            func(colFamilyType)
           }
         }
       }
 
       CompressionCodec.ALL_COMPRESSION_CODECS.foreach { codecShortName =>
-        test(s"$name - with codec $codecShortName - with colFamiliesEnabled=$colFamiliesEnabled") {
+        test(s"$name - with codec $codecShortName - with colFamilyType=$colFamilyType") {
           withSQLConf(SQLConf.STATE_STORE_COMPRESSION_CODEC.key -> codecShortName) {
-            func(colFamiliesEnabled)
+            func(colFamilyType)
           }
         }
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -16,39 +16,38 @@
  */
 
 package org.apache.spark.sql.execution.streaming.state
-//scalastyle:off
-//import java.io.{File, IOException}
-import java.io.File
+
+import java.io.{File, IOException}
 import java.net.URI
 import java.util
-//import java.util.UUID
+import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.collection.mutable
-//import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Random
 
-//import org.apache.commons.io.FileUtils
+import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
 import org.scalatest.{BeforeAndAfter, PrivateMethodTester}
-//import org.scalatest.concurrent.Eventually._
-//import org.scalatest.time.SpanSugar._
+import org.scalatest.concurrent.Eventually._
+import org.scalatest.time.SpanSugar._
 
-//import org.apache.spark._
-//import org.apache.spark.LocalSparkContext._
-//import org.apache.spark.sql.SparkSession
+import org.apache.spark._
+import org.apache.spark.LocalSparkContext._
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.util.quietly
-//import org.apache.spark.sql.execution.streaming._
-//import org.apache.spark.sql.execution.streaming.state.StateStoreCoordinatorSuite.withCoordinatorRef
-//import org.apache.spark.sql.functions.count
+import org.apache.spark.sql.execution.streaming._
+import org.apache.spark.sql.execution.streaming.state.StateStoreCoordinatorSuite.withCoordinatorRef
+import org.apache.spark.sql.functions.count
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.Utils
-// scalastyle:on
+
 class FakeStateStoreProviderWithMaintenanceError extends StateStoreProvider {
   import FakeStateStoreProviderWithMaintenanceError._
   private var id: StateStoreId = null
@@ -102,7 +101,7 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
     StateStore.stop()
     require(!StateStore.isMaintenanceRunning)
   }
-/*
+
   test("retaining only two latest versions when MAX_BATCHES_TO_RETAIN_IN_MEMORY set to 2") {
     tryWithProviderResource(
       newStoreProvider(minDeltasForSnapshot = 10, numOfVersToRetainInMemory = 2)) { provider =>
@@ -911,7 +910,7 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
       assertCacheHitAndMiss(reloadedStoreV2.metrics, expectedCacheHitCount = 0,
         expectedCacheMissCount = 2)
     }
-  } */
+  }
 
   override def newStoreProvider(): HDFSBackedStateStoreProvider = {
     newStoreProvider(opId = Random.nextInt(), partition = 0)
@@ -1054,7 +1053,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
 
   protected val keySchema: StructType = StateStoreTestsHelper.keySchema
   protected val valueSchema: StructType = StateStoreTestsHelper.valueSchema
-/*
+
   testWithAllCodec("get, put, remove, commit, and all data iterator") { colFamiliesEnabled =>
     tryWithProviderResource(newStoreProvider(colFamiliesEnabled)) { provider =>
       // Verify state before starting a new set of updates
@@ -1109,7 +1108,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
           === Set(("b", 0) -> 2))
       }
     }
-  } */
+  }
 
   testWithAllCodec("prefix scan") { colFamiliesEnabled =>
     tryWithProviderResource(newStoreProvider(keySchema, PrefixKeyScanStateEncoderSpec(keySchema, 1),
@@ -1170,7 +1169,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
       verifyScan(Seq("d"), Seq.empty)
     }
   }
-/*
+
   testWithAllCodec(s"numKeys metrics") { colFamiliesEnabled =>
     tryWithProviderResource(newStoreProvider(colFamiliesEnabled)) { provider =>
       // Verify state before starting a new set of updates
@@ -1625,7 +1624,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
     // Shouldn't throw
     StateStoreProvider.validateStateRowFormat(
       keyRow, keySchema, valueRow, keySchema, storeConf)
-  } */
+  }
 
   /** Return a new provider with a random id */
   def newStoreProvider(): ProviderClass

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -16,38 +16,39 @@
  */
 
 package org.apache.spark.sql.execution.streaming.state
-
-import java.io.{File, IOException}
+//scalastyle:off
+//import java.io.{File, IOException}
+import java.io.File
 import java.net.URI
 import java.util
-import java.util.UUID
+//import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 
 import scala.collection.mutable
-import scala.jdk.CollectionConverters._
+//import scala.jdk.CollectionConverters._
 import scala.util.Random
 
-import org.apache.commons.io.FileUtils
+//import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
 import org.scalatest.{BeforeAndAfter, PrivateMethodTester}
-import org.scalatest.concurrent.Eventually._
-import org.scalatest.time.SpanSugar._
+//import org.scalatest.concurrent.Eventually._
+//import org.scalatest.time.SpanSugar._
 
-import org.apache.spark._
-import org.apache.spark.LocalSparkContext._
-import org.apache.spark.sql.SparkSession
+//import org.apache.spark._
+//import org.apache.spark.LocalSparkContext._
+//import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.catalyst.util.quietly
-import org.apache.spark.sql.execution.streaming._
-import org.apache.spark.sql.execution.streaming.state.StateStoreCoordinatorSuite.withCoordinatorRef
-import org.apache.spark.sql.functions.count
+//import org.apache.spark.sql.execution.streaming._
+//import org.apache.spark.sql.execution.streaming.state.StateStoreCoordinatorSuite.withCoordinatorRef
+//import org.apache.spark.sql.functions.count
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.Utils
-
+// scalastyle:on
 class FakeStateStoreProviderWithMaintenanceError extends StateStoreProvider {
   import FakeStateStoreProviderWithMaintenanceError._
   private var id: StateStoreId = null
@@ -90,7 +91,7 @@ private object FakeStateStoreProviderWithMaintenanceError {
 class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
   with BeforeAndAfter {
   import StateStoreTestsHelper._
-  import StateStoreCoordinatorSuite._
+  // import StateStoreCoordinatorSuite._
 
   before {
     StateStore.stop()
@@ -101,7 +102,7 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
     StateStore.stop()
     require(!StateStore.isMaintenanceRunning)
   }
-
+/*
   test("retaining only two latest versions when MAX_BATCHES_TO_RETAIN_IN_MEMORY set to 2") {
     tryWithProviderResource(
       newStoreProvider(minDeltasForSnapshot = 10, numOfVersToRetainInMemory = 2)) { provider =>
@@ -910,7 +911,7 @@ class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
       assertCacheHitAndMiss(reloadedStoreV2.metrics, expectedCacheHitCount = 0,
         expectedCacheMissCount = 2)
     }
-  }
+  } */
 
   override def newStoreProvider(): HDFSBackedStateStoreProvider = {
     newStoreProvider(opId = Random.nextInt(), partition = 0)
@@ -1053,7 +1054,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
 
   protected val keySchema: StructType = StateStoreTestsHelper.keySchema
   protected val valueSchema: StructType = StateStoreTestsHelper.valueSchema
-
+/*
   testWithAllCodec("get, put, remove, commit, and all data iterator") { colFamiliesEnabled =>
     tryWithProviderResource(newStoreProvider(colFamiliesEnabled)) { provider =>
       // Verify state before starting a new set of updates
@@ -1624,7 +1625,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
     // Shouldn't throw
     StateStoreProvider.validateStateRowFormat(
       keyRow, keySchema, valueRow, keySchema, storeConf)
-  }
+  } */
 
   /** Return a new provider with a random id */
   def newStoreProvider(): ProviderClass

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -1109,7 +1109,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
           === Set(("b", 0) -> 2))
       }
     }
-  }
+  } */
 
   testWithAllCodec("prefix scan") { colFamiliesEnabled =>
     tryWithProviderResource(newStoreProvider(keySchema, PrefixKeyScanStateEncoderSpec(keySchema, 1),
@@ -1170,7 +1170,7 @@ abstract class StateStoreSuiteBase[ProviderClass <: StateStoreProvider]
       verifyScan(Seq("d"), Seq.empty)
     }
   }
-
+/*
   testWithAllCodec(s"numKeys metrics") { colFamiliesEnabled =>
     tryWithProviderResource(newStoreProvider(colFamiliesEnabled)) { provider =>
       // Verify state before starting a new set of updates

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -90,7 +90,7 @@ private object FakeStateStoreProviderWithMaintenanceError {
 class StateStoreSuite extends StateStoreSuiteBase[HDFSBackedStateStoreProvider]
   with BeforeAndAfter {
   import StateStoreTestsHelper._
-  // import StateStoreCoordinatorSuite._
+  import StateStoreCoordinatorSuite._
 
   before {
     StateStore.stop()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StreamingSessionWindowStateManagerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StreamingSessionWindowStateManagerSuite.scala
@@ -185,7 +185,7 @@ class StreamingSessionWindowStateManagerSuite extends StreamTest with BeforeAndA
       val store = StateStore.get(
         storeProviderId, manager.getStateKeySchema, manager.getStateValueSchema,
         PrefixKeyScanStateEncoderSpec(manager.getStateKeySchema, manager.getNumColsForPrefixKey),
-        stateInfo.storeVersion, useColumnFamilies = false, storeConf, new Configuration)
+        stateInfo.storeVersion, useColumnFamilies = ColumnFamilyType.None, storeConf, new Configuration)
 
       try {
         f(manager, store)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/ValueStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/ValueStateSuite.scala
@@ -24,11 +24,12 @@ import scala.util.Random
 
 import org.apache.hadoop.conf.Configuration
 import org.scalatest.BeforeAndAfter
-
 import org.apache.spark.{SparkException, SparkUnsupportedOperationException}
+
 import org.apache.spark.sql.Encoders
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.execution.streaming.{ImplicitGroupingKeyTracker, StatefulProcessorHandleImpl, ValueStateImplWithTTL}
+import org.apache.spark.sql.execution.streaming.state.ColumnFamilyType.ColumnFamilyType
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.{TimeMode, TTLConfig, ValueState}
 import org.apache.spark.sql.test.SharedSparkSession
@@ -46,7 +47,7 @@ class ValueStateSuite extends StateVariableSuiteBase {
   import StateStoreTestsHelper._
 
   test("Implicit key operations") {
-    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+    tryWithProviderResource(newStoreProviderWithStateVariable(ColumnFamilyType.UseVirtualColFamily)) { provider =>
       val store = provider.getStore(0)
       val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
         Encoders.STRING.asInstanceOf[ExpressionEncoder[Any]], TimeMode.None())
@@ -90,7 +91,7 @@ class ValueStateSuite extends StateVariableSuiteBase {
   }
 
   test("Value state operations for single instance") {
-    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+    tryWithProviderResource(newStoreProviderWithStateVariable(ColumnFamilyType.UseVirtualColFamily)) { provider =>
       val store = provider.getStore(0)
       val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
         Encoders.STRING.asInstanceOf[ExpressionEncoder[Any]], TimeMode.None())
@@ -116,7 +117,7 @@ class ValueStateSuite extends StateVariableSuiteBase {
   }
 
   test("Value state operations for multiple instances") {
-    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+    tryWithProviderResource(newStoreProviderWithStateVariable(ColumnFamilyType.UseVirtualColFamily)) { provider =>
       val store = provider.getStore(0)
       val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
         Encoders.STRING.asInstanceOf[ExpressionEncoder[Any]], TimeMode.None())
@@ -161,7 +162,7 @@ class ValueStateSuite extends StateVariableSuiteBase {
   }
 
   test("Value state operations for unsupported type name should fail") {
-    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+    tryWithProviderResource(newStoreProviderWithStateVariable(ColumnFamilyType.UseVirtualColFamily)) { provider =>
       val store = provider.getStore(0)
       val handle = new StatefulProcessorHandleImpl(store,
         UUID.randomUUID(), Encoders.STRING.asInstanceOf[ExpressionEncoder[Any]], TimeMode.None())
@@ -188,7 +189,7 @@ class ValueStateSuite extends StateVariableSuiteBase {
     val ex = intercept[StateStoreMultipleColumnFamiliesNotSupportedException] {
       provider.init(
         storeId, keySchema, valueSchema, NoPrefixKeyStateEncoderSpec(keySchema),
-        useColumnFamilies = true, storeConf, new Configuration)
+        useColumnFamilies = ColumnFamilyType.UseVirtualColFamily, storeConf, new Configuration)
     }
     checkError(
       ex,
@@ -201,7 +202,7 @@ class ValueStateSuite extends StateVariableSuiteBase {
   }
 
   test("test SQL encoder - Value state operations for Primitive(Double) instances") {
-    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+    tryWithProviderResource(newStoreProviderWithStateVariable(ColumnFamilyType.UseVirtualColFamily)) { provider =>
       val store = provider.getStore(0)
       val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
         Encoders.STRING.asInstanceOf[ExpressionEncoder[Any]], TimeMode.None())
@@ -227,7 +228,7 @@ class ValueStateSuite extends StateVariableSuiteBase {
   }
 
   test("test SQL encoder - Value state operations for Primitive(Long) instances") {
-    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+    tryWithProviderResource(newStoreProviderWithStateVariable(ColumnFamilyType.UseVirtualColFamily)) { provider =>
       val store = provider.getStore(0)
       val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
         Encoders.STRING.asInstanceOf[ExpressionEncoder[Any]], TimeMode.None())
@@ -253,7 +254,7 @@ class ValueStateSuite extends StateVariableSuiteBase {
   }
 
   test("test SQL encoder - Value state operations for case class instances") {
-    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+    tryWithProviderResource(newStoreProviderWithStateVariable(ColumnFamilyType.UseVirtualColFamily)) { provider =>
       val store = provider.getStore(0)
       val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
         Encoders.STRING.asInstanceOf[ExpressionEncoder[Any]], TimeMode.None())
@@ -279,7 +280,7 @@ class ValueStateSuite extends StateVariableSuiteBase {
   }
 
   test("test SQL encoder - Value state operations for POJO instances") {
-    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+    tryWithProviderResource(newStoreProviderWithStateVariable(ColumnFamilyType.UseVirtualColFamily)) { provider =>
       val store = provider.getStore(0)
       val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
         Encoders.STRING.asInstanceOf[ExpressionEncoder[Any]], TimeMode.None())
@@ -306,7 +307,7 @@ class ValueStateSuite extends StateVariableSuiteBase {
 
 
   test(s"test Value state TTL") {
-    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+    tryWithProviderResource(newStoreProviderWithStateVariable(ColumnFamilyType.UseVirtualColFamily)) { provider =>
       val store = provider.getStore(0)
       val timestampMs = 10
       val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
@@ -362,7 +363,7 @@ class ValueStateSuite extends StateVariableSuiteBase {
   }
 
   test("test negative or zero TTL duration throws error") {
-    tryWithProviderResource(newStoreProviderWithStateVariable(true)) { provider =>
+    tryWithProviderResource(newStoreProviderWithStateVariable(ColumnFamilyType.UseVirtualColFamily)) { provider =>
       val store = provider.getStore(0)
       val batchTimestampMs = 10
       val handle = new StatefulProcessorHandleImpl(store, UUID.randomUUID(),
@@ -416,7 +417,7 @@ abstract class StateVariableSuiteBase extends SharedSparkSession
   protected def useMultipleValuesPerKey = false
 
   protected def newStoreProviderWithStateVariable(
-      useColumnFamilies: Boolean): RocksDBStateStoreProvider = {
+      useColumnFamilies: ColumnFamilyType): RocksDBStateStoreProvider = {
     newStoreProviderWithStateVariable(StateStoreId(newDir(), Random.nextInt(), 0),
       NoPrefixKeyStateEncoderSpec(schemaForKeyRow),
       useColumnFamilies = useColumnFamilies)
@@ -427,7 +428,7 @@ abstract class StateVariableSuiteBase extends SharedSparkSession
       keyStateEncoderSpec: KeyStateEncoderSpec,
       sqlConf: SQLConf = SQLConf.get,
       conf: Configuration = new Configuration,
-      useColumnFamilies: Boolean = false): RocksDBStateStoreProvider = {
+      useColumnFamilies: ColumnFamilyType = ColumnFamilyType.None): RocksDBStateStoreProvider = {
     val provider = new RocksDBStateStoreProvider()
     provider.init(
       storeId, schemaForKeyRow, schemaForValueRow, keyStateEncoderSpec,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
