### PR TITLE
[SPARK-48922][SQL] Optimize nested data type insertion performance

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TableOutputResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TableOutputResolver.scala
@@ -413,6 +413,8 @@ object TableOutputResolver extends SQLConfHelper with Logging {
       resolveColumnsByPosition(tableName, Seq(param), Seq(fakeAttr), conf, addError, colPath)
     }
     if (res.length == 1) {
+      // If the element expression have not changed, we just check original array field.
+      // Otherwise, we add transformations to the elements.
       if (res.head.fastEquals(param)) {
         input match {
           case n: NamedExpression =>
@@ -460,6 +462,8 @@ object TableOutputResolver extends SQLConfHelper with Logging {
     }
 
     if (resKey.length == 1 && resValue.length == 1) {
+      // If the key and value expressions have not changed, we just check original map field.
+      // Otherwise, we construct a new map by adding transformations to the keys and values.
       if (resKey.head.fastEquals(keyParam) && resValue.head.fastEquals(valueParam)) {
         input match {
           case n: NamedExpression =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TableOutputResolver.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TableOutputResolver.scala
@@ -414,7 +414,11 @@ object TableOutputResolver extends SQLConfHelper with Logging {
     }
     if (res.length == 1) {
       if (res.head.fastEquals(param)) {
-        Some(Alias(nullCheckedInput, expected.name)())
+        input match {
+          case n: NamedExpression =>
+            checkField(tableName, expected, n, byName, conf, addError, colPath)
+          case _ => None
+        }
       } else {
         val func = LambdaFunction(res.head, Seq(param))
         Some(Alias(ArrayTransform(nullCheckedInput, func), expected.name)())
@@ -457,7 +461,11 @@ object TableOutputResolver extends SQLConfHelper with Logging {
 
     if (resKey.length == 1 && resValue.length == 1) {
       if (resKey.head.fastEquals(keyParam) && resValue.head.fastEquals(valueParam)) {
-        Some(Alias(nullCheckedInput, expected.name)())
+        input match {
+          case n: NamedExpression =>
+            checkField(tableName, expected, n, byName, conf, addError, colPath)
+          case _ => None
+        }
       } else {
         val newKeys = if (!resKey.head.fastEquals(keyParam)) {
           val keyFunc = LambdaFunction(resKey.head, Seq(keyParam))

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/subquery-nested-data.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/subquery/subquery-nested-data.sql.out
@@ -23,7 +23,7 @@ CreateDataSourceTableCommand `spark_catalog`.`default`.`x`, false
 insert into x values (map(1, 2), 3), (map(1, 4), 5), (map(2, 3), 4), (map(5, 6), 7)
 -- !query analysis
 InsertIntoHadoopFsRelationCommand file:[not included in comparison]/{warehouse_dir}/x, false, Parquet, [path=file:[not included in comparison]/{warehouse_dir}/x], Append, `spark_catalog`.`default`.`x`, org.apache.spark.sql.execution.datasources.InMemoryFileIndex(file:[not included in comparison]/{warehouse_dir}/x), [xm, x2]
-+- Project [map_from_arrays(transform(map_keys(col1#x), lambdafunction(lambda key#x, lambda key#x, false)), transform(map_values(col1#x), lambdafunction(lambda value#x, lambda value#x, false))) AS xm#x, cast(col2#x as int) AS x2#x]
++- Project [cast(col1#x as map<int,int>) AS xm#x, cast(col2#x as int) AS x2#x]
    +- LocalRelation [col1#x, col2#x]
 
 
@@ -37,7 +37,7 @@ CreateDataSourceTableCommand `spark_catalog`.`default`.`y`, false
 insert into y values (map(1, 2), 10), (map(1, 3), 20), (map(2, 3), 20), (map(8, 3), 20)
 -- !query analysis
 InsertIntoHadoopFsRelationCommand file:[not included in comparison]/{warehouse_dir}/y, false, Parquet, [path=file:[not included in comparison]/{warehouse_dir}/y], Append, `spark_catalog`.`default`.`y`, org.apache.spark.sql.execution.datasources.InMemoryFileIndex(file:[not included in comparison]/{warehouse_dir}/y), [ym, y2]
-+- Project [map_from_arrays(transform(map_keys(col1#x), lambdafunction(lambda key#x, lambda key#x, false)), transform(map_values(col1#x), lambdafunction(lambda value#x, lambda value#x, false))) AS ym#x, cast(col2#x as int) AS y2#x]
++- Project [cast(col1#x as map<int,int>) AS ym#x, cast(col2#x as int) AS y2#x]
    +- LocalRelation [col1#x, col2#x]
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/InsertTableWithComplexTypeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/InsertTableWithComplexTypeBenchmark.scala
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.benchmark
+
+import org.apache.spark.benchmark.Benchmark
+
+/**
+ * Benchmark to measure insert into table with complex data type.
+ * To run this benchmark:
+ * {{{
+ *   1. without sbt:
+ *      bin/spark-submit --class <this class>
+ *        --jars <spark core test jar>,<spark catalyst test jar> < spark sql test jar>
+ *   2. build/sbt "sql/Test/runMain <this class>"
+ *   3. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/Test/runMain <this class>"
+ *      Results will be written to
+ *      "benchmarks/InsertTableWithComplexTypeBenchmark-results.txt".
+ * }}}
+ */
+object InsertTableWithComplexTypeBenchmark extends DataSourceWriteBenchmark {
+
+  val tempMapView = "tempMapView"
+  val tempArrayView = "tempArrayView"
+  override val numRows = 1024 * 10
+
+  def prepareTempViews(): Unit = {
+    // Prepare a temp view with map type
+    import spark.implicits._
+    spark.range(numRows).map { _ =>
+      (0 until 100).map(i => i->i).toMap
+    }.createOrReplaceTempView(tempMapView)
+
+    // Prepare a temp view with array type
+    spark.range(numRows).map { _ =>
+      (0 until 100).toArray
+    }.createOrReplaceTempView(tempArrayView)
+  }
+
+  def insertMapTypeTableWithoutConversion(table: String, benchmark: Benchmark): Unit = {
+    spark.sql(s"CREATE TABLE $table(i MAP<INT, INT>) USING parquet")
+    benchmark.addCase(s"insert map type table without conversion") { _ =>
+      spark.sql(s"INSERT INTO $table SELECT * FROM $tempMapView")
+    }
+  }
+
+  def insertMapTypeTableWithConversion(table: String, benchmark: Benchmark): Unit = {
+    spark.sql(s"CREATE TABLE $table(i MAP<String, String>) USING parquet")
+    benchmark.addCase(s"insert map type table with conversion") { _ =>
+      spark.sql(s"INSERT INTO $table SELECT * FROM $tempMapView")
+    }
+  }
+
+  def insertArrayTypeTableWithoutConversion(table: String, benchmark: Benchmark): Unit = {
+    spark.sql(s"CREATE TABLE $table(i ARRAY<INT>) USING parquet")
+    benchmark.addCase(s"insert array type table without conversion") { _ =>
+      spark.sql(s"INSERT INTO $table SELECT * FROM $tempArrayView")
+    }
+  }
+
+  def insertArrayTypeTableWithConversion(table: String, benchmark: Benchmark): Unit = {
+    spark.sql(s"CREATE TABLE $table(i ARRAY<String>) USING parquet")
+    benchmark.addCase(s"insert array type table with conversion") { _ =>
+      spark.sql(s"INSERT INTO $table SELECT * FROM $tempArrayView")
+    }
+  }
+
+  override def runBenchmarkSuite(mainArgs: Array[String]): Unit = {
+    val mapTable1 = "mapTable1"
+    val mapTable2 = "mapTable2"
+    val arrayTable1 = "arrayTable1"
+    val arrayTable2 = "arrayTable2"
+
+    withTempTable(tempMapView, tempArrayView) {
+      prepareTempViews()
+      withTable(mapTable1, mapTable2, arrayTable1, arrayTable2) {
+        val mapTypeBenchmark =
+          new Benchmark(s"Insert map type table benchmark, totalRows = $numRows",
+            numRows, output = output)
+        insertMapTypeTableWithConversion(mapTable2, mapTypeBenchmark)
+        insertMapTypeTableWithoutConversion(mapTable1, mapTypeBenchmark)
+        mapTypeBenchmark.run()
+
+        val arrayTypeBenchmark =
+          new Benchmark(s"Insert array type table benchmark, totalRows = $numRows",
+            numRows, output = output)
+        insertArrayTypeTableWithConversion(arrayTable2, arrayTypeBenchmark)
+        insertArrayTypeTableWithoutConversion(arrayTable1, arrayTypeBenchmark)
+        arrayTypeBenchmark.run()
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

To improve insertion performance, we do not need to add transform expressions when there is no conversion for complex types.

### Why are the changes needed?
During the upgrade from Spark 3.1.1 to 3.5.0, I found a performance regression in map type inserts.

There are some extra conversion expressions in project before insert, which doesn't seem to be always necessary.

```
map_from_arrays(transform(map_keys(map#516), lambdafunction(lambda key#652, lambda key#652, false)), transform(map_values(map#516), lambdafunction(lambda value#654, lambda value#654, false))) AS map#656 
```

### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added benchmark case.

before this pr:
```
Java HotSpot(TM) 64-Bit Server VM 17.0.10+11-LTS-240 on Linux 3.10.0-957.el7.x86_64
Intel Core Processor (Skylake, IBRS)
Insert map type table benchmark, totalRows = 10240:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
----------------------------------------------------------------------------------------------------------------------------------
insert map type table with conversion                        1054           1092          54          0.0      102906.7       1.0X
insert map type table without conversion                      540            582          47          0.0       52770.3       2.0X

Java HotSpot(TM) 64-Bit Server VM 17.0.10+11-LTS-240 on Linux 3.10.0-957.el7.x86_64
Intel Core Processor (Skylake, IBRS)
Insert array type table benchmark, totalRows = 10240:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------
insert array type table with conversion                         372            399          20          0.0       36337.9       1.0X
insert array type table without conversion                      233            255          19          0.0       22775.5       1.6X
```

after this pr:
```
Java HotSpot(TM) 64-Bit Server VM 17.0.10+11-LTS-240 on Linux 3.10.0-957.el7.x86_64
Intel Core Processor (Skylake, IBRS)
Insert map type table benchmark, totalRows = 10240:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
----------------------------------------------------------------------------------------------------------------------------------
insert map type table with conversion                        1222           1226           6          0.0      119360.0       1.0X
insert map type table without conversion                      417            429          12          0.0       40714.5       2.9X

Java HotSpot(TM) 64-Bit Server VM 17.0.10+11-LTS-240 on Linux 3.10.0-957.el7.x86_64
Intel Core Processor (Skylake, IBRS)
Insert array type table benchmark, totalRows = 10240:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------------------
insert array type table with conversion                         389            433          31          0.0       37967.2       1.0X
insert array type table without conversion                      207            241          23          0.0       20246.6       1.9X
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No