### PR TITLE
[SPARK-48914][SQL][TESTS] Add OFFSET operator as an option in the subquery generator

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/querytest/GeneratedSubquerySuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/querytest/GeneratedSubquerySuite.scala
@@ -154,8 +154,7 @@ class GeneratedSubquerySuite extends DockerJDBCIntegrationSuite with QueryGenera
     } else {
       operatorInSubquery match {
         case lo: LimitAndOffset =>
-          var offsetValue = lo.offsetValue
-          if (requireNoOffsetInCorrelatedSubquery) offsetValue = 0
+          val offsetValue = if (requireNoOffsetInCorrelatedSubquery) 0 else lo.offsetValue
 
           if (offsetValue == 0 && lo.limitValue == 0) {
             None
@@ -379,10 +378,10 @@ class GeneratedSubquerySuite extends DockerJDBCIntegrationSuite with QueryGenera
       val aggregates = combinations.map {
         case (af, groupBy) => Aggregate(Seq(af), if (groupBy) Seq(groupByColumn) else Seq())
       }
-      val limitValue = Seq(0, 1, 10)
-      val offsetValue = Seq(0, 1, 10)
-      val limitAndOffsetOperators = limitValue.flatMap(limit => offsetValue.map(offset =>
-        LimitAndOffset(limit, offset))).filter(lo => lo.limitValue != 0 || lo.offsetValue != 0)
+      val limitValues = Seq(0, 1, 10)
+      val offsetValues = Seq(0, 1, 10)
+      val limitAndOffsetOperators = limitValues.flatMap(limit => offsetValues.map(offset =>
+        LimitAndOffset(limit, offset))).filter(lo => !(lo.limitValue == 0 && lo.offsetValue == 0))
       val subqueryOperators = limitAndOffsetOperators ++ aggregates
 
       for {

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/querytest/GeneratedSubquerySuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/querytest/GeneratedSubquerySuite.scala
@@ -126,16 +126,20 @@ class GeneratedSubquerySuite extends DockerJDBCIntegrationSuite with QueryGenera
       case _ => None
     }
 
-    // For the OrderBy, consider whether or not the result of the subquery is required to be sorted.
-    // This is to maintain test determinism. This is affected by whether the subquery has a limit
-    // clause.
-    val requiresLimitOne = isScalarSubquery && (operatorInSubquery match {
+    // For some situation needs exactly one row as output, we force the
+    // subquery to have a limit of 1 and no offset value (in case it outputs
+    // empty result set).
+    val requiresExactlyOneRowOutput = isScalarSubquery && (operatorInSubquery match {
       case a: Aggregate => a.groupingExpressions.nonEmpty
-      case l: Limit => l.limitValue > 1
       case _ => true
     })
 
-    val orderByClause = if (requiresLimitOne || operatorInSubquery.isInstanceOf[Limit]) {
+    // For the OrderBy, consider whether or not the result of the subquery is required to be sorted.
+    // This is to maintain test determinism. This is affected by whether the subquery has a limit
+    // clause or an offset clause.
+    val orderByClause = if (
+      requiresExactlyOneRowOutput || operatorInSubquery.isInstanceOf[LimitAndOffset]
+    ) {
       Some(OrderByClause(projections))
     } else {
       None
@@ -143,16 +147,23 @@ class GeneratedSubquerySuite extends DockerJDBCIntegrationSuite with QueryGenera
 
     // For the Limit clause, consider whether the subquery needs to return 1 row, or whether the
     // operator to be included is a Limit.
-    val limitClause = if (requiresLimitOne) {
-      Some(Limit(1))
+    val limitAndOffsetClause = if (requiresExactlyOneRowOutput) {
+      Some(LimitAndOffset(1, 0))
     } else {
       operatorInSubquery match {
-        case limit: Limit => Some(limit)
+        case lo: LimitAndOffset =>
+          if (lo.offsetValue == 0 && lo.limitValue == 0) {
+            None
+          } else {
+            Some(lo)
+          }
         case _ => None
       }
     }
 
-    Query(selectClause, fromClause, whereClause, groupByClause, orderByClause, limitClause)
+    Query(
+      selectClause, fromClause, whereClause, groupByClause, orderByClause, limitAndOffsetClause
+    )
   }
 
   /**
@@ -236,7 +247,7 @@ class GeneratedSubquerySuite extends DockerJDBCIntegrationSuite with QueryGenera
     val orderByClause = Some(OrderByClause(queryProjection))
 
     Query(selectClause, fromClause, whereClause, groupByClause = None,
-      orderByClause, limitClause = None)
+      orderByClause, limitAndOffsetClause = None)
   }
 
   private def getPostgresResult(stmt: Statement, sql: String): Array[Row] = {
@@ -363,7 +374,11 @@ class GeneratedSubquerySuite extends DockerJDBCIntegrationSuite with QueryGenera
       val aggregates = combinations.map {
         case (af, groupBy) => Aggregate(Seq(af), if (groupBy) Seq(groupByColumn) else Seq())
       }
-      val subqueryOperators = Seq(Limit(1), Limit(10)) ++ aggregates
+      val limitValue = Seq(0, 1, 10)
+      val offsetValue = Seq(0, 1, 10)
+      val limitAndOffsetOperators = limitValue.flatMap(limit => offsetValue.map(offset =>
+        LimitAndOffset(limit, offset))).filter(lo => lo.limitValue != 0 || lo.offsetValue != 0)
+      val subqueryOperators = limitAndOffsetOperators ++ aggregates
 
       for {
         subqueryOperator <- subqueryOperators

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/querytest/GeneratedSubquerySuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/querytest/GeneratedSubquerySuite.scala
@@ -363,7 +363,7 @@ class GeneratedSubquerySuite extends DockerJDBCIntegrationSuite with QueryGenera
         limit => offsetValues.map(
           offset => LimitAndOffset(limit, offset)
         )
-      ).filter(lo => !(lo._1 == 0 && lo._2 == 0))
+      ).filter(lo => !(lo.limitValue == 0 && lo.offsetValue == 0))
     }
 
     case class SubquerySpec(query: String, isCorrelated: Boolean, subqueryType: SubqueryType.Value)

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryGeneratorHelper.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryGeneratorHelper.scala
@@ -189,10 +189,10 @@ trait QueryGeneratorHelper {
     override def toString: String = {
       val limitClause = if (limitValue > 0) { s"LIMIT $limitValue" } else { "" }
       val offsetClause = if (offsetValue > 0) { s"OFFSET $offsetValue" } else { "" }
-      if (limitClause.nonEmpty || offsetClause.nonEmpty) {
-        limitClause + " " + offsetClause
+      if (limitClause.nonEmpty && offsetClause.nonEmpty) {
+        s"$limitClause $offsetClause"
       } else {
-          ""
+        s"$limitClause$offsetClause"
       }
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryGeneratorHelper.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryGeneratorHelper.scala
@@ -185,8 +185,16 @@ trait QueryGeneratorHelper {
       f"groupingExpr=[${groupingExpressions.mkString(",")}])"
   }
 
-  case class Limit(limitValue: Int) extends Operator with Clause {
-    override def toString: String = f"LIMIT $limitValue"
+  case class LimitAndOffset(limitValue: Int, offsetValue: Int) extends Operator with Clause {
+    override def toString: String = {
+      val limitClause = if (limitValue > 0) { s"LIMIT $limitValue" } else { "" }
+      val offsetClause = if (offsetValue > 0) { s"OFFSET $offsetValue" } else { "" }
+      if (limitClause.nonEmpty || offsetClause.nonEmpty) {
+        limitClause + " " + offsetClause
+      } else {
+          ""
+      }
+    }
   }
 
   object SubqueryLocation extends Enumeration {
@@ -223,7 +231,7 @@ trait QueryGeneratorHelper {
       whereClause: Option[WhereClause] = None,
       groupByClause: Option[GroupByClause] = None,
       orderByClause: Option[OrderByClause] = None,
-      limitClause: Option[Limit] = None
+      limitAndOffsetClause: Option[LimitAndOffset] = None
   ) extends Operator {
 
     override def toString: String = {
@@ -232,7 +240,7 @@ trait QueryGeneratorHelper {
 
       f"$selectClause $fromClause${getOptionClauseString(whereClause)}" +
         f"${getOptionClauseString(groupByClause)}${getOptionClauseString(orderByClause)}" +
-        f"${getOptionClauseString(limitClause)}"
+        f"${getOptionClauseString(limitAndOffsetClause)}"
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
This adds offset operator in subquery generator suite.


### Why are the changes needed?
Complete the subquery generator functionality


### Does this PR introduce _any_ user-facing change?
previously there's no subqueries having offset operator being tested. Currently offset operator is added.


### How was this patch tested?
query test


### Was this patch authored or co-authored using generative AI tooling?
No