### PR TITLE
[SPARK-48842][DOCS] Document non-determinism of max_by and min_by

### DIFF
--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -1558,8 +1558,8 @@ setMethod("max",
 #' @details
 #' \code{max_by}: Returns the value associated with the maximum value of ord.
 #'
-#' Note: the function is non-deterministic when the maximum value from `y` is associated
-#' with multiple values from `x`.
+#' Note: The function is non-deterministic so the output order can be different
+#' for those associated the same values of `x`.
 #'
 #' @rdname column_aggregate_functions
 #' @aliases max_by max_by,Column-method
@@ -1636,8 +1636,8 @@ setMethod("min",
 #' @details
 #' \code{min_by}: Returns the value associated with the minimum value of ord.
 #'
-#' Note: the function is non-deterministic when the minimum value from `y` is associated
-#' with multiple values from `x`.
+#' Note: The function is non-deterministic so the output order can be different
+#' for those associated the same values of `x`.
 #'
 #' @rdname column_aggregate_functions
 #' @aliases min_by min_by,Column-method

--- a/R/pkg/R/functions.R
+++ b/R/pkg/R/functions.R
@@ -1558,6 +1558,9 @@ setMethod("max",
 #' @details
 #' \code{max_by}: Returns the value associated with the maximum value of ord.
 #'
+#' Note: the function is non-deterministic when the maximum value from `y` is associated
+#' with multiple values from `x`.
+#'
 #' @rdname column_aggregate_functions
 #' @aliases max_by max_by,Column-method
 #' @note max_by since 3.3.0
@@ -1632,6 +1635,9 @@ setMethod("min",
 
 #' @details
 #' \code{min_by}: Returns the value associated with the minimum value of ord.
+#'
+#' Note: the function is non-deterministic when the minimum value from `y` is associated
+#' with multiple values from `x`.
 #'
 #' @rdname column_aggregate_functions
 #' @aliases min_by min_by,Column-method

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -884,8 +884,9 @@ object functions {
   /**
    * Aggregate function: returns the value associated with the maximum value of ord.
    *
-   * @note The function is non-deterministic when the maximum value from `ord` is associated
-   * with multiple values from `e`.
+   * @note
+   *   The function is non-deterministic when the maximum value from `ord` is associated with
+   *   multiple values from `e`.
    *
    * @group agg_funcs
    * @since 3.4.0
@@ -935,8 +936,9 @@ object functions {
   /**
    * Aggregate function: returns the value associated with the minimum value of ord.
    *
-   * @note The function is non-deterministic when the minimum value from `ord` is associated
-   * with multiple values from `e`.
+   * @note
+   *   The function is non-deterministic when the minimum value from `ord` is associated with
+   *   multiple values from `e`.
    *
    * @group agg_funcs
    * @since 3.4.0

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -884,6 +884,9 @@ object functions {
   /**
    * Aggregate function: returns the value associated with the maximum value of ord.
    *
+   * @note The function is non-deterministic when the maximum value from `ord` is associated
+   * with multiple values from `e`.
+   *
    * @group agg_funcs
    * @since 3.4.0
    */
@@ -931,6 +934,9 @@ object functions {
 
   /**
    * Aggregate function: returns the value associated with the minimum value of ord.
+   *
+   * @note The function is non-deterministic when the minimum value from `ord` is associated
+   * with multiple values from `e`.
    *
    * @group agg_funcs
    * @since 3.4.0

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -885,8 +885,8 @@ object functions {
    * Aggregate function: returns the value associated with the maximum value of ord.
    *
    * @note
-   *   The function is non-deterministic when the maximum value from `ord` is associated with
-   *   multiple values from `e`.
+   *   The function is non-deterministic so the output order can be different for
+   *   those associated the same values of `e`.
    *
    * @group agg_funcs
    * @since 3.4.0
@@ -937,8 +937,8 @@ object functions {
    * Aggregate function: returns the value associated with the minimum value of ord.
    *
    * @note
-   *   The function is non-deterministic when the minimum value from `ord` is associated with
-   *   multiple values from `e`.
+   *   The function is non-deterministic so the output order can be different for
+   *   those associated the same values of `e`.
    *
    * @group agg_funcs
    * @since 3.4.0

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -885,8 +885,8 @@ object functions {
    * Aggregate function: returns the value associated with the maximum value of ord.
    *
    * @note
-   *   The function is non-deterministic so the output order can be different for
-   *   those associated the same values of `e`.
+   *   The function is non-deterministic so the output order can be different for those associated
+   *   the same values of `e`.
    *
    * @group agg_funcs
    * @since 3.4.0
@@ -937,8 +937,8 @@ object functions {
    * Aggregate function: returns the value associated with the minimum value of ord.
    *
    * @note
-   *   The function is non-deterministic so the output order can be different for
-   *   those associated the same values of `e`.
+   *   The function is non-deterministic so the output order can be different for those associated
+   *   the same values of `e`.
    *
    * @group agg_funcs
    * @since 3.4.0

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -1273,8 +1273,8 @@ def max_by(col: "ColumnOrName", ord: "ColumnOrName") -> Column:
 
     Notes
     -----
-    The function is non-deterministic when the maximum value from `ord` is associated
-    with multiple values from `col`.
+    The function is non-deterministic so the output order can be different for those
+    associated the same values of `col`.
 
     Parameters
     ----------
@@ -1359,8 +1359,8 @@ def min_by(col: "ColumnOrName", ord: "ColumnOrName") -> Column:
 
     Notes
     -----
-    The function is non-deterministic when the minimum value from `ord` is associated
-    with multiple values from `col`.
+    The function is non-deterministic so the output order can be different for those
+    associated the same values of `col`.
 
     Parameters
     ----------

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -1343,6 +1343,7 @@ def max_by(col: "ColumnOrName", ord: "ColumnOrName") -> Column:
     +----------+---------------------------+
 
     Example 4: Non-deterministic when the maximum 'v' is accociated with multiple 'id'
+
     >>> import pyspark.sql.functions as sf
     >>> df = spark.range(1000).withColumn("v", sf.lit(1))
     >>> df.repartition(9).select(sf.max_by("id", "v")).show() # doctest: +SKIP
@@ -1453,6 +1454,7 @@ def min_by(col: "ColumnOrName", ord: "ColumnOrName") -> Column:
     +----------+---------------------------+
 
     Example 4: Non-deterministic when the minimum 'v' is accociated with multiple 'id'
+
     >>> import pyspark.sql.functions as sf
     >>> df = spark.range(1000).withColumn("v", sf.lit(1))
     >>> df.repartition(9).select(sf.min_by("id", "v")).show() # doctest: +SKIP

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -1271,6 +1271,11 @@ def max_by(col: "ColumnOrName", ord: "ColumnOrName") -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    Notes
+    -----
+    The function is non-deterministic when the maximum value from `ord` is associated
+    with multiple values from `col`.
+
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
@@ -1285,11 +1290,6 @@ def max_by(col: "ColumnOrName", ord: "ColumnOrName") -> Column:
     :class:`~pyspark.sql.Column`
         A column object representing the value from `col` that is associated with
         the maximum value from `ord`.
-
-    Notes
-    -----
-    The function is non-deterministic when the maximum value from `ord` is accociated
-    with multiple values from `col`.
 
     Examples
     --------
@@ -1341,31 +1341,6 @@ def max_by(col: "ColumnOrName", ord: "ColumnOrName") -> Column:
     |   Consult|                      Henry|
     |   Finance|                     George|
     +----------+---------------------------+
-
-    Example 4: Non-deterministic when the maximum 'v' is accociated with multiple 'id'
-
-    >>> import pyspark.sql.functions as sf
-    >>> df = spark.range(1000).withColumn("v", sf.lit(1))
-    >>> df.repartition(9).select(sf.max_by("id", "v")).show() # doctest: +SKIP
-    +-------------+
-    |max_by(id, v)|
-    +-------------+
-    |          933|
-    +-------------+
-
-    >>> df.repartition(10).select(sf.max_by("id", "v")).show() # doctest: +SKIP
-    +-------------+
-    |max_by(id, v)|
-    +-------------+
-    |          935|
-    +-------------+
-
-    >>> df.repartition(11).select(sf.max_by("id", "v")).show() # doctest: +SKIP
-    +-------------+
-    |max_by(id, v)|
-    +-------------+
-    |          918|
-    +-------------+
     """
     return _invoke_function_over_columns("max_by", col, ord)
 
@@ -1382,6 +1357,11 @@ def min_by(col: "ColumnOrName", ord: "ColumnOrName") -> Column:
     .. versionchanged:: 3.4.0
         Supports Spark Connect.
 
+    Notes
+    -----
+    The function is non-deterministic when the minimum value from `ord` is associated
+    with multiple values from `col`.
+
     Parameters
     ----------
     col : :class:`~pyspark.sql.Column` or str
@@ -1396,11 +1376,6 @@ def min_by(col: "ColumnOrName", ord: "ColumnOrName") -> Column:
     :class:`~pyspark.sql.Column`
         Column object that represents the value from `col` associated with
         the minimum value from `ord`.
-
-    Notes
-    -----
-    The function is non-deterministic when the minimum value from `ord` is accociated
-    with multiple values from `col`.
 
     Examples
     --------
@@ -1452,31 +1427,6 @@ def min_by(col: "ColumnOrName", ord: "ColumnOrName") -> Column:
     |   Consult|                        Eva|
     |   Finance|                      Frank|
     +----------+---------------------------+
-
-    Example 4: Non-deterministic when the minimum 'v' is accociated with multiple 'id'
-
-    >>> import pyspark.sql.functions as sf
-    >>> df = spark.range(1000).withColumn("v", sf.lit(1))
-    >>> df.repartition(9).select(sf.min_by("id", "v")).show() # doctest: +SKIP
-    +-------------+
-    |min_by(id, v)|
-    +-------------+
-    |          933|
-    +-------------+
-
-    >>> df.repartition(10).select(sf.min_by("id", "v")).show() # doctest: +SKIP
-    +-------------+
-    |min_by(id, v)|
-    +-------------+
-    |          935|
-    +-------------+
-
-    >>> df.repartition(11).select(sf.min_by("id", "v")).show() # doctest: +SKIP
-    +-------------+
-    |min_by(id, v)|
-    +-------------+
-    |          918|
-    +-------------+
     """
     return _invoke_function_over_columns("min_by", col, ord)
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -1286,6 +1286,11 @@ def max_by(col: "ColumnOrName", ord: "ColumnOrName") -> Column:
         A column object representing the value from `col` that is associated with
         the maximum value from `ord`.
 
+    Notes
+    -----
+    The function is non-deterministic when the maximum value from `ord` is accociated
+    with multiple values from `col`.
+
     Examples
     --------
     Example 1: Using `max_by` with groupBy
@@ -1336,6 +1341,30 @@ def max_by(col: "ColumnOrName", ord: "ColumnOrName") -> Column:
     |   Consult|                      Henry|
     |   Finance|                     George|
     +----------+---------------------------+
+
+    Example 4: Non-deterministic when the the maximum 'v' is accociated with multiple 'id'
+    >>> import pyspark.sql.functions as sf
+    >>> df = spark.range(1000).withColumn("v", sf.lit(1))
+    >>> df.repartition(9).select(sf.max_by("id", "v")).show() # doctest: +SKIP
+    +-------------+
+    |max_by(id, v)|
+    +-------------+
+    |          933|
+    +-------------+
+
+    >>> df.repartition(10).select(sf.max_by("id", "v")).show() # doctest: +SKIP
+    +-------------+
+    |max_by(id, v)|
+    +-------------+
+    |          935|
+    +-------------+
+
+    >>> df.repartition(11).select(sf.max_by("id", "v")).show() # doctest: +SKIP
+    +-------------+
+    |max_by(id, v)|
+    +-------------+
+    |          918|
+    +-------------+
     """
     return _invoke_function_over_columns("max_by", col, ord)
 
@@ -1366,6 +1395,11 @@ def min_by(col: "ColumnOrName", ord: "ColumnOrName") -> Column:
     :class:`~pyspark.sql.Column`
         Column object that represents the value from `col` associated with
         the minimum value from `ord`.
+
+    Notes
+    -----
+    The function is non-deterministic when the minimum value from `ord` is accociated
+    with multiple values from `col`.
 
     Examples
     --------
@@ -1417,6 +1451,30 @@ def min_by(col: "ColumnOrName", ord: "ColumnOrName") -> Column:
     |   Consult|                        Eva|
     |   Finance|                      Frank|
     +----------+---------------------------+
+
+    Example 4: Non-deterministic when the the minimum 'v' is accociated with multiple 'id'
+    >>> import pyspark.sql.functions as sf
+    >>> df = spark.range(1000).withColumn("v", sf.lit(1))
+    >>> df.repartition(9).select(sf.min_by("id", "v")).show() # doctest: +SKIP
+    +-------------+
+    |min_by(id, v)|
+    +-------------+
+    |          933|
+    +-------------+
+
+    >>> df.repartition(10).select(sf.min_by("id", "v")).show() # doctest: +SKIP
+    +-------------+
+    |min_by(id, v)|
+    +-------------+
+    |          935|
+    +-------------+
+
+    >>> df.repartition(11).select(sf.min_by("id", "v")).show() # doctest: +SKIP
+    +-------------+
+    |min_by(id, v)|
+    +-------------+
+    |          918|
+    +-------------+
     """
     return _invoke_function_over_columns("min_by", col, ord)
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -1342,7 +1342,7 @@ def max_by(col: "ColumnOrName", ord: "ColumnOrName") -> Column:
     |   Finance|                     George|
     +----------+---------------------------+
 
-    Example 4: Non-deterministic when the the maximum 'v' is accociated with multiple 'id'
+    Example 4: Non-deterministic when the maximum 'v' is accociated with multiple 'id'
     >>> import pyspark.sql.functions as sf
     >>> df = spark.range(1000).withColumn("v", sf.lit(1))
     >>> df.repartition(9).select(sf.max_by("id", "v")).show() # doctest: +SKIP
@@ -1452,7 +1452,7 @@ def min_by(col: "ColumnOrName", ord: "ColumnOrName") -> Column:
     |   Finance|                      Frank|
     +----------+---------------------------+
 
-    Example 4: Non-deterministic when the the minimum 'v' is accociated with multiple 'id'
+    Example 4: Non-deterministic when the minimum 'v' is accociated with multiple 'id'
     >>> import pyspark.sql.functions as sf
     >>> df = spark.range(1000).withColumn("v", sf.lit(1))
     >>> df.repartition(9).select(sf.min_by("id", "v")).show() # doctest: +SKIP

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/MaxByAndMinBy.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/MaxByAndMinBy.scala
@@ -99,6 +99,10 @@ abstract class MaxMinBy extends DeclarativeAggregate with BinaryLike[Expression]
       > SELECT _FUNC_(x, y) FROM VALUES ('a', 10), ('b', 50), ('c', 20) AS tab(x, y);
        b
   """,
+  note = """
+    The function is non-deterministic when the maximum value from `y` is associated
+    with multiple values from `x`.
+  """,
   group = "agg_funcs",
   since = "3.0.0")
 case class MaxBy(valueExpr: Expression, orderingExpr: Expression) extends MaxMinBy {
@@ -121,6 +125,10 @@ case class MaxBy(valueExpr: Expression, orderingExpr: Expression) extends MaxMin
     Examples:
       > SELECT _FUNC_(x, y) FROM VALUES ('a', 10), ('b', 50), ('c', 20) AS tab(x, y);
        a
+  """,
+  note = """
+    The function is non-deterministic when the minimum value from `y` is associated
+    with multiple values from `x`.
   """,
   group = "agg_funcs",
   since = "3.0.0")

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/MaxByAndMinBy.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/MaxByAndMinBy.scala
@@ -100,8 +100,8 @@ abstract class MaxMinBy extends DeclarativeAggregate with BinaryLike[Expression]
        b
   """,
   note = """
-    The function is non-deterministic when the maximum value from `y` is associated
-    with multiple values from `x`.
+    The function is non-deterministic so the output order can be different for
+    those associated the same values of `x`.
   """,
   group = "agg_funcs",
   since = "3.0.0")
@@ -127,8 +127,8 @@ case class MaxBy(valueExpr: Expression, orderingExpr: Expression) extends MaxMin
        a
   """,
   note = """
-    The function is non-deterministic when the minimum value from `y` is associated
-    with multiple values from `x`.
+    The function is non-deterministic so the output order can be different for
+    those associated the same values of `x`.
   """,
   group = "agg_funcs",
   since = "3.0.0")

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -902,6 +902,9 @@ object functions {
   /**
    * Aggregate function: returns the value associated with the maximum value of ord.
    *
+   * @note The function is non-deterministic when the maximum value from `ord` is associated
+   * with multiple values from `e`.
+   *
    * @group agg_funcs
    * @since 3.3.0
    */
@@ -951,6 +954,9 @@ object functions {
 
   /**
    * Aggregate function: returns the value associated with the minimum value of ord.
+   *
+   * @note The function is non-deterministic when the minimum value from `ord` is associated
+   * with multiple values from `e`.
    *
    * @group agg_funcs
    * @since 3.3.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -902,8 +902,8 @@ object functions {
   /**
    * Aggregate function: returns the value associated with the maximum value of ord.
    *
-   * @note The function is non-deterministic when the maximum value from `ord` is associated
-   * with multiple values from `e`.
+   * @note The function is non-deterministic so the output order can be different for
+   * those associated the same values of `e`.
    *
    * @group agg_funcs
    * @since 3.3.0
@@ -955,8 +955,8 @@ object functions {
   /**
    * Aggregate function: returns the value associated with the minimum value of ord.
    *
-   * @note The function is non-deterministic when the minimum value from `ord` is associated
-   * with multiple values from `e`.
+   * @note The function is non-deterministic so the output order can be different for
+   * those associated the same values of `e`.
    *
    * @group agg_funcs
    * @since 3.3.0


### PR DESCRIPTION
### What changes were proposed in this pull request?
Document non-determinism of max_by and min_by

### Why are the changes needed?
I have been confused by this non-determinism twice, it occurred like a correctness bug to me.
So I think we need to document it


### Does this PR introduce _any_ user-facing change?
doc change only


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no