### PR TITLE
[SPARK-48892][ML] Avoid per-row param read in `Tokenizer`

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/Tokenizer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/Tokenizer.scala
@@ -143,25 +143,16 @@ class RegexTokenizer @Since("1.4.0") (@Since("1.4.0") override val uid: String)
 
   override protected def createTransformFunc: String => Seq[String] = {
     val re = $(pattern).r
+    val localToLowercase = $(toLowercase)
+    val localGaps = $(gaps)
     val localMinTokenLength = $(minTokenLength)
 
-    ($(toLowercase), $(gaps)) match {
-      case (true, true) =>
-        (originStr: String) =>
-          re.split(originStr.toLowerCase()).toImmutableArraySeq
-            .filter(_.length >= localMinTokenLength)
-
-      case (true, false) =>
-        (originStr: String) => re.findAllIn(originStr.toLowerCase()).toSeq
-          .filter(_.length >= localMinTokenLength)
-
-      case (false, true) =>
-        (originStr: String) => re.split(originStr).toImmutableArraySeq
-          .filter(_.length >= localMinTokenLength)
-
-      case (false, false) =>
-        (originStr: String) => re.findAllIn(originStr).toSeq
-          .filter(_.length >= localMinTokenLength)
+    (originStr: String) => {
+      // scalastyle:off caselocale
+      val str = if (localToLowercase) originStr.toLowerCase() else originStr
+      // scalastyle:on caselocale
+      val tokens = if (localGaps) re.split(str).toImmutableArraySeq else re.findAllIn(str).toSeq
+      tokens.filter(_.length >= localMinTokenLength)
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Inspired by https://github.com/apache/spark/pull/47258, I am checking other ML implementations, and find that we can also optimize `Tokenizer` in the same way


### Why are the changes needed?
the function `createTransformFunc` is to build the udf for `UnaryTransformer.transform`:
https://github.com/apache/spark/blob/d679dabdd1b5ad04b8c7deb1c06ce886a154a928/mllib/src/main/scala/org/apache/spark/ml/Transformer.scala#L118

existing implementation read the params for each row.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI and manually tests:

create test dataset
```
spark.range(1000000).select(uuid().as("uuid")).write.mode("overwrite").parquet("/tmp/regex_tokenizer.parquet")
```

duration
```
val df = spark.read.parquet("/tmp/regex_tokenizer.parquet")
import org.apache.spark.ml.feature._
val tokenizer = new RegexTokenizer().setPattern("-").setInputCol("uuid")
Seq.range(0, 1000).foreach(i => tokenizer.transform(df).count()) // warm up
val tic = System.currentTimeMillis; Seq.range(0, 1000).foreach(i => tokenizer.transform(df).count()); System.currentTimeMillis - tic
```

result (before this PR)
```
scala> val tic = System.currentTimeMillis; Seq.range(0, 1000).foreach(i => tokenizer.transform(df).count()); System.currentTimeMillis - tic
val tic: Long = 1720613235068
val res5: Long = 50397
```

result (after this PR)
```
scala> val tic = System.currentTimeMillis; Seq.range(0, 1000).foreach(i => tokenizer.transform(df).count()); System.currentTimeMillis - tic
val tic: Long = 1720612871256
val res5: Long = 43748
```

### Was this patch authored or co-authored using generative AI tooling?
No
