### PR TITLE
[SPARK-48882][SS] Assign names to streaming output mode related error classes

### DIFF
--- a/R/pkg/tests/fulltests/test_streaming.R
+++ b/R/pkg/tests/fulltests/test_streaming.R
@@ -147,8 +147,7 @@ test_that("Unsupported operation", {
   # memory sink without aggregation
   df <- read.stream("json", path = jsonDir, schema = schema, maxFilesPerTrigger = 1)
   expect_error(write.stream(df, "memory", queryName = "people", outputMode = "complete"),
-               paste0(".*(start : analysis error - Complete output mode not supported when there ",
-                      "are no streaming aggregations on streaming DataFrames/Datasets).*"))
+               ".*analysis error.*complete.*not supported.*no streaming aggregations*")
 })
 
 test_that("Terminated by error", {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1059,12 +1059,6 @@
     ],
     "sqlState" : "42K03"
   },
-  "DATA_SOURCE_UNSUPPORTED_STREAMING_OUTPUT_MODE" : {
-    "message" : [
-      "Data source <className> does not support streaming output mode <outputMode>."
-    ],
-    "sqlState" : "42KDE"
-  },
   "DATETIME_OVERFLOW" : {
     "message" : [
       "Datetime operation overflow: <operation>."
@@ -2946,12 +2940,6 @@
     ],
     "sqlState" : "42601"
   },
-  "INVALID_STREAMING_OUTPUT_MODE" : {
-    "message" : [
-      "Invalid streaming output mode: <outputMode>. Accepted output modes are 'Append', 'Complete', 'Update'."
-    ],
-    "sqlState" : "42KDE"
-  },
   "INVALID_SUBQUERY_EXPRESSION" : {
     "message" : [
       "Invalid subquery:"
@@ -4156,6 +4144,29 @@
     ],
     "sqlState" : "42601"
   },
+  "STREAMING_OUTPUT_MODE" : {
+    "message" : [
+      "Invalid streaming output mode: <outputMode>."
+    ],
+    "subClass" : {
+      "INVALID" : {
+        "message" : [
+          "Accepted output modes are 'Append', 'Complete', 'Update'."
+        ]
+      },
+      "UNSUPPORTED_DATASOURCE" : {
+        "message" : [
+          "This output mode is not supported in Data Source <className>."
+        ]
+      },
+      "UNSUPPORTED_OPERATION" : {
+        "message" : [
+          "This output mode is not supported for <operation> on streaming DataFrames/DataSets."
+        ]
+      }
+    },
+    "sqlState" : "42KDE"
+  },
   "STREAMING_PYTHON_RUNNER_INITIALIZATION_FAILURE" : {
     "message" : [
       "Streaming Runner initialization failed, returned <resFromPython>. Cause: <msg>"
@@ -4985,12 +4996,6 @@
       }
     },
     "sqlState" : "42K0E"
-  },
-  "UNSUPPORTED_OUTPUT_MODE_FOR_STREAMING_OPERATION" : {
-    "message" : [
-      "The output mode <outputMode> is not supported for <operation> on streaming DataFrames/DataSets."
-    ],
-    "sqlState" : "42KDE"
   },
   "UNSUPPORTED_OVERWRITE" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2940,6 +2940,24 @@
     ],
     "sqlState" : "42601"
   },
+  "INVALID_STREAMING_OUTPUT_MODE" : {
+    "message" : [
+      "Invalid output mode: <outputMode>."
+    ],
+    "subClass" : {
+      "NOT_SUPPORTED_IN_FILE_SINK" : {
+        "message" : [
+          "Only 'append' output mode is supported in File Sink."
+        ]
+      },
+      "UNKNOWN" : {
+        "message" : [
+          "Accepted output modes are 'append', 'complete', 'update'."
+        ]
+      }
+    },
+    "sqlState" : "42KDE"
+  },
   "INVALID_SUBQUERY_EXPRESSION" : {
     "message" : [
       "Invalid subquery:"
@@ -5774,11 +5792,6 @@
       "Failed to resolve the schema for <format> for the partition column: <partitionColumn>. It must be specified manually."
     ]
   },
-  "_LEGACY_ERROR_TEMP_1131" : {
-    "message" : [
-      "Data source <className> does not support <outputMode> output mode."
-    ]
-  },
   "_LEGACY_ERROR_TEMP_1132" : {
     "message" : [
       "A schema needs to be specified when using <className>."
@@ -7201,11 +7214,6 @@
       "StreamingRelationExec cannot be executed."
     ]
   },
