### PR TITLE
[SPARK-48936][CONNECT] Makes spark-shell works with Spark connect

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -109,6 +109,16 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <!--
+      Included so Spark Connect client was compiled before triggering assembly.
+      See 'get-connect-client-jar' below. This will not be included in the packaging output.
+    -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-connect-client-jvm_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
     <!--
       Because we don't shade dependencies anymore, we need to restore Guava to compile scope so
@@ -158,6 +168,78 @@
               </zip>
             </target>
           </configuration>
+      </plugin>
+      <plugin>
+        <!--
+          Here we download ammonite dependency required for Spark Connect REPL and copy
+          Spark Connect client to target's jars/connect-repl directory. Both jars will
+          only be loaded when we run Spark Connect shell, see also
+          AbstractCommandBuilder.buildClassPath and SPARK-48936.
+        -->
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>get-ammonite-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>${basedir}/../build/mvn</executable>
+              <arguments>
+                <argument>dependency:copy</argument>
+                <argument>-Dartifact=com.lihaoyi:ammonite_${scala.version}:${ammonite.version}</argument>
+                <argument>-DoutputDirectory=${basedir}/target/scala-${scala.binary.version}/jars/connect-repl</argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>get-ammonite-pom</id>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <executable>${basedir}/../build/mvn</executable>
+              <arguments>
+                <argument>dependency:copy</argument>
+                <argument>-Dartifact=com.lihaoyi:ammonite_${scala.version}:${ammonite.version}:pom</argument>
+                <argument>-DoutputDirectory=${basedir}/target/scala-${scala.binary.version}/jars/connect-repl</argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>get-ammonite-deps</id>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <executable>${basedir}/../build/mvn</executable>
+              <arguments>
+                <argument>dependency:copy-dependencies</argument>
+                <argument>-DoutputDirectory=${basedir}/target/scala-${scala.binary.version}/jars/connect-repl</argument>
+                <argument>--file</argument>
+                <argument>${basedir}/target/scala-${scala.binary.version}/jars/connect-repl/ammonite_${scala.version}-${ammonite.version}.pom</argument>
+              </arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>get-connect-client-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>cp</executable>
+              <arguments>
+                <argument>${basedir}/../connector/connect/client/jvm/target/spark-connect-client-jvm_${scala.binary.version}-${version}.jar</argument>
+                <argument>${basedir}/target/scala-${scala.binary.version}/jars/connect-repl</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/bin/spark-shell
+++ b/bin/spark-shell
@@ -74,22 +74,7 @@ function main() {
   if $connect_shell; then
      export SPARK_SUBMIT_OPTS
      export SPARK_CONNECT_SHELL=1
-     if [ -d "${SPARK_HOME}/jars" ]; then
-       # Production code path
-       coordinate=$(find "${SPARK_HOME}/jars" -type f -name 'spark-connect_*')
-       coordinate=$(basename $coordinate)
-       sparkver=${${${coordinate##*_}%.jar*}#*-}
-       scalaver=${${${coordinate##*_}%.jar*}%%-*}
-       "${SPARK_HOME}"/bin/spark-submit \
-         --class org.apache.spark.sql.application.ConnectRepl \
-         --packages com.lihaoyi:ammonite_2.13.14:3.0.0-M2,org.apache.spark:spark-connect-client-jvm_$scalaver:$sparkver --name "Connect shell" "$@"
-     else
-       # Development code path
-       SCCLASSPATH=$(connector/connect/bin/spark-connect-scala-client-classpath)
-       "${SPARK_HOME}"/bin/spark-submit \
-         --class org.apache.spark.sql.application.ConnectRepl \
-         --conf spark.driver.extraClassPath=$SCCLASSPATH --name "Connect shell" "$@"
-     fi
+     "${SPARK_HOME}"/bin/spark-submit --class org.apache.spark.sql.application.ConnectRepl --name "Connect shell" "$@"
   elif $cygwin; then
     # Workaround for issue involving JLine and Cygwin
     # (see http://sourceforge.net/p/jline/bugs/40/).

--- a/bin/spark-shell
+++ b/bin/spark-shell
@@ -34,7 +34,7 @@ fi
 
 export _SPARK_CMD_USAGE="Usage: ./bin/spark-shell [options]
 
-Scala REPL options:
+Scala REPL options, Spark Classic only:
   -I <file>                   preload <file>, enforcing line-by-line interpretation"
 
 # SPARK-4161: scala does not assume use of the java classpath,
@@ -44,8 +44,53 @@ Scala REPL options:
 # through spark.driver.extraClassPath is not automatically propagated.
 SPARK_SUBMIT_OPTS="$SPARK_SUBMIT_OPTS -Dscala.usejavacp=true"
 
+# In order to start Spark Connect shell, we should identify if spark.remote
+# or --remote is set. Spark Connect does not support loading configurations
+# yet.
+connect_shell=false
+cur_arg="$0"
+for arg in "${@:1}"
+do
+  # --conf spark.remote=... or -c spark.remote=...
+  if [[ $cur_arg == "--conf" || $cur_arg == "-c" ]]; then
+    if [[ $arg == "spark.remote"* ]]; then
+      connect_shell=true
+    fi
+  fi
+
+  # --conf=spark.remote=... or -c=spark.remote=...
+  if [[ $arg == "--conf=spark.remote"* || $arg == "-c=spark.remote"* ]]; then
+    connect_shell=true
+  fi
+
+  # --remote= or --remote
+  if [[ $arg == "--remote"* ]]; then
+    connect_shell=true
+  fi
+  cur_arg=$arg
+done
+
 function main() {
-  if $cygwin; then
+  if $connect_shell; then
+     export SPARK_SUBMIT_OPTS
+     export SPARK_CONNECT_SHELL=1
+     if [ -d "${SPARK_HOME}/jars" ]; then
+       # Production code path
+       coordinate=$(find "${SPARK_HOME}/jars" -type f -name 'spark-connect_*')
+       coordinate=$(basename $coordinate)
+       sparkver=${${${coordinate##*_}%.jar*}#*-}
+       scalaver=${${${coordinate##*_}%.jar*}%%-*}
+       "${SPARK_HOME}"/bin/spark-submit \
+         --class org.apache.spark.sql.application.ConnectRepl \
+         --packages com.lihaoyi:ammonite_2.13.14:3.0.0-M2,org.apache.spark:spark-connect-client-jvm_$scalaver:$sparkver --name "Connect shell" "$@"
+     else
+       # Development code path
+       SCCLASSPATH=$(connector/connect/bin/spark-connect-scala-client-classpath)
+       "${SPARK_HOME}"/bin/spark-submit \
+         --class org.apache.spark.sql.application.ConnectRepl \
+         --conf spark.driver.extraClassPath=$SCCLASSPATH --name "Connect shell" "$@"
+     fi
+  elif $cygwin; then
     # Workaround for issue involving JLine and Cygwin
     # (see http://sourceforge.net/p/jline/bugs/40/).
     # If you're using the Mintty terminal emulator in Cygwin, may need to set the

--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/application/ReplE2ESuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/application/ReplE2ESuite.scala
@@ -64,6 +64,7 @@ class ReplE2ESuite extends ConnectFunSuite with RemoteSparkSession with BeforeAn
     val args = Array("--port", serverPort.toString)
     val task = new Runnable {
       override def run(): Unit = {
+        System.setProperty("spark.sql.abc", "abc")
         ConnectRepl.doMain(
           args = args,
           semaphore = Some(semaphore),
@@ -554,5 +555,14 @@ class ReplE2ESuite extends ConnectFunSuite with RemoteSparkSession with BeforeAn
         |""".stripMargin
     val output = runCommandsInShell(input)
     assertContains(": Long = 1045", output)
+  }
+
+  test("Simple configuration set in startup") {
+    val input =
+      """
+        |spark.conf.get("spark.sql.abc")
+      """.stripMargin
+    val output = runCommandsInShell(input)
+    assertContains("abc", output)
   }
 }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -748,6 +748,8 @@ private[spark] class SparkSubmit extends Logging {
           (clusterManager & opt.clusterManager) != 0) {
         if (opt.clOption != null) { childArgs += opt.clOption += opt.value }
         if (opt.confKey != null) {
+          // Used in SparkConnectClient because Spark Connect client does not have SparkConf.
+          if (opt.confKey == "spark.remote") System.setProperty("spark.remote", opt.value)
           if (opt.mergeFn.isDefined && sparkConf.contains(opt.confKey)) {
             sparkConf.set(opt.confKey, opt.mergeFn.get.apply(sparkConf.get(opt.confKey), opt.value))
           } else {
@@ -1075,6 +1077,7 @@ object SparkSubmit extends CommandLineUtils with Logging {
   private val SPARK_SHELL = "spark-shell"
   private val PYSPARK_SHELL = "pyspark-shell"
   private val SPARKR_SHELL = "sparkr-shell"
+  private val CONNECT_SHELL = "connect-shell"
   private val SPARKR_PACKAGE_ARCHIVE = "sparkr.zip"
   private val R_PACKAGE_ARCHIVE = "rpkg.zip"
 
@@ -1149,7 +1152,7 @@ object SparkSubmit extends CommandLineUtils with Logging {
    * Return whether the given primary resource represents a shell.
    */
   private[deploy] def isShell(res: String): Boolean = {
-    (res == SPARK_SHELL || res == PYSPARK_SHELL || res == SPARKR_SHELL)
+    (res == SPARK_SHELL || res == PYSPARK_SHELL || res == SPARKR_SHELL || res == CONNECT_SHELL)
   }
 
   /**

--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -187,7 +187,7 @@ echo "Spark $VERSION$GITREVSTRING built for Hadoop $SPARK_HADOOP_VERSION" > "$DI
 echo "Build flags: $@" >> "$DISTDIR/RELEASE"
 
 # Copy jars
-cp "$SPARK_HOME"/assembly/target/scala*/jars/* "$DISTDIR/jars/"
+cp -r "$SPARK_HOME"/assembly/target/scala*/jars/* "$DISTDIR/jars/"
 
 # Only create the hive-jackson directory if they exist.
 if [ -f "$DISTDIR"/jars/jackson-core-asl-1.9.13.jar ]; then

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -209,8 +209,18 @@ abstract class AbstractCommandBuilder {
       boolean isConnectShell = "1".equals(getenv("SPARK_CONNECT_SHELL"));
       if (isConnectShell) {
         for (File f: new File(jarsDir).listFiles()) {
-          // Exclude Spark Classic SQL jar if we're in Spark Connect Shell
-          if (!f.getName().startsWith("spark-sql_")) {
+          // Exclude Spark Classic SQL and Spark Connect server jars
+          // if we're in Spark Connect Shell. Also exclude Spark SQL API and
+          // Spark Connect Common which Spark Connect client shades.
+          // Then, we add the Spark Connect shell and its dependencies in connect-repl
+          // See also SPARK-48936.
+          if (f.isDirectory() && f.getName().equals("connect-repl")) {
+            addToClassPath(cp, join(File.separator, f.toString(), "*"));
+          } else if (
+              !f.getName().startsWith("spark-sql_") &&
+              !f.getName().startsWith("spark-connect_") &&
+              !f.getName().startsWith("spark-sql-api_") &&
+              !f.getName().startsWith("spark-connect-common_")) {
             addToClassPath(cp, f.toString());
           }
         }

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -206,7 +206,17 @@ abstract class AbstractCommandBuilder {
           addToClassPath(cp, f.toString());
         }
       }
-      addToClassPath(cp, join(File.separator, jarsDir, "*"));
+      boolean isConnectShell = "1".equals(getenv("SPARK_CONNECT_SHELL"));
+      if (isConnectShell) {
+        for (File f: new File(jarsDir).listFiles()) {
+          // Exclude Spark Classic SQL jar if we're in Spark Connect Shell
+          if (!f.getName().startsWith("spark-sql_")) {
+            addToClassPath(cp, f.toString());
+          }
+        }
+      } else {
+        addToClassPath(cp, join(File.separator, jarsDir, "*"));
+      }
     }
 
     addToClassPath(cp, getenv("HADOOP_CONF_DIR"));

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -83,6 +83,7 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
   private static final Map<String, String> specialClasses = new HashMap<>();
   static {
     specialClasses.put("org.apache.spark.repl.Main", "spark-shell");
+    specialClasses.put("org.apache.spark.sql.application.ConnectRepl", "connect-shell");
     specialClasses.put("org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver",
       SparkLauncher.NO_RESOURCE);
     specialClasses.put("org.apache.spark.sql.hive.thriftserver.HiveThriftServer2",

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,6 @@
     <!-- managed up from 3.2.1 for SPARK-11652 -->
     <commons.collections.version>3.2.2</commons.collections.version>
     <commons.collections4.version>4.4</commons.collections4.version>
-    <!-- Update Scala version in bin/spark-shell script together -->
     <scala.version>2.13.14</scala.version>
     <scala.binary.version>2.13</scala.binary.version>
     <scalatest-maven-plugin.version>2.2.0</scalatest-maven-plugin.version>
@@ -228,7 +227,6 @@
     and ./python/packaging/connect/setup.py too.
     -->
     <arrow.version>17.0.0</arrow.version>
-    <!-- Update bin/spark-shell's ammonite version together. -->
     <ammonite.version>3.0.0-M2</ammonite.version>
 
     <!-- org.fusesource.leveldbjni will be used except on arm64 platform. -->
@@ -331,6 +329,8 @@
     <db2.jcc.version>11.5.9.0</db2.jcc.version>
     <mssql.jdbc.version>12.8.0.jre11</mssql.jdbc.version>
     <ojdbc11.version>23.5.0.24.07</ojdbc11.version>
+    <!-- Used for SBT build to retrieve the Spark version -->
+    <spark.version>${project.version}</spark.version>
   </properties>
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,7 @@
     <!-- managed up from 3.2.1 for SPARK-11652 -->
     <commons.collections.version>3.2.2</commons.collections.version>
     <commons.collections4.version>4.4</commons.collections4.version>
+    <!-- Update Scala version in bin/spark-shell script together -->
     <scala.version>2.13.14</scala.version>
     <scala.binary.version>2.13</scala.binary.version>
     <scalatest-maven-plugin.version>2.2.0</scalatest-maven-plugin.version>
@@ -227,6 +228,7 @@
     and ./python/packaging/connect/setup.py too.
     -->
     <arrow.version>17.0.0</arrow.version>
+    <!-- Update bin/spark-shell's ammonite version together. -->
     <ammonite.version>3.0.0-M2</ammonite.version>
 
     <!-- org.fusesource.leveldbjni will be used except on arm64 platform. -->

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
@@ -620,7 +620,9 @@ object SparkConnectClient {
      * Configure the builder using the env SPARK_REMOTE environment variable.
      */
     def loadFromEnvironment(): Builder = {
-      sys.env.get(SparkConnectClient.SPARK_REMOTE).foreach(connectionString)
+      Option(System.getProperty("spark.remote")) // Set from Spark Submit
+        .orElse(sys.env.get(SparkConnectClient.SPARK_REMOTE))
+        .foreach(connectionString)
       this
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add the support of `--remote` at `bin/spark-shell` so it can use Spark Connect easily.

At high level:

```
./bin/spark-shell --remote "local[*]"
...
spark.range(10).show()
```

1. Start `ConnectRepl`
2. Start the Spark Connect server locally at `ConnectRepl.scala`
3. Create a Spark Connect client, and expose it to the shell users
4. When users exit, Spark Connect server is also terminated.

```
./bin/spark-shell --remote "sc://localhost"
...
spark.range(10).show()
```

1. Start `ConnectRepl`
2. Create a Spark Connect client, and expose it to the shell users

The approach of classpath handling is as follows:

- Place all Spark Connect REPL related dependencies and jars into `jars/connect-repl`.
- Only when we run Spark Connect shell, we load the dependencies at `jars/connect-repl` (and exclude Spark Classic jars, and jars shaded in Spark Connect client).

In order to allow configurations set in Spark Shell, this PR leverages properties (that already contains Spark configurations), and set it in the Spark Connect client. 

### Why are the changes needed?

`bin/pyspark --remote` also works. In order for end users to try Spark Connect out, should have the consistent way.

### Does this PR introduce _any_ user-facing change?

Yes, now `bin/spark-shell` supports `--remote` option.

### How was this patch tested?

Manually tested as below:

```
./bin/spark-shell --remote "local[*]"
...
spark.range(10).show()
```

```
./sbin/start-connect-server.sh --wait
...
./bin/spark-shell --remote "sc://localhost"
...
spark.range(10).show()
```

```
./bin/spark-shell --remote "local[*]" --conf spark.sql.ansi.enabled=false
...
spark.conf.get("spark.sql.ansi.enabled")
```


```
./bin/spark-shell --remote "local[*]" --conf spark.sql.ansi.enabled=false --conf spark.abcabc=abc --conf spark.sql.debug=true
...
spark.conf.get("spark.sql.debug")
spark.conf.get("spark.sql.ansi.enabled")
```

```
./sbin/start-connect-server.sh --wait
...
./bin/spark-shell --remote "sc://localhost" --conf spark.sql.ansi.enabled=false --conf spark.abcabc=abc --conf spark.sql.debug=true
...
spark.conf.get("spark.sql.debug")
spark.conf.get("spark.sql.ansi.enabled")
```

### Was this patch authored or co-authored using generative AI tooling?

No.