### PR TITLE
[SPARK-42307][SQL] Assign name for error _LEGACY_ERROR_TEMP_2232

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -586,6 +586,12 @@
     ],
     "sqlState" : "42703"
   },
+  "COLUMN_VALUE_IS_NULL" : {
+    "message" : [
+      "Value at index <index> is null."
+    ],
+    "sqlState" : "22000"
+  },
   "COMPARATOR_RETURNS_NULL" : {
     "message" : [
       "The comparator has returned a NULL for a comparison between <firstValue> and <secondValue>.",
@@ -7251,11 +7257,6 @@
   "_LEGACY_ERROR_TEMP_2230" : {
     "message" : [
       "Primitive types are not supported."
-    ]
-  },
-  "COLUMN_VALUE_IS_NULL" : {
-    "message" : [
-      "Value at index <index> is null."
     ]
   },
   "_LEGACY_ERROR_TEMP_2233" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -7253,7 +7253,7 @@
       "Primitive types are not supported."
     ]
   },
-  "_LEGACY_ERROR_TEMP_2232" : {
+  "COLUMN_VALUE_IS_NULL" : {
     "message" : [
       "Value at index <index> is null."
     ]

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -586,12 +586,6 @@
     ],
     "sqlState" : "42703"
   },
-  "COLUMN_VALUE_IS_NULL" : {
-    "message" : [
-      "Value at index <index> is null."
-    ],
-    "sqlState" : "22000"
-  },
   "COMPARATOR_RETURNS_NULL" : {
     "message" : [
       "The comparator has returned a NULL for a comparison between <firstValue> and <secondValue>.",
@@ -3751,6 +3745,12 @@
       "More than one row returned by a subquery used as a row."
     ],
     "sqlState" : "21000"
+  },
+  "ROW_VALUE_IS_NULL" : {
+    "message" : [
+      "Found NULL in a row at the index <index>, expected a non-NULL value."
+    ],
+    "sqlState" : "22023"
   },
   "RULE_ID_NOT_FOUND" : {
     "message" : [

--- a/sql/api/src/main/scala/org/apache/spark/sql/Row.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Row.scala
@@ -29,7 +29,7 @@ import org.json4s.{JArray, JBool, JDecimal, JDouble, JField, JLong, JNull, JObje
 import org.json4s.JsonAST.JValue
 import org.json4s.jackson.JsonMethods.{compact, pretty, render}
 
-import org.apache.spark.{SparkException, SparkIllegalArgumentException}
+import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.annotation.{Stable, Unstable}
 import org.apache.spark.sql.catalyst.expressions.GenericRow
 import org.apache.spark.sql.catalyst.util.{DateFormatter, SparkDateTimeUtils, TimestampFormatter, UDTUtils}
@@ -219,45 +219,40 @@ trait Row extends Serializable {
    * Returns the value at position i as a primitive boolean.
    *
    * @throws ClassCastException when data type does not match.
-   * @throws org.apache.spark.SparkException when value is null.
+   * @throws org.apache.spark.SparkRuntimeException when value is null.
    */
-  @throws[SparkException]
   def getBoolean(i: Int): Boolean = getAnyValAs[Boolean](i)
 
   /**
    * Returns the value at position i as a primitive byte.
    *
    * @throws ClassCastException when data type does not match.
-   * @throws org.apache.spark.SparkException when value is null.
+   * @throws org.apache.spark.SparkRuntimeException when value is null.
    */
-  @throws[SparkException]
   def getByte(i: Int): Byte = getAnyValAs[Byte](i)
 
   /**
    * Returns the value at position i as a primitive short.
    *
    * @throws ClassCastException when data type does not match.
-   * @throws org.apache.spark.SparkException when value is null.
+   * @throws org.apache.spark.SparkRuntimeException when value is null.
    */
-  @throws[SparkException]
   def getShort(i: Int): Short = getAnyValAs[Short](i)
 
   /**
    * Returns the value at position i as a primitive int.
    *
    * @throws ClassCastException when data type does not match.
-   * @throws org.apache.spark.SparkException when value is null.
+   * @throws org.apache.spark.SparkRuntimeException when value is null.
    */
-  @throws[SparkException]
   def getInt(i: Int): Int = getAnyValAs[Int](i)
 
   /**
    * Returns the value at position i as a primitive long.
    *
    * @throws ClassCastException when data type does not match.
-   * @throws org.apache.spark.SparkException when value is null.
+   * @throws org.apache.spark.SparkRuntimeException when value is null.
    */
-  @throws[SparkException]
   def getLong(i: Int): Long = getAnyValAs[Long](i)
 
   /**
@@ -265,18 +260,16 @@ trait Row extends Serializable {
    * Throws an exception if the type mismatches or if the value is null.
    *
    * @throws ClassCastException when data type does not match.
-   * @throws org.apache.spark.SparkException when value is null.
+   * @throws org.apache.spark.SparkRuntimeException when value is null.
    */
-  @throws[SparkException]
   def getFloat(i: Int): Float = getAnyValAs[Float](i)
 
   /**
    * Returns the value at position i as a primitive double.
    *
    * @throws ClassCastException when data type does not match.
-   * @throws org.apache.spark.SparkException when value is null.
+   * @throws org.apache.spark.SparkRuntimeException when value is null.
    */
-  @throws[SparkException]
   def getDouble(i: Int): Double = getAnyValAs[Double](i)
 
   /**
@@ -530,9 +523,8 @@ trait Row extends Serializable {
    *
    * @throws UnsupportedOperationException when schema is not defined.
    * @throws ClassCastException when data type does not match.
-   * @throws org.apache.spark.SparkException when value is null.
+   * @throws org.apache.spark.SparkRuntimeException when value is null.
    */
-  @throws[SparkException]
   private def getAnyValAs[T <: AnyVal](i: Int): T =
     if (isNullAt(i)) throw DataTypeErrors.valueIsNullError(i)
     else getAs[T](i)

--- a/sql/api/src/main/scala/org/apache/spark/sql/Row.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Row.scala
@@ -29,7 +29,7 @@ import org.json4s.{JArray, JBool, JDecimal, JDouble, JField, JLong, JNull, JObje
 import org.json4s.JsonAST.JValue
 import org.json4s.jackson.JsonMethods.{compact, pretty, render}
 
-import org.apache.spark.SparkIllegalArgumentException
+import org.apache.spark.{SparkException, SparkIllegalArgumentException}
 import org.apache.spark.annotation.{Stable, Unstable}
 import org.apache.spark.sql.catalyst.expressions.GenericRow
 import org.apache.spark.sql.catalyst.util.{DateFormatter, SparkDateTimeUtils, TimestampFormatter, UDTUtils}
@@ -221,6 +221,7 @@ trait Row extends Serializable {
    * @throws ClassCastException when data type does not match.
    * @throws org.apache.spark.SparkException when value is null.
    */
+  @throws[SparkException]
   def getBoolean(i: Int): Boolean = getAnyValAs[Boolean](i)
 
   /**
@@ -229,6 +230,7 @@ trait Row extends Serializable {
    * @throws ClassCastException when data type does not match.
    * @throws org.apache.spark.SparkException when value is null.
    */
+  @throws[SparkException]
   def getByte(i: Int): Byte = getAnyValAs[Byte](i)
 
   /**
@@ -237,6 +239,7 @@ trait Row extends Serializable {
    * @throws ClassCastException when data type does not match.
    * @throws org.apache.spark.SparkException when value is null.
    */
+  @throws[SparkException]
   def getShort(i: Int): Short = getAnyValAs[Short](i)
 
   /**
@@ -245,6 +248,7 @@ trait Row extends Serializable {
    * @throws ClassCastException when data type does not match.
    * @throws org.apache.spark.SparkException when value is null.
    */
+  @throws[SparkException]
   def getInt(i: Int): Int = getAnyValAs[Int](i)
 
   /**
@@ -253,6 +257,7 @@ trait Row extends Serializable {
    * @throws ClassCastException when data type does not match.
    * @throws org.apache.spark.SparkException when value is null.
    */
+  @throws[SparkException]
   def getLong(i: Int): Long = getAnyValAs[Long](i)
 
   /**
@@ -262,6 +267,7 @@ trait Row extends Serializable {
    * @throws ClassCastException when data type does not match.
    * @throws org.apache.spark.SparkException when value is null.
    */
+  @throws[SparkException]
   def getFloat(i: Int): Float = getAnyValAs[Float](i)
 
   /**
@@ -270,6 +276,7 @@ trait Row extends Serializable {
    * @throws ClassCastException when data type does not match.
    * @throws org.apache.spark.SparkException when value is null.
    */
+  @throws[SparkException]
   def getDouble(i: Int): Double = getAnyValAs[Double](i)
 
   /**
@@ -525,6 +532,7 @@ trait Row extends Serializable {
    * @throws ClassCastException when data type does not match.
    * @throws org.apache.spark.SparkException when value is null.
    */
+  @throws[SparkException]
   private def getAnyValAs[T <: AnyVal](i: Int): T =
     if (isNullAt(i)) throw DataTypeErrors.valueIsNullError(i)
     else getAs[T](i)

--- a/sql/api/src/main/scala/org/apache/spark/sql/Row.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Row.scala
@@ -219,6 +219,7 @@ trait Row extends Serializable {
    * Returns the value at position i as a primitive boolean.
    *
    * @throws ClassCastException when data type does not match.
+   * @throws SparkException when value is null.
    */
   def getBoolean(i: Int): Boolean = getAnyValAs[Boolean](i)
 
@@ -226,6 +227,7 @@ trait Row extends Serializable {
    * Returns the value at position i as a primitive byte.
    *
    * @throws ClassCastException when data type does not match.
+   * @throws SparkException when value is null.
    */
   def getByte(i: Int): Byte = getAnyValAs[Byte](i)
 
@@ -233,6 +235,7 @@ trait Row extends Serializable {
    * Returns the value at position i as a primitive short.
    *
    * @throws ClassCastException when data type does not match.
+   * @throws SparkException when value is null.
    */
   def getShort(i: Int): Short = getAnyValAs[Short](i)
 
@@ -240,6 +243,7 @@ trait Row extends Serializable {
    * Returns the value at position i as a primitive int.
    *
    * @throws ClassCastException when data type does not match.
+   * @throws SparkException when value is null.
    */
   def getInt(i: Int): Int = getAnyValAs[Int](i)
 
@@ -247,6 +251,7 @@ trait Row extends Serializable {
    * Returns the value at position i as a primitive long.
    *
    * @throws ClassCastException when data type does not match.
+   * @throws SparkException when value is null.
    */
   def getLong(i: Int): Long = getAnyValAs[Long](i)
 
@@ -255,6 +260,7 @@ trait Row extends Serializable {
    * Throws an exception if the type mismatches or if the value is null.
    *
    * @throws ClassCastException when data type does not match.
+   * @throws SparkException when value is null.
    */
   def getFloat(i: Int): Float = getAnyValAs[Float](i)
 
@@ -262,6 +268,7 @@ trait Row extends Serializable {
    * Returns the value at position i as a primitive double.
    *
    * @throws ClassCastException when data type does not match.
+   * @throws SparkException when value is null.
    */
   def getDouble(i: Int): Double = getAnyValAs[Double](i)
 
@@ -516,6 +523,7 @@ trait Row extends Serializable {
    *
    * @throws UnsupportedOperationException when schema is not defined.
    * @throws ClassCastException when data type does not match.
+   * @throws SparkException when value is null.
    */
   private def getAnyValAs[T <: AnyVal](i: Int): T =
     if (isNullAt(i)) throw DataTypeErrors.valueIsNullError(i)

--- a/sql/api/src/main/scala/org/apache/spark/sql/Row.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Row.scala
@@ -219,7 +219,7 @@ trait Row extends Serializable {
    * Returns the value at position i as a primitive boolean.
    *
    * @throws ClassCastException when data type does not match.
-   * @throws SparkException when value is null.
+   * @throws org.apache.spark.SparkException when value is null.
    */
   def getBoolean(i: Int): Boolean = getAnyValAs[Boolean](i)
 
@@ -227,7 +227,7 @@ trait Row extends Serializable {
    * Returns the value at position i as a primitive byte.
    *
    * @throws ClassCastException when data type does not match.
-   * @throws SparkException when value is null.
+   * @throws org.apache.spark.SparkException when value is null.
    */
   def getByte(i: Int): Byte = getAnyValAs[Byte](i)
 
@@ -235,7 +235,7 @@ trait Row extends Serializable {
    * Returns the value at position i as a primitive short.
    *
    * @throws ClassCastException when data type does not match.
-   * @throws SparkException when value is null.
+   * @throws org.apache.spark.SparkException when value is null.
    */
   def getShort(i: Int): Short = getAnyValAs[Short](i)
 
@@ -243,7 +243,7 @@ trait Row extends Serializable {
    * Returns the value at position i as a primitive int.
    *
    * @throws ClassCastException when data type does not match.
-   * @throws SparkException when value is null.
+   * @throws org.apache.spark.SparkException when value is null.
    */
   def getInt(i: Int): Int = getAnyValAs[Int](i)
 
@@ -251,7 +251,7 @@ trait Row extends Serializable {
    * Returns the value at position i as a primitive long.
    *
    * @throws ClassCastException when data type does not match.
-   * @throws SparkException when value is null.
+   * @throws org.apache.spark.SparkException when value is null.
    */
   def getLong(i: Int): Long = getAnyValAs[Long](i)
 
@@ -260,7 +260,7 @@ trait Row extends Serializable {
    * Throws an exception if the type mismatches or if the value is null.
    *
    * @throws ClassCastException when data type does not match.
-   * @throws SparkException when value is null.
+   * @throws org.apache.spark.SparkException when value is null.
    */
   def getFloat(i: Int): Float = getAnyValAs[Float](i)
 
@@ -268,7 +268,7 @@ trait Row extends Serializable {
    * Returns the value at position i as a primitive double.
    *
    * @throws ClassCastException when data type does not match.
-   * @throws SparkException when value is null.
+   * @throws org.apache.spark.SparkException when value is null.
    */
   def getDouble(i: Int): Double = getAnyValAs[Double](i)
 
@@ -523,7 +523,7 @@ trait Row extends Serializable {
    *
    * @throws UnsupportedOperationException when schema is not defined.
    * @throws ClassCastException when data type does not match.
-   * @throws SparkException when value is null.
+   * @throws org.apache.spark.SparkException when value is null.
    */
   private def getAnyValAs[T <: AnyVal](i: Int): T =
     if (isNullAt(i)) throw DataTypeErrors.valueIsNullError(i)

--- a/sql/api/src/main/scala/org/apache/spark/sql/Row.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Row.scala
@@ -219,7 +219,6 @@ trait Row extends Serializable {
    * Returns the value at position i as a primitive boolean.
    *
    * @throws ClassCastException when data type does not match.
-   * @throws NullPointerException when value is null.
    */
   def getBoolean(i: Int): Boolean = getAnyValAs[Boolean](i)
 
@@ -227,7 +226,6 @@ trait Row extends Serializable {
    * Returns the value at position i as a primitive byte.
    *
    * @throws ClassCastException when data type does not match.
-   * @throws NullPointerException when value is null.
    */
   def getByte(i: Int): Byte = getAnyValAs[Byte](i)
 
@@ -235,7 +233,6 @@ trait Row extends Serializable {
    * Returns the value at position i as a primitive short.
    *
    * @throws ClassCastException when data type does not match.
-   * @throws NullPointerException when value is null.
    */
   def getShort(i: Int): Short = getAnyValAs[Short](i)
 
@@ -243,7 +240,6 @@ trait Row extends Serializable {
    * Returns the value at position i as a primitive int.
    *
    * @throws ClassCastException when data type does not match.
-   * @throws NullPointerException when value is null.
    */
   def getInt(i: Int): Int = getAnyValAs[Int](i)
 
@@ -251,7 +247,6 @@ trait Row extends Serializable {
    * Returns the value at position i as a primitive long.
    *
    * @throws ClassCastException when data type does not match.
-   * @throws NullPointerException when value is null.
    */
   def getLong(i: Int): Long = getAnyValAs[Long](i)
 
@@ -260,7 +255,6 @@ trait Row extends Serializable {
    * Throws an exception if the type mismatches or if the value is null.
    *
    * @throws ClassCastException when data type does not match.
-   * @throws NullPointerException when value is null.
    */
   def getFloat(i: Int): Float = getAnyValAs[Float](i)
 
@@ -268,7 +262,6 @@ trait Row extends Serializable {
    * Returns the value at position i as a primitive double.
    *
    * @throws ClassCastException when data type does not match.
-   * @throws NullPointerException when value is null.
    */
   def getDouble(i: Int): Double = getAnyValAs[Double](i)
 
@@ -523,7 +516,6 @@ trait Row extends Serializable {
    *
    * @throws UnsupportedOperationException when schema is not defined.
    * @throws ClassCastException when data type does not match.
-   * @throws NullPointerException when value is null.
    */
   private def getAnyValAs[T <: AnyVal](i: Int): T =
     if (isNullAt(i)) throw DataTypeErrors.valueIsNullError(i)

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/DataTypeErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/DataTypeErrors.scala
@@ -273,7 +273,7 @@ private[sql] object DataTypeErrors extends DataTypeErrorsBase {
 
   def valueIsNullError(index: Int): Throwable = {
     new SparkException(
-      errorClass = "COLUMN_VALUE_IS_NULL",
+      errorClass = "ROW_VALUE_IS_NULL",
       messageParameters = Map(
         "index" -> index.toString),
       cause = null)

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/DataTypeErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/DataTypeErrors.scala
@@ -273,7 +273,7 @@ private[sql] object DataTypeErrors extends DataTypeErrorsBase {
 
   def valueIsNullError(index: Int): Throwable = {
     new SparkException(
-      errorClass = "_LEGACY_ERROR_TEMP_2232",
+      errorClass = "COLUMN_VALUE_IS_NULL",
       messageParameters = Map(
         "index" -> index.toString),
       cause = null)

--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/DataTypeErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/DataTypeErrors.scala
@@ -272,7 +272,7 @@ private[sql] object DataTypeErrors extends DataTypeErrorsBase {
   }
 
   def valueIsNullError(index: Int): Throwable = {
-    new SparkException(
+    new SparkRuntimeException(
       errorClass = "ROW_VALUE_IS_NULL",
       messageParameters = Map(
         "index" -> index.toString),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/RowTest.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/RowTest.scala
@@ -24,7 +24,7 @@ import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers._
 
-import org.apache.spark.{SparkException, SparkIllegalArgumentException, SparkUnsupportedOperationException}
+import org.apache.spark.{SparkIllegalArgumentException, SparkRuntimeException, SparkUnsupportedOperationException}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{GenericRow, GenericRowWithSchema}
 import org.apache.spark.sql.types._
@@ -87,8 +87,9 @@ class RowTest extends AnyFunSpec with Matchers {
       sampleRowWithoutCol3.getValuesMap[String](List("col1", "col2")) shouldBe expected
     }
 
-    it("getAs() on type extending AnyVal throws an exception when accessing field that is null") {
-      intercept[SparkException] {
+    it("getAnyValAs() on type extending AnyVal throws an exception when accessing " +
+      "field that is null") {
+      intercept[SparkRuntimeException] {
         sampleRowWithoutCol3.getInt(sampleRowWithoutCol3.fieldIndex("col3"))
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.{SparkFunSuite, SparkUnsupportedOperationException}
+import org.apache.spark.{SparkException, SparkFunSuite, SparkUnsupportedOperationException}
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, SpecificInternalRow}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
@@ -121,6 +121,19 @@ class RowSuite extends SparkFunSuite with SharedSparkSession {
       },
       errorClass = "UNSUPPORTED_CALL.FIELD_INDEX",
       parameters = Map("methodName" -> "fieldIndex", "className" -> "Row", "fieldName" -> "`foo`")
+    )
+  }
+
+  test("SPARK-42307 - Trying to get the value from a null column should result in error") {
+    val position = 0
+    val rowWithNullValue = Row.fromSeq(Seq(null))
+
+    checkError(
+      exception = intercept[SparkException] {
+        rowWithNullValue.getLong(position)
+      },
+      errorClass = "COLUMN_VALUE_IS_NULL",
+      parameters = Map("index" -> position.toString)
     )
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.{SparkException, SparkFunSuite, SparkUnsupportedOperationException}
+import org.apache.spark.{SparkFunSuite, SparkRuntimeException, SparkUnsupportedOperationException}
 import org.apache.spark.sql.catalyst.expressions.{GenericInternalRow, SpecificInternalRow}
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
@@ -129,7 +129,7 @@ class RowSuite extends SparkFunSuite with SharedSparkSession {
     val rowWithNullValue = Row.fromSeq(Seq(null))
 
     checkError(
-      exception = intercept[SparkException] {
+      exception = intercept[SparkRuntimeException] {
         rowWithNullValue.getLong(position)
       },
       errorClass = "ROW_VALUE_IS_NULL",

--- a/sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala
@@ -132,7 +132,7 @@ class RowSuite extends SparkFunSuite with SharedSparkSession {
       exception = intercept[SparkException] {
         rowWithNullValue.getLong(position)
       },
-      errorClass = "COLUMN_VALUE_IS_NULL",
+      errorClass = "ROW_VALUE_IS_NULL",
       parameters = Map("index" -> position.toString)
     )
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/RowSuite.scala
@@ -124,7 +124,7 @@ class RowSuite extends SparkFunSuite with SharedSparkSession {
     )
   }
 
-  test("SPARK-42307 - Trying to get the value from a null column should result in error") {
+  test("SPARK-42307: get a value from a null column should result in error") {
     val position = 0
     val rowWithNullValue = Row.fromSeq(Seq(null))
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

In this PR, I propose to replace the legacy error name `_LEGACY_ERROR_TEMP_2232` with `ROW_VALUE_IS_NULL `, and add a test case for it.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Proper name improves user experience with Spark SQL.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Ran all the tests in the suite:
```
build/sbt "testOnly *org.apache.spark.sql.RowSuite"
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No