### PR TITLE
[SPARK-48943][TESTS] Upgrade `h2` to 2.3.230 and enhance the test coverage of behavior changes of `asin` and `acos` complying Standard SQL 

### DIFF
--- a/connect/server/pom.xml
+++ b/connect/server/pom.xml
@@ -254,7 +254,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>2.2.220</version>
+      <version>2.3.230</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -166,7 +166,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>2.2.220</version>
+      <version>2.3.230</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.connector.expressions.Expression
 import org.apache.spark.sql.execution.FormattedMode
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2ScanRelation, V1ScanWrapper}
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
-import org.apache.spark.sql.functions.{abs, acos, asin, atan, atan2, avg, ceil, coalesce, cos, cosh, cot, count, count_distinct, degrees, exp, floor, lit, log => logarithm, log10, not, pow, radians, round, signum, sin, sinh, sqrt, sum, tan, tanh, udf, when}
+import org.apache.spark.sql.functions.{abs, acos, asin, avg, ceil, coalesce, count, count_distinct, degrees, exp, floor, lit, log => logarithm, log10, not, pow, radians, round, signum, sqrt, sum, udf, when}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.{DataType, IntegerType, StringType}
@@ -1258,49 +1258,32 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
     checkAnswer(df15, Seq(Row(1, "cathy", 9000, 1200, false),
       Row(2, "alex", 12000, 1200, false), Row(6, "jen", 12000, 1200, true)))
 
