### PR TITLE
[SPARK-48920][BUILD][3.5] Upgrade ORC to 1.9.4

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -212,9 +212,9 @@ opencsv/2.3//opencsv-2.3.jar
 opentracing-api/0.33.0//opentracing-api-0.33.0.jar
 opentracing-noop/0.33.0//opentracing-noop-0.33.0.jar
 opentracing-util/0.33.0//opentracing-util-0.33.0.jar
-orc-core/1.9.3/shaded-protobuf/orc-core-1.9.3-shaded-protobuf.jar
-orc-mapreduce/1.9.3/shaded-protobuf/orc-mapreduce-1.9.3-shaded-protobuf.jar
-orc-shims/1.9.3//orc-shims-1.9.3.jar
+orc-core/1.9.4/shaded-protobuf/orc-core-1.9.4-shaded-protobuf.jar
+orc-mapreduce/1.9.4/shaded-protobuf/orc-mapreduce-1.9.4-shaded-protobuf.jar
+orc-shims/1.9.4//orc-shims-1.9.4.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <!-- After 10.15.1.3, the minimum required version is JDK9 -->
     <derby.version>10.14.2.0</derby.version>
     <parquet.version>1.13.1</parquet.version>
-    <orc.version>1.9.3</orc.version>
+    <orc.version>1.9.4</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>
     <jetty.version>9.4.54.v20240208</jetty.version>
     <jakartaservlet.version>4.0.3</jakartaservlet.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade ORC to 1.9.4 for Apache Spark 3.5.2.


### Why are the changes needed?
This is the latest version of ORC 1.9.x.
- https://orc.apache.org/news/2024/07/16/ORC-1.9.4/
- https://github.com/apache/orc/releases/tag/v1.9.4


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?
No.