### PR TITLE
[SPARK-48917][BUILD] Upgrade tink to 1.14.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -265,7 +265,7 @@ stax-api/1.0.1//stax-api-1.0.1.jar
 stream/2.9.8//stream-2.9.8.jar
 super-csv/2.2.0//super-csv-2.2.0.jar
 threeten-extra/1.7.1//threeten-extra-1.7.1.jar
-tink/1.13.0//tink-1.13.0.jar
+tink/1.14.0//tink-1.14.0.jar
 transaction-api/1.1//transaction-api-1.1.jar
 txw2/3.0.2//txw2-3.0.2.jar
 univocity-parsers/2.9.1//univocity-parsers-2.9.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -2774,6 +2774,10 @@
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <commons-cli.version>1.8.0</commons-cli.version>
     <bouncycastle.version>1.78</bouncycastle.version>
-    <tink.version>1.13.0</tink.version>
+    <tink.version>1.14.0</tink.version>
     <datasketches.version>6.0.0</datasketches.version>
     <netty.version>4.1.110.Final</netty.version>
     <netty-tcnative.version>2.0.65.Final</netty-tcnative.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `tink` from `1.13.0` to `1.14.0`.


### Why are the changes needed?
- The full release notes: https://github.com/tink-crypto/tink-java/releases/tag/v1.14.0
Performance improvements

- The new version brings some performance improvements and bug fixes:
  Improved performance of AES-EAX AEAD.
  Improved performance of AES-SIV Deterministic AEAD.
  Improved performance of AES-CMAC PRF.
  Improved performance of ECIES Hybrid Encryption.

  Fixed bug in binary keyset parsing that resulted in a TinkBugException when parsing invalid input.
  Fixed bug in JSON keyset parsing that resulted in a RuntimeException when parsing invalid input.
  Fixed bug where the channel obtained from newSeekableDecryptingChannel falsely returned -1 on read calls. This only happens if read was called with an empty buffer, and if the previous call to read sucessfully read the end of the stream.



### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