-  "_LEGACY_ERROR_TEMP_2211" : {
-    "message" : [
-      "Invalid output mode: <outputMode>."
-    ]
-  },
   "_LEGACY_ERROR_TEMP_2212" : {
     "message" : [
       "Invalid catalog name: <name>."
@@ -8520,11 +8528,6 @@
   "_LEGACY_ERROR_TEMP_3260" : {
     "message" : [
       "'<s>' is an invalid timestamp"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3261" : {
-    "message" : [
-      "Unknown output mode <outputMode>. Accepted output modes are 'append', 'complete', 'update'"
     ]
   },
   "_LEGACY_ERROR_TEMP_3262" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1059,6 +1059,12 @@
     ],
     "sqlState" : "42K03"
   },
+  "DATA_SOURCE_UNSUPPORTED_STREAMING_OUTPUT_MODE" : {
+    "message" : [
+      "Data source <className> does not support streaming output mode <outputMode>."
+    ],
+    "sqlState" : "42KDE"
+  },
   "DATETIME_OVERFLOW" : {
     "message" : [
       "Datetime operation overflow: <operation>."
@@ -2942,20 +2948,8 @@
   },
   "INVALID_STREAMING_OUTPUT_MODE" : {
     "message" : [
-      "Invalid output mode: <outputMode>."
+      "Invalid streaming output mode: <outputMode>. Accepted output modes are 'Append', 'Complete', 'Update'."
     ],
-    "subClass" : {
-      "NOT_SUPPORTED_IN_FILE_SINK" : {
-        "message" : [
-          "Only 'append' output mode is supported in File Sink."
-        ]
-      },
-      "UNKNOWN" : {
-        "message" : [
-          "Accepted output modes are 'append', 'complete', 'update'."
-        ]
-      }
-    },
     "sqlState" : "42KDE"
   },
   "INVALID_SUBQUERY_EXPRESSION" : {
@@ -4991,6 +4985,12 @@
       }
     },
     "sqlState" : "42K0E"
+  },
+  "UNSUPPORTED_OUTPUT_MODE_FOR_STREAMING_OPERATION" : {
+    "message" : [
+      "The output mode <outputMode> is not supported for <operation> on streaming DataFrames/DataSets."
+    ],
+    "sqlState" : "42KDE"
   },
   "UNSUPPORTED_OVERWRITE" : {
     "message" : [

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/streaming/InternalOutputModes.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/streaming/InternalOutputModes.scala
@@ -58,7 +58,7 @@ private[sql] object InternalOutputModes {
       case "update" =>
         OutputMode.Update
       case _ => throw new SparkIllegalArgumentException(
-          errorClass = "_LEGACY_ERROR_TEMP_3261",
+          errorClass = "INVALID_STREAMING_OUTPUT_MODE.UNKNOWN",
           messageParameters = Map("outputMode" -> outputMode))
     }
   }

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/streaming/InternalOutputModes.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/streaming/InternalOutputModes.scala
@@ -58,7 +58,7 @@ private[sql] object InternalOutputModes {
       case "update" =>
         OutputMode.Update
       case _ => throw new SparkIllegalArgumentException(
-          errorClass = "INVALID_STREAMING_OUTPUT_MODE.UNKNOWN",
+          errorClass = "INVALID_STREAMING_OUTPUT_MODE",
           messageParameters = Map("outputMode" -> outputMode))
     }
   }

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/streaming/InternalOutputModes.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/streaming/InternalOutputModes.scala
@@ -58,7 +58,7 @@ private[sql] object InternalOutputModes {
       case "update" =>
         OutputMode.Update
       case _ => throw new SparkIllegalArgumentException(
-          errorClass = "INVALID_STREAMING_OUTPUT_MODE",
+          errorClass = "STREAMING_OUTPUT_MODE.INVALID",
           messageParameters = Map("outputMode" -> outputMode))
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.errors
 
+import java.util.Locale
+
 import scala.collection.mutable
 
 import org.apache.hadoop.fs.Path
@@ -1635,13 +1637,11 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("path" -> path))
   }
 
