### PR TITLE
[SPARK-48930][CORE] Redact `awsAccessKeyId` by including `accesskey` pattern

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1249,7 +1249,7 @@ package object config {
         "like YARN and event logs.")
       .version("2.1.2")
       .regexConf
-      .createWithDefault("(?i)secret|password|token|access[.]key".r)
+      .createWithDefault("(?i)secret|password|token|access[.]?key".r)
 
   private[spark] val STRING_REDACTION_PATTERN =
     ConfigBuilder("spark.redaction.string.regex")

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -1091,6 +1091,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
     // Set a non-secret key
     sparkConf.set("spark.regular.property", "regular_value")
     sparkConf.set("spark.hadoop.fs.s3a.access_key", "regular_value")
+    sparkConf.set("spark.hadoop.fs.s3.awsAccessKeyId", "regular_value")
     // Set a property with a regular key but secret in the value
     sparkConf.set("spark.sensitive.property", "has_secret_in_value")
 
@@ -1103,6 +1104,8 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
     assert(redactedConf("spark.sensitive.property") === Utils.REDACTION_REPLACEMENT_TEXT)
     assert(redactedConf("spark.hadoop.fs.s3a.access.key") === Utils.REDACTION_REPLACEMENT_TEXT)
     assert(redactedConf("spark.hadoop.fs.s3a.access_key") === "regular_value")
+    assert(
+      redactedConf("spark.hadoop.fs.s3.awsAccessKeyId") === Utils.REDACTION_REPLACEMENT_TEXT)
   }
 
   test("redact sensitive information in command line args") {

--- a/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/UtilsSuite.scala
@@ -1084,6 +1084,7 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
     // Set some secret keys
     val secretKeys = Seq(
       "spark.executorEnv.HADOOP_CREDSTORE_PASSWORD",
+      "spark.hadoop.fs.s3.awsAccessKeyId",
       "spark.hadoop.fs.s3a.access.key",
       "spark.my.password",
       "spark.my.sECreT")
@@ -1091,7 +1092,6 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
     // Set a non-secret key
     sparkConf.set("spark.regular.property", "regular_value")
     sparkConf.set("spark.hadoop.fs.s3a.access_key", "regular_value")
-    sparkConf.set("spark.hadoop.fs.s3.awsAccessKeyId", "regular_value")
     // Set a property with a regular key but secret in the value
     sparkConf.set("spark.sensitive.property", "has_secret_in_value")
 
@@ -1104,8 +1104,6 @@ class UtilsSuite extends SparkFunSuite with ResetSystemProperties {
     assert(redactedConf("spark.sensitive.property") === Utils.REDACTION_REPLACEMENT_TEXT)
     assert(redactedConf("spark.hadoop.fs.s3a.access.key") === Utils.REDACTION_REPLACEMENT_TEXT)
     assert(redactedConf("spark.hadoop.fs.s3a.access_key") === "regular_value")
-    assert(
-      redactedConf("spark.hadoop.fs.s3.awsAccessKeyId") === Utils.REDACTION_REPLACEMENT_TEXT)
   }
 
   test("redact sensitive information in command line args") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to redact `awsAccessKeyId` by including `accesskey` pattern.

- **Apache Spark 4.0.0-preview1**
There is no point to redact `fs.s3a.access.key` because the same value is exposed via `fs.s3.awsAccessKeyId` like the following. We need to redact all.

```
$ AWS_ACCESS_KEY_ID=A AWS_SECRET_ACCESS_KEY=B bin/spark-shell
```

![Screenshot 2024-07-17 at 12 45 44](https://github.com/user-attachments/assets/e3040c5d-3eb9-4944-a6d6-5179b7647426)

### Why are the changes needed?

Since Apache Spark 1.1.0, `AWS_ACCESS_KEY_ID` is propagated like the following. However, Apache Spark does not redact them all consistently. 
- #450

https://github.com/apache/spark/blob/5d16c3134c442a5546251fd7c42b1da9fdf3969e/core/src/main/scala/org/apache/spark/deploy/SparkHadoopUtil.scala#L481-L486


### Does this PR introduce _any_ user-facing change?

Users may see more redactions on configurations whose name contains `accesskey` case-insensitively. However, those configurations are highly likely to be related to the credentials.

### How was this patch tested?

Pass the CIs with the newly added test cases.

### Was this patch authored or co-authored using generative AI tooling?

No.