### PR TITLE
[MINOR][TESTS] Replace `getResource` with `getWorkspaceFilePath` to enable `HiveUDFSuite` to run successfully in the IDE

### DIFF
--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveUDFSuite.scala
@@ -93,7 +93,8 @@ class HiveUDFSuite extends QueryTest with TestHiveSingleton with SQLTestUtils {
         """.
             stripMargin.format(classOf[PairSerDe].getName))
 
-      val location = Utils.getSparkClassLoader.getResource("data/files/testUDF").getFile
+      val location = getWorkspaceFilePath(
+        "hive", "src", "test", "resources", "data", "files", "testUDF").toUri.toURL.getFile
       sql(s"""
         ALTER TABLE hiveUDFTestTable
         ADD IF NOT EXISTS PARTITION(partition='testUDF')


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to replace `getResource` with `getWorkspaceFilePath` to enable `HiveUDFSuite#hive struct udf` to run successfully in the IDE.

### Why are the changes needed?
- Before:
  <img width="1269" alt="image" src="https://github.com/apache/spark/assets/15246973/be0c770b-3381-4ca9-9485-728bf4d23943">

- After:
  <img width="871" alt="image" src="https://github.com/apache/spark/assets/15246973/ac1b0dad-9ed0-441f-ad69-bca826207a55">



### Does this PR introduce _any_ user-facing change?
No, only test.


### How was this patch tested?
- Pass GA
- Manually test.

### Was this patch authored or co-authored using generative AI tooling?
No.
