### PR TITLE
[SPARK-48862][PYTHON][CONNECT] Avoid calling `_proto_to_string` when INFO level is not enabled

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -24,6 +24,7 @@ from pyspark.sql.connect.utils import check_dependencies
 
 check_dependencies(__name__)
 
+import logging
 import threading
 import os
 import platform
@@ -862,7 +863,8 @@ class SparkConnectClient(object):
         """
         Return given plan as a PyArrow Table iterator.
         """
-        logger.info(f"Executing plan {self._proto_to_string(plan)}")
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(f"Executing plan {self._proto_to_string(plan)}")
         req = self._execute_plan_request_with_metadata()
         req.plan.CopyFrom(plan)
         with Progress(handlers=self._progress_handlers, operation_id=req.operation_id) as progress:
@@ -878,7 +880,8 @@ class SparkConnectClient(object):
         """
         Return given plan as a PyArrow Table.
         """
-        logger.info(f"Executing plan {self._proto_to_string(plan)}")
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(f"Executing plan {self._proto_to_string(plan)}")
         req = self._execute_plan_request_with_metadata()
         req.plan.CopyFrom(plan)
         table, schema, metrics, observed_metrics, _ = self._execute_and_fetch(req, observations)
@@ -894,7 +897,8 @@ class SparkConnectClient(object):
         """
         Return given plan as a pandas DataFrame.
         """
-        logger.info(f"Executing plan {self._proto_to_string(plan)}")
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(f"Executing plan {self._proto_to_string(plan)}")
         req = self._execute_plan_request_with_metadata()
         req.plan.CopyFrom(plan)
         (self_destruct_conf,) = self.get_config_with_defaults(
@@ -996,7 +1000,8 @@ class SparkConnectClient(object):
         """
         Return schema for given plan.
         """
-        logger.info(f"Schema for plan: {self._proto_to_string(plan)}")
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(f"Schema for plan: {self._proto_to_string(plan)}")
         schema = self._analyze(method="schema", plan=plan).schema
         assert schema is not None
         # Server side should populate the struct field which is the schema.
@@ -1007,7 +1012,8 @@ class SparkConnectClient(object):
         """
         Return explain string for given plan.
         """
-        logger.info(f"Explain (mode={explain_mode}) for plan {self._proto_to_string(plan)}")
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(f"Explain (mode={explain_mode}) for plan {self._proto_to_string(plan)}")
         result = self._analyze(
             method="explain", plan=plan, explain_mode=explain_mode
         ).explain_string
@@ -1020,7 +1026,8 @@ class SparkConnectClient(object):
         """
         Execute given command.
         """
-        logger.info(f"Execute command for command {self._proto_to_string(command)}")
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(f"Execute command for command {self._proto_to_string(command)}")
         req = self._execute_plan_request_with_metadata()
         if self._user_id:
             req.user_context.user_id = self._user_id
@@ -1041,7 +1048,8 @@ class SparkConnectClient(object):
         """
         Execute given command. Similar to execute_command, but the value is returned using yield.
         """
-        logger.info(f"Execute command as iterator for command {self._proto_to_string(command)}")
+        if logger.isEnabledFor(logging.INFO):
+            logger.info(f"Execute command as iterator for command {self._proto_to_string(command)}")
         req = self._execute_plan_request_with_metadata()
         if self._user_id:
             req.user_context.user_id = self._user_id


### PR DESCRIPTION
### What changes were proposed in this pull request?

Avoid calling `_proto_to_string` when INFO level is not enabled.

### Why are the changes needed?

We should avoid `_proto_to_string` as it takes long time, although the result is not used if INFO level is not enabled.

E.g.,

```py
from functools import reduce

df = createDataFrame()
def project_schema(n=100):
    return reduce(lambda df, _: df.select(F.col("a"), F.col("b"), F.col("c"), F.col("d")), range(n), df).schema

profile(project_schema)
```

<img width="1104" alt="Screenshot 2024-07-10 at 17 24 18" src="https://github.com/apache/spark/assets/506656/66c2f50e-13b8-43f0-a46c-dcad4e7bfe89">

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

The existing tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
