### PR TITLE
[SPARK-48879][SQL] Expand the charset list with Chinese Standard Charsets

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3840,8 +3840,8 @@ object functions {
 
   /**
    * Computes the first argument into a string from a binary using the provided character set (one
-   * of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16'). If either argument
-   * is null, the result will also be null.
+   * of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16', 'UTF-32',
+   * 'GB2312', 'GBK', 'GB18030', 'BIG5'). If either argument is null, the result will also be null.
    *
    * @group string_funcs
    * @since 3.4.0
@@ -3851,8 +3851,8 @@ object functions {
 
   /**
    * Computes the first argument into a binary from a string using the provided character set (one
-   * of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16'). If either argument
-   * is null, the result will also be null.
+   * of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16', 'UTF-32',
+   * 'GB2312', 'GBK', 'GB18030', 'BIG5'). If either argument is null, the result will also be null.
    *
    * @group string_funcs
    * @since 3.4.0

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3840,8 +3840,8 @@ object functions {
 
   /**
    * Computes the first argument into a string from a binary using the provided character set (one
-   * of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16', 'UTF-32',
-   * 'GB2312', 'GBK', 'GB18030', 'BIG5'). If either argument is null, the result will also be null.
+   * of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16', 'UTF-32', 'GB2312',
+   * 'GBK', 'GB18030', 'BIG5'). If either argument is null, the result will also be null.
    *
    * @group string_funcs
    * @since 3.4.0
@@ -3851,8 +3851,8 @@ object functions {
 
   /**
    * Computes the first argument into a binary from a string using the provided character set (one
-   * of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16', 'UTF-32',
-   * 'GB2312', 'GBK', 'GB18030', 'BIG5'). If either argument is null, the result will also be null.
+   * of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16', 'UTF-32', 'GB2312',
+   * 'GBK', 'GB18030', 'BIG5'). If either argument is null, the result will also be null.
    *
    * @group string_funcs
    * @since 3.4.0

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -2853,7 +2853,7 @@ object Decode {
   arguments = """
     Arguments:
       * bin - a binary expression to decode
-      * charset - one of the charsets 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16', 'UTF-32' to decode `bin` into a STRING. It is case insensitive.
+      * charset - one of the charsets 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16', 'UTF-32', 'GB2312', 'GBK', 'GB18030', 'BIG5' to decode `bin` into a STRING. It is case insensitive.
   """,
   examples = """
     Examples:
@@ -2941,7 +2941,7 @@ object StringDecode {
   arguments = """
     Arguments:
       * str - a string expression
-      * charset - one of the charsets 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16', 'UTF-32' to encode `str` into a BINARY. It is case insensitive.
+      * charset - one of the charsets 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16', 'UTF-32', 'GB2312', 'GBK', 'GB18030', 'BIG5' to encode `str` into a BINARY. It is case insensitive.
   """,
   examples = """
     Examples:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharsetProvider.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/CharsetProvider.scala
@@ -14,16 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- package org.apache.spark.sql.catalyst.util
- import java.nio.charset.{Charset, CharsetDecoder, CharsetEncoder, CodingErrorAction, IllegalCharsetNameException, UnsupportedCharsetException}
- import java.util.Locale
+package org.apache.spark.sql.catalyst.util
 
- import org.apache.spark.sql.errors.QueryExecutionErrors
+import java.nio.charset.{Charset, CharsetDecoder, CharsetEncoder, CodingErrorAction, IllegalCharsetNameException, UnsupportedCharsetException}
+import java.util.Locale
+
+import org.apache.spark.sql.errors.QueryExecutionErrors
 
 private[sql] object CharsetProvider {
 
-  final lazy val VALID_CHARSETS =
-    Set("US-ASCII", "ISO-8859-1", "UTF-8", "UTF-16BE", "UTF-16LE", "UTF-16", "UTF-32")
+  final lazy val VALID_CHARSETS = Set(
+    "US-ASCII", "ISO-8859-1", "UTF-8", "UTF-16BE", "UTF-16LE", "UTF-16", "UTF-32",
+    "GB2312", "GBK", "GB18030", "BIG5")
 
   def forName(
       charset: String,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/CharsetProviderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/CharsetProviderSuite.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.util
+
+import org.apache.spark.SparkFunSuite
+
+class CharsetProviderSuite extends SparkFunSuite {
+  test("Track the Spark charsets are also valid on JDKs") {
+    CharsetProvider.VALID_CHARSETS.foreach( charsetStr => {
+      val charset = CharsetProvider.forName(charsetStr, legacyCharsets = false)
+      assert(charset.name.equalsIgnoreCase(charsetStr))
+    })
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3783,9 +3783,9 @@ object functions {
     Column.fn("concat_ws", lit(sep) +: exprs: _*)
 
   /**
-   * Computes the first argument into a string from a binary using the provided character set
-   * (one of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16').
-   * If either argument is null, the result will also be null.
+   * Computes the first argument into a string from a binary using the provided character set (one
+   * of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16', 'UTF-32', 'GB2312',
+   * 'GBK', 'GB18030', 'BIG5'). If either argument is null, the result will also be null.
    *
    * @group string_funcs
    * @since 1.5.0
@@ -3794,9 +3794,9 @@ object functions {
     Column.fn("decode", value, lit(charset))
 
   /**
-   * Computes the first argument into a binary from a string using the provided character set
-   * (one of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16').
-   * If either argument is null, the result will also be null.
+   * Computes the first argument into a binary from a string using the provided character set (one
+   * of 'US-ASCII', 'ISO-8859-1', 'UTF-8', 'UTF-16BE', 'UTF-16LE', 'UTF-16', 'UTF-32', 'GB2312',
+   * 'GBK', 'GB18030', 'BIG5'). If either argument is null, the result will also be null.
    *
    * @group string_funcs
    * @since 1.5.0

--- a/sql/core/src/test/resources/sql-tests/results/ansi/string-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/string-functions.sql.out
@@ -846,7 +846,7 @@ org.apache.spark.SparkIllegalArgumentException
   "sqlState" : "22023",
   "messageParameters" : {
     "charset" : "WINDOWS-1252",
-    "charsets" : "UTF-16LE, UTF-8, UTF-32, UTF-16BE, UTF-16, US-ASCII, ISO-8859-1",
+    "charsets" : "UTF-16LE, GB18030, UTF-8, UTF-32, GB2312, GBK, UTF-16BE, UTF-16, BIG5, US-ASCII, ISO-8859-1",
     "functionName" : "`encode`",
     "parameter" : "`charset`"
   }
@@ -864,7 +864,7 @@ org.apache.spark.SparkIllegalArgumentException
   "sqlState" : "22023",
   "messageParameters" : {
     "charset" : "WINDOWS-1252",
-    "charsets" : "UTF-16LE, UTF-8, UTF-32, UTF-16BE, UTF-16, US-ASCII, ISO-8859-1",
+    "charsets" : "UTF-16LE, GB18030, UTF-8, UTF-32, GB2312, GBK, UTF-16BE, UTF-16, BIG5, US-ASCII, ISO-8859-1",
     "functionName" : "`encode`",
     "parameter" : "`charset`"
   }
@@ -882,7 +882,7 @@ org.apache.spark.SparkIllegalArgumentException
   "sqlState" : "22023",
   "messageParameters" : {
     "charset" : "Windows-xxx",
-    "charsets" : "UTF-16LE, UTF-8, UTF-32, UTF-16BE, UTF-16, US-ASCII, ISO-8859-1",
+    "charsets" : "UTF-16LE, GB18030, UTF-8, UTF-32, GB2312, GBK, UTF-16BE, UTF-16, BIG5, US-ASCII, ISO-8859-1",
     "functionName" : "`encode`",
     "parameter" : "`charset`"
   }
@@ -900,7 +900,7 @@ org.apache.spark.SparkIllegalArgumentException
   "sqlState" : "22023",
   "messageParameters" : {
     "charset" : "Windows-xxx",
-    "charsets" : "UTF-16LE, UTF-8, UTF-32, UTF-16BE, UTF-16, US-ASCII, ISO-8859-1",
+    "charsets" : "UTF-16LE, GB18030, UTF-8, UTF-32, GB2312, GBK, UTF-16BE, UTF-16, BIG5, US-ASCII, ISO-8859-1",
     "functionName" : "`encode`",
     "parameter" : "`charset`"
   }
@@ -1144,7 +1144,7 @@ org.apache.spark.SparkIllegalArgumentException
   "sqlState" : "22023",
   "messageParameters" : {
     "charset" : "Windows-xxx",
-    "charsets" : "UTF-16LE, UTF-8, UTF-32, UTF-16BE, UTF-16, US-ASCII, ISO-8859-1",
+    "charsets" : "UTF-16LE, GB18030, UTF-8, UTF-32, GB2312, GBK, UTF-16BE, UTF-16, BIG5, US-ASCII, ISO-8859-1",
     "functionName" : "`decode`",
     "parameter" : "`charset`"
   }
@@ -1162,7 +1162,7 @@ org.apache.spark.SparkIllegalArgumentException
   "sqlState" : "22023",
   "messageParameters" : {
     "charset" : "Windows-xxx",
-    "charsets" : "UTF-16LE, UTF-8, UTF-32, UTF-16BE, UTF-16, US-ASCII, ISO-8859-1",
+    "charsets" : "UTF-16LE, GB18030, UTF-8, UTF-32, GB2312, GBK, UTF-16BE, UTF-16, BIG5, US-ASCII, ISO-8859-1",
     "functionName" : "`decode`",
     "parameter" : "`charset`"
   }
@@ -1212,7 +1212,7 @@ org.apache.spark.SparkIllegalArgumentException
   "sqlState" : "22023",
   "messageParameters" : {
     "charset" : "WINDOWS-1252",
-    "charsets" : "UTF-16LE, UTF-8, UTF-32, UTF-16BE, UTF-16, US-ASCII, ISO-8859-1",
+    "charsets" : "UTF-16LE, GB18030, UTF-8, UTF-32, GB2312, GBK, UTF-16BE, UTF-16, BIG5, US-ASCII, ISO-8859-1",
     "functionName" : "`decode`",
     "parameter" : "`charset`"
   }
@@ -1230,7 +1230,7 @@ org.apache.spark.SparkIllegalArgumentException
   "sqlState" : "22023",
   "messageParameters" : {
     "charset" : "WINDOWS-1252",
-    "charsets" : "UTF-16LE, UTF-8, UTF-32, UTF-16BE, UTF-16, US-ASCII, ISO-8859-1",
+    "charsets" : "UTF-16LE, GB18030, UTF-8, UTF-32, GB2312, GBK, UTF-16BE, UTF-16, BIG5, US-ASCII, ISO-8859-1",
     "functionName" : "`decode`",
     "parameter" : "`charset`"
   }

--- a/sql/core/src/test/resources/sql-tests/results/string-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/string-functions.sql.out
@@ -778,7 +778,7 @@ org.apache.spark.SparkIllegalArgumentException
   "sqlState" : "22023",
   "messageParameters" : {
     "charset" : "WINDOWS-1252",
-    "charsets" : "UTF-16LE, UTF-8, UTF-32, UTF-16BE, UTF-16, US-ASCII, ISO-8859-1",
+    "charsets" : "UTF-16LE, GB18030, UTF-8, UTF-32, GB2312, GBK, UTF-16BE, UTF-16, BIG5, US-ASCII, ISO-8859-1",
     "functionName" : "`encode`",
     "parameter" : "`charset`"
   }
@@ -796,7 +796,7 @@ org.apache.spark.SparkIllegalArgumentException
   "sqlState" : "22023",
   "messageParameters" : {
     "charset" : "WINDOWS-1252",
-    "charsets" : "UTF-16LE, UTF-8, UTF-32, UTF-16BE, UTF-16, US-ASCII, ISO-8859-1",
+    "charsets" : "UTF-16LE, GB18030, UTF-8, UTF-32, GB2312, GBK, UTF-16BE, UTF-16, BIG5, US-ASCII, ISO-8859-1",
     "functionName" : "`encode`",
     "parameter" : "`charset`"
   }
@@ -814,7 +814,7 @@ org.apache.spark.SparkIllegalArgumentException
   "sqlState" : "22023",
   "messageParameters" : {
     "charset" : "Windows-xxx",
-    "charsets" : "UTF-16LE, UTF-8, UTF-32, UTF-16BE, UTF-16, US-ASCII, ISO-8859-1",
+    "charsets" : "UTF-16LE, GB18030, UTF-8, UTF-32, GB2312, GBK, UTF-16BE, UTF-16, BIG5, US-ASCII, ISO-8859-1",
     "functionName" : "`encode`",
     "parameter" : "`charset`"
   }
@@ -832,7 +832,7 @@ org.apache.spark.SparkIllegalArgumentException
   "sqlState" : "22023",
   "messageParameters" : {
     "charset" : "Windows-xxx",
-    "charsets" : "UTF-16LE, UTF-8, UTF-32, UTF-16BE, UTF-16, US-ASCII, ISO-8859-1",
+    "charsets" : "UTF-16LE, GB18030, UTF-8, UTF-32, GB2312, GBK, UTF-16BE, UTF-16, BIG5, US-ASCII, ISO-8859-1",
     "functionName" : "`encode`",
     "parameter" : "`charset`"
   }
@@ -1076,7 +1076,7 @@ org.apache.spark.SparkIllegalArgumentException
   "sqlState" : "22023",
   "messageParameters" : {
     "charset" : "Windows-xxx",
-    "charsets" : "UTF-16LE, UTF-8, UTF-32, UTF-16BE, UTF-16, US-ASCII, ISO-8859-1",
+    "charsets" : "UTF-16LE, GB18030, UTF-8, UTF-32, GB2312, GBK, UTF-16BE, UTF-16, BIG5, US-ASCII, ISO-8859-1",
     "functionName" : "`decode`",
     "parameter" : "`charset`"
   }
@@ -1094,7 +1094,7 @@ org.apache.spark.SparkIllegalArgumentException
   "sqlState" : "22023",
   "messageParameters" : {
     "charset" : "Windows-xxx",
-    "charsets" : "UTF-16LE, UTF-8, UTF-32, UTF-16BE, UTF-16, US-ASCII, ISO-8859-1",
+    "charsets" : "UTF-16LE, GB18030, UTF-8, UTF-32, GB2312, GBK, UTF-16BE, UTF-16, BIG5, US-ASCII, ISO-8859-1",
     "functionName" : "`decode`",
     "parameter" : "`charset`"
   }
@@ -1144,7 +1144,7 @@ org.apache.spark.SparkIllegalArgumentException
   "sqlState" : "22023",
   "messageParameters" : {
     "charset" : "WINDOWS-1252",
-    "charsets" : "UTF-16LE, UTF-8, UTF-32, UTF-16BE, UTF-16, US-ASCII, ISO-8859-1",
+    "charsets" : "UTF-16LE, GB18030, UTF-8, UTF-32, GB2312, GBK, UTF-16BE, UTF-16, BIG5, US-ASCII, ISO-8859-1",
     "functionName" : "`decode`",
     "parameter" : "`charset`"
   }
@@ -1162,7 +1162,7 @@ org.apache.spark.SparkIllegalArgumentException
   "sqlState" : "22023",
   "messageParameters" : {
     "charset" : "WINDOWS-1252",
-    "charsets" : "UTF-16LE, UTF-8, UTF-32, UTF-16BE, UTF-16, US-ASCII, ISO-8859-1",
+    "charsets" : "UTF-16LE, GB18030, UTF-8, UTF-32, GB2312, GBK, UTF-16BE, UTF-16, BIG5, US-ASCII, ISO-8859-1",
     "functionName" : "`decode`",
     "parameter" : "`charset`"
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?


This PR expands the charset list with Chinese Standard Charsets
https://en.wikipedia.org/wiki/GB_2312
https://en.wikipedia.org/wiki/GBK_(character_encoding)
https://en.wikipedia.org/wiki/GB_18030
https://en.wikipedia.org/wiki/Big5


### Why are the changes needed?

Improve the charset list for real-world workloads

### Does this PR introduce _any_ user-facing change?

Yes, more charsets are valid

### Was this patch authored or co-authored using generative AI tooling?

no