### PR TITLE
[SPARK-48876][BUILD] Upgrade Guava used by the connect module to 33.2.1-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,7 +288,7 @@
     <spark.test.docker.removePulledImage>true</spark.test.docker.removePulledImage>
 
     <!-- Version used in Connect -->
-    <connect.guava.version>33.1.0-jre</connect.guava.version>
+    <connect.guava.version>33.2.1-jre</connect.guava.version>
     <guava.failureaccess.version>1.0.2</guava.failureaccess.version>
     <io.grpc.version>1.62.2</io.grpc.version>
     <mima.version>1.1.3</mima.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade Guava used by the `connect` module to `33.2.1-jre`.


### Why are the changes needed?
The new version bring some fixes and changes as follows:
- Changed InetAddress-String conversion methods to preserve the IPv6 scope ID if present. The scope ID can be necessary for IPv6-capable devices with multiple network interfaces. 
- Added HttpHeaders constants Ad-Auction-Allowed, Permissions-Policy-Report-Only, and Sec-GPC 
- Fixed a potential NullPointerException in ImmutableMap.Builder on a rare code path。

The full release notes:
- https://github.com/google/guava/releases/tag/v33.2.0
- https://github.com/google/guava/releases/tag/v33.2.1


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
