### PR TITLE
[SPARK-48926][SQL][TESTS] Use `checkError` method to optimize exception check logic related to `UNRESOLVED_COLUMN` error classes

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/LateralColumnAliasSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/LateralColumnAliasSuite.scala
@@ -514,8 +514,17 @@ class LateralColumnAliasSuite extends LateralColumnAliasSuiteBase {
          |  FROM (SELECT 1 AS id1, id1 + 1 AS id2)) > 5
          |""".stripMargin
     withLCAOff {
-      assert(intercept[AnalysisException] { sql(query2) }
-        .getErrorClass == "UNRESOLVED_COLUMN.WITHOUT_SUGGESTION")
+      checkError(
+        exception = intercept[AnalysisException] {
+          sql(query2)
+        },
+        errorClass = "UNRESOLVED_COLUMN.WITHOUT_SUGGESTION",
+        sqlState = "42703",
+        parameters = Map("objectName" -> s"`id1`"),
+        context = ExpectedContext(
+          fragment = "id1",
+          start = 73,
+          stop = 75))
     }
     withLCAOn { checkAnswer(sql(query2), Seq.empty) }
 
@@ -783,18 +792,44 @@ class LateralColumnAliasSuite extends LateralColumnAliasSuiteBase {
   }
 
   test("Attribute cannot be resolved by LCA remain unresolved") {
-    assert(intercept[AnalysisException] {
-      sql(s"SELECT dept AS d, d AS new_dept, new_dep + 1 AS newer_dept FROM $testTable")
-    }.getErrorClass == "UNRESOLVED_COLUMN.WITH_SUGGESTION")
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql(s"SELECT dept AS d, d AS new_dept, new_dep + 1 AS newer_dept FROM $testTable")
+      },
+      errorClass = "UNRESOLVED_COLUMN.WITH_SUGGESTION",
+      sqlState = "42703",
+      parameters = Map("objectName" -> s"`new_dep`",
+        "proposal" -> "`dept`, `name`, `bonus`, `salary`, `properties`"),
+      context = ExpectedContext(
+        fragment = "new_dep",
+        start = 33,
+        stop = 39))
 
-    assert(intercept[AnalysisException] {
-      sql(s"SELECT count(name) AS cnt, cnt + 1, count(unresovled) FROM $testTable GROUP BY dept")
-    }.getErrorClass == "UNRESOLVED_COLUMN.WITH_SUGGESTION")
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql(s"SELECT count(name) AS cnt, cnt + 1, count(unresovled) FROM $testTable GROUP BY dept")
+      },
+      errorClass = "UNRESOLVED_COLUMN.WITH_SUGGESTION",
+      sqlState = "42703",
+      parameters = Map("objectName" -> s"`unresovled`",
+        "proposal" -> "`name`, `bonus`, `dept`, `properties`, `salary`"),
+      context = ExpectedContext(
+        fragment = "unresovled",
+        start = 42,
+        stop = 51))
 
-    assert(intercept[AnalysisException] {
-      sql(s"SELECT * FROM range(1, 7) WHERE (" +
-        s"SELECT id2 FROM (SELECT 1 AS id, other_id + 1 AS id2)) > 5")
-    }.getErrorClass == "UNRESOLVED_COLUMN.WITHOUT_SUGGESTION")
+    checkError(
+      exception = intercept[AnalysisException] {
+        sql(s"SELECT * FROM range(1, 7) WHERE (" +
+          s"SELECT id2 FROM (SELECT 1 AS id, other_id + 1 AS id2)) > 5")
+      },
+      errorClass = "UNRESOLVED_COLUMN.WITHOUT_SUGGESTION",
+      sqlState = "42703",
+      parameters = Map("objectName" -> s"`other_id`"),
+      context = ExpectedContext(
+        fragment = "other_id",
+        start = 66,
+        stop = 73))
   }
 
   test("Pushed-down aggregateExpressions should have no duplicates") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR aims to use `checkError` method to optimize exception check logic related to `UNRESOLVED_COLUMN` error classes

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Unify error classes check way to `checkError` method.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Pass related test cases.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.