### PR TITLE
[SPARK-46743][SQL][FOLLOW UP] Count bug after ScalarSubqery is folded if it has an empty relation

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/querytest/GeneratedSubquerySuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/querytest/GeneratedSubquerySuite.scala
@@ -445,20 +445,5 @@ object GeneratedSubquerySuite {
   // Limit number of generated queries per test so that tests will not take too long.
   private val NUM_QUERIES_PER_TEST = 1000
 
-  // scalastyle:off line.size.limit
-  private val KNOWN_QUERIES_WITH_DIFFERENT_RESULTS = Seq(
-    // SPARK-46743
-    "SELECT outer_table.a, outer_table.b, (SELECT COUNT(null_table.a) AS aggFunctionAlias FROM null_table WHERE null_table.a = outer_table.a) AS subqueryAlias FROM outer_table ORDER BY a DESC NULLS FIRST, b DESC NULLS FIRST, subqueryAlias DESC NULLS FIRST;",
-    // SPARK-46743
-    "SELECT outer_table.a, outer_table.b, (SELECT COUNT(null_table.a) AS aggFunctionAlias FROM null_table INNER JOIN join_table ON null_table.a = join_table.a WHERE null_table.a = outer_table.a) AS subqueryAlias FROM outer_table ORDER BY a DESC NULLS FIRST, b DESC NULLS FIRST, subqueryAlias DESC NULLS FIRST;",
-    // SPARK-46743
-    "SELECT outer_table.a, outer_table.b, (SELECT COUNT(null_table.a) AS aggFunctionAlias FROM null_table LEFT OUTER JOIN join_table ON null_table.a = join_table.a WHERE null_table.a = outer_table.a) AS subqueryAlias FROM outer_table ORDER BY a DESC NULLS FIRST, b DESC NULLS FIRST, subqueryAlias DESC NULLS FIRST;",
-    // SPARK-46743
-    "SELECT outer_table.a, outer_table.b, (SELECT COUNT(null_table.a) AS aggFunctionAlias FROM null_table RIGHT OUTER JOIN join_table ON null_table.a = join_table.a WHERE null_table.a = outer_table.a) AS subqueryAlias FROM outer_table ORDER BY a DESC NULLS FIRST, b DESC NULLS FIRST, subqueryAlias DESC NULLS FIRST;",
-    // SPARK-46743
-    "SELECT outer_table.a, outer_table.b, (SELECT COUNT(innerSubqueryAlias.a) AS aggFunctionAlias FROM (SELECT null_table.a, null_table.b FROM null_table INTERSECT SELECT join_table.a, join_table.b FROM join_table) AS innerSubqueryAlias WHERE innerSubqueryAlias.a = outer_table.a) AS subqueryAlias FROM outer_table ORDER BY a DESC NULLS FIRST, b DESC NULLS FIRST, subqueryAlias DESC NULLS FIRST;",
-    // SPARK-46743
-    "SELECT outer_table.a, outer_table.b, (SELECT COUNT(innerSubqueryAlias.a) AS aggFunctionAlias FROM (SELECT null_table.a, null_table.b FROM null_table EXCEPT SELECT join_table.a, join_table.b FROM join_table) AS innerSubqueryAlias WHERE innerSubqueryAlias.a = outer_table.a) AS subqueryAlias FROM outer_table ORDER BY a DESC NULLS FIRST, b DESC NULLS FIRST, subqueryAlias DESC NULLS FIRST;"
-  )
-  // scalastyle:on line.size.limit
+  private val KNOWN_QUERIES_WITH_DIFFERENT_RESULTS = Seq()
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.analysis._
 import org.apache.spark.sql.catalyst.catalog.{InMemoryCatalog, SessionCatalog}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
+import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
@@ -332,7 +333,9 @@ abstract class Optimizer(catalogManager: CatalogManager)
       // Do not optimize DPP subquery, as it was created from optimized plan and we should not
       // optimize it again, to save optimization time and avoid breaking broadcast/subquery reuse.
       case d: DynamicPruningSubquery => d
-      case s @ ScalarSubquery(a @ Aggregate(group, _, child), _, _, _, _, mayHaveCountBug)
+      case s @ ScalarSubquery(
+        PhysicalOperation(projections, predicates, a @ Aggregate(group, _, child)),
+        _, _, _, _, mayHaveCountBug)
         if conf.getConf(SQLConf.DECORRELATE_SUBQUERY_PREVENT_CONSTANT_FOLDING_FOR_COUNT_BUG) &&
           mayHaveCountBug.nonEmpty && mayHaveCountBug.get =>
         // This is a subquery with an aggregate that may suffer from a COUNT bug.
@@ -357,19 +360,28 @@ abstract class Optimizer(catalogManager: CatalogManager)
         val needProject = projectOverAggregateChild.output.zip(optimizedInput.output).exists {
           case (oldAttr, newAttr) => oldAttr.exprId != newAttr.exprId
         }
-        if (needProject) {
+        val optimizedAgg = if (needProject) {
           val updatedProjectList = projectOverAggregateChild.output.zip(optimizedInput.output).map {
             case (oldAttr, newAttr) => Alias(newAttr, newAttr.name)(exprId = oldAttr.exprId)
           }
-          s.withNewPlan(a.withNewChildren(Seq(Project(updatedProjectList, optimizedInput))))
+          a.withNewChildren(Seq(Project(updatedProjectList, optimizedInput)))
         } else {
           // Remove the top-level project if it is trivial. We do it to minimize plan changes.
           optimizedInput match {
             case Project(projectList, input) if projectList.forall(_.isInstanceOf[Attribute]) =>
-              s.withNewPlan(a.withNewChildren(Seq(input)))
-            case _ => s.withNewPlan(a.withNewChildren(Seq(optimizedInput)))
+              a.withNewChildren(Seq(input))
+            case _ => a.withNewChildren(Seq(optimizedInput))
           }
         }
+        val newPlan = Project(projections,
+          if (predicates.nonEmpty) Filter(predicates.reduce(And), optimizedAgg) else optimizedAgg
+        )
+        val needTopLevelProject = newPlan.output.zip(optimizedAgg.output).exists {
+          case (oldAttr, newAttr) => oldAttr.exprId != newAttr.exprId
+        }
+        s.withNewPlan(
+          if (needTopLevelProject) newPlan else newPlan.child
+        )
       case s: SubqueryExpression =>
         val Subquery(newPlan, _) = Optimizer.this.execute(Subquery.fromExpression(s))
         // At this point we have an optimized subquery plan that we are going to attach

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -89,6 +89,12 @@ object ConstantFolding extends Rule[LogicalPlan] {
           e
       }
 
+    // Don't replace ScalarSubquery if its plan is an aggregate that may suffer from a COUNT bug.
+    case s @ ScalarSubquery(a @ Aggregate(_, _, _), _, _, _, _, mayHaveCountBug)
+      if conf.getConf(SQLConf.DECORRELATE_SUBQUERY_PREVENT_CONSTANT_FOLDING_FOR_COUNT_BUG) &&
+        mayHaveCountBug.nonEmpty && mayHaveCountBug.get =>
+      s
+
     // Replace ScalarSubquery with null if its maxRows is 0
     case s: ScalarSubquery if s.plan.maxRows.contains(0) =>
       Literal(null, s.dataType)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -90,7 +90,7 @@ object ConstantFolding extends Rule[LogicalPlan] {
       }
 
     // Don't replace ScalarSubquery if its plan is an aggregate that may suffer from a COUNT bug.
-    case s @ ScalarSubquery(a @ Aggregate(_, _, _), _, _, _, _, mayHaveCountBug)
+    case s @ ScalarSubquery(_, _, _, _, _, mayHaveCountBug)
       if conf.getConf(SQLConf.DECORRELATE_SUBQUERY_PREVENT_CONSTANT_FOLDING_FOR_COUNT_BUG) &&
         mayHaveCountBug.nonEmpty && mayHaveCountBug.get =>
       s

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/scalar-subquery/scalar-subquery-count-bug.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/scalar-subquery/scalar-subquery-count-bug.sql.out
@@ -234,6 +234,166 @@ Project [scalar-subquery#x [a#x] AS scalarsubquery(a)#xL]
 
 
 -- !query
+SELECT
+  (
+    SELECT
+      COUNT(null_view.a) AS result
+    FROM
+      null_view
+    INNER JOIN r
+      ON r.c = null_view.a
+      AND r.c IS NOT NULL
+    WHERE
+      null_view.a = l.a
+  )
+FROM
+  l
+-- !query analysis
+Project [scalar-subquery#x [a#x] AS scalarsubquery(a)#xL]
+:  +- Aggregate [count(a#x) AS result#xL]
+:     +- Filter (a#x = outer(a#x))
+:        +- Join Inner, ((c#x = a#x) AND isnotnull(c#x))
+:           :- SubqueryAlias null_view
+:           :  +- View (`null_view`, [a#x, b#x])
+:           :     +- Project [cast(CAST(NULL AS INT)#x as int) AS a#x, cast(CAST(NULL AS INT)#x as int) AS b#x]
+:           :        +- Project [cast(null as int) AS CAST(NULL AS INT)#x, cast(null as int) AS CAST(NULL AS INT)#x]
+:           :           +- OneRowRelation
+:           +- SubqueryAlias r
+:              +- View (`r`, [c#x, d#x])
+:                 +- Project [cast(col1#x as int) AS c#x, cast(col2#x as decimal(2,1)) AS d#x]
+:                    +- LocalRelation [col1#x, col2#x]
++- SubqueryAlias l
+   +- View (`l`, [a#x, b#x])
+      +- Project [cast(col1#x as int) AS a#x, cast(col2#x as decimal(2,1)) AS b#x]
+         +- LocalRelation [col1#x, col2#x]
+
+
+-- !query
+SELECT
+(
+  SELECT
+    COUNT(null_view.a) AS result
+  FROM
+    null_view
+  INNER JOIN r
+    ON r.c = null_view.a
+    AND r.c IS NOT NULL
+  WHERE
+    null_view.a = l.a
+  HAVING COUNT(*) > -1
+)
+FROM
+  l
+-- !query analysis
+Project [scalar-subquery#x [a#x] AS scalarsubquery(a)#xL]
+:  +- Project [result#xL]
+:     +- Filter (count(1)#xL > cast(-1 as bigint))
+:        +- Aggregate [count(a#x) AS result#xL, count(1) AS count(1)#xL]
+:           +- Filter (a#x = outer(a#x))
+:              +- Join Inner, ((c#x = a#x) AND isnotnull(c#x))
+:                 :- SubqueryAlias null_view
+:                 :  +- View (`null_view`, [a#x, b#x])
+:                 :     +- Project [cast(CAST(NULL AS INT)#x as int) AS a#x, cast(CAST(NULL AS INT)#x as int) AS b#x]
+:                 :        +- Project [cast(null as int) AS CAST(NULL AS INT)#x, cast(null as int) AS CAST(NULL AS INT)#x]
+:                 :           +- OneRowRelation
+:                 +- SubqueryAlias r
+:                    +- View (`r`, [c#x, d#x])
+:                       +- Project [cast(col1#x as int) AS c#x, cast(col2#x as decimal(2,1)) AS d#x]
+:                          +- LocalRelation [col1#x, col2#x]
++- SubqueryAlias l
+   +- View (`l`, [a#x, b#x])
+      +- Project [cast(col1#x as int) AS a#x, cast(col2#x as decimal(2,1)) AS b#x]
+         +- LocalRelation [col1#x, col2#x]
+
+
+-- !query
+SELECT
+  (
+    SELECT
+      COUNT(f.a) AS result
+    FROM
+    (
+        SELECT a, b FROM null_view
+        INTERSECT
+        SELECT c, d FROM r WHERE c IS NOT NULL
+    ) AS f
+    WHERE
+      f.a = l.a
+  )
+FROM
+  l
+-- !query analysis
+Project [scalar-subquery#x [a#x] AS scalarsubquery(a)#xL]
+:  +- Aggregate [count(a#x) AS result#xL]
+:     +- Filter (a#x = outer(a#x))
+:        +- SubqueryAlias f
+:           +- Intersect false
+:              :- Project [a#x, cast(b#x as decimal(11,1)) AS b#x]
+:              :  +- Project [a#x, b#x]
+:              :     +- SubqueryAlias null_view
+:              :        +- View (`null_view`, [a#x, b#x])
+:              :           +- Project [cast(CAST(NULL AS INT)#x as int) AS a#x, cast(CAST(NULL AS INT)#x as int) AS b#x]
+:              :              +- Project [cast(null as int) AS CAST(NULL AS INT)#x, cast(null as int) AS CAST(NULL AS INT)#x]
+:              :                 +- OneRowRelation
+:              +- Project [c#x, cast(d#x as decimal(11,1)) AS d#x]
+:                 +- Project [c#x, d#x]
+:                    +- Filter isnotnull(c#x)
+:                       +- SubqueryAlias r
+:                          +- View (`r`, [c#x, d#x])
+:                             +- Project [cast(col1#x as int) AS c#x, cast(col2#x as decimal(2,1)) AS d#x]
+:                                +- LocalRelation [col1#x, col2#x]
++- SubqueryAlias l
+   +- View (`l`, [a#x, b#x])
+      +- Project [cast(col1#x as int) AS a#x, cast(col2#x as decimal(2,1)) AS b#x]
+         +- LocalRelation [col1#x, col2#x]
+
+
+-- !query
+SELECT
+(
+  SELECT
+    COUNT(f.a) AS result
+  FROM
+  (
+      SELECT a, b FROM null_view
+      INTERSECT
+      SELECT c, d FROM r WHERE c IS NOT NULL
+  ) AS f
+  WHERE
+    f.a = l.a
+  HAVING COUNT(*) > -1
+)
+FROM
+  l
+-- !query analysis
+Project [scalar-subquery#x [a#x] AS scalarsubquery(a)#xL]
+:  +- Project [result#xL]
+:     +- Filter (count(1)#xL > cast(-1 as bigint))
+:        +- Aggregate [count(a#x) AS result#xL, count(1) AS count(1)#xL]
+:           +- Filter (a#x = outer(a#x))
+:              +- SubqueryAlias f
+:                 +- Intersect false
+:                    :- Project [a#x, cast(b#x as decimal(11,1)) AS b#x]
+:                    :  +- Project [a#x, b#x]
+:                    :     +- SubqueryAlias null_view
+:                    :        +- View (`null_view`, [a#x, b#x])
+:                    :           +- Project [cast(CAST(NULL AS INT)#x as int) AS a#x, cast(CAST(NULL AS INT)#x as int) AS b#x]
+:                    :              +- Project [cast(null as int) AS CAST(NULL AS INT)#x, cast(null as int) AS CAST(NULL AS INT)#x]
+:                    :                 +- OneRowRelation
+:                    +- Project [c#x, cast(d#x as decimal(11,1)) AS d#x]
+:                       +- Project [c#x, d#x]
+:                          +- Filter isnotnull(c#x)
+:                             +- SubqueryAlias r
+:                                +- View (`r`, [c#x, d#x])
+:                                   +- Project [cast(col1#x as int) AS c#x, cast(col2#x as decimal(2,1)) AS d#x]
+:                                      +- LocalRelation [col1#x, col2#x]
++- SubqueryAlias l
+   +- View (`l`, [a#x, b#x])
+      +- Project [cast(col1#x as int) AS a#x, cast(col2#x as decimal(2,1)) AS b#x]
+         +- LocalRelation [col1#x, col2#x]
+
+
+-- !query
 set spark.sql.optimizer.decorrelateSubqueryLegacyIncorrectCountHandling.enabled = true
 -- !query analysis
 SetCommand (spark.sql.optimizer.decorrelateSubqueryLegacyIncorrectCountHandling.enabled,Some(true))

--- a/sql/core/src/test/resources/sql-tests/inputs/subquery/scalar-subquery/scalar-subquery-count-bug.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/subquery/scalar-subquery/scalar-subquery-count-bug.sql
@@ -82,6 +82,73 @@ SELECT
 FROM
   l;
 
+-- Count bug over a subquery with an empty relation after optimization.
+SELECT
+  (
+    SELECT
+      COUNT(null_view.a) AS result
+    FROM
+      null_view
+    INNER JOIN r
+      ON r.c = null_view.a
+      AND r.c IS NOT NULL
+    WHERE
+      null_view.a = l.a
+  )
+FROM
+  l;
+
+-- Same as above but with a filter (HAVING) above the aggregate
+SELECT
+(
+  SELECT
+    COUNT(null_view.a) AS result
+  FROM
+    null_view
+  INNER JOIN r
+    ON r.c = null_view.a
+    AND r.c IS NOT NULL
+  WHERE
+    null_view.a = l.a
+  HAVING COUNT(*) > -1
+)
+FROM
+  l;
+
+-- Same as above but with intersect
+SELECT
+  (
+    SELECT
+      COUNT(f.a) AS result
+    FROM
+    (
+        SELECT a, b FROM null_view
+        INTERSECT
+        SELECT c, d FROM r WHERE c IS NOT NULL
+    ) AS f
+    WHERE
+      f.a = l.a
+  )
+FROM
+  l;
+
+SELECT
+(
+  SELECT
+    COUNT(f.a) AS result
+  FROM
+  (
+      SELECT a, b FROM null_view
+      INTERSECT
+      SELECT c, d FROM r WHERE c IS NOT NULL
+  ) AS f
+  WHERE
+    f.a = l.a
+  HAVING COUNT(*) > -1
+)
+FROM
+  l;
+
 
 set spark.sql.optimizer.decorrelateSubqueryLegacyIncorrectCountHandling.enabled = true;
 

--- a/sql/core/src/test/resources/sql-tests/results/subquery/scalar-subquery/scalar-subquery-count-bug.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/subquery/scalar-subquery/scalar-subquery-count-bug.sql.out
@@ -206,6 +206,122 @@ struct<scalarsubquery(a):bigint>
 
 
 -- !query
+SELECT
+  (
+    SELECT
+      COUNT(null_view.a) AS result
+    FROM
+      null_view
+    INNER JOIN r
+      ON r.c = null_view.a
+      AND r.c IS NOT NULL
+    WHERE
+      null_view.a = l.a
+  )
+FROM
+  l
+-- !query schema
+struct<scalarsubquery(a):bigint>
+-- !query output
+0
+0
+0
+0
+0
+0
+0
+0
+
+
+-- !query
+SELECT
+(
+  SELECT
+    COUNT(null_view.a) AS result
+  FROM
+    null_view
+  INNER JOIN r
+    ON r.c = null_view.a
+    AND r.c IS NOT NULL
+  WHERE
+    null_view.a = l.a
+  HAVING COUNT(*) > -1
+)
+FROM
+  l
+-- !query schema
+struct<scalarsubquery(a):bigint>
+-- !query output
+0
+0
+0
+0
+0
+0
+0
+0
+
+
+-- !query
+SELECT
+  (
+    SELECT
+      COUNT(f.a) AS result
+    FROM
+    (
+        SELECT a, b FROM null_view
+        INTERSECT
+        SELECT c, d FROM r WHERE c IS NOT NULL
+    ) AS f
+    WHERE
+      f.a = l.a
+  )
+FROM
+  l
+-- !query schema
+struct<scalarsubquery(a):bigint>
+-- !query output
+0
+0
+0
+0
+0
+0
+0
+0
+
+
+-- !query
+SELECT
+(
+  SELECT
+    COUNT(f.a) AS result
+  FROM
+  (
+      SELECT a, b FROM null_view
+      INTERSECT
+      SELECT c, d FROM r WHERE c IS NOT NULL
+  ) AS f
+  WHERE
+    f.a = l.a
+  HAVING COUNT(*) > -1
+)
+FROM
+  l
+-- !query schema
+struct<scalarsubquery(a):bigint>
+-- !query output
+0
+0
+0
+0
+0
+0
+0
+0
+
+
+-- !query
 set spark.sql.optimizer.decorrelateSubqueryLegacyIncorrectCountHandling.enabled = true
 -- !query schema
 struct<key:string,value:string>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In this PR https://github.com/apache/spark/pull/45125, we handled the case where an Aggregate is folded into a Project, causing a count bug. We missed cases where:
1. The entire ScalarSubquery's plan is regarded as empty relation, and is folded completely. 
2. There are operations above the Aggregate in the subquery (such as filter and project).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  3. If you fix a bug, you can clarify why it is a bug.
-->
This PR fixes that by adding the case handling in ConstantFolding and OptimizeSubqueries.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. There was a correctness error which happens when the scalar subquery is count-bug-susceptible, and empty, and thus folded by `ConstantFolding`. 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added SQL query tests in `scalar-subquery-count-bug.sql`.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.