### PR TITLE
[SPARK-48933][BUILD] Upgrade `protobuf-java` to `3.25.3`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.4.0</hadoop.version>
     <!-- SPARK-41247: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->
-    <protobuf.version>3.25.1</protobuf.version>
+    <protobuf.version>3.25.3</protobuf.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <zookeeper.version>3.9.2</zookeeper.version>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -89,7 +89,7 @@ object BuildCommons {
 
   // Google Protobuf version used for generating the protobuf.
   // SPARK-41247: needs to be consistent with `protobuf.version` in `pom.xml`.
-  val protoVersion = "3.25.1"
+  val protoVersion = "3.25.3"
   // GRPC version used for Spark Connect.
   val grpcVersion = "1.62.2"
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `protobuf-java` from `3.25.1` to `3.25.3`.

### Why are the changes needed?
- v3.25.1 VS v.3.25.3:
  https://github.com/protocolbuffers/protobuf/compare/v3.25.1...v3.25.3


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
