### PR TITLE
[SPARK-48915][SQL][TESTS][FOLLOWUP] Add some uncovered predicates(!=, <, <=, >, >=) for correlation in `GeneratedSubquerySuite`

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/querytest/GeneratedSubquerySuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/querytest/GeneratedSubquerySuite.scala
@@ -162,7 +162,7 @@ class GeneratedSubquerySuite extends DockerJDBCIntegrationSuite with QueryGenera
    * @param subqueryAlias
    * @param subqueryLocation The clause of the main query where the subquery is located.
    * @param subqueryType The type of subquery, such as SCALAR, RELATION, PREDICATE
-   * @param isCorrelated Whether the subquery is to be correlated.
+   * @param correlationConditions The correlated conditions of subquery.
    * @param isDistinct Whether subquery results is to be de-duplicated, i.e. have a DISTINCT clause.
    * @param operatorInSubquery The operator to be included in the subquery.
    */
@@ -172,16 +172,10 @@ class GeneratedSubquerySuite extends DockerJDBCIntegrationSuite with QueryGenera
       subqueryAlias: String,
       subqueryLocation: SubqueryLocation.Value,
       subqueryType: SubqueryType.Value,
-      isCorrelated: Boolean,
+      correlationConditions: Seq[Predicate],
       isDistinct: Boolean,
       operatorInSubquery: Operator): Query = {
 
-    // Correlation conditions, this is hardcoded for now.
-    val correlationConditions = if (isCorrelated) {
-      Seq(Equals(innerTable.output.head, outerTable.output.head))
-    } else {
-      Seq()
-    }
     val isScalarSubquery = Seq(SubqueryType.ATTRIBUTE,
       SubqueryType.SCALAR_PREDICATE_EQUALS, SubqueryType.SCALAR_PREDICATE_NOT_EQUALS,
       SubqueryType.SCALAR_PREDICATE_LESS_THAN, SubqueryType.SCALAR_PREDICATE_LESS_THAN_OR_EQUALS,
@@ -324,9 +318,23 @@ class GeneratedSubquerySuite extends DockerJDBCIntegrationSuite with QueryGenera
         case _ => Seq(true, false)
       }
 
+    def generateCorrelationConditions(innerTable: Relation, outerTable: Relation,
+                                      isCorrelated: Boolean): Seq[Seq[Predicate]] = {
+      if (isCorrelated) {
+        Seq(Seq(Equals(innerTable.output.head, outerTable.output.head)),
+          Seq(NotEquals(innerTable.output.head, outerTable.output.head)),
+          Seq(LessThan(innerTable.output.head, outerTable.output.head)),
+          Seq(LessThanOrEquals(innerTable.output.head, outerTable.output.head)),
+          Seq(GreaterThan(innerTable.output.head, outerTable.output.head)),
+          Seq(GreaterThanOrEquals(innerTable.output.head, outerTable.output.head)))
+      } else {
+        Seq(Seq())
+      }
+    }
+
     def distinctChoices(subqueryOperator: Operator): Seq[Boolean] = {
       subqueryOperator match {
-        // Don't do DISTINCT if there is no group by because it is redundant.
+        // Don't do DISTINCT if there is group by because it is redundant.
         case Aggregate(_, groupingExpressions) if groupingExpressions.isEmpty => Seq(false)
         case _ => Seq(true, false)
       }
@@ -343,6 +351,7 @@ class GeneratedSubquerySuite extends DockerJDBCIntegrationSuite with QueryGenera
         Seq(SubqueryLocation.WHERE, SubqueryLocation.SELECT, SubqueryLocation.FROM)
       subqueryType <- subqueryTypeChoices(subqueryLocation)
       isCorrelated <- correlationChoices(subqueryLocation)
+      correlationCondition <- generateCorrelationConditions(innerTable, outerTable, isCorrelated)
     } {
       // Hardcoded aggregation column and group by column.
       val (aggColumn, groupByColumn) = innerTable.output.head -> innerTable.output(1)
@@ -361,7 +370,7 @@ class GeneratedSubquerySuite extends DockerJDBCIntegrationSuite with QueryGenera
         isDistinct <- distinctChoices(subqueryOperator)
       } {
         generatedQuerySpecs += SubquerySpec(generateQuery(innerTable, outerTable,
-          subqueryAlias, subqueryLocation, subqueryType, isCorrelated, isDistinct,
+          subqueryAlias, subqueryLocation, subqueryType, correlationCondition, isDistinct,
           subqueryOperator).toString + ";", isCorrelated, subqueryType)
       }
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In PR #47386, we improves coverage of predicate types of scalar subquery in the WHERE clause.
Follow up, this PR as aims to add some uncovered predicates(!=, <, <=, >, >=) for correlation in `GeneratedSubquerySuite`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Better coverage of current subquery tests with correlation in `GeneratedSubquerySuite`.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.