### PR TITLE
[SPARK-48899][K8S] Fix `ENV` key value format in K8s Dockerfiles

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -55,7 +55,7 @@ RUN ln -s $(basename $(ls /opt/spark/examples/jars/spark-examples_*.jar)) /opt/s
 COPY kubernetes/tests /opt/spark/tests
 COPY data /opt/spark/data
 
-ENV SPARK_HOME /opt/spark
+ENV SPARK_HOME=/opt/spark
 
 WORKDIR /opt/spark/work-dir
 RUN chmod g+w /opt/spark/work-dir

--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/R/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/R/Dockerfile
@@ -32,7 +32,7 @@ RUN \
   rm -rf /var/cache/apt/* && rm -rf /var/lib/apt/lists/*
 
 COPY R ${SPARK_HOME}/R
-ENV R_HOME /usr/lib/R
+ENV R_HOME=/usr/lib/R
 
 WORKDIR /opt/spark/work-dir
 ENTRYPOINT [ "/opt/entrypoint.sh" ]


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `ENV` key value format in K8s Dockerfiles.

### Why are the changes needed?

To follow the Docker guideline to fix the following legacy format.
- https://docs.docker.com/reference/build-checks/legacy-key-value-format/
```
- LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.