### PR TITLE
[SPARK-48758][Core] Race condition between executor registration and heartbeat

### DIFF
--- a/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
+++ b/core/src/main/scala/org/apache/spark/HeartbeatReceiver.scala
@@ -177,13 +177,6 @@ private[spark] class HeartbeatReceiver(sc: SparkContext, clock: Clock)
   }
 
   /**
-   * If the heartbeat receiver is not stopped, notify it of executor registrations.
-   */
-  override def onExecutorAdded(executorAdded: SparkListenerExecutorAdded): Unit = {
-    addExecutor(executorAdded.executorId)
-  }
-
-  /**
    * Send ExecutorRemoved to the event loop to remove an executor. Only for test.
    *
    * @return if HeartbeatReceiver is stopped, return None. Otherwise, return a Some(Future) that

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -282,6 +282,8 @@ class SparkContext(config: SparkConf) extends Logging {
   // An asynchronous listener bus for Spark events
   private[spark] def listenerBus: LiveListenerBus = _listenerBus
 
+  private[spark] def heartbeatReceiver: RpcEndpointRef = _heartbeatReceiver
+
   // This function allows components created by SparkEnv to be mocked in unit tests:
   private[spark] def createSparkEnv(
       conf: SparkConf,

--- a/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/cluster/CoarseGrainedSchedulerBackend.scala
@@ -95,6 +95,8 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
 
   private val listenerBus = scheduler.sc.listenerBus
 
+  private val heartbeatReceiver = scheduler.sc.heartbeatReceiver
+
   // Executors we have requested the cluster manager to kill that have not died yet; maps
   // the executor ID to whether it was explicitly killed by the driver (and thus shouldn't
   // be considered an app-related failure). Visible for testing only.
@@ -309,6 +311,7 @@ class CoarseGrainedSchedulerBackend(scheduler: TaskSchedulerImpl, val rpcEnv: Rp
               currentExecutorIdCounter = executorId.toInt
             }
           }
+          heartbeatReceiver.ask[Boolean](ExecutorRegistered(executorId))
           listenerBus.post(
             SparkListenerExecutorAdded(System.currentTimeMillis(), executorId, data))
           // Note: some tests expect the reply to come after we put the executor in the map


### PR DESCRIPTION
### What changes were proposed in this pull request?
We found a race condition in our prod jobs when executor finished registration but when the it starts to heartbeat, the driver tells the executor is still unknown. We proposed to sync the executor registration status directly between the `CoarseGrainedSchedulerBackend` and the `HeartbeatReciever` to prevent the race condition.


### Why are the changes needed?
It caused by the `HeartbeatReciever` is only hearing any registered executor from `CoarseGrainedSchedulerBackend ` through the message bus, and by the nature of the asynchronous message delivering mechanism of message bus, there is no guarantee of how long it can take between message posting and message receiving. In our prod failure job case, the time is longer than 2min (the interval between executor finished registration and started the heartbeat), so it caused the inconsistent states of which executors were registered between `HeartbeatReciever` and `CoarseGrainedSchedulerBackend`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Unit test and we've been running this fix in our production for a while and no failure from this race condition happened any more.

### Was this patch authored or co-authored using generative AI tooling?
No
