### PR TITLE
[SPARK-48895][R][INFRA] Use R 4.4.1 in `windows` R GitHub Action job

### DIFF
--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-name: "Build / SparkR-only (master, 4.4.0, windows-2022)"
+name: "Build / SparkR-only (master, 4.4.1, windows-2022)"
 
 on:
   schedule:
@@ -50,10 +50,10 @@ jobs:
       with:
         distribution: zulu
         java-version: 17
-    - name: Install R 4.4.0
+    - name: Install R 4.4.1
       uses: r-lib/actions/setup-r@v2
       with:
-        r-version: 4.4.0
+        r-version: 4.4.1
     - name: Install R dependencies
       run: |
         Rscript -e "install.packages(c('knitr', 'rmarkdown', 'testthat', 'e1071', 'survival', 'arrow', 'xml2'), repos='https://cloud.r-project.org/')"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use R 4.4.1 in `windows` R GitHub Action job.

### Why are the changes needed?

R 4.4.1 is the latest release which is released on 2024-06-14

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.