-    val df16 = spark.table("h2.test.employee")
-      .filter(sin($"bonus") < -0.08)
-      .filter(sinh($"bonus") > 200)
-      .filter(cos($"bonus") > 0.9)
-      .filter(cosh($"bonus") > 200)
-      .filter(tan($"bonus") < -0.08)
-      .filter(tanh($"bonus") === 1)
-      .filter(cot($"bonus") < -11)
-      .filter(asin($"bonus") > 0.1)
-      .filter(acos($"bonus") > 1.4)
-      .filter(atan($"bonus") > 1.4)
-      .filter(atan2($"bonus", $"bonus") > 0.7)
-    checkFiltersRemoved(df16)
-    checkPushedInfo(df16, "PushedFilters: [" +
-      "BONUS IS NOT NULL, SIN(BONUS) < -0.08, SINH(BONUS) > 200.0, COS(BONUS) > 0.9, " +
-      "COSH(BONUS) > 200.0, TAN(BONUS) < -0.08, TANH(BONUS) = 1.0, COT(BONUS) < -11.0, " +
-      "ASIN(BONUS) > 0.1, ACOS(BONUS) > 1.4, ATAN(BONUS) > 1.4, (ATAN2(BONUS, BONUS)) > 0.7],")
-
-    // When arguments for asin and acos are invalid (< -1 || > 1) in H2
-    val e = intercept[SparkException] {
-      checkAnswer(df16, Seq(Row(1, "cathy", 9000, 1200, false),
-        Row(2, "alex", 12000, 1200, false), Row(6, "jen", 12000, 1200, true)))
-    }
-    assert(e.getCause.getClass === classOf[org.h2.jdbc.JdbcSQLDataException])
-    assert(e.getCause.getMessage.contains("Invalid value"))
-
-    // When arguments for asin and acos are valid (>= -1 && <= 1) in H2
-    val df17 = sql(
+    val df16 = sql(
       """
         |SELECT * FROM h2.test.employee
-        |WHERE asin(bonus / salary) > 0.13
+        |WHERE sin(bonus) < -0.08
+        |AND sinh(bonus) > 200
+        |AND cos(bonus) > 0.9
+        |AND cosh(bonus) > 200
+        |AND tan(bonus) < -0.08
+        |AND tanh(bonus) = 1
+        |AND cot(bonus) < -11
+        |AND asin(bonus / salary) > 0.13
         |AND acos(bonus / salary) < 1.47
+        |AND atan(bonus) > 1.4
+        |AND atan2(bonus, bonus) > 0.7
         |""".stripMargin)
-    checkFiltersRemoved(df17)
-    checkPushedInfo(df17, "PushedFilters: [" +
-      "BONUS IS NOT NULL, SALARY IS NOT NULL, " +
-      "ASIN(BONUS / CAST(SALARY AS double)) > 0.13, " +
-      "ACOS(BONUS / CAST(SALARY AS double)) < 1.47]")
-    checkAnswer(df17, Seq(Row(1, "cathy", 9000, 1200, false),
-      Row(2, "david", 10000, 1300, true)))
+    checkFiltersRemoved(df16)
+    checkPushedInfo(df16, "PushedFilters: [" +
+      "BONUS IS NOT NULL, SALARY IS NOT NULL, SIN(BONUS) < -0.08, SINH(BONUS) > 200.0, " +
+      "COS(BONUS) > 0.9, COSH(BONUS) > 200.0, TAN(BONUS) < -0.08, TANH(BONUS) = 1.0, " +
+      "COT(BONUS) < -11.0, ASIN(BONUS / CAST(SALARY AS double)) > 0.13, " +
+      "ACOS(BONUS / CAST(SALARY AS double)) < 1.47, " +
+      "ATAN(BONUS) > 1.4, (ATAN2(BONUS, BONUS)) > 0.7],")
+    checkAnswer(df16, Seq(Row(1, "cathy", 9000, 1200, false)))
 
     // H2 does not support log2, asinh, acosh, atanh, cbrt
-    val df18 = sql(
+    val df17 = sql(
       """
         |SELECT * FROM h2.test.employee
         |WHERE log2(dept) > 2.5
@@ -1309,10 +1292,28 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
         |AND atanh(bonus / salary) > 0.1
         |AND cbrt(dept) > 1.8
         |""".stripMargin)
-    checkFiltersRemoved(df18, false)
-    checkPushedInfo(df18,
+    checkFiltersRemoved(df17, false)
+    checkPushedInfo(df17,
       "PushedFilters: [DEPT IS NOT NULL, BONUS IS NOT NULL, SALARY IS NOT NULL]")
-    checkAnswer(df18, Seq(Row(6, "jen", 12000, 1200, true)))
+    checkAnswer(df17, Seq(Row(6, "jen", 12000, 1200, true)))
+  }
+
+  test("SPARK-48943: arguments for asin and acos are invalid (< -1 || > 1) in H2") {
+    val df1 = spark.table("h2.test.employee").filter(acos($"bonus") > 1.4)
+    val e1 = intercept[SparkException] {
+      checkAnswer(df1, Seq(Row(1, "cathy", 9000, 1200, false)))
+    }
+    assert(e1.getCause.getClass === classOf[org.h2.jdbc.JdbcSQLDataException])
+    assert(e1.getCause.getMessage.contains("Invalid value")
+      && e1.getCause.getMessage.contains("ACOS"))
+
+    val df2 = spark.table("h2.test.employee").filter(asin($"bonus") > 0.1)
+    val e2 = intercept[SparkException] {
+      checkAnswer(df2, Seq(Row(1, "cathy", 9000, 1200, false)))
+    }
+    assert(e2.getCause.getClass === classOf[org.h2.jdbc.JdbcSQLDataException])
+    assert(e2.getCause.getMessage.contains("Invalid value")
+      && e2.getCause.getMessage.contains("ASIN"))
   }
 
   test("SPARK-38432: escape the single quote, _ and % for DS V2 pushdown") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR aims to upgrade `h2` from 2.2.220 to 2.3.230 and enhance the test coverage of behavior changes of `asin` and `acos` complying Standard SQL.

The detail of behavior changes as follows:
After this commit( https://github.com/h2database/h2database/commit/186647d4a35d05681febf4f53502b306aa6d511a), the behavior of `asin` and `acos` has changed in h2, complying with Standard SQL, and throwing exceptions directly when the argument is invalid(< -1d || > 1d).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
2.3.230 is latest version of `h2`, there are a lot of bug fixes and improvements.
Full change notes:
https://www.h2database.com/html/changelog.html

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Update a exist test case and add a new test case.
Pass GA and manually test `JDBCV2Suite`.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.