### PR TITLE
[SPARK-48927][CORE] Show the number of cached RDDs in `StoragePage`

### DIFF
--- a/core/src/main/scala/org/apache/spark/ui/storage/StoragePage.scala
+++ b/core/src/main/scala/org/apache/spark/ui/storage/StoragePage.scala
@@ -49,7 +49,7 @@ private[ui] class StoragePage(parent: SparkUITab, store: AppStatusStore) extends
             onClick="collapseTable('collapse-aggregated-rdds','aggregated-rdds')">
           <h4>
             <span class="collapse-table-arrow arrow-open"></span>
-            <a>RDDs</a>
+            <a>RDDs ({rdds.length})</a>
           </h4>
         </span>
         <div class="aggregated-rdds collapsible-table">


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to show the number of cached RDDs in `StoragePage` like the other `Jobs` page or `Stages` page.

### Why are the changes needed?

To improve the UX by providing additional summary information in a consistent way.

**BEFORE**

![Screenshot 2024-07-17 at 09 46 44](https://github.com/user-attachments/assets/3e57bf91-e97d-404d-aeda-159ab9cb65e3)

**AFTER**

![Screenshot 2024-07-17 at 09 46 01](https://github.com/user-attachments/assets/d416ea16-8255-48d8-ade4-624dcac8f46e)


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.