### PR TITLE
[SPARK-48873][SQL] Use UnsafeRow in JSON parser.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -574,7 +574,7 @@ class JacksonParser(
       applyExistenceDefaultValuesToRow(schema, row, bitmask)
       Some(convertRow(row, schema))
     } else {
-      throw PartialResultException(convertRow(row, schema), badRecordException.get)
+      throw PartialResultException(row, badRecordException.get)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/json/JacksonParser.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.json
 import java.io.{ByteArrayOutputStream, CharConversionException}
 import java.nio.charset.MalformedInputException
 
+import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.util.control.NonFatal
 
@@ -513,6 +514,21 @@ class JacksonParser(
       throw CannotParseJSONFieldException(parser.currentName, parser.getText, token, dataType)
   }
 
+  private val useUnsafeRow = SQLConf.get.getConf(SQLConf.JSON_USE_UNSAFE_ROW)
+  private val cachedUnsafeProjection = mutable.HashMap.empty[StructType, UnsafeProjection]
+
+  protected final def convertRow(row: InternalRow, schema: StructType): InternalRow = {
+    if (useUnsafeRow) {
+      val p = cachedUnsafeProjection.getOrElseUpdate(schema, UnsafeProjection.create(schema))
+      // The copy is necessary: each time `UnsafeProjection` produces a row, it updates an
+      // internal `UnsafeRow` object and returns the reference. We need to avoid overwriting
+      // previously returned results.
+      p(row).copy()
+    } else {
+      row
+    }
+  }
+
   /**
    * Parse an object from the token stream into a new Row representing the schema.
    * Fields in the json that are not defined in the requested schema will be dropped.
@@ -556,9 +572,9 @@ class JacksonParser(
       None
     } else if (badRecordException.isEmpty) {
       applyExistenceDefaultValuesToRow(schema, row, bitmask)
-      Some(row)
+      Some(convertRow(row, schema))
     } else {
-      throw PartialResultException(row, badRecordException.get)
+      throw PartialResultException(convertRow(row, schema), badRecordException.get)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4367,6 +4367,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val JSON_USE_UNSAFE_ROW =
+    buildConf("spark.sql.json.useUnsafeRow")
+      .internal()
+      .doc("When set to true, use UnsafeRow to represent struct result in the JSON parser.")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val LEGACY_CSV_ENABLE_DATE_TIME_PARSING_FALLBACK =
     buildConf("spark.sql.legacy.csv.enableDateTimeParsingFallback")
       .internal()

--- a/sql/core/benchmarks/DataSourceReadBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/DataSourceReadBenchmark-jdk21-results.txt
@@ -2,430 +2,437 @@
 SQL Single Numeric Column Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single BOOLEAN Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            9893           9962          97          1.6         629.0       1.0X
-SQL Json                                           7942           8051         155          2.0         504.9       1.2X
-SQL Parquet Vectorized: DataPageV1                   84             96           8        187.9           5.3     118.2X
-SQL Parquet Vectorized: DataPageV2                   95            107           9        166.3           6.0     104.6X
-SQL Parquet MR: DataPageV1                         1727           1730           3          9.1         109.8       5.7X
-SQL Parquet MR: DataPageV2                         1615           1615           1          9.7         102.6       6.1X
-SQL ORC Vectorized                                  135            146           8        116.4           8.6      73.2X
-SQL ORC MR                                         1495           1511          22         10.5          95.0       6.6X
+SQL CSV                                            9728           9736          11          1.6         618.5       1.0X
+SQL Json                                           7883           7959         107          2.0         501.2       1.2X
+SQL Json with UnsafeRow                            8410           8425          21          1.9         534.7       1.2X
+SQL Parquet Vectorized: DataPageV1                   80             94           7        195.5           5.1     120.9X
+SQL Parquet Vectorized: DataPageV2                   93            107           8        169.1           5.9     104.6X
+SQL Parquet MR: DataPageV1                         1767           1774           9          8.9         112.4       5.5X
+SQL Parquet MR: DataPageV2                         1650           1651           1          9.5         104.9       5.9X
+SQL ORC Vectorized                                  120            131           9        131.2           7.6      81.1X
+SQL ORC MR                                         1503           1523          28         10.5          95.6       6.5X
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single BOOLEAN Column Scan:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                    92             93           1        170.7           5.9       1.0X
-ParquetReader Vectorized: DataPageV2                   112            113           1        140.8           7.1       0.8X
-ParquetReader Vectorized -> Row: DataPageV1             72             73           1        218.6           4.6       1.3X
-ParquetReader Vectorized -> Row: DataPageV2             94             96           2        167.5           6.0       1.0X
+ParquetReader Vectorized: DataPageV1                    90             91           1        173.9           5.8       1.0X
+ParquetReader Vectorized: DataPageV2                   109            111           2        144.5           6.9       0.8X
+ParquetReader Vectorized -> Row: DataPageV1             73             74           1        216.2           4.6       1.2X
+ParquetReader Vectorized -> Row: DataPageV2             92             93           1        171.0           5.8       1.0X
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single TINYINT Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            9431           9439          11          1.7         599.6       1.0X
-SQL Json                                           8552           8570          26          1.8         543.7       1.1X
-SQL Parquet Vectorized: DataPageV1                   96            105           9        164.4           6.1      98.6X
-SQL Parquet Vectorized: DataPageV2                   93            104           9        168.4           5.9     101.0X
-SQL Parquet MR: DataPageV1                         1816           1821           6          8.7         115.5       5.2X
-SQL Parquet MR: DataPageV2                         1742           1746           5          9.0         110.8       5.4X
-SQL ORC Vectorized                                  107            113           6        146.6           6.8      87.9X
-SQL ORC MR                                         1582           1598          22          9.9         100.6       6.0X
+SQL CSV                                            9593           9609          24          1.6         609.9       1.0X
+SQL Json                                           8658           8671          18          1.8         550.5       1.1X
+SQL Json with UnsafeRow                            9473           9473           1          1.7         602.2       1.0X
+SQL Parquet Vectorized: DataPageV1                   95            102           5        165.5           6.0     100.9X
+SQL Parquet Vectorized: DataPageV2                   96            113          13        163.8           6.1      99.9X
+SQL Parquet MR: DataPageV1                         1871           1877           8          8.4         119.0       5.1X
+SQL Parquet MR: DataPageV2                         1864           1879          21          8.4         118.5       5.1X
+SQL ORC Vectorized                                  139            150          11        113.3           8.8      69.1X
+SQL ORC MR                                         1638           1640           3          9.6         104.1       5.9X
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single TINYINT Column Scan:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                    66             68           2        238.1           4.2       1.0X
-ParquetReader Vectorized: DataPageV2                    66             67           1        239.4           4.2       1.0X
-ParquetReader Vectorized -> Row: DataPageV1             44             46           3        357.8           2.8       1.5X
-ParquetReader Vectorized -> Row: DataPageV2             44             45           1        357.9           2.8       1.5X
+ParquetReader Vectorized: DataPageV1                    68             71           1        231.7           4.3       1.0X
+ParquetReader Vectorized: DataPageV2                    68             71           2        232.2           4.3       1.0X
+ParquetReader Vectorized -> Row: DataPageV1             44             47           2        354.7           2.8       1.5X
+ParquetReader Vectorized -> Row: DataPageV2             45             46           1        351.5           2.8       1.5X
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single SMALLINT Column Scan:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            9996          10013          25          1.6         635.5       1.0X
-SQL Json                                           8898           8902           5          1.8         565.7       1.1X
-SQL Parquet Vectorized: DataPageV1                  121            137          14        129.7           7.7      82.4X
-SQL Parquet Vectorized: DataPageV2                  139            153          14        113.1           8.8      71.9X
-SQL Parquet MR: DataPageV1                         2015           2035          28          7.8         128.1       5.0X
-SQL Parquet MR: DataPageV2                         2000           2012          17          7.9         127.2       5.0X
-SQL ORC Vectorized                                  143            174          27        109.8           9.1      69.8X
-SQL ORC MR                                         1959           1990          44          8.0         124.6       5.1X
+SQL CSV                                           10289          10295           9          1.5         654.1       1.0X
+SQL Json                                           8947           8950           4          1.8         568.8       1.1X
+SQL Json with UnsafeRow                            9474           9475           2          1.7         602.3       1.1X
+SQL Parquet Vectorized: DataPageV1                  113            125          13        138.8           7.2      90.8X
+SQL Parquet Vectorized: DataPageV2                  135            146          14        116.9           8.6      76.5X
+SQL Parquet MR: DataPageV1                         1985           2001          22          7.9         126.2       5.2X
+SQL Parquet MR: DataPageV2                         1947           1972          36          8.1         123.8       5.3X
+SQL ORC Vectorized                                  140            151          15        112.1           8.9      73.3X
+SQL ORC MR                                         1668           1708          56          9.4         106.1       6.2X
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single SMALLINT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                   151            160           8        104.3           9.6       1.0X
-ParquetReader Vectorized: DataPageV2                   168            180          14         93.5          10.7       0.9X
-ParquetReader Vectorized -> Row: DataPageV1            160            166           6         98.3          10.2       0.9X
-ParquetReader Vectorized -> Row: DataPageV2            164            175          12         96.1          10.4       0.9X
+ParquetReader Vectorized: DataPageV1                   156            164           5        100.6           9.9       1.0X
+ParquetReader Vectorized: DataPageV2                   173            188           8         91.0          11.0       0.9X
+ParquetReader Vectorized -> Row: DataPageV1            151            155           4        104.5           9.6       1.0X
+ParquetReader Vectorized -> Row: DataPageV2            182            186           4         86.7          11.5       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single INT Column Scan:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           11250          11336         121          1.4         715.3       1.0X
-SQL Json                                           9272           9279          10          1.7         589.5       1.2X
-SQL Parquet Vectorized: DataPageV1                  109            126          14        144.4           6.9     103.3X
-SQL Parquet Vectorized: DataPageV2                  190            195           5         82.8          12.1      59.2X
-SQL Parquet MR: DataPageV1                         2338           2342           6          6.7         148.6       4.8X
-SQL Parquet MR: DataPageV2                         2332           2343          17          6.7         148.2       4.8X
-SQL ORC Vectorized                                  179            193          12         87.9          11.4      62.9X
-SQL ORC MR                                         2094           2095           1          7.5         133.2       5.4X
+SQL CSV                                           11381          11468         123          1.4         723.6       1.0X
+SQL Json                                           9302           9306           7          1.7         591.4       1.2X
+SQL Json with UnsafeRow                            9981           9989          12          1.6         634.6       1.1X
+SQL Parquet Vectorized: DataPageV1                  100            115          13        156.7           6.4     113.4X
+SQL Parquet Vectorized: DataPageV2                  180            196          15         87.4          11.4      63.2X
+SQL Parquet MR: DataPageV1                         1959           1971          16          8.0         124.6       5.8X
+SQL Parquet MR: DataPageV2                         1995           2009          19          7.9         126.8       5.7X
+SQL ORC Vectorized                                  176            192          24         89.3          11.2      64.6X
+SQL ORC MR                                         1660           1673          18          9.5         105.6       6.9X
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single INT Column Scan:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                   134            138           2        117.7           8.5       1.0X
-ParquetReader Vectorized: DataPageV2                   210            215           7         74.8          13.4       0.6X
-ParquetReader Vectorized -> Row: DataPageV1            128            133           8        123.3           8.1       1.0X
-ParquetReader Vectorized -> Row: DataPageV2            225            232           6         70.0          14.3       0.6X
+ParquetReader Vectorized: DataPageV1                   134            139           5        117.1           8.5       1.0X
+ParquetReader Vectorized: DataPageV2                   229            234           4         68.6          14.6       0.6X
+ParquetReader Vectorized -> Row: DataPageV1            142            145           3        110.8           9.0       0.9X
+ParquetReader Vectorized -> Row: DataPageV2            224            230           5         70.2          14.2       0.6X
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single BIGINT Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           11683          11683           1          1.3         742.8       1.0X
-SQL Json                                           9457           9460           4          1.7         601.3       1.2X
-SQL Parquet Vectorized: DataPageV1                  277            312          21         56.9          17.6      42.2X
-SQL Parquet Vectorized: DataPageV2                  281            291          10         56.0          17.9      41.6X
-SQL Parquet MR: DataPageV1                         2506           2517          15          6.3         159.4       4.7X
-SQL Parquet MR: DataPageV2                         2053           2058           7          7.7         130.5       5.7X
-SQL ORC Vectorized                                  166            172          12         95.0          10.5      70.5X
-SQL ORC MR                                         1709           1738          40          9.2         108.7       6.8X
+SQL CSV                                           11003          11024          30          1.4         699.5       1.0X
+SQL Json                                           9303           9305           2          1.7         591.5       1.2X
+SQL Json with UnsafeRow                            9951           9962          16          1.6         632.7       1.1X
+SQL Parquet Vectorized: DataPageV1                  275            296          16         57.3          17.5      40.1X
+SQL Parquet Vectorized: DataPageV2                  275            287          11         57.3          17.5      40.1X
+SQL Parquet MR: DataPageV1                         2535           2546          15          6.2         161.2       4.3X
+SQL Parquet MR: DataPageV2                         2089           2116          38          7.5         132.8       5.3X
+SQL ORC Vectorized                                  163            172          12         96.6          10.4      67.6X
+SQL ORC MR                                         1731           1745          20          9.1         110.0       6.4X
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single BIGINT Column Scan:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                   311            331          16         50.6          19.8       1.0X
-ParquetReader Vectorized: DataPageV2                   265            280          21         59.4          16.8       1.2X
-ParquetReader Vectorized -> Row: DataPageV1            317            321           3         49.6          20.2       1.0X
-ParquetReader Vectorized -> Row: DataPageV2            254            262          13         62.0          16.1       1.2X
+ParquetReader Vectorized: DataPageV1                   308            314           4         51.0          19.6       1.0X
+ParquetReader Vectorized: DataPageV2                   278            287           9         56.5          17.7       1.1X
+ParquetReader Vectorized -> Row: DataPageV1            316            323           6         49.7          20.1       1.0X
+ParquetReader Vectorized -> Row: DataPageV2            258            276           9         60.9          16.4       1.2X
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single FLOAT Column Scan:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           11446          11452           8          1.4         727.7       1.0X
-SQL Json                                          10952          10955           4          1.4         696.3       1.0X
-SQL Parquet Vectorized: DataPageV1                   83             97          16        189.5           5.3     137.9X
-SQL Parquet Vectorized: DataPageV2                   82             94          12        192.7           5.2     140.2X
-SQL Parquet MR: DataPageV1                         2107           2120          18          7.5         134.0       5.4X
-SQL Parquet MR: DataPageV2                         1975           2003          40          8.0         125.5       5.8X
-SQL ORC Vectorized                                  235            245          14         66.9          14.9      48.7X
-SQL ORC MR                                         1779           1801          30          8.8         113.1       6.4X
+SQL CSV                                           11484          11544          84          1.4         730.2       1.0X
+SQL Json                                          10930          10957          38          1.4         694.9       1.1X
+SQL Json with UnsafeRow                           11604          11605           2          1.4         737.8       1.0X
+SQL Parquet Vectorized: DataPageV1                  110            134           9        142.3           7.0     103.9X
+SQL Parquet Vectorized: DataPageV2                   85            119          20        185.0           5.4     135.0X
+SQL Parquet MR: DataPageV1                         2069           2077          12          7.6         131.6       5.6X
+SQL Parquet MR: DataPageV2                         1981           1988          10          7.9         126.0       5.8X
+SQL ORC Vectorized                                  236            250          17         66.7          15.0      48.7X
+SQL ORC MR                                         1767           1768           3          8.9         112.3       6.5X
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single FLOAT Column Scan:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                   134            141           8        117.1           8.5       1.0X
-ParquetReader Vectorized: DataPageV2                   147            151           4        107.3           9.3       0.9X
-ParquetReader Vectorized -> Row: DataPageV1            144            151           7        109.2           9.2       0.9X
-ParquetReader Vectorized -> Row: DataPageV2            128            139           7        123.3           8.1       1.1X
+ParquetReader Vectorized: DataPageV1                   136            138           2        115.6           8.6       1.0X
+ParquetReader Vectorized: DataPageV2                   134            152           9        117.4           8.5       1.0X
+ParquetReader Vectorized -> Row: DataPageV1            129            133           5        122.0           8.2       1.1X
+ParquetReader Vectorized -> Row: DataPageV2            143            149           7        109.7           9.1       0.9X
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single DOUBLE Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           11723          11745          31          1.3         745.3       1.0X
-SQL Json                                          11373          11395          31          1.4         723.1       1.0X
-SQL Parquet Vectorized: DataPageV1                  304            316          11         51.7          19.3      38.6X
-SQL Parquet Vectorized: DataPageV2                  276            301          16         56.9          17.6      42.4X
-SQL Parquet MR: DataPageV1                         2427           2438          16          6.5         154.3       4.8X
-SQL Parquet MR: DataPageV2                         2365           2381          22          6.7         150.4       5.0X
-SQL ORC Vectorized                                  577            580           2         27.3          36.7      20.3X
-SQL ORC MR                                         2149           2174          35          7.3         136.6       5.5X
+SQL CSV                                           11706          11860         218          1.3         744.2       1.0X
+SQL Json                                          11600          11609          13          1.4         737.5       1.0X
+SQL Json with UnsafeRow                           12254          12258           5          1.3         779.1       1.0X
+SQL Parquet Vectorized: DataPageV1                  267            290          17         58.9          17.0      43.8X
+SQL Parquet Vectorized: DataPageV2                  272            288          13         57.8          17.3      43.1X
+SQL Parquet MR: DataPageV1                         2470           2478          10          6.4         157.1       4.7X
+SQL Parquet MR: DataPageV2                         2418           2419           2          6.5         153.7       4.8X
+SQL ORC Vectorized                                  575            580           7         27.3          36.6      20.4X
+SQL ORC MR                                         2173           2185          17          7.2         138.1       5.4X
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single DOUBLE Column Scan:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                   325            333           5         48.4          20.6       1.0X
-ParquetReader Vectorized: DataPageV2                   324            333           8         48.5          20.6       1.0X
-ParquetReader Vectorized -> Row: DataPageV1            312            326          14         50.4          19.8       1.0X
-ParquetReader Vectorized -> Row: DataPageV2            323            329           6         48.6          20.6       1.0X
+ParquetReader Vectorized: DataPageV1                   319            339          17         49.3          20.3       1.0X
+ParquetReader Vectorized: DataPageV2                   327            331           6         48.2          20.8       1.0X
+ParquetReader Vectorized -> Row: DataPageV1            322            327           5         48.8          20.5       1.0X
+ParquetReader Vectorized -> Row: DataPageV2            324            330           7         48.6          20.6       1.0X
 
 
 ================================================================================================
 SQL Single Numeric Column Scan in Struct
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single TINYINT Column Scan in Struct:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2116           2119           4          7.4         134.5       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2127           2157          42          7.4         135.3       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                             146            153           9        107.5           9.3      14.5X
-SQL Parquet MR: DataPageV1                                            2589           2609          28          6.1         164.6       0.8X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2883           2886           4          5.5         183.3       0.7X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             104            121          18        151.6           6.6      20.4X
-SQL Parquet MR: DataPageV2                                            2472           2505          46          6.4         157.2       0.9X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2834           2851          25          5.6         180.2       0.7X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             106            121          13        148.8           6.7      20.0X
+SQL ORC MR                                                            2120           2193         103          7.4         134.8       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           2119           2170          71          7.4         134.7       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             148            155           9        106.1           9.4      14.3X
+SQL Parquet MR: DataPageV1                                            2352           2428         108          6.7         149.5       0.9X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2712           2736          34          5.8         172.4       0.8X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             106            118          14        148.4           6.7      20.0X
+SQL Parquet MR: DataPageV2                                            2359           2364           6          6.7         150.0       0.9X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2661           2670          12          5.9         169.2       0.8X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             145            161          12        108.4           9.2      14.6X
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single SMALLINT Column Scan in Struct:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2332           2378          65          6.7         148.3       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2331           2360          41          6.7         148.2       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                             257            270          10         61.2          16.3       9.1X
-SQL Parquet MR: DataPageV1                                            2383           2385           2          6.6         151.5       1.0X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2944           2945           1          5.3         187.2       0.8X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             120            134          16        130.9           7.6      19.4X
-SQL Parquet MR: DataPageV2                                            2323           2334          17          6.8         147.7       1.0X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2983           2992          12          5.3         189.7       0.8X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             231            263          16         68.0          14.7      10.1X
+SQL ORC MR                                                            2099           2100           1          7.5         133.4       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           2112           2131          27          7.4         134.3       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             274            286          19         57.4          17.4       7.7X
+SQL Parquet MR: DataPageV1                                            2431           2432           2          6.5         154.6       0.9X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           3258           3266          12          4.8         207.1       0.6X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             131            133           1        120.3           8.3      16.1X
+SQL Parquet MR: DataPageV2                                            2400           2419          27          6.6         152.6       0.9X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           3188           3199          16          4.9         202.7       0.7X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             163            176          14         96.5          10.4      12.9X
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single INT Column Scan in Struct:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2196           2201           7          7.2         139.6       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2243           2312          97          7.0         142.6       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                             278            292          18         56.6          17.7       7.9X
-SQL Parquet MR: DataPageV1                                            2539           2540           1          6.2         161.4       0.9X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           3499           3514          20          4.5         222.5       0.6X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             112            117           4        139.9           7.2      19.5X
-SQL Parquet MR: DataPageV2                                            2555           2563          12          6.2         162.4       0.9X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           3424           3441          25          4.6         217.7       0.6X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             242            250           5         64.9          15.4       9.1X
+SQL ORC MR                                                            2190           2206          22          7.2         139.3       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           2227           2246          27          7.1         141.6       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             299            307          10         52.6          19.0       7.3X
+SQL Parquet MR: DataPageV1                                            2553           2556           4          6.2         162.3       0.9X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2928           2930           4          5.4         186.1       0.7X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             116            136          21        135.3           7.4      18.8X
+SQL Parquet MR: DataPageV2                                            2508           2513           8          6.3         159.4       0.9X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2991           2996           6          5.3         190.2       0.7X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             281            287           6         55.9          17.9       7.8X
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single BIGINT Column Scan in Struct:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2219           2229          15          7.1         141.1       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2234           2248          21          7.0         142.0       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                             290            309          18         54.2          18.5       7.6X
-SQL Parquet MR: DataPageV1                                            2806           2812           8          5.6         178.4       0.8X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           3281           3296          20          4.8         208.6       0.7X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             326            335          10         48.3          20.7       6.8X
-SQL Parquet MR: DataPageV2                                            2430           2454          34          6.5         154.5       0.9X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2898           2912          20          5.4         184.3       0.8X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             251            288          23         62.6          16.0       8.8X
+SQL ORC MR                                                            2177           2268         129          7.2         138.4       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           2218           2222           6          7.1         141.0       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             301            312          16         52.2          19.1       7.2X
+SQL Parquet MR: DataPageV1                                            2806           2814          12          5.6         178.4       0.8X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           3519           3528          12          4.5         223.7       0.6X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             329            333           4         47.8          20.9       6.6X
+SQL Parquet MR: DataPageV2                                            2412           2434          31          6.5         153.4       0.9X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           3047           3066          27          5.2         193.7       0.7X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             266            303          18         59.1          16.9       8.2X
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single FLOAT Column Scan in Struct:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2313           2372          83          6.8         147.1       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2405           2419          19          6.5         152.9       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                             337            355          19         46.6          21.5       6.9X
-SQL Parquet MR: DataPageV1                                            2604           2617          17          6.0         165.6       0.9X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           3103           3112          12          5.1         197.3       0.7X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)              95            100           4        165.2           6.1      24.3X
-SQL Parquet MR: DataPageV2                                            2674           2698          34          5.9         170.0       0.9X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           3215           3237          32          4.9         204.4       0.7X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)              87            101           9        180.4           5.5      26.5X
+SQL ORC MR                                                            2286           2306          28          6.9         145.4       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           2308           2324          24          6.8         146.7       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             355            372          20         44.4          22.5       6.4X
+SQL Parquet MR: DataPageV1                                            2513           2521          11          6.3         159.8       0.9X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2957           2979          31          5.3         188.0       0.8X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             100            107           6        156.8           6.4      22.8X
+SQL Parquet MR: DataPageV2                                            2465           2476          17          6.4         156.7       0.9X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2923           2937          19          5.4         185.9       0.8X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             110            115           5        142.6           7.0      20.7X
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single DOUBLE Column Scan in Struct:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2676           2684          12          5.9         170.1       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2595           2596           2          6.1         165.0       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                             697            708          16         22.6          44.3       3.8X
-SQL Parquet MR: DataPageV1                                            2836           2854          25          5.5         180.3       0.9X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           3428           3435          10          4.6         218.0       0.8X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             307            319          11         51.2          19.5       8.7X
-SQL Parquet MR: DataPageV2                                            2903           2904           2          5.4         184.6       0.9X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           3511           3518           9          4.5         223.2       0.8X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             317            322           4         49.7          20.1       8.5X
+SQL ORC MR                                                            2635           2636           2          6.0         167.5       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           2617           2652          50          6.0         166.4       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             708            718          11         22.2          45.0       3.7X
+SQL Parquet MR: DataPageV1                                            2892           2893           0          5.4         183.9       0.9X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           3227           3234           9          4.9         205.2       0.8X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             312            326          18         50.4          19.8       8.4X
+SQL Parquet MR: DataPageV2                                            2808           2809           1          5.6         178.5       0.9X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           3184           3190           8          4.9         202.5       0.8X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             278            314          26         56.6          17.7       9.5X
 
 
 ================================================================================================
 SQL Nested Column Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Nested Column Scan:                                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                           12857          12956          97          0.1       12261.0       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                          12868          12963          93          0.1       12272.0       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                            7063           7109          31          0.1        6735.6       1.8X
-SQL Parquet MR: DataPageV1                                            9067           9173          81          0.1        8646.8       1.4X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           9287           9373          59          0.1        8856.4       1.4X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)            5899           5931          25          0.2        5625.7       2.2X
-SQL Parquet MR: DataPageV2                                            9529           9579          54          0.1        9087.2       1.3X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           9864          10035         165          0.1        9406.6       1.3X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)            5650           5702          49          0.2        5388.4       2.3X
+SQL ORC MR                                                           12644          12768          64          0.1       12058.1       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                          12692          12849         156          0.1       12104.4       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                            7121           7151          18          0.1        6791.0       1.8X
+SQL Parquet MR: DataPageV1                                            9395           9657         344          0.1        8959.8       1.3X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           9651           9737          64          0.1        9203.9       1.3X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)            6027           6091          31          0.2        5748.1       2.1X
+SQL Parquet MR: DataPageV2                                            9789          10011         235          0.1        9335.6       1.3X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)          10103          10325         198          0.1        9634.9       1.3X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)            5717           5737          15          0.2        5451.9       2.2X
 
 
 ================================================================================================
 Int and String Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Int and String Scan:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           10098          10209         156          1.0         963.0       1.0X
-SQL Json                                           9940           9993          75          1.1         947.9       1.0X
-SQL Parquet Vectorized: DataPageV1                 1682           1707          36          6.2         160.4       6.0X
-SQL Parquet Vectorized: DataPageV2                 1912           1930          25          5.5         182.4       5.3X
-SQL Parquet MR: DataPageV1                         3861           3870          13          2.7         368.2       2.6X
-SQL Parquet MR: DataPageV2                         3961           3969          10          2.6         377.8       2.5X
-SQL ORC Vectorized                                 1768           1780          18          5.9         168.6       5.7X
-SQL ORC MR                                         3478           3493          21          3.0         331.7       2.9X
+SQL CSV                                           10032          10142         155          1.0         956.7       1.0X
+SQL Json                                          10411          10433          31          1.0         992.9       1.0X
+SQL Parquet Vectorized: DataPageV1                 1695           1712          24          6.2         161.7       5.9X
+SQL Parquet Vectorized: DataPageV2                 1914           1924          15          5.5         182.5       5.2X
+SQL Parquet MR: DataPageV1                         3927           3951          34          2.7         374.5       2.6X
+SQL Parquet MR: DataPageV2                         3890           3905          21          2.7         371.0       2.6X
+SQL ORC Vectorized                                 1738           1784          65          6.0         165.7       5.8X
+SQL ORC MR                                         3380           3387          11          3.1         322.3       3.0X
 
 
 ================================================================================================
 Repeated String Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Repeated String:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            5870           5882          17          1.8         559.8       1.0X
-SQL Json                                           6337           6345          10          1.7         604.4       0.9X
-SQL Parquet Vectorized: DataPageV1                  457            473          22         23.0          43.5      12.9X
-SQL Parquet Vectorized: DataPageV2                  491            501           8         21.3          46.9      11.9X
-SQL Parquet MR: DataPageV1                         1631           1648          24          6.4         155.6       3.6X
-SQL Parquet MR: DataPageV2                         1580           1606          36          6.6         150.7       3.7X
-SQL ORC Vectorized                                  372            378           8         28.2          35.5      15.8X
-SQL ORC MR                                         1732           1735           5          6.1         165.1       3.4X
+SQL CSV                                            5964           5978          20          1.8         568.8       1.0X
+SQL Json                                           6741           6752          15          1.6         642.9       0.9X
+SQL Parquet Vectorized: DataPageV1                  431            433           3         24.3          41.1      13.8X
+SQL Parquet Vectorized: DataPageV2                  427            435          13         24.6          40.7      14.0X
+SQL Parquet MR: DataPageV1                         1557           1576          28          6.7         148.4       3.8X
+SQL Parquet MR: DataPageV2                         1499           1518          27          7.0         143.0       4.0X
+SQL ORC Vectorized                                  374            380           9         28.0          35.7      16.0X
+SQL ORC MR                                         1611           1616           7          6.5         153.7       3.7X
 
 
 ================================================================================================
 Partitioned Table Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Partitioned Table:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-Data column - CSV                                          10956          10967          15          1.4         696.5       1.0X
-Data column - Json                                          9169           9189          29          1.7         583.0       1.2X
-Data column - Parquet Vectorized: DataPageV1                 108            126          16        145.8           6.9     101.6X
-Data column - Parquet Vectorized: DataPageV2                 217            233          20         72.5          13.8      50.5X
-Data column - Parquet MR: DataPageV1                        2229           2346         166          7.1         141.7       4.9X
-Data column - Parquet MR: DataPageV2                        2224           2240          23          7.1         141.4       4.9X
-Data column - ORC Vectorized                                 178            184           4         88.3          11.3      61.5X
-Data column - ORC MR                                        2040           2069          41          7.7         129.7       5.4X
-Partition column - CSV                                      3493           3514          30          4.5         222.1       3.1X
-Partition column - Json                                     8200           8367         236          1.9         521.3       1.3X
-Partition column - Parquet Vectorized: DataPageV1             29             36           7        543.6           1.8     378.6X
-Partition column - Parquet Vectorized: DataPageV2             28             35           7        560.2           1.8     390.2X
-Partition column - Parquet MR: DataPageV1                   1233           1255          31         12.8          78.4       8.9X
-Partition column - Parquet MR: DataPageV2                   1239           1248          13         12.7          78.8       8.8X
-Partition column - ORC Vectorized                             29             34           6        547.3           1.8     381.2X
-Partition column - ORC MR                                   1300           1304           5         12.1          82.6       8.4X
-Both columns - CSV                                         10899          10923          34          1.4         693.0       1.0X
-Both columns - Json                                         9755           9777          31          1.6         620.2       1.1X
-Both columns - Parquet Vectorized: DataPageV1                187            215          18         83.9          11.9      58.5X
-Both columns - Parquet Vectorized: DataPageV2                266            290          24         59.0          16.9      41.1X
-Both columns - Parquet MR: DataPageV1                       2368           2379          15          6.6         150.6       4.6X
-Both columns - Parquet MR: DataPageV2                       2315           2323          11          6.8         147.2       4.7X
-Both columns - ORC Vectorized                                181            210          27         86.8          11.5      60.4X
-Both columns - ORC MR                                       2214           2274          86          7.1         140.7       4.9X
+Data column - CSV                                          11247          11259          17          1.4         715.0       1.0X
+Data column - Json                                          9667           9668           2          1.6         614.6       1.2X
+Data column - Parquet Vectorized: DataPageV1                 108            120          10        145.9           6.9     104.3X
+Data column - Parquet Vectorized: DataPageV2                 225            241          14         70.0          14.3      50.0X
+Data column - Parquet MR: DataPageV1                        2495           2496           2          6.3         158.6       4.5X
+Data column - Parquet MR: DataPageV2                        2492           2508          24          6.3         158.4       4.5X
+Data column - ORC Vectorized                                 178            201          25         88.6          11.3      63.3X
+Data column - ORC MR                                        2099           2121          32          7.5         133.4       5.4X
+Partition column - CSV                                      3830           3831           2          4.1         243.5       2.9X
+Partition column - Json                                     9238           9241           4          1.7         587.4       1.2X
+Partition column - Parquet Vectorized: DataPageV1             30             42          11        533.0           1.9     381.1X
+Partition column - Parquet Vectorized: DataPageV2             28             34           7        563.1           1.8     402.7X
+Partition column - Parquet MR: DataPageV1                   1218           1240          30         12.9          77.5       9.2X
+Partition column - Parquet MR: DataPageV2                   1214           1224          14         13.0          77.2       9.3X
+Partition column - ORC Vectorized                             28             34           6        554.3           1.8     396.3X
+Partition column - ORC MR                                   1349           1361          16         11.7          85.8       8.3X
+Both columns - CSV                                         11136          11146          15          1.4         708.0       1.0X
+Both columns - Json                                        10111          10125          20          1.6         642.8       1.1X
+Both columns - Parquet Vectorized: DataPageV1                153            165          14        102.6           9.7      73.4X
+Both columns - Parquet Vectorized: DataPageV2                276            320          37         57.0          17.5      40.8X
+Both columns - Parquet MR: DataPageV1                       2626           2649          33          6.0         167.0       4.3X
+Both columns - Parquet MR: DataPageV2                       2559           2589          42          6.1         162.7       4.4X
+Both columns - ORC Vectorized                                193            203          13         81.5          12.3      58.3X
+Both columns - ORC MR                                       2224           2260          50          7.1         141.4       5.1X
 
 
 ================================================================================================
 String with Nulls Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 String with Nulls Scan (0.0%):            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            6979           7004          35          1.5         665.6       1.0X
-SQL Json                                           8795           8811          23          1.2         838.8       0.8X
-SQL Parquet Vectorized: DataPageV1                 1153           1174          30          9.1         110.0       6.1X
-SQL Parquet Vectorized: DataPageV2                 1419           1454          51          7.4         135.3       4.9X
-SQL Parquet MR: DataPageV1                         3349           3358          14          3.1         319.3       2.1X
-SQL Parquet MR: DataPageV2                         3710           3720          13          2.8         353.8       1.9X
-ParquetReader Vectorized: DataPageV1                788            795          10         13.3          75.2       8.9X
-ParquetReader Vectorized: DataPageV2               1033           1057          35         10.2          98.5       6.8X
-SQL ORC Vectorized                                  815            820           4         12.9          77.7       8.6X
-SQL ORC MR                                         2914           2955          58          3.6         277.9       2.4X
+SQL CSV                                            7230           7323         132          1.5         689.5       1.0X
+SQL Json                                           9219           9228          12          1.1         879.2       0.8X
+SQL Parquet Vectorized: DataPageV1                 1100           1130          42          9.5         104.9       6.6X
+SQL Parquet Vectorized: DataPageV2                 1394           1403          12          7.5         133.0       5.2X
+SQL Parquet MR: DataPageV1                         3277           3284          10          3.2         312.5       2.2X
+SQL Parquet MR: DataPageV2                         3383           3390          10          3.1         322.6       2.1X
+ParquetReader Vectorized: DataPageV1                751            760           8         14.0          71.6       9.6X
+ParquetReader Vectorized: DataPageV2               1055           1075          28          9.9         100.6       6.9X
+SQL ORC Vectorized                                  758            774          25         13.8          72.3       9.5X
+SQL ORC MR                                         2768           2783          22          3.8         264.0       2.6X
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 String with Nulls Scan (50.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            5379           5379           1          1.9         513.0       1.0X
-SQL Json                                           7512           7522          14          1.4         716.4       0.7X
-SQL Parquet Vectorized: DataPageV1                  766            773          10         13.7          73.1       7.0X
-SQL Parquet Vectorized: DataPageV2                  953            973          29         11.0          90.9       5.6X
-SQL Parquet MR: DataPageV1                         2627           2634          11          4.0         250.5       2.0X
-SQL Parquet MR: DataPageV2                         2857           2863           8          3.7         272.4       1.9X
-ParquetReader Vectorized: DataPageV1                686            701          22         15.3          65.4       7.8X
-ParquetReader Vectorized: DataPageV2                868            882          16         12.1          82.8       6.2X
-SQL ORC Vectorized                                  952            980          34         11.0          90.8       5.6X
-SQL ORC MR                                         2794           2796           3          3.8         266.4       1.9X
+SQL CSV                                            5476           5500          33          1.9         522.2       1.0X
+SQL Json                                           7780           7781           2          1.3         742.0       0.7X
+SQL Parquet Vectorized: DataPageV1                  709            735          30         14.8          67.6       7.7X
+SQL Parquet Vectorized: DataPageV2                  920            942          32         11.4          87.8       6.0X
+SQL Parquet MR: DataPageV1                         2805           2814          13          3.7         267.5       2.0X
+SQL Parquet MR: DataPageV2                         2849           2903          76          3.7         271.7       1.9X
+ParquetReader Vectorized: DataPageV1                691            692           2         15.2          65.9       7.9X
+ParquetReader Vectorized: DataPageV2                915            919           4         11.5          87.2       6.0X
+SQL ORC Vectorized                                  946            973          24         11.1          90.3       5.8X
+SQL ORC MR                                         2749           2749           0          3.8         262.2       2.0X
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 String with Nulls Scan (95.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            4196           4197           2          2.5         400.2       1.0X
-SQL Json                                           5466           5479          19          1.9         521.3       0.8X
-SQL Parquet Vectorized: DataPageV1                  156            159           4         67.2          14.9      26.9X
-SQL Parquet Vectorized: DataPageV2                  184            190           6         57.0          17.5      22.8X
-SQL Parquet MR: DataPageV1                         1656           1659           4          6.3         157.9       2.5X
-SQL Parquet MR: DataPageV2                         1604           1604           0          6.5         153.0       2.6X
-ParquetReader Vectorized: DataPageV1                163            164           1         64.5          15.5      25.8X
-ParquetReader Vectorized: DataPageV2                190            193           2         55.3          18.1      22.1X
-SQL ORC Vectorized                                  315            322           6         33.3          30.0      13.3X
-SQL ORC MR                                         1610           1615           6          6.5         153.6       2.6X
+SQL CSV                                            4258           4276          24          2.5         406.1       1.0X
+SQL Json                                           5410           5416           9          1.9         516.0       0.8X
+SQL Parquet Vectorized: DataPageV1                  151            155           5         69.3          14.4      28.2X
+SQL Parquet Vectorized: DataPageV2                  179            184           5         58.6          17.1      23.8X
+SQL Parquet MR: DataPageV1                         1612           1657          63          6.5         153.8       2.6X
+SQL Parquet MR: DataPageV2                         1585           1590           8          6.6         151.1       2.7X
+ParquetReader Vectorized: DataPageV1                163            166           4         64.5          15.5      26.2X
+ParquetReader Vectorized: DataPageV2                191            193           1         54.8          18.2      22.3X
+SQL ORC Vectorized                                  301            310           9         34.9          28.7      14.2X
+SQL ORC MR                                         1542           1543           1          6.8         147.1       2.8X
 
 
 ================================================================================================
 Single Column Scan From Wide Columns
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Single Column Scan from 10 columns:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            1157           1159           3          0.9        1103.2       1.0X
-SQL Json                                           1698           1702           5          0.6        1619.7       0.7X
-SQL Parquet Vectorized: DataPageV1                   24             29           6         43.3          23.1      47.8X
-SQL Parquet Vectorized: DataPageV2                   32             38           6         32.5          30.8      35.8X
-SQL Parquet MR: DataPageV1                          163            170           8          6.4         155.3       7.1X
-SQL Parquet MR: DataPageV2                          159            167           6          6.6         151.8       7.3X
-SQL ORC Vectorized                                   28             34           7         37.5          26.7      41.4X
-SQL ORC MR                                          130            136           6          8.1         123.8       8.9X
+SQL CSV                                            1341           1342           1          0.8        1278.9       1.0X
+SQL Json                                           1749           1760          16          0.6        1667.7       0.8X
+SQL Parquet Vectorized: DataPageV1                   23             28           6         45.1          22.2      57.6X
+SQL Parquet Vectorized: DataPageV2                   31             36           6         34.3          29.1      43.9X
+SQL Parquet MR: DataPageV1                          153            161           7          6.9         145.7       8.8X
+SQL Parquet MR: DataPageV2                          151            160           6          6.9         144.3       8.9X
+SQL ORC Vectorized                                   27             31           6         39.3          25.5      50.2X
+SQL ORC MR                                          131            138           9          8.0         124.5      10.3X
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Single Column Scan from 50 columns:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            2485           2523          55          0.4        2369.7       1.0X
-SQL Json                                           5915           5940          35          0.2        5641.2       0.4X
-SQL Parquet Vectorized: DataPageV1                   29             36           7         36.2          27.6      85.8X
-SQL Parquet Vectorized: DataPageV2                   35             39           6         30.2          33.1      71.6X
-SQL Parquet MR: DataPageV1                          168            173           4          6.2         160.0      14.8X
-SQL Parquet MR: DataPageV2                          164            175           8          6.4         156.2      15.2X
-SQL ORC Vectorized                                   32             35           5         33.1          30.2      78.5X
-SQL ORC MR                                          142            148           5          7.4         135.1      17.5X
+SQL CSV                                            2706           2724          26          0.4        2580.6       1.0X
+SQL Json                                           5370           5376           9          0.2        5121.3       0.5X
+SQL Parquet Vectorized: DataPageV1                   27             32           6         39.2          25.5     101.2X
+SQL Parquet Vectorized: DataPageV2                   34             40           7         30.5          32.8      78.6X
+SQL Parquet MR: DataPageV1                          156            162           6          6.7         149.0      17.3X
+SQL Parquet MR: DataPageV2                          155            166           8          6.8         147.9      17.5X
+SQL ORC Vectorized                                   30             34           5         35.2          28.4      90.9X
+SQL ORC MR                                          134            144           9          7.8         128.0      20.2X
 
-OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 21.0.3+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Single Column Scan from 100 columns:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            4100           4175         105          0.3        3910.5       1.0X
-SQL Json                                           9817           9951         190          0.1        9362.4       0.4X
-SQL Parquet Vectorized: DataPageV1                   34             45          10         31.0          32.2     121.4X
-SQL Parquet Vectorized: DataPageV2                   41             47           7         25.5          39.2      99.7X
-SQL Parquet MR: DataPageV1                          179            187           8          5.9         170.8      22.9X
-SQL Parquet MR: DataPageV2                          169            183          14          6.2         161.0      24.3X
-SQL ORC Vectorized                                   38             45           9         27.4          36.5     107.1X
-SQL ORC MR                                          143            146           3          7.3         136.1      28.7X
+SQL CSV                                            4390           4395           7          0.2        4187.0       1.0X
+SQL Json                                           9854           9936         116          0.1        9397.6       0.4X
+SQL Parquet Vectorized: DataPageV1                   34             39           7         30.7          32.5     128.7X
+SQL Parquet Vectorized: DataPageV2                   42             46           6         25.1          39.8     105.2X
+SQL Parquet MR: DataPageV1                          167            176           9          6.3         159.0      26.3X
+SQL Parquet MR: DataPageV2                          164            174           9          6.4         156.4      26.8X
+SQL ORC Vectorized                                   36             40           6         29.0          34.4     121.5X
+SQL ORC MR                                          141            147           7          7.4         134.3      31.2X
 
 

--- a/sql/core/benchmarks/DataSourceReadBenchmark-results.txt
+++ b/sql/core/benchmarks/DataSourceReadBenchmark-results.txt
@@ -1,431 +1,438 @@
-DataSourceReadBenchmark-jdk21-results.txt================================================================================================
+================================================================================================
 SQL Single Numeric Column Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single BOOLEAN Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           10363          10364           2          1.5         658.9       1.0X
-SQL Json                                           8667           8699          46          1.8         551.0       1.2X
-SQL Parquet Vectorized: DataPageV1                  103            114           8        153.3           6.5     101.0X
-SQL Parquet Vectorized: DataPageV2                  101            111           6        155.4           6.4     102.4X
-SQL Parquet MR: DataPageV1                         1809           1813           6          8.7         115.0       5.7X
-SQL Parquet MR: DataPageV2                         1715           1720           8          9.2         109.0       6.0X
-SQL ORC Vectorized                                  139            146           5        113.1           8.8      74.5X
-SQL ORC MR                                         1508           1511           5         10.4          95.8       6.9X
+SQL CSV                                           10854          10862          12          1.4         690.1       1.0X
+SQL Json                                           8728           8896         238          1.8         554.9       1.2X
+SQL Json with UnsafeRow                            9797           9841          62          1.6         622.9       1.1X
+SQL Parquet Vectorized: DataPageV1                  105            119           8        149.2           6.7     103.0X
+SQL Parquet Vectorized: DataPageV2                  108            115           6        146.2           6.8     100.9X
+SQL Parquet MR: DataPageV1                         1861           1872          16          8.5         118.3       5.8X
+SQL Parquet MR: DataPageV2                         1770           1771           1          8.9         112.5       6.1X
+SQL ORC Vectorized                                  147            154           3        107.2           9.3      74.0X
+SQL ORC MR                                         1650           1650           0          9.5         104.9       6.6X
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single BOOLEAN Column Scan:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                    88             90           2        178.9           5.6       1.0X
-ParquetReader Vectorized: DataPageV2                    95             96           1        166.2           6.0       0.9X
-ParquetReader Vectorized -> Row: DataPageV1             73             74           1        215.3           4.6       1.2X
-ParquetReader Vectorized -> Row: DataPageV2             81             83           1        193.1           5.2       1.1X
+ParquetReader Vectorized: DataPageV1                    96             97           1        163.7           6.1       1.0X
+ParquetReader Vectorized: DataPageV2                   102            104           4        154.4           6.5       0.9X
+ParquetReader Vectorized -> Row: DataPageV1             75             77           1        208.5           4.8       1.3X
+ParquetReader Vectorized -> Row: DataPageV2             82             83           2        192.8           5.2       1.2X
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single TINYINT Column Scan:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           11538          11589          73          1.4         733.5       1.0X
-SQL Json                                           9586           9596          14          1.6         609.5       1.2X
-SQL Parquet Vectorized: DataPageV1                  109            116           6        144.8           6.9     106.2X
-SQL Parquet Vectorized: DataPageV2                  110            118           8        142.6           7.0     104.6X
-SQL Parquet MR: DataPageV1                         1901           1953          74          8.3         120.9       6.1X
-SQL Parquet MR: DataPageV2                         1817           1832          22          8.7         115.5       6.4X
-SQL ORC Vectorized                                  118            126           7        133.6           7.5      98.0X
-SQL ORC MR                                         1505           1535          43         10.5          95.7       7.7X
+SQL CSV                                           10361          10395          48          1.5         658.7       1.0X
+SQL Json                                           9825           9848          32          1.6         624.7       1.1X
+SQL Json with UnsafeRow                           10692          10700          11          1.5         679.8       1.0X
+SQL Parquet Vectorized: DataPageV1                  108            115           6        145.6           6.9      95.9X
+SQL Parquet Vectorized: DataPageV2                  106            115           6        147.9           6.8      97.4X
+SQL Parquet MR: DataPageV1                         1924           1937          18          8.2         122.4       5.4X
+SQL Parquet MR: DataPageV2                         1841           1858          25          8.5         117.0       5.6X
+SQL ORC Vectorized                                  113            117           4        138.8           7.2      91.4X
+SQL ORC MR                                         1554           1564          14         10.1          98.8       6.7X
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single TINYINT Column Scan:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                    93             94           1        169.9           5.9       1.0X
-ParquetReader Vectorized: DataPageV2                    93             94           1        169.1           5.9       1.0X
-ParquetReader Vectorized -> Row: DataPageV1             61             62           1        258.0           3.9       1.5X
-ParquetReader Vectorized -> Row: DataPageV2             61             62           1        258.4           3.9       1.5X
+ParquetReader Vectorized: DataPageV1                    85             88           4        185.9           5.4       1.0X
+ParquetReader Vectorized: DataPageV2                    84             86           2        186.5           5.4       1.0X
+ParquetReader Vectorized -> Row: DataPageV1             62             64           1        252.7           4.0       1.4X
+ParquetReader Vectorized -> Row: DataPageV2             62             63           1        253.9           3.9       1.4X
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single SMALLINT Column Scan:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           12200          12203           5          1.3         775.7       1.0X
-SQL Json                                           9813           9854          57          1.6         623.9       1.2X
-SQL Parquet Vectorized: DataPageV1                  101            107           6        156.1           6.4     121.0X
-SQL Parquet Vectorized: DataPageV2                  129            135           6        122.3           8.2      94.9X
-SQL Parquet MR: DataPageV1                         1968           1989          29          8.0         125.1       6.2X
-SQL Parquet MR: DataPageV2                         1913           1916           3          8.2         121.6       6.4X
-SQL ORC Vectorized                                  130            135           6        120.8           8.3      93.7X
-SQL ORC MR                                         1593           1600          10          9.9         101.3       7.7X
+SQL CSV                                           10958          10970          18          1.4         696.7       1.0X
+SQL Json                                          10164          10169           7          1.5         646.2       1.1X
+SQL Json with UnsafeRow                           11113          11137          33          1.4         706.5       1.0X
+SQL Parquet Vectorized: DataPageV1                  110            116           6        142.8           7.0      99.5X
+SQL Parquet Vectorized: DataPageV2                  131            136           3        120.3           8.3      83.8X
+SQL Parquet MR: DataPageV1                         2110           2116           8          7.5         134.2       5.2X
+SQL Parquet MR: DataPageV2                         2044           2061          23          7.7         130.0       5.4X
+SQL ORC Vectorized                                  130            137           5        121.2           8.2      84.5X
+SQL ORC MR                                         1813           1834          31          8.7         115.2       6.0X
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single SMALLINT Column Scan:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                   138            140           2        113.9           8.8       1.0X
-ParquetReader Vectorized: DataPageV2                   166            168           3         94.8          10.6       0.8X
-ParquetReader Vectorized -> Row: DataPageV1            136            138           6        115.6           8.6       1.0X
-ParquetReader Vectorized -> Row: DataPageV2            164            166           2         96.1          10.4       0.8X
+ParquetReader Vectorized: DataPageV1                   155            158           2        101.3           9.9       1.0X
+ParquetReader Vectorized: DataPageV2                   172            174           3         91.4          10.9       0.9X
+ParquetReader Vectorized -> Row: DataPageV1            148            150           2        106.0           9.4       1.0X
+ParquetReader Vectorized -> Row: DataPageV2            165            166           1         95.5          10.5       0.9X
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single INT Column Scan:               Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           13361          13368           9          1.2         849.5       1.0X
-SQL Json                                          10099          10118          27          1.6         642.1       1.3X
-SQL Parquet Vectorized: DataPageV1                  108            131          29        145.0           6.9     123.2X
-SQL Parquet Vectorized: DataPageV2                  177            185           7         88.9          11.3      75.5X
-SQL Parquet MR: DataPageV1                         2031           2083          74          7.7         129.1       6.6X
-SQL Parquet MR: DataPageV2                         2022           2026           5          7.8         128.6       6.6X
-SQL ORC Vectorized                                  146            151           4        107.7           9.3      91.5X
-SQL ORC MR                                         1642           1642           0          9.6         104.4       8.1X
+SQL CSV                                           12062          12063           1          1.3         766.9       1.0X
+SQL Json                                          10430          10455          36          1.5         663.1       1.2X
+SQL Json with UnsafeRow                           11379          11381           4          1.4         723.5       1.1X
+SQL Parquet Vectorized: DataPageV1                  102            108           4        154.0           6.5     118.1X
+SQL Parquet Vectorized: DataPageV2                  175            181           4         90.1          11.1      69.1X
+SQL Parquet MR: DataPageV1                         2106           2117          16          7.5         133.9       5.7X
+SQL Parquet MR: DataPageV2                         2044           2051           9          7.7         130.0       5.9X
+SQL ORC Vectorized                                  141            150          13        111.7           8.9      85.7X
+SQL ORC MR                                         1797           1798           1          8.8         114.3       6.7X
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single INT Column Scan:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                   141            143           2        111.9           8.9       1.0X
-ParquetReader Vectorized: DataPageV2                   209            210           1         75.3          13.3       0.7X
-ParquetReader Vectorized -> Row: DataPageV1            138            140           2        113.9           8.8       1.0X
-ParquetReader Vectorized -> Row: DataPageV2            207            210           7         76.1          13.1       0.7X
+ParquetReader Vectorized: DataPageV1                   145            147           1        108.3           9.2       1.0X
+ParquetReader Vectorized: DataPageV2                   219            221           2         71.9          13.9       0.7X
+ParquetReader Vectorized -> Row: DataPageV1            138            141           3        113.6           8.8       1.0X
+ParquetReader Vectorized -> Row: DataPageV2            212            215           3         74.1          13.5       0.7X
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single BIGINT Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           13316          13326          13          1.2         846.6       1.0X
-SQL Json                                           9808           9885         109          1.6         623.6       1.4X
-SQL Parquet Vectorized: DataPageV1                  290            293           3         54.3          18.4      46.0X
-SQL Parquet Vectorized: DataPageV2                  235            238           3         66.9          14.9      56.6X
-SQL Parquet MR: DataPageV1                         2404           2409           7          6.5         152.9       5.5X
-SQL Parquet MR: DataPageV2                         2007           2030          33          7.8         127.6       6.6X
-SQL ORC Vectorized                                  150            153           3        104.8           9.5      88.7X
-SQL ORC MR                                         1625           1634          13          9.7         103.3       8.2X
+SQL CSV                                           12027          12040          18          1.3         764.7       1.0X
+SQL Json                                          10400          10419          27          1.5         661.2       1.2X
+SQL Json with UnsafeRow                           11274          11284          14          1.4         716.8       1.1X
+SQL Parquet Vectorized: DataPageV1                  279            282           2         56.4          17.7      43.1X
+SQL Parquet Vectorized: DataPageV2                  175            180           3         89.6          11.2      68.5X
+SQL Parquet MR: DataPageV1                         2508           2510           3          6.3         159.4       4.8X
+SQL Parquet MR: DataPageV2                         2093           2125          45          7.5         133.0       5.7X
+SQL ORC Vectorized                                  152            157           3        103.2           9.7      78.9X
+SQL ORC MR                                         1849           1861          17          8.5         117.5       6.5X
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single BIGINT Column Scan:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                   334            335           2         47.1          21.2       1.0X
-ParquetReader Vectorized: DataPageV2                   277            279           2         56.9          17.6       1.2X
-ParquetReader Vectorized -> Row: DataPageV1            351            355           3         44.8          22.3       1.0X
-ParquetReader Vectorized -> Row: DataPageV2            297            303           7         52.9          18.9       1.1X
+ParquetReader Vectorized: DataPageV1                   322            324           2         48.9          20.5       1.0X
+ParquetReader Vectorized: DataPageV2                   215            218           2         73.1          13.7       1.5X
+ParquetReader Vectorized -> Row: DataPageV1            338            341           2         46.5          21.5       1.0X
+ParquetReader Vectorized -> Row: DataPageV2            234            235           2         67.3          14.9       1.4X
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single FLOAT Column Scan:             Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           13826          13835          13          1.1         879.0       1.0X
-SQL Json                                          11577          11606          40          1.4         736.1       1.2X
-SQL Parquet Vectorized: DataPageV1                   87            103          11        181.0           5.5     159.1X
-SQL Parquet Vectorized: DataPageV2                   88            101           7        178.8           5.6     157.2X
-SQL Parquet MR: DataPageV1                         2072           2075           4          7.6         131.7       6.7X
-SQL Parquet MR: DataPageV2                         2075           2087          17          7.6         131.9       6.7X
-SQL ORC Vectorized                                  261            273          10         60.2          16.6      52.9X
-SQL ORC MR                                         1720           1726           8          9.1         109.4       8.0X
+SQL CSV                                           12458          12497          55          1.3         792.1       1.0X
+SQL Json                                          12317          12326          13          1.3         783.1       1.0X
+SQL Json with UnsafeRow                           13080          13087           9          1.2         831.6       1.0X
+SQL Parquet Vectorized: DataPageV1                   85             91           3        184.7           5.4     146.3X
+SQL Parquet Vectorized: DataPageV2                   86             89           3        183.8           5.4     145.6X
+SQL Parquet MR: DataPageV1                         2126           2154          40          7.4         135.2       5.9X
+SQL Parquet MR: DataPageV2                         2050           2084          48          7.7         130.4       6.1X
+SQL ORC Vectorized                                  240            251           8         65.5          15.3      51.9X
+SQL ORC MR                                         1944           1954          13          8.1         123.6       6.4X
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single FLOAT Column Scan:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                   135            138           5        116.9           8.6       1.0X
-ParquetReader Vectorized: DataPageV2                   134            135           2        117.7           8.5       1.0X
-ParquetReader Vectorized -> Row: DataPageV1            149            155           5        105.3           9.5       0.9X
-ParquetReader Vectorized -> Row: DataPageV2            133            140          11        118.4           8.4       1.0X
+ParquetReader Vectorized: DataPageV1                   140            142           1        112.2           8.9       1.0X
+ParquetReader Vectorized: DataPageV2                   140            142           1        112.3           8.9       1.0X
+ParquetReader Vectorized -> Row: DataPageV1            134            136           2        117.3           8.5       1.0X
+ParquetReader Vectorized -> Row: DataPageV2            135            137           2        116.7           8.6       1.0X
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single DOUBLE Column Scan:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           14086          14095          13          1.1         895.6       1.0X
-SQL Json                                          11716          11726          14          1.3         744.9       1.2X
-SQL Parquet Vectorized: DataPageV1                  280            291           8         56.2          17.8      50.3X
-SQL Parquet Vectorized: DataPageV2                  282            287           4         55.8          17.9      50.0X
-SQL Parquet MR: DataPageV1                         2479           2498          27          6.3         157.6       5.7X
-SQL Parquet MR: DataPageV2                         2492           2509          23          6.3         158.4       5.7X
-SQL ORC Vectorized                                  622            628           7         25.3          39.5      22.6X
-SQL ORC MR                                         2084           2093          14          7.5         132.5       6.8X
+SQL CSV                                           12683          12695          16          1.2         806.4       1.0X
+SQL Json                                          12559          12560           1          1.3         798.5       1.0X
+SQL Json with UnsafeRow                           13265          13265           0          1.2         843.4       1.0X
+SQL Parquet Vectorized: DataPageV1                  270            273           3         58.2          17.2      46.9X
+SQL Parquet Vectorized: DataPageV2                  265            269           3         59.4          16.8      47.9X
+SQL Parquet MR: DataPageV1                         2525           2525           0          6.2         160.5       5.0X
+SQL Parquet MR: DataPageV2                         2419           2422           4          6.5         153.8       5.2X
+SQL ORC Vectorized                                  604            607           2         26.1          38.4      21.0X
+SQL ORC MR                                         2440           2448          11          6.4         155.1       5.2X
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Parquet Reader Single DOUBLE Column Scan:    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-ParquetReader Vectorized: DataPageV1                   346            348           2         45.4          22.0       1.0X
-ParquetReader Vectorized: DataPageV2                   347            349           4         45.4          22.0       1.0X
-ParquetReader Vectorized -> Row: DataPageV1            355            358           4         44.3          22.6       1.0X
-ParquetReader Vectorized -> Row: DataPageV2            354            357           5         44.4          22.5       1.0X
+ParquetReader Vectorized: DataPageV1                   339            344           5         46.3          21.6       1.0X
+ParquetReader Vectorized: DataPageV2                   339            340           1         46.4          21.6       1.0X
+ParquetReader Vectorized -> Row: DataPageV1            341            344           3         46.1          21.7       1.0X
+ParquetReader Vectorized -> Row: DataPageV2            339            340           1         46.4          21.6       1.0X
 
 
 ================================================================================================
 SQL Single Numeric Column Scan in Struct
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single TINYINT Column Scan in Struct:                    Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2210           2239          41          7.1         140.5       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2196           2226          43          7.2         139.6       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                             106            138          35        148.1           6.8      20.8X
-SQL Parquet MR: DataPageV1                                            2436           2446          14          6.5         154.9       0.9X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2790           2819          40          5.6         177.4       0.8X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             107            113           7        146.4           6.8      20.6X
-SQL Parquet MR: DataPageV2                                            2308           2310           4          6.8         146.7       1.0X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2855           2862           9          5.5         181.5       0.8X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             125            137          11        125.9           7.9      17.7X
+SQL ORC MR                                                            2261           2269          12          7.0         143.7       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           2265           2267           3          6.9         144.0       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             125            133           5        125.5           8.0      18.0X
+SQL Parquet MR: DataPageV1                                            2387           2388           1          6.6         151.8       0.9X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2751           2758          10          5.7         174.9       0.8X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             111            119           6        141.9           7.0      20.4X
+SQL Parquet MR: DataPageV2                                            2373           2406          47          6.6         150.9       1.0X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2702           2713          16          5.8         171.8       0.8X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             112            118           5        140.0           7.1      20.1X
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single SMALLINT Column Scan in Struct:                   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2174           2175           2          7.2         138.2       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2170           2183          19          7.2         137.9       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                             272            279           7         57.7          17.3       8.0X
-SQL Parquet MR: DataPageV1                                            2539           2547          11          6.2         161.4       0.9X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2723           2741          25          5.8         173.1       0.8X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             131            140           8        119.7           8.4      16.5X
-SQL Parquet MR: DataPageV2                                            2430           2430           0          6.5         154.5       0.9X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2748           2749           2          5.7         174.7       0.8X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             244            254           8         64.4          15.5       8.9X
+SQL ORC MR                                                            2281           2325          62          6.9         145.0       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           2273           2278           6          6.9         144.5       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             271            280           8         58.1          17.2       8.4X
+SQL Parquet MR: DataPageV1                                            2540           2544           6          6.2         161.5       0.9X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2950           2951           1          5.3         187.5       0.8X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             116            119           3        135.8           7.4      19.7X
+SQL Parquet MR: DataPageV2                                            2389           2396          10          6.6         151.9       1.0X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2851           2855           7          5.5         181.2       0.8X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             158            162           3         99.8          10.0      14.5X
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single INT Column Scan in Struct:                        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2156           2188          46          7.3         137.1       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2176           2228          73          7.2         138.4       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                             272            295          19         57.8          17.3       7.9X
-SQL Parquet MR: DataPageV1                                            2542           2544           3          6.2         161.6       0.8X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2963           2973          14          5.3         188.4       0.7X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             135            144           9        116.8           8.6      16.0X
-SQL Parquet MR: DataPageV2                                            2393           2412          28          6.6         152.1       0.9X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2939           2942           4          5.4         186.9       0.7X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             267            275           7         58.9          17.0       8.1X
+SQL ORC MR                                                            2315           2399         118          6.8         147.2       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           2310           2319          12          6.8         146.9       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             272            278           7         57.9          17.3       8.5X
+SQL Parquet MR: DataPageV1                                            2370           2407          52          6.6         150.7       1.0X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2834           2837           5          5.6         180.2       0.8X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             125            128           3        125.6           8.0      18.5X
+SQL Parquet MR: DataPageV2                                            2343           2400          80          6.7         149.0       1.0X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2742           2755          18          5.7         174.4       0.8X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             269            274           4         58.4          17.1       8.6X
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single BIGINT Column Scan in Struct:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2236           2261          35          7.0         142.2       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2212           2256          63          7.1         140.6       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                             279            294          17         56.3          17.8       8.0X
-SQL Parquet MR: DataPageV1                                            2785           2796          15          5.6         177.1       0.8X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           3213           3327         162          4.9         204.3       0.7X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             308            321          10         51.1          19.6       7.3X
-SQL Parquet MR: DataPageV2                                            2454           2496          59          6.4         156.0       0.9X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2719           2744          36          5.8         172.9       0.8X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             278            285           3         56.6          17.7       8.0X
+SQL ORC MR                                                            2305           2340          49          6.8         146.5       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           2317           2322           7          6.8         147.3       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             275            284           7         57.3          17.5       8.4X
+SQL Parquet MR: DataPageV1                                            2882           2899          25          5.5         183.2       0.8X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           3541           3583          59          4.4         225.1       0.7X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             286            295           5         54.9          18.2       8.0X
+SQL Parquet MR: DataPageV2                                            2548           2622         105          6.2         162.0       0.9X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2900           2904           6          5.4         184.4       0.8X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             182            185           3         86.2          11.6      12.6X
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single FLOAT Column Scan in Struct:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2286           2327          57          6.9         145.4       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2290           2299          13          6.9         145.6       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                             356            385          18         44.2          22.6       6.4X
-SQL Parquet MR: DataPageV1                                            2374           2410          51          6.6         150.9       1.0X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           3159           3169          14          5.0         200.8       0.7X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             103            122          14        153.3           6.5      22.3X
-SQL Parquet MR: DataPageV2                                            2446           2456          14          6.4         155.5       0.9X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           3008           3010           3          5.2         191.3       0.8X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)              93            107          10        169.1           5.9      24.6X
+SQL ORC MR                                                            2313           2359          64          6.8         147.1       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           2371           2401          43          6.6         150.7       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             347            358          10         45.3          22.1       6.7X
+SQL Parquet MR: DataPageV1                                            2414           2449          49          6.5         153.5       1.0X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           2846           2858          16          5.5         181.0       0.8X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)              94            106          11        166.6           6.0      24.5X
+SQL Parquet MR: DataPageV2                                            2359           2403          63          6.7         150.0       1.0X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           2750           2760          14          5.7         174.8       0.8X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)              93            100           7        169.7           5.9      25.0X
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Single DOUBLE Column Scan in Struct:                     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                            2626           2658          45          6.0         167.0       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                           2738           2746          11          5.7         174.1       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                             778            779           1         20.2          49.5       3.4X
-SQL Parquet MR: DataPageV1                                            2911           2911           1          5.4         185.0       0.9X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           3340           3354          19          4.7         212.4       0.8X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             298            310           9         52.7          19.0       8.8X
-SQL Parquet MR: DataPageV2                                            2959           2966          11          5.3         188.1       0.9X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           3281           3289          10          4.8         208.6       0.8X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             297            305           8         52.9          18.9       8.8X
+SQL ORC MR                                                            2822           2901         112          5.6         179.4       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                           2829           2857          40          5.6         179.9       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                             754            760           7         20.8          48.0       3.7X
+SQL Parquet MR: DataPageV1                                            2869           2926          81          5.5         182.4       1.0X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           3425           3426           2          4.6         217.7       0.8X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)             277            283           5         56.8          17.6      10.2X
+SQL Parquet MR: DataPageV2                                            2936           2938           3          5.4         186.7       1.0X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           3321           3325           7          4.7         211.1       0.8X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)             286            293           6         54.9          18.2       9.9X
 
 
 ================================================================================================
 SQL Nested Column Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 SQL Nested Column Scan:                                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 -------------------------------------------------------------------------------------------------------------------------------------------
-SQL ORC MR                                                           13102          13223         110          0.1       12495.0       1.0X
-SQL ORC Vectorized (Nested Column Disabled)                          12894          13024         101          0.1       12296.2       1.0X
-SQL ORC Vectorized (Nested Column Enabled)                            7180           7220          36          0.1        6847.0       1.8X
-SQL Parquet MR: DataPageV1                                            8625           8658          23          0.1        8225.2       1.5X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           9197           9324          94          0.1        8771.2       1.4X
-SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)            5862           6041          81          0.2        5590.5       2.2X
-SQL Parquet MR: DataPageV2                                            9564           9731         184          0.1        9120.6       1.4X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           9814           9865          50          0.1        9359.5       1.3X
-SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)            5651           5735          38          0.2        5389.3       2.3X
+SQL ORC MR                                                           13594          13772         227          0.1       12964.0       1.0X
+SQL ORC Vectorized (Nested Column Disabled)                          13494          13741         198          0.1       12869.2       1.0X
+SQL ORC Vectorized (Nested Column Enabled)                            7230           7257          19          0.1        6895.2       1.9X
+SQL Parquet MR: DataPageV1                                            8787           8812          31          0.1        8379.7       1.5X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Disabled)           9165           9226          34          0.1        8740.6       1.5X
+SQL Parquet Vectorized: DataPageV1 (Nested Column Enabled)            5807           5843          23          0.2        5538.3       2.3X
+SQL Parquet MR: DataPageV2                                            9607           9651          30          0.1        9161.9       1.4X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Disabled)           9961           9991          27          0.1        9499.6       1.4X
+SQL Parquet Vectorized: DataPageV2 (Nested Column Enabled)            5624           5650          17          0.2        5363.2       2.4X
 
 
 ================================================================================================
 Int and String Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Int and String Scan:                      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                           12381          12387           8          0.8        1180.8       1.0X
-SQL Json                                          10369          10422          75          1.0         988.8       1.2X
-SQL Parquet Vectorized: DataPageV1                 1801           1809          12          5.8         171.8       6.9X
-SQL Parquet Vectorized: DataPageV2                 2010           2024          21          5.2         191.7       6.2X
-SQL Parquet MR: DataPageV1                         3932           3944          16          2.7         375.0       3.1X
-SQL Parquet MR: DataPageV2                         4029           4043          20          2.6         384.2       3.1X
-SQL ORC Vectorized                                 1838           1839           2          5.7         175.3       6.7X
-SQL ORC MR                                         3529           3549          28          3.0         336.5       3.5X
+SQL CSV                                           11004          11110         151          1.0        1049.4       1.0X
+SQL Json                                          10865          10875          15          1.0        1036.1       1.0X
+SQL Parquet Vectorized: DataPageV1                 1790           1804          20          5.9         170.7       6.1X
+SQL Parquet Vectorized: DataPageV2                 1907           1910           4          5.5         181.9       5.8X
+SQL Parquet MR: DataPageV1                         4100           4124          35          2.6         391.0       2.7X
+SQL Parquet MR: DataPageV2                         4108           4113           7          2.6         391.8       2.7X
+SQL ORC Vectorized                                 1839           1848          13          5.7         175.4       6.0X
+SQL ORC MR                                         3844           3846           4          2.7         366.5       2.9X
 
 
 ================================================================================================
 Repeated String Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Repeated String:                          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            7396           7452          80          1.4         705.4       1.0X
-SQL Json                                           6836           6847          14          1.5         652.0       1.1X
-SQL Parquet Vectorized: DataPageV1                  468            474           5         22.4          44.6      15.8X
-SQL Parquet Vectorized: DataPageV2                  458            475          12         22.9          43.7      16.1X
-SQL Parquet MR: DataPageV1                         1621           1625           4          6.5         154.6       4.6X
-SQL Parquet MR: DataPageV2                         1645           1654          13          6.4         156.8       4.5X
-SQL ORC Vectorized                                  390            395           3         26.9          37.2      19.0X
-SQL ORC MR                                         1787           1791           5          5.9         170.4       4.1X
+SQL CSV                                            6465           6473          12          1.6         616.5       1.0X
+SQL Json                                           7466           7469           4          1.4         712.0       0.9X
+SQL Parquet Vectorized: DataPageV1                  481            494          11         21.8          45.8      13.4X
+SQL Parquet Vectorized: DataPageV2                  484            491           9         21.7          46.2      13.3X
+SQL Parquet MR: DataPageV1                         1756           1757           1          6.0         167.5       3.7X
+SQL Parquet MR: DataPageV2                         1737           1739           3          6.0         165.6       3.7X
+SQL ORC Vectorized                                  398            404           4         26.3          38.0      16.2X
+SQL ORC MR                                         1974           1980           8          5.3         188.3       3.3X
 
 
 ================================================================================================
 Partitioned Table Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Partitioned Table:                                 Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------------
-Data column - CSV                                          13711          13750          55          1.1         871.7       1.0X
-Data column - Json                                          9919           9951          44          1.6         630.7       1.4X
-Data column - Parquet Vectorized: DataPageV1                 111            130          16        142.2           7.0     124.0X
-Data column - Parquet Vectorized: DataPageV2                 259            274           9         60.7          16.5      52.9X
-Data column - Parquet MR: DataPageV1                        2372           2381          13          6.6         150.8       5.8X
-Data column - Parquet MR: DataPageV2                        2337           2339           4          6.7         148.6       5.9X
-Data column - ORC Vectorized                                 139            162          16        113.0           8.9      98.5X
-Data column - ORC MR                                        2068           2078          15          7.6         131.4       6.6X
-Partition column - CSV                                      3797           3846          69          4.1         241.4       3.6X
-Partition column - Json                                     8388           8396          10          1.9         533.3       1.6X
-Partition column - Parquet Vectorized: DataPageV1             32             35           4        498.4           2.0     434.5X
-Partition column - Parquet Vectorized: DataPageV2             31             35           4        500.3           2.0     436.1X
-Partition column - Parquet MR: DataPageV1                   1241           1242           1         12.7          78.9      11.1X
-Partition column - Parquet MR: DataPageV2                   1222           1224           3         12.9          77.7      11.2X
-Partition column - ORC Vectorized                             30             33           3        531.0           1.9     462.9X
-Partition column - ORC MR                                   1232           1241          13         12.8          78.3      11.1X
-Both columns - CSV                                         13510          13516           9          1.2         858.9       1.0X
-Both columns - Json                                        10324          10374          71          1.5         656.4       1.3X
-Both columns - Parquet Vectorized: DataPageV1                121            144          18        130.3           7.7     113.6X
-Both columns - Parquet Vectorized: DataPageV2                259            274          16         60.8          16.4      53.0X
-Both columns - Parquet MR: DataPageV1                       2338           2356          25          6.7         148.7       5.9X
-Both columns - Parquet MR: DataPageV2                       2320           2322           2          6.8         147.5       5.9X
-Both columns - ORC Vectorized                                177            193          17         89.1          11.2      77.7X
-Both columns - ORC MR                                       2109           2135          36          7.5         134.1       6.5X
+Data column - CSV                                          12344          12372          40          1.3         784.8       1.0X
+Data column - Json                                         10569          10573           6          1.5         671.9       1.2X
+Data column - Parquet Vectorized: DataPageV1                 105            126          19        150.2           6.7     117.9X
+Data column - Parquet Vectorized: DataPageV2                 244            252           6         64.5          15.5      50.6X
+Data column - Parquet MR: DataPageV1                        2438           2453          22          6.5         155.0       5.1X
+Data column - Parquet MR: DataPageV2                        2304           2307           3          6.8         146.5       5.4X
+Data column - ORC Vectorized                                 154            162          10        102.5           9.8      80.4X
+Data column - ORC MR                                        2123           2130          10          7.4         135.0       5.8X
+Partition column - CSV                                      4053           4135         116          3.9         257.7       3.0X
+Partition column - Json                                     8918           8937          27          1.8         567.0       1.4X
+Partition column - Parquet Vectorized: DataPageV1             35             38           3        447.3           2.2     351.0X
+Partition column - Parquet Vectorized: DataPageV2             34             38           4        464.2           2.2     364.3X
+Partition column - Parquet MR: DataPageV1                   1270           1270           0         12.4          80.7       9.7X
+Partition column - Parquet MR: DataPageV2                   1258           1266          12         12.5          80.0       9.8X
+Partition column - ORC Vectorized                             36             41           4        442.9           2.3     347.6X
+Partition column - ORC MR                                   1297           1300           5         12.1          82.4       9.5X
+Both columns - CSV                                         11984          12065         116          1.3         761.9       1.0X
+Both columns - Json                                        11067          11120          76          1.4         703.6       1.1X
+Both columns - Parquet Vectorized: DataPageV1                144            157          11        109.3           9.2      85.8X
+Both columns - Parquet Vectorized: DataPageV2                305            322           9         51.6          19.4      40.5X
+Both columns - Parquet MR: DataPageV1                       2656           2668          17          5.9         168.9       4.6X
+Both columns - Parquet MR: DataPageV2                       2604           2631          38          6.0         165.6       4.7X
+Both columns - ORC Vectorized                                185            221          24         85.1          11.8      66.8X
+Both columns - ORC MR                                       2222           2233          17          7.1         141.2       5.6X
 
 
 ================================================================================================
 String with Nulls Scan
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 String with Nulls Scan (0.0%):            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            8866           8885          26          1.2         845.5       1.0X
-SQL Json                                           9201           9207           8          1.1         877.5       1.0X
-SQL Parquet Vectorized: DataPageV1                 1286           1291           6          8.2         122.7       6.9X
-SQL Parquet Vectorized: DataPageV2                 1554           1566          17          6.7         148.2       5.7X
-SQL Parquet MR: DataPageV1                         3482           3506          34          3.0         332.1       2.5X
-SQL Parquet MR: DataPageV2                         3607           3635          40          2.9         344.0       2.5X
-ParquetReader Vectorized: DataPageV1                792            794           2         13.2          75.5      11.2X
-ParquetReader Vectorized: DataPageV2               1116           1123          10          9.4         106.5       7.9X
-SQL ORC Vectorized                                  912            934          20         11.5          87.0       9.7X
-SQL ORC MR                                         2987           3000          18          3.5         284.9       3.0X
+SQL CSV                                            7865           7883          26          1.3         750.1       1.0X
+SQL Json                                           9607           9625          26          1.1         916.2       0.8X
+SQL Parquet Vectorized: DataPageV1                 1269           1282          17          8.3         121.1       6.2X
+SQL Parquet Vectorized: DataPageV2                 1373           1378           7          7.6         130.9       5.7X
+SQL Parquet MR: DataPageV1                         3515           3519           6          3.0         335.2       2.2X
+SQL Parquet MR: DataPageV2                         3705           3720          22          2.8         353.3       2.1X
+ParquetReader Vectorized: DataPageV1                819            825           6         12.8          78.1       9.6X
+ParquetReader Vectorized: DataPageV2                891            892           2         11.8          84.9       8.8X
+SQL ORC Vectorized                                  927            935           8         11.3          88.4       8.5X
+SQL ORC MR                                         3000           3018          26          3.5         286.1       2.6X
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 String with Nulls Scan (50.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            6247           6258          16          1.7         595.8       1.0X
-SQL Json                                           7887           7902          22          1.3         752.1       0.8X
-SQL Parquet Vectorized: DataPageV1                  824            836          19         12.7          78.5       7.6X
-SQL Parquet Vectorized: DataPageV2                 1027           1033          10         10.2          97.9       6.1X
-SQL Parquet MR: DataPageV1                         2799           2799           0          3.7         266.9       2.2X
-SQL Parquet MR: DataPageV2                         2883           2893          15          3.6         274.9       2.2X
-ParquetReader Vectorized: DataPageV1                740            741           1         14.2          70.6       8.4X
-ParquetReader Vectorized: DataPageV2                905            906           1         11.6          86.3       6.9X
-SQL ORC Vectorized                                  983            986           3         10.7          93.8       6.4X
-SQL ORC MR                                         2738           2741           4          3.8         261.1       2.3X
+SQL CSV                                            5928           5949          30          1.8         565.3       1.0X
+SQL Json                                           8205           8210           6          1.3         782.5       0.7X
+SQL Parquet Vectorized: DataPageV1                  862            887          22         12.2          82.2       6.9X
+SQL Parquet Vectorized: DataPageV2                  911            932          19         11.5          86.9       6.5X
+SQL Parquet MR: DataPageV1                         3011           3016           7          3.5         287.1       2.0X
+SQL Parquet MR: DataPageV2                         3182           3190          11          3.3         303.5       1.9X
+ParquetReader Vectorized: DataPageV1                758            766           8         13.8          72.2       7.8X
+ParquetReader Vectorized: DataPageV2                826            833           8         12.7          78.8       7.2X
+SQL ORC Vectorized                                  970            971           2         10.8          92.5       6.1X
+SQL ORC MR                                         2809           2817          10          3.7         267.9       2.1X
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 String with Nulls Scan (95.0%):           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            4395           4398           4          2.4         419.2       1.0X
-SQL Json                                           5649           5663          20          1.9         538.7       0.8X
-SQL Parquet Vectorized: DataPageV1                  164            170           7         64.1          15.6      26.9X
-SQL Parquet Vectorized: DataPageV2                  186            190           4         56.4          17.7      23.6X
-SQL Parquet MR: DataPageV1                         1769           1771           2          5.9         168.7       2.5X
-SQL Parquet MR: DataPageV2                         1721           1730          13          6.1         164.2       2.6X
-ParquetReader Vectorized: DataPageV1                169            170           2         62.1          16.1      26.0X
-ParquetReader Vectorized: DataPageV2                193            195           2         54.3          18.4      22.8X
-SQL ORC Vectorized                                  313            316           3         33.5          29.9      14.0X
-SQL ORC MR                                         1580           1592          18          6.6         150.6       2.8X
+SQL CSV                                            4372           4394          31          2.4         416.9       1.0X
+SQL Json                                           5965           5967           2          1.8         568.9       0.7X
+SQL Parquet Vectorized: DataPageV1                  166            173           5         63.3          15.8      26.4X
+SQL Parquet Vectorized: DataPageV2                  179            184           4         58.5          17.1      24.4X
+SQL Parquet MR: DataPageV1                         1841           1842           1          5.7         175.6       2.4X
+SQL Parquet MR: DataPageV2                         1834           1838           4          5.7         174.9       2.4X
+ParquetReader Vectorized: DataPageV1                171            173           4         61.5          16.3      25.6X
+ParquetReader Vectorized: DataPageV2                184            185           1         57.0          17.5      23.8X
+SQL ORC Vectorized                                  299            301           3         35.1          28.5      14.6X
+SQL ORC MR                                         1618           1624           9          6.5         154.3       2.7X
 
 
 ================================================================================================
 Single Column Scan From Wide Columns
 ================================================================================================
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Single Column Scan from 10 columns:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            1197           1198           1          0.9        1141.7       1.0X
-SQL Json                                           1855           1857           3          0.6        1769.2       0.6X
-SQL Parquet Vectorized: DataPageV1                   25             29           4         41.4          24.2      47.3X
-SQL Parquet Vectorized: DataPageV2                   34             37           5         30.9          32.4      35.2X
-SQL Parquet MR: DataPageV1                          160            167           6          6.6         152.7       7.5X
-SQL Parquet MR: DataPageV2                          154            158           4          6.8         146.7       7.8X
-SQL ORC Vectorized                                   29             32           3         36.6          27.3      41.8X
-SQL ORC MR                                          135            148          37          7.8         128.3       8.9X
+SQL CSV                                            1285           1287           3          0.8        1225.1       1.0X
+SQL Json                                           1771           1772           2          0.6        1689.1       0.7X
+SQL Parquet Vectorized: DataPageV1                   27             32           4         38.2          26.2      46.8X
+SQL Parquet Vectorized: DataPageV2                   37             40           3         28.4          35.2      34.8X
+SQL Parquet MR: DataPageV1                          178            182           5          5.9         169.6       7.2X
+SQL Parquet MR: DataPageV2                          176            180           2          6.0         167.9       7.3X
+SQL ORC Vectorized                                   31             34           4         33.9          29.5      41.5X
+SQL ORC MR                                          136            145           8          7.7         129.8       9.4X
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Single Column Scan from 50 columns:       Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            2630           2651          29          0.4        2508.3       1.0X
-SQL Json                                           6628           6696          96          0.2        6321.0       0.4X
-SQL Parquet Vectorized: DataPageV1                   29             33           4         36.2          27.6      90.8X
-SQL Parquet Vectorized: DataPageV2                   38             41           4         27.7          36.1      69.4X
-SQL Parquet MR: DataPageV1                          164            167           2          6.4         156.9      16.0X
-SQL Parquet MR: DataPageV2                          160            165           4          6.5         152.9      16.4X
-SQL ORC Vectorized                                   33             36           4         31.6          31.6      79.3X
-SQL ORC MR                                          141            145           6          7.5         134.2      18.7X
+SQL CSV                                            2784           2787           5          0.4        2655.2       1.0X
+SQL Json                                           6099           6175         107          0.2        5816.6       0.5X
+SQL Parquet Vectorized: DataPageV1                   31             35           3         33.9          29.5      90.1X
+SQL Parquet Vectorized: DataPageV2                   42             45           4         25.2          39.7      66.9X
+SQL Parquet MR: DataPageV1                          184            188           4          5.7         175.5      15.1X
+SQL Parquet MR: DataPageV2                          183            187           3          5.7         174.5      15.2X
+SQL ORC Vectorized                                   35             39           4         30.4          32.9      80.7X
+SQL ORC MR                                          143            145           3          7.4         135.9      19.5X
 
-OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1022-azure
+OpenJDK 64-Bit Server VM 17.0.11+9-LTS on Linux 6.5.0-1023-azure
 AMD EPYC 7763 64-Core Processor
 Single Column Scan from 100 columns:      Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-SQL CSV                                            4436           4536         141          0.2        4230.6       1.0X
-SQL Json                                          12445          12624         253          0.1       11868.7       0.4X
-SQL Parquet Vectorized: DataPageV1                   36             39           4         29.2          34.3     123.5X
-SQL Parquet Vectorized: DataPageV2                   46             49           3         23.0          43.5      97.3X
-SQL Parquet MR: DataPageV1                          176            182           4          6.0         167.8      25.2X
-SQL Parquet MR: DataPageV2                          172            180           7          6.1         164.4      25.7X
-SQL ORC Vectorized                                   39             43           4         26.8          37.3     113.6X
-SQL ORC MR                                          148            154          11          7.1         141.5      29.9X
+SQL CSV                                            4605           4642          53          0.2        4391.7       1.0X
+SQL Json                                          11392          11433          57          0.1       10864.7       0.4X
+SQL Parquet Vectorized: DataPageV1                   39             44           4         26.7          37.4     117.4X
+SQL Parquet Vectorized: DataPageV2                   48             53           4         21.6          46.2      95.0X
+SQL Parquet MR: DataPageV1                          198            202           2          5.3         188.8      23.3X
+SQL Parquet MR: DataPageV2                          196            202           4          5.4         186.7      23.5X
+SQL ORC Vectorized                                   41             45           3         25.4          39.3     111.8X
+SQL ORC MR                                          153            157           4          6.9         145.8      30.1X
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DataSourceReadBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/DataSourceReadBenchmark.scala
@@ -169,6 +169,12 @@ object DataSourceReadBenchmark extends SqlBasedBenchmark {
           spark.sql(s"select $query from jsonTable").noop()
         }
 
+        sqlBenchmark.addCase("SQL Json with UnsafeRow") { _ =>
+          withSQLConf(SQLConf.JSON_USE_UNSAFE_ROW.key -> "true") {
+            spark.sql(s"select $query from jsonTable").noop()
+          }
+        }
+
         withParquetVersions { version =>
           sqlBenchmark.addCase(s"SQL Parquet Vectorized: DataPage$version") { _ =>
             spark.sql(s"select $query from parquet${version}Table").noop()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -4010,3 +4010,8 @@ class JsonLegacyTimeParserSuite extends JsonSuite {
       .sparkConf
       .set(SQLConf.LEGACY_TIME_PARSER_POLICY, "legacy")
 }
+
+class JsonUnsafeRowSuite extends JsonSuite {
+  override protected def sparkConf: SparkConf =
+    super.sparkConf.set(SQLConf.JSON_USE_UNSAFE_ROW, true)
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

It uses `UnsafeRow` to represent struct result in the JSON parser. It saves memory compared to the current `GenericInternalRow`. The change is guarded by a flag and disabled by default.

The benchmark shows that enabling the flag brings ~10% slowdown. This is basically expected because converting to `UnsafeRow` requires some work. The purpose of the PR is to provide an alternative to save memory.

I did the following experiment. It generates a big `.gz` JSON file containing a single large array. Each array element is a struct with 50 string fields and will be parsed into a row by the JSON reader.

```
s = b'{"field00":null,"field01":"field01_<v>","field02":"field02_<v>","field03":"field03_<v>","field04":"field04_<v>","field05":"field05_<v>","field06":"field06_<v>","field07":"field07_<v>","field08":"field08_<v>","field09":"field09_<v>","field10":null,"field11":"field11_<v>","field12":"field12_<v>","field13":"field13_<v>","field14":"field14_<v>","field15":"field15_<v>","field16":"field16_<v>","field17":"field17_<v>","field18":"field18_<v>","field19":"field19_<v>","field20":null,"field21":"field21_<v>","field22":"field22_<v>","field23":"field23_<v>","field24":"field24_<v>","field25":"field25_<v>","field26":"field26_<v>","field27":"field27_<v>","field28":"field28_<v>","field29":"field29_<v>","field30":null,"field31":"field31_<v>","field32":"field32_<v>","field33":"field33_<v>","field34":"field34_<v>","field35":"field35_<v>","field36":"field36_<v>","field37":"field37_<v>","field38":"field38_<v>","field39":"field39_<v>","field40":null,"field41":"field41_<v>","field42":"field42_<v>","field43":"field43_<v>","field44":"field44_<v>","field45":"field45_<v>","field46":"field46_<v>","field47":"field47_<v>","field48":"field48_<v>","field49":"field49_<v>"}'

import gzip

def write(n):
  with gzip.open(f'json{n}.gz', 'w') as f:
    f.write(b'[')
    for i in range(n):
        if i != 0:
            f.write(b',')
        f.write(s.replace(b'<v>', str(i).encode('ascii')))
    f.write(b']')

write(100000)
```

Then it processes the file in Spark shell with the following command:

```
./bin/spark-shell --conf spark.driver.memory=1g --conf spark.executor.memory=1g  --master "local[1]"

> val schema = "field00 string, field01 string, field02 string, field03 string, field04 string, field05 string, field06 string, field07 string, field08 string, field09 string, field10 string, field11 string, field12 string, field13 string, field14 string, field15 string, field16 string, field17 string, field18 string, field19 string, field20 string, field21 string, field22 string, field23 string, field24 string, field25 string, field26 string, field27 string, field28 string, field29 string, field30 string, field31 string, field32 string, field33 string, field34 string, field35 string, field36 string, field37 string, field38 string, field39 string, field40 string, field41 string, field42 string, field43 string, field44 string, field45 string, field46 string, field47 string, field48 string, field49 string"
> spark.conf.set("spark.sql.json.useUnsafeRow", "false")
> spark.read.schema(schema).option("multiline", "true").json("json100000.gz").selectExpr("sum(hash(struct(*)))").collect()
```

When the flag is off (the current behavior), the query can process 2.5e5 rows but fails to process 3e5 rows. When the flag is on, the query can process 8e5 rows but fails to process 9e5 rows. We can say this change reduces the memory consumption to about 1/3.

### Why are the changes needed?

It reduces the memory requirement of JSON-related query.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

A new JSON unit test with the config flag on.

### Was this patch authored or co-authored using generative AI tooling?

No.