-  def dataSourceOutputModeUnsupportedError(
-      className: String, outputMode: OutputMode): Throwable = {
+  def fileSinkOutputModeUnsupportedError(
+      className: String, outputMode: OutputMode): AnalysisException = {
     new AnalysisException(
-      errorClass = "_LEGACY_ERROR_TEMP_1131",
-      messageParameters = Map(
-        "className" -> className,
-        "outputMode" -> outputMode.toString))
+      errorClass = "INVALID_STREAMING_OUTPUT_MODE.NOT_SUPPORTED_IN_FILE_SINK",
+      messageParameters = Map("outputMode" -> outputMode.toString.toLowerCase(Locale.ROOT)))
   }
 
   def schemaNotSpecifiedForSchemaRelationProviderError(className: String): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1640,7 +1640,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
   def dataSourceOutputModeUnsupportedError(
       className: String, outputMode: OutputMode): AnalysisException = {
     new AnalysisException(
-      errorClass = "DATA_SOURCE_UNSUPPORTED_STREAMING_OUTPUT_MODE",
+      errorClass = "STREAMING_OUTPUT_MODE.UNSUPPORTED_DATASOURCE",
       messageParameters = Map(
         "className" -> className,
         "outputMode" -> outputMode.toString.toLowerCase(Locale.ROOT)))
@@ -1649,7 +1649,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
   def unsupportedOutputModeForStreamingOperationError(
       outputMode: OutputMode, operation: String): AnalysisException = {
     new AnalysisException(
-      errorClass = "UNSUPPORTED_OUTPUT_MODE_FOR_STREAMING_OPERATION",
+      errorClass = "STREAMING_OUTPUT_MODE.UNSUPPORTED_OPERATION",
       messageParameters = Map(
         "outputMode" -> outputMode.toString().toLowerCase(Locale.ROOT),
         "operation" -> operation))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1637,11 +1637,22 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("path" -> path))
   }
 
-  def fileSinkOutputModeUnsupportedError(
+  def dataSourceOutputModeUnsupportedError(
       className: String, outputMode: OutputMode): AnalysisException = {
     new AnalysisException(
-      errorClass = "INVALID_STREAMING_OUTPUT_MODE.NOT_SUPPORTED_IN_FILE_SINK",
-      messageParameters = Map("outputMode" -> outputMode.toString.toLowerCase(Locale.ROOT)))
+      errorClass = "DATA_SOURCE_UNSUPPORTED_STREAMING_OUTPUT_MODE",
+      messageParameters = Map(
+        "className" -> className,
+        "outputMode" -> outputMode.toString.toLowerCase(Locale.ROOT)))
+  }
+
+  def unsupportedOutputModeForStreamingOperationError(
+      outputMode: OutputMode, operation: String): AnalysisException = {
+    new AnalysisException(
+      errorClass = "UNSUPPORTED_OUTPUT_MODE_FOR_STREAMING_OPERATION",
+      messageParameters = Map(
+        "outputMode" -> outputMode.toString().toLowerCase(Locale.ROOT),
+        "operation" -> operation))
   }
 
   def schemaNotSpecifiedForSchemaRelationProviderError(className: String): Throwable = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1750,11 +1750,10 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def invalidStreamingOutputModeError(
-      outputMode: Option[OutputMode]): SparkUnsupportedOperationException = {
-    new SparkUnsupportedOperationException(
-      errorClass = "_LEGACY_ERROR_TEMP_2211",
-      messageParameters = Map(
-        "outputMode" -> outputMode.toString()))
+      outputMode: Option[OutputMode]): SparkIllegalArgumentException = {
+    new SparkIllegalArgumentException(
+      errorClass = "INVALID_STREAMING_OUTPUT_MODE.UNKNOWN",
+      messageParameters = Map("outputMode" -> outputMode.get.toString()))
   }
 
   def pythonStreamingDataSourceRuntimeError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1749,11 +1749,14 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
     new SparkUnsupportedOperationException(errorClass = "_LEGACY_ERROR_TEMP_2210")
   }
 
