### PR TITLE
[SPARK-48763][FOLLOWUP] Make `dev/lint-scala` error message more accurate

### DIFF
--- a/dev/lint-scala
+++ b/dev/lint-scala
@@ -36,7 +36,7 @@ ERRORS=$(./build/mvn \
 )
 
 if test ! -z "$ERRORS"; then
-  echo -e "The scalafmt check failed on connector/connect at following occurrences:\n\n$ERRORS\n"
+  echo -e "The scalafmt check failed on connect or connector/connect at following occurrences:\n\n$ERRORS\n"
   echo "Before submitting your change, please make sure to format your code using the following command:"
   echo "./build/mvn scalafmt:format -Dscalafmt.skip=false -Dscalafmt.validateOnly=false -Dscalafmt.changedOnly=false -pl connect/common -pl connect/server -pl connector/connect/client/jvm"
   exit 1


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr is followuping https://github.com/apache/spark/pull/47157, to make `dev/lint-scala` error message more accurate.


### Why are the changes needed?
After move from: `connector/connect/server` `connector/connect/common` to: `connect/server``connect/common`
Our error message in `dev/lint-scala` should be updated synchronously.

eg:
<img width="709" alt="image" src="https://github.com/apache/spark/assets/15246973/d749e371-7621-4063-b512-279d0690d573">
<img width="772" alt="image" src="https://github.com/apache/spark/assets/15246973/44b80571-bdb6-40cb-9571-8b34d009b5f8">

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.
Manually test.


### Was this patch authored or co-authored using generative AI tooling?
No.
