### PR TITLE
[SPARK-48821][SQL] Support `Update` in `DataFrameWriterV2`

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/api/Catalog.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/api/Catalog.scala
@@ -533,18 +533,19 @@ abstract class Catalog {
    *   catalog.update("source", Map("salary" -> lit(200)), $"salary" === 100)
    * }}}
    *
-   * @param tableName is either a qualified or unqualified name that designates a table.
-   *                  If no database identifier is provided, it refers to a table in the
-   *                  current database.
-   * @param assignments A Map of column names to Column expressions representing the updates
-   *     to be applied.
-   * @param condition the update condition
+   * @param tableName
+   *   is either a qualified or unqualified name that designates a table. If no database
+   *   identifier is provided, it refers to a table in the current database.
+   * @param assignments
+   *   A Map of column names to Column expressions representing the updates to be applied.
+   * @param condition
+   *   the update condition
    * @since 4.1.0
    */
   def updateTable(
-    tableName: String,
-    assignments: Map[String, org.apache.spark.sql.Column],
-    condition: org.apache.spark.sql.Column): Unit =
+      tableName: String,
+      assignments: Map[String, org.apache.spark.sql.Column],
+      condition: org.apache.spark.sql.Column): Unit =
     throw new SparkUnsupportedOperationException(
       errorClass = "_LEGACY_ERROR_TEMP_2041",
       messageParameters = Map("methodName" -> "updateTable"))
@@ -557,16 +558,16 @@ abstract class Catalog {
    *   catalog.update("source", Map("salary" -> lit(200)))
    * }}}
    *
-   * @param tableName is either a qualified or unqualified name that designates a table.
-   *                  If no database identifier is provided, it refers to a table in the
-   *                  current database.
-   * @param assignments A Map of column names to Column expressions representing the updates
-   *     to be applied.
+   * @param tableName
+   *   is either a qualified or unqualified name that designates a table. If no database
+   *   identifier is provided, it refers to a table in the current database.
+   * @param assignments
+   *   A Map of column names to Column expressions representing the updates to be applied.
    * @since 4.1.0
    */
   def updateTable(
-    tableName: String,
-    assignments: Map[String, org.apache.spark.sql.Column]): Unit =
+      tableName: String,
+      assignments: Map[String, org.apache.spark.sql.Column]): Unit =
     throw new SparkUnsupportedOperationException(
       errorClass = "_LEGACY_ERROR_TEMP_2041",
       messageParameters = Map("methodName" -> "updateTable"))

--- a/sql/api/src/main/scala/org/apache/spark/sql/api/Catalog.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/api/Catalog.scala
@@ -21,6 +21,7 @@ import scala.jdk.CollectionConverters._
 
 import _root_.java.util
 
+import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.annotation.Stable
 import org.apache.spark.sql.{AnalysisException, Row}
 import org.apache.spark.sql.catalog.{CatalogMetadata, Column, Database, Function, Table}
@@ -523,6 +524,52 @@ abstract class Catalog {
       schema: StructType,
       description: String,
       options: Map[String, String]): Dataset[Row]
+
+  /**
+   * Update rows in a table that match a condition.
+   *
+   * Scala Example:
+   * {{{
+   *   catalog.update("source", Map("salary" -> lit(200)), $"salary" === 100)
+   * }}}
+   *
+   * @param tableName is either a qualified or unqualified name that designates a table.
+   *                  If no database identifier is provided, it refers to a table in the
+   *                  current database.
+   * @param assignments A Map of column names to Column expressions representing the updates
+   *     to be applied.
+   * @param condition the update condition
+   * @since 4.1.0
+   */
+  def updateTable(
+    tableName: String,
+    assignments: Map[String, org.apache.spark.sql.Column],
+    condition: org.apache.spark.sql.Column): Unit =
+    throw new SparkUnsupportedOperationException(
+      errorClass = "_LEGACY_ERROR_TEMP_2041",
+      messageParameters = Map("methodName" -> "updateTable"))
+
+  /**
+   * Update rows in a table.
+   *
+   * Scala Example:
+   * {{{
+   *   catalog.update("source", Map("salary" -> lit(200)))
+   * }}}
+   *
+   * @param tableName is either a qualified or unqualified name that designates a table.
+   *                  If no database identifier is provided, it refers to a table in the
+   *                  current database.
+   * @param assignments A Map of column names to Column expressions representing the updates
+   *     to be applied.
+   * @since 4.1.0
+   */
+  def updateTable(
+    tableName: String,
+    assignments: Map[String, org.apache.spark.sql.Column]): Unit =
+    throw new SparkUnsupportedOperationException(
+      errorClass = "_LEGACY_ERROR_TEMP_2041",
+      messageParameters = Map("methodName" -> "updateTable"))
 
   /**
    * Drops the local temporary view with the given view name in the catalog. If the view has been

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/UpdateTableAPISuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/UpdateTableAPISuite.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.functions._
+
+class UpdateTableAPISuite extends RowLevelOperationSuiteBase {
+
+  import testImplicits._
+
+  test("Basic Update") {
+    createAndInitTable("pk INT, salary INT, dep STRING",
+      """{ "pk": 1, "salary": 300, "dep": 'hr' }
+        |{ "pk": 2, "salary": 150, "dep": 'software' }
+        |{ "pk": 3, "salary": 120, "dep": 'hr' }
+        |""".stripMargin)
+
+    spark.catalog.updateTable(
+        tableNameAsString, Map("salary" -> lit(-1)), $"pk" >= 2)
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString"),
+      Seq(
+        Row(1, 300, "hr"),
+        Row(2, -1, "software"),
+        Row(3, -1, "hr")))
+  }
+
+  test("Update without where clause") {
+    createAndInitTable("pk INT, salary INT, dep STRING",
+      """{ "pk": 1, "salary": 300, "dep": 'hr' }
+        |{ "pk": 2, "salary": 150, "dep": 'software' }
+        |{ "pk": 3, "salary": 120, "dep": 'hr' }
+        |""".stripMargin)
+
+    spark.catalog.updateTable(tableNameAsString,
+      Map("dep" -> lit("software")))
+
+    checkAnswer(
+      sql(s"SELECT * FROM $tableNameAsString"),
+      Seq(
+        Row(1, 300, "software"),
+        Row(2, 150, "software"),
+        Row(3, 120, "software")))
+  }
+}


### PR DESCRIPTION
  ### What changes were proposed in this pull request?
Add Update support in DataFrameWriterV2

 ### Why are the changes needed?
Spark currently supports update sql statement. We want DataFrame to have the same support.

 ### Does this PR introduce any user-facing change?
Yes. This PR introduces new API like the following:

      spark.table("source")
        .update(Map("salary" -> lit(-1)), $"pk" >= 2)
        
 ### How was this patch tested?
new tests

 ### Was this patch authored or co-authored using generative AI tooling?
No