### PR TITLE
[SPARK-48804][SQL][TESTS][FOLLOWUP] Fix compilation warning `adaptation of an empty argument list by inserting () is deprecated`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCommitterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCommitterSuite.scala
@@ -116,7 +116,7 @@ class ParquetCommitterSuite extends SparkFunSuite with SQLTestUtils
   test("SPARK-48804: Fail fast on unloadable or invalid committers") {
     Seq("invalid", getClass.getName).foreach { committer =>
       val e = intercept[IllegalArgumentException] {
-        withSQLConf(SQLConf.PARQUET_OUTPUT_COMMITTER_CLASS.key -> committer)()
+        withSQLConf(SQLConf.PARQUET_OUTPUT_COMMITTER_CLASS.key -> committer) {}
       }
       assert(e.getMessage.contains(classOf[OutputCommitter].getName))
     }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveComparisonTest.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveComparisonTest.scala
@@ -100,8 +100,9 @@ abstract class HiveComparisonTest extends SparkFunSuite with BeforeAndAfterAll {
       .map(name => new File(targetDir, s"$suiteName.$name"))
 
   /** The local directory with cached golden answer will be stored. */
-  protected val answerCache = new File("src" + File.separator + "test" +
-    File.separator + "resources" + File.separator + "golden")
+  private val answerCache = getWorkspaceFilePath(
+    "sql", "hive", "src", "test", "resources", "golden").toFile
+
   if (!answerCache.exists) {
     answerCache.mkdir()
   }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -18,7 +18,6 @@
 package org.apache.spark.sql.hive.execution
 
 import java.io.File
-import java.net.URI
 import java.nio.file.Files
 import java.sql.Timestamp
 
@@ -379,7 +378,7 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
       """.stripMargin).queryExecution.analyzed
 
       assertResult(false, "Incorrect cast detected\n" + analyzedPlan) {
-      var hasCast = false
+        var hasCast = false
         analyzedPlan.collect {
           case p: Project => p.transformExpressionsUp { case c: Cast => hasCast = true; c }
         }
@@ -405,22 +404,22 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
 
   createQueryTest("transform with custom field delimiter",
     s"""
-      |SELECT TRANSFORM (key) ROW FORMAT DELIMITED FIELDS TERMINATED BY ${delimiter}
-      |USING 'cat' AS (tKey) ROW FORMAT DELIMITED FIELDS TERMINATED BY ${delimiter} FROM src;
+      |SELECT TRANSFORM (key) ROW FORMAT DELIMITED FIELDS TERMINATED BY $delimiter
+      |USING 'cat' AS (tKey) ROW FORMAT DELIMITED FIELDS TERMINATED BY $delimiter FROM src;
     """.stripMargin.replaceAll("\n", " "),
     skip = !TestUtils.testCommandAvailable("/bin/bash"))
 
   createQueryTest("transform with custom field delimiter2",
     s"""
-      |SELECT TRANSFORM (key, value) ROW FORMAT DELIMITED FIELDS TERMINATED BY ${delimiter}
-      |USING 'cat' ROW FORMAT DELIMITED FIELDS TERMINATED BY ${delimiter} FROM src;
+      |SELECT TRANSFORM (key, value) ROW FORMAT DELIMITED FIELDS TERMINATED BY $delimiter
+      |USING 'cat' ROW FORMAT DELIMITED FIELDS TERMINATED BY $delimiter FROM src;
     """.stripMargin.replaceAll("\n", " "),
     skip = !TestUtils.testCommandAvailable("/bin/bash"))
 
   createQueryTest("transform with custom field delimiter3",
     s"""
-      |SELECT TRANSFORM (*) ROW FORMAT DELIMITED FIELDS TERMINATED BY ${delimiter}
-      |USING 'cat' ROW FORMAT DELIMITED FIELDS TERMINATED BY ${delimiter} FROM src;
+      |SELECT TRANSFORM (*) ROW FORMAT DELIMITED FIELDS TERMINATED BY $delimiter
+      |USING 'cat' ROW FORMAT DELIMITED FIELDS TERMINATED BY $delimiter FROM src;
     """.stripMargin.replaceAll("\n", " "),
     skip = !TestUtils.testCommandAvailable("/bin/bash"))
 
@@ -679,15 +678,23 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
     assert(actual === expected)
   }
 
-  // TODO: adopt this test when Spark SQL has the functionality / framework to report errors.
-  // See https://github.com/apache/spark/pull/1055#issuecomment-45820167 for a discussion.
-  ignore("non-boolean conditions in a CaseWhen are illegal") {
+  test("non-boolean conditions in a CaseWhen are illegal") {
     checkError(
       exception = intercept[AnalysisException] {
         sql("SELECT (CASE WHEN key > 2 THEN 3 WHEN 1 THEN 2 ELSE 0 END) FROM src").collect()
       },
-      errorClass = null,
-      parameters = Map.empty)
+      errorClass = "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
+      parameters = Map(
+        "sqlExpr" -> "\"CASE WHEN (key > 2) THEN 3 WHEN 1 THEN 2 ELSE 0 END\"",
+        "paramIndex" -> "second",
+        "inputSql" -> "\"1\"",
+        "inputType" -> "\"INT\"",
+        "requiredType" -> "\"BOOLEAN\""),
+      context = ExpectedContext(
+        fragment = "CASE WHEN key > 2 THEN 3 WHEN 1 THEN 2 ELSE 0 END",
+        start = 8,
+        stop = 56)
+    )
   }
 
   createQueryTest("case sensitivity when query Hive table",
@@ -708,7 +715,7 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
     }
   }
 
-  def isExplanation(result: DataFrame): Boolean = {
+  private def isExplanation(result: DataFrame): Boolean = {
     val explanation = result.select("plan").collect().map { case Row(plan: String) => plan }
     explanation.head.startsWith("== Physical Plan ==")
   }
@@ -804,18 +811,19 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
   }
 
   test("ADD JAR command") {
-    sql("CREATE TABLE alter1(a INT, b INT) USING HIVE")
-    checkError(
-      exception = intercept[AnalysisException] {
-        sql(
-          """ALTER TABLE alter1 SET SERDE 'org.apache.hadoop.hive.serde2.TestSerDe'
-            |WITH serdeproperties('s1'='9')""".stripMargin)
-      },
-      errorClass = "_LEGACY_ERROR_TEMP_3065",
-      parameters = Map(
-        "clazz" -> "org.apache.hadoop.hive.ql.metadata.HiveException",
-        "msg" -> "at least one column must be specified for the table"))
-    sql("DROP TABLE alter1")
+    withTable("alter1") {
+      sql("CREATE TABLE alter1(a INT, b INT) USING HIVE")
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql(
+            """ALTER TABLE alter1 SET SERDE 'org.apache.hadoop.hive.serde2.TestSerDe'
+              |WITH serdeproperties('s1'='9')""".stripMargin)
+        },
+        errorClass = "_LEGACY_ERROR_TEMP_3065",
+        parameters = Map(
+          "clazz" -> "org.apache.hadoop.hive.ql.metadata.HiveException",
+          "msg" -> "at least one column must be specified for the table"))
+    }
   }
 
   test("ADD JAR command 2") {
@@ -823,12 +831,13 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
     val testJar = HiveTestJars.getHiveHcatalogCoreJar().toURI
     val testData = TestHive.getHiveFile("data/files/sample.json").toURI
     sql(s"ADD JAR $testJar")
-    sql(
-      """CREATE TABLE t1(a string, b string)
-      |ROW FORMAT SERDE 'org.apache.hive.hcatalog.data.JsonSerDe'""".stripMargin)
-    sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE t1""")
-    sql("select * from src join t1 on src.key = t1.a")
-    sql("DROP TABLE t1")
+    withTable("t1") {
+      sql(
+        """CREATE TABLE t1(a string, b string)
+          |ROW FORMAT SERDE 'org.apache.hive.hcatalog.data.JsonSerDe'""".stripMargin)
+      sql(s"""LOAD DATA LOCAL INPATH "$testData" INTO TABLE t1""")
+      sql("select * from src join t1 on src.key = t1.a")
+    }
     assert(sql("list jars").
       filter(_.getString(0).contains(HiveTestJars.getHiveHcatalogCoreJar().getName)).count() > 0)
     assert(sql("list jar").
@@ -854,12 +863,13 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
     val funcJar = TestHive.getHiveFile("TestUDTF.jar")
     val jarURL = funcJar.toURI.toURL
     sql(s"ADD JAR $jarURL")
-    sql(
-      """CREATE TEMPORARY FUNCTION udtf_count2 AS
-        |'org.apache.spark.sql.hive.execution.GenericUDTFCount2'
-      """.stripMargin)
-    assert(sql("DESCRIBE FUNCTION udtf_count2").count() > 1)
-    sql("DROP TEMPORARY FUNCTION udtf_count2")
+    withUserDefinedFunction("udtf_count2" -> true) {
+      sql(
+        """CREATE TEMPORARY FUNCTION udtf_count2 AS
+          |'org.apache.spark.sql.hive.execution.GenericUDTFCount2'
+        """.stripMargin)
+      assert(sql("DESCRIBE FUNCTION udtf_count2").count() > 1)
+    }
   }
 
   test("ADD FILE command") {
@@ -1167,43 +1177,47 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
       |DROP TABLE IF EXISTS dynamic_part_table;
     """.stripMargin)
 
-  ignore("Dynamic partition folder layout") {
-    sql("DROP TABLE IF EXISTS dynamic_part_table")
-    sql("CREATE TABLE dynamic_part_table(intcol INT) PARTITIONED BY (partcol1 INT, partcol2 INT)")
-    sql("SET hive.exec.dynamic.partition.mode=nonstrict")
+  test("Dynamic partition folder layout") {
+    withTempDir { dir =>
+      withTable("dynamic_part_table") {
+        sql("CREATE TABLE dynamic_part_table(intcol INT) USING HIVE " +
+          s"PARTITIONED BY (partcol1 INT, partcol2 INT) " +
+          s"LOCATION '${dir.getCanonicalPath}/dynamic_part_table'")
+        sql("SET hive.exec.dynamic.partition.mode=nonstrict")
 
-    val data = Map(
-      Seq("1", "1") -> 1,
-      Seq("1", "NULL") -> 2,
-      Seq("NULL", "1") -> 3,
-      Seq("NULL", "NULL") -> 4)
+        val data = Map(
+          Seq("1", "1") -> 1,
+          Seq("1", "NULL") -> 2,
+          Seq("NULL", "1") -> 3,
+          Seq("NULL", "NULL") -> 4)
 
-    data.foreach { case (parts, value) =>
-      sql(
-        s"""INSERT INTO TABLE dynamic_part_table PARTITION(partcol1, partcol2)
-           |SELECT $value, ${parts.mkString(", ")} FROM src WHERE key=150
+        data.foreach { case (parts, value) =>
+          sql(
+            s"""INSERT INTO TABLE dynamic_part_table PARTITION(partcol1, partcol2)
+               |SELECT $value, ${parts.mkString(", ")} FROM src WHERE key=150
          """.stripMargin)
 
-      val partFolder = Seq("partcol1", "partcol2")
-        .zip(parts)
-        .map { case (k, v) =>
-          if (v == "NULL") {
-            s"$k=${ConfVars.DEFAULTPARTITIONNAME.defaultStrVal}"
-          } else {
-            s"$k=$v"
-          }
+          val partFolder = Seq("partcol1", "partcol2")
+            .zip(parts)
+            .map { case (k, v) =>
+              if (v == "NULL") {
+                s"$k=${ConfVars.DEFAULTPARTITIONNAME.defaultStrVal}"
+              } else {
+                s"$k=$v"
+              }
+            }
+            .mkString("/")
+
+          // Loads partition data to a temporary table to verify contents
+          val path = s"${dir.getCanonicalPath}/dynamic_part_table/$partFolder/part-00000*"
+
+          sql("DROP TABLE IF EXISTS dp_verify")
+          sql("CREATE TABLE dp_verify(intcol INT) USING HIVE")
+          sql(s"LOAD DATA LOCAL INPATH '$path' INTO TABLE dp_verify")
+
+          assert(sql("SELECT * FROM dp_verify").collect() === Array(Row(value)))
         }
-        .mkString("/")
-
-      // Loads partition data to a temporary table to verify contents
-      val warehousePathFile = new URI(sparkSession.getWarehousePath()).getPath
-      val path = s"$warehousePathFile/dynamic_part_table/$partFolder/part-00000"
-
-      sql("DROP TABLE IF EXISTS dp_verify")
-      sql("CREATE TABLE dp_verify(intcol INT)")
-      sql(s"LOAD DATA LOCAL INPATH '$path' INTO TABLE dp_verify")
-
-      assert(sql("SELECT * FROM dp_verify").collect() === Array(Row(value)))
+      }
     }
   }
 
