### PR TITLE
[SPARK-48840][INFRA] Remove unnecessary existence check for `./dev/free_disk_space_container`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -449,10 +449,7 @@ jobs:
           pyspark-coursier-
     - name: Free up disk space
       shell: 'script -q -e -c "bash {0}"'
-      run: |
-        if [ -f ./dev/free_disk_space_container ]; then
-          ./dev/free_disk_space_container
-        fi
+      run: ./dev/free_disk_space_container
     - name: Install Java ${{ matrix.java }}
       uses: actions/setup-java@v4
       with:
@@ -558,10 +555,7 @@ jobs:
         restore-keys: |
           sparkr-coursier-
     - name: Free up disk space
-      run: |
-        if [ -f ./dev/free_disk_space_container ]; then
-          ./dev/free_disk_space_container
-        fi
+      run: ./dev/free_disk_space_container
     - name: Install Java ${{ inputs.java }}
       uses: actions/setup-java@v4
       with:
@@ -685,10 +679,7 @@ jobs:
         restore-keys: |
           docs-maven-
     - name: Free up disk space
-      run: |
-        if [ -f ./dev/free_disk_space_container ]; then
-          ./dev/free_disk_space_container
-        fi
+      run: ./dev/free_disk_space_container
     - name: Install Java ${{ inputs.java }}
       uses: actions/setup-java@v4
       with:
@@ -831,10 +822,7 @@ jobs:
         restore-keys: |
           docs-maven-
     - name: Free up disk space
-      run: |
-        if [ -f ./dev/free_disk_space_container ]; then
-          ./dev/free_disk_space_container
-        fi
+      run: ./dev/free_disk_space_container
     - name: Install Java ${{ inputs.java }}
       uses: actions/setup-java@v4
       with:


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR removed the check for the existence of `./dev/free_disk_space_container` before execution,  because `./dev/free_disk_space_container` has already been backported to branch-3.4 and branch-3.5 through https://github.com/apache/spark/pull/45624 and https://github.com/apache/spark/pull/43381,  so there is no need to check its existence before execution.

### Why are the changes needed?
Remove unnecessary existence check for `./dev/free_disk_space_container`.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No