### PR TITLE
[SPARK-48810][CONNECT] Session stop() API should be idempotent and not fail if the session is already closed by the server.

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -712,8 +712,8 @@ class SparkSession private[sql] (
   /**
    * Close the [[SparkSession]].
    *
-   * Release the current session and close the GRPC connection to the server. The API will
-   * not error if any of these operations fail. Closing a closed session is a no-op.
+   * Release the current session and close the GRPC connection to the server. The API will not
+   * error if any of these operations fail. Closing a closed session is a no-op.
    *
    * Close the allocator. Fail if there are still open [[SparkResult]]s.
    *

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -84,6 +84,10 @@ class SparkSession private[sql] (
 
   private[sql] val observationRegistry = new ConcurrentHashMap[Long, Observation]()
 
+  private[sql] def hijackServerSideSessionIdForTesting(suffix: String) = {
+    client.hijackServerSideSessionIdForTesting(suffix)
+  }
+
   /**
    * Runtime configuration interface for Spark.
    *

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/SparkSessionE2ESuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/SparkSessionE2ESuite.scala
@@ -421,4 +421,23 @@ class SparkSessionE2ESuite extends ConnectFunSuite with RemoteSparkSession {
     assert(session2.range(3).collect().length == 3)
   }
 
+  test("SPARK-48810: session.stop should not throw when the session is invalid") {
+    val remote = s"sc://localhost:$serverPort"
+
+    SparkSession.clearDefaultSession()
+    SparkSession.clearActiveSession()
+
+    val session = SparkSession
+      .builder()
+      .remote(remote)
+      .getOrCreate()
+
+    session.range(3).collect()
+
+    session.hijackServerSideSessionIdForTesting("-testing")
+
+    // no error is thrown here.
+    session.stop()
+  }
+
 }

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -818,6 +818,16 @@ class SparkSession:
     clearTags.__doc__ = PySparkSession.clearTags.__doc__
 
     def stop(self) -> None:
+        """
+        Release the current session and close the GRPC connection to the Spark Connect server.
+        Reset the active session so that calls to getOrCreate() creates a new session.
+        If the session was created in local mode, the Spark Connect server running locally is also
+        terminated.
+
+        This API is best-effort and idempotent, i.e., if any of the operations fail, the API will
+        not produce an error. Stopping an already stopped session is a no-op.
+        """
+
         # Whereas the regular PySpark session immediately terminates the Spark Context
         # itself, meaning that stopping all Spark sessions, this will only stop this one session
         # on the server.
@@ -859,8 +869,6 @@ class SparkSession:
                 del os.environ["SPARK_CONNECT_MODE_ENABLED"]
                 if "SPARK_REMOTE" in os.environ:
                     del os.environ["SPARK_REMOTE"]
-
-    stop.__doc__ = PySparkSession.stop.__doc__
 
     @property
     def is_stopped(self) -> bool:

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -22,7 +22,6 @@ check_dependencies(__name__)
 import threading
 import os
 import warnings
-import grpc
 from collections.abc import Sized
 import functools
 from threading import RLock

--- a/python/pyspark/sql/tests/connect/test_connect_session.py
+++ b/python/pyspark/sql/tests/connect/test_connect_session.py
@@ -270,6 +270,17 @@ class SparkConnectSessionTests(ReusedConnectTestCase):
         session = RemoteSparkSession.builder.remote("sc://localhost").getOrCreate()
         session.range(3).collect()
 
+    def test_stop_invalid_session(self):  # SPARK-47986
+        session = RemoteSparkSession.builder.remote("sc://localhost").getOrCreate()
+        # run a simple query so the session id is synchronized.
+        session.range(3).collect()
+
+        # change the server side session id to simulate that the server has terminated this session.
+        session._client._server_session_id = str(uuid.uuid4())
+
+        # Should not throw any error
+        session.stop()
+
 
 class SparkConnectSessionWithOptionsTest(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Improve the error handling of the `stop()` API in the `SparkSesion`
class to not throw if there is any error related to releasing a session or
closing the underlying GRPC channel. Both are best effort.

In the case of Pyspark, do not fail if the local Spark Connect service
cannot be stopped.

### Why are the changes needed?

In some cases, the Spark Connect Service will terminate the session, usually
because the underlying cluster or driver has restarted.
In the cases, calling stop() throws an error which is unactionable. However,
stop() still needs to be called in order to reset the active session.

Further, the stop() API should be idempotent.

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Attached unit tests.

Confirmed that removing the code changes results in the
tests failing (as expected).

### Was this patch authored or co-authored using generative AI tooling?

No.
