### PR TITLE
[SPARK-48893][SQL][PYTHON][DOCS] Add some examples for `linearRegression` built-in functions

### DIFF
--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -4039,7 +4039,7 @@ def regr_r2(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 5: Some paris's x or y values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> df = df = spark.sql("SELECT * FROM VALUES (1, 1), (2, null), (null, 3), (4, 4) AS tab(y, x)")
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 1), (2, null), (null, 3), (4, 4) AS tab(y, x)")
     >>> df.select(sf.regr_r2("y", "x")).show()
     +-------------+
     |regr_r2(y, x)|

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -3671,16 +3671,84 @@ def regr_avgx(y: "ColumnOrName", x: "ColumnOrName") -> Column:
 
     Examples
     --------
-    >>> from pyspark.sql import functions as sf
-    >>> x = (sf.col("id") % 3).alias("x")
-    >>> y = (sf.randn(42) + x * 10).alias("y")
-    >>> spark.range(0, 1000, 1, 1).select(x, y).select(
-    ...     sf.regr_avgx("y", "x"), sf.avg("x")
-    ... ).show()
+    Example 1: All paris are non-null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 2), (2, 2), (2, 3), (2, 4)], schema)
+    >>> df.select(sf.regr_avgx("y", "x"), sf.avg("x")).show()
     +---------------+------+
     |regr_avgx(y, x)|avg(x)|
     +---------------+------+
-    |          0.999| 0.999|
+    |           2.75|  2.75|
+    +---------------+------+
+
+    Example 2: All paris's x values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, None)], schema)
+    >>> df.select(sf.regr_avgx("y", "x"), sf.avg("x")).show()
+    +---------------+------+
+    |regr_avgx(y, x)|avg(x)|
+    +---------------+------+
+    |           NULL|  NULL|
+    +---------------+------+
+
+    Example 3: All paris's y values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(None, 1)], schema)
+    >>> df.select(sf.regr_avgx("y", "x"), sf.avg("x")).show()
+    +---------------+------+
+    |regr_avgx(y, x)|avg(x)|
+    +---------------+------+
+    |           NULL|   1.0|
+    +---------------+------+
+
+    Example 4: Some paris's x values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 2), (2, None), (2, 3), (2, 4)], schema)
+    >>> df.select(sf.regr_avgx("y", "x"), sf.avg("x")).show()
+    +---------------+------+
+    |regr_avgx(y, x)|avg(x)|
+    +---------------+------+
+    |            3.0|   3.0|
+    +---------------+------+
+
+    Example 5: Some paris's x or y values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 2), (2, None), (None, 3), (2, 4)], schema)
+    >>> df.select(sf.regr_avgx("y", "x"), sf.avg("x")).show()
+    +---------------+------+
+    |regr_avgx(y, x)|avg(x)|
+    +---------------+------+
+    |            3.0|   3.0|
     +---------------+------+
     """
     return _invoke_function_over_columns("regr_avgx", y, x)
@@ -3708,17 +3776,85 @@ def regr_avgy(y: "ColumnOrName", x: "ColumnOrName") -> Column:
 
     Examples
     --------
-    >>> from pyspark.sql import functions as sf
-    >>> x = (sf.col("id") % 3).alias("x")
-    >>> y = (sf.randn(42) + x * 10).alias("y")
-    >>> spark.range(0, 1000, 1, 1).select(x, y).select(
-    ...     sf.regr_avgy("y", "x"), sf.avg("y")
-    ... ).show()
-    +-----------------+-----------------+
-    |  regr_avgy(y, x)|           avg(y)|
-    +-----------------+-----------------+
-    |9.980732994136...|9.980732994136...|
-    +-----------------+-----------------+
+    Example 1: All paris are non-null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 2), (2, 2), (2, 3), (2, 4)], schema)
+    >>> df.select(sf.regr_avgy("y", "x"), sf.avg("y")).show()
+    +---------------+------+
+    |regr_avgy(y, x)|avg(y)|
+    +---------------+------+
+    |           1.75|  1.75|
+    +---------------+------+
+
+    Example 2: All paris's x values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, None)], schema)
+    >>> df.select(sf.regr_avgy("y", "x"), sf.avg("y")).show()
+    +---------------+------+
+    |regr_avgy(y, x)|avg(y)|
+    +---------------+------+
+    |           NULL|   1.0|
+    +---------------+------+
+
+    Example 3: All paris's y values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(None, 1)], schema)
+    >>> df.select(sf.regr_avgy("y", "x"), sf.avg("y")).show()
+    +---------------+------+
+    |regr_avgy(y, x)|avg(y)|
+    +---------------+------+
+    |           NULL|  NULL|
+    +---------------+------+
+
+    Example 4: Some paris's x values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 2), (2, None), (2, 3), (2, 4)], schema)
+    >>> df.select(sf.regr_avgy("y", "x"), sf.avg("y")).show()
+    +------------------+------+
+    |   regr_avgy(y, x)|avg(y)|
+    +------------------+------+
+    |1.6666666666666667|  1.75|
+    +------------------+------+
+
+    Example 5: Some paris's x or y values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 2), (2, None), (None, 3), (2, 4)], schema)
+    >>> df.select(sf.regr_avgy("y", "x"), sf.avg("y")).show()
+    +---------------+------------------+
+    |regr_avgy(y, x)|            avg(y)|
+    +---------------+------------------+
+    |            1.5|1.6666666666666667|
+    +---------------+------------------+
     """
     return _invoke_function_over_columns("regr_avgy", y, x)
 
@@ -3745,16 +3881,84 @@ def regr_count(y: "ColumnOrName", x: "ColumnOrName") -> Column:
 
     Examples
     --------
