### PR TITLE
[MINOR][SQL][TESTS] Fix compilation warning `adaptation of an empty argument list by inserting () is deprecated`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCommitterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCommitterSuite.scala
@@ -116,7 +116,7 @@ class ParquetCommitterSuite extends SparkFunSuite with SQLTestUtils
   test("SPARK-48804: Fail fast on unloadable or invalid committers") {
     Seq("invalid", getClass.getName).foreach { committer =>
       val e = intercept[IllegalArgumentException] {
-        withSQLConf(SQLConf.PARQUET_OUTPUT_COMMITTER_CLASS.key -> committer)()
+        withSQLConf(SQLConf.PARQUET_OUTPUT_COMMITTER_CLASS.key -> committer)(())
       }
       assert(e.getMessage.contains(classOf[OutputCommitter].getName))
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix  compilation warning: `adaptation of an empty argument list by inserting () is deprecated`


### Why are the changes needed?
Fix compilation warning.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually check.
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
