### PR TITLE
[SPARK-48881][SQL] Some dynamic partitions can be compensated to specific partition values

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala
@@ -473,7 +473,7 @@ case class DataSource(
     // will be adjusted within InsertIntoHadoopFsRelation.
     InsertIntoHadoopFsRelationCommand(
       outputPath = outputPath,
-      staticPartitions = Map.empty,
+      statementStaticPartitions = Map.empty,
       ifPartitionNotExists = false,
       partitionColumns = partitionColumns.map(UnresolvedAttribute.quoted),
       bucketSpec = bucketSpec,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -35,11 +35,13 @@ import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.{EqualTo => ExpressionsEqualTo, In => ExpressionsIn}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
-import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoDir, InsertIntoStatement, LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.plans.logical.{Filter => LogicalFilter, InsertIntoDir, InsertIntoStatement, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
+import org.apache.spark.sql.catalyst.trees.TreePattern.{JOIN, UNION}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util.{GeneratedColumn, ResolveDefaultColumns, V2ExpressionBuilder}
 import org.apache.spark.sql.connector.catalog.SupportsRead
@@ -186,6 +188,7 @@ object DataSourceAnalysis extends Rule[LogicalPlan] {
       // values in the PARTITION clause (e.g. b in the above example).
       // dynamic_partitioning_columns are partitioning columns that do not assigned
       // values in the PARTITION clause (e.g. c in the above example).
+      val pullTopPredicateParts = mutable.Map[String, Option[String]]()
       val actualQuery = if (parts.exists(_._2.isDefined)) {
         val projectList = convertStaticPartitions(
           sourceAttributes = query.output,
@@ -194,6 +197,22 @@ object DataSourceAnalysis extends Rule[LogicalPlan] {
           targetPartitionSchema = t.partitionSchema)
         Project(projectList, query)
       } else {
+        query.transformWithPruning(!_.containsAnyPattern(UNION, JOIN)) {
+          case filter @ LogicalFilter(condition, _) if
+            condition.deterministic && !SubqueryExpression.hasSubquery(condition) =>
+            val normalizedFilters = DataSourceStrategy.normalizeExprs(Seq(condition), l.output)
+            val (partitionKeyFilters, _) = DataSourceUtils
+              .getPartitionFiltersAndDataFilters(t.partitionSchema, normalizedFilters)
+
+            partitionKeyFilters.map {
+              case ExpressionsEqualTo(AttributeReference(name, _, _, _), Literal(value, _)) =>
+                pullTopPredicateParts += (name -> Some(value.toString))
+              case ExpressionsIn(AttributeReference(name, _, _, _), list @ Seq(Literal(value, _)))
+                if list.size == 1 => pullTopPredicateParts += (name -> Some(value.toString))
+              case _ => // do nothing
+            }
+            filter
+        }
         query
       }
 
@@ -208,11 +227,13 @@ object DataSourceAnalysis extends Rule[LogicalPlan] {
 
       val partitionSchema = actualQuery.resolve(
         t.partitionSchema, t.sparkSession.sessionState.analyzer.resolver)
-      val staticPartitions = parts.filter(_._2.nonEmpty).map { case (k, v) => k -> v.get }
+      val pullTopPredicateStaticPartitions = pullTopPredicateParts.filter(_._2.nonEmpty)
+        .map { case (k, v) => k -> v.get }.toMap
+      val statementStaticPartitions = parts.filter(_._2.nonEmpty).map { case (k, v) => k -> v.get }
 
       val insertCommand = InsertIntoHadoopFsRelationCommand(
         outputPath,
-        staticPartitions,
+        statementStaticPartitions,
         i.ifPartitionNotExists,
         partitionSchema,
         t.bucketSpec,
@@ -222,7 +243,8 @@ object DataSourceAnalysis extends Rule[LogicalPlan] {
         mode,
         table,
         Some(t.location),
-        actualQuery.output.map(_.name))
+        actualQuery.output.map(_.name),
+        pullTopPredicateStaticPartitions)
 
       // For dynamic partition overwrite, we do not delete partition directories ahead.
       // We write to staging directories and move to final partition directories after writing

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceStrategy.scala
@@ -35,11 +35,13 @@ import org.apache.spark.sql.catalyst.catalog._
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.{EqualTo => ExpressionsEqualTo, In => ExpressionsIn}
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
-import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoDir, InsertIntoStatement, LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.plans.logical.{Filter => LogicalFilter, InsertIntoDir, InsertIntoStatement, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.streaming.StreamingRelationV2
+import org.apache.spark.sql.catalyst.trees.TreePattern.{JOIN, UNION}
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util.{GeneratedColumn, ResolveDefaultColumns, V2ExpressionBuilder}
 import org.apache.spark.sql.connector.catalog.SupportsRead
@@ -186,6 +188,7 @@ object DataSourceAnalysis extends Rule[LogicalPlan] {
       // values in the PARTITION clause (e.g. b in the above example).
       // dynamic_partitioning_columns are partitioning columns that do not assigned
       // values in the PARTITION clause (e.g. c in the above example).
+      val pullTopPredicateParts = mutable.Map[String, Option[String]]()
       val actualQuery = if (parts.exists(_._2.isDefined)) {
         val projectList = convertStaticPartitions(
           sourceAttributes = query.output,
@@ -194,6 +197,22 @@ object DataSourceAnalysis extends Rule[LogicalPlan] {
           targetPartitionSchema = t.partitionSchema)
         Project(projectList, query)
       } else {
+        query.transformWithPruning(!_.containsAnyPattern(UNION, JOIN)) {
+          case filter @ LogicalFilter(condition, _) if
+            condition.deterministic && !SubqueryExpression.hasSubquery(condition) =>
+            val normalizedFilters = DataSourceStrategy.normalizeExprs(Seq(condition), l.output)
+            val (partitionKeyFilters, _) = DataSourceUtils
+              .getPartitionFiltersAndDataFilters(t.partitionSchema, normalizedFilters)
+
+            partitionKeyFilters.map {
+              case ExpressionsEqualTo(AttributeReference(name, _, _, _), Literal(value, _)) =>
+                pullTopPredicateParts += (name -> Some(value.toString))
+              case ExpressionsIn(AttributeReference(name, _, _, _), list @ Seq(Literal(value, _)))
+                if list.size == 1 => pullTopPredicateParts += (name -> Some(value.toString))
+              case _ => // do nothing
+            }
+            filter
+        }
         query
       }
 
@@ -208,7 +227,8 @@ object DataSourceAnalysis extends Rule[LogicalPlan] {
 
       val partitionSchema = actualQuery.resolve(
         t.partitionSchema, t.sparkSession.sessionState.analyzer.resolver)
-      val staticPartitions = parts.filter(_._2.nonEmpty).map { case (k, v) => k -> v.get }
+      val staticPartitions = (parts ++ pullTopPredicateParts).filter(_._2.nonEmpty)
+        .map { case (k, v) => k -> v.get }
 
       val insertCommand = InsertIntoHadoopFsRelationCommand(
         outputPath,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCommitterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/parquet/ParquetCommitterSuite.scala
@@ -116,7 +116,7 @@ class ParquetCommitterSuite extends SparkFunSuite with SQLTestUtils
   test("SPARK-48804: Fail fast on unloadable or invalid committers") {
     Seq("invalid", getClass.getName).foreach { committer =>
       val e = intercept[IllegalArgumentException] {
-        withSQLConf(SQLConf.PARQUET_OUTPUT_COMMITTER_CLASS.key -> committer)()
+        withSQLConf(SQLConf.PARQUET_OUTPUT_COMMITTER_CLASS.key -> committer)(())
       }
       assert(e.getMessage.contains(classOf[OutputCommitter].getName))
     }


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
when writing dynamic partitions, some dynamic partitions in InsertIntoHadoopFsRelationCommand can be compensated to specific partition values.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When executing the following SQL ：
INSERT OVERWRITE TABLE A PARTITION(event_day, event_type) SELECT id, event_day, event_type from B where event_day = '20240712'

before it staticPartitions would be empty in InsertIntoHadoopFsRelationCommand
<img width="1262" alt="image" src="https://github.com/user-attachments/assets/c43aa071-ddcb-4260-b693-ce0bacaf6b38">

after  it staticPartitions would be specific partition values
<img width="1369" alt="image" src="https://github.com/user-attachments/assets/d4acf179-cb03-4694-bf1f-ec661b800b30">

The benefit is that when executing
<img width="848" alt="image" src="https://github.com/user-attachments/assets/b14048d2-1ad8-4da0-866c-7c97140565bb">

 in InsertIntoHadoopFsRelationCommand, it can greatly reduce the pressure on hive and improve the efficiency of task execution.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
manually test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
NO