@@ -1218,7 +1232,7 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
           |select '2011-01-11', '2011-01-11+15:18:26' from src tablesample (1 rows)
           |union all
           |select '2011-01-11', '2011-01-11+16:18:26' from src tablesample (1 rows) ) s
-    """.stripMargin)
+        """.stripMargin)
       sql("create table sc_part (key string) partitioned by (ts string) stored as rcfile")
       sql("insert overwrite table sc_part partition(ts) select * from sc")
       sql("drop table sc_part")
@@ -1288,7 +1302,7 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
 
     assertResult(1, "Duplicated project detected\n" + analyzedPlan) {
       analyzedPlan.collect {
-        case i: InsertIntoHiveTable => i.query.collect { case p: Project => () }.size
+        case i: InsertIntoHiveTable => i.query.collect { case _: Project => () }.size
       }.sum
     }
   }
@@ -1307,7 +1321,7 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
 
       assertResult(2, "Duplicated project detected\n" + analyzedPlan) {
         analyzedPlan.collect {
-          case i: InsertIntoHiveTable => i.query.collect { case p: Project => () }.size
+          case i: InsertIntoHiveTable => i.query.collect { case _: Project => () }.size
         }.sum
       }
     }
@@ -1334,69 +1348,69 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
   }
 
   test("current_database with multiple sessions") {
-    sql("create database a")
-    sql("use a")
-    val s2 = newSession()
-    s2.sql("create database b")
-    s2.sql("use b")
+    withCurrentCatalogAndNamespace {
+      sql("create database a")
+      sql("use a")
+      val s2 = newSession()
+      s2.sql("create database b")
+      s2.sql("use b")
 
-    assert(sql("select current_database()").first() === Row("a"))
-    assert(s2.sql("select current_database()").first() === Row("b"))
+      assert(sql("select current_database()").first() === Row("a"))
+      assert(s2.sql("select current_database()").first() === Row("b"))
 
-    try {
-      sql("create table test_a(key INT, value STRING)")
-      s2.sql("create table test_b(key INT, value STRING)")
+      try {
+        sql("create table test_a(key INT, value STRING)")
+        s2.sql("create table test_b(key INT, value STRING)")
 
-      sql("select * from test_a")
-      checkError(
-        exception = intercept[AnalysisException] {
-          sql("select * from test_b")
-        },
-        errorClass = "TABLE_OR_VIEW_NOT_FOUND",
-        parameters = Map("relationName" -> "`test_b`"),
-        context = ExpectedContext(
-          fragment = "test_b",
-          start = 14,
-          stop = 19))
+        sql("select * from test_a")
+        checkError(
+          exception = intercept[AnalysisException] {
+            sql("select * from test_b")
+          },
+          errorClass = "TABLE_OR_VIEW_NOT_FOUND",
+          parameters = Map("relationName" -> "`test_b`"),
+          context = ExpectedContext(
+            fragment = "test_b",
+            start = 14,
+            stop = 19))
 
-      sql("select * from b.test_b")
+        sql("select * from b.test_b")
 
-      s2.sql("select * from test_b")
-      checkError(
-        exception = intercept[AnalysisException] {
-          s2.sql("select * from test_a")
-        },
-        errorClass = "TABLE_OR_VIEW_NOT_FOUND",
-        parameters = Map("relationName" -> "`test_a`"),
-        context = ExpectedContext(
-          fragment = "test_a",
-          start = 14,
-          stop = 19))
-      s2.sql("select * from a.test_a")
-    } finally {
-      sql("DROP TABLE IF EXISTS test_a")
-      s2.sql("DROP TABLE IF EXISTS test_b")
+        s2.sql("select * from test_b")
+        checkError(
+          exception = intercept[AnalysisException] {
+            s2.sql("select * from test_a")
+          },
+          errorClass = "TABLE_OR_VIEW_NOT_FOUND",
+          parameters = Map("relationName" -> "`test_a`"),
+          context = ExpectedContext(
+            fragment = "test_a",
+            start = 14,
+            stop = 19))
+        s2.sql("select * from a.test_a")
+      } finally {
+        sql("DROP TABLE IF EXISTS test_a")
+        s2.sql("DROP TABLE IF EXISTS test_b")
+      }
     }
-
   }
 
   test("use database") {
     val currentDatabase = sql("select current_database()").first().getString(0)
+    withCurrentCatalogAndNamespace {
+      sql("CREATE DATABASE hive_test_db")
+      sql("USE hive_test_db")
+      assert("hive_test_db" == sql("select current_database()").first().getString(0))
 
-    sql("CREATE DATABASE hive_test_db")
-    sql("USE hive_test_db")
-    assert("hive_test_db" == sql("select current_database()").first().getString(0))
+      assert("hive_test_db" == sql("select current_schema()").first().getString(0))
 
-    assert("hive_test_db" == sql("select current_schema()").first().getString(0))
-
-    checkError(
-      exception = intercept[AnalysisException] {
-        sql("USE not_existing_db")
-      },
-      errorClass = "SCHEMA_NOT_FOUND",
-      parameters = Map("schemaName" -> "`not_existing_db`"))
-
-    sql(s"USE $currentDatabase")
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql("USE not_existing_db")
+        },
+        errorClass = "SCHEMA_NOT_FOUND",
+        parameters = Map("schemaName" -> "`not_existing_db`"))
+    }
     assert(currentDatabase == sql("select current_database()").first().getString(0))
   }
 
