### PR TITLE
[SPARK-48652][SQL] Fix casting issue in Spark SQL when comparing string column to integer value

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -1001,17 +1001,9 @@ abstract class BinaryComparison extends BinaryOperator with Predicate {
   protected lazy val ordering: Ordering[Any] = new Ordering[Any] {
     override def compare(x: Any, y: Any): Int = {
       (x, y) match {
-        // Handle comparison when the left side is a String and the right side is an Integer
-        case (xs: String, yi: Int) => xs.toIntOption match {
-          case Some(xi) => xi.compareTo(yi)
-          case None => xs.compareTo(yi.toString)
-        }
-        // Handle comparison when the left side is an Integer and the right side is a String
-        case (xi: Int, ys: String) => ys.toIntOption match {
-          case Some(yi) => xi.compareTo(yi)
-          case None => xi.toString.compareTo(ys)
-        }
-        case _ => TypeUtils.getInterpretedOrdering(left.dataType).compare(x, y)
+        case (xs: String, yi: Int) => xs.compare(yi.toString)
+        case (xi: Int, ys: String) => xi.toString.compare(ys)
+        case _ => super.compare(x, y)
       }
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -998,8 +998,25 @@ abstract class BinaryComparison extends BinaryOperator with Predicate {
     }
   }
 
-  protected lazy val ordering: Ordering[Any] = TypeUtils.getInterpretedOrdering(left.dataType)
+  protected lazy val ordering: Ordering[Any] = new Ordering[Any] {
+    override def compare(x: Any, y: Any): Int = {
+      (x, y) match {
+        // Handle comparison when the left side is a String and the right side is an Integer
+        case (xs: String, yi: Int) => xs.toIntOption match {
+          case Some(xi) => xi.compareTo(yi)
+          case None => xs.compareTo(yi.toString)
+        }
+        // Handle comparison when the left side is an Integer and the right side is a String
+        case (xi: Int, ys: String) => ys.toIntOption match {
+          case Some(yi) => xi.compareTo(yi)
+          case None => xi.toString.compareTo(ys)
+        }
+        case _ => TypeUtils.getInterpretedOrdering(left.dataType).compare(x, y)
+      }
+    }
+  }
 }
+
 
 
 object BinaryComparison {
@@ -1044,6 +1061,15 @@ case class EqualTo(left: Expression, right: Expression)
 
   override def symbol: String = "="
 
+  override def checkInputDataTypes(): TypeCheckResult = {
+    (left.dataType, right.dataType) match {
+      case (StringType, IntegerType) | (IntegerType, StringType) =>
+        TypeCheckResult.TypeCheckSuccess
+      case _ =>
+        super.checkInputDataTypes()
+    }
+  }
+
   // +---------+---------+---------+---------+
   // | =       | TRUE    | FALSE   | UNKNOWN |
   // +---------+---------+---------+---------+
@@ -1051,7 +1077,13 @@ case class EqualTo(left: Expression, right: Expression)
   // | FALSE   | FALSE   | TRUE    | UNKNOWN |
   // | UNKNOWN | UNKNOWN | UNKNOWN | UNKNOWN |
   // +---------+---------+---------+---------+
-  protected override def nullSafeEval(left: Any, right: Any): Any = ordering.equiv(left, right)
+  protected override def nullSafeEval(input1: Any, input2: Any): Any = {
+    (input1, input2) match {
+      case (l: String, r: Int) => l == r.toString
+      case (l: Int, r: String) => l.toString == r
+      case _ => ordering.equiv(input1, input2)
+    }
+  }
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     defineCodeGen(ctx, ev, (c1, c2) => ctx.genEqual(left.dataType, c1, c2))
@@ -1108,7 +1140,21 @@ case class EqualNullSafe(left: Expression, right: Expression) extends BinaryComp
     } else if (input1 == null || input2 == null) {
       false
     } else {
-      ordering.equiv(input1, input2)
+       if (left.dataType == StringType && right.dataType == IntegerType) {
+        try {
+          ordering.equiv(input1.toString.toInt, input2)
+        } catch {
+          case _: NumberFormatException => false
+        }
+      } else if (left.dataType == IntegerType && right.dataType == StringType) {
+        try {
+          ordering.equiv(input1, input2.toString.toInt)
+        } catch {
+          case _: NumberFormatException => false
+        }
+      } else {
+        ordering.equiv(input1, input2)
+      }
     }
   }
 
@@ -1193,7 +1239,23 @@ case class LessThan(left: Expression, right: Expression)
 
   override def symbol: String = "<"
 
-  protected override def nullSafeEval(input1: Any, input2: Any): Any = ordering.lt(input1, input2)
+  protected override def nullSafeEval(input1: Any, input2: Any): Any = {
+    if (left.dataType == StringType && right.dataType == IntegerType) {
+      try {
+        ordering.lt(input1.toString.toInt, input2)
+      } catch {
+        case _: NumberFormatException => false
+      }
+    } else if (left.dataType == IntegerType && right.dataType == StringType) {
+      try {
+        ordering.lt(input1, input2.toString.toInt)
+      } catch {
+        case _: NumberFormatException => false
+      }
+    } else {
+      ordering.lt(input1, input2)
+    }
+  }
 
   override protected def withNewChildrenInternal(
     newLeft: Expression, newRight: Expression): Expression = copy(left = newLeft, right = newRight)
@@ -1228,11 +1290,28 @@ case class LessThanOrEqual(left: Expression, right: Expression)
 
   override def symbol: String = "<="
 
