### PR TITLE
[SPARK-48902][BUILD] Upgrade `commons-codec` to 1.17.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -37,7 +37,7 @@ checker-qual/3.42.0//checker-qual-3.42.0.jar
 chill-java/0.10.0//chill-java-0.10.0.jar
 chill_2.13/0.10.0//chill_2.13-0.10.0.jar
 commons-cli/1.8.0//commons-cli-1.8.0.jar
-commons-codec/1.17.0//commons-codec-1.17.0.jar
+commons-codec/1.17.1//commons-codec-1.17.1.jar
 commons-collections/3.2.2//commons-collections-3.2.2.jar
 commons-collections4/4.4//commons-collections4-4.4.jar
 commons-compiler/3.1.9//commons-compiler-3.1.9.jar

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
     <org.glassfish.jaxb.txw2.version>3.0.2</org.glassfish.jaxb.txw2.version>
     <snappy.version>1.1.10.5</snappy.version>
     <netlib.ludovic.dev.version>3.0.3</netlib.ludovic.dev.version>
-    <commons-codec.version>1.17.0</commons-codec.version>
+    <commons-codec.version>1.17.1</commons-codec.version>
     <commons-compress.version>1.26.2</commons-compress.version>
     <commons-io.version>2.16.1</commons-io.version>
     <!-- To support Hive UDF jars built by Hive 2.0.0 ~ 2.3.9 and 3.0.0 ~ 3.1.3. -->


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `commons-codec` from `1.17.0` to `1.17.1`.


### Why are the changes needed?
The full release notes: https://commons.apache.org/proper/commons-codec/changes-report.html#a1.17.1
This version has fixed some bugs from the previous version, eg:
- Md5Crypt now throws IllegalArgumentException on an invalid prefix



### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
