### PR TITLE
[SPARK-48459][CONNECT][PYTHON][FOLLOWUP] Ignore to_plan from with_origin

### DIFF
--- a/python/pyspark/errors/utils.py
+++ b/python/pyspark/errors/utils.py
@@ -286,11 +286,11 @@ def with_origin_to_class(
         return lambda cls: with_origin_to_class(cls, ignores)
     else:
         cls = cls_or_ignores
-        skipping = set(
-            ["__init__", "__new__", "__iter__", "__nonzero__", "__repr__", "__bool__"]
-            + (ignores or [])
-        )
         if os.environ.get("PYSPARK_PIN_THREAD", "true").lower() == "true":
+            skipping = set(
+                ["__init__", "__new__", "__iter__", "__nonzero__", "__repr__", "__bool__"]
+                + (ignores or [])
+            )
             for name, method in cls.__dict__.items():
                 # Excluding Python magic methods that do not utilize JVM functions.
                 if callable(method) and name not in skipping:

--- a/python/pyspark/errors/utils.py
+++ b/python/pyspark/errors/utils.py
@@ -20,7 +20,20 @@ import functools
 import inspect
 import os
 import threading
-from typing import Any, Callable, Dict, Match, TypeVar, Type, Optional, TYPE_CHECKING
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Match,
+    TypeVar,
+    Type,
+    Optional,
+    Union,
+    TYPE_CHECKING,
+    cast,
+    overload,
+)
 import pyspark
 from pyspark.errors.error_classes import ERROR_CLASSES_MAP
 
@@ -251,20 +264,36 @@ def _with_origin(func: Callable[..., Any]) -> Callable[..., Any]:
     return wrapper
 
 
-def with_origin_to_class(cls: Type[T]) -> Type[T]:
+@overload
+def with_origin_to_class(cls_or_ignores: Type[T], ignores: Optional[List[str]] = None) -> Type[T]:
+    ...
+
+
+@overload
+def with_origin_to_class(
+    cls_or_ignores: Optional[List[str]] = None,
+) -> Callable[[Type[T]], Type[T]]:
+    ...
+
+
+def with_origin_to_class(
+    cls_or_ignores: Optional[Union[Type[T], List[str]]] = None, ignores: Optional[List[str]] = None
+) -> Union[Type[T], Callable[[Type[T]], Type[T]]]:
     """
     Decorate all methods of a class with `_with_origin` to capture call site information.
     """
-    if os.environ.get("PYSPARK_PIN_THREAD", "true").lower() == "true":
-        for name, method in cls.__dict__.items():
-            # Excluding Python magic methods that do not utilize JVM functions.
-            if callable(method) and name not in (
-                "__init__",
-                "__new__",
-                "__iter__",
-                "__nonzero__",
-                "__repr__",
-                "__bool__",
-            ):
-                setattr(cls, name, _with_origin(method))
-    return cls
+    if cls_or_ignores is None or isinstance(cls_or_ignores, list):
+        ignores = cls_or_ignores or []
+        return lambda cls: cast(Type[T], with_origin_to_class(cls, ignores))
+    else:
+        cls = cls_or_ignores
+        skipping = set(
+            ["__init__", "__new__", "__iter__", "__nonzero__", "__repr__", "__bool__"]
+            + (ignores or [])
+        )
+        if os.environ.get("PYSPARK_PIN_THREAD", "true").lower() == "true":
+            for name, method in cls.__dict__.items():
+                # Excluding Python magic methods that do not utilize JVM functions.
+                if callable(method) and name not in skipping:
+                    setattr(cls, name, _with_origin(method))
+        return cls

--- a/python/pyspark/errors/utils.py
+++ b/python/pyspark/errors/utils.py
@@ -31,7 +31,6 @@ from typing import (
     Optional,
     Union,
     TYPE_CHECKING,
-    cast,
     overload,
 )
 import pyspark
@@ -284,7 +283,7 @@ def with_origin_to_class(
     """
     if cls_or_ignores is None or isinstance(cls_or_ignores, list):
         ignores = cls_or_ignores or []
-        return lambda cls: cast(Type[T], with_origin_to_class(cls, ignores))
+        return lambda cls: with_origin_to_class(cls, ignores)
     else:
         cls = cls_or_ignores
         skipping = set(

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -100,7 +100,7 @@ def _to_expr(v: Any) -> Expression:
     return v._expr if isinstance(v, Column) else LiteralExpression._from_value(v)
 
 
-@with_origin_to_class
+@with_origin_to_class(["to_plan"])
 class Column(ParentColumn):
     def __new__(
         cls,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Ignores `connect.Column.to_plan` from `with_origin`.

### Why are the changes needed?

Capturing call site on `connect.Column.to_plan` takes long time when creating proto plans if there are many `connect.Column` objects, although the call sites on `connect.Column.to_plan` are not necessary.

E.g.,

```py
from pyspark.sql import functions as F

df = createDataFrame()
def schema():
    return df.select(*([F.col("a"), F.col("b"), F.col("c"), F.col("d")] * 10)).schema

profile(schema)
```

<img width="1109" alt="Screenshot 2024-07-10 at 13 40 33" src="https://github.com/apache/spark/assets/506656/776978ce-bef9-47ef-b4a5-0d206683736d">

The total function calls / duration for this is:

- before

```
28393570 function calls (28381720 primitive calls) in 3.450 seconds
```

- after

```
109970 function calls (98120 primitive calls) in 0.184 seconds
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
