### PR TITLE
[SPARK-48871] Fix INVALID_NON_DETERMINISTIC_EXPRESSIONS validation in…

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -143,6 +143,14 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
       errorClass, missingCol, orderedCandidates, a.origin)
   }
 
+  private def operatorAllowsNonDeterministicExpressions(plan: LogicalPlan): Boolean = {
+    plan match {
+      case p: AllowsNonDeterministicExpression =>
+        p.canPassNonDeterministicExpressionsCheck
+      case _ => false
+    }
+  }
+
   def checkAnalysis(plan: LogicalPlan): Unit = {
     // We should inline all CTE relations to restore the original plan shape, as the analysis check
     // may need to match certain plan shapes. For dangling CTE relations, they will still be kept
@@ -718,6 +726,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
                 "dataType" -> toSQLType(mapCol.dataType)))
 
           case o if o.expressions.exists(!_.deterministic) &&
+            !operatorAllowsNonDeterministicExpressions(o) &&
             !o.isInstanceOf[Project] &&
             // non-deterministic expressions inside CollectMetrics have been
             // already validated inside checkMetric function

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -145,8 +145,8 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
 
   private def operatorAllowsNonDeterministicExpressions(plan: LogicalPlan): Boolean = {
     plan match {
-      case p: AllowsNonDeterministicExpression =>
-        p.canPassNonDeterministicExpressionsCheck
+      case p: SupportsNonDeterministicExpression =>
+        p.allowNonDeterministicExpression
       case _ => false
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -143,6 +143,9 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
       errorClass, missingCol, orderedCandidates, a.origin)
   }
 
+  /**
+   * Checks whether the operator allows non-deterministic expressions.
+   */
   private def operatorAllowsNonDeterministicExpressions(plan: LogicalPlan): Boolean = {
     plan match {
       case p: SupportsNonDeterministicExpression =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1999,6 +1999,16 @@ case class DeduplicateWithinWatermark(keys: Seq[Attribute], child: LogicalPlan) 
 trait SupportsSubquery extends LogicalPlan
 
 /**
+ * Trait that logical plans can extend to check whether it can allow non-deterministic
+ * expressions and pass the CheckAnalysis rule.
+ */
+trait SupportsNonDeterministicExpression extends LogicalPlan {
+
+  /** Returns whether it allows non-deterministic expressions. */
+  def allowNonDeterministicExpression: Boolean
+}
+
+/**
  * Collect arbitrary (named) metrics from a dataset. As soon as the query reaches a completion
  * point (batch query completes or streaming query epoch completes) an event is emitted on the
  * driver which can be observed by attaching a listener to the spark session. The metrics are named
@@ -2227,14 +2237,4 @@ object AsOfJoin {
           Subtract(leftAsOf, rightAsOf), Subtract(rightAsOf, leftAsOf))
     }
   }
-}
-
-/**
- * Trait that logical plans can extend to check whether it can allow non-deterministic
- * expressions and pass the CheckAnalysis rule.
- */
-trait AllowsNonDeterministicExpression extends LogicalPlan {
-
-  /** Returns whether it can pass the non-deterministic expressions CheckAnalysis rule. */
-  def canPassNonDeterministicExpressionsCheck: Boolean
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -2228,3 +2228,13 @@ object AsOfJoin {
     }
   }
 }
+
+/**
+ * Trait that logical plans can extend to check whether it can allow non-deterministic
+ * expressions and pass the CheckAnalysis rule.
+ */
+trait AllowsNonDeterministicExpression extends LogicalPlan {
+
+  /** Returns whether it can pass the non-deterministic expressions CheckAnalysis rule. */
+  def canPassNonDeterministicExpressionsCheck: Boolean
+}

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -92,13 +92,10 @@ case class UnresolvedTestPlan() extends UnresolvedLeafNode
 
 case class SupportsNonDeterministicExpressionTestOperator(
     actions: Seq[Expression],
-    tolerateNonDeterministicExpression: Boolean)
-    extends SupportsNonDeterministicExpression {
-  override def allowNonDeterministicExpression: Boolean = tolerateNonDeterministicExpression
+    allowNonDeterministicExpression: Boolean)
+  extends LeafNode with SupportsNonDeterministicExpression {
+  
   override def output: Seq[Attribute] = Seq()
-  override def children: Seq[LogicalPlan] = Seq()
-  override protected def withNewChildrenInternal(
-      newChildren: IndexedSeq[LogicalPlan]): LogicalPlan = this
 }
 
 class AnalysisErrorSuite extends AnalysisTest with DataTypeErrorsBase {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -1377,12 +1377,12 @@ class AnalysisErrorSuite extends AnalysisTest with DataTypeErrorsBase {
     val nonDeterministicExpressions = Seq(new Rand())
     val tolerantPlan =
       SupportsNonDeterministicExpressionTestOperator(
-        nonDeterministicExpressions, tolerateNonDeterministicExpression = true)
+        nonDeterministicExpressions, allowNonDeterministicExpression = true)
     assertAnalysisSuccess(tolerantPlan)
 
     val intolerantPlan =
       SupportsNonDeterministicExpressionTestOperator(
-        nonDeterministicExpressions, tolerateNonDeterministicExpression = false)
+        nonDeterministicExpressions, allowNonDeterministicExpression = false)
     assertAnalysisError(
       intolerantPlan,
       "INVALID_NON_DETERMINISTIC_EXPRESSIONS" :: Nil

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -1376,7 +1376,7 @@ class AnalysisErrorSuite extends AnalysisTest with DataTypeErrorsBase {
       "expr" -> "\"_w0\"",
       "exprType" -> "\"MAP<STRING, STRING>\""))
 
-  test("SPARK-48871: AllowsNonDeterministicExpression allow lists non-deterministic expressions") {
+  test("SPARK-48871: SupportsNonDeterministicExpression allows non-deterministic expressions") {
     val nonDeterministicExpressions = Seq(new Rand())
     val tolerantPlan =
       SupportsNonDeterministicExpressionTestOperator(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/AnalysisErrorSuite.scala
@@ -94,7 +94,6 @@ case class SupportsNonDeterministicExpressionTestOperator(
     actions: Seq[Expression],
     allowNonDeterministicExpression: Boolean)
   extends LeafNode with SupportsNonDeterministicExpression {
-  
   override def output: Seq[Attribute] = Seq()
 }
 


### PR DESCRIPTION
… CheckAnalysis

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
The PR added a trait that logical plans can extend to implement a method to decide whether there can be non-deterministic expressions for the operator, and check this method in checkAnalysis. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
I encountered the `INVALID_NON_DETERMINISTIC_EXPRESSIONS` exception when attempting to use a non-deterministic udf in my query. The non-deterministic expression can be safely allowed for my custom LogicalPlan, but it is disabled in the checkAnalysis phase. The CheckAnalysis rule is too strict so that reasonable use cases of non-deterministic expressions are also disabled.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
The test case `"SPARK-48871: AllowsNonDeterministicExpression allow lists non-deterministic expressions"` is added.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