-  def invalidStreamingOutputModeError(
-      outputMode: Option[OutputMode]): SparkIllegalArgumentException = {
-    new SparkIllegalArgumentException(
-      errorClass = "INVALID_STREAMING_OUTPUT_MODE.UNKNOWN",
-      messageParameters = Map("outputMode" -> outputMode.get.toString()))
+  def unsupportedOutputModeForStreamingOperationError(
+      outputMode: OutputMode,
+      operation: String): SparkUnsupportedOperationException = {
+    new SparkUnsupportedOperationException(
+      errorClass = "UNSUPPORTED_OUTPUT_MODE_FOR_STREAMING_OPERATION",
+      messageParameters = Map(
+        "outputMode" -> outputMode.toString().toLowerCase(Locale.ROOT),
+        "operation" -> operation))
   }
 
   def pythonStreamingDataSourceRuntimeError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -1753,7 +1753,7 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       outputMode: OutputMode,
       operation: String): SparkUnsupportedOperationException = {
     new SparkUnsupportedOperationException(
-      errorClass = "UNSUPPORTED_OUTPUT_MODE_FOR_STREAMING_OPERATION",
+      errorClass = "STREAMING_OUTPUT_MODE.UNSUPPORTED_OPERATION",
       messageParameters = Map(
         "outputMode" -> outputMode.toString().toLowerCase(Locale.ROOT),
         "operation" -> operation))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/UnsupportedOperationsSuite.scala
@@ -1052,7 +1052,7 @@ class UnsupportedOperationsSuite extends SparkFunSuite with SQLHelper {
         exception = intercept[AnalysisException] {
           UnsupportedOperationChecker.checkForStreaming(wrapInStreaming(plan), outputMode)
         },
-        errorClass = "UNSUPPORTED_OUTPUT_MODE_FOR_STREAMING_OPERATION",
+        errorClass = "STREAMING_OUTPUT_MODE.UNSUPPORTED_OPERATION",
         sqlState = "42KDE",
         parameters = Map(
           "outputMode" -> outputMode.toString.toLowerCase(Locale.ROOT),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/streaming/InternalOutputModesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/streaming/InternalOutputModesSuite.scala
@@ -41,7 +41,7 @@ class InternalOutputModesSuite extends SparkFunSuite {
       exception = intercept[SparkIllegalArgumentException] {
         InternalOutputModes(outputMode)
       },
-      errorClass = "INVALID_STREAMING_OUTPUT_MODE",
+      errorClass = "STREAMING_OUTPUT_MODE.INVALID",
       parameters = Map("outputMode" -> outputMode))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/streaming/InternalOutputModesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/streaming/InternalOutputModesSuite.scala
@@ -41,7 +41,7 @@ class InternalOutputModesSuite extends SparkFunSuite {
       exception = intercept[SparkIllegalArgumentException] {
         InternalOutputModes(outputMode)
       },
-      errorClass = "INVALID_STREAMING_OUTPUT_MODE.UNKNOWN",
+      errorClass = "INVALID_STREAMING_OUTPUT_MODE",
       parameters = Map("outputMode" -> outputMode))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/streaming/InternalOutputModesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/streaming/InternalOutputModesSuite.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.catalyst.streaming
 
-import java.util.Locale
-
 import org.apache.spark.{SparkFunSuite, SparkIllegalArgumentException}
 import org.apache.spark.sql.streaming.OutputMode
 
@@ -38,13 +36,12 @@ class InternalOutputModesSuite extends SparkFunSuite {
   }
 
   test("unsupported strings") {
-    def testMode(outputMode: String): Unit = {
-      val acceptedModes = Seq("append", "update", "complete")
-      val e = intercept[SparkIllegalArgumentException](InternalOutputModes(outputMode))
-      (Seq("output mode", "unknown", outputMode) ++ acceptedModes).foreach { s =>
-        assert(e.getMessage.toLowerCase(Locale.ROOT).contains(s.toLowerCase(Locale.ROOT)))
-      }
-    }
-    testMode("Xyz")
+    val outputMode = "Xyz"
+    checkError(
+      exception = intercept[SparkIllegalArgumentException] {
+        InternalOutputModes(outputMode)
+      },
+      errorClass = "INVALID_STREAMING_OUTPUT_MODE.UNKNOWN",
+      parameters = Map("outputMode" -> outputMode))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -320,7 +320,7 @@ case class DataSource(
           throw QueryExecutionErrors.dataPathNotSpecifiedError()
         })
         if (outputMode != OutputMode.Append) {
-          throw QueryCompilationErrors.fileSinkOutputModeUnsupportedError(className, outputMode)
+          throw QueryCompilationErrors.dataSourceOutputModeUnsupportedError(className, outputMode)
         }
         new FileStreamSink(sparkSession, path, fileFormat, partitionColumns, caseInsensitiveOptions)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -320,7 +320,7 @@ case class DataSource(
           throw QueryExecutionErrors.dataPathNotSpecifiedError()
         })
         if (outputMode != OutputMode.Append) {
-          throw QueryCompilationErrors.dataSourceOutputModeUnsupportedError(className, outputMode)
+          throw QueryCompilationErrors.fileSinkOutputModeUnsupportedError(className, outputMode)
         }
         new FileStreamSink(sparkSession, path, fileFormat, partitionColumns, caseInsensitiveOptions)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -688,7 +688,8 @@ case class StateStoreSaveExec(
               }
             }
 
-          case _ => throw QueryExecutionErrors.invalidStreamingOutputModeError(outputMode)
+          case _ => throw QueryExecutionErrors.unsupportedOutputModeForStreamingOperationError(
+            outputMode.get, "streaming aggregations")
         }
     }
   }
