### PR TITLE
[SPARK-48784][SQL] Add ::: syntax as a shorthand for try_cast

### DIFF
--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseLexer.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseLexer.g4
@@ -501,6 +501,7 @@ CONCAT_PIPE: '||';
 HAT: '^';
 COLON: ':';
 DOUBLE_COLON: '::';
+TRIPLE_COLON: ':::';
 ARROW: '->';
 FAT_ARROW : '=>';
 HENT_START: '/*+';

--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -1043,6 +1043,7 @@ primaryExpression
     | name=(CAST | TRY_CAST) LEFT_PAREN expression AS dataType RIGHT_PAREN                     #cast
     | primaryExpression collateClause                                                      #collate
     | primaryExpression DOUBLE_COLON dataType                                                  #castByColon
+    | primaryExpression TRIPLE_COLON dataType                                                  #tryCastByColon
     | STRUCT LEFT_PAREN (argument+=namedExpression (COMMA argument+=namedExpression)*)? RIGHT_PAREN #struct
     | FIRST LEFT_PAREN expression (IGNORE NULLS)? RIGHT_PAREN                                  #first
     | ANY_VALUE LEFT_PAREN expression (IGNORE NULLS)? RIGHT_PAREN                              #any_value

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/try_cast.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/try_cast.sql.out
@@ -28,6 +28,20 @@ Project [try_cast(-4.56 as bigint) AS TRY_CAST(-4.56 AS BIGINT)#xL]
 
 
 -- !query
+SELECT '1.23' ::: long
+-- !query analysis
+Project [try_cast(1.23 as bigint) AS TRY_CAST(1.23 AS BIGINT)#xL]
++- OneRowRelation
+
+
+-- !query
+SELECT '-4.56' ::: int
+-- !query analysis
+Project [try_cast(-4.56 as int) AS TRY_CAST(-4.56 AS INT)#x]
++- OneRowRelation
+
+
+-- !query
 SELECT TRY_CAST('abc' AS int)
 -- !query analysis
 Project [try_cast(abc as int) AS TRY_CAST(abc AS INT)#x]
@@ -36,6 +50,13 @@ Project [try_cast(abc as int) AS TRY_CAST(abc AS INT)#x]
 
 -- !query
 SELECT TRY_CAST('abc' AS long)
+-- !query analysis
+Project [try_cast(abc as bigint) AS TRY_CAST(abc AS BIGINT)#xL]
++- OneRowRelation
+
+
+-- !query
+SELECT 'abc' ::: long
 -- !query analysis
 Project [try_cast(abc as bigint) AS TRY_CAST(abc AS BIGINT)#xL]
 +- OneRowRelation
@@ -56,6 +77,13 @@ Project [try_cast( as bigint) AS TRY_CAST( AS BIGINT)#xL]
 
 
 -- !query
+SELECT '' ::: int
+-- !query analysis
+Project [try_cast( as int) AS TRY_CAST( AS INT)#x]
++- OneRowRelation
+
+
+-- !query
 SELECT TRY_CAST(NULL AS int)
 -- !query analysis
 Project [try_cast(null as int) AS TRY_CAST(NULL AS INT)#x]
@@ -64,6 +92,13 @@ Project [try_cast(null as int) AS TRY_CAST(NULL AS INT)#x]
 
 -- !query
 SELECT TRY_CAST(NULL AS long)
+-- !query analysis
+Project [try_cast(null as bigint) AS TRY_CAST(NULL AS BIGINT)#xL]
++- OneRowRelation
+
+
+-- !query
+SELECT NULL ::: long
 -- !query analysis
 Project [try_cast(null as bigint) AS TRY_CAST(NULL AS BIGINT)#xL]
 +- OneRowRelation
@@ -84,6 +119,13 @@ Project [try_cast(123.a as bigint) AS TRY_CAST(123.a AS BIGINT)#xL]
 
 
 -- !query
+SELECT '123.a' ::: int
+-- !query analysis
+Project [try_cast(123.a as int) AS TRY_CAST(123.a AS INT)#x]
++- OneRowRelation
+
+
+-- !query
 SELECT TRY_CAST('-2147483648' AS int)
 -- !query analysis
 Project [try_cast(-2147483648 as int) AS TRY_CAST(-2147483648 AS INT)#x]
@@ -92,6 +134,20 @@ Project [try_cast(-2147483648 as int) AS TRY_CAST(-2147483648 AS INT)#x]
 
 -- !query
 SELECT TRY_CAST('-2147483649' AS int)
+-- !query analysis
+Project [try_cast(-2147483649 as int) AS TRY_CAST(-2147483649 AS INT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT '-2147483648' ::: int
+-- !query analysis
+Project [try_cast(-2147483648 as int) AS TRY_CAST(-2147483648 AS INT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT '-2147483649' ::: int
 -- !query analysis
 Project [try_cast(-2147483649 as int) AS TRY_CAST(-2147483649 AS INT)#x]
 +- OneRowRelation
@@ -112,6 +168,20 @@ Project [try_cast(2147483648 as int) AS TRY_CAST(2147483648 AS INT)#x]
 
 
 -- !query
+SELECT '2147483647' ::: int
+-- !query analysis
+Project [try_cast(2147483647 as int) AS TRY_CAST(2147483647 AS INT)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT '2147483648' ::: int
+-- !query analysis
+Project [try_cast(2147483648 as int) AS TRY_CAST(2147483648 AS INT)#x]
++- OneRowRelation
+
+
+-- !query
 SELECT TRY_CAST('-9223372036854775808' AS long)
 -- !query analysis
 Project [try_cast(-9223372036854775808 as bigint) AS TRY_CAST(-9223372036854775808 AS BIGINT)#xL]
@@ -120,6 +190,20 @@ Project [try_cast(-9223372036854775808 as bigint) AS TRY_CAST(-92233720368547758
 
 -- !query
 SELECT TRY_CAST('-9223372036854775809' AS long)
+-- !query analysis
+Project [try_cast(-9223372036854775809 as bigint) AS TRY_CAST(-9223372036854775809 AS BIGINT)#xL]
++- OneRowRelation
+
+
+-- !query
+SELECT '-9223372036854775808' ::: long
+-- !query analysis
+Project [try_cast(-9223372036854775808 as bigint) AS TRY_CAST(-9223372036854775808 AS BIGINT)#xL]
++- OneRowRelation
+
+
+-- !query
+SELECT '-9223372036854775809' ::: long
 -- !query analysis
 Project [try_cast(-9223372036854775809 as bigint) AS TRY_CAST(-9223372036854775809 AS BIGINT)#xL]
 +- OneRowRelation
@@ -140,6 +224,20 @@ Project [try_cast(9223372036854775808 as bigint) AS TRY_CAST(9223372036854775808
 
 
 -- !query
+SELECT '9223372036854775807' ::: long
+-- !query analysis
+Project [try_cast(9223372036854775807 as bigint) AS TRY_CAST(9223372036854775807 AS BIGINT)#xL]
++- OneRowRelation
+
+
+-- !query
+SELECT '9223372036854775808' ::: long
+-- !query analysis
+Project [try_cast(9223372036854775808 as bigint) AS TRY_CAST(9223372036854775808 AS BIGINT)#xL]
++- OneRowRelation
+
+
+-- !query
 SELECT TRY_CAST('interval 3 month 1 hour' AS interval)
 -- !query analysis
 Project [try_cast(interval 3 month 1 hour as interval) AS TRY_CAST(interval 3 month 1 hour AS INTERVAL)#x]
@@ -148,6 +246,20 @@ Project [try_cast(interval 3 month 1 hour as interval) AS TRY_CAST(interval 3 mo
 
 -- !query
 SELECT TRY_CAST('abc' AS interval)
+-- !query analysis
+Project [try_cast(abc as interval) AS TRY_CAST(abc AS INTERVAL)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT 'interval 3 month 1 hour' ::: interval
+-- !query analysis
+Project [try_cast(interval 3 month 1 hour as interval) AS TRY_CAST(interval 3 month 1 hour AS INTERVAL)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT 'abc' ::: interval
 -- !query analysis
 Project [try_cast(abc as interval) AS TRY_CAST(abc AS INTERVAL)#x]
 +- OneRowRelation
@@ -175,6 +287,20 @@ Project [try_cast(abc as boolean) AS TRY_CAST(abc AS BOOLEAN)#x]
 
 
 -- !query
+select 'false' ::: boolean
+-- !query analysis
+Project [try_cast(false as boolean) AS TRY_CAST(false AS BOOLEAN)#x]
++- OneRowRelation
+
+
+-- !query
+select 'abc' ::: boolean
+-- !query analysis
+Project [try_cast(abc as boolean) AS TRY_CAST(abc AS BOOLEAN)#x]
++- OneRowRelation
+
+
+-- !query
 SELECT TRY_CAST("2021-01-01" AS date)
 -- !query analysis
 Project [try_cast(2021-01-01 as date) AS TRY_CAST(2021-01-01 AS DATE)#x]
@@ -189,6 +315,20 @@ Project [try_cast(2021-101-01 as date) AS TRY_CAST(2021-101-01 AS DATE)#x]
 
 
 -- !query
+SELECT "2021-01-01" ::: date
+-- !query analysis
+Project [try_cast(2021-01-01 as date) AS TRY_CAST(2021-01-01 AS DATE)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT "2021-101-01" ::: date
+-- !query analysis
+Project [try_cast(2021-101-01 as date) AS TRY_CAST(2021-101-01 AS DATE)#x]
++- OneRowRelation
+
+
+-- !query
 SELECT TRY_CAST("2021-01-01 00:00:00" AS timestamp)
 -- !query analysis
 Project [try_cast(2021-01-01 00:00:00 as timestamp) AS TRY_CAST(2021-01-01 00:00:00 AS TIMESTAMP)#x]
@@ -197,6 +337,20 @@ Project [try_cast(2021-01-01 00:00:00 as timestamp) AS TRY_CAST(2021-01-01 00:00
 
 -- !query
 SELECT TRY_CAST("2021-101-01 00:00:00" AS timestamp)
+-- !query analysis
+Project [try_cast(2021-101-01 00:00:00 as timestamp) AS TRY_CAST(2021-101-01 00:00:00 AS TIMESTAMP)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT "2021-01-01 00:00:00" ::: timestamp
+-- !query analysis
+Project [try_cast(2021-01-01 00:00:00 as timestamp) AS TRY_CAST(2021-01-01 00:00:00 AS TIMESTAMP)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT "2021-101-01 00:00:00" ::: timestamp
 -- !query analysis
 Project [try_cast(2021-101-01 00:00:00 as timestamp) AS TRY_CAST(2021-101-01 00:00:00 AS TIMESTAMP)#x]
 +- OneRowRelation

--- a/sql/core/src/test/resources/sql-tests/inputs/try_cast.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/try_cast.sql
@@ -3,52 +3,87 @@ SELECT TRY_CAST('1.23' AS int);
 SELECT TRY_CAST('1.23' AS long);
 SELECT TRY_CAST('-4.56' AS int);
 SELECT TRY_CAST('-4.56' AS long);
+-- triple colon syntax
+SELECT '1.23' ::: long;
+SELECT '-4.56' ::: int;
 
 -- TRY_CAST string which are not numbers to integral should return null
 SELECT TRY_CAST('abc' AS int);
 SELECT TRY_CAST('abc' AS long);
+-- triple colon syntax
+SELECT 'abc' ::: long;
 
 -- TRY_CAST empty string to integral should return null
 SELECT TRY_CAST('' AS int);
 SELECT TRY_CAST('' AS long);
+-- triple colon syntax
+SELECT '' ::: int;
 
 -- TRY_CAST null to integral should return null
 SELECT TRY_CAST(NULL AS int);
 SELECT TRY_CAST(NULL AS long);
+-- triple colon syntax
+SELECT NULL ::: long;
 
 -- TRY_CAST invalid decimal string to integral should return null
 SELECT TRY_CAST('123.a' AS int);
 SELECT TRY_CAST('123.a' AS long);
+-- triple colon syntax
+SELECT '123.a' ::: int;
 
 -- '-2147483648' is the smallest int value
 SELECT TRY_CAST('-2147483648' AS int);
 SELECT TRY_CAST('-2147483649' AS int);
+-- triple colon syntax
+SELECT '-2147483648' ::: int;
+SELECT '-2147483649' ::: int;
 
 -- '2147483647' is the largest int value
 SELECT TRY_CAST('2147483647' AS int);
 SELECT TRY_CAST('2147483648' AS int);
+-- triple colon syntax
+SELECT '2147483647' ::: int;
+SELECT '2147483648' ::: int;
 
 -- '-9223372036854775808' is the smallest long value
 SELECT TRY_CAST('-9223372036854775808' AS long);
 SELECT TRY_CAST('-9223372036854775809' AS long);
+-- triple colon syntax
+SELECT '-9223372036854775808' ::: long;
+SELECT '-9223372036854775809' ::: long;
 
 -- '9223372036854775807' is the largest long value
 SELECT TRY_CAST('9223372036854775807' AS long);
 SELECT TRY_CAST('9223372036854775808' AS long);
+-- triple colon syntax
+SELECT '9223372036854775807' ::: long;
+SELECT '9223372036854775808' ::: long;
 
 -- TRY_CAST string to interval and interval to string
 SELECT TRY_CAST('interval 3 month 1 hour' AS interval);
 SELECT TRY_CAST('abc' AS interval);
+-- triple colon syntax
+SELECT 'interval 3 month 1 hour' ::: interval;
+SELECT 'abc' ::: interval;
 
 -- TRY_CAST string to boolean
 select TRY_CAST('true' as boolean);
 select TRY_CAST('false' as boolean);
 select TRY_CAST('abc' as boolean);
+-- triple colon syntax
+select 'false' ::: boolean;
+select 'abc' ::: boolean;
 
 -- TRY_CAST string to date
 SELECT TRY_CAST("2021-01-01" AS date);
 SELECT TRY_CAST("2021-101-01" AS date);
+-- triple colon syntax
+SELECT "2021-01-01" ::: date;
+SELECT "2021-101-01" ::: date;
 
 -- TRY_CAST string to timestamp
 SELECT TRY_CAST("2021-01-01 00:00:00" AS timestamp);
 SELECT TRY_CAST("2021-101-01 00:00:00" AS timestamp);
+-- triple colon syntax
+SELECT "2021-01-01 00:00:00" ::: timestamp;
+SELECT "2021-101-01 00:00:00" ::: timestamp;

--- a/sql/core/src/test/resources/sql-tests/results/try_cast.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/try_cast.sql.out
@@ -32,6 +32,22 @@ NULL
 
 
 -- !query
+SELECT '1.23' ::: long
+-- !query schema
+struct<TRY_CAST(1.23 AS BIGINT):bigint>
+-- !query output
+NULL
+
+
+-- !query
+SELECT '-4.56' ::: int
+-- !query schema
+struct<TRY_CAST(-4.56 AS INT):int>
+-- !query output
+NULL
+
+
+-- !query
 SELECT TRY_CAST('abc' AS int)
 -- !query schema
 struct<TRY_CAST(abc AS INT):int>
@@ -41,6 +57,14 @@ NULL
 
 -- !query
 SELECT TRY_CAST('abc' AS long)
+-- !query schema
+struct<TRY_CAST(abc AS BIGINT):bigint>
+-- !query output
+NULL
+
+
+-- !query
+SELECT 'abc' ::: long
 -- !query schema
 struct<TRY_CAST(abc AS BIGINT):bigint>
 -- !query output
@@ -64,6 +88,14 @@ NULL
 
 
 -- !query
+SELECT '' ::: int
+-- !query schema
+struct<TRY_CAST( AS INT):int>
+-- !query output
+NULL
+
+
+-- !query
 SELECT TRY_CAST(NULL AS int)
 -- !query schema
 struct<TRY_CAST(NULL AS INT):int>
@@ -73,6 +105,14 @@ NULL
 
 -- !query
 SELECT TRY_CAST(NULL AS long)
+-- !query schema
+struct<TRY_CAST(NULL AS BIGINT):bigint>
+-- !query output
+NULL
+
+
+-- !query
+SELECT NULL ::: long
 -- !query schema
 struct<TRY_CAST(NULL AS BIGINT):bigint>
 -- !query output
@@ -96,6 +136,14 @@ NULL
 
 
 -- !query
+SELECT '123.a' ::: int
+-- !query schema
+struct<TRY_CAST(123.a AS INT):int>
+-- !query output
+NULL
+
+
+-- !query
 SELECT TRY_CAST('-2147483648' AS int)
 -- !query schema
 struct<TRY_CAST(-2147483648 AS INT):int>
@@ -105,6 +153,22 @@ struct<TRY_CAST(-2147483648 AS INT):int>
 
 -- !query
 SELECT TRY_CAST('-2147483649' AS int)
+-- !query schema
+struct<TRY_CAST(-2147483649 AS INT):int>
+-- !query output
+NULL
+
+
+-- !query
+SELECT '-2147483648' ::: int
+-- !query schema
+struct<TRY_CAST(-2147483648 AS INT):int>
+-- !query output
+-2147483648
+
+
+-- !query
+SELECT '-2147483649' ::: int
 -- !query schema
 struct<TRY_CAST(-2147483649 AS INT):int>
 -- !query output
@@ -128,6 +192,22 @@ NULL
 
 
 -- !query
+SELECT '2147483647' ::: int
+-- !query schema
+struct<TRY_CAST(2147483647 AS INT):int>
+-- !query output
+2147483647
+
+
+-- !query
+SELECT '2147483648' ::: int
+-- !query schema
+struct<TRY_CAST(2147483648 AS INT):int>
+-- !query output
+NULL
+
+
+-- !query
 SELECT TRY_CAST('-9223372036854775808' AS long)
 -- !query schema
 struct<TRY_CAST(-9223372036854775808 AS BIGINT):bigint>
@@ -137,6 +217,22 @@ struct<TRY_CAST(-9223372036854775808 AS BIGINT):bigint>
 
 -- !query
 SELECT TRY_CAST('-9223372036854775809' AS long)
+-- !query schema
+struct<TRY_CAST(-9223372036854775809 AS BIGINT):bigint>
+-- !query output
+NULL
+
+
+-- !query
+SELECT '-9223372036854775808' ::: long
+-- !query schema
+struct<TRY_CAST(-9223372036854775808 AS BIGINT):bigint>
+-- !query output
+-9223372036854775808
+
+
+-- !query
+SELECT '-9223372036854775809' ::: long
 -- !query schema
 struct<TRY_CAST(-9223372036854775809 AS BIGINT):bigint>
 -- !query output
@@ -160,6 +256,22 @@ NULL
 
 
 -- !query
+SELECT '9223372036854775807' ::: long
+-- !query schema
+struct<TRY_CAST(9223372036854775807 AS BIGINT):bigint>
+-- !query output
+9223372036854775807
+
+
+-- !query
+SELECT '9223372036854775808' ::: long
+-- !query schema
+struct<TRY_CAST(9223372036854775808 AS BIGINT):bigint>
+-- !query output
+NULL
+
+
+-- !query
 SELECT TRY_CAST('interval 3 month 1 hour' AS interval)
 -- !query schema
 struct<TRY_CAST(interval 3 month 1 hour AS INTERVAL):interval>
@@ -169,6 +281,22 @@ struct<TRY_CAST(interval 3 month 1 hour AS INTERVAL):interval>
 
 -- !query
 SELECT TRY_CAST('abc' AS interval)
+-- !query schema
+struct<TRY_CAST(abc AS INTERVAL):interval>
+-- !query output
+NULL
+
+
+-- !query
+SELECT 'interval 3 month 1 hour' ::: interval
+-- !query schema
+struct<TRY_CAST(interval 3 month 1 hour AS INTERVAL):interval>
+-- !query output
+3 months 1 hours
+
+
+-- !query
+SELECT 'abc' ::: interval
 -- !query schema
 struct<TRY_CAST(abc AS INTERVAL):interval>
 -- !query output
@@ -200,6 +328,22 @@ NULL
 
 
 -- !query
+select 'false' ::: boolean
+-- !query schema
+struct<TRY_CAST(false AS BOOLEAN):boolean>
+-- !query output
+false
+
+
+-- !query
+select 'abc' ::: boolean
+-- !query schema
+struct<TRY_CAST(abc AS BOOLEAN):boolean>
+-- !query output
+NULL
+
+
+-- !query
 SELECT TRY_CAST("2021-01-01" AS date)
 -- !query schema
 struct<TRY_CAST(2021-01-01 AS DATE):date>
@@ -216,6 +360,22 @@ NULL
 
 
 -- !query
+SELECT "2021-01-01" ::: date
+-- !query schema
+struct<TRY_CAST(2021-01-01 AS DATE):date>
+-- !query output
+2021-01-01
+
+
+-- !query
+SELECT "2021-101-01" ::: date
+-- !query schema
+struct<TRY_CAST(2021-101-01 AS DATE):date>
+-- !query output
+NULL
+
+
+-- !query
 SELECT TRY_CAST("2021-01-01 00:00:00" AS timestamp)
 -- !query schema
 struct<TRY_CAST(2021-01-01 00:00:00 AS TIMESTAMP):timestamp>
@@ -225,6 +385,22 @@ struct<TRY_CAST(2021-01-01 00:00:00 AS TIMESTAMP):timestamp>
 
 -- !query
 SELECT TRY_CAST("2021-101-01 00:00:00" AS timestamp)
+-- !query schema
+struct<TRY_CAST(2021-101-01 00:00:00 AS TIMESTAMP):timestamp>
+-- !query output
+NULL
+
+
+-- !query
+SELECT "2021-01-01 00:00:00" ::: timestamp
+-- !query schema
+struct<TRY_CAST(2021-01-01 00:00:00 AS TIMESTAMP):timestamp>
+-- !query output
+2021-01-01 00:00:00
+
+
+-- !query
+SELECT "2021-101-01 00:00:00" ::: timestamp
 -- !query schema
 struct<TRY_CAST(2021-101-01 00:00:00 AS TIMESTAMP):timestamp>
 -- !query output


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add the `:::` (triple colon) as syntactic sugar for `try_cast`.

### Why are the changes needed?

This syntactic sugar makes it easier/simpler to call `try_cast`. Now, something like this is possible:

```
> select '123.456':::int;
  NULL
```

### Does this PR introduce _any_ user-facing change?

Yes, this is new syntax. It enables using `:::` as shorthand for `try_cast`.

### How was this patch tested?

New unit tests and sql tests.

### Was this patch authored or co-authored using generative AI tooling?

No