### PR TITLE
[SPARK-48931][SS] Reduce Cloud Store List API cost for state store maintenance task

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
@@ -396,8 +396,8 @@ private[spark] object LogKeys {
   case object MAX_NUM_PARTITIONS extends LogKey
   case object MAX_NUM_POSSIBLE_BINS extends LogKey
   case object MAX_NUM_ROWS_IN_MEMORY_BUFFER extends LogKey
-  case object MAX_SERVICE_NAME_LENGTH extends LogKey
   case object MAX_SEEN_VERSION extends LogKey
+  case object MAX_SERVICE_NAME_LENGTH extends LogKey
   case object MAX_SIZE extends LogKey
   case object MAX_SLOTS extends LogKey
   case object MAX_SPLIT_BYTES extends LogKey
@@ -425,6 +425,7 @@ private[spark] object LogKeys {
   case object MIN_SHARE extends LogKey
   case object MIN_SIZE extends LogKey
   case object MIN_TIME extends LogKey
+  case object MIN_VERSIONS_TO_DELETE extends LogKey
   case object MIN_VERSION_NUM extends LogKey
   case object MISSING_PARENT_STAGES extends LogKey
   case object MODEL_WEIGHTS extends LogKey
@@ -851,8 +852,8 @@ private[spark] object LogKeys {
   case object USER_NAME extends LogKey
   case object UUID extends LogKey
   case object VALUE extends LogKey
-  case object VERSION_NUM extends LogKey
   case object VERSIONS_TO_DELETE extends LogKey
+  case object VERSION_NUM extends LogKey
   case object VIEW_ACLS extends LogKey
   case object VIEW_ACLS_GROUPS extends LogKey
   case object VIRTUAL_CORES extends LogKey

--- a/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
@@ -397,6 +397,7 @@ private[spark] object LogKeys {
   case object MAX_NUM_POSSIBLE_BINS extends LogKey
   case object MAX_NUM_ROWS_IN_MEMORY_BUFFER extends LogKey
   case object MAX_SERVICE_NAME_LENGTH extends LogKey
+  case object MAX_SEEN_VERSION extends LogKey
   case object MAX_SIZE extends LogKey
   case object MAX_SLOTS extends LogKey
   case object MAX_SPLIT_BYTES extends LogKey
@@ -420,6 +421,7 @@ private[spark] object LogKeys {
   case object MIN_NUM_FREQUENT_PATTERN extends LogKey
   case object MIN_POINT_PER_CLUSTER extends LogKey
   case object MIN_RATE extends LogKey
+  case object MIN_SEEN_VERSION extends LogKey
   case object MIN_SHARE extends LogKey
   case object MIN_SIZE extends LogKey
   case object MIN_TIME extends LogKey
@@ -850,6 +852,7 @@ private[spark] object LogKeys {
   case object UUID extends LogKey
   case object VALUE extends LogKey
   case object VERSION_NUM extends LogKey
+  case object VERSIONS_TO_DELETE extends LogKey
   case object VIEW_ACLS extends LogKey
   case object VIEW_ACLS_GROUPS extends LogKey
   case object VIRTUAL_CORES extends LogKey

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2132,9 +2132,10 @@ object SQLConf {
   val RATIO_EXTRA_SPACE_ALLOWED_IN_CHECKPOINT =
     buildConf("spark.sql.streaming.ratioExtraSpaceAllowedInCheckpoint")
     .internal()
-    .doc("The ratio of extra space allowed for batch deletion of files when maintenance" +
-      " is invoked. The minimum number of stale versions we retain in checkpoint location" +
-      " for batch deletion is calculated by minBatchesToRetain * ratioOfExtraVersionsAllowed.")
+    .doc("The ratio of extra space allowed for batch deletion of files when maintenance is" +
+      "invoked. When value > 0, it optimizes the cost of discovering and deleting old checkpoint " +
+      "versions. The minimum number of stale versions we retain in checkpoint location for batch " +
+      "deletion is calculated by minBatchesToRetain * ratioExtraSpaceAllowedInCheckpoint.")
     .version("4.0.0")
     .doubleConf
     .createWithDefault(0.3)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2129,12 +2129,15 @@ object SQLConf {
     .intConf
     .createWithDefault(100)
 
-  val MIN_VERSIONS_TO_DELETE = buildConf("spark.sql.streaming.minVersionsToDelete")
+  val RATIO_EXTRA_SPACE_ALLOWED_IN_CHECKPOINT =
+    buildConf("spark.sql.streaming.ratioExtraSpaceAllowedInCheckpoint")
     .internal()
-    .doc("The minimum number of stale versions to delete when maintenance is invoked.")
-    .version("2.1.1")
-    .intConf
-    .createWithDefault(30)
+    .doc("The ratio of extra space allowed for batch deletion of files when maintenance" +
+      " is invoked. The minimum number of stale versions we retain in checkpoint location" +
+      " for batch deletion is calculated by minBatchesToRetain * ratioOfExtraVersionsAllowed.")
+    .version("4.0.0")
+    .doubleConf
+    .createWithDefault(0.3)
 
   val MAX_BATCHES_TO_RETAIN_IN_MEMORY = buildConf("spark.sql.streaming.maxBatchesToRetainInMemory")
     .internal()
@@ -5413,7 +5416,7 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def minBatchesToRetain: Int = getConf(MIN_BATCHES_TO_RETAIN)
 
-  def minVersionsToDelete: Int = getConf(MIN_VERSIONS_TO_DELETE)
+  def ratioExtraSpaceAllowedInCheckpoint: Double = getConf(RATIO_EXTRA_SPACE_ALLOWED_IN_CHECKPOINT)
 
   def maxBatchesToRetainInMemory: Int = getConf(MAX_BATCHES_TO_RETAIN_IN_MEMORY)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -2129,6 +2129,13 @@ object SQLConf {
     .intConf
     .createWithDefault(100)
 
+  val MIN_VERSIONS_TO_DELETE = buildConf("spark.sql.streaming.minVersionsToDelete")
+    .internal()
+    .doc("The minimum number of stale versions to delete when maintenance is invoked.")
+    .version("2.1.1")
+    .intConf
+    .createWithDefault(30)
+
   val MAX_BATCHES_TO_RETAIN_IN_MEMORY = buildConf("spark.sql.streaming.maxBatchesToRetainInMemory")
     .internal()
     .doc("The maximum number of batches which will be retained in memory to avoid " +
@@ -5405,6 +5412,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def coalesceShufflePartitionsEnabled: Boolean = getConf(COALESCE_PARTITIONS_ENABLED)
 
   def minBatchesToRetain: Int = getConf(MIN_BATCHES_TO_RETAIN)
+
+  def minVersionsToDelete: Int = getConf(MIN_VERSIONS_TO_DELETE)
 
   def maxBatchesToRetainInMemory: Int = getConf(MAX_BATCHES_TO_RETAIN_IN_MEMORY)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -185,6 +185,8 @@ class RocksDB(
         val latestSnapshotVersion = fileManager.getLatestSnapshotVersion(version)
         val metadata = fileManager.loadCheckpointFromDfs(latestSnapshotVersion, workingDir)
         loadedVersion = latestSnapshotVersion
+        // Initialize maxVersion upon successful load from DFS
+        fileManager.initializeMaxVersion()
 
         // reset last snapshot version
         if (lastSnapshotVersion > latestSnapshotVersion) {
@@ -554,6 +556,12 @@ class RocksDB(
         }
       }
 
+      // Set maxVersion when checkpoint files synced to DFS successfully
+      // We need to handle this explicitly in RocksDB as we could use different
+      // changeLogWriter instances in fileManager instance when committing
+      fileManager.setMaxVersion(newVersion)
+
+
       numKeysOnLoadedVersion = numKeysOnWritingVersion
       loadedVersion = newVersion
       commitLatencyMs ++= Map(
@@ -640,7 +648,7 @@ class RocksDB(
       uploadSnapshot()
     }
     val cleanupTime = timeTakenMs {
-      fileManager.deleteOldVersions(conf.minVersionsToRetain)
+      fileManager.deleteOldVersions(conf.minVersionsToRetain, conf.minVersionsToDelete)
     }
     logInfo(log"Cleaned old data, time taken: ${MDC(LogKeys.TIME_UNITS, cleanupTime)} ms")
   }
@@ -896,6 +904,7 @@ class ByteArrayPair(var key: Array[Byte] = null, var value: Array[Byte] = null) 
  */
 case class RocksDBConf(
     minVersionsToRetain: Int,
+    minVersionsToDelete: Int,
     minDeltasForSnapshot: Int,
     compactOnCommit: Boolean,
     enableChangelogCheckpointing: Boolean,
@@ -1078,6 +1087,7 @@ object RocksDBConf {
 
     RocksDBConf(
       storeConf.minVersionsToRetain,
+      storeConf.minVersionsToDelete,
       storeConf.minDeltasForSnapshot,
       getBooleanConf(COMPACT_ON_COMMIT_CONF),
       getBooleanConf(ENABLE_CHANGELOG_CHECKPOINTING_CONF),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -556,11 +556,10 @@ class RocksDB(
         }
       }
 
-      // Set maxVersion when checkpoint files synced to DFS successfully
+      // Set maxVersion when checkpoint files are synced to DFS successfully
       // We need to handle this explicitly in RocksDB as we could use different
       // changeLogWriter instances in fileManager instance when committing
       fileManager.setMaxVersion(newVersion)
-
 
       numKeysOnLoadedVersion = numKeysOnWritingVersion
       loadedVersion = newVersion

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -903,7 +903,7 @@ class ByteArrayPair(var key: Array[Byte] = null, var value: Array[Byte] = null) 
  */
 case class RocksDBConf(
     minVersionsToRetain: Int,
-    minVersionsToDelete: Int,
+    minVersionsToDelete: Long,
     minDeltasForSnapshot: Int,
     compactOnCommit: Boolean,
     enableChangelogCheckpointing: Boolean,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -186,7 +186,7 @@ class RocksDB(
         val metadata = fileManager.loadCheckpointFromDfs(latestSnapshotVersion, workingDir)
         loadedVersion = latestSnapshotVersion
         // Initialize maxVersion upon successful load from DFS
-        fileManager.initializeMaxVersion()
+        fileManager.setMaxVersion(version)
 
         // reset last snapshot version
         if (lastSnapshotVersion > latestSnapshotVersion) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -186,7 +186,7 @@ class RocksDB(
         val metadata = fileManager.loadCheckpointFromDfs(latestSnapshotVersion, workingDir)
         loadedVersion = latestSnapshotVersion
         // Initialize maxVersion upon successful load from DFS
-        fileManager.setMaxVersion(version)
+        fileManager.setMaxSeenVersion(version)
 
         // reset last snapshot version
         if (lastSnapshotVersion > latestSnapshotVersion) {
@@ -559,7 +559,7 @@ class RocksDB(
       // Set maxVersion when checkpoint files are synced to DFS successfully
       // We need to handle this explicitly in RocksDB as we could use different
       // changeLogWriter instances in fileManager instance when committing
-      fileManager.setMaxVersion(newVersion)
+      fileManager.setMaxSeenVersion(newVersion)
 
       numKeysOnLoadedVersion = numKeysOnWritingVersion
       loadedVersion = newVersion

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
@@ -451,7 +451,15 @@ class RocksDBFileManager(
       // is to clean up files if maxSeenVersion fails to be initialized
       if (maxSeenVersion.isDefined) {
         val versionsToDelete = maxSeenVersion.get - minSeenVersion + 1 - numVersionsToRetain
-        if (versionsToDelete < minVersionsToDelete) return
+        if (versionsToDelete < minVersionsToDelete) {
+          logInfo(log"Skipping deleting files." +
+            log"${MDC(LogKeys.VERSIONS_TO_DELETE, versionsToDelete)}" +
+            log" stale versions are not enough for batch deletion.")
+          logInfo(log"Estimated maximum version is " +
+            log"${MDC(LogKeys.MAX_SEEN_VERSION, maxSeenVersion.get)}" +
+            log" and minimum version is ${MDC(LogKeys.MIN_SEEN_VERSION, minSeenVersion)}")
+          return
+        }
       }
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
@@ -408,6 +408,8 @@ class RocksDBFileManager(
   def setMaxVersion(version: Long): Unit = {
     if (maxVersion.isDefined) {
       maxVersion = Some(Math.max(maxVersion.get, version))
+    } else {
+      maxVersion = Some(version)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
@@ -449,13 +449,15 @@ class RocksDBFileManager(
 
   /**
    * Delete old versions by deleting the associated version and SST files.
-   * At a high-level, this method finds which versions to delete, and which SST files that were
+   * At a high-level, when enough stale version files are present for batch deletion,
+   * this method finds which versions to delete, and which SST files that were
    * last used in those versions. It's safe to delete these SST files because a SST file can
    * be reused only in successive versions. Therefore, if a SST file F was last used in version
    * V, then it won't be used in version V+1 or later, and if version V can be deleted, then
    * F can safely be deleted as well.
    *
-   * To find old files, it does the following.
+   * First, it checks whether enough stale version files are present for batch deletion.
+   * If true, it does the following to find old files.
    * - List all the existing [version].zip files
    * - Find the min version that needs to be retained based on the given `numVersionsToRetain`.
    * - Accordingly decide which versions should be deleted.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
@@ -311,8 +311,6 @@ class RocksDBFileManager(
       metadataFile.delete()
       metadata
     }
-    // Initialize maxVersion on load
-    if (maxVersion.isEmpty) initializeMaxVersion()
     logFilesInDir(localDir, log"Loaded checkpoint files " +
       log"for version ${MDC(LogKeys.VERSION_NUM, version)}")
     metadata

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreConf.scala
@@ -42,9 +42,9 @@ class StateStoreConf(
   val minVersionsToRetain: Int = sqlConf.minBatchesToRetain
 
   /**
-   * Minimum number of stale snapshot version files that need to be present
-   * in the DFS checkpoint directory when maintenance is invoked, after which
-   * RocksDBFileManager will delete version and other associated files.
+   * Minimum number of stale checkpoint versions that need to be present in the DFS
+   * checkpoint directory for old state checkpoint version deletion to be invoked.
+   * This is to amortize the cost of discovering and deleting old checkpoint versions.
    */
   val minVersionsToDelete: Int = sqlConf.minVersionsToDelete
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreConf.scala
@@ -41,7 +41,11 @@ class StateStoreConf(
   /** Minimum versions a State Store implementation should retain to allow rollbacks */
   val minVersionsToRetain: Int = sqlConf.minBatchesToRetain
 
-  /** Minimum number of stale versions to delete when maintenance is invoked */
+  /**
+   * Minimum number of stale snapshot version files that need to be present
+   * in the DFS checkpoint directory when maintenance is invoked, after which
+   * RocksDBFileManager will delete version and other associated files.
+   */
   val minVersionsToDelete: Int = sqlConf.minVersionsToDelete
 
   /** Maximum count of versions a State Store implementation should retain in memory */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreConf.scala
@@ -41,6 +41,9 @@ class StateStoreConf(
   /** Minimum versions a State Store implementation should retain to allow rollbacks */
   val minVersionsToRetain: Int = sqlConf.minBatchesToRetain
 
+  /** Minimum number of stale versions to delete when maintenance is invoked */
+  val minVersionsToDelete: Int = sqlConf.minVersionsToDelete
+
   /** Maximum count of versions a State Store implementation should retain in memory */
   val maxVersionsToRetainInMemory: Int = sqlConf.maxBatchesToRetainInMemory
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreConf.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreConf.scala
@@ -46,7 +46,8 @@ class StateStoreConf(
    * checkpoint directory for old state checkpoint version deletion to be invoked.
    * This is to amortize the cost of discovering and deleting old checkpoint versions.
    */
-  val minVersionsToDelete: Int = sqlConf.minVersionsToDelete
+  val minVersionsToDelete: Long =
+    Math.round(sqlConf.ratioExtraSpaceAllowedInCheckpoint * sqlConf.minBatchesToRetain)
 
   /** Maximum count of versions a State Store implementation should retain in memory */
   val maxVersionsToRetainInMemory: Int = sqlConf.maxBatchesToRetainInMemory

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -230,12 +230,49 @@ class RocksDBSuite extends AlsoTestWithChangelogCheckpointingEnabled with Shared
   }
 
   testWithColumnFamilies(
-    "RocksDB: purge changelog and snapshots",
+    "RocksDB: only delete files when number of stale version files >= minVersionsToDelete",
+    TestWithBothChangelogCheckpointingEnabledAndDisabled) { colFamiliesEnabled =>
+    // When minVersionsToDelete > 0 deleting version files only occurs
+    // when number of stale version files >= minVersionsToDelete
+    val remoteDir = Utils.createTempDir().toString
+    new File(remoteDir).delete() // to make sure that the directory gets created
+    val conf = dbConf.copy(
+      minVersionsToRetain = 5,
+      minDeltasForSnapshot = 0,
+      minVersionsToDelete = 3)
+
+    withDB(remoteDir = remoteDir, conf = conf, useColumnFamilies = colFamiliesEnabled) { db =>
+      // Commit 7 versions
+      // invoke maintenance for each batch
+      // 5 versions to keep, 2 stale versions
+      for (version <- 0 to 6) {
+        db.load(version)
+        db.commit()
+        // no files should be deleted as number of stale files is less than minVersionsToDelete = 3
+        db.doMaintenance()
+      }
+
+      // Verify no snapshot versions or change log versions files were deleted
+      assert(snapshotVersionsPresent(remoteDir) == (1 to 7))
+
+      // Commit version 8
+      db.load(7)
+      db.commit()
+
+      // 3 stale version files present
+      // should delete versions 1 to 3 and keep 5 latest versions
+      db.doMaintenance()
+      assert(snapshotVersionsPresent(remoteDir) == (4 to 8))
+    }
+  }
+
+  testWithColumnFamilies(
+    "RocksDB: purge changelog and snapshots with minVersionsToDelete = 0",
     TestWithChangelogCheckpointingEnabled) { colFamiliesEnabled =>
     val remoteDir = Utils.createTempDir().toString
     new File(remoteDir).delete() // to make sure that the directory gets created
     val conf = dbConf.copy(enableChangelogCheckpointing = true,
-      minVersionsToRetain = 3, minDeltasForSnapshot = 1)
+      minVersionsToRetain = 3, minDeltasForSnapshot = 1, minVersionsToDelete = 0)
     withDB(remoteDir, conf = conf, useColumnFamilies = colFamiliesEnabled) { db =>
       db.load(0)
       db.commit()
@@ -268,6 +305,63 @@ class RocksDBSuite extends AlsoTestWithChangelogCheckpointingEnabled with Shared
       // 5 is the latest snapshot <= maxSnapshotVersionPresent - minVersionsToRetain + 1
       assert(snapshotVersionsPresent(remoteDir) === Seq(5, 8))
       assert(changelogVersionsPresent(remoteDir) == (5 to 8))
+    }
+  }
+
+  testWithColumnFamilies(
+    "RocksDB: purge changelog and snapshots with minVersionsToDelete > 0",
+    TestWithChangelogCheckpointingEnabled) { colFamiliesEnabled =>
+    val remoteDir = Utils.createTempDir().toString
+    new File(remoteDir).delete() // to make sure that the directory gets created
+    val conf = dbConf.copy(enableChangelogCheckpointing = true,
+      minVersionsToRetain = 3, minDeltasForSnapshot = 1, minVersionsToDelete = 3)
+    withDB(remoteDir, conf = conf, useColumnFamilies = colFamiliesEnabled) { db =>
+      // Commit 4 versions
+      // stale versions: (1, 2)
+      // keep versions: (3, 4)
+      for (version <- 0 to 3) {
+        db.load(version)
+        db.commit()
+        db.doMaintenance()
+      }
+      assert(snapshotVersionsPresent(remoteDir) == (1 to 4))
+      assert(changelogVersionsPresent(remoteDir) == (1 to 4))
+
+      // Commit 2 more versions
+      // stale versions: (1, 2, 3)
+      // keep versions: (4, 5, 6)
+      for (version <- 4 to 5) {
+        db.load(version)
+        db.commit()
+      }
+
+      assert(snapshotVersionsPresent(remoteDir) == (1 to 4))
+      assert(changelogVersionsPresent(remoteDir) == (1 to 6))
+
+      // Should delete stale versions for zip files and change log files
+      // since number of stale versions >= minVersionsToDelete
+      db.doMaintenance()
+
+      assert(snapshotVersionsPresent(remoteDir) == Seq(4, 6))
+      assert(changelogVersionsPresent(remoteDir) == Seq(4, 5, 6))
+
+      // Commit 2 more versions
+      // stale versions: (4, 5)
+      // keep versions: (6, 7, 8)
+      for (version <- 6 to 7) {
+        db.load(version)
+        db.commit()
+      }
+
+      assert(snapshotVersionsPresent(remoteDir) == Seq(4, 6))
+      assert(changelogVersionsPresent(remoteDir) == (4 to 8))
+
+      // should upload latest snapshot but not delete any files
+      // since number of stale versions < minVersionsToDelete
+      db.doMaintenance()
+
+      assert(snapshotVersionsPresent(remoteDir) == Seq(4, 6, 8))
+      assert(changelogVersionsPresent(remoteDir) == (4 to 8))
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Currently, during the state store maintenance process, we find which old version files of the **RocksDB** state store to delete by listing all existing snapshotted version files in the checkpoint directory every 1 minute by default. The frequent list calls in the cloud can result in high costs. To address this concern and reduce the cost associated with state store maintenance, we should aim to minimize the frequency of listing object stores inside the maintenance task. To minimize the frequency, we will try to accumulate versions to delete and only call list when the number of versions to delete reaches a configured threshold. 

The changes include:
1.  Adding new configuration variable `ratioExtraSpaceAllowedInCheckpoint` in **SQLConf**. This determines the ratio of extra versions files we want to retain in the checkpoint directory compared to number of versions to retain for rollbacks (`minBatchesToRetain`).
2. Using this config and `minBatchesToRetain`, set `minVersionsToDelete` config inside **StateStoreConf** to `minVersionsToDelete = ratioExtraVersionsAllowedInCheckpoint * minBatchesToRetain.`
3.  Using `minSeenVersion` and `maxSeenVersion` variables in **RocksDBFileManager** to estimate min/max version present in directory and control deletion frequency. This is done by ensuring number of stale versions to delete is at least `minVersionsToDelete`


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, maintenance operations like snapshotting, purging, deletion, and file management is done asynchronously for each data partition. We want to shift away periodic deletion and instead rely on the estimated number of files in the checkpoint directory to reduce list calls and introduce batch deletion.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added unit tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.