### PR TITLE
[SPARK-48834][SQL] Disable variant input/output to python scalar UDFs, UDTFs, UDAFs during query compilation

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -954,6 +954,16 @@
           "The input of <functionName> can't be <dataType> type data."
         ]
       },
+      "UNSUPPORTED_UDF_INPUT_TYPE" : {
+        "message" : [
+          "UDFs do not support <dataType> type input data."
+        ]
+      },
+      "UNSUPPORTED_UDF_OUTPUT_TYPE" : {
+        "message" : [
+          "UDFs do not support <dataType> type output data."
+        ]
+      },
       "VALUE_OUT_OF_RANGE" : {
         "message" : [
           "The <exprName> must be between <valueRange> (current value = <currentValue>)."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -956,12 +956,12 @@
       },
       "UNSUPPORTED_UDF_INPUT_TYPE" : {
         "message" : [
-          "UDFs do not support <dataType> type input data."
+          "UDFs do not support '<dataType>' as an input data type."
         ]
       },
       "UNSUPPORTED_UDF_OUTPUT_TYPE" : {
         "message" : [
-          "UDFs do not support <dataType> type output data."
+          "UDFs do not support '<dataType>' as an output data type."
         ]
       },
       "VALUE_OUT_OF_RANGE" : {

--- a/connect/common/src/main/scala/org/apache/spark/sql/connect/client/arrow/ArrowDeserializer.scala
+++ b/connect/common/src/main/scala/org/apache/spark/sql/connect/client/arrow/ArrowDeserializer.scala
@@ -359,7 +359,7 @@ object ArrowDeserializers {
           }
         }
 
-      case (CalendarIntervalEncoder | _: UDTEncoder[_], _) =>
+      case (CalendarIntervalEncoder | VariantEncoder | _: UDTEncoder[_], _) =>
         throw ExecutionErrors.unsupportedDataTypeError(encoder.dataType)
 
       case _ =>

--- a/connect/common/src/main/scala/org/apache/spark/sql/connect/client/arrow/ArrowSerializer.scala
+++ b/connect/common/src/main/scala/org/apache/spark/sql/connect/client/arrow/ArrowSerializer.scala
@@ -442,7 +442,7 @@ object ArrowSerializer {
           o => getter.invoke(o)
         }
 
-      case (CalendarIntervalEncoder | _: UDTEncoder[_], _) =>
+      case (CalendarIntervalEncoder | VariantEncoder | _: UDTEncoder[_], _) =>
         throw ExecutionErrors.unsupportedDataTypeError(encoder.dataType)
 
       case _ =>

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -2232,7 +2232,8 @@ class TypesTestsMixin:
         tests = [
             ("a:int, b:string", True),
             (
-                "a struct<>, b map<int, binary>, c array<array<map<struct<a: int, b: int>, binary>>>",
+                "a struct<>, b map<int, binary>, "
+                + "c array<array<map<struct<a: int, b: int>, binary>>>",
                 True,
             ),
             ("struct<>", True),

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -29,6 +29,7 @@ from pyspark.sql import Row
 from pyspark.sql import functions as F
 from pyspark.errors import (
     AnalysisException,
+    ParseException,
     PySparkTypeError,
     PySparkValueError,
     PySparkRuntimeError,
@@ -2215,6 +2216,43 @@ class TypesTestsMixin:
             DataType.fromDDL("a int, v variant"),
             StructType([StructField("a", IntegerType()), StructField("v", VariantType())]),
         )
+
+    # Ensures that changing the implementation of `DataType.fromDDL` in PR #47253 does not change
+    # `fromDDL`'s behavior.
+    def test_spark48834_from_ddl_matches_udf_schema_string(self):
+        from pyspark.sql.functions import udf
+
+        def schema_from_udf(ddl):
+            schema = (
+                self.spark.active().range(0).select(udf(lambda x: x, returnType=ddl)("id")).schema
+            )
+            assert len(schema) == 1
+            return schema[0].dataType
+
+        tests = [
+            ("a:int, b:string", True),
+            (
+                "a struct<>, b map<int, binary>, c array<array<map<struct<a: int, b: int>, binary>>>",
+                True,
+            ),
+            ("struct<>", True),
+            ("struct<a: string, b: array<long>>", True),
+            ("", True),
+            ("<a: int, b: variant>", False),
+            ("randomstring", False),
+            ("struct", False),
+        ]
+        for test, is_valid_input in tests:
+            if is_valid_input:
+                self.assertEqual(DataType.fromDDL(test), schema_from_udf(test))
+            else:
+                with self.assertRaises(ParseException) as from_ddl_pe:
+                    DataType.fromDDL(test)
+                with self.assertRaises(ParseException) as udf_pe:
+                    schema_from_udf(test)
+                self.assertEqual(
+                    from_ddl_pe.exception.getErrorClass(), udf_pe.exception.getErrorClass()
+                )
 
     def test_collated_string(self):
         dfs = [

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -194,16 +194,7 @@ class DataType:
         >>> DataType.fromDDL("b: string, a: int")
         StructType([StructField('b', StringType(), True), StructField('a', IntegerType(), True)])
         """
-        from pyspark.sql import SparkSession
-        from pyspark.sql.functions import udf
-
-        # Intentionally uses SparkSession so one implementation can be shared with/without
-        # Spark Connect.
-        schema = (
-            SparkSession.active().range(0).select(udf(lambda x: x, returnType=ddl)("id")).schema
-        )
-        assert len(schema) == 1
-        return schema[0].dataType
+        return _parse_datatype_string(ddl)
 
     @classmethod
     def _data_type_build_formatted_string(
@@ -1578,6 +1569,11 @@ class VariantType(AtomicType):
             return None
         return VariantVal(obj["value"], obj["metadata"])
 
+    def toInternal(self, obj: Any) -> Any:
+        raise PySparkNotImplementedError(
+            error_class="NOT_IMPLEMENTED",
+            message_parameters={"feature": "VariantType.toInternal"},
+        )
 
 class UserDefinedType(DataType):
     """User-defined type (UDT).

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -1575,6 +1575,7 @@ class VariantType(AtomicType):
             message_parameters={"feature": "VariantType.toInternal"},
         )
 
+
 class UserDefinedType(DataType):
     """User-defined type (UDT).
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/ScalaReflection.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.catalyst.encoders.{AgnosticEncoder, OuterScopes}
 import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders._
 import org.apache.spark.sql.errors.ExecutionErrors
 import org.apache.spark.sql.types._
-import org.apache.spark.unsafe.types.CalendarInterval
+import org.apache.spark.unsafe.types.{CalendarInterval, VariantVal}
 
 private[catalyst] object ScalaSubtypeLock
 
@@ -322,6 +322,7 @@ object ScalaReflection extends ScalaReflection {
       case t if isSubtype(t, localTypeOf[java.sql.Timestamp]) => STRICT_TIMESTAMP_ENCODER
       case t if isSubtype(t, localTypeOf[java.time.Instant]) => STRICT_INSTANT_ENCODER
       case t if isSubtype(t, localTypeOf[java.time.LocalDateTime]) => LocalDateTimeEncoder
+      case t if isSubtype(t, localTypeOf[VariantVal]) => VariantEncoder
       case t if isSubtype(t, localTypeOf[Row]) => UnboundRowEncoder
 
       // UDT encoders

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionEvalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/variant/VariantExpressionEvalUtils.scala
@@ -75,6 +75,16 @@ object VariantExpressionEvalUtils {
     new VariantVal(v.getValue, v.getMetadata)
   }
 
+  /** Returns `true` if a data type is or has a child variant type. */
+  def typeContainsVariant(dt: DataType): Boolean = dt match {
+    case _: VariantType => true
+    case st: StructType => st.fields.exists(f => typeContainsVariant(f.dataType))
+    case at: ArrayType => typeContainsVariant(at.elementType)
+    // Variants cannot be map keys.
+    case mt: MapType => typeContainsVariant(mt.valueType)
+    case _ => false
+  }
+
   private def buildVariant(builder: VariantBuilder, input: Any, dataType: DataType): Unit = {
     if (input == null) {
       builder.appendNull()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3825,6 +3825,12 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
         "class" -> unsupported.getClass.toString))
   }
 
+  def unsupportedUDFOuptutType(sqlExpr: String, dt: DataType): Throwable = {
+    new AnalysisException(
+      errorClass = "DATATYPE_MISMATCH.UNSUPPORTED_UDF_OUTPUT_TYPE",
+      messageParameters = Map("sqlExpr" -> sqlExpr, "dataType" -> toSQLType(dt)))
+  }
+
   def funcBuildError(funcName: String, cause: Exception): Throwable = {
     cause.getCause match {
       case st: SparkThrowable with Throwable => st

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3825,10 +3825,10 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
         "class" -> unsupported.getClass.toString))
   }
 
-  def unsupportedUDFOuptutType(sqlExpr: String, dt: DataType): Throwable = {
+  def unsupportedUDFOuptutType(expr: Expression, dt: DataType): Throwable = {
     new AnalysisException(
       errorClass = "DATATYPE_MISMATCH.UNSUPPORTED_UDF_OUTPUT_TYPE",
-      messageParameters = Map("sqlExpr" -> sqlExpr, "dataType" -> toSQLType(dt)))
+      messageParameters = Map("sqlExpr" -> toSQLExpr(expr), "dataType" -> toSQLType(dt)))
   }
 
   def funcBuildError(funcName: String, cause: Exception): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3828,7 +3828,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
   def unsupportedUDFOuptutType(expr: Expression, dt: DataType): Throwable = {
     new AnalysisException(
       errorClass = "DATATYPE_MISMATCH.UNSUPPORTED_UDF_OUTPUT_TYPE",
-      messageParameters = Map("sqlExpr" -> toSQLExpr(expr), "dataType" -> toSQLType(dt)))
+      messageParameters = Map("sqlExpr" -> toSQLExpr(expr), "dataType" -> dt.sql))
   }
 
   def funcBuildError(funcName: String, cause: Exception): Throwable = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDFSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/ScalaUDFSuite.scala
@@ -24,8 +24,10 @@ import scala.reflect.runtime.universe.TypeTag
 import org.apache.spark.{SparkException, SparkFunSuite}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions.codegen.CodegenContext
+import org.apache.spark.sql.catalyst.expressions.variant.{ParseJson, VariantGet}
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.types.{DecimalType, IntegerType, StringType}
+import org.apache.spark.sql.types.{DecimalType, IntegerType, StringType, VariantType}
+import org.apache.spark.unsafe.types.VariantVal
 
 class ScalaUDFSuite extends SparkFunSuite with ExpressionEvalHelper {
 
@@ -41,6 +43,34 @@ class ScalaUDFSuite extends SparkFunSuite with ExpressionEvalHelper {
     val stringUdf = ScalaUDF((s: String) => s + "x", StringType, Literal("a") :: Nil,
       Option(resolvedEncoder[String]()) :: Nil)
     checkEvaluation(stringUdf, "ax")
+  }
+
+  test("variant basic input output") {
+    val variantUdf = ScalaUDF(
+      (v: VariantVal) => v,
+      VariantType,
+      ParseJson(Literal("{\"a\": \"b\"}")).replacement :: Nil,
+      Option(resolvedEncoder[VariantVal]()) :: Nil)
+    checkEvaluation(VariantGet(variantUdf, Literal("$.a"), StringType, true), "b")
+  }
+
+  test("variant basic output string") {
+    val variantUdf = ScalaUDF(
+      (v: VariantVal) => v.toString(),
+      StringType,
+      ParseJson(Literal("{\"a\": \"b\"}")).replacement :: Nil,
+      Option(resolvedEncoder[VariantVal]()) :: Nil)
+    checkEvaluation(variantUdf, "{\"a\":\"b\"}")
+  }
+
+  test("variant basic output variant") {
+    val variantUdf = ScalaUDF(
+      // The variant value below corresponds to a JSON string of {"a": "b"}.
+      () => new VariantVal(Array[Byte](2, 1, 0, 0, 2, 5, 98), Array[Byte](1, 1, 0, 1, 97)),
+      VariantType,
+      Seq(),
+      Option(resolvedEncoder[VariantVal]()) :: Nil)
+    checkEvaluation(VariantGet(variantUdf, Literal("$.a"), StringType, true), "b")
   }
 
   test("better error message for NPE") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
@@ -86,6 +86,61 @@ class PythonUDFSuite extends QueryTest with SharedSparkSession {
     checkAnswer(actual, expected)
   }
 
+  test("variant input to pandas grouped agg UDF") {
+    assume(shouldTestPandasUDFs)
+    val df = spark.range(0, 10).selectExpr(
+      """parse_json(format_string('{"%s": "test"}', id)) as v""")
+
+    val testUdf = TestGroupedAggPandasUDFStringifiedMax(name = "pandas_udf")
+    checkError(
+      exception = intercept[AnalysisException] {
+        df.agg(testUdf(df("v"))).collect()
+      },
+      errorClass = "DATATYPE_MISMATCH.UNSUPPORTED_UDF_INPUT_TYPE",
+      parameters = Map("sqlExpr" -> "\"pandas_udf(v)\"", "dataType" -> "\"VARIANT\""))
+  }
+
+  test("complex variant input to pandas grouped agg UDF") {
+    val df = spark.range(0, 10).selectExpr(
+      """array(parse_json(format_string('{"%s": "test"}', id))) as arr_v""")
+
+    val testUdf = TestGroupedAggPandasUDFStringifiedMax(name = "pandas_udf")
+    checkError(
+      exception = intercept[AnalysisException] {
+        df.agg(testUdf(df("arr_v"))).collect()
+      },
+      errorClass = "DATATYPE_MISMATCH.UNSUPPORTED_UDF_INPUT_TYPE",
+      parameters = Map("sqlExpr" -> "\"pandas_udf(arr_v)\"", "dataType" -> "\"ARRAY<VARIANT>\""))
+  }
+
+  test("variant output to pandas grouped agg UDF") {
+    assume(shouldTestPandasUDFs)
+    val df = spark.range(0, 10).toDF("id")
+
+    val testUdf = TestGroupedAggPandasUDFReturnVariant(name = "pandas_udf")
+    checkError(
+      exception = intercept[AnalysisException] {
+        df.agg(testUdf(df("id"))).collect()
+      },
+      errorClass = "DATATYPE_MISMATCH.UNSUPPORTED_UDF_OUTPUT_TYPE",
+      parameters = Map("sqlExpr" -> "\"pandas_udf(id)\"", "dataType" -> "\"VARIANT\""))
+  }
+
+  test("complex variant output to pandas grouped agg UDF") {
+    assume(shouldTestPandasUDFs)
+    val df = spark.range(0, 10).toDF("id")
+
+    val testUdf = TestGroupedAggPandasUDFReturnComplexVariant(name = "pandas_udf")
+    checkError(
+      exception = intercept[AnalysisException] {
+        df.agg(testUdf(df("id"))).collect()
+      },
+      errorClass = "DATATYPE_MISMATCH.UNSUPPORTED_UDF_OUTPUT_TYPE",
+      parameters = Map(
+        "sqlExpr" -> "\"pandas_udf(id)\"",
+        "dataType" -> "\"STRUCT<a: STRUCT<v: VARIANT>>\""))
+  }
+
   test("SPARK-34265: Instrument Python UDF execution using SQL Metrics") {
     assume(shouldTestPythonUDFs)
     val pythonSQLMetrics = List(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
@@ -97,7 +97,7 @@ class PythonUDFSuite extends QueryTest with SharedSparkSession {
         df.agg(testUdf(df("v"))).collect()
       },
       errorClass = "DATATYPE_MISMATCH.UNSUPPORTED_UDF_INPUT_TYPE",
-      parameters = Map("sqlExpr" -> "\"pandas_udf(v)\"", "dataType" -> "\"VARIANT\""))
+      parameters = Map("sqlExpr" -> "\"pandas_udf(v)\"", "dataType" -> "VARIANT"))
   }
 
   test("complex variant input to pandas grouped agg UDF") {
@@ -110,7 +110,7 @@ class PythonUDFSuite extends QueryTest with SharedSparkSession {
         df.agg(testUdf(df("arr_v"))).collect()
       },
       errorClass = "DATATYPE_MISMATCH.UNSUPPORTED_UDF_INPUT_TYPE",
-      parameters = Map("sqlExpr" -> "\"pandas_udf(arr_v)\"", "dataType" -> "\"ARRAY<VARIANT>\""))
+      parameters = Map("sqlExpr" -> "\"pandas_udf(arr_v)\"", "dataType" -> "ARRAY<VARIANT>"))
   }
 
   test("variant output to pandas grouped agg UDF") {
@@ -123,7 +123,7 @@ class PythonUDFSuite extends QueryTest with SharedSparkSession {
         df.agg(testUdf(df("id"))).collect()
       },
       errorClass = "DATATYPE_MISMATCH.UNSUPPORTED_UDF_OUTPUT_TYPE",
-      parameters = Map("sqlExpr" -> "\"pandas_udf(id)\"", "dataType" -> "\"VARIANT\""))
+      parameters = Map("sqlExpr" -> "\"pandas_udf(id)\"", "dataType" -> "VARIANT"))
   }
 
   test("complex variant output to pandas grouped agg UDF") {
@@ -138,7 +138,7 @@ class PythonUDFSuite extends QueryTest with SharedSparkSession {
       errorClass = "DATATYPE_MISMATCH.UNSUPPORTED_UDF_OUTPUT_TYPE",
       parameters = Map(
         "sqlExpr" -> "\"pandas_udf(id)\"",
-        "dataType" -> "\"STRUCT<a: STRUCT<v: VARIANT>>\""))
+        "dataType" -> "STRUCT<a: STRUCT<v: VARIANT>>"))
   }
 
   test("SPARK-34265: Instrument Python UDF execution using SQL Metrics") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDTFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDTFSuite.scala
@@ -42,6 +42,32 @@ class PythonUDTFSuite extends QueryTest with SharedSparkSession {
       |        yield a, b, b - a
       |""".stripMargin
 
+  private val variantInputScript: String =
+    """
+      |class InputVariantUDTF:
+      |    def eval(self, a):
+      |        yield str(a)
+      |""".stripMargin
+
+  private val variantStr =
+    "VariantVal(VariantVal(bytes([2, 1, 0, 0, 2, 5, 98]), bytes([1, 1, 0, 1, 97])))"
+
+  private val variantOutputScript: String =
+    """
+      |class SimpleOutputVariantUDTF:
+      |    from pyspark.sql.types import VariantVal
+      |    def eval(self):
+      |        yield {0}
+      |""".format(variantStr).stripMargin
+
+  private val arrayOfVariantOutputScript: String =
+    """
+      |class OutputArrayOfVariantUDTF:
+      |    from pyspark.sql.types import VariantVal
+      |    def eval(self):
+      |        yield [{0}]
+      |""".format(variantStr).stripMargin
+
   private val returnType: StructType = StructType.fromDDL("a int, b int, c int")
 
   private val pythonUDTF: UserDefinedPythonTableFunction =
@@ -71,10 +97,99 @@ class PythonUDTFSuite extends QueryTest with SharedSparkSession {
       UDTFForwardStateFromAnalyze.name,
       UDTFForwardStateFromAnalyze.pythonScript, None)
 
+  private val variantInputUDTF: UserDefinedPythonTableFunction =
+    createUserDefinedPythonTableFunction(
+      "InputVariantUDTF",
+      variantInputScript,
+      Some(StructType.fromDDL("o STRING"))
+    )
+
+  private val variantOutputUDTF: UserDefinedPythonTableFunction =
+    createUserDefinedPythonTableFunction(
+      "SimpleOutputVariantUDTF",
+      variantOutputScript,
+      Some(StructType.fromDDL("v VARIANT"))
+    )
+
+  private val arrayOfVariantOutputUDTF: UserDefinedPythonTableFunction =
+    createUserDefinedPythonTableFunction(
+      "OutputArrayOfVariantUDTF",
+      arrayOfVariantOutputScript,
+      Some(StructType.fromDDL("v ARRAY<VARIANT>"))
+    )
+
   test("Simple PythonUDTF") {
     assume(shouldTestPythonUDFs)
     val df = pythonUDTF(spark, lit(1), lit(2))
     checkAnswer(df, Seq(Row(1, 2, -1), Row(1, 2, 1), Row(1, 2, 3)))
+  }
+
+  test("Simple variant input UDTF") {
+    assume(shouldTestPythonUDFs)
+    withTempView("t") {
+      spark.udtf.registerPython("variantInputUDTF", variantInputUDTF)
+      spark.range(0, 10).selectExpr("parse_json(cast(id as string)) v").createOrReplaceTempView("t")
+      checkError(
+        exception = intercept[AnalysisException] {
+          spark.sql("select udtf.* from t, lateral variantInputUDTF(v) udtf").collect()
+        },
+        errorClass = "DATATYPE_MISMATCH.UNSUPPORTED_UDF_INPUT_TYPE",
+        parameters = Map(
+          "sqlExpr" -> "\"InputVariantUDTF(outer(v#2))\"",
+          "dataType" -> "\"VARIANT\""))
+    }
+  }
+
+  test("Complex variant input UDTF") {
+    assume(shouldTestPythonUDFs)
+    withTempView("t") {
+      spark.udtf.registerPython("variantInputUDTF", variantInputUDTF)
+      spark.range(0, 10)
+        .selectExpr("map(id, parse_json(cast(id as string))) map_v")
+        .createOrReplaceTempView("t")
+      checkError(
+        exception = intercept[AnalysisException] {
+          spark.sql("select udtf.* from t, lateral variantInputUDTF(map_v) udtf").collect()
+        },
+        errorClass = "DATATYPE_MISMATCH.UNSUPPORTED_UDF_INPUT_TYPE",
+        parameters = Map(
+          "sqlExpr" -> "\"InputVariantUDTF(outer(map_v#2))\"",
+          "dataType" -> "\"MAP<BIGINT, VARIANT>\""))
+    }
+  }
+
+  test("Simple variant output UDTF") {
+    assume(shouldTestPythonUDFs)
+      spark.udtf.registerPython("variantOutUDTF", variantOutputUDTF)
+      checkError(
+        exception = intercept[AnalysisException] {
+          spark.sql("select * from variantOutUDTF()").collect()
+        },
+        errorClass = "DATATYPE_MISMATCH.UNSUPPORTED_UDF_OUTPUT_TYPE",
+        parameters = Map(
+          "sqlExpr" -> "\"SimpleOutputVariantUDTF()\"",
+          "dataType" -> "\"VARIANT\""),
+        context = ExpectedContext(
+          fragment = "variantOutUDTF()",
+          start = 14,
+          stop = 29))
+  }
+
+  test("Complex variant output UDTF") {
+    assume(shouldTestPythonUDFs)
+      spark.udtf.registerPython("arrayOfVariantOutUDTF", arrayOfVariantOutputUDTF)
+      checkError(
+        exception = intercept[AnalysisException] {
+          spark.sql("select * from arrayOfVariantOutUDTF()").collect()
+        },
+        errorClass = "DATATYPE_MISMATCH.UNSUPPORTED_UDF_OUTPUT_TYPE",
+        parameters = Map(
+          "sqlExpr" -> "\"OutputArrayOfVariantUDTF()\"",
+          "dataType" -> "\"ARRAY<VARIANT>\""),
+        context = ExpectedContext(
+          fragment = "arrayOfVariantOutUDTF()",
+          start = 14,
+          stop = 36))
   }
 
   test("PythonUDTF with lateral join") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDTFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDTFSuite.scala
@@ -136,7 +136,7 @@ class PythonUDTFSuite extends QueryTest with SharedSparkSession {
         errorClass = "DATATYPE_MISMATCH.UNSUPPORTED_UDF_INPUT_TYPE",
         parameters = Map(
           "sqlExpr" -> """"InputVariantUDTF\(outer\(v#\d+\)\)"""",
-          "dataType" -> "\"VARIANT\""),
+          "dataType" -> "VARIANT"),
         matchPVals = true,
         queryContext = Array(ExpectedContext(
           fragment = "variantInputUDTF(v) udtf",
@@ -159,7 +159,7 @@ class PythonUDTFSuite extends QueryTest with SharedSparkSession {
         errorClass = "DATATYPE_MISMATCH.UNSUPPORTED_UDF_INPUT_TYPE",
         parameters = Map(
           "sqlExpr" -> """"InputVariantUDTF\(outer\(map_v#\d+\)\)"""",
-          "dataType" -> "\"MAP<BIGINT, VARIANT>\""),
+          "dataType" -> "MAP<BIGINT, VARIANT>"),
         matchPVals = true,
         queryContext = Array(ExpectedContext(
           fragment = "variantInputUDTF(map_v) udtf",
@@ -178,7 +178,7 @@ class PythonUDTFSuite extends QueryTest with SharedSparkSession {
         errorClass = "DATATYPE_MISMATCH.UNSUPPORTED_UDF_OUTPUT_TYPE",
         parameters = Map(
           "sqlExpr" -> "\"SimpleOutputVariantUDTF()\"",
-          "dataType" -> "\"VARIANT\""),
+          "dataType" -> "VARIANT"),
         context = ExpectedContext(
           fragment = "variantOutUDTF()",
           start = 14,
@@ -195,7 +195,7 @@ class PythonUDTFSuite extends QueryTest with SharedSparkSession {
         errorClass = "DATATYPE_MISMATCH.UNSUPPORTED_UDF_OUTPUT_TYPE",
         parameters = Map(
           "sqlExpr" -> "\"OutputArrayOfVariantUDTF()\"",
-          "dataType" -> "\"ARRAY<VARIANT>\""),
+          "dataType" -> "ARRAY<VARIANT>"),
         context = ExpectedContext(
           fragment = "arrayOfVariantOutUDTF()",
           start = 14,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDTFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDTFSuite.scala
@@ -135,8 +135,13 @@ class PythonUDTFSuite extends QueryTest with SharedSparkSession {
         },
         errorClass = "DATATYPE_MISMATCH.UNSUPPORTED_UDF_INPUT_TYPE",
         parameters = Map(
-          "sqlExpr" -> "\"InputVariantUDTF(outer(v#2))\"",
-          "dataType" -> "\"VARIANT\""))
+          "sqlExpr" -> """"InputVariantUDTF\(outer\(v#\d+\)\)"""",
+          "dataType" -> "\"VARIANT\""),
+        matchPVals = true,
+        queryContext = Array(ExpectedContext(
+          fragment = "variantInputUDTF(v) udtf",
+          start = 30,
+          stop = 53)))
     }
   }
 
@@ -153,8 +158,13 @@ class PythonUDTFSuite extends QueryTest with SharedSparkSession {
         },
         errorClass = "DATATYPE_MISMATCH.UNSUPPORTED_UDF_INPUT_TYPE",
         parameters = Map(
-          "sqlExpr" -> "\"InputVariantUDTF(outer(map_v#2))\"",
-          "dataType" -> "\"MAP<BIGINT, VARIANT>\""))
+          "sqlExpr" -> """"InputVariantUDTF\(outer\(map_v#\d+\)\)"""",
+          "dataType" -> "\"MAP<BIGINT, VARIANT>\""),
+        matchPVals = true,
+        queryContext = Array(ExpectedContext(
+          fragment = "variantInputUDTF(map_v) udtf",
+          start = 30,
+          stop = 57)))
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Throws an exception if a variant is the input/output type to/from python UDF, UDAF, UDTF

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

currently, variant input/output types to scalar UDFs will fail during execution or return a `net.razorvine.pickle.objects.ClassDictConstructor` to the user python code. For a better UX, we should fail during query compilation for failures, and block returning `ClassDictConstructor` to user code as we one day want to actually return `VariantVal`s to the user code. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes - attempting to use variants in python UDFs will now throw an exception rather than returning a `ClassDictConstructor` as before. However, we want to make this change now as we one day want to be able to return `VariantVal`s to the user code and do not want users relying on this current behavior

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
added UTs

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no