### PR TITLE
[SPARK-48623][CORE] Migrate FileAppender logs to structured logging

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
@@ -758,6 +758,7 @@ private[spark] object LogKeys {
   case object STORAGE_LEVEL_REPLICATION extends LogKey
   case object STORAGE_MEMORY_SIZE extends LogKey
   case object STORE_ID extends LogKey
+  case object STRATEGY extends LogKey
   case object STREAMING_CONTEXT extends LogKey
   case object STREAMING_DATA_SOURCE_DESCRIPTION extends LogKey
   case object STREAMING_DATA_SOURCE_NAME extends LogKey

--- a/core/src/main/scala/org/apache/spark/util/logging/FileAppender.scala
+++ b/core/src/main/scala/org/apache/spark/util/logging/FileAppender.scala
@@ -20,7 +20,7 @@ package org.apache.spark.util.logging
 import java.io.{File, FileOutputStream, InputStream, IOException}
 
 import org.apache.spark.SparkConf
-import org.apache.spark.internal.{config, Logging, MDC}
+import org.apache.spark.internal.{config, Logging, LogKeys, MDC}
 import org.apache.spark.internal.LogKeys._
 import org.apache.spark.util.{IntParam, Utils}
 
@@ -177,8 +177,8 @@ private[spark] object FileAppender extends Logging {
             inputStream, file, new SizeBasedRollingPolicy(bytes), conf, closeStreams = closeStreams)
         case _ =>
           logWarning(
-            log"Illegal size [${MDC(NUM_BYTES, rollingSizeBytes)}] " +
-              log"for rolling executor logs, rolling logs not enabled")
+            log"Illegal size [${MDC(LogKeys.NUM_BYTES, rollingSizeBytes)}] " +
+            log"for rolling executor logs, rolling logs not enabled")
           new FileAppender(inputStream, file, closeStreams = closeStreams)
       }
     }
@@ -192,8 +192,8 @@ private[spark] object FileAppender extends Logging {
         createSizeBasedAppender()
       case _ =>
         logWarning(
-          s"Illegal strategy [$rollingStrategy] for rolling executor logs, " +
-            s"rolling logs not enabled")
+          log"Illegal strategy [${MDC(LogKeys.STRATEGY, rollingStrategy)}] for " +
+          log"rolling executor logs, rolling logs not enabled")
         new FileAppender(inputStream, file, closeStreams = closeStreams)
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR migrates `src/main/scala/org/apache/spark/util/logging/FileAppender.scala` to comply with the scala style changes in https://github.com/apache/spark/pull/46947

### Why are the changes needed?
This makes development and PR review of the structured logging migration easier.

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
Tested by ensuring dev/scalastyle checks pass

### Was this patch authored or co-authored using generative AI tooling?
No