### PR TITLE
[SPARK-48799][SS] Refactor versioning for operator metadata read/write and callers

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/metadata/StateMetadataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/metadata/StateMetadataSource.scala
@@ -188,7 +188,7 @@ class StateMetadataPartitionReader(
     } else Array.empty
   }
 
-  private[sql] def allOperatorStateMetadata: Array[OperatorStateMetadata] = {
+  private def allOperatorStateMetadata: Array[OperatorStateMetadata] = {
     val stateDir = new Path(checkpointLocation, "state")
     val opIds = fileManager
       .list(stateDir, pathNameCanBeParsedAsLongFilter).map(f => pathToLong(f.getPath)).sorted
@@ -197,7 +197,7 @@ class StateMetadataPartitionReader(
     }
   }
 
-  private[state] lazy val stateMetadata: Iterator[StateMetadataTableEntry] = {
+  private[sql] lazy val stateMetadata: Iterator[StateMetadataTableEntry] = {
     allOperatorStateMetadata.flatMap { operatorStateMetadata =>
       require(operatorStateMetadata.version == 1)
       val operatorStateMetadataV1 = operatorStateMetadata.asInstanceOf[OperatorStateMetadataV1]

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.execution.datasources.v2.state.metadata.StateMetadat
 import org.apache.spark.sql.execution.exchange.ShuffleExchangeLike
 import org.apache.spark.sql.execution.python.FlatMapGroupsInPandasWithStateExec
 import org.apache.spark.sql.execution.streaming.sources.WriteToMicroBatchDataSourceV1
-import org.apache.spark.sql.execution.streaming.state.{OperatorStateMetadataV1, OperatorStateMetadataWriter}
+import org.apache.spark.sql.execution.streaming.state.OperatorStateMetadataWriter
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.util.{SerializableConfiguration, Utils}
@@ -442,12 +442,8 @@ class IncrementalExecution(
             val reader = new StateMetadataPartitionReader(
               new Path(checkpointLocation).getParent.toString,
               new SerializableConfiguration(hadoopConf))
-            val opMetadataList = reader.allOperatorStateMetadata
-            ret = opMetadataList.map { operatorMetadata =>
-              val metadataInfoV1 = operatorMetadata
-                .asInstanceOf[OperatorStateMetadataV1]
-                .operatorInfo
-              metadataInfoV1.operatorId -> metadataInfoV1.operatorName
+            ret = reader.stateMetadata.map { metadataTableEntry =>
+              metadataTableEntry.operatorId -> metadataTableEntry.operatorName
             }.toMap
           } catch {
             case e: Exception =>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Refactor versioning for operator metadata read/write and callers


### Why are the changes needed?
Provides clear separation around version management for operator metadata related updates. Also needed for subsequent changes in this area


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing unit tests

```
===== POSSIBLE THREAD LEAK IN SUITE o.a.s.sql.execution.streaming.state.OperatorStateMetadataSuite, threads: block-manager-ask-thread-pool-92 (daemon=true), Idle Worker Monitor for python3 (daemon=true), rpc-boss-3-1 (daemon=true), block-manager-ask-thread-pool-8 (daemon=true), block-manager-ask-thread-pool-59 (daemon=true), ForkJoinPool.commonPool-worker-3 (daemon=true), block-manager-ask-thread-pool-29 (daemon=true), block-manager-ask-thread-pool-90 (daemon=true), block-manager-ask-thread-pool-48 (daemo...
[info] Run completed in 30 seconds, 35 milliseconds.
[info] Total number of tests run: 10
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 10, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 44 s, completed Jul 3, 2024, 3:00:58 PM
```


### Was this patch authored or co-authored using generative AI tooling?
No
