### PR TITLE
[MINOR][SQL][TESTS] Enable test case `testOrcAPI` in `JavaDataFrameReaderWriterSuite`

### DIFF
--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameReaderWriterSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaDataFrameReaderWriterSuite.java
@@ -144,10 +144,7 @@ public class JavaDataFrameReaderWriterSuite {
         .write().parquet(output);
   }
 
-  /**
-   * This only tests whether API compiles, but does not run it as orc()
-   * cannot be run without Hive classes.
-   */
+  @Test
   public void testOrcAPI() {
     spark.read().schema(schema).orc();
     spark.read().schema(schema).orc(input);


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR enabled test case `testOrcAPI` in `JavaDataFrameReaderWriterSuite` because this test no longer depends on Hive classes, we can test it like other test cases in this Suite.



### Why are the changes needed?
Enable test case `testOrcAPI` in `JavaDataFrameReaderWriterSuite`

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No