### PR TITLE
[SPARK-48804][SQL][TESTS][FOLLOWUP] Fix compilation warning `adaptation of an empty argument list by inserting () is deprecated`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCommitterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCommitterSuite.scala
@@ -116,7 +116,7 @@ class ParquetCommitterSuite extends SparkFunSuite with SQLTestUtils
   test("SPARK-48804: Fail fast on unloadable or invalid committers") {
     Seq("invalid", getClass.getName).foreach { committer =>
       val e = intercept[IllegalArgumentException] {
-        withSQLConf(SQLConf.PARQUET_OUTPUT_COMMITTER_CLASS.key -> committer)()
+        withSQLConf(SQLConf.PARQUET_OUTPUT_COMMITTER_CLASS.key -> committer) {}
       }
       assert(e.getMessage.contains(classOf[OutputCommitter].getName))
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to fix a compilation warning related to Scala 2.11:

```
[warn] /Users/yangjie01/SourceCode/git/spark-mine-sbt/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCommitterSuite.scala:119:77: adaptation of an empty argument list by inserting () is deprecated: this is unlikely to be what you want
[warn]         signature: SQLTestUtilsBase.withSQLConf[T](pairs: (String, String)*)(f: => T): T
[warn]   given arguments: <none>
[warn]  after adaptation: SQLTestUtilsBase.withSQLConf((): Unit)
[warn] Applicable -Wconf / @nowarn filters for this warning: msg=<part of the message>, cat=deprecation, site=org.apache.spark.sql.execution.datasources.parquet.ParquetCommitterSuite, origin=org.apache.spark.sql.test.SQLTestUtilsBase.withSQLConf, version=2.11.0
[warn]         withSQLConf(SQLConf.PARQUET_OUTPUT_COMMITTER_CLASS.key -> committer)()
```

### Why are the changes needed?
Fix compilation warning

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No