### PR TITLE
[SPARK-48820][SQL][DOC] Correct the examples for Collate functions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collationExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collationExpressions.scala
@@ -38,7 +38,7 @@ import org.apache.spark.sql.types._
     Examples:
       > SET spark.sql.collation.enabled=true;
       spark.sql.collation.enabled	true
-      > SELECT COLLATION('Spark SQL' _FUNC_ UTF8_LCASE);
+      > SELECT _FUNC_('Spark SQL', 'UTF8_LCASE');
       UTF8_LCASE
       > SET spark.sql.collation.enabled=false;
       spark.sql.collation.enabled	false
@@ -107,6 +107,8 @@ case class Collate(child: Expression, collationName: String)
       spark.sql.collation.enabled	true
       > SELECT _FUNC_('Spark SQL');
       UTF8_BINARY
+      > SELECT _FUNC_('Spark SQL' collate UTF8_LCASE);
+      UTF8_LCASE
       > SET spark.sql.collation.enabled=false;
       spark.sql.collation.enabled	false
   """,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collationExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collationExpressions.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.types._
       > SET spark.sql.collation.enabled=true;
       spark.sql.collation.enabled	true
       > SELECT _FUNC_('Spark SQL', 'UTF8_LCASE');
-      UTF8_LCASE
+      Spark SQL
       > SET spark.sql.collation.enabled=false;
       spark.sql.collation.enabled	false
   """,

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -81,7 +81,7 @@
 | org.apache.spark.sql.catalyst.expressions.Chr | char | SELECT char(65) | struct<char(65):string> |
 | org.apache.spark.sql.catalyst.expressions.Chr | chr | SELECT chr(65) | struct<chr(65):string> |
 | org.apache.spark.sql.catalyst.expressions.Coalesce | coalesce | SELECT coalesce(NULL, 1, NULL) | struct<coalesce(NULL, 1, NULL):int> |
-| org.apache.spark.sql.catalyst.expressions.CollateExpressionBuilder | collate | SELECT COLLATION('Spark SQL' collate UTF8_LCASE) | struct<collation(collate(Spark SQL)):string> |
+| org.apache.spark.sql.catalyst.expressions.CollateExpressionBuilder | collate | SELECT collate('Spark SQL', 'UTF8_LCASE') | struct<collate(Spark SQL):string collate UTF8_LCASE> |
 | org.apache.spark.sql.catalyst.expressions.Collation | collation | SELECT collation('Spark SQL') | struct<collation(Spark SQL):string> |
 | org.apache.spark.sql.catalyst.expressions.Concat | concat | SELECT concat('Spark', 'SQL') | struct<concat(Spark, SQL):string> |
 | org.apache.spark.sql.catalyst.expressions.ConcatWs | concat_ws | SELECT concat_ws(' ', 'Spark', 'SQL') | struct<concat_ws( , Spark, SQL):string> |


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to correct the examples for `Collate` functions.


### Why are the changes needed?
According to the code in `FunctionRegistry` show below.
```
    expressionBuilder("collate", CollateExpressionBuilder),
    expression[Collation]("collation"),
```

, `SELECT COLLATION('Spark SQL' collate UTF8_LCASE);` and `CollateExpressionBuilder` are not related.
In fact, `SELECT COLLATION('Spark SQL' collate UTF8_LCASE);` is related to `Collation`.


### Does this PR introduce _any_ user-facing change?
'No'.
New feature.


### How was this patch tested?
GA.


### Was this patch authored or co-authored using generative AI tooling?
'No'.
