### PR TITLE
[SPARK-48780][SQL] Make errors in NamedParametersSupport generic to handle functions and procedures

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1081,7 +1081,7 @@
   },
   "DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT" : {
     "message" : [
-      "Call to routine <functionName> is invalid because it includes multiple argument assignments to the same parameter name <parameterName>."
+      "Call to routine <routineName> is invalid because it includes multiple argument assignments to the same parameter name <parameterName>."
     ],
     "subClass" : {
       "BOTH_POSITIONAL_AND_NAMED" : {
@@ -3578,7 +3578,7 @@
   },
   "REQUIRED_PARAMETER_NOT_FOUND" : {
     "message" : [
-      "Cannot invoke function <functionName> because the parameter named <parameterName> is required, but the function call did not supply a value. Please update the function call to supply an argument value (either positionally at index <index> or by name) and retry the query again."
+      "Cannot invoke routine <routineName> because the parameter named <parameterName> is required, but the routine call did not supply a value. Please update the routine call to supply an argument value (either positionally at index <index> or by name) and retry the query again."
     ],
     "sqlState" : "4274K"
   },
@@ -4113,7 +4113,7 @@
   },
   "UNEXPECTED_POSITIONAL_ARGUMENT" : {
     "message" : [
-      "Cannot invoke function <functionName> because it contains positional argument(s) following the named argument assigned to <parameterName>; please rearrange them so the positional arguments come first and then retry the query again."
+      "Cannot invoke routine <routineName> because it contains positional argument(s) following the named argument assigned to <parameterName>; please rearrange them so the positional arguments come first and then retry the query again."
     ],
     "sqlState" : "4274K"
   },
@@ -4155,7 +4155,7 @@
   },
   "UNRECOGNIZED_PARAMETER_NAME" : {
     "message" : [
-      "Cannot invoke function <functionName> because the function call included a named argument reference for the argument named <argumentName>, but this function does not include any signature containing an argument with this name. Did you mean one of the following? [<proposal>]."
+      "Cannot invoke routine <routineName> because the routine call included a named argument reference for the argument named <argumentName>, but this routine does not include any signature containing an argument with this name. Did you mean one of the following? [<proposal>]."
     ],
     "sqlState" : "4274K"
   },

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/NamedArgumentExpression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/NamedArgumentExpression.scala
@@ -20,13 +20,13 @@ package org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.types.DataType
 
 /**
- * This represents an argument expression to a function call accompanied with an
+ * This represents an argument expression to a routine call accompanied with an
  * explicit reference to the corresponding argument name as a string. In this way,
  * the analyzer can make sure that the provided values match up to the arguments
  * as intended, and the arguments may appear in any order.
  * This unary expression is unevaluable because we intend to replace it with
  * the provided value itself during query analysis (after possibly rearranging
- * the parsed argument list to match up the names to the expected function
+ * the parsed argument list to match up the names to the expected routine
  * signature).
  *
  * SQL Syntax: key => value
@@ -37,8 +37,8 @@ import org.apache.spark.sql.types.DataType
  *   The second argument generates NamedArgumentExpression("charset", Literal("utf-8"))
  * SELECT encode(charset => "utf-8", value => "abc");
  *
- * @param key The name of the function argument
- * @param value The value of the function argument
+ * @param key The name of the routine argument
+ * @param value The value of the routine argument
  */
 case class NamedArgumentExpression(key: String, value: Expression)
   extends UnaryExpression with Unevaluable {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/FunctionBuilderBase.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/FunctionBuilderBase.scala
@@ -124,8 +124,7 @@ object NamedParametersSupport {
       functionName: String): Seq[Expression] = {
     val parameters: Seq[InputParameter] = functionSignature.parameters
     if (parameters.dropWhile(_.default.isEmpty).exists(_.default.isEmpty)) {
-      throw QueryCompilationErrors.unexpectedRequiredParameterInFunctionSignature(
-        functionName, functionSignature)
+      throw QueryCompilationErrors.unexpectedRequiredParameter(functionName, parameters)
     }
 
     val (positionalArgs, namedArgs) = splitAndCheckNamedArguments(args, functionName)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, AttributeSet, CreateMap, CreateStruct, Expression, GroupingID, NamedExpression, SpecifiedWindowFrame, WindowFrame, WindowFunction, WindowSpecDefinition}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AnyValue
 import org.apache.spark.sql.catalyst.plans.JoinType
-import org.apache.spark.sql.catalyst.plans.logical.{Assignment, FunctionSignature, Join, LogicalPlan, SerdeInfo, Window}
+import org.apache.spark.sql.catalyst.plans.logical.{Assignment, InputParameter, Join, LogicalPlan, SerdeInfo, Window}
 import org.apache.spark.sql.catalyst.trees.{Origin, TreeNode}
 import org.apache.spark.sql.catalyst.util.{quoteIdentifier, FailFastMode, ParseMode, PermissiveMode}
 import org.apache.spark.sql.connector.catalog._
@@ -51,11 +51,11 @@ import org.apache.spark.util.ArrayImplicits._
  */
 private[sql] object QueryCompilationErrors extends QueryErrorsBase with CompilationErrors {
 
-  def unexpectedRequiredParameterInFunctionSignature(
-      functionName: String, functionSignature: FunctionSignature) : Throwable = {
-    val errorMessage = s"Function $functionName has an unexpected required argument for" +
-      s" the provided function signature $functionSignature. All required arguments should" +
-      " come before optional arguments."
+  def unexpectedRequiredParameter(
+      routineName: String, parameters: Seq[InputParameter]): Throwable = {
+    val errorMessage = s"Routine ${toSQLId(routineName)} has an unexpected required argument for" +
+      s" the provided routine signature ${parameters.mkString("[", ", ", "]")}." +
+      s" All required arguments should come before optional arguments."
     SparkException.internalError(errorMessage)
   }
 
@@ -67,42 +67,42 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
   }
 
   def positionalAndNamedArgumentDoubleReference(
-      functionName: String, parameterName: String) : Throwable = {
+      routineName: String, parameterName: String): Throwable = {
     val errorClass =
       "DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT.BOTH_POSITIONAL_AND_NAMED"
     new AnalysisException(
       errorClass = errorClass,
       messageParameters = Map(
-        "functionName" -> toSQLId(functionName),
+        "routineName" -> toSQLId(routineName),
         "parameterName" -> toSQLId(parameterName))
     )
   }
 
   def doubleNamedArgumentReference(
-      functionName: String, parameterName: String): Throwable = {
+      routineName: String, parameterName: String): Throwable = {
     val errorClass =
       "DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT.DOUBLE_NAMED_ARGUMENT_REFERENCE"
     new AnalysisException(
       errorClass = errorClass,
       messageParameters = Map(
-        "functionName" -> toSQLId(functionName),
+        "routineName" -> toSQLId(routineName),
         "parameterName" -> toSQLId(parameterName))
     )
   }
 
   def requiredParameterNotFound(
-      functionName: String, parameterName: String, index: Int) : Throwable = {
+      routineName: String, parameterName: String, index: Int) : Throwable = {
     new AnalysisException(
       errorClass = "REQUIRED_PARAMETER_NOT_FOUND",
       messageParameters = Map(
-        "functionName" -> toSQLId(functionName),
+        "routineName" -> toSQLId(routineName),
         "parameterName" -> toSQLId(parameterName),
         "index" -> index.toString)
     )
   }
 
   def unrecognizedParameterName(
-      functionName: String, argumentName: String, candidates: Seq[String]): Throwable = {
+      routineName: String, argumentName: String, candidates: Seq[String]): Throwable = {
     import org.apache.spark.sql.catalyst.util.StringUtils.orderSuggestedIdentifiersBySimilarity
 
     val inputs = candidates.map(candidate => Seq(candidate))
@@ -111,19 +111,19 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
     new AnalysisException(
       errorClass = "UNRECOGNIZED_PARAMETER_NAME",
       messageParameters = Map(
-        "functionName" -> toSQLId(functionName),
+        "routineName" -> toSQLId(routineName),
         "argumentName" -> toSQLId(argumentName),
         "proposal" -> recommendations.mkString(" "))
     )
   }
 
   def unexpectedPositionalArgument(
-      functionName: String,
+      routineName: String,
       precedingNamedArgument: String): Throwable = {
     new AnalysisException(
       errorClass = "UNEXPECTED_POSITIONAL_ARGUMENT",
       messageParameters = Map(
-        "functionName" -> toSQLId(functionName),
+        "routineName" -> toSQLId(routineName),
         "parameterName" -> toSQLId(precedingNamedArgument))
     )
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/NamedParameterFunctionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/NamedParameterFunctionSuite.scala
@@ -104,13 +104,13 @@ class NamedParameterFunctionSuite extends AnalysisTest {
       exception = parseRearrangeException(
         signature, Seq(k1Arg, k2Arg, k3Arg, k4Arg, namedK1Arg), "foo"),
       errorClass = errorClass,
-      parameters = Map("functionName" -> toSQLId("foo"), "parameterName" -> toSQLId("k1"))
+      parameters = Map("routineName" -> toSQLId("foo"), "parameterName" -> toSQLId("k1"))
     )
     checkError(
       exception = parseRearrangeException(
         signature, Seq(k1Arg, k2Arg, k3Arg, k4Arg, k4Arg), "foo"),
       errorClass = "DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT.DOUBLE_NAMED_ARGUMENT_REFERENCE",
-      parameters = Map("functionName" -> toSQLId("foo"), "parameterName" -> toSQLId("k4"))
+      parameters = Map("routineName" -> toSQLId("foo"), "parameterName" -> toSQLId("k4"))
     )
   }
 
@@ -119,7 +119,7 @@ class NamedParameterFunctionSuite extends AnalysisTest {
       exception = parseRearrangeException(signature, Seq(k1Arg, k2Arg, k3Arg), "foo"),
       errorClass = "REQUIRED_PARAMETER_NOT_FOUND",
       parameters = Map(
-        "functionName" -> toSQLId("foo"), "parameterName" -> toSQLId("k4"), "index" -> "2"))
+        "routineName" -> toSQLId("foo"), "parameterName" -> toSQLId("k4"), "index" -> "2"))
   }
 
   test("UNRECOGNIZED_PARAMETER_NAME") {
@@ -127,7 +127,7 @@ class NamedParameterFunctionSuite extends AnalysisTest {
       exception = parseRearrangeException(signature,
         Seq(k1Arg, k2Arg, k3Arg, k4Arg, NamedArgumentExpression("k5", Literal("k5"))), "foo"),
       errorClass = "UNRECOGNIZED_PARAMETER_NAME",
-      parameters = Map("functionName" -> toSQLId("foo"), "argumentName" -> toSQLId("k5"),
+      parameters = Map("routineName" -> toSQLId("foo"), "argumentName" -> toSQLId("k5"),
         "proposal" -> (toSQLId("k1") + " " + toSQLId("k2") + " " + toSQLId("k3")))
     )
   }
@@ -137,14 +137,14 @@ class NamedParameterFunctionSuite extends AnalysisTest {
       exception = parseRearrangeException(signature,
         Seq(k2Arg, k3Arg, k1Arg, k4Arg), "foo"),
       errorClass = "UNEXPECTED_POSITIONAL_ARGUMENT",
-      parameters = Map("functionName" -> toSQLId("foo"), "parameterName" -> toSQLId("k3"))
+      parameters = Map("routineName" -> toSQLId("foo"), "parameterName" -> toSQLId("k3"))
     )
   }
 
   test("INTERNAL_ERROR: Enforce optional arguments after required arguments") {
-    val errorMessage = s"Function foo has an unexpected required argument for the provided" +
-      s" function signature ${illegalSignature}. All required arguments should come before" +
-      s" optional arguments."
+    val errorMessage = s"Routine ${toSQLId("foo")} has an unexpected required argument for" +
+      s" the provided routine signature ${illegalSignature.parameters.mkString("[", ", ", "]")}." +
+      s" All required arguments should come before optional arguments."
     checkError(
       exception = parseRearrangeException(illegalSignature, args, "foo"),
       errorClass = "INTERNAL_ERROR",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/named-function-arguments.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/named-function-arguments.sql.out
@@ -225,8 +225,8 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "UNEXPECTED_POSITIONAL_ARGUMENT",
   "sqlState" : "4274K",
   "messageParameters" : {
-    "functionName" : "`mask`",
-    "parameterName" : "`lowerChar`"
+    "parameterName" : "`lowerChar`",
+    "routineName" : "`mask`"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -246,8 +246,8 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT.DOUBLE_NAMED_ARGUMENT_REFERENCE",
   "sqlState" : "4274K",
   "messageParameters" : {
-    "functionName" : "`mask`",
-    "parameterName" : "`digitChar`"
+    "parameterName" : "`digitChar`",
+    "routineName" : "`mask`"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -267,8 +267,8 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT.BOTH_POSITIONAL_AND_NAMED",
   "sqlState" : "4274K",
   "messageParameters" : {
-    "functionName" : "`mask`",
-    "parameterName" : "`str`"
+    "parameterName" : "`str`",
+    "routineName" : "`mask`"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -288,9 +288,9 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "REQUIRED_PARAMETER_NOT_FOUND",
   "sqlState" : "4274K",
   "messageParameters" : {
-    "functionName" : "`mask`",
     "index" : "0",
-    "parameterName" : "`str`"
+    "parameterName" : "`str`",
+    "routineName" : "`mask`"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -311,8 +311,8 @@ org.apache.spark.sql.AnalysisException
   "sqlState" : "4274K",
   "messageParameters" : {
     "argumentName" : "`cellular`",
-    "functionName" : "`mask`",
-    "proposal" : "`str` `upperChar` `otherChar`"
+    "proposal" : "`str` `upperChar` `otherChar`",
+    "routineName" : "`mask`"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/udtf/udtf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/udtf/udtf.sql.out
@@ -677,8 +677,8 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT.DOUBLE_NAMED_ARGUMENT_REFERENCE",
   "sqlState" : "4274K",
   "messageParameters" : {
-    "functionName" : "`UDTFForwardStateFromAnalyzeWithKwargs`",
-    "parameterName" : "`argument`"
+    "parameterName" : "`argument`",
+    "routineName" : "`UDTFForwardStateFromAnalyzeWithKwargs`"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -870,8 +870,8 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT.DOUBLE_NAMED_ARGUMENT_REFERENCE",
   "sqlState" : "4274K",
   "messageParameters" : {
-    "functionName" : "`UDTFWithSinglePartition`",
-    "parameterName" : "`initial_count`"
+    "parameterName" : "`initial_count`",
+    "routineName" : "`UDTFWithSinglePartition`"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/named-function-arguments.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/named-function-arguments.sql.out
@@ -210,8 +210,8 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "UNEXPECTED_POSITIONAL_ARGUMENT",
   "sqlState" : "4274K",
   "messageParameters" : {
-    "functionName" : "`mask`",
-    "parameterName" : "`lowerChar`"
+    "parameterName" : "`lowerChar`",
+    "routineName" : "`mask`"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -233,8 +233,8 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT.DOUBLE_NAMED_ARGUMENT_REFERENCE",
   "sqlState" : "4274K",
   "messageParameters" : {
-    "functionName" : "`mask`",
-    "parameterName" : "`digitChar`"
+    "parameterName" : "`digitChar`",
+    "routineName" : "`mask`"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -256,8 +256,8 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT.BOTH_POSITIONAL_AND_NAMED",
   "sqlState" : "4274K",
   "messageParameters" : {
-    "functionName" : "`mask`",
-    "parameterName" : "`str`"
+    "parameterName" : "`str`",
+    "routineName" : "`mask`"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -279,9 +279,9 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "REQUIRED_PARAMETER_NOT_FOUND",
   "sqlState" : "4274K",
   "messageParameters" : {
-    "functionName" : "`mask`",
     "index" : "0",
-    "parameterName" : "`str`"
+    "parameterName" : "`str`",
+    "routineName" : "`mask`"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -304,8 +304,8 @@ org.apache.spark.sql.AnalysisException
   "sqlState" : "4274K",
   "messageParameters" : {
     "argumentName" : "`cellular`",
-    "functionName" : "`mask`",
-    "proposal" : "`str` `upperChar` `otherChar`"
+    "proposal" : "`str` `upperChar` `otherChar`",
+    "routineName" : "`mask`"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/udtf/udtf.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/udtf/udtf.sql.out
@@ -816,8 +816,8 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT.DOUBLE_NAMED_ARGUMENT_REFERENCE",
   "sqlState" : "4274K",
   "messageParameters" : {
-    "functionName" : "`UDTFForwardStateFromAnalyzeWithKwargs`",
-    "parameterName" : "`argument`"
+    "parameterName" : "`argument`",
+    "routineName" : "`UDTFForwardStateFromAnalyzeWithKwargs`"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1033,8 +1033,8 @@ org.apache.spark.sql.AnalysisException
   "errorClass" : "DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT.DOUBLE_NAMED_ARGUMENT_REFERENCE",
   "sqlState" : "4274K",
   "messageParameters" : {
-    "functionName" : "`UDTFWithSinglePartition`",
-    "parameterName" : "`initial_count`"
+    "parameterName" : "`initial_count`",
+    "routineName" : "`UDTFWithSinglePartition`"
   },
   "queryContext" : [ {
     "objectType" : "",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR makes errors in `NamedParametersSupport` generic so that we can reuse that class to handle argument rearrangement both in functions and procedures. It is a subset of changes from PR #47183.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

These changes are needed in preparation for adding support for stored procedures.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Exists tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.
