### PR TITLE
[SPARK-48832][CONNECT][TESTS] Add dedicated error tests for Spark Connect

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -1419,6 +1419,7 @@ pyspark_errors = Module(
     python_test_goals=[
         # unittests
         "pyspark.errors.tests.test_errors",
+        "pyspark.errors.tests.connect.test_parity_errors",
     ],
 )
 

--- a/dev/tox.ini
+++ b/dev/tox.ini
@@ -33,6 +33,7 @@ per-file-ignores =
     examples/src/main/python/sql/datasource.py: F841,
     # Exclude * imports in test files
     python/pyspark/errors/tests/*.py: F403,
+    python/pyspark/errors/tests/connect/*.py: F403,
     python/pyspark/ml/tests/*.py: F403,
     python/pyspark/mllib/tests/*.py: F403,
     python/pyspark/pandas/tests/*.py: F401 F403,

--- a/python/pyspark/errors/tests/connect/__init__.py
+++ b/python/pyspark/errors/tests/connect/__init__.py
@@ -1,0 +1,16 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/pyspark/errors/tests/connect/test_parity_errors.py
+++ b/python/pyspark/errors/tests/connect/test_parity_errors.py
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark.errors.tests.test_errors import ErrorsTestsMixin
+from pyspark.testing.connectutils import ReusedConnectTestCase
+
+
+class ErrorsParityTests(ErrorsTestsMixin, ReusedConnectTestCase):
+    pass
+
+
+if __name__ == "__main__":
+    import unittest
+    from pyspark.errors.tests.connect.test_parity_errors import *  # noqa: F401
+
+    try:
+        import xmlrunner  # type: ignore[import]
+
+        testRunner = xmlrunner.XMLTestRunner(output="target/test-reports", verbosity=2)
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/python/pyspark/errors/tests/test_errors.py
+++ b/python/pyspark/errors/tests/test_errors.py
@@ -24,7 +24,7 @@ from pyspark.errors.error_classes import ERROR_CLASSES_JSON
 from pyspark.errors.utils import ErrorClassesReader
 
 
-class ErrorsTest(unittest.TestCase):
+class ErrorsTestsMixin:
     def test_error_classes_sorted(self):
         # Test error classes is sorted alphabetically
         error_reader = ErrorClassesReader()
@@ -53,6 +53,10 @@ class ErrorsTest(unittest.TestCase):
     def test_invalid_error_class(self):
         with self.assertRaisesRegex(ValueError, "Cannot find main error class"):
             PySparkValueError(error_class="invalid", message_parameters={})
+
+
+class ErrorsTests(ErrorsTestsMixin, unittest.TestCase):
+    pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

### What changes were proposed in this pull request?

This PR proposes to add dedicated error tests for Spark Connect

### Why are the changes needed?

To improve the test coverage for Spark Connect


### Does this PR introduce _any_ user-facing change?

No, this is test-only fix.

### How was this patch tested?

Extended the existing UTs.

### Was this patch authored or co-authored using generative AI tooling?

No.