@@ -1409,7 +1423,7 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
       sqlState = None,
       parameters = Map(
         "routineName" -> "`not_a_udf`",
-        "searchPath" -> "[`system`.`builtin`, `system`.`session`, `spark_catalog`.`a`]"),
+        "searchPath" -> "[`system`.`builtin`, `system`.`session`, `spark_catalog`.`default`]"),
       context = ExpectedContext(
         fragment = "not_a_udf()",
         start = 0,
@@ -1426,7 +1440,7 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
           sqlState = None,
           parameters = Map(
             "routineName" -> "`not_a_udf`",
-            "searchPath" -> "[`system`.`builtin`, `system`.`session`, `spark_catalog`.`a`]"),
+            "searchPath" -> "[`system`.`builtin`, `system`.`session`, `spark_catalog`.`default`]"),
           context = ExpectedContext(
             fragment = "not_a_udf()",
             start = 0,

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveQuerySuite.scala
@@ -242,7 +242,7 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
         |  2 = true, 2L = true, 2Y = true, true = 2, true = 2L, true = 2Y,
         |  2 = false, 2L = false, 2Y = false, false = 2, false = 2L, false = 2Y
         |FROM src LIMIT 1
-      """.stripMargin)
+    """.stripMargin)
   }
 
   test("CREATE TABLE AS runs once") {
@@ -284,7 +284,7 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
       """
         | SELECT DATEDIFF(CAST(value AS timestamp), CAST('2002-03-21 00:00:00' AS timestamp))
         | FROM src LIMIT 1
-      """.stripMargin)
+    """.stripMargin)
   }
 
   createQueryTest("Date comparison test 1",
@@ -373,12 +373,12 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
 
       val analyzedPlan = sql(
         """
