### PR TITLE
[SPARK-48510][CONNECT][FOLLOW-UP-MK2] Fix for UDAF `toColumn` API when running tests in Maven

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/expressions/Aggregator.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/expressions/Aggregator.scala
@@ -133,10 +133,20 @@ abstract class Aggregator[-IN, BUF, OUT] extends Serializable {
 
     import scala.reflect.api._
     def areCompatibleMirrors(one: Mirror[_], another: Mirror[_]): Boolean = {
+      def checkAllParents(target: JavaMirror, candidate: JavaMirror): Boolean = {
+        var current = candidate.classLoader
+        while (current != null) {
+          if (current == target.classLoader) {
+            return true
+          }
+          current = current.getParent
+        }
+        false
+      }
+
       (one, another) match {
         case (a: JavaMirror, b: JavaMirror) =>
-          Iterator.iterate(b.classLoader)(_.getParent).contains(a.classLoader) ||
-          Iterator.iterate(a.classLoader)(_.getParent).contains(b.classLoader)
+          a == b || checkAllParents(a, b) || checkAllParents(b, a)
         case _ => one == another
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR follows https://github.com/apache/spark/pull/47368 as another try to fix the broken tests. The previous try failed due to NPE, caused by `Iterator.iterate` generating an **infinite** flow of values.

I can't reproduce the previous issue locally, so my fix is purely based on the error message: https://github.com/apache/spark/actions/runs/9974746135/job/27562881993.

### Why are the changes needed?

Because previous one failed.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Locally.

### Was this patch authored or co-authored using generative AI tooling?

No.