### PR TITLE
[SPARK-33902][SQL] Throw error for CREATE TABLE LIKE in V2 tables

### DIFF
--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -116,8 +116,8 @@ statement
     | createTableHeader (LEFT_PAREN colDefinitionList RIGHT_PAREN)? tableProvider?
         createTableClauses
         (AS? query)?                                                   #createTable
-    | CREATE TABLE (IF errorCapturingNot EXISTS)? target=tableIdentifier
-        LIKE source=tableIdentifier
+    | CREATE TABLE (IF errorCapturingNot EXISTS)? target=identifierReference
+        LIKE source=identifierReference
         (tableProvider |
         rowFormat |
         createFileFormat |

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTableSpec.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTableSpec.scala
@@ -49,6 +49,8 @@ object ResolveTableSpec extends Rule[LogicalPlan] {
         resolveTableSpec(t, t.tableSpec, s => t.copy(tableSpec = s))
       case t: CreateTableAsSelect =>
         resolveTableSpec(t, t.tableSpec, s => t.copy(tableSpec = s))
+      case t: CreateTableLike =>
+        resolveTableSpec(t, t.tableSpec, s => t.copy(tableSpec = s))
       case t: ReplaceTable =>
         resolveTableSpec(t, t.tableSpec, s => t.copy(tableSpec = s))
       case t: ReplaceTableAsSelect =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -4237,6 +4237,59 @@ class AstBuilder extends DataTypeAstBuilder with SQLConfHelper with Logging {
   }
 
   /**
+   * Create a [[CreateTableLike]] logical plan.
+   *
+   * For example:
+   * {{{
+   *   CREATE TABLE [IF NOT EXISTS] [db_name.]table_name
+   *   LIKE [other_db_name.]existing_table_name
+   *   [USING provider |
+   *    [
+   *     [ROW FORMAT row_format]
+   *     [STORED AS file_format] [WITH SERDEPROPERTIES (...)]
+   *    ]
+   *   ]
+   *   [locationSpec]
+   *   [TBLPROPERTIES (property_name=property_value, ...)]
+   * }}}
+   */
+  override def visitCreateTableLike(ctx: CreateTableLikeContext): LogicalPlan = withOrigin(ctx) {
+    val targetTable = withIdentClause(ctx.target, UnresolvedIdentifier(_))
+    val sourceTable = createUnresolvedTableOrView(ctx.source, "CREATE TABLE ... LIKE")
+
+    checkDuplicateClauses(ctx.tableProvider, "PROVIDER", ctx)
+    checkDuplicateClauses(ctx.createFileFormat, "STORED AS/BY", ctx)
+    checkDuplicateClauses(ctx.rowFormat, "ROW FORMAT", ctx)
+    checkDuplicateClauses(ctx.locationSpec, "LOCATION", ctx)
+    checkDuplicateClauses(ctx.TBLPROPERTIES, "TBLPROPERTIES", ctx)
+    val provider = ctx.tableProvider.asScala.headOption.map(_.multipartIdentifier.getText)
+    val location = visitLocationSpecList(ctx.locationSpec())
+    val serdeInfo = getSerdeInfo(
+      ctx.rowFormat.asScala.toSeq, ctx.createFileFormat.asScala.toSeq, ctx)
+    if (provider.isDefined && serdeInfo.isDefined) {
+      invalidStatement(s"CREATE TABLE LIKE ... USING ... ${serdeInfo.get.describe}", ctx)
+    }
+    // For "CREATE TABLE dst LIKE src ROW FORMAT SERDE xxx" which doesn't specify the file format,
+    // it's a bit weird to use the default file format, but it's also weird to get file format
+    // from the source table while the serde class is user-specified.
+    // Here we require both serde and format to be specified, to avoid confusion.
+    serdeInfo match {
+      case Some(SerdeInfo(storedAs, formatClasses, serde, _)) =>
+        if (storedAs.isEmpty && formatClasses.isEmpty && serde.isDefined) {
+          throw QueryParsingErrors.rowFormatNotUsedWithStoredAsError(ctx)
+        }
+      case _ =>
+    }
+
+    val properties = Option(ctx.tableProps).map(visitPropertyKeyValues).getOrElse(Map.empty)
+    val cleanedProperties = cleanTableProperties(ctx, properties)
+    val tableSpec = UnresolvedTableSpec(cleanedProperties, provider, OptionList(Seq.empty),
+      location, None, serdeInfo, external = location.isEmpty)
+
+    CreateTableLike(targetTable, sourceTable, tableSpec, ctx.EXISTS != null)
+  }
+
+  /**
    * Create a [[DropTable]] command.
    */
   override def visitDropTable(ctx: DropTableContext): LogicalPlan = withOrigin(ctx) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -524,6 +524,24 @@ case class CreateTableAsSelect(
 }
 
 /**
+ * Create a new table using the definition of an existing table with a v2 catalog.
+ */
+case class CreateTableLike(
+  targetName: LogicalPlan,
+  sourceName: LogicalPlan,
+  tableSpec: TableSpecBase,
+  ignoreIfExists: Boolean)
+  extends BinaryCommand {
+  override def left: LogicalPlan = targetName
+
+  override def right: LogicalPlan = sourceName
+
+  override protected def withNewChildrenInternal(
+    newLeft: LogicalPlan, newRight: LogicalPlan): LogicalPlan =
+    copy(targetName = newLeft, sourceName = newRight)
+}
+
+/**
  * Replace a table with a v2 catalog.
  *
  * If the table does not exist, and orCreate is true, then it will be created.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1556,6 +1556,10 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
     notSupportedForV2TablesError("MSCK REPAIR TABLE")
   }
 
+  def createTableLikeNotSupportedForV2TablesError(): Throwable = {
+    notSupportedForV2TablesError("CREATE TABLE ... LIKE")
+  }
+
   def databaseFromV1SessionCatalogNotSpecifiedError(): Throwable = {
     new AnalysisException(
       errorClass = "_LEGACY_ERROR_TEMP_1125",

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -199,6 +199,19 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
         c
       }
 
+    case c @ CreateTableLike(
+        ResolvedV1Identifier(targetIdent), ResolvedV1TableOrViewIdentifier(sourceIdent),
+        tableSpec: TableSpec, _) =>
+      val (storageFormat, _) = getStorageFormatAndProvider(
+        c.tableSpec.provider, tableSpec.options, c.tableSpec.location, c.tableSpec.serde,
+        ctas = false)
+      if (tableSpec.provider.isEmpty || !isV2Provider(tableSpec.provider.get)) {
+        CreateTableLikeCommand(targetIdent, sourceIdent, storageFormat, tableSpec.provider,
+          tableSpec.properties, c.ignoreIfExists)
+      } else {
+        c
+      }
+
     case RefreshTable(ResolvedV1TableOrViewIdentifier(ident)) =>
       RefreshTableCommand(ident)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -884,58 +884,6 @@ class SparkSqlAstBuilder extends AstBuilder {
   }
 
   /**
-   * Create a [[CreateTableLikeCommand]] command.
-   *
-   * For example:
-   * {{{
-   *   CREATE TABLE [IF NOT EXISTS] [db_name.]table_name
-   *   LIKE [other_db_name.]existing_table_name
-   *   [USING provider |
-   *    [
-   *     [ROW FORMAT row_format]
-   *     [STORED AS file_format] [WITH SERDEPROPERTIES (...)]
-   *    ]
-   *   ]
-   *   [locationSpec]
-   *   [TBLPROPERTIES (property_name=property_value, ...)]
-   * }}}
-   */
-  override def visitCreateTableLike(ctx: CreateTableLikeContext): LogicalPlan = withOrigin(ctx) {
-    val targetTable = visitTableIdentifier(ctx.target)
-    val sourceTable = visitTableIdentifier(ctx.source)
-    checkDuplicateClauses(ctx.tableProvider, "PROVIDER", ctx)
-    checkDuplicateClauses(ctx.createFileFormat, "STORED AS/BY", ctx)
-    checkDuplicateClauses(ctx.rowFormat, "ROW FORMAT", ctx)
-    checkDuplicateClauses(ctx.locationSpec, "LOCATION", ctx)
-    checkDuplicateClauses(ctx.TBLPROPERTIES, "TBLPROPERTIES", ctx)
-    val provider = ctx.tableProvider.asScala.headOption.map(_.multipartIdentifier.getText)
-    val location = visitLocationSpecList(ctx.locationSpec())
-    val serdeInfo = getSerdeInfo(
-      ctx.rowFormat.asScala.toSeq, ctx.createFileFormat.asScala.toSeq, ctx)
-    if (provider.isDefined && serdeInfo.isDefined) {
-      invalidStatement(s"CREATE TABLE LIKE ... USING ... ${serdeInfo.get.describe}", ctx)
-    }
-
-    // For "CREATE TABLE dst LIKE src ROW FORMAT SERDE xxx" which doesn't specify the file format,
-    // it's a bit weird to use the default file format, but it's also weird to get file format
-    // from the source table while the serde class is user-specified.
-    // Here we require both serde and format to be specified, to avoid confusion.
-    serdeInfo match {
-      case Some(SerdeInfo(storedAs, formatClasses, serde, _)) =>
-        if (storedAs.isEmpty && formatClasses.isEmpty && serde.isDefined) {
-          throw QueryParsingErrors.rowFormatNotUsedWithStoredAsError(ctx)
-        }
-      case _ =>
-    }
-
-    val storage = toStorageFormat(location, serdeInfo, ctx)
-    val properties = Option(ctx.tableProps).map(visitPropertyKeyValues).getOrElse(Map.empty)
-    val cleanedProperties = cleanTableProperties(ctx, properties)
-    CreateTableLikeCommand(
-      targetTable, sourceTable, storage, provider, cleanedProperties, ctx.EXISTS != null)
-  }
-
-  /**
    * Create a [[ScriptInputOutputSchema]].
    */
   override protected def withScriptIOSchema(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2Strategy.scala
@@ -202,6 +202,9 @@ class DataSourceV2Strategy(session: SparkSession) extends Strategy with Predicat
             qualifyLocInTableSpec(tableSpec), options, ifNotExists) :: Nil
       }
 
+    case CreateTableLike(_, _, _, _) =>
+      throw QueryCompilationErrors.createTableLikeNotSupportedForV2TablesError()
+
     case RefreshTable(r: ResolvedTable) =>
       RefreshTableExec(r.catalog, r.identifier, recacheTable(r)) :: Nil
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/charvarchar.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/charvarchar.sql.out
@@ -55,7 +55,7 @@ DescribeColumnCommand `spark_catalog`.`default`.`char_tbl2`, [spark_catalog, def
 -- !query
 create table char_tbl3 like char_tbl
 -- !query analysis
-CreateTableLikeCommand `char_tbl3`, `char_tbl`, Storage(), false
+CreateTableLikeCommand `spark_catalog`.`default`.`char_tbl3`, `spark_catalog`.`default`.`char_tbl`, Storage(), false
 
 
 -- !query

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -2398,6 +2398,18 @@ class DataSourceV2SQLSuiteV1Filter
     }
   }
 
