### PR TITLE
[SPARK-48857][SQL] Restrict charsets in CSVOptions

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -105,8 +105,9 @@ class CSVOptions(
     parameters.getOrElse(SEP, parameters.getOrElse(DELIMITER, ",")))
   val parseMode: ParseMode =
     parameters.get(MODE).map(ParseMode.fromString).getOrElse(PermissiveMode)
-  val charset = parameters.getOrElse(ENCODING,
-    parameters.getOrElse(CHARSET, StandardCharsets.UTF_8.name()))
+  val charset = parameters.get(ENCODING).orElse(parameters.get(CHARSET))
+    .map(CharsetProvider.forName(_, SQLConf.get.legacyJavaCharsets, caller = "CSVOptions"))
+    .getOrElse(StandardCharsets.UTF_8).name()
 
   val quote = getChar(QUOTE, '\"')
   val escape = getChar(ESCAPE, '\\')

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharsetProvider.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharsetProvider.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ package org.apache.spark.sql.catalyst.util
+ import java.nio.charset.{Charset, CharsetDecoder, CharsetEncoder, CodingErrorAction, IllegalCharsetNameException, UnsupportedCharsetException}
+ import java.util.Locale
+
+ import org.apache.spark.sql.errors.QueryExecutionErrors
+
+private[sql] object CharsetProvider {
+
+  final lazy val VALID_CHARSETS =
+    Set("US-ASCII", "ISO-8859-1", "UTF-8", "UTF-16BE", "UTF-16LE", "UTF-16", "UTF-32")
+
+  def forName(
+      charset: String,
+      legacyCharsets: Boolean,
+      caller: String = ""): Charset = {
+    if (legacyCharsets || VALID_CHARSETS.contains(charset.toUpperCase(Locale.ROOT))) {
+      try {
+        Charset.forName(charset)
+      } catch {
+        case _: IllegalCharsetNameException |
+             _: UnsupportedCharsetException |
+             _: IllegalArgumentException =>
+          throw QueryExecutionErrors.invalidCharsetError(caller, charset)
+      }
+    } else {
+      throw QueryExecutionErrors.invalidCharsetError(caller, charset)
+    }
+  }
+
+  def newEncoder(charset: String,
+      legacyCharsets: Boolean,
+      legacyErrorAction: Boolean,
+      caller: String = "encode"): CharsetEncoder = {
+    val codingErrorAction = if (legacyErrorAction) {
+      CodingErrorAction.REPLACE
+    } else {
+      CodingErrorAction.REPORT
+    }
+
+    forName(charset, legacyCharsets, caller)
+      .newEncoder()
+      .onMalformedInput(codingErrorAction)
+      .onUnmappableCharacter(codingErrorAction)
+  }
+
+  def newDecoder(charset: String,
+      legacyCharsets: Boolean,
+      legacyErrorAction: Boolean,
+      caller: String = "decode"): CharsetDecoder = {
+    val codingErrorAction = if (legacyErrorAction) {
+      CodingErrorAction.REPLACE
+    } else {
+      CodingErrorAction.REPORT
+    }
+
+    forName(charset, legacyCharsets, caller)
+      .newDecoder()
+      .onMalformedInput(codingErrorAction)
+      .onUnmappableCharacter(codingErrorAction)
+  }
+
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -18,11 +18,11 @@
 package org.apache.spark.sql.execution.datasources.csv
 
 import java.io.{EOFException, File}
-import java.nio.charset.{Charset, StandardCharsets, UnsupportedCharsetException}
+import java.nio.charset.{Charset, StandardCharsets}
 import java.nio.file.{Files, StandardOpenOption}
 import java.sql.{Date, Timestamp}
 import java.text.SimpleDateFormat
-import java.time.{Duration, Instant, LocalDate, LocalDateTime, Period}
+import java.time._
 import java.util.Locale
 
 import scala.jdk.CollectionConverters._
@@ -35,11 +35,12 @@ import org.apache.hadoop.io.SequenceFile.CompressionType
 import org.apache.hadoop.io.compress.GzipCodec
 import org.apache.logging.log4j.Level
 
-import org.apache.spark.{SparkConf, SparkException, SparkIllegalArgumentException, SparkRuntimeException, SparkUpgradeException, TestUtils}
-import org.apache.spark.sql.{AnalysisException, Column, DataFrame, Encoders, QueryTest, Row}
+import org.apache.spark._
+import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.csv.CSVOptions
 import org.apache.spark.sql.catalyst.expressions.ToStringBase
 import org.apache.spark.sql.catalyst.util.{DateTimeTestUtils, DateTimeUtils, HadoopCompressionCodec}
+import org.apache.spark.sql.errors.QueryExecutionErrors.toSQLId
 import org.apache.spark.sql.execution.datasources.CommonFileDataSourceSuite
 import org.apache.spark.sql.internal.{LegacyBehaviorPolicy, SQLConf}
 import org.apache.spark.sql.internal.SQLConf.BinaryOutputStyle
@@ -260,15 +261,17 @@ abstract class CSVSuite
   }
 
   test("bad encoding name") {
-    val exception = intercept[UnsupportedCharsetException] {
-      spark
-        .read
-        .format("csv")
-        .option("charset", "1-9588-osi")
-        .load(testFile(carsFile8859))
-    }
-
-    assert(exception.getMessage.contains("1-9588-osi"))
+    checkError(
+      exception = intercept[SparkIllegalArgumentException] {
+        spark.read.format("csv").option("charset", "1-9588-osi")
+          .load(testFile(carsFile8859))
+      },
+      errorClass = "INVALID_PARAMETER_VALUE.CHARSET",
+      parameters = Map(
+        "charset" -> "1-9588-osi",
+        "functionName" -> toSQLId("CSVOptions"),
+        "parameter" -> toSQLId("charset"))
+    )
   }
 
   test("test different encoding") {
@@ -620,31 +623,38 @@ abstract class CSVSuite
 
     Seq("iso-8859-1", "utf-8", "utf-16", "utf-32", "windows-1250").foreach { encoding =>
       withTempPath { path =>
-        val csvDir = new File(path, "csv")
-        Seq(content).toDF().write
-          .option("encoding", encoding)
-          .csv(csvDir.getCanonicalPath)
+        withSQLConf(SQLConf.LEGACY_JAVA_CHARSETS.key -> "true") {
+          val csvDir = new File(path, "csv")
+          Seq(content).toDF().write
+            .option("encoding", encoding)
+            .csv(csvDir.getCanonicalPath)
 
-        csvDir.listFiles().filter(_.getName.endsWith("csv")).foreach({ csvFile =>
-          val readback = Files.readAllBytes(csvFile.toPath)
-          val expected = (content + Properties.lineSeparator).getBytes(Charset.forName(encoding))
-          assert(readback === expected)
-        })
+          csvDir.listFiles().filter(_.getName.endsWith("csv")).foreach({ csvFile =>
+            val readback = Files.readAllBytes(csvFile.toPath)
+            val expected = (content + Properties.lineSeparator).getBytes(Charset.forName(encoding))
+            assert(readback === expected)
+          })
+        }
       }
     }
   }
 
   test("SPARK-19018: error handling for unsupported charsets") {
-    val exception = intercept[SparkException] {
-      withTempPath { path =>
-        val csvDir = new File(path, "csv").getCanonicalPath
-        Seq("a,A,c,A,b,B").toDF().write
-          .option("encoding", "1-9588-osi")
-          .csv(csvDir)
-      }
-    }
-
-    assert(exception.getCause.getMessage.contains("1-9588-osi"))
+    checkError(
+      exception = intercept[SparkIllegalArgumentException] {
+        withTempPath { path =>
+          val csvDir = new File(path, "csv").getCanonicalPath
+          Seq("a,A,c,A,b,B").toDF().write
+            .option("encoding", "1-9588-osi")
+            .csv(csvDir)
+        }
+      },
+      errorClass = "INVALID_PARAMETER_VALUE.CHARSET",
+      parameters = Map(
+        "charset" -> "1-9588-osi",
+        "functionName" -> toSQLId("CSVOptions"),
+        "parameter" -> toSQLId("charset"))
+    )
   }
 
   test("commented lines in CSV data") {
@@ -2303,18 +2313,20 @@ abstract class CSVSuite
     val df = spark.range(3).toDF()
     Seq("UTF-8", "ISO-8859-1", "CP1251", "US-ASCII", "UTF-16BE", "UTF-32LE").foreach { encoding =>
       Seq(true, false).foreach { header =>
-        withTempPath { path =>
-          df.write
-            .option("encoding", encoding)
-            .option("header", header)
-            .csv(path.getCanonicalPath)
-          val readback = spark.read
-            .option("multiLine", true)
-            .option("encoding", encoding)
-            .option("inferSchema", true)
-            .option("header", header)
-            .csv(path.getCanonicalPath)
-          checkAnswer(readback, df)
+        withSQLConf(SQLConf.LEGACY_JAVA_CHARSETS.key -> "true") {
+          withTempPath { path =>
+            df.write
+              .option("encoding", encoding)
+              .option("header", header)
+              .csv(path.getCanonicalPath)
+            val readback = spark.read
+              .option("multiLine", true)
+              .option("encoding", encoding)
+              .option("inferSchema", true)
+              .option("header", header)
+              .csv(path.getCanonicalPath)
+            checkAnswer(readback, df)
+          }
         }
       }
     }
@@ -2350,48 +2362,54 @@ abstract class CSVSuite
 
           val expected = Seq(("a", 1), ("\nc", 2), ("\nd", 3))
             .toDF("_c0", "_c1")
-          Seq(false, true).foreach { multiLine =>
-            val reader = spark
-              .read
-              .option("lineSep", lineSep)
-              .option("multiLine", multiLine)
-              .option("encoding", encoding)
-            val df = if (inferSchema) {
-              reader.option("inferSchema", true).csv(path.getAbsolutePath)
-            } else {
-              reader.schema(schema).csv(path.getAbsolutePath)
+          withSQLConf(SQLConf.LEGACY_JAVA_CHARSETS.key -> "true") {
+            Seq(false, true).foreach { multiLine =>
+              val reader = spark
+                .read
+                .option("lineSep", lineSep)
+                .option("multiLine", multiLine)
+                .option("encoding", encoding)
+              val df = if (inferSchema) {
+                reader.option("inferSchema", true).csv(path.getAbsolutePath)
+              } else {
+                reader.schema(schema).csv(path.getAbsolutePath)
+              }
+              checkAnswer(df, expected)
             }
-            checkAnswer(df, expected)
           }
         }
       }
 
       // Write
       withTempPath { path =>
-        Seq("a", "b", "c").toDF("value").coalesce(1)
-          .write
-          .option("lineSep", lineSep)
-          .option("encoding", encoding)
-          .csv(path.getAbsolutePath)
-        val partFile = TestUtils.recursiveList(path).filter(f => f.getName.startsWith("part-")).head
-        val readBack = new String(Files.readAllBytes(partFile.toPath), encoding)
-        assert(
-          readBack === s"a${lineSep}b${lineSep}c${lineSep}")
+        withSQLConf(SQLConf.LEGACY_JAVA_CHARSETS.key -> "true") {
+          Seq("a", "b", "c").toDF("value").coalesce(1)
+            .write
+            .option("lineSep", lineSep)
+            .option("encoding", encoding)
+            .csv(path.getAbsolutePath)
+          val partFile =
+            TestUtils.recursiveList(path).filter(f => f.getName.startsWith("part-")).head
+          val readBack = new String(Files.readAllBytes(partFile.toPath), encoding)
+          assert(readBack === s"a${lineSep}b${lineSep}c${lineSep}")
+        }
       }
 
       // Roundtrip
       withTempPath { path =>
         val df = Seq("a", "b", "c").toDF()
-        df.write
-          .option("lineSep", lineSep)
-          .option("encoding", encoding)
-          .csv(path.getAbsolutePath)
-        val readBack = spark
-          .read
-          .option("lineSep", lineSep)
-          .option("encoding", encoding)
-          .csv(path.getAbsolutePath)
-        checkAnswer(df, readBack)
+        withSQLConf(SQLConf.LEGACY_JAVA_CHARSETS.key -> "true") {
+          df.write
+            .option("lineSep", lineSep)
+            .option("encoding", encoding)
+            .csv(path.getAbsolutePath)
+          val readBack = spark
+            .read
+            .option("lineSep", lineSep)
+            .option("encoding", encoding)
+            .csv(path.getAbsolutePath)
+          checkAnswer(df, readBack)
+        }
       }
     }
   }


### PR DESCRIPTION


### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

SPARK-46115 SPARK-46220 started the work for building a consistent charset list for spark, the PR brings it to CSV options

### Why are the changes needed?

To make the charset list consistent across different platforms/JDKs

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, legacyCharsets is provided

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no