### PR TITLE
[SPARK-48884][PYTHON] Remove unused helper function `PythonSQLUtils.makeInterval`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
@@ -20,11 +20,9 @@ package org.apache.spark.sql.api.python
 import java.io.InputStream
 import java.net.Socket
 import java.nio.channels.Channels
-import java.util.Locale
 
 import net.razorvine.pickle.{Pickler, Unpickler}
 
-import org.apache.spark.SparkException
 import org.apache.spark.api.python.DechunkedInputStream
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys.CLASS_LOADER
@@ -148,22 +146,6 @@ private[sql] object PythonSQLUtils extends Logging {
     Column(EWM(e.expr, alpha, ignoreNA))
 
   def nullIndex(e: Column): Column = Column(NullIndex(e.expr))
-
-  def makeInterval(unit: String, e: Column): Column = {
-    val zero = MakeInterval(years = Literal(0), months = Literal(0), weeks = Literal(0),
-      days = Literal(0), hours = Literal(0), mins = Literal(0), secs = Literal(0))
-
-    unit.toUpperCase(Locale.ROOT) match {
-      case "YEAR" => Column(zero.copy(years = e.expr))
-      case "MONTH" => Column(zero.copy(months = e.expr))
-      case "WEEK" => Column(zero.copy(weeks = e.expr))
-      case "DAY" => Column(zero.copy(days = e.expr))
-      case "HOUR" => Column(zero.copy(hours = e.expr))
-      case "MINUTE" => Column(zero.copy(mins = e.expr))
-      case "SECOND" => Column(zero.copy(secs = e.expr))
-      case _ => throw SparkException.internalError(s"Got the unexpected unit '$unit'.")
-    }
-  }
 
   def pandasProduct(e: Column, ignoreNA: Boolean): Column = {
     Column(PandasProduct(e.expr, ignoreNA).toAggregateExpression(false))


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove unused helper function `PythonSQLUtils.makeInterval`


### Why are the changes needed?
As a followup cleanup of https://github.com/apache/spark/commit/bd14d6412a3124eecce1493fcad436280915ba71


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
NO