-          |INSERT OVERWRITE table test_partition PARTITION (b=1, c)
-          |SELECT 'a', 'c' from ptest
-        """.stripMargin).queryExecution.analyzed
+        |INSERT OVERWRITE table test_partition PARTITION (b=1, c)
+        |SELECT 'a', 'c' from ptest
+      """.stripMargin).queryExecution.analyzed
 
       assertResult(false, "Incorrect cast detected\n" + analyzedPlan) {
-        var hasCast = false
+      var hasCast = false
         analyzedPlan.collect {
           case p: Project => p.transformExpressionsUp { case c: Cast => hasCast = true; c }
         }
@@ -404,22 +404,22 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
 
   createQueryTest("transform with custom field delimiter",
     s"""
-      |SELECT TRANSFORM (key) ROW FORMAT DELIMITED FIELDS TERMINATED BY $delimiter
-      |USING 'cat' AS (tKey) ROW FORMAT DELIMITED FIELDS TERMINATED BY $delimiter FROM src;
+      |SELECT TRANSFORM (key) ROW FORMAT DELIMITED FIELDS TERMINATED BY ${delimiter}
+      |USING 'cat' AS (tKey) ROW FORMAT DELIMITED FIELDS TERMINATED BY ${delimiter} FROM src;
     """.stripMargin.replaceAll("\n", " "),
     skip = !TestUtils.testCommandAvailable("/bin/bash"))
 
   createQueryTest("transform with custom field delimiter2",
     s"""
-      |SELECT TRANSFORM (key, value) ROW FORMAT DELIMITED FIELDS TERMINATED BY $delimiter
-      |USING 'cat' ROW FORMAT DELIMITED FIELDS TERMINATED BY $delimiter FROM src;
+      |SELECT TRANSFORM (key, value) ROW FORMAT DELIMITED FIELDS TERMINATED BY ${delimiter}
+      |USING 'cat' ROW FORMAT DELIMITED FIELDS TERMINATED BY ${delimiter} FROM src;
     """.stripMargin.replaceAll("\n", " "),
     skip = !TestUtils.testCommandAvailable("/bin/bash"))
 
   createQueryTest("transform with custom field delimiter3",
     s"""
-      |SELECT TRANSFORM (*) ROW FORMAT DELIMITED FIELDS TERMINATED BY $delimiter
-      |USING 'cat' ROW FORMAT DELIMITED FIELDS TERMINATED BY $delimiter FROM src;
+      |SELECT TRANSFORM (*) ROW FORMAT DELIMITED FIELDS TERMINATED BY ${delimiter}
+      |USING 'cat' ROW FORMAT DELIMITED FIELDS TERMINATED BY ${delimiter} FROM src;
     """.stripMargin.replaceAll("\n", " "),
     skip = !TestUtils.testCommandAvailable("/bin/bash"))
 
@@ -441,16 +441,16 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
       val expected = sql("SELECT key FROM small_src").collect().head
       val res = sql(
         """
-          |SELECT TRANSFORM (key) ROW FORMAT SERDE
-          |'org.apache.hadoop.hive.serde2.avro.AvroSerDe'
-          |WITH SERDEPROPERTIES ('avro.schema.literal'='{"namespace":
-          |"testing.hive.avro.serde","name": "src","type": "record","fields":
-          |[{"name":"key","type":"int"}]}') USING 'cat' AS (tKey INT) ROW FORMAT SERDE
-          |'org.apache.hadoop.hive.serde2.avro.AvroSerDe' WITH SERDEPROPERTIES
-          |('avro.schema.literal'='{"namespace": "testing.hive.avro.serde","name":
-          |"src","type": "record","fields": [{"name":"key","type":"int"}]}')
-          |FROM small_src
-        """.stripMargin.replaceAll(System.lineSeparator(), " ")).collect().head
+        |SELECT TRANSFORM (key) ROW FORMAT SERDE
+        |'org.apache.hadoop.hive.serde2.avro.AvroSerDe'
+        |WITH SERDEPROPERTIES ('avro.schema.literal'='{"namespace":
+        |"testing.hive.avro.serde","name": "src","type": "record","fields":
+        |[{"name":"key","type":"int"}]}') USING 'cat' AS (tKey INT) ROW FORMAT SERDE
+        |'org.apache.hadoop.hive.serde2.avro.AvroSerDe' WITH SERDEPROPERTIES
+        |('avro.schema.literal'='{"namespace": "testing.hive.avro.serde","name":
+        |"src","type": "record","fields": [{"name":"key","type":"int"}]}')
+        |FROM small_src
+      """.stripMargin.replaceAll(System.lineSeparator(), " ")).collect().head
 
       assert(expected(0) === res(0))
     }
@@ -1233,7 +1233,7 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
           |select '2011-01-11', '2011-01-11+15:18:26' from src tablesample (1 rows)
           |union all
           |select '2011-01-11', '2011-01-11+16:18:26' from src tablesample (1 rows) ) s
-        """.stripMargin)
+    """.stripMargin)
       sql("create table sc_part (key string) partitioned by (ts string) stored as rcfile")
       sql("insert overwrite table sc_part partition(ts) select * from sc")
       sql("drop table sc_part")
@@ -1278,13 +1278,13 @@ class HiveQuerySuite extends HiveComparisonTest with SQLTestUtils with BeforeAnd
 
       sql(
         """
