### PR TITLE
[SPARK-48792][SQL] Fix regression  for INSERT with partial column list to a table with char/varchar

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -81,7 +81,7 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
           checkPlainResult(spark.table("t"), typ, v)
         }
         sql("INSERT OVERWRITE t VALUES ('1', null)")
-        checkPlainResult(spark.table("t"), typ, null)
+         (spark.table("t"), typ, null)
       }
     }
   }
@@ -658,6 +658,17 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
           sql("INSERT INTO t SELECT 'aaa'")
           checkAnswer(sql("select * from t"), Row("aaa"))
         }
+      }
+    }
+  }
+
+  test("SPARK-48792: Fix INSERT with partial column list to a table with char/varchar") {
+    Seq("char", "varchar").foreach { typ =>
+      withTable("students") {
+        sql(s"CREATE TABLE students (name $typ(64), address $typ(64)) USING $format")
+        sql("INSERT INTO students VALUES ('Kent Yao', 'Hangzhou')")
+        sql("INSERT INTO students (address) VALUES ('<unknown>')")
+        checkAnswer(sql("SELECT count(*) FROM students"), Row(2))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CharVarcharTestSuite.scala
@@ -81,7 +81,7 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
           checkPlainResult(spark.table("t"), typ, v)
         }
         sql("INSERT OVERWRITE t VALUES ('1', null)")
-         (spark.table("t"), typ, null)
+        checkPlainResult(spark.table("t"), typ, null)
       }
     }
   }
@@ -663,6 +663,8 @@ trait CharVarcharTestSuite extends QueryTest with SQLTestUtils {
   }
 
   test("SPARK-48792: Fix INSERT with partial column list to a table with char/varchar") {
+    assume(format != "foo",
+      "TODO: TableOutputResolver.resolveOutputColumns supportColDefaultValue is false")
     Seq("char", "varchar").foreach { typ =>
       withTable("students") {
         sql(s"CREATE TABLE students (name $typ(64), address $typ(64)) USING $format")


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

#41262 introduced a regression by applying literals with char/varchar type in query output for table insertions, see

https://github.com/apache/spark/pull/41262/files#diff-6e331e8f1c67b5920fb46263b6e582ec6e6a253ee45543559c9692a72a1a40ecR187-R188

This causes bugs 

```java
24/07/03 16:29:01 ERROR Executor: Exception in task 0.0 in stage 0.0 (TID 0)
org.apache.spark.SparkException: [INTERNAL_ERROR] Unsupported data type VarcharType(64). SQLSTATE: XX000
	at org.apache.spark.SparkException$.internalError(SparkException.scala:92)
	at org.apache.spark.SparkException$.internalError(SparkException.scala:96)
``` 

```java
org.apache.spark.SparkUnsupportedOperationException: VarcharType(64) is not supported yet.
	at org.apache.spark.sql.errors.QueryExecutionErrors$.dataTypeUnsupportedYetError(QueryExecutionErrors.scala:993)
	at org.apache.spark.sql.execution.datasources.orc.OrcSerializer.newConverter(OrcSerializer.scala:209)
	at org.apache.spark.sql.execution.datasources.orc.OrcSerializer.$anonfun$converters$2(OrcSerializer.scala:35)
	at scala.collection.immutable.List.map(List.scala:247)
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Bugfix

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

no
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

new tests
### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->no
