### PR TITLE
[DO-NOT-MERGE][SQL] Reduce the number of shuffles in SQL in local mode

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/FlatMapGroupsWithStateStreamingSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/streaming/FlatMapGroupsWithStateStreamingSuite.scala
@@ -77,7 +77,7 @@ class FlatMapGroupsWithStateStreamingSuite extends QueryTest with RemoteSparkSes
         q.processAllAvailable()
         eventually(timeout(30.seconds)) {
           checkDataset(
-            spark.table("my_sink").toDF().as[ClickState],
+            spark.table("my_sink").toDF().sort("count").as[ClickState],
             ClickState("c", 1),
             ClickState("b", 2),
             ClickState("a", 3))
@@ -122,7 +122,7 @@ class FlatMapGroupsWithStateStreamingSuite extends QueryTest with RemoteSparkSes
         q.processAllAvailable()
         eventually(timeout(30.seconds)) {
           checkDataset(
-            spark.table("my_sink").toDF().as[ClickState],
+            spark.table("my_sink").toDF().sort("count").as[ClickState],
             ClickState("c", 1),
             ClickState("b", 3),
             ClickState("a", 5))
@@ -164,7 +164,7 @@ class FlatMapGroupsWithStateStreamingSuite extends QueryTest with RemoteSparkSes
         q.processAllAvailable()
         eventually(timeout(30.seconds)) {
           checkDataset(
-            spark.table("my_sink").toDF().as[ClickState],
+            spark.table("my_sink").toDF().sort("count").as[ClickState],
             ClickState("c", 1),
             ClickState("b", 2),
             ClickState("a", 3))
@@ -210,7 +210,7 @@ class FlatMapGroupsWithStateStreamingSuite extends QueryTest with RemoteSparkSes
         q.processAllAvailable()
         eventually(timeout(30.seconds)) {
           checkDataset(
-            spark.table("my_sink").toDF().as[ClickState],
+            spark.table("my_sink").toDF().sort("count").as[ClickState],
             ClickState("c", 1),
             ClickState("b", 3),
             ClickState("a", 5))

--- a/python/pyspark/ml/feature.py
+++ b/python/pyspark/ml/feature.py
@@ -2534,7 +2534,7 @@ class MinHashLSH(
     >>> model.approxSimilarityJoin(df, df2, 0.6, distCol="JaccardDistance").select(
     ...     col("datasetA.id").alias("idA"),
     ...     col("datasetB.id").alias("idB"),
-    ...     col("JaccardDistance")).show()
+    ...     col("JaccardDistance")).sort("idA").show()
     +---+---+---------------+
     |idA|idB|JaccardDistance|
     +---+---+---------------+

--- a/python/pyspark/sql/context.py
+++ b/python/pyspark/sql/context.py
@@ -205,7 +205,7 @@ class SQLContext:
 
         Examples
         --------
-        >>> sqlContext.getConf("spark.sql.shuffle.partitions")
+        >>> sqlContext.getConf("spark.sql.shuffle.partitions")  # doctest: +SKIP
         '200'
         >>> sqlContext.getConf("spark.sql.shuffle.partitions", "10")
         '10'

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -643,7 +643,7 @@ object SQLConf {
 
   // Lazily get the number of cores to make sure SparkContext created first.
   private lazy val defaultShufflePartition: Option[Int] = SparkContext.getActive.flatMap { sc =>
-    if (sc.master.startsWith("local")) Some(SparkContext.numDriverCores(sc.master)) else None
+    if (sc.isLocal) Some(SparkContext.numDriverCores(sc.master)) else None
   }
 
   val SHUFFLE_PARTITIONS = buildConf("spark.sql.shuffle.partitions")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to change `spark.sql.shuffle.partitions` to the number of executor threads when users specify the master as `local[...]`.

### Why are the changes needed?

The static number of `200` is a bit unreasonable, and sometimes it makes small jobs very slow. With this change, the new comers can leverage performance improvement in their laptop.

### Does this PR introduce _any_ user-facing change?

Yes. If users use `master` as `local[...]`, then `spark.sql.shuffle.partitions` will be set the number of executor threads.

### How was this patch tested?

Manually tested in my PySpark shell, and checked it in UI.

### Was this patch authored or co-authored using generative AI tooling?

No.