@@ -936,7 +937,8 @@ case class SessionWindowStateStoreSaveExec(
             }
           }
 
-        case _ => throw QueryExecutionErrors.invalidStreamingOutputModeError(outputMode)
+        case _ => throw throw QueryExecutionErrors.unsupportedOutputModeForStreamingOperationError(
+          outputMode.get, "session window streaming aggregations")
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonStreamingDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonStreamingDataSourceSuite.scala
@@ -1035,7 +1035,7 @@ class PythonStreamingDataSourceWriteSuite extends PythonDataSourceSuiteBase {
         exception = intercept[AnalysisException] {
           runQuery("complete")
         },
-        errorClass = "UNSUPPORTED_OUTPUT_MODE_FOR_STREAMING_OPERATION",
+        errorClass = "STREAMING_OUTPUT_MODE.UNSUPPORTED_OPERATION",
         sqlState = "42KDE",
         parameters = Map(
           "outputMode" -> "complete",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonStreamingDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonStreamingDataSourceSuite.scala
@@ -1035,10 +1035,11 @@ class PythonStreamingDataSourceWriteSuite extends PythonDataSourceSuiteBase {
         exception = intercept[AnalysisException] {
           runQuery("complete")
         },
-        errorClass = "_LEGACY_ERROR_TEMP_3102",
+        errorClass = "UNSUPPORTED_OUTPUT_MODE_FOR_STREAMING_OPERATION",
+        sqlState = "42KDE",
         parameters = Map(
-          "msg" -> ("Complete output mode not supported when there are no streaming aggregations" +
-            " on streaming DataFrames/Datasets")))
+          "outputMode" -> "complete",
+          "operation" -> "no streaming aggregations"))
 
       // Query should fail in planning with "invalid" mode.
       val error2 = intercept[IllegalArgumentException] {

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSinkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSinkSuite.scala
@@ -280,7 +280,7 @@ abstract class FileStreamSinkSuite extends StreamTest {
           exception = intercept[AnalysisException] {
             df.writeStream.format("parquet").outputMode(mode).start(dir.getCanonicalPath)
           },
-          errorClass = "DATA_SOURCE_UNSUPPORTED_STREAMING_OUTPUT_MODE",
+          errorClass = "STREAMING_OUTPUT_MODE.UNSUPPORTED_DATASOURCE",
           sqlState = "42KDE",
           parameters = Map("className" -> "parquet", "outputMode" -> mode))
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSinkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSinkSuite.scala
@@ -274,14 +274,15 @@ abstract class FileStreamSinkSuite extends StreamTest {
     val outputDir = Utils.createTempDir(namePrefix = "stream.output").getCanonicalPath
 
     withTempDir { dir =>
+
       def testOutputMode(mode: String): Unit = {
         checkError(
           exception = intercept[AnalysisException] {
             df.writeStream.format("parquet").outputMode(mode).start(dir.getCanonicalPath)
           },
-          errorClass = "INVALID_STREAMING_OUTPUT_MODE.NOT_SUPPORTED_IN_FILE_SINK",
+          errorClass = "DATA_SOURCE_UNSUPPORTED_STREAMING_OUTPUT_MODE",
           sqlState = "42KDE",
-          parameters = Map("outputMode" -> mode))
+          parameters = Map("className" -> "parquet", "outputMode" -> mode))
       }
       testOutputMode("update")
       testOutputMode("complete")

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSinkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/FileStreamSinkSuite.scala
@@ -274,16 +274,15 @@ abstract class FileStreamSinkSuite extends StreamTest {
     val outputDir = Utils.createTempDir(namePrefix = "stream.output").getCanonicalPath
 
     withTempDir { dir =>
-
       def testOutputMode(mode: String): Unit = {
-        val e = intercept[AnalysisException] {
-          df.writeStream.format("parquet").outputMode(mode).start(dir.getCanonicalPath)
-        }
-        Seq(mode, "not support").foreach { w =>
-          assert(e.getMessage.toLowerCase(Locale.ROOT).contains(w))
-        }
+        checkError(
+          exception = intercept[AnalysisException] {
+            df.writeStream.format("parquet").outputMode(mode).start(dir.getCanonicalPath)
+          },
+          errorClass = "INVALID_STREAMING_OUTPUT_MODE.NOT_SUPPORTED_IN_FILE_SINK",
+          sqlState = "42KDE",
+          parameters = Map("outputMode" -> mode))
       }
-
       testOutputMode("update")
       testOutputMode("complete")
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -1257,7 +1257,7 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
       inputData2.toDF().createOrReplaceTempView("s2")
       val unioned = spark.sql(
         "select s1.value from s1 union select s2.value from s2")
-      checkExceptionMessage(unioned)
+      checkAppendOutputModeException(unioned)
     }
   }
 
@@ -1266,7 +1266,7 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
     withTempView("deduptest") {
       inputData.toDF().toDF("value").createOrReplaceTempView("deduptest")
       val distinct = spark.sql("select distinct value from deduptest")
-      checkExceptionMessage(distinct)
+      checkAppendOutputModeException(distinct)
     }
   }
 
@@ -1449,16 +1449,20 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
     }
   }
 
