### PR TITLE
[SPARK-49106][DOCS] Documented `Prometheus` endpoints

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1079,7 +1079,41 @@ Each instance can report to zero or more _sinks_. Sinks are contained in the
 * `CSVSink`: Exports metrics data to CSV files at regular intervals.
 * `JmxSink`: Registers metrics for viewing in a JMX console.
 * `MetricsServlet`: Adds a servlet within the existing Spark UI to serve metrics data as JSON data.
+ 
+
 * `PrometheusServlet`: (Experimental) Adds a servlet within the existing Spark UI to serve metrics data in Prometheus format.
+
+The Prometheus Servlet mirrors the JSON data exposed by the <code>Metrics Servlet</code> and the REST API, but in a time-series format. The following are the equivalent Prometheus Servlet endpoints.   
+
+<table>
+  <thead><tr><th></th></th><th>JSON End Point</th><th>Prometheus End Point</th></tr></thead>
+  <tr>
+    <td>Master</td>
+    <td><code>/metrics/master/json/</code></td>
+    <td><code>/metrics/master/prometheus/</code></td>
+  </tr>
+  <tr>
+    <td>Master</td>
+    <td><code>/metrics/applications/json/</code></td>
+    <td><code>/metrics/applications/prometheus/</code></td>
+  </tr>
+  <tr>
+    <td>Worker</td>
+    <td><code>/metrics/json/</code></td>
+    <td><code>/metrics/prometheus/</code></td>
+  </tr>
+  <tr>
+    <td>Driver</td>
+    <td><code>/metrics/json/</code></td>
+    <td><code>/metrics/prometheus/</code></td>
+  </tr>
+  <tr>
+    <td>Driver</td>
+    <td><code>/api/v1/applications/{id}/executors/	</code></td>
+    <td><code>/metrics/executors/prometheus/</code></td>
+  </tr>
+</table>
+
 * `GraphiteSink`: Sends metrics to a Graphite node.
 * `Slf4jSink`: Sends metrics to slf4j as log entries.
 * `StatsdSink`: Sends metrics to a StatsD node.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1086,29 +1086,37 @@ Each instance can report to zero or more _sinks_. Sinks are contained in the
 The Prometheus Servlet mirrors the JSON data exposed by the <code>Metrics Servlet</code> and the REST API, but in a time-series format. The following are the equivalent Prometheus Servlet endpoints.   
 
 <table>
-  <thead><tr><th></th></th><th>JSON End Point</th><th>Prometheus End Point</th></tr></thead>
+  <thead><tr><th></th></th>
+<th>Port</th>
+<th>JSON End Point</th>
+<th>Prometheus End Point</th></tr></thead>
   <tr>
     <td>Master</td>
+    <td>8080</td>
     <td><code>/metrics/master/json/</code></td>
     <td><code>/metrics/master/prometheus/</code></td>
   </tr>
   <tr>
     <td>Master</td>
+    <td>8080</td>
     <td><code>/metrics/applications/json/</code></td>
     <td><code>/metrics/applications/prometheus/</code></td>
   </tr>
   <tr>
     <td>Worker</td>
+    <td>8081</td>
     <td><code>/metrics/json/</code></td>
     <td><code>/metrics/prometheus/</code></td>
   </tr>
   <tr>
     <td>Driver</td>
+    <td>4040</td>
     <td><code>/metrics/json/</code></td>
     <td><code>/metrics/prometheus/</code></td>
   </tr>
   <tr>
     <td>Driver</td>
+    <td>4040</td>
     <td><code>/api/v1/applications/{id}/executors/	</code></td>
     <td><code>/metrics/executors/prometheus/</code></td>
   </tr>

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1118,7 +1118,7 @@ The Prometheus Servlet mirrors the JSON data exposed by the <code>Metrics Servle
   <tr>
     <td>Driver</td>
     <td>4040</td>
-    <td><code>/api/v1/applications/{id}/executors/	</code></td>
+    <td><code>/api/v1/applications/{id}/executors/</code></td>
     <td><code>/metrics/executors/prometheus/</code></td>
   </tr>
 </table>

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1079,8 +1079,6 @@ Each instance can report to zero or more _sinks_. Sinks are contained in the
 * `CSVSink`: Exports metrics data to CSV files at regular intervals.
 * `JmxSink`: Registers metrics for viewing in a JMX console.
 * `MetricsServlet`: Adds a servlet within the existing Spark UI to serve metrics data as JSON data.
- 
-
 * `PrometheusServlet`: (Experimental) Adds a servlet within the existing Spark UI to serve metrics data in Prometheus format.
 
 The Prometheus Servlet mirrors the JSON data exposed by the <code>Metrics Servlet</code> and the REST API, but in a time-series format. The following are the equivalent Prometheus Servlet endpoints.   

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1087,10 +1087,14 @@ Each instance can report to zero or more _sinks_. Sinks are contained in the
 The Prometheus Servlet mirrors the JSON data exposed by the <code>Metrics Servlet</code> and the REST API, but in a time-series format. The following are the equivalent Prometheus Servlet endpoints.   
 
 <table>
-  <thead><tr><th></th></th>
-<th>Port</th>
-<th>JSON End Point</th>
-<th>Prometheus End Point</th></tr></thead>
+  <thead>
+    <tr>
+      <th>Component</th>
+      <th>Port</th>
+      <th>JSON End Point</th>
+      <th>Prometheus End Point</th>
+    </tr>
+  </thead>
   <tr>
     <td>Master</td>
     <td>8080</td>

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1080,6 +1080,9 @@ Each instance can report to zero or more _sinks_. Sinks are contained in the
 * `JmxSink`: Registers metrics for viewing in a JMX console.
 * `MetricsServlet`: Adds a servlet within the existing Spark UI to serve metrics data as JSON data.
 * `PrometheusServlet`: (Experimental) Adds a servlet within the existing Spark UI to serve metrics data in Prometheus format.
+* `GraphiteSink`: Sends metrics to a Graphite node.
+* `Slf4jSink`: Sends metrics to slf4j as log entries.
+* `StatsdSink`: Sends metrics to a StatsD node.
 
 The Prometheus Servlet mirrors the JSON data exposed by the <code>Metrics Servlet</code> and the REST API, but in a time-series format. The following are the equivalent Prometheus Servlet endpoints.   
 
@@ -1119,10 +1122,6 @@ The Prometheus Servlet mirrors the JSON data exposed by the <code>Metrics Servle
     <td><code>/metrics/executors/prometheus/</code></td>
   </tr>
 </table>
-
-* `GraphiteSink`: Sends metrics to a Graphite node.
-* `Slf4jSink`: Sends metrics to slf4j as log entries.
-* `StatsdSink`: Sends metrics to a StatsD node.
 
 Spark also supports a Ganglia sink which is not included in the default build due to
 licensing restrictions:


### PR DESCRIPTION
### What changes were proposed in this pull request?

Since SPARK-46886 enables `spark.ui.prometheus.enabled` by default, this PR aims to provide clear documentation on the endpoints exposed by this PR.
 
![Screenshot 2024-08-04 at 15 03 34](https://github.com/user-attachments/assets/0b7ba631-68c4-43c8-8903-2068a9f7a135)


### Why are the changes needed?

Enable the experimental Prometheus Metrics feature on Spark to be used. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
N/A


### Was this patch authored or co-authored using generative AI tooling?
No