-  protected override def nullSafeEval(input1: Any, input2: Any): Any = ordering.lteq(input1, input2)
+  protected override def nullSafeEval(input1: Any, input2: Any): Any = {
+    if (left.dataType == StringType && right.dataType == IntegerType) {
+      try {
+        ordering.lteq(input1.toString.toInt, input2)
+      } catch {
+        case _: NumberFormatException => false
+      }
+    } else if (left.dataType == IntegerType && right.dataType == StringType) {
+      try {
+        ordering.lteq(input1, input2.toString.toInt)
+      } catch {
+        case _: NumberFormatException => false
+      }
+    } else {
+      ordering.lteq(input1, input2)
+    }
+  }
 
   override protected def withNewChildrenInternal(
     newLeft: Expression, newRight: Expression): Expression = copy(left = newLeft, right = newRight)
 }
+
 
 @ExpressionDescription(
   usage = "expr1 _FUNC_ expr2 - Returns true if `expr1` is greater than `expr2`.",
@@ -1263,7 +1342,23 @@ case class GreaterThan(left: Expression, right: Expression)
 
   override def symbol: String = ">"
 
-  protected override def nullSafeEval(input1: Any, input2: Any): Any = ordering.gt(input1, input2)
+  protected override def nullSafeEval(input1: Any, input2: Any): Any = {
+    if (left.dataType == StringType && right.dataType == IntegerType) {
+      try {
+        ordering.gt(input1.toString.toInt, input2)
+      } catch {
+        case _: NumberFormatException => false
+      }
+    } else if (left.dataType == IntegerType && right.dataType == StringType) {
+      try {
+        ordering.gt(input1, input2.toString.toInt)
+      } catch {
+        case _: NumberFormatException => false
+      }
+    } else {
+      ordering.gt(input1, input2)
+    }
+  }
 
   override protected def withNewChildrenInternal(
     newLeft: Expression, newRight: Expression): Expression = copy(left = newLeft, right = newRight)
@@ -1298,7 +1393,23 @@ case class GreaterThanOrEqual(left: Expression, right: Expression)
 
   override def symbol: String = ">="
 
-  protected override def nullSafeEval(input1: Any, input2: Any): Any = ordering.gteq(input1, input2)
+  protected override def nullSafeEval(input1: Any, input2: Any): Any = {
+    if (left.dataType == StringType && right.dataType == IntegerType) {
+      try {
+        ordering.gteq(input1.toString.toInt, input2)
+      } catch {
+        case _: NumberFormatException => false
+      }
+    } else if (left.dataType == IntegerType && right.dataType == StringType) {
+      try {
+        ordering.gteq(input1, input2.toString.toInt)
+      } catch {
+        case _: NumberFormatException => false
+      }
+    } else {
+      ordering.gteq(input1, input2)
+    }
+  }
 
   override protected def withNewChildrenInternal(
       newLeft: Expression, newRight: Expression): GreaterThanOrEqual =

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/BinaryComparisonSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/BinaryComparisonSuite.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.unsafe.types.UTF8String
+
+class BinaryComparisonSuite extends SparkFunSuite {
+
+  test("EqualTo with String and Integer") {
+    val expr = EqualTo(Literal(UTF8String.fromString("123")),
+                       Literal(UTF8String.fromString("123")))
+    assert(expr.eval(null) === true)
+  }
+
+  test("EqualNullSafe with String and Integer") {
+    val expr = EqualNullSafe(Literal(UTF8String.fromString("123")),
+                             Literal(UTF8String.fromString("123")))
+    assert(expr.eval(null) === true)
+  }
+
+  test("LessThan with String and Integer") {
+    val expr = LessThan(Literal(UTF8String.fromString("123")),
+                        Literal(UTF8String.fromString("124")))
+    assert(expr.eval(null) === true)
+  }
+
+  test("LessThanOrEqual with String and Integer") {
+    val expr = LessThanOrEqual(Literal(UTF8String.fromString("123")),
+                               Literal(UTF8String.fromString("123")))
+    assert(expr.eval(null) === true)
+  }
+
+  test("GreaterThan with String and Integer") {
+    val expr = GreaterThan(Literal(UTF8String.fromString("124")),
+                           Literal(UTF8String.fromString("123")))
+    assert(expr.eval(null) === true)
+  }
+
+  test("GreaterThanOrEqual with String and Integer") {
+    val expr = GreaterThanOrEqual(Literal(UTF8String.fromString("123")),
+                                  Literal(UTF8String.fromString("123")))
+    assert(expr.eval(null) === true)
+  }
+
+  test("In with mixed types") {
+    val expr = In(Literal(UTF8String.fromString("123")),
+                  Seq(Literal(UTF8String.fromString("123")),
+                      Literal(UTF8String.fromString("456"))))
+    assert(expr.eval(null) === true)
+  }
+
+  test("InSet with mixed types") {
+    val expr = InSet(Literal(UTF8String.fromString("123")),
+                     Set(UTF8String.fromString("123"),
+                         UTF8String.fromString("456")))
+    assert(expr.eval(null) === true)
+  }
+
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR addresses a type casting issue in Spark SQL where comparing a string column to an integer value results in an empty result set. The changes ensure that Spark SQL handles such comparisons in a manner similar to Redshift by casting the integer to a string before comparison.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
The current behavior in Spark SQL leads to unexpected empty result sets when comparing a string column to an integer value. This is inconsistent with the behavior of other SQL systems like Redshift, which cast the integer to a string for comparison. The changes are needed to make Spark SQL's behavior more intuitive and consistent with other systems.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
Yes. Users will now get expected results when comparing string columns to integer values in Spark SQL. Previously, such comparisons would yield empty result sets due to type casting issues.

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
The patch was tested by adding new unit tests in the **BinaryComparisonSuite** to cover various comparison scenarios between string columns and integer values. These tests ensure that the comparisons behave as expected and return correct results.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No.

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
