### PR TITLE
[SPARK-48804][SQL] Add classIsLoadable & OutputCommitter.isAssignableFrom check for output committer class configrations

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkClassUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkClassUtils.scala
@@ -50,6 +50,25 @@ private[spark] trait SparkClassUtils {
   def classIsLoadable(clazz: String): Boolean = {
     Try { classForName(clazz, initialize = false) }.isSuccess
   }
+
+  /**
+   * Determines whether the provided class is loadable in the current thread and a subclass
+   * of the given parent class.
+   *
+   * @param clazz the fully qualified class name of the class to check
+   *              for loadability and inheritance from `parent`
+   * @param parent the parent class which the class represented. If parent
+   *               is null, only checks if the class is loadable
+   * @return true if `clazz` is loadable and a subclass of `parent`, otherwise false
+   */
+  def classIsLoadableAndSubOf(
+      clazz: String,
+      parent: Class[_]): Boolean = {
+    Try {
+      val cls = classForName(clazz, initialize = false)
+      parent == null || parent.isAssignableFrom(cls)
+    }.getOrElse(false)
+  }
 }
 
 private[spark] object SparkClassUtils extends SparkClassUtils

--- a/common/utils/src/main/scala/org/apache/spark/util/SparkClassUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkClassUtils.scala
@@ -52,21 +52,21 @@ private[spark] trait SparkClassUtils {
   }
 
   /**
-   * Determines whether the provided class is loadable in the current thread and a subclass
-   * of the given parent class.
+   * Determines whether the provided class is loadable in the current thread and assignable
+   * from the target class.
    *
    * @param clazz the fully qualified class name of the class to check
    *              for loadability and inheritance from `parent`
-   * @param parent the parent class which the class represented. If parent
+   * @param targetClass the target class which the class represented. If target
    *               is null, only checks if the class is loadable
-   * @return true if `clazz` is loadable and a subclass of `parent`, otherwise false
+   * @return true if `clazz` is loadable and assignable from `target`, otherwise false
    */
-  def classIsLoadableAndSubOf(
+  def classIsLoadableAndAssignableFrom(
       clazz: String,
-      parent: Class[_]): Boolean = {
+      targetClass: Class[_]): Boolean = {
     Try {
       val cls = classForName(clazz, initialize = false)
-      parent == null || parent.isAssignableFrom(cls)
+      targetClass == null || targetClass.isAssignableFrom(cls)
     }.getOrElse(false)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5193,7 +5193,7 @@ object SQLConf {
  * SQLConf is thread-safe (internally synchronized, so safe to be used in multiple threads).
  */
 class SQLConf extends Serializable with Logging with SqlApiConf {
-  import org.apache.spark.sql.internal.SQLConf._
+  import SQLConf._
 
   /** Only low degree of contention is expected for conf, thus NOT using ConcurrentHashMap. */
   @transient protected[spark] val settings = java.util.Collections.synchronizedMap(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -17,8 +17,8 @@
 
 package org.apache.spark.sql.internal
 
-import java.util
 import java.util.{Locale, Properties, TimeZone}
+import java.util
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import java.util.zip.Deflater

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1164,7 +1164,7 @@ object SQLConf {
     .version("1.5.0")
     .internal()
     .stringConf
-    .checkValue(Utils.classIsLoadableAndSubOf(_, classOf[OutputCommitter]),
+    .checkValue(Utils.classIsLoadableAndAssignableFrom(_, classOf[OutputCommitter]),
       s"Class must be loadable and subclass of ${classOf[OutputCommitter].getName}")
     .createWithDefault("org.apache.parquet.hadoop.ParquetOutputCommitter")
 
@@ -1737,7 +1737,7 @@ object SQLConf {
     .version("1.4.0")
     .internal()
     .stringConf
-    .checkValue(Utils.classIsLoadableAndSubOf(_, classOf[OutputCommitter]),
+    .checkValue(Utils.classIsLoadableAndAssignableFrom(_, classOf[OutputCommitter]),
       s"Class must be loadable and subclass of ${classOf[OutputCommitter].getName}")
     .createOptional
 
@@ -1746,7 +1746,7 @@ object SQLConf {
       .version("2.1.1")
       .internal()
       .stringConf
-      .checkValue(Utils.classIsLoadableAndSubOf(_, classOf[FileCommitProtocol]),
+      .checkValue(Utils.classIsLoadableAndAssignableFrom(_, classOf[FileCommitProtocol]),
         s"Class must be loadable and subclass of ${classOf[FileCommitProtocol].getName}")
       .createWithDefault(
         "org.apache.spark.sql.execution.datasources.SQLHadoopMapReduceCommitProtocol")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -35,6 +35,7 @@ import org.apache.hadoop.mapreduce.OutputCommitter
 import org.apache.spark.{ErrorMessageFormat, SparkConf, SparkContext, SparkException, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.internal.config._
+import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.io.CompressionCodec
 import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.sql.catalyst.ScalaReflection
@@ -1745,6 +1746,8 @@ object SQLConf {
       .version("2.1.1")
       .internal()
       .stringConf
+      .checkValue(Utils.classIsLoadableAndSubOf(_, classOf[FileCommitProtocol]),
+        s"Class must be loadable and subclass of ${classOf[FileCommitProtocol].getName}")
       .createWithDefault(
         "org.apache.spark.sql.execution.datasources.SQLHadoopMapReduceCommitProtocol")
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCommitterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCommitterSuite.scala
@@ -113,7 +113,7 @@ class ParquetCommitterSuite extends SparkFunSuite with SQLTestUtils
     result
   }
 
-  test("Fail fast on unloadable or invalid committers") {
+  test("SPARK-48804: Fail fast on unloadable or invalid committers") {
     Seq("invalid", getClass.getName).foreach { committer =>
       val e = intercept[IllegalArgumentException] {
         withSQLConf(SQLConf.PARQUET_OUTPUT_COMMITTER_CLASS.key -> committer)()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCommitterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCommitterSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources.parquet
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
-import org.apache.hadoop.mapreduce.{JobContext, TaskAttemptContext}
+import org.apache.hadoop.mapreduce.{JobContext, OutputCommitter, TaskAttemptContext}
 import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter
 import org.apache.parquet.hadoop.{ParquetOutputCommitter, ParquetOutputFormat}
 
@@ -111,6 +111,15 @@ class ParquetCommitterSuite extends SparkFunSuite with SQLTestUtils
         }
     }
     result
+  }
+
+  test("Fail fast on unloadable or invalid committers") {
+    Seq("invalid", getClass.getName).foreach { committer =>
+      val e = intercept[IllegalArgumentException] {
+        withSQLConf(SQLConf.PARQUET_OUTPUT_COMMITTER_CLASS.key -> committer)()
+      }
+      assert(e.getMessage.contains(classOf[OutputCommitter].getName))
+    }
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request proposed adding a checker for class values provided by users in `spark.sql.sources.outputCommitterClass` and `spark.sql.parquet.output.committer.class` to make sure the given class is visible from the classpath and a subclass of `org.apache.hadoop.mapreduce.OutputCommitter`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Ensure that an invalid configuration results in immediate application or query failure rather than failing late during setupJob.
### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

no
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->no
