### PR TITLE
[SPARK-48861][SQL] Enable shuffle file removal/skipMigration for all SQL executions

### DIFF
--- a/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/SparkConnectPlanExecution.scala
+++ b/connect/server/src/main/scala/org/apache/spark/sql/connect/execution/SparkConnectPlanExecution.scala
@@ -35,9 +35,8 @@ import org.apache.spark.sql.connect.config.Connect.CONNECT_GRPC_ARROW_MAX_BATCH_
 import org.apache.spark.sql.connect.planner.SparkConnectPlanner
 import org.apache.spark.sql.connect.service.ExecuteHolder
 import org.apache.spark.sql.connect.utils.MetricGenerator
-import org.apache.spark.sql.execution.{DoNotCleanup, LocalTableScanExec, RemoveShuffleFiles, SkipMigration, SQLExecution}
+import org.apache.spark.sql.execution.{LocalTableScanExec, SQLExecution}
 import org.apache.spark.sql.execution.arrow.ArrowConverters
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.ThreadUtils
 
@@ -60,20 +59,11 @@ private[execution] class SparkConnectPlanExecution(executeHolder: ExecuteHolder)
     val planner = new SparkConnectPlanner(executeHolder)
     val tracker = executeHolder.eventsManager.createQueryPlanningTracker()
     val conf = session.sessionState.conf
-    val shuffleCleanupMode =
-      if (conf.getConf(SQLConf.SHUFFLE_DEPENDENCY_FILE_CLEANUP_ENABLED)) {
-        RemoveShuffleFiles
-      } else if (conf.getConf(SQLConf.SHUFFLE_DEPENDENCY_SKIP_MIGRATION_ENABLED)) {
-        SkipMigration
-      } else {
-        DoNotCleanup
-      }
     val dataframe =
       Dataset.ofRows(
         sessionHolder.session,
         planner.transformRelation(request.getPlan.getRoot, cachePlan = true),
-        tracker,
-        shuffleCleanupMode)
+        tracker)
     responseObserver.onNext(createSchemaResponse(request.getSessionId, dataframe.schema))
     processAsArrowBatches(dataframe, responseObserver, executeHolder)
     responseObserver.onNext(MetricGenerator.createMetricsResponse(sessionHolder, dataframe))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2989,19 +2989,19 @@ object SQLConf {
 
   val SHUFFLE_DEPENDENCY_SKIP_MIGRATION_ENABLED =
     buildConf("spark.sql.shuffleDependency.skipMigration.enabled")
-      .doc("When enabled, shuffle dependencies for a Spark Connect SQL execution are marked at " +
+      .doc("When enabled, shuffle dependencies for a Spark SQL execution are marked at " +
         "the end of the execution, and they will not be migrated during decommissions.")
       .version("4.0.0")
       .booleanConf
-      .createWithDefault(Utils.isTesting)
+      .createWithDefault(false)
 
   val SHUFFLE_DEPENDENCY_FILE_CLEANUP_ENABLED =
     buildConf("spark.sql.shuffleDependency.fileCleanup.enabled")
-      .doc("When enabled, shuffle files will be cleaned up at the end of Spark Connect " +
+      .doc("When enabled, shuffle files will be cleaned up at the end of Spark " +
         "SQL executions.")
       .version("4.0.0")
       .booleanConf
-      .createWithDefault(Utils.isTesting)
+      .createWithDefault(false)
 
   val SORT_MERGE_JOIN_EXEC_BUFFER_IN_MEMORY_THRESHOLD =
     buildConf("spark.sql.sortMergeJoinExec.buffer.in.memory.threshold")

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -95,26 +95,13 @@ private[sql] object Dataset {
       new Dataset[Row](qe, ExpressionEncoder(qe.analyzed.schema))
   }
 
-  def ofRows(
-      sparkSession: SparkSession,
-      logicalPlan: LogicalPlan,
-      shuffleCleanupMode: ShuffleCleanupMode): DataFrame =
-    sparkSession.withActive {
-      val qe = new QueryExecution(
-        sparkSession, logicalPlan, shuffleCleanupMode = shuffleCleanupMode)
-      qe.assertAnalyzed()
-      new Dataset[Row](qe, ExpressionEncoder(qe.analyzed.schema))
-    }
-
   /** A variant of ofRows that allows passing in a tracker so we can track query parsing time. */
   def ofRows(
       sparkSession: SparkSession,
       logicalPlan: LogicalPlan,
-      tracker: QueryPlanningTracker,
-      shuffleCleanupMode: ShuffleCleanupMode = DoNotCleanup)
+      tracker: QueryPlanningTracker)
     : DataFrame = sparkSession.withActive {
-    val qe = new QueryExecution(
-      sparkSession, logicalPlan, tracker, shuffleCleanupMode = shuffleCleanupMode)
+    val qe = new QueryExecution(sparkSession, logicalPlan, tracker)
     qe.assertAnalyzed()
     new Dataset[Row](qe, ExpressionEncoder(qe.analyzed.schema))
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -64,7 +64,7 @@ class QueryExecution(
 
   val id: Long = QueryExecution.nextExecutionId
 
-  def shuffleCleanupMode: ShuffleCleanupMode = {
+  val shuffleCleanupMode: ShuffleCleanupMode = {
     val conf = sparkSession.sessionState.conf
     val shuffleCleanupMode =
       if (conf.getConf(SQLConf.SHUFFLE_DEPENDENCY_FILE_CLEANUP_ENABLED)) {


### PR DESCRIPTION
This PR follows https://github.com/apache/spark/pull/45930 and https://github.com/apache/spark/pull/46302 (which is open as of the creation of this PR) to enable shuffle file cleanup for all SQL executions, not just Spark Connect.

The prior PR https://github.com/apache/spark/pull/45930 introduces two new configs: `spark.sql.shuffleDependency.skipMigration.enabled` and `spark.sql.shuffleDependency.fileCleanup.enabled`. These two configs are not specifically namespaced to Spark Connect and I'd like to make sure we can use them from all QueryExecutions. Before this PR, only Spark Connect could enable it.

My change is to move the check for `shuffleCleanupMode` inside of `QueryExecution`, instead of having that be passed to this class in the constructor. I also am explicitly turning on these features in the tests, rather than using `Utils.isTesting`. 

I would love to hear any concerns on why we shouldn't do this or what testing you want to see. I have run Standalone tests (note I needed https://github.com/apache/spark/pull/46302) and can run other tests if required or can code them.