-    >>> from pyspark.sql import functions as sf
-    >>> x = (sf.col("id") % 3).alias("x")
-    >>> y = (sf.randn(42) + x * 10).alias("y")
-    >>> spark.range(0, 1000, 1, 1).select(x, y).select(
-    ...     sf.regr_count("y", "x"), sf.count(sf.lit(0))
-    ... ).show()
+    Example 1: All paris are non-null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 2), (2, 2), (2, 3), (2, 4)], schema)
+    >>> df.select(sf.regr_count("y", "x"), sf.count(sf.lit(0))).show()
     +----------------+--------+
     |regr_count(y, x)|count(0)|
     +----------------+--------+
-    |            1000|    1000|
+    |               4|       4|
+    +----------------+--------+
+
+    Example 2: All paris's x values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, None)], schema)
+    >>> df.select(sf.regr_count("y", "x"), sf.count(sf.lit(0))).show()
+    +----------------+--------+
+    |regr_count(y, x)|count(0)|
+    +----------------+--------+
+    |               0|       1|
+    +----------------+--------+
+
+    Example 3: All paris's y values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(None, 1)], schema)
+    >>> df.select(sf.regr_count("y", "x"), sf.count(sf.lit(0))).show()
+    +----------------+--------+
+    |regr_count(y, x)|count(0)|
+    +----------------+--------+
+    |               0|       1|
+    +----------------+--------+
+
+    Example 4: Some paris's x values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 2), (2, None), (2, 3), (2, 4)], schema)
+    >>> df.select(sf.regr_count("y", "x"), sf.count(sf.lit(0))).show()
+    +----------------+--------+
+    |regr_count(y, x)|count(0)|
+    +----------------+--------+
+    |               3|       4|
+    +----------------+--------+
+
+    Example 5: Some paris's x or y values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 2), (2, None), (None, 3), (2, 4)], schema)
+    >>> df.select(sf.regr_count("y", "x"), sf.count(sf.lit(0))).show()
+    +----------------+--------+
+    |regr_count(y, x)|count(0)|
+    +----------------+--------+
+    |               2|       4|
     +----------------+--------+
     """
     return _invoke_function_over_columns("regr_count", y, x)
@@ -3783,16 +3987,84 @@ def regr_intercept(y: "ColumnOrName", x: "ColumnOrName") -> Column:
 
     Examples
     --------
-    >>> from pyspark.sql import functions as sf
-    >>> x = (sf.col("id") % 3).alias("x")
-    >>> y = (sf.randn(42) + x * 10).alias("y")
-    >>> spark.range(0, 1000, 1, 1).select(x, y).select(
-    ...     sf.regr_intercept("y", "x")
-    ... ).show()
+    Example 1: All paris are non-null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 1), (2, 2), (3, 3), (4, 4)], schema)
+    >>> df.select(sf.regr_intercept("y", "x")).show()
     +--------------------+
     |regr_intercept(y, x)|
     +--------------------+
-    |-0.04961745990969568|
+    |                 0.0|
+    +--------------------+
+
+    Example 2: All paris's x values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, None)], schema)
+    >>> df.select(sf.regr_intercept("y", "x")).show()
+    +--------------------+
+    |regr_intercept(y, x)|
+    +--------------------+
+    |                NULL|
+    +--------------------+
+
+    Example 3: All paris's y values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(None, 1)], schema)
+    >>> df.select(sf.regr_intercept("y", "x")).show()
+    +--------------------+
+    |regr_intercept(y, x)|
+    +--------------------+
+    |                NULL|
+    +--------------------+
+
+    Example 4: Some paris's x values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 1), (2, None), (3, 3), (4, 4)], schema)
+    >>> df.select(sf.regr_intercept("y", "x")).show()
+    +--------------------+
+    |regr_intercept(y, x)|
+    +--------------------+
+    |                 0.0|
+    +--------------------+
+
+    Example 5: Some paris's x or y values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 1), (2, None), (None, 3), (4, 4)], schema)
+    >>> df.select(sf.regr_intercept("y", "x")).show()
+    +--------------------+
+    |regr_intercept(y, x)|
+    +--------------------+
+    |                 0.0|
     +--------------------+
     """
     return _invoke_function_over_columns("regr_intercept", y, x)
@@ -3820,17 +4092,85 @@ def regr_r2(y: "ColumnOrName", x: "ColumnOrName") -> Column:
 
     Examples
     --------
-    >>> from pyspark.sql import functions as sf
-    >>> x = (sf.col("id") % 3).alias("x")
-    >>> y = (sf.randn(42) + x * 10).alias("y")
-    >>> spark.range(0, 1000, 1, 1).select(x, y).select(
-    ...     sf.regr_r2("y", "x")
-    ... ).show()
+    Example 1: All paris are non-null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 2), (2, 2), (2, 3), (2, 4)], schema)
+    >>> df.select(sf.regr_r2("y", "x")).show()
     +------------------+
     |     regr_r2(y, x)|
     +------------------+
-    |0.9851908293645...|
+    |0.2727272727272726|
     +------------------+