-  private def checkExceptionMessage(df: DataFrame): Unit = {
+  private def checkAppendOutputModeException(df: DataFrame): Unit = {
     withTempDir { outputDir =>
       withTempDir { checkpointDir =>
-        val exception = intercept[AnalysisException](
-          df.writeStream
-            .option("checkpointLocation", checkpointDir.getCanonicalPath)
-            .start(outputDir.getCanonicalPath))
-        assert(exception.getMessage.contains(
-          "Append output mode not supported when there are streaming aggregations on streaming " +
-            "DataFrames/DataSets without watermark"))
+        checkError(
+          exception = intercept[AnalysisException] {
+            df.writeStream
+              .option("checkpointLocation", checkpointDir.getCanonicalPath)
+              .start(outputDir.getCanonicalPath)
+          },
+          errorClass = "UNSUPPORTED_OUTPUT_MODE_FOR_STREAMING_OPERATION",
+          sqlState = "42KDE",
+          parameters = Map(
+            "outputMode" -> "append",
+            "operation" -> "streaming aggregations without watermark"))
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQuerySuite.scala
@@ -1458,7 +1458,7 @@ class StreamingQuerySuite extends StreamTest with BeforeAndAfter with Logging wi
               .option("checkpointLocation", checkpointDir.getCanonicalPath)
               .start(outputDir.getCanonicalPath)
           },
-          errorClass = "UNSUPPORTED_OUTPUT_MODE_FOR_STREAMING_OPERATION",
+          errorClass = "STREAMING_OUTPUT_MODE.UNSUPPORTED_OPERATION",
           sqlState = "42KDE",
           parameters = Map(
             "outputMode" -> "append",

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingSessionWindowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingSessionWindowSuite.scala
@@ -600,30 +600,36 @@ class StreamingSessionWindowSuite extends StreamTest
     val inputData = MemoryStream[(String, Long)]
     val sessionUpdates = sessionWindowQuery(inputData)
 
-    val e = intercept[AnalysisException] {
-      testStream(sessionUpdates, OutputMode.Update())(
-        AddData(inputData, ("hello", 40L)),
-        CheckAnswer() // this is just to trigger the exception
-      )
-    }
-    Seq("Update output mode", "not supported", "for session window").foreach { m =>
-      assert(e.getMessage.toLowerCase(Locale.ROOT).contains(m.toLowerCase(Locale.ROOT)))
-    }
+    checkError(
+      exception = intercept[AnalysisException] {
+        testStream(sessionUpdates, OutputMode.Update())(
+          AddData(inputData, ("hello", 40L)),
+          CheckAnswer() // this is just to trigger the exception
+        )
+      },
+      errorClass = "UNSUPPORTED_OUTPUT_MODE_FOR_STREAMING_OPERATION",
+      sqlState = "42KDE",
+      parameters = Map(
+        "outputMode" -> OutputMode.Update().toString.toLowerCase(Locale.ROOT),
+        "operation" -> "session window streaming aggregations"))
   }
 
   testWithAllOptions("update mode - session window - no key") {
     val inputData = MemoryStream[Int]
     val windowedAggregation = sessionWindowQueryOnGlobalKey(inputData)
 
-    val e = intercept[AnalysisException] {
-      testStream(windowedAggregation, OutputMode.Update())(
-        AddData(inputData, 40),
-        CheckAnswer() // this is just to trigger the exception
-      )
-    }
-    Seq("Update output mode", "not supported", "for session window").foreach { m =>
-      assert(e.getMessage.toLowerCase(Locale.ROOT).contains(m.toLowerCase(Locale.ROOT)))
-    }
+    checkError(
+      exception = intercept[AnalysisException] {
+        testStream(windowedAggregation, OutputMode.Update())(
+          AddData(inputData, 40),
+          CheckAnswer() // this is just to trigger the exception
+        )
+      },
+      errorClass = "UNSUPPORTED_OUTPUT_MODE_FOR_STREAMING_OPERATION",
+      sqlState = "42KDE",
+      parameters = Map(
+        "outputMode" -> OutputMode.Update().toString.toLowerCase(Locale.ROOT),
+        "operation" -> "session window streaming aggregations"))
   }
 
   // Test that session window works with mean, median, std dev, variance, UDAFs

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingSessionWindowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingSessionWindowSuite.scala
@@ -607,7 +607,7 @@ class StreamingSessionWindowSuite extends StreamTest
           CheckAnswer() // this is just to trigger the exception
         )
       },
-      errorClass = "UNSUPPORTED_OUTPUT_MODE_FOR_STREAMING_OPERATION",
+      errorClass = "STREAMING_OUTPUT_MODE.UNSUPPORTED_OPERATION",
       sqlState = "42KDE",
       parameters = Map(
         "outputMode" -> OutputMode.Update().toString.toLowerCase(Locale.ROOT),
@@ -625,7 +625,7 @@ class StreamingSessionWindowSuite extends StreamTest
           CheckAnswer() // this is just to trigger the exception
         )
       },
