### PR TITLE
[SPARK-48717][FOLLOWUP][PYTHON][SS] Catch Cancelled Job Group wrapped by Py4JJavaError in StreamExecution

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -712,8 +712,8 @@ object StreamExecution {
       //                      exception
       // UncheckedExecutionException - thrown by codes that cannot throw a checked
       //                               ExecutionException, such as BiFunction.apply
-      case e2@(_: UncheckedIOException | _: ExecutionException | _: UncheckedExecutionException)
-        if e2.getCause != null =>
+      case e2 @ (_: UncheckedIOException | _: ExecutionException | _: UncheckedExecutionException)
+          if e2.getCause != null =>
         isInterruptionException(e2.getCause, sc)
       case fe: ForeachBatchUserFuncException => isInterruptionException(fe.getCause, sc)
       case se: SparkException =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StreamExecution.scala
@@ -692,40 +692,45 @@ object StreamExecution {
       s"((.|\\r\\n|\\r|\\n)*)(${IO_EXCEPTION_NAMES.mkString("|")})").r
 
   @scala.annotation.tailrec
-  def isInterruptionException(e: Throwable, sc: SparkContext): Boolean = e match {
-    // InterruptedIOException - thrown when an I/O operation is interrupted
-    // ClosedByInterruptException - thrown when an I/O operation upon a channel is interrupted
-    case _: InterruptedException | _: InterruptedIOException | _: ClosedByInterruptException =>
-      true
-    // The cause of the following exceptions may be one of the above exceptions:
-    //
-    // UncheckedIOException - thrown by codes that cannot throw a checked IOException, such as
-    //                        BiFunction.apply
-    // ExecutionException - thrown by codes running in a thread pool and these codes throw an
-    //                      exception
-    // UncheckedExecutionException - thrown by codes that cannot throw a checked
-    //                               ExecutionException, such as BiFunction.apply
-    case e2 @ (_: UncheckedIOException | _: ExecutionException | _: UncheckedExecutionException)
-        if e2.getCause != null =>
-      isInterruptionException(e2.getCause, sc)
-    case fe: ForeachBatchUserFuncException => isInterruptionException(fe.getCause, sc)
-    case se: SparkException =>
+  def isInterruptionException(e: Throwable, sc: SparkContext): Boolean = {
+    def isCancelledJobGroup(errorMsg: String): Boolean = {
       val jobGroup = sc.getLocalProperty("spark.jobGroup.id")
       if (jobGroup == null) return false
-      val errorMsg = se.getMessage
-      if (errorMsg.contains("cancelled") && errorMsg.contains(jobGroup) && se.getCause == null) {
+      errorMsg.contains("cancelled") && errorMsg.contains(jobGroup)
+    }
+
+    e match {
+      // InterruptedIOException - thrown when an I/O operation is interrupted
+      // ClosedByInterruptException - thrown when an I/O operation upon a channel is interrupted
+      case _: InterruptedException | _: InterruptedIOException | _: ClosedByInterruptException =>
         true
-      } else if (se.getCause != null) {
-        isInterruptionException(se.getCause, sc)
-      } else {
+      // The cause of the following exceptions may be one of the above exceptions:
+      //
+      // UncheckedIOException - thrown by codes that cannot throw a checked IOException, such as
+      //                        BiFunction.apply
+      // ExecutionException - thrown by codes running in a thread pool and these codes throw an
+      //                      exception
+      // UncheckedExecutionException - thrown by codes that cannot throw a checked
+      //                               ExecutionException, such as BiFunction.apply
+      case e2@(_: UncheckedIOException | _: ExecutionException | _: UncheckedExecutionException)
+        if e2.getCause != null =>
+        isInterruptionException(e2.getCause, sc)
+      case fe: ForeachBatchUserFuncException => isInterruptionException(fe.getCause, sc)
+      case se: SparkException =>
+        if (se.getCause == null) {
+          isCancelledJobGroup(se.getMessage)
+        } else {
+          isInterruptionException(se.getCause, sc)
+        }
+      // py4j.Py4JException - with pinned thread mode on, the exception can be interrupted by Py4J
+      //                      access, for example, in `DataFrameWriter.foreachBatch`. See also
+      //                      SPARK-39218.
+      case e: py4j.Py4JException =>
+        PROXY_ERROR.findFirstIn(e.getMessage).isDefined || (e.getMessage
+          .contains("org.apache.spark.SparkException") && isCancelledJobGroup(e.getMessage))
+      case _ =>
         false
-      }
-    // py4j.Py4JException - with pinned thread mode on, the exception can be interrupted by Py4J
-    //                      access, for example, in `DataFrameWriter.foreachBatch`. See also
-    //                      SPARK-39218.
-    case e: py4j.Py4JException => PROXY_ERROR.findFirstIn(e.getMessage).isDefined
-    case _ =>
-      false
+    }
   }
 
   /** Whether the path contains special chars that will be escaped when converting to a `URI`. */

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -1355,6 +1355,33 @@ class StreamSuite extends StreamTest {
     // scalastyle:on line.size.limit
     val febError2 = ForeachBatchUserFuncException(e2)
     assert(StreamExecution.isInterruptionException(febError2, spark.sparkContext))
+
+    // scalastyle:off line.size.limit
+    val e3 = new py4j.Py4JException(
+      """
+        py4j.protocol.Py4JJavaError: An error occurred while calling o6032.save.
+        |: org.apache.spark.SparkException: [SPARK_JOB_CANCELLED] Job 89 cancelled part of cancelled job group a5bc7e26-f199-463e-95ad-4ec960a62d79 SQLSTATE: XXKDA
+        |at org.apache.spark.scheduler.DAGScheduler.handleJobCancellation(DAGScheduler.scala:3747)
+        |at org.apache.spark.scheduler.DAGScheduler.$anonfun$handleJobGroupCancelled$4(DAGScheduler.scala:1592)
+        |at scala.runtime.java8.JFunction1$mcVI$sp.apply(JFunction1$mcVI$sp.java:23)
+        |at scala.collection.mutable.HashSet.foreach(HashSet.scala:79)
+        |at org.apache.spark.scheduler.DAGScheduler.handleJobGroupCancelled(DAGScheduler.scala:1591)
+        |at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive(DAGScheduler.scala:4102)
+        |at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:4058)
+        |at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:4046)
+        |at org.apache.spark.util.EventLoop$$anon$1.run(EventLoop.scala:54)
+        |at org.apache.spark.scheduler.DAGScheduler.$anonfun$runJob$1(DAGScheduler.scala:1348)
+        |""".stripMargin)
+    // scalastyle:on line.size.limit
+    val febError3 = ForeachBatchUserFuncException(e3)
+    val prevJobId = spark.sparkContext.getLocalProperty("spark.jobGroup.id")
+    try {
+      spark.sparkContext.setLocalProperty(
+        "spark.jobGroup.id", "a5bc7e26-f199-463e-95ad-4ec960a62d79")
+      assert(StreamExecution.isInterruptionException(febError3, spark.sparkContext))
+    } finally {
+      spark.sparkContext.setLocalProperty("spark.jobGroup.id", prevJobId)
+    }
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
The previous commit https://github.com/apache/spark/commit/1581264a5d77e1731a987020a448ddc3f3ea8f27 doesn't capture the situation when a job group is cancelled. This patches that situation.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Bug fix, without this change, calling query.stop() would sometimes (when there is a python foreachBatch function, and this error is thrown) cause query appears as failed.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added unit test.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No