+
+    Example 2: All paris's x values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, None)], schema)
+    >>> df.select(sf.regr_r2("y", "x")).show()
+    +-------------+
+    |regr_r2(y, x)|
+    +-------------+
+    |         NULL|
+    +-------------+
+
+    Example 3: All paris's y values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(None, 1)], schema)
+    >>> df.select(sf.regr_r2("y", "x")).show()
+    +-------------+
+    |regr_r2(y, x)|
+    +-------------+
+    |         NULL|
+    +-------------+
+
+    Example 4: Some paris's x values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 2), (2, None), (2, 3), (2, 4)], schema)
+    >>> df.select(sf.regr_r2("y", "x")).show()
+    +------------------+
+    |     regr_r2(y, x)|
+    +------------------+
+    |0.7500000000000001|
+    +------------------+
+
+    Example 5: Some paris's x or y values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 2), (2, None), (None, 3), (2, 4)], schema)
+    >>> df.select(sf.regr_r2("y", "x")).show()
+    +-------------+
+    |regr_r2(y, x)|
+    +-------------+
+    |          1.0|
+    +-------------+
     """
     return _invoke_function_over_columns("regr_r2", y, x)
 
@@ -3857,17 +4197,85 @@ def regr_slope(y: "ColumnOrName", x: "ColumnOrName") -> Column:
 
     Examples
     --------
-    >>> from pyspark.sql import functions as sf
-    >>> x = (sf.col("id") % 3).alias("x")
-    >>> y = (sf.randn(42) + x * 10).alias("y")
-    >>> spark.range(0, 1000, 1, 1).select(x, y).select(
-    ...     sf.regr_slope("y", "x")
-    ... ).show()
-    +------------------+
-    |  regr_slope(y, x)|
-    +------------------+
-    |10.040390844891...|
-    +------------------+
+    Example 1: All paris are non-null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 1), (2, 2), (3, 3), (4, 4)], schema)
+    >>> df.select(sf.regr_slope("y", "x")).show()
+    +----------------+
+    |regr_slope(y, x)|
+    +----------------+
+    |             1.0|
+    +----------------+
+
+    Example 2: All paris's x values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, None)], schema)
+    >>> df.select(sf.regr_slope("y", "x")).show()
+    +----------------+
+    |regr_slope(y, x)|
+    +----------------+
+    |            NULL|
+    +----------------+
+
+    Example 3: All paris's y values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(None, 1)], schema)
+    >>> df.select(sf.regr_slope("y", "x")).show()
+    +----------------+
+    |regr_slope(y, x)|
+    +----------------+
+    |            NULL|
+    +----------------+
+
+    Example 4: Some paris's x values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 1), (2, None), (3, 3), (4, 4)], schema)
+    >>> df.select(sf.regr_slope("y", "x")).show()
+    +----------------+
+    |regr_slope(y, x)|
+    +----------------+
+    |             1.0|
+    +----------------+
+
+    Example 5: Some paris's x or y values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 1), (2, None), (None, 3), (4, 4)], schema)
+    >>> df.select(sf.regr_slope("y", "x")).show()
+    +----------------+
+    |regr_slope(y, x)|
+    +----------------+
+    |             1.0|
+    +----------------+
     """
     return _invoke_function_over_columns("regr_slope", y, x)
 
@@ -3894,17 +4302,85 @@ def regr_sxx(y: "ColumnOrName", x: "ColumnOrName") -> Column:
 
     Examples
     --------
-    >>> from pyspark.sql import functions as sf
-    >>> x = (sf.col("id") % 3).alias("x")
-    >>> y = (sf.randn(42) + x * 10).alias("y")
-    >>> spark.range(0, 1000, 1, 1).select(x, y).select(
-    ...     sf.regr_sxx("y", "x")
-    ... ).show()
-    +-----------------+
-    |   regr_sxx(y, x)|
-    +-----------------+
-    |666.9989999999...|
-    +-----------------+
+    Example 1: All paris are non-null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 2), (2, 2), (2, 3), (2, 4)], schema)
+    >>> df.select(sf.regr_sxx("y", "x")).show()
+    +------------------+
+    |    regr_sxx(y, x)|
+    +------------------+
+    |2.7499999999999996|
+    +------------------+
+
+    Example 2: All paris's x values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, None)], schema)
+    >>> df.select(sf.regr_sxx("y", "x")).show()
+    +--------------+
+    |regr_sxx(y, x)|
+    +--------------+
+    |          NULL|
+    +--------------+
+
+    Example 3: All paris's y values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(None, 1)], schema)
+    >>> df.select(sf.regr_sxx("y", "x")).show()
+    +--------------+
+    |regr_sxx(y, x)|
+    +--------------+
+    |          NULL|
+    +--------------+
+
+    Example 4: Some paris's x values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 2), (2, None), (2, 3), (2, 4)], schema)
+    >>> df.select(sf.regr_sxx("y", "x")).show()
+    +--------------+
+    |regr_sxx(y, x)|
+    +--------------+
+    |           2.0|
+    +--------------+
+
+    Example 5: Some paris's x or y values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 2), (2, None), (None, 3), (2, 4)], schema)
+    >>> df.select(sf.regr_sxx("y", "x")).show()
+    +--------------+
+    |regr_sxx(y, x)|
+    +--------------+
+    |           2.0|
+    +--------------+
     """
     return _invoke_function_over_columns("regr_sxx", y, x)
 
@@ -3931,17 +4407,85 @@ def regr_sxy(y: "ColumnOrName", x: "ColumnOrName") -> Column:
 
     Examples
     --------
-    >>> from pyspark.sql import functions as sf
-    >>> x = (sf.col("id") % 3).alias("x")
-    >>> y = (sf.randn(42) + x * 10).alias("y")
-    >>> spark.range(0, 1000, 1, 1).select(x, y).select(
-    ...     sf.regr_sxy("y", "x")
-    ... ).show()
-    +----------------+
-    |  regr_sxy(y, x)|
-    +----------------+
-    |6696.93065315...|
-    +----------------+
+    Example 1: All paris are non-null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 2), (2, 2), (2, 3), (2, 4)], schema)
+    >>> df.select(sf.regr_sxy("y", "x")).show()
+    +------------------+
+    |    regr_sxy(y, x)|
+    +------------------+
+    |0.7499999999999998|
+    +------------------+
+
+    Example 2: All paris's x values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, None)], schema)
+    >>> df.select(sf.regr_sxy("y", "x")).show()
+    +--------------+
+    |regr_sxy(y, x)|
+    +--------------+
+    |          NULL|
+    +--------------+
+
+    Example 3: All paris's y values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(None, 1)], schema)
+    >>> df.select(sf.regr_sxy("y", "x")).show()
+    +--------------+
+    |regr_sxy(y, x)|
+    +--------------+
+    |          NULL|
+    +--------------+
+
+    Example 4: Some paris's x values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 2), (2, None), (2, 3), (2, 4)], schema)
+    >>> df.select(sf.regr_sxy("y", "x")).show()
+    +--------------+
+    |regr_sxy(y, x)|
+    +--------------+
+    |           1.0|
+    +--------------+
+
+    Example 5: Some paris's x or y values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 2), (2, None), (None, 3), (2, 4)], schema)
+    >>> df.select(sf.regr_sxy("y", "x")).show()
+    +--------------+
+    |regr_sxy(y, x)|
+    +--------------+
+    |           1.0|
+    +--------------+
     """
     return _invoke_function_over_columns("regr_sxy", y, x)
 