-          SELECT name, message
-          FROM rawLogs
-          JOIN (
-            SELECT name
-            FROM logFiles
-          ) files
-          ON rawLogs.filename = files.name
+        SELECT name, message
+        FROM rawLogs
+        JOIN (
+          SELECT name
+          FROM logFiles
+        ) files
+        ON rawLogs.filename = files.name
         """).createOrReplaceTempView("boom")
 
       // This should be successfully analyzed


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to fix a compilation warning related to Scala 2.11:

```
[warn] /Users/yangjie01/SourceCode/git/spark-mine-sbt/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCommitterSuite.scala:119:77: adaptation of an empty argument list by inserting () is deprecated: this is unlikely to be what you want
[warn]         signature: SQLTestUtilsBase.withSQLConf[T](pairs: (String, String)*)(f: => T): T
[warn]   given arguments: <none>
[warn]  after adaptation: SQLTestUtilsBase.withSQLConf((): Unit)
[warn] Applicable -Wconf / @nowarn filters for this warning: msg=<part of the message>, cat=deprecation, site=org.apache.spark.sql.execution.datasources.parquet.ParquetCommitterSuite, origin=org.apache.spark.sql.test.SQLTestUtilsBase.withSQLConf, version=2.11.0
[warn]         withSQLConf(SQLConf.PARQUET_OUTPUT_COMMITTER_CLASS.key -> committer)()
```

### Why are the changes needed?
Fix compilation warning

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No