### PR TITLE
[SPARK-48839][SQL] Inject Runtime Filter for multi-level join with function condition

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/InjectRuntimeFilter.scala
@@ -129,7 +129,7 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
         // join keys, but for transitive join keys we need to check the join type.
         // We assume other rules have already pushed predicates through join if possible.
         // So the predicate references won't pass on anymore.
-        if (left.output.exists(_.semanticEquals(targetKey))) {
+        if (targetKey.references.subsetOf(left.outputSet)) {
           extract(left, AttributeSet.empty, hasHitFilter = false, hasHitSelectiveFilter = false,
             currentPlan = left, targetKey = targetKey).orElse {
             // An example that extract from the right side if the join keys are transitive.
@@ -148,7 +148,7 @@ object InjectRuntimeFilter extends Rule[LogicalPlan] with PredicateHelper with J
               None
             }
           }
-        } else if (right.output.exists(_.semanticEquals(targetKey))) {
+        } else if (targetKey.references.subsetOf(right.outputSet)) {
           extract(right, AttributeSet.empty, hasHitFilter = false, hasHitSelectiveFilter = false,
             currentPlan = right, targetKey = targetKey).orElse {
             // An example that extract from the left side if the join keys are transitive.

--- a/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/InjectRuntimeFilterSuite.scala
@@ -316,6 +316,8 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
         "bf1.c1 = bf2.c2 and bf3.c3 = bf2.c2 where bf2.a2 = 5", 2)
       assertRewroteWithBloomFilter("select * from bf1 right outer join bf2 join bf3 on " +
         "bf1.c1 = bf2.c2 and bf3.c3 = bf2.c2 where bf2.a2 = 5", 2)
+      assertRewroteWithBloomFilter("select * from bf1 left outer join bf2 join bf3 on " +
+        "bf1.c1 = bf2.c2 and bf3.c3 = if(bf2.c2 < 5, 5, bf2.c2) where bf2.a2 = 5", 2)
       // bf1 and bf2 hasn't shuffle. bf1 as creation side and inject runtime filter for bf3.
       assertRewroteWithBloomFilter("select * from (select * from bf1 left semi join bf2 on " +
         "bf1.c1 = bf2.c2 where bf1.a1 = 5) as a join bf3 on bf3.c3 = a.c1")
@@ -328,6 +330,8 @@ class InjectRuntimeFilterSuite extends QueryTest with SQLTestUtils with SharedSp
         "bf1.c1 = bf2.c2 and bf3.c3 = bf1.c1 where bf1.a1 = 5", 2)
       assertRewroteWithBloomFilter("select * from bf1 right outer join bf2 join bf3 on " +
         "bf1.c1 = bf2.c2 and bf3.c3 = bf1.c1 where bf1.a1 = 5", 2)
+      assertRewroteWithBloomFilter("select * from bf1 left outer join bf2 join bf3 on " +
+        "bf1.c1 = bf2.c2 and bf3.c3 = if(bf1.c1 < 5, 5, bf1.c1) where bf1.a1 < 10", 2)
       // bf2 as creation side and inject runtime filter for bf1 and bf3(join keys are transitive).
       assertRewroteWithBloomFilter("select * from (select * from bf1 join bf2 on " +
         "bf1.c1 = bf2.c2 where bf2.a2 = 5) as a join bf3 on bf3.c3 = a.c1", 2)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Use `filterCreationSideKey.references` to determine which side of the join to use when extracting selectiveFilterOverScan .

### Why are the changes needed?

InjectRuntimeFilter is effective when there is a single join with function condition, but it will not be effective when there are multiple joins.

like:

```
-- bf1 as creation side and inject runtime filter for bf3.
select * from bf1 join bf3 on bf3.c3 = if(bf1.c1 < 5, 5, bf1.c1) where bf1.a1 = 5

-- bf1 will not inject runtime filter for bf3.
select * from bf1 join bf2 on bf1.c1 = bf2.c2 join bf3 on bf3.c3 = if(bf1.c1 < 5, 5, bf1.c1) where bf1.a1 = 5
```

### Does this PR introduce _any_ user-facing change?

yes, Inject Runtime Filter for multi-level join with function condition.

### How was this patch tested?

added unit test.


### Was this patch authored or co-authored using generative AI tooling?

No