@@ -3968,17 +4512,85 @@ def regr_syy(y: "ColumnOrName", x: "ColumnOrName") -> Column:
 
     Examples
     --------
-    >>> from pyspark.sql import functions as sf
-    >>> x = (sf.col("id") % 3).alias("x")
-    >>> y = (sf.randn(42) + x * 10).alias("y")
-    >>> spark.range(0, 1000, 1, 1).select(x, y).select(
-    ...     sf.regr_syy("y", "x")
-    ... ).show()
-    +-----------------+
-    |   regr_syy(y, x)|
-    +-----------------+
-    |68250.53503811...|
-    +-----------------+
+    Example 1: All paris are non-null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 2), (2, 2), (2, 3), (2, 4)], schema)
+    >>> df.select(sf.regr_syy("y", "x")).show()
+    +------------------+
+    |    regr_syy(y, x)|
+    +------------------+
+    |0.7499999999999999|
+    +------------------+
+
+    Example 2: All paris's x values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, None)], schema)
+    >>> df.select(sf.regr_syy("y", "x")).show()
+    +--------------+
+    |regr_syy(y, x)|
+    +--------------+
+    |          NULL|
+    +--------------+
+
+    Example 3: All paris's y values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(None, 1)], schema)
+    >>> df.select(sf.regr_syy("y", "x")).show()
+    +--------------+
+    |regr_syy(y, x)|
+    +--------------+
+    |          NULL|
+    +--------------+
+
+    Example 4: Some paris's x values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 2), (2, None), (2, 3), (2, 4)], schema)
+    >>> df.select(sf.regr_syy("y", "x")).show()
+    +------------------+
+    |    regr_syy(y, x)|
+    +------------------+
+    |0.6666666666666666|
+    +------------------+
+
+    Example 5: Some paris's x or y values are null
+
+    >>> import pyspark.sql.functions as sf
+    >>> from pyspark.sql.types import IntegerType, StructField, StructType
+    >>> schema = StructType([
+    ...   StructField('y', IntegerType(), True),
+    ...   StructField('x', IntegerType(), True)
+    ... ])
+    >>> df = spark.createDataFrame([(1, 2), (2, None), (None, 3), (2, 4)], schema)
+    >>> df.select(sf.regr_syy("y", "x")).show()
+    +--------------+
+    |regr_syy(y, x)|
+    +--------------+
+    |           0.5|
+    +--------------+
     """
     return _invoke_function_over_columns("regr_syy", y, x)
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -3674,12 +3674,7 @@ def regr_avgx(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 1: All paris are non-null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 2), (2, 2), (2, 3), (2, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 2), (2, 2), (2, 3), (2, 4) AS tab(y, x)")
     >>> df.select(sf.regr_avgx("y", "x"), sf.avg("x")).show()
     +---------------+------+
     |regr_avgx(y, x)|avg(x)|
@@ -3690,12 +3685,7 @@ def regr_avgx(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 2: All paris's x values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, None)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, null) AS tab(y, x)")
     >>> df.select(sf.regr_avgx("y", "x"), sf.avg("x")).show()
     +---------------+------+
     |regr_avgx(y, x)|avg(x)|
@@ -3706,12 +3696,7 @@ def regr_avgx(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 3: All paris's y values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(None, 1)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (null, 1) AS tab(y, x)")
     >>> df.select(sf.regr_avgx("y", "x"), sf.avg("x")).show()
     +---------------+------+
     |regr_avgx(y, x)|avg(x)|
@@ -3722,12 +3707,7 @@ def regr_avgx(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 4: Some paris's x values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 2), (2, None), (2, 3), (2, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 2), (2, null), (2, 3), (2, 4) AS tab(y, x)")
     >>> df.select(sf.regr_avgx("y", "x"), sf.avg("x")).show()
     +---------------+------+
     |regr_avgx(y, x)|avg(x)|
@@ -3738,12 +3718,7 @@ def regr_avgx(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 5: Some paris's x or y values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 2), (2, None), (None, 3), (2, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 2), (2, null), (null, 3), (2, 4) AS tab(y, x)")
     >>> df.select(sf.regr_avgx("y", "x"), sf.avg("x")).show()
     +---------------+------+
     |regr_avgx(y, x)|avg(x)|
@@ -3779,12 +3754,7 @@ def regr_avgy(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 1: All paris are non-null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 2), (2, 2), (2, 3), (2, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 2), (2, 2), (2, 3), (2, 4) AS tab(y, x)")
     >>> df.select(sf.regr_avgy("y", "x"), sf.avg("y")).show()
     +---------------+------+
     |regr_avgy(y, x)|avg(y)|
@@ -3795,12 +3765,7 @@ def regr_avgy(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 2: All paris's x values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, None)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, null) AS tab(y, x)")
     >>> df.select(sf.regr_avgy("y", "x"), sf.avg("y")).show()
     +---------------+------+
     |regr_avgy(y, x)|avg(y)|
@@ -3811,12 +3776,7 @@ def regr_avgy(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 3: All paris's y values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(None, 1)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (null, 1) AS tab(y, x)")
     >>> df.select(sf.regr_avgy("y", "x"), sf.avg("y")).show()
     +---------------+------+
     |regr_avgy(y, x)|avg(y)|
@@ -3827,33 +3787,23 @@ def regr_avgy(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 4: Some paris's x values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 2), (2, None), (2, 3), (2, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 2), (2, null), (2, 3), (2, 4) AS tab(y, x)")
     >>> df.select(sf.regr_avgy("y", "x"), sf.avg("y")).show()
     +------------------+------+
     |   regr_avgy(y, x)|avg(y)|
     +------------------+------+
-    |1.6666666666666667|  1.75|
+    |1.6666666666666...|  1.75|
     +------------------+------+
 
     Example 5: Some paris's x or y values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 2), (2, None), (None, 3), (2, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 2), (2, null), (null, 3), (2, 4) AS tab(y, x)")
     >>> df.select(sf.regr_avgy("y", "x"), sf.avg("y")).show()
     +---------------+------------------+
     |regr_avgy(y, x)|            avg(y)|
     +---------------+------------------+
-    |            1.5|1.6666666666666667|
+    |            1.5|1.6666666666666...|
     +---------------+------------------+
     """
     return _invoke_function_over_columns("regr_avgy", y, x)
@@ -3884,12 +3834,7 @@ def regr_count(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 1: All paris are non-null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 2), (2, 2), (2, 3), (2, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 2), (2, 2), (2, 3), (2, 4) AS tab(y, x)")
     >>> df.select(sf.regr_count("y", "x"), sf.count(sf.lit(0))).show()
     +----------------+--------+
     |regr_count(y, x)|count(0)|
@@ -3900,12 +3845,7 @@ def regr_count(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 2: All paris's x values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, None)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, null) AS tab(y, x)")
     >>> df.select(sf.regr_count("y", "x"), sf.count(sf.lit(0))).show()
     +----------------+--------+
     |regr_count(y, x)|count(0)|
@@ -3916,12 +3856,7 @@ def regr_count(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 3: All paris's y values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(None, 1)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (null, 1) AS tab(y, x)")
     >>> df.select(sf.regr_count("y", "x"), sf.count(sf.lit(0))).show()
     +----------------+--------+
     |regr_count(y, x)|count(0)|
@@ -3932,12 +3867,7 @@ def regr_count(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 4: Some paris's x values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 2), (2, None), (2, 3), (2, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 2), (2, null), (2, 3), (2, 4) AS tab(y, x)")
     >>> df.select(sf.regr_count("y", "x"), sf.count(sf.lit(0))).show()
     +----------------+--------+
     |regr_count(y, x)|count(0)|
@@ -3948,12 +3878,7 @@ def regr_count(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 5: Some paris's x or y values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 2), (2, None), (None, 3), (2, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 2), (2, null), (null, 3), (2, 4) AS tab(y, x)")
     >>> df.select(sf.regr_count("y", "x"), sf.count(sf.lit(0))).show()
     +----------------+--------+
     |regr_count(y, x)|count(0)|
@@ -3990,12 +3915,7 @@ def regr_intercept(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 1: All paris are non-null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 1), (2, 2), (3, 3), (4, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 1), (2, 2), (3, 3), (4, 4) AS tab(y, x)")
     >>> df.select(sf.regr_intercept("y", "x")).show()
     +--------------------+
     |regr_intercept(y, x)|
@@ -4006,12 +3926,7 @@ def regr_intercept(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 2: All paris's x values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, None)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, null) AS tab(y, x)")
     >>> df.select(sf.regr_intercept("y", "x")).show()
     +--------------------+
     |regr_intercept(y, x)|
@@ -4022,12 +3937,7 @@ def regr_intercept(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 3: All paris's y values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(None, 1)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (null, 1) AS tab(y, x)")
     >>> df.select(sf.regr_intercept("y", "x")).show()
     +--------------------+
     |regr_intercept(y, x)|
@@ -4038,12 +3948,7 @@ def regr_intercept(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 4: Some paris's x values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 1), (2, None), (3, 3), (4, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 1), (2, null), (3, 3), (4, 4) AS tab(y, x)")
     >>> df.select(sf.regr_intercept("y", "x")).show()
     +--------------------+
     |regr_intercept(y, x)|
@@ -4054,12 +3959,7 @@ def regr_intercept(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 5: Some paris's x or y values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 1), (2, None), (None, 3), (4, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 1), (2, null), (null, 3), (4, 4) AS tab(y, x)")
     >>> df.select(sf.regr_intercept("y", "x")).show()
     +--------------------+
     |regr_intercept(y, x)|
@@ -4095,28 +3995,18 @@ def regr_r2(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 1: All paris are non-null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 2), (2, 2), (2, 3), (2, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 1), (2, 2), (3, 3), (4, 4) AS tab(y, x)")
     >>> df.select(sf.regr_r2("y", "x")).show()
-    +------------------+
-    |     regr_r2(y, x)|
-    +------------------+
-    |0.2727272727272726|
-    +------------------+
+    +-------------+
+    |regr_r2(y, x)|
+    +-------------+
+    |          1.0|
+    +-------------+
 
     Example 2: All paris's x values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, None)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, null) AS tab(y, x)")
     >>> df.select(sf.regr_r2("y", "x")).show()
     +-------------+
     |regr_r2(y, x)|
@@ -4127,12 +4017,7 @@ def regr_r2(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 3: All paris's y values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(None, 1)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (null, 1) AS tab(y, x)")
     >>> df.select(sf.regr_r2("y", "x")).show()
     +-------------+
     |regr_r2(y, x)|
@@ -4143,28 +4028,18 @@ def regr_r2(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 4: Some paris's x values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 2), (2, None), (2, 3), (2, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 1), (2, null), (3, 3), (4, 4) AS tab(y, x)")
     >>> df.select(sf.regr_r2("y", "x")).show()
-    +------------------+
-    |     regr_r2(y, x)|
-    +------------------+
-    |0.7500000000000001|
-    +------------------+
+    +-------------+
+    |regr_r2(y, x)|
+    +-------------+
+    |          1.0|
+    +-------------+
 
     Example 5: Some paris's x or y values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 2), (2, None), (None, 3), (2, 4)], schema)
+    >>> df = df = spark.sql("SELECT * FROM VALUES (1, 1), (2, null), (null, 3), (4, 4) AS tab(y, x)")
     >>> df.select(sf.regr_r2("y", "x")).show()
     +-------------+
     |regr_r2(y, x)|
@@ -4200,12 +4075,7 @@ def regr_slope(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 1: All paris are non-null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 1), (2, 2), (3, 3), (4, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 1), (2, 2), (3, 3), (4, 4) AS tab(y, x)")
     >>> df.select(sf.regr_slope("y", "x")).show()
     +----------------+
     |regr_slope(y, x)|
@@ -4216,12 +4086,7 @@ def regr_slope(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 2: All paris's x values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, None)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, null) AS tab(y, x)")
     >>> df.select(sf.regr_slope("y", "x")).show()
     +----------------+
     |regr_slope(y, x)|
@@ -4232,12 +4097,7 @@ def regr_slope(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 3: All paris's y values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(None, 1)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (null, 1) AS tab(y, x)")
     >>> df.select(sf.regr_slope("y", "x")).show()
     +----------------+
     |regr_slope(y, x)|
@@ -4248,12 +4108,7 @@ def regr_slope(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 4: Some paris's x values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 1), (2, None), (3, 3), (4, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 1), (2, null), (3, 3), (4, 4) AS tab(y, x)")
     >>> df.select(sf.regr_slope("y", "x")).show()
     +----------------+
     |regr_slope(y, x)|
@@ -4264,12 +4119,7 @@ def regr_slope(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 5: Some paris's x or y values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 1), (2, None), (None, 3), (4, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 1), (2, null), (null, 3), (4, 4) AS tab(y, x)")
     >>> df.select(sf.regr_slope("y", "x")).show()
     +----------------+
     |regr_slope(y, x)|
@@ -4305,28 +4155,18 @@ def regr_sxx(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 1: All paris are non-null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 2), (2, 2), (2, 3), (2, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 1), (2, 2), (3, 3), (4, 4) AS tab(y, x)")
     >>> df.select(sf.regr_sxx("y", "x")).show()
-    +------------------+
-    |    regr_sxx(y, x)|
-    +------------------+
-    |2.7499999999999996|
-    +------------------+
+    +--------------+
+    |regr_sxx(y, x)|
+    +--------------+
+    |           5.0|
+    +--------------+
 
     Example 2: All paris's x values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, None)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, null) AS tab(y, x)")
     >>> df.select(sf.regr_sxx("y", "x")).show()
     +--------------+
     |regr_sxx(y, x)|
@@ -4337,12 +4177,7 @@ def regr_sxx(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 3: All paris's y values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(None, 1)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (null, 1) AS tab(y, x)")
     >>> df.select(sf.regr_sxx("y", "x")).show()
     +--------------+
     |regr_sxx(y, x)|
@@ -4353,33 +4188,23 @@ def regr_sxx(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 4: Some paris's x values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 2), (2, None), (2, 3), (2, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 1), (2, null), (3, 3), (4, 4) AS tab(y, x)")
     >>> df.select(sf.regr_sxx("y", "x")).show()
-    +--------------+
-    |regr_sxx(y, x)|
-    +--------------+
-    |           2.0|
-    +--------------+
+    +-----------------+
+    |   regr_sxx(y, x)|
+    +-----------------+
+    |4.666666666666...|
+    +-----------------+
 
     Example 5: Some paris's x or y values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 2), (2, None), (None, 3), (2, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 1), (2, null), (null, 3), (4, 4) AS tab(y, x)")
     >>> df.select(sf.regr_sxx("y", "x")).show()
     +--------------+
     |regr_sxx(y, x)|
     +--------------+
-    |           2.0|
+    |           4.5|
     +--------------+
     """
     return _invoke_function_over_columns("regr_sxx", y, x)
@@ -4410,28 +4235,18 @@ def regr_sxy(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 1: All paris are non-null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 2), (2, 2), (2, 3), (2, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 1), (2, 2), (3, 3), (4, 4) AS tab(y, x)")
     >>> df.select(sf.regr_sxy("y", "x")).show()
-    +------------------+
-    |    regr_sxy(y, x)|
-    +------------------+
-    |0.7499999999999998|
-    +------------------+
+    +--------------+
+    |regr_sxy(y, x)|
+    +--------------+
+    |           5.0|
+    +--------------+
 
     Example 2: All paris's x values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, None)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, null) AS tab(y, x)")
     >>> df.select(sf.regr_sxy("y", "x")).show()
     +--------------+
     |regr_sxy(y, x)|
@@ -4442,12 +4257,7 @@ def regr_sxy(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 3: All paris's y values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(None, 1)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (null, 1) AS tab(y, x)")
     >>> df.select(sf.regr_sxy("y", "x")).show()
     +--------------+
     |regr_sxy(y, x)|
@@ -4458,33 +4268,23 @@ def regr_sxy(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 4: Some paris's x values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 2), (2, None), (2, 3), (2, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 1), (2, null), (3, 3), (4, 4) AS tab(y, x)")
     >>> df.select(sf.regr_sxy("y", "x")).show()
-    +--------------+
-    |regr_sxy(y, x)|
-    +--------------+
-    |           1.0|
-    +--------------+
+    +-----------------+
+    |   regr_sxy(y, x)|
+    +-----------------+
+    |4.666666666666...|
+    +-----------------+
 
     Example 5: Some paris's x or y values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 2), (2, None), (None, 3), (2, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 1), (2, null), (null, 3), (4, 4) AS tab(y, x)")
     >>> df.select(sf.regr_sxy("y", "x")).show()
     +--------------+
     |regr_sxy(y, x)|
     +--------------+
-    |           1.0|
+    |           4.5|
     +--------------+
     """
     return _invoke_function_over_columns("regr_sxy", y, x)
@@ -4515,28 +4315,18 @@ def regr_syy(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 1: All paris are non-null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 2), (2, 2), (2, 3), (2, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 1), (2, 2), (3, 3), (4, 4) AS tab(y, x)")
     >>> df.select(sf.regr_syy("y", "x")).show()
-    +------------------+
-    |    regr_syy(y, x)|
-    +------------------+
-    |0.7499999999999999|
-    +------------------+
+    +--------------+
+    |regr_syy(y, x)|
+    +--------------+
+    |           5.0|
+    +--------------+
 
     Example 2: All paris's x values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, None)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, null) AS tab(y, x)")
     >>> df.select(sf.regr_syy("y", "x")).show()
     +--------------+
     |regr_syy(y, x)|
@@ -4547,12 +4337,7 @@ def regr_syy(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 3: All paris's y values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(None, 1)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (null, 1) AS tab(y, x)")
     >>> df.select(sf.regr_syy("y", "x")).show()
     +--------------+
     |regr_syy(y, x)|
@@ -4563,33 +4348,23 @@ def regr_syy(y: "ColumnOrName", x: "ColumnOrName") -> Column:
     Example 4: Some paris's x values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 2), (2, None), (2, 3), (2, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 1), (2, null), (3, 3), (4, 4) AS tab(y, x)")
     >>> df.select(sf.regr_syy("y", "x")).show()
-    +------------------+
-    |    regr_syy(y, x)|
-    +------------------+
-    |0.6666666666666666|
-    +------------------+
+    +-----------------+
+    |   regr_syy(y, x)|
+    +-----------------+
+    |4.666666666666...|
+    +-----------------+
 
     Example 5: Some paris's x or y values are null
 
     >>> import pyspark.sql.functions as sf
-    >>> from pyspark.sql.types import IntegerType, StructField, StructType
-    >>> schema = StructType([
-    ...   StructField('y', IntegerType(), True),
-    ...   StructField('x', IntegerType(), True)
-    ... ])
-    >>> df = spark.createDataFrame([(1, 2), (2, None), (None, 3), (2, 4)], schema)
+    >>> df = spark.sql("SELECT * FROM VALUES (1, 1), (2, null), (null, 3), (4, 4) AS tab(y, x)")
     >>> df.select(sf.regr_syy("y", "x")).show()
     +--------------+
     |regr_syy(y, x)|
     +--------------+
-    |           0.5|
+    |           4.5|
     +--------------+
     """
     return _invoke_function_over_columns("regr_syy", y, x)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/linearRegression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/linearRegression.scala
@@ -330,7 +330,7 @@ case class RegrSlope(left: Expression, right: Expression) extends DeclarativeAgg
        NULL
       > SELECT _FUNC_(y, x) FROM VALUES (1, 1), (2, null), (3, 3), (4, 4) AS tab(y, x);
        0.0
-      > SELECT _FUNC_(y, x) FROM VALUES (1, 2), (2, null), (null, 3), (4, 4) AS tab(y, x);
+      > SELECT _FUNC_(y, x) FROM VALUES (1, 1), (2, null), (null, 3), (4, 4) AS tab(y, x);
        0.0
   """,
   group = "agg_funcs",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/linearRegression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/linearRegression.scala
@@ -29,6 +29,10 @@ import org.apache.spark.sql.types.{AbstractDataType, DataType, DoubleType, Numer
     Examples:
       > SELECT _FUNC_(y, x) FROM VALUES (1, 2), (2, 2), (2, 3), (2, 4) AS tab(y, x);
        4
+      > SELECT _FUNC_(y, x) FROM VALUES (1, null) AS tab(y, x);
+       0
+      > SELECT _FUNC_(y, x) FROM VALUES (null, 1) AS tab(y, x);
+       0
       > SELECT _FUNC_(y, x) FROM VALUES (1, 2), (2, null), (2, 3), (2, 4) AS tab(y, x);
        3
       > SELECT _FUNC_(y, x) FROM VALUES (1, 2), (2, null), (null, 3), (2, 4) AS tab(y, x);
@@ -158,6 +162,10 @@ case class RegrR2(y: Expression, x: Expression) extends PearsonCorrelation(y, x,
     Examples:
       > SELECT _FUNC_(y, x) FROM VALUES (1, 2), (2, 2), (2, 3), (2, 4) AS tab(y, x);
        2.75
+      > SELECT _FUNC_(y, x) FROM VALUES (1, null) AS tab(y, x);
+       NULL
+      > SELECT _FUNC_(y, x) FROM VALUES (null, 1) AS tab(y, x);
+       NULL
       > SELECT _FUNC_(y, x) FROM VALUES (1, 2), (2, null), (2, 3), (2, 4) AS tab(y, x);
        2.0
       > SELECT _FUNC_(y, x) FROM VALUES (1, 2), (2, null), (null, 3), (2, 4) AS tab(y, x);
@@ -189,6 +197,10 @@ case class RegrSXX(
     Examples:
       > SELECT _FUNC_(y, x) FROM VALUES (1, 2), (2, 2), (2, 3), (2, 4) AS tab(y, x);
        0.75
+      > SELECT _FUNC_(y, x) FROM VALUES (1, null) AS tab(y, x);
+       NULL
+      > SELECT _FUNC_(y, x) FROM VALUES (null, 1) AS tab(y, x);
+       NULL
       > SELECT _FUNC_(y, x) FROM VALUES (1, 2), (2, null), (2, 3), (2, 4) AS tab(y, x);
        1.0
       > SELECT _FUNC_(y, x) FROM VALUES (1, 2), (2, null), (null, 3), (2, 4) AS tab(y, x);
@@ -214,6 +226,10 @@ case class RegrSXY(y: Expression, x: Expression) extends Covariance(y, x, true) 
     Examples:
       > SELECT _FUNC_(y, x) FROM VALUES (1, 2), (2, 2), (2, 3), (2, 4) AS tab(y, x);
        0.75
+      > SELECT _FUNC_(y, x) FROM VALUES (1, null) AS tab(y, x);
+       NULL
+      > SELECT _FUNC_(y, x) FROM VALUES (null, 1) AS tab(y, x);
+       NULL
       > SELECT _FUNC_(y, x) FROM VALUES (1, 2), (2, null), (2, 3), (2, 4) AS tab(y, x);
        0.6666666666666666
       > SELECT _FUNC_(y, x) FROM VALUES (1, 2), (2, null), (null, 3), (2, 4) AS tab(y, x);
@@ -243,12 +259,16 @@ case class RegrSYY(
   usage = "_FUNC_(y, x) - Returns the slope of the linear regression line for non-null pairs in a group, where `y` is the dependent variable and `x` is the independent variable.",
   examples = """
     Examples:
-      > SELECT _FUNC_(y, x) FROM VALUES (1,1), (2,2), (3,3) AS tab(y, x);
+      > SELECT _FUNC_(y, x) FROM VALUES (1, 1), (2, 2), (3, 3), (4, 4) AS tab(y, x);
        1.0
       > SELECT _FUNC_(y, x) FROM VALUES (1, null) AS tab(y, x);
        NULL
       > SELECT _FUNC_(y, x) FROM VALUES (null, 1) AS tab(y, x);
        NULL
+      > SELECT _FUNC_(y, x) FROM VALUES (1, 1), (2, null), (3, 3), (4, 4) AS tab(y, x);
+       1.0
+      > SELECT _FUNC_(y, x) FROM VALUES (1, 1), (2, null), (null, 3), (4, 4) AS tab(y, x);
+       1.0
   """,
   group = "agg_funcs",
   since = "3.4.0")
@@ -302,12 +322,16 @@ case class RegrSlope(left: Expression, right: Expression) extends DeclarativeAgg
   usage = "_FUNC_(y, x) - Returns the intercept of the univariate linear regression line for non-null pairs in a group, where `y` is the dependent variable and `x` is the independent variable.",
   examples = """
     Examples:
-      > SELECT _FUNC_(y, x) FROM VALUES (1,1), (2,2), (3,3) AS tab(y, x);
+      > SELECT _FUNC_(y, x) FROM VALUES (1, 1), (2, 2), (3, 3), (4, 4) AS tab(y, x);
        0.0
       > SELECT _FUNC_(y, x) FROM VALUES (1, null) AS tab(y, x);
        NULL
       > SELECT _FUNC_(y, x) FROM VALUES (null, 1) AS tab(y, x);
        NULL
+      > SELECT _FUNC_(y, x) FROM VALUES (1, 1), (2, null), (3, 3), (4, 4) AS tab(y, x);
+       0.0
+      > SELECT _FUNC_(y, x) FROM VALUES (1, 2), (2, null), (null, 3), (4, 4) AS tab(y, x);
+       0.0
   """,
   group = "agg_funcs",
   since = "3.4.0")

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -427,12 +427,12 @@
 | org.apache.spark.sql.catalyst.expressions.aggregate.RegrAvgX | regr_avgx | SELECT regr_avgx(y, x) FROM VALUES (1, 2), (2, 2), (2, 3), (2, 4) AS tab(y, x) | struct<regr_avgx(y, x):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.RegrAvgY | regr_avgy | SELECT regr_avgy(y, x) FROM VALUES (1, 2), (2, 2), (2, 3), (2, 4) AS tab(y, x) | struct<regr_avgy(y, x):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.RegrCount | regr_count | SELECT regr_count(y, x) FROM VALUES (1, 2), (2, 2), (2, 3), (2, 4) AS tab(y, x) | struct<regr_count(y, x):bigint> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.RegrIntercept | regr_intercept | SELECT regr_intercept(y, x) FROM VALUES (1,1), (2,2), (3,3) AS tab(y, x) | struct<regr_intercept(y, x):double> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.RegrIntercept | regr_intercept | SELECT regr_intercept(y, x) FROM VALUES (1, 1), (2, 2), (3, 3), (4, 4) AS tab(y, x) | struct<regr_intercept(y, x):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.RegrR2 | regr_r2 | SELECT regr_r2(y, x) FROM VALUES (1, 2), (2, 2), (2, 3), (2, 4) AS tab(y, x) | struct<regr_r2(y, x):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.RegrSXX | regr_sxx | SELECT regr_sxx(y, x) FROM VALUES (1, 2), (2, 2), (2, 3), (2, 4) AS tab(y, x) | struct<regr_sxx(y, x):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.RegrSXY | regr_sxy | SELECT regr_sxy(y, x) FROM VALUES (1, 2), (2, 2), (2, 3), (2, 4) AS tab(y, x) | struct<regr_sxy(y, x):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.RegrSYY | regr_syy | SELECT regr_syy(y, x) FROM VALUES (1, 2), (2, 2), (2, 3), (2, 4) AS tab(y, x) | struct<regr_syy(y, x):double> |
-| org.apache.spark.sql.catalyst.expressions.aggregate.RegrSlope | regr_slope | SELECT regr_slope(y, x) FROM VALUES (1,1), (2,2), (3,3) AS tab(y, x) | struct<regr_slope(y, x):double> |
+| org.apache.spark.sql.catalyst.expressions.aggregate.RegrSlope | regr_slope | SELECT regr_slope(y, x) FROM VALUES (1, 1), (2, 2), (3, 3), (4, 4) AS tab(y, x) | struct<regr_slope(y, x):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.Skewness | skewness | SELECT skewness(col) FROM VALUES (-10), (-20), (100), (1000) AS tab(col) | struct<skewness(col):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.StddevPop | stddev_pop | SELECT stddev_pop(col) FROM VALUES (1), (2), (3) AS tab(col) | struct<stddev_pop(col):double> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.StddevSamp | std | SELECT std(col) FROM VALUES (1), (2), (3) AS tab(col) | struct<std(col):double> |


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR aims to add some extra examples for `linearRegression` built-in functions.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

- Align the use examples for this series of functions. 
- Allow users to better understand the usage of `linearRegression` related methods from sql built-in functions docs(https://spark.apache.org/docs/latest/api/sql/index.html).

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Pass GA and Manual testing for new examples.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.