+  test("CREATE TABLE ... LIKE") {
+    val t = "testcat.ns1.ns2.tbl"
+    val t1 = "testcat.ns1.ns2.tbl1"
+    withTable(t) {
+      spark.sql(s"CREATE TABLE $t (id bigint, data string) USING foo")
+
+      testNotSupportedV2Command("CREATE TABLE",
+        s"$t1 LIKE $t",
+        Some("CREATE TABLE ... LIKE"))
+    }
+  }
+
   test("CREATE VIEW") {
     val v = "testcat.ns1.ns2.v"
     checkError(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.command
 
 import org.apache.spark.SparkThrowable
 import org.apache.spark.sql.catalyst.FunctionIdentifier
-import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, GlobalTempView, LocalTempView, SchemaCompensation, UnresolvedAttribute, UnresolvedFunctionName, UnresolvedIdentifier}
+import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, GlobalTempView, LocalTempView, SchemaCompensation, UnresolvedAttribute, UnresolvedFunctionName, UnresolvedIdentifier, UnresolvedTableOrView}
 import org.apache.spark.sql.catalyst.catalog.{ArchiveResource, FileResource, FunctionResource, JarResource}
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans
@@ -722,83 +722,53 @@ class DDLParserSuite extends AnalysisTest with SharedSparkSession {
   }
 
   test("create table like") {
-    val v1 = "CREATE TABLE table1 LIKE table2"
-    val (target, source, fileFormat, provider, properties, exists) =
-      parser.parsePlan(v1).collect {
-        case CreateTableLikeCommand(t, s, f, p, pr, e) => (t, s, f, p, pr, e)
-      }.head
-    assert(exists == false)
-    assert(target.database.isEmpty)
-    assert(target.table == "table1")
-    assert(source.database.isEmpty)
-    assert(source.table == "table2")
-    assert(fileFormat.locationUri.isEmpty)
-    assert(provider.isEmpty)
+    comparePlans(
+      parser.parsePlan("CREATE TABLE table1 LIKE table2"),
+      CreateTableLike(UnresolvedIdentifier(Seq("table1")),
+        UnresolvedTableOrView(Seq("table2"), "CREATE TABLE ... LIKE", allowTempView = true),
+        UnresolvedTableSpec(Map.empty, None, OptionList(Seq.empty), None, None, None,
+          external = true),
+        ignoreIfExists = false))
 
-    val v2 = "CREATE TABLE IF NOT EXISTS table1 LIKE table2"
-    val (target2, source2, fileFormat2, provider2, properties2, exists2) =
-      parser.parsePlan(v2).collect {
-        case CreateTableLikeCommand(t, s, f, p, pr, e) => (t, s, f, p, pr, e)
-      }.head
-    assert(exists2)
-    assert(target2.database.isEmpty)
-    assert(target2.table == "table1")
-    assert(source2.database.isEmpty)
-    assert(source2.table == "table2")
-    assert(fileFormat2.locationUri.isEmpty)
-    assert(provider2.isEmpty)
+    comparePlans(
+      parser.parsePlan("CREATE TABLE IF NOT EXISTS table1 LIKE table2"),
+      CreateTableLike(UnresolvedIdentifier(Seq("table1")),
+        UnresolvedTableOrView(Seq("table2"), "CREATE TABLE ... LIKE", allowTempView = true),
+        UnresolvedTableSpec(Map.empty, None, OptionList(Seq.empty), None, None, None,
+          external = true),
+        ignoreIfExists = true))
 
-    val v3 = "CREATE TABLE table1 LIKE table2 LOCATION '/spark/warehouse'"
-    val (target3, source3, fileFormat3, provider3, properties3, exists3) =
-      parser.parsePlan(v3).collect {
-        case CreateTableLikeCommand(t, s, f, p, pr, e) => (t, s, f, p, pr, e)
-      }.head
-    assert(!exists3)
-    assert(target3.database.isEmpty)
-    assert(target3.table == "table1")
-    assert(source3.database.isEmpty)
-    assert(source3.table == "table2")
-    assert(fileFormat3.locationUri.map(_.toString) == Some("/spark/warehouse"))
-    assert(provider3.isEmpty)
+    comparePlans(
+      parser.parsePlan("CREATE TABLE table1 LIKE table2 LOCATION '/spark/warehouse'"),
+      CreateTableLike(UnresolvedIdentifier(Seq("table1")),
+        UnresolvedTableOrView(Seq("table2"), "CREATE TABLE ... LIKE", allowTempView = true),
+        UnresolvedTableSpec(Map.empty, None, OptionList(Seq.empty), Some("/spark/warehouse"),
+          None, None, external = false),
+        ignoreIfExists = false))
 
-    val v4 = "CREATE TABLE IF NOT EXISTS table1 LIKE table2 LOCATION '/spark/warehouse'"
-    val (target4, source4, fileFormat4, provider4, properties4, exists4) =
-      parser.parsePlan(v4).collect {
-        case CreateTableLikeCommand(t, s, f, p, pr, e) => (t, s, f, p, pr, e)
-      }.head
-    assert(exists4)
-    assert(target4.database.isEmpty)
-    assert(target4.table == "table1")
-    assert(source4.database.isEmpty)
-    assert(source4.table == "table2")
-    assert(fileFormat4.locationUri.map(_.toString) == Some("/spark/warehouse"))
-    assert(provider4.isEmpty)
+    comparePlans(
+      parser.parsePlan("CREATE TABLE IF NOT EXISTS table1 LIKE table2 LOCATION '/spark/warehouse'"),
+      CreateTableLike(UnresolvedIdentifier(Seq("table1")),
+        UnresolvedTableOrView(Seq("table2"), "CREATE TABLE ... LIKE", allowTempView = true),
+        UnresolvedTableSpec(Map.empty, None, OptionList(Seq.empty), Some("/spark/warehouse"),
+          None, None, external = false),
+        ignoreIfExists = true))
 
-    val v5 = "CREATE TABLE IF NOT EXISTS table1 LIKE table2 USING parquet"
-    val (target5, source5, fileFormat5, provider5, properties5, exists5) =
-      parser.parsePlan(v5).collect {
-        case CreateTableLikeCommand(t, s, f, p, pr, e) => (t, s, f, p, pr, e)
-      }.head
-    assert(exists5)
-    assert(target5.database.isEmpty)
-    assert(target5.table == "table1")
-    assert(source5.database.isEmpty)
-    assert(source5.table == "table2")
-    assert(fileFormat5.locationUri.isEmpty)
-    assert(provider5 == Some("parquet"))
+    comparePlans(
+      parser.parsePlan("CREATE TABLE IF NOT EXISTS table1 LIKE table2 USING parquet"),
+      CreateTableLike(UnresolvedIdentifier(Seq("table1")),
+        UnresolvedTableOrView(Seq("table2"), "CREATE TABLE ... LIKE", allowTempView = true),
+        UnresolvedTableSpec(Map.empty, Some("parquet"), OptionList(Seq.empty), None,
+          None, None, external = true),
+        ignoreIfExists = true))
 
-    val v6 = "CREATE TABLE IF NOT EXISTS table1 LIKE table2 USING ORC"
-    val (target6, source6, fileFormat6, provider6, properties6, exists6) =
-      parser.parsePlan(v6).collect {
-        case CreateTableLikeCommand(t, s, f, p, pr, e) => (t, s, f, p, pr, e)
-      }.head
-    assert(exists6)
-    assert(target6.database.isEmpty)
-    assert(target6.table == "table1")
-    assert(source6.database.isEmpty)
-    assert(source6.table == "table2")
-    assert(fileFormat6.locationUri.isEmpty)
-    assert(provider6 == Some("ORC"))
+    comparePlans(
+      parser.parsePlan("CREATE TABLE IF NOT EXISTS table1 LIKE table2 USING ORC"),
+      CreateTableLike(UnresolvedIdentifier(Seq("table1")),
+        UnresolvedTableOrView(Seq("table2"), "CREATE TABLE ... LIKE", allowTempView = true),
+        UnresolvedTableSpec(Map.empty, Some("ORC"), OptionList(Seq.empty), None,
+          None, None, external = true),
+        ignoreIfExists = true))
   }
 
   test("SET CATALOG") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This PR throws an error when `CREATE TABLE LIKE` SQL command is used on V2 tables
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Prior to this change `CREATE TABLE LIKE` was converted to the `CreateTableLikeCommand` V1 command directly in the parser layer. This change uses the new resolution framework to create a `CreateTableLike` logical node which is then converted to a V1 `CreateTableLikeCommand` for V1 tables and throws an error for V2 tables. A future PR will add support for `CREATE TABLE LIKE` with V2 tables.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
For V1 tables, if the source table does not exist, previously it would throw a `NoSuchTableException` within the command implementation. However now since table resolution is done in the Analyzer, a non-existent source table will throw an `AnalysisException`. This behavior change is common for all commands onboarded to the new table resolution framework.

<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Existing unit tests for V1 tables. New unit tests for V2 tables.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No