-      errorClass = "UNSUPPORTED_OUTPUT_MODE_FOR_STREAMING_OPERATION",
+      errorClass = "STREAMING_OUTPUT_MODE.UNSUPPORTED_OPERATION",
       sqlState = "42KDE",
       parameters = Map(
         "outputMode" -> OutputMode.Update().toString.toLowerCase(Locale.ROOT),

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateChainingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateChainingSuite.scala
@@ -185,13 +185,17 @@ class TransformWithStateChainingSuite extends StreamTest {
         .groupBy(window($"outputEventTime", "1 minute"))
         .count()
 
-      val ex = intercept[ExtendedAnalysisException] {
-        testStream(result, OutputMode.Append())(
-          StartStream()
-        )
-      }
-      assert(ex.getMessage.contains("there are streaming aggregations on" +
-        " streaming DataFrames/DataSets without watermark"))
+      checkError(
+        exception = intercept[AnalysisException] {
+          testStream(result, OutputMode.Append())(
+            StartStream()
+          )
+        },
+        errorClass = "UNSUPPORTED_OUTPUT_MODE_FOR_STREAMING_OPERATION",
+        sqlState = "42KDE",
+        parameters = Map(
+          "outputMode" -> "append",
+          "operation" -> "streaming aggregations without watermark"))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateChainingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateChainingSuite.scala
@@ -191,7 +191,7 @@ class TransformWithStateChainingSuite extends StreamTest {
             StartStream()
           )
         },
-        errorClass = "UNSUPPORTED_OUTPUT_MODE_FOR_STREAMING_OPERATION",
+        errorClass = "STREAMING_OUTPUT_MODE.UNSUPPORTED_OPERATION",
         sqlState = "42KDE",
         parameters = Map(
           "outputMode" -> "append",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR aims to assign names to streaming output mode related error classes:

- _LEGACY_ERROR_TEMP_1131 -> STREAMING_OUTPUT_MODE.UNSUPPORTED_DATASOURCE
- _LEGACY_ERROR_TEMP_3261 -> STREAMING_OUTPUT_MODE.INVALID
- _LEGACY_ERROR_TEMP_2211 -> STREAMING_OUTPUT_MODE.UNSUPPORTED_OPERATION

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Proper error names and messages improve user experience with SS.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, this PR changes user-facing error class and message.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.