### PR TITLE
[SPARK-48856][SQL] Use isolated JobArtifactSet for each spark session

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/python/PythonWorkerUtils.scala
+++ b/core/src/main/scala/org/apache/spark/api/python/PythonWorkerUtils.scala
@@ -66,9 +66,13 @@ private[spark] object PythonWorkerUtils extends Logging {
       pythonIncludes: Set[String],
       dataOut: DataOutputStream): Unit = {
     // sparkFilesDir
-    val root = jobArtifactUUID.map { uuid =>
-      new File(SparkFiles.getRootDirectory(), uuid).getAbsolutePath
-    }.getOrElse(SparkFiles.getRootDirectory())
+    var root = SparkFiles.getRootDirectory()
+    // sparkFiles add by context.addPyFile is in default jobArtifact
+    // sparkFiles add by sql add file is in session jobArtifact
+    jobArtifactUUID.foreach { uuid =>
+      val sessionRoot = new File(SparkFiles.getRootDirectory(), uuid).getAbsolutePath
+       root = s"$root;$sessionRoot"
+    }
     writeUTF(root, dataOut)
 
     // Python includes (*.zip and *.egg files)

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -1178,6 +1178,11 @@ private[spark] class Executor(
           log" timestamp ${LogMDC(TIMESTAMP, timestamp)}")
         // Fetch file with useCache mode, close cache for local mode.
         Utils.fetchFile(name, root, conf, hadoopConf, timestamp, useCache = !isLocal)
+        // Hack here, fetch file to SparkFiles.getRootDirectory() also for python udf use
+        if (!root.getAbsolutePath.equals(new File(SparkFiles.getRootDirectory()).getAbsolutePath)) {
+          Utils.fetchFile(name, new File(SparkFiles.getRootDirectory()),
+            conf, hadoopConf, timestamp, useCache = !isLocal)
+        }
         state.currentFiles(name) = timestamp
       }
       for ((name, timestamp) <- newArchives if

--- a/core/src/test/scala/org/apache/spark/executor/ClassLoaderIsolationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/executor/ClassLoaderIsolationSuite.scala
@@ -45,9 +45,6 @@ class ClassLoaderIsolationSuite extends SparkFunSuite with LocalSparkContext  {
 
   test("Executor classloader isolation with JobArtifactSet") {
     sc = new SparkContext(new SparkConf().setAppName("test").setMaster("local"))
-    sc.addJar(jar1)
-    sc.addJar(jar2)
-    sc.addJar(jar3)
 
     // TestHelloV2's test method returns '2'
     val artifactSetWithHelloV2 = new JobArtifactSet(

--- a/sql/core/src/main/scala/org/apache/spark/sql/artifact/ArtifactManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/artifact/ArtifactManager.scala
@@ -70,7 +70,7 @@ class ArtifactManager(session: SparkSession) extends Logging {
   protected[artifact] val (classDir, classURI): (Path, String) =
     (ArtifactUtils.concatenatePaths(artifactPath, "classes"), s"$artifactURI/classes/")
 
-  protected[artifact] val state: JobArtifactState =
+  val state: JobArtifactState =
     JobArtifactState(session.sessionUUID, Option(classURI))
 
   def withResources[T](f: => T): T = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/SessionJobArtifactStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SessionJobArtifactStateSuite.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import java.io.File
+
+import org.apache.spark.{JobArtifactSet, SparkFunSuite}
+
+class SessionJobArtifactStateSuite extends SparkFunSuite {
+
+  protected var rootSession: SparkSession = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    rootSession = SparkSession.builder()
+      .master("local")
+      .config("default-config", "default")
+      .getOrCreate()
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      if (rootSession != null) {
+        rootSession.stop()
+        rootSession = null
+        SparkSession.clearActiveSession()
+        SparkSession.clearDefaultSession()
+      }
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  test("use new job artifact state in new spark session") {
+    val newSession = rootSession.newSession()
+    assert(newSession ne rootSession)
+    assert(newSession.sessionUUID ne rootSession.sessionUUID)
+    assert(newSession.artifactManager.state ne rootSession.artifactManager.state)
+  }
+
+  test("clone job artifact state from parent while clone spark session") {
+    withTempDir { dir =>
+      val jarPath = File.createTempFile("testJar", ".jar", dir).getAbsolutePath
+      JobArtifactSet.withActiveJobArtifactState(rootSession.artifactManager.state) {
+        rootSession.sparkContext.addJar(jarPath)
+      }
+      val newSession = rootSession.cloneSession()
+      assert(newSession ne rootSession)
+      assert(newSession.sessionUUID ne rootSession.sessionUUID)
+      JobArtifactSet.withActiveJobArtifactState(newSession.artifactManager.state) {
+        val jobArtifactSet = JobArtifactSet.getActiveOrDefault(newSession.sparkContext)
+
+        // Artifacts from the other state must be not visible to this state.
+        assert(jobArtifactSet.state.contains(newSession.artifactManager.state))
+        assert(jobArtifactSet.jars.nonEmpty)
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLSuite.scala
@@ -2171,7 +2171,8 @@ abstract class DDLSuite extends QueryTest with DDLSuiteBase {
       root = Utils.createTempDir().getCanonicalPath, namePrefix = "addDirectory")
     val testFile = File.createTempFile("testFile", "1", directoryToAdd)
     spark.sql(s"ADD FILE $directoryToAdd")
-    assert(new File(SparkFiles.get(s"${directoryToAdd.getName}/${testFile.getName}")).exists())
+    assert(new File(SparkFiles.get(
+      s"${spark.sessionUUID}/${directoryToAdd.getName}/${testFile.getName}")).exists())
   }
 
   test(s"Add a directory when ${SQLConf.LEGACY_ADD_SINGLE_FILE_IN_ADD_FILE.key} set to true") {

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
@@ -494,16 +494,13 @@ class HiveThriftBinaryServerSuite extends HiveThriftServer2Test {
   }
 
   test("test add jar") {
-    withMultipleConnectionJdbcStatement("smallKV", "addJar")(
+    withJdbcStatement("smallKV", "addJar")(
       {
         statement =>
           val jarFile = HiveTestJars.getHiveHcatalogCoreJar().getCanonicalPath
 
           statement.executeQuery(s"ADD JAR $jarFile")
-      },
 
-      {
-        statement =>
           val queries = Seq(
             "CREATE TABLE smallKV(key INT, val STRING) USING hive",
             s"LOAD DATA LOCAL INPATH '${TestData.smallKv}' OVERWRITE INTO TABLE smallKV",

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -3269,7 +3269,11 @@ class HiveDDLSuite
       val jarName = "TestUDTF.jar"
       val jar = spark.asInstanceOf[TestHiveSparkSession].getHiveFile(jarName).toURI.toString
       spark.sparkContext.allAddedJars.keys.find(_.contains(jarName))
-        .foreach(k => spark.sparkContext.addedJars.get("default").foreach(_.remove(k)))
+        .foreach { jar =>
+          spark.sparkContext.addedJars.keys.foreach { key =>
+            spark.sparkContext.addedJars(key).remove(jar)
+          }
+        }
       assert(!spark.sparkContext.listJars().exists(_.contains(jarName)))
       val e = intercept[AnalysisException] {
         sql("CREATE TEMPORARY FUNCTION f1 AS " +

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/test/TestHive.scala
@@ -159,6 +159,50 @@ class TestHiveContext(
     sparkSession.reset()
   }
 
+  def cleanTempArtifacts(cleanFiles: Seq[String],
+                         cleanJars: Seq[String],
+                         cleanArchives: Seq[String]): Unit = {
+    cleanFiles.flatMap { file =>
+      sparkContext.allAddedFiles.keys.map { addedFile =>
+        if (addedFile.contains(file)) {
+          addedFile
+        } else {
+          ""
+        }
+      }.filter(_ != "").toSeq
+    }.foreach { file =>
+      sparkContext.addedFiles.keys.foreach { key =>
+        sparkContext.addedFiles(key).remove(file)
+      }
+    }
+    cleanJars.flatMap { jar =>
+      sparkContext.allAddedJars.keys.map { addedJar =>
+        if (addedJar.contains(jar)) {
+          addedJar
+        } else {
+          ""
+        }
+      }.filter(_ != "").toSeq
+    }.foreach { jar =>
+      sparkContext.addedJars.keys.foreach { key =>
+        sparkContext.addedJars(key).remove(jar)
+      }
+    }
+    cleanArchives.flatMap { archive =>
+      sparkContext.allAddedArchives.keys.map { addedArchive =>
+        if (addedArchive.contains(archive)) {
+          addedArchive
+        } else {
+          ""
+        }
+      }.filter(_ != "").toSeq
+    }.foreach { archive =>
+      sparkContext.addedArchives.keys.foreach { key =>
+        sparkContext.addedArchives(key).remove(archive)
+      }
+    }
+  }
+
 }
 
 /**
@@ -251,6 +295,7 @@ private[hive] class TestHiveSparkSession(
       Some(sessionState),
       loadTestTables)
     result.sessionState // force copy of SessionState
+    cloneJobArtifactSet(sessionUUID, result.sessionUUID)
     result
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use isolated JobArtifactSet for each spark session


### Why are the changes needed?
Consider multi user use same spark cluster with independent spark session, for example Kyuubi group session share level

User may use different udf jar to register function, but may has same name udf in different udf jar.
In this case, the valid udf class is always the class from the first load udf jar, this not meet users expections, user want use the udf class for the jar load by themself


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
New unit test in SessionJobArtifactStateSuite


### Was this patch authored or co-authored using generative AI tooling?
No
