### PR TITLE
[SPARK-48860][TESTS] Update `ui-test` to use `ws` 8.18.0

### DIFF
--- a/ui-test/package-lock.json
+++ b/ui-test/package-lock.json
@@ -2632,7 +2632,7 @@
         "whatwg-encoding": "^2.0.0",
         "whatwg-mimetype": "^3.0.0",
         "whatwg-url": "^11.0.0",
-        "ws": "^8.11.0",
+        "ws": "^8.18.0",
         "xml-name-validator": "^4.0.0"
       },
       "engines": {
@@ -4112,10 +4112,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a test dependency update to use `ws` 8.18.0.

### Why are the changes needed?

Although Apache Spark binary is not affected by this, this PR aims to resolve this alert which recommends `ws` versions 8.17.1+.

- https://github.com/apache/spark/security/dependabot/95

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs with the new dependency.

### Was this patch authored or co-authored using generative AI tooling?

No.