### PR TITLE
[SPARK-48961][PYTHON] Make the parameter naming of `PySparkException` consistent with JVM

### DIFF
--- a/python/docs/source/development/contributing.rst
+++ b/python/docs/source/development/contributing.rst
@@ -279,8 +279,8 @@ Throw with arbitrary error message:
 .. code-block:: python
 
   class PySparkTestError(PySparkException):
-      def __init__(self, error_class: str, message_parameters: Dict[str, str]):
-          super().__init__(error_class=error_class, message_parameters=message_parameters)
+      def __init__(self, errorClass: str, messageParameters: Dict[str, str]):
+          super().__init__(errorClass=errorClass, messageParameters=messageParameters)
   
       def getMessageParameters(self) -> Optional[Dict[str, str]]:
           return super().getMessageParameters()

--- a/python/docs/source/development/logger.rst
+++ b/python/docs/source/development/logger.rst
@@ -52,7 +52,7 @@ Example log entry:
         "file": "/path/to/file.py",
         "line_no": "17",
         "fragment": "divide"
-        "error_class": "DIVIDE_BY_ZERO"
+        "errorClass": "DIVIDE_BY_ZERO"
       },
       "exception": {
         "class": "Py4JJavaError",

--- a/python/pyspark/accumulators.py
+++ b/python/pyspark/accumulators.py
@@ -149,8 +149,8 @@ class Accumulator(Generic[T]):
         """Get the accumulator's value; only usable in driver program"""
         if self._deserialized:
             raise PySparkRuntimeError(
-                error_class="VALUE_NOT_ACCESSIBLE",
-                message_parameters={
+                errorClass="VALUE_NOT_ACCESSIBLE",
+                messageParameters={
                     "value": "Accumulator.value",
                 },
             )
@@ -161,8 +161,8 @@ class Accumulator(Generic[T]):
         """Sets the accumulator's value; only usable in driver program"""
         if self._deserialized:
             raise PySparkRuntimeError(
-                error_class="VALUE_NOT_ACCESSIBLE",
-                message_parameters={
+                errorClass="VALUE_NOT_ACCESSIBLE",
+                messageParameters={
                     "value": "Accumulator.value",
                 },
             )

--- a/python/pyspark/conf.py
+++ b/python/pyspark/conf.py
@@ -188,8 +188,8 @@ class SparkConf:
         """Set an environment variable to be passed to executors."""
         if (key is not None and pairs is not None) or (key is None and pairs is None):
             raise PySparkRuntimeError(
-                error_class="KEY_VALUE_PAIR_REQUIRED",
-                message_parameters={},
+                errorClass="KEY_VALUE_PAIR_REQUIRED",
+                messageParameters={},
             )
         elif key is not None:
             self.set("spark.executorEnv.{}".format(key), cast(str, value))

--- a/python/pyspark/core/broadcast.py
+++ b/python/pyspark/core/broadcast.py
@@ -59,8 +59,8 @@ def _from_id(bid: int) -> "Broadcast[Any]":
 
     if bid not in _broadcastRegistry:
         raise PySparkRuntimeError(
-            error_class="BROADCAST_VARIABLE_NOT_LOADED",
-            message_parameters={
+            errorClass="BROADCAST_VARIABLE_NOT_LOADED",
+            messageParameters={
                 "variable": str(bid),
             },
         )
@@ -299,8 +299,8 @@ class Broadcast(Generic[T]):
         """
         if self._jbroadcast is None:
             raise PySparkRuntimeError(
-                error_class="INVALID_BROADCAST_OPERATION",
-                message_parameters={"operation": "unpersisted"},
+                errorClass="INVALID_BROADCAST_OPERATION",
+                messageParameters={"operation": "unpersisted"},
             )
         self._jbroadcast.unpersist(blocking)
 
@@ -329,8 +329,8 @@ class Broadcast(Generic[T]):
         """
         if self._jbroadcast is None:
             raise PySparkRuntimeError(
-                error_class="INVALID_BROADCAST_OPERATION",
-                message_parameters={"operation": "destroyed"},
+                errorClass="INVALID_BROADCAST_OPERATION",
+                messageParameters={"operation": "destroyed"},
             )
         self._jbroadcast.destroy(blocking)
         os.unlink(self._path)
@@ -338,8 +338,8 @@ class Broadcast(Generic[T]):
     def __reduce__(self) -> Tuple[Callable[[int], "Broadcast[T]"], Tuple[int]]:
         if self._jbroadcast is None:
             raise PySparkRuntimeError(
-                error_class="INVALID_BROADCAST_OPERATION",
-                message_parameters={"operation": "serialized"},
+                errorClass="INVALID_BROADCAST_OPERATION",
+                messageParameters={"operation": "serialized"},
             )
         assert self._pickle_registry is not None
         self._pickle_registry.add(self)

--- a/python/pyspark/core/context.py
+++ b/python/pyspark/core/context.py
@@ -184,8 +184,8 @@ class SparkContext:
     ):
         if "SPARK_CONNECT_MODE_ENABLED" in os.environ and "SPARK_LOCAL_REMOTE" not in os.environ:
             raise PySparkRuntimeError(
-                error_class="CONTEXT_UNAVAILABLE_FOR_REMOTE_CLIENT",
-                message_parameters={},
+                errorClass="CONTEXT_UNAVAILABLE_FOR_REMOTE_CLIENT",
+                messageParameters={},
             )
 
         if conf is None or conf.get("spark.executor.allowSparkContext", "false").lower() != "true":
@@ -271,13 +271,13 @@ class SparkContext:
         # Check that we have at least the required parameters
         if not self._conf.contains("spark.master"):
             raise PySparkRuntimeError(
-                error_class="MASTER_URL_NOT_SET",
-                message_parameters={},
+                errorClass="MASTER_URL_NOT_SET",
+                messageParameters={},
             )
         if not self._conf.contains("spark.app.name"):
             raise PySparkRuntimeError(
-                error_class="APPLICATION_NAME_NOT_SET",
-                message_parameters={},
+                errorClass="APPLICATION_NAME_NOT_SET",
+                messageParameters={},
             )
 
         # Read back our properties from the conf in case we loaded some of them from
@@ -465,8 +465,8 @@ class SparkContext:
     def __getnewargs__(self) -> NoReturn:
         # This method is called when attempting to pickle SparkContext, which is always an error:
         raise PySparkRuntimeError(
-            error_class="CONTEXT_ONLY_VALID_ON_DRIVER",
-            message_parameters={},
+            errorClass="CONTEXT_ONLY_VALID_ON_DRIVER",
+            messageParameters={},
         )
 
     def __enter__(self) -> "SparkContext":
@@ -2535,8 +2535,8 @@ class SparkContext:
             self.profiler_collector.show_profiles()
         else:
             raise PySparkRuntimeError(
-                error_class="INCORRECT_CONF_FOR_PROFILE",
-                message_parameters={},
+                errorClass="INCORRECT_CONF_FOR_PROFILE",
+                messageParameters={},
             )
 
     def dump_profiles(self, path: str) -> None:
@@ -2552,8 +2552,8 @@ class SparkContext:
             self.profiler_collector.dump_profiles(path)
         else:
             raise PySparkRuntimeError(
-                error_class="INCORRECT_CONF_FOR_PROFILE",
-                message_parameters={},
+                errorClass="INCORRECT_CONF_FOR_PROFILE",
+                messageParameters={},
             )
 
     def getConf(self) -> SparkConf:
@@ -2591,8 +2591,8 @@ class SparkContext:
         """
         if TaskContext.get() is not None:
             raise PySparkRuntimeError(
-                error_class="CONTEXT_ONLY_VALID_ON_DRIVER",
-                message_parameters={},
+                errorClass="CONTEXT_ONLY_VALID_ON_DRIVER",
+                messageParameters={},
             )
 
 

--- a/python/pyspark/core/rdd.py
+++ b/python/pyspark/core/rdd.py
@@ -137,8 +137,8 @@ def portable_hash(x: Hashable) -> int:
 
     if "PYTHONHASHSEED" not in os.environ:
         raise PySparkRuntimeError(
-            error_class="PYTHON_HASH_SEED_NOT_SET",
-            message_parameters={},
+            errorClass="PYTHON_HASH_SEED_NOT_SET",
+            messageParameters={},
         )
 
     if x is None:
@@ -246,8 +246,8 @@ class RDD(Generic[T_co]):
     def __getnewargs__(self) -> NoReturn:
         # This method is called when attempting to pickle an RDD, which is always an error:
         raise PySparkRuntimeError(
-            error_class="RDD_TRANSFORM_ONLY_VALID_ON_DRIVER",
-            message_parameters={},
+            errorClass="RDD_TRANSFORM_ONLY_VALID_ON_DRIVER",
+            messageParameters={},
         )
 
     @property
@@ -1581,8 +1581,8 @@ class RDD(Generic[T_co]):
                 pipe.wait()
                 if checkCode and pipe.returncode:
                     raise PySparkRuntimeError(
-                        error_class="PIPE_FUNCTION_EXITED",
-                        message_parameters={
+                        errorClass="PIPE_FUNCTION_EXITED",
+                        messageParameters={
                             "func_name": command,
                             "error_code": str(pipe.returncode),
                         },
@@ -5105,8 +5105,8 @@ class RDD(Generic[T_co]):
         self: "RDD[Any]", schema: Optional[Any] = None, sampleRatio: Optional[float] = None
     ) -> "DataFrame":
         raise PySparkRuntimeError(
-            error_class="CALL_BEFORE_INITIALIZE",
-            message_parameters={
+            errorClass="CALL_BEFORE_INITIALIZE",
+            messageParameters={
                 "func_name": "RDD.toDF",
                 "object": "SparkSession",
             },

--- a/python/pyspark/errors/exceptions/base.py
+++ b/python/pyspark/errors/exceptions/base.py
@@ -34,24 +34,24 @@ class PySparkException(Exception):
     def __init__(
         self,
         message: Optional[str] = None,
-        error_class: Optional[str] = None,
-        message_parameters: Optional[Dict[str, str]] = None,
-        query_contexts: Optional[List["QueryContext"]] = None,
+        errorClass: Optional[str] = None,
+        messageParameters: Optional[Dict[str, str]] = None,
+        contexts: Optional[List["QueryContext"]] = None,
     ):
-        if query_contexts is None:
-            query_contexts = []
+        if contexts is None:
+            contexts = []
         self._error_reader = ErrorClassesReader()
 
         if message is None:
             self._message = self._error_reader.get_error_message(
-                cast(str, error_class), cast(Dict[str, str], message_parameters)
+                cast(str, errorClass), cast(Dict[str, str], messageParameters)
             )
         else:
             self._message = message
 
-        self._error_class = error_class
-        self._message_parameters = message_parameters
-        self._query_contexts = query_contexts
+        self._errorClass = errorClass
+        self._messageParameters = messageParameters
+        self._contexts = contexts
 
     def getErrorClass(self) -> Optional[str]:
         """
@@ -66,7 +66,7 @@ class PySparkException(Exception):
         :meth:`PySparkException.getQueryContext`
         :meth:`PySparkException.getSqlState`
         """
-        return self._error_class
+        return self._errorClass
 
     def getMessageParameters(self) -> Optional[Dict[str, str]]:
         """
@@ -81,7 +81,7 @@ class PySparkException(Exception):
         :meth:`PySparkException.getQueryContext`
         :meth:`PySparkException.getSqlState`
         """
-        return self._message_parameters
+        return self._messageParameters
 
     def getSqlState(self) -> Optional[str]:
         """
@@ -128,28 +128,28 @@ class PySparkException(Exception):
         :meth:`PySparkException.getMessage`
         :meth:`PySparkException.getSqlState`
         """
-        return self._query_contexts
+        return self._contexts
 
     def _log_exception(self) -> None:
-        query_contexts = self.getQueryContext()
-        query_context = query_contexts[0] if len(query_contexts) != 0 else None
-        if query_context:
-            if query_context.contextType().name == "DataFrame":
+        contexts = self.getQueryContext()
+        context = contexts[0] if len(contexts) != 0 else None
+        if context:
+            if context.contextType().name == "DataFrame":
                 logger = PySparkLogger.getLogger("DataFrameQueryContextLogger")
-                call_site = query_context.callSite().split(":")
+                call_site = context.callSite().split(":")
                 line_no = call_site[1] if len(call_site) == 2 else ""
                 logger.exception(
                     self.getMessage(),
                     file=call_site[0],
                     line_no=line_no,
-                    fragment=query_context.fragment(),
-                    error_class=self.getErrorClass(),
+                    fragment=context.fragment(),
+                    errorClass=self.getErrorClass(),
                 )
             else:
                 logger = PySparkLogger.getLogger("SQLQueryContextLogger")
                 logger.exception(
                     self.getMessage(),
-                    error_class=self.getErrorClass(),
+                    errorClass=self.getErrorClass(),
                 )
 
     def __str__(self) -> str:
@@ -299,11 +299,11 @@ class PySparkAssertionError(PySparkException, AssertionError):
     def __init__(
         self,
         message: Optional[str] = None,
-        error_class: Optional[str] = None,
-        message_parameters: Optional[Dict[str, str]] = None,
+        errorClass: Optional[str] = None,
+        messageParameters: Optional[Dict[str, str]] = None,
         data: Optional[Iterable["Row"]] = None,
     ):
-        super().__init__(message, error_class, message_parameters)
+        super().__init__(message, errorClass, messageParameters)
         self.data = data
 
 

--- a/python/pyspark/errors/exceptions/captured.py
+++ b/python/pyspark/errors/exceptions/captured.py
@@ -146,11 +146,11 @@ class CapturedException(PySparkException):
         if self._origin is not None and is_instance_of(
             gw, self._origin, "org.apache.spark.SparkThrowable"
         ):
-            error_class = self._origin.getErrorClass()
-            message_parameters = self._origin.getMessageParameters()
+            errorClass = self._origin.getErrorClass()
+            messageParameters = self._origin.getMessageParameters()
 
             error_message = gw.jvm.org.apache.spark.SparkThrowableHelper.getMessage(
-                error_class, message_parameters
+                errorClass, messageParameters
             )
 
             return error_message

--- a/python/pyspark/errors/exceptions/connect.py
+++ b/python/pyspark/errors/exceptions/connect.py
@@ -56,9 +56,9 @@ def convert_exception(
 ) -> SparkConnectException:
     classes = []
     sql_state = None
-    error_class = None
-    message_parameters = None
-    query_contexts: Optional[List[BaseQueryContext]] = None
+    errorClass = None
+    messageParameters = None
+    contexts: Optional[List[BaseQueryContext]] = None
 
     if "classes" in info.metadata:
         classes = json.loads(info.metadata["classes"])
@@ -67,10 +67,10 @@ def convert_exception(
         sql_state = info.metadata["sqlState"]
 
     if "errorClass" in info.metadata:
-        error_class = info.metadata["errorClass"]
+        errorClass = info.metadata["errorClass"]
 
     if "messageParameters" in info.metadata:
-        message_parameters = json.loads(info.metadata["messageParameters"])
+        messageParameters = json.loads(info.metadata["messageParameters"])
 
     stacktrace: Optional[str] = None
     if resp is not None and resp.HasField("root_error_idx"):
@@ -86,136 +86,136 @@ def convert_exception(
         and resp.errors
         and hasattr(resp.errors[resp.root_error_idx], "spark_throwable")
     ):
-        message_parameters = dict(
+        messageParameters = dict(
             resp.errors[resp.root_error_idx].spark_throwable.message_parameters
         )
-        query_contexts = []
-        for query_context in resp.errors[resp.root_error_idx].spark_throwable.query_contexts:
-            if query_context.context_type == pb2.FetchErrorDetailsResponse.QueryContext.SQL:
-                query_contexts.append(SQLQueryContext(query_context))
+        contexts = []
+        for context in resp.errors[resp.root_error_idx].spark_throwable.query_contexts:
+            if context.context_type == pb2.FetchErrorDetailsResponse.QueryContext.SQL:
+                contexts.append(SQLQueryContext(context))
             else:
-                query_contexts.append(DataFrameQueryContext(query_context))
+                contexts.append(DataFrameQueryContext(context))
 
     if "org.apache.spark.sql.catalyst.parser.ParseException" in classes:
         return ParseException(
             message,
-            error_class=error_class,
-            message_parameters=message_parameters,
+            errorClass=errorClass,
+            messageParameters=messageParameters,
             sql_state=sql_state,
             server_stacktrace=stacktrace,
             display_server_stacktrace=display_server_stacktrace,
-            query_contexts=query_contexts,
+            contexts=contexts,
         )
     # Order matters. ParseException inherits AnalysisException.
     elif "org.apache.spark.sql.AnalysisException" in classes:
         return AnalysisException(
             message,
-            error_class=error_class,
-            message_parameters=message_parameters,
+            errorClass=errorClass,
+            messageParameters=messageParameters,
             sql_state=sql_state,
             server_stacktrace=stacktrace,
             display_server_stacktrace=display_server_stacktrace,
-            query_contexts=query_contexts,
+            contexts=contexts,
         )
     elif "org.apache.spark.sql.streaming.StreamingQueryException" in classes:
         return StreamingQueryException(
             message,
-            error_class=error_class,
-            message_parameters=message_parameters,
+            errorClass=errorClass,
+            messageParameters=messageParameters,
             sql_state=sql_state,
             server_stacktrace=stacktrace,
             display_server_stacktrace=display_server_stacktrace,
-            query_contexts=query_contexts,
+            contexts=contexts,
         )
     elif "org.apache.spark.sql.execution.QueryExecutionException" in classes:
         return QueryExecutionException(
             message,
-            error_class=error_class,
-            message_parameters=message_parameters,
+            errorClass=errorClass,
+            messageParameters=messageParameters,
             sql_state=sql_state,
             server_stacktrace=stacktrace,
             display_server_stacktrace=display_server_stacktrace,
-            query_contexts=query_contexts,
+            contexts=contexts,
         )
     # Order matters. NumberFormatException inherits IllegalArgumentException.
     elif "java.lang.NumberFormatException" in classes:
         return NumberFormatException(
             message,
-            error_class=error_class,
-            message_parameters=message_parameters,
+            errorClass=errorClass,
+            messageParameters=messageParameters,
             sql_state=sql_state,
             server_stacktrace=stacktrace,
             display_server_stacktrace=display_server_stacktrace,
-            query_contexts=query_contexts,
+            contexts=contexts,
         )
     elif "java.lang.IllegalArgumentException" in classes:
         return IllegalArgumentException(
             message,
-            error_class=error_class,
-            message_parameters=message_parameters,
+            errorClass=errorClass,
+            messageParameters=messageParameters,
             sql_state=sql_state,
             server_stacktrace=stacktrace,
             display_server_stacktrace=display_server_stacktrace,
-            query_contexts=query_contexts,
+            contexts=contexts,
         )
     elif "java.lang.ArithmeticException" in classes:
         return ArithmeticException(
             message,
-            error_class=error_class,
-            message_parameters=message_parameters,
+            errorClass=errorClass,
+            messageParameters=messageParameters,
             sql_state=sql_state,
             server_stacktrace=stacktrace,
             display_server_stacktrace=display_server_stacktrace,
-            query_contexts=query_contexts,
+            contexts=contexts,
         )
     elif "java.lang.UnsupportedOperationException" in classes:
         return UnsupportedOperationException(
             message,
-            error_class=error_class,
-            message_parameters=message_parameters,
+            errorClass=errorClass,
+            messageParameters=messageParameters,
             sql_state=sql_state,
             server_stacktrace=stacktrace,
             display_server_stacktrace=display_server_stacktrace,
-            query_contexts=query_contexts,
+            contexts=contexts,
         )
     elif "java.lang.ArrayIndexOutOfBoundsException" in classes:
         return ArrayIndexOutOfBoundsException(
             message,
-            error_class=error_class,
-            message_parameters=message_parameters,
+            errorClass=errorClass,
+            messageParameters=messageParameters,
             sql_state=sql_state,
             server_stacktrace=stacktrace,
             display_server_stacktrace=display_server_stacktrace,
-            query_contexts=query_contexts,
+            contexts=contexts,
         )
     elif "java.time.DateTimeException" in classes:
         return DateTimeException(
             message,
-            error_class=error_class,
+            errorClass=errorClass,
             sql_state=sql_state,
             server_stacktrace=stacktrace,
             display_server_stacktrace=display_server_stacktrace,
-            query_contexts=query_contexts,
+            contexts=contexts,
         )
     elif "org.apache.spark.SparkRuntimeException" in classes:
         return SparkRuntimeException(
             message,
-            error_class=error_class,
-            message_parameters=message_parameters,
+            errorClass=errorClass,
+            messageParameters=messageParameters,
             sql_state=sql_state,
             server_stacktrace=stacktrace,
             display_server_stacktrace=display_server_stacktrace,
-            query_contexts=query_contexts,
+            contexts=contexts,
         )
     elif "org.apache.spark.SparkUpgradeException" in classes:
         return SparkUpgradeException(
             message,
-            error_class=error_class,
-            message_parameters=message_parameters,
+            errorClass=errorClass,
+            messageParameters=messageParameters,
             sql_state=sql_state,
             server_stacktrace=stacktrace,
             display_server_stacktrace=display_server_stacktrace,
-            query_contexts=query_contexts,
+            contexts=contexts,
         )
     elif "org.apache.spark.api.python.PythonException" in classes:
         return PythonException(
@@ -225,34 +225,34 @@ def convert_exception(
     elif "org.apache.spark.SparkNoSuchElementException" in classes:
         return SparkNoSuchElementException(
             message,
-            error_class=error_class,
-            message_parameters=message_parameters,
+            errorClass=errorClass,
+            messageParameters=messageParameters,
             sql_state=sql_state,
             server_stacktrace=stacktrace,
             display_server_stacktrace=display_server_stacktrace,
-            query_contexts=query_contexts,
+            contexts=contexts,
         )
     # Make sure that the generic SparkException is handled last.
     elif "org.apache.spark.SparkException" in classes:
         return SparkException(
             message,
-            error_class=error_class,
-            message_parameters=message_parameters,
+            errorClass=errorClass,
+            messageParameters=messageParameters,
             sql_state=sql_state,
             server_stacktrace=stacktrace,
             display_server_stacktrace=display_server_stacktrace,
-            query_contexts=query_contexts,
+            contexts=contexts,
         )
     else:
         return SparkConnectGrpcException(
             message,
             reason=info.reason,
-            message_parameters=message_parameters,
-            error_class=error_class,
+            messageParameters=messageParameters,
+            errorClass=errorClass,
             sql_state=sql_state,
             server_stacktrace=stacktrace,
             display_server_stacktrace=display_server_stacktrace,
-            query_contexts=query_contexts,
+            contexts=contexts,
         )
 
 
@@ -291,40 +291,40 @@ class SparkConnectGrpcException(SparkConnectException):
     def __init__(
         self,
         message: Optional[str] = None,
-        error_class: Optional[str] = None,
-        message_parameters: Optional[Dict[str, str]] = None,
+        errorClass: Optional[str] = None,
+        messageParameters: Optional[Dict[str, str]] = None,
         reason: Optional[str] = None,
         sql_state: Optional[str] = None,
         server_stacktrace: Optional[str] = None,
         display_server_stacktrace: bool = False,
-        query_contexts: Optional[List[BaseQueryContext]] = None,
+        contexts: Optional[List[BaseQueryContext]] = None,
     ) -> None:
-        if query_contexts is None:
-            query_contexts = []
+        if contexts is None:
+            contexts = []
         self._message = message  # type: ignore[assignment]
         if reason is not None:
             self._message = f"({reason}) {self._message}"
 
-        # PySparkException has the assumption that error_class and message_parameters are
+        # PySparkException has the assumption that errorClass and messageParameters are
         # only occurring together. If only one is set, we assume the message to be fully
         # parsed.
-        tmp_error_class = error_class
-        tmp_message_parameters = message_parameters
-        if error_class is not None and message_parameters is None:
+        tmp_error_class = errorClass
+        tmp_message_parameters = messageParameters
+        if errorClass is not None and messageParameters is None:
             tmp_error_class = None
-        elif error_class is None and message_parameters is not None:
+        elif errorClass is None and messageParameters is not None:
             tmp_message_parameters = None
 
         super().__init__(
             message=self._message,
-            error_class=tmp_error_class,
-            message_parameters=tmp_message_parameters,
+            errorClass=tmp_error_class,
+            messageParameters=tmp_message_parameters,
         )
-        self._error_class = error_class
+        self._errorClass = errorClass
         self._sql_state: Optional[str] = sql_state
         self._stacktrace: Optional[str] = server_stacktrace
         self._display_stacktrace: bool = display_server_stacktrace
-        self._query_contexts: List[BaseQueryContext] = query_contexts
+        self._contexts: List[BaseQueryContext] = contexts
         self._log_exception()
 
     def getSqlState(self) -> Optional[str]:
@@ -459,12 +459,12 @@ class SQLQueryContext(BaseQueryContext):
     def callSite(self) -> str:
         raise UnsupportedOperationException(
             "",
-            error_class="UNSUPPORTED_CALL.WITHOUT_SUGGESTION",
-            message_parameters={"className": "SQLQueryContext", "methodName": "callSite"},
+            errorClass="UNSUPPORTED_CALL.WITHOUT_SUGGESTION",
+            messageParameters={"className": "SQLQueryContext", "methodName": "callSite"},
             sql_state="0A000",
             server_stacktrace=None,
             display_server_stacktrace=False,
-            query_contexts=[],
+            contexts=[],
         )
 
     def summary(self) -> str:
@@ -481,45 +481,45 @@ class DataFrameQueryContext(BaseQueryContext):
     def objectType(self) -> str:
         raise UnsupportedOperationException(
             "",
-            error_class="UNSUPPORTED_CALL.WITHOUT_SUGGESTION",
-            message_parameters={"className": "DataFrameQueryContext", "methodName": "objectType"},
+            errorClass="UNSUPPORTED_CALL.WITHOUT_SUGGESTION",
+            messageParameters={"className": "DataFrameQueryContext", "methodName": "objectType"},
             sql_state="0A000",
             server_stacktrace=None,
             display_server_stacktrace=False,
-            query_contexts=[],
+            contexts=[],
         )
 
     def objectName(self) -> str:
         raise UnsupportedOperationException(
             "",
-            error_class="UNSUPPORTED_CALL.WITHOUT_SUGGESTION",
-            message_parameters={"className": "DataFrameQueryContext", "methodName": "objectName"},
+            errorClass="UNSUPPORTED_CALL.WITHOUT_SUGGESTION",
+            messageParameters={"className": "DataFrameQueryContext", "methodName": "objectName"},
             sql_state="0A000",
             server_stacktrace=None,
             display_server_stacktrace=False,
-            query_contexts=[],
+            contexts=[],
         )
 
     def startIndex(self) -> int:
         raise UnsupportedOperationException(
             "",
-            error_class="UNSUPPORTED_CALL.WITHOUT_SUGGESTION",
-            message_parameters={"className": "DataFrameQueryContext", "methodName": "startIndex"},
+            errorClass="UNSUPPORTED_CALL.WITHOUT_SUGGESTION",
+            messageParameters={"className": "DataFrameQueryContext", "methodName": "startIndex"},
             sql_state="0A000",
             server_stacktrace=None,
             display_server_stacktrace=False,
-            query_contexts=[],
+            contexts=[],
         )
 
     def stopIndex(self) -> int:
         raise UnsupportedOperationException(
             "",
-            error_class="UNSUPPORTED_CALL.WITHOUT_SUGGESTION",
-            message_parameters={"className": "DataFrameQueryContext", "methodName": "stopIndex"},
+            errorClass="UNSUPPORTED_CALL.WITHOUT_SUGGESTION",
+            messageParameters={"className": "DataFrameQueryContext", "methodName": "stopIndex"},
             sql_state="0A000",
             server_stacktrace=None,
             display_server_stacktrace=False,
-            query_contexts=[],
+            contexts=[],
         )
 
     def fragment(self) -> str:

--- a/python/pyspark/errors/tests/test_errors.py
+++ b/python/pyspark/errors/tests/test_errors.py
@@ -52,7 +52,7 @@ class ErrorsTest(unittest.TestCase):
 
     def test_invalid_error_class(self):
         with self.assertRaisesRegex(ValueError, "Cannot find main error class"):
-            PySparkValueError(error_class="invalid", message_parameters={})
+            PySparkValueError(errorClass="invalid", messageParameters={})
 
 
 if __name__ == "__main__":

--- a/python/pyspark/errors/utils.py
+++ b/python/pyspark/errors/utils.py
@@ -70,16 +70,16 @@ class ErrorClassesReader:
     def __init__(self) -> None:
         self.error_info_map = ERROR_CLASSES_MAP
 
-    def get_error_message(self, error_class: str, message_parameters: Dict[str, str]) -> str:
+    def get_error_message(self, errorClass: str, messageParameters: Dict[str, str]) -> str:
         """
         Returns the completed error message by applying message parameters to the message template.
         """
-        message_template = self.get_message_template(error_class)
+        message_template = self.get_message_template(errorClass)
         # Verify message parameters.
         message_parameters_from_template = re.findall("<([a-zA-Z0-9_-]+)>", message_template)
-        assert set(message_parameters_from_template) == set(message_parameters), (
-            f"Undefined error message parameter for error class: {error_class}. "
-            f"Parameters: {message_parameters}"
+        assert set(message_parameters_from_template) == set(messageParameters), (
+            f"Undefined error message parameter for error class: {errorClass}. "
+            f"Parameters: {messageParameters}"
         )
 
         def replace_match(match: Match[str]) -> str:
@@ -88,14 +88,14 @@ class ErrorClassesReader:
         # Convert <> to {} only when paired.
         message_template = re.sub(r"<([^<>]*)>", replace_match, message_template)
 
-        return message_template.format(**message_parameters)
+        return message_template.format(**messageParameters)
 
-    def get_message_template(self, error_class: str) -> str:
+    def get_message_template(self, errorClass: str) -> str:
         """
         Returns the message template for corresponding error class from error-conditions.json.
 
         For example,
-        when given `error_class` is "EXAMPLE_ERROR_CLASS",
+        when given `errorClass` is "EXAMPLE_ERROR_CLASS",
         and corresponding error class in error-conditions.json looks like the below:
 
         .. code-block:: python
@@ -109,7 +109,7 @@ class ErrorClassesReader:
         In this case, this function returns:
         "Problem <A> because of <B>."
 
-        For sub error class, when given `error_class` is "EXAMPLE_ERROR_CLASS.SUB_ERROR_CLASS",
+        For sub error class, when given `errorClass` is "EXAMPLE_ERROR_CLASS.SUB_ERROR_CLASS",
         and corresponding error class in error-conditions.json looks like the below:
 
         .. code-block:: python
@@ -130,7 +130,7 @@ class ErrorClassesReader:
         In this case, this function returns:
         "Problem <A> because <B>. Do <C> to fix the problem."
         """
-        error_classes = error_class.split(".")
+        error_classes = errorClass.split(".")
         len_error_classes = len(error_classes)
         assert len_error_classes in (1, 2)
 

--- a/python/pyspark/java_gateway.py
+++ b/python/pyspark/java_gateway.py
@@ -108,8 +108,8 @@ def launch_gateway(conf=None, popen_kwargs=None):
 
             if not os.path.isfile(conn_info_file):
                 raise PySparkRuntimeError(
-                    error_class="JAVA_GATEWAY_EXITED",
-                    message_parameters={},
+                    errorClass="JAVA_GATEWAY_EXITED",
+                    messageParameters={},
                 )
 
             with open(conn_info_file, "rb") as info:

--- a/python/pyspark/logger/tests/test_logger.py
+++ b/python/pyspark/logger/tests/test_logger.py
@@ -102,7 +102,7 @@ class LoggerTestsMixin:
             self.assertTrue(err_msg in log_json["msg"])
             self.assertTrue(err_msg in log_json["exception"]["msg"])
             self.assertEqual(log_json["context"]["fragment"], "__truediv__")
-            self.assertEqual(log_json["context"]["error_class"], "DIVIDE_BY_ZERO")
+            self.assertEqual(log_json["context"]["errorClass"], "DIVIDE_BY_ZERO")
             # Only the class name is different between classic and connect.
             # Py4JJavaError for classic, _MultiThreadedRendezvous for connect
             self.assertTrue(

--- a/python/pyspark/pandas/frame.py
+++ b/python/pyspark/pandas/frame.py
@@ -3746,8 +3746,8 @@ defaultdict(<class 'list'>, {'col..., 'col...})]
         allowed_inclusive_values = ["left", "right", "both", "neither"]
         if inclusive not in allowed_inclusive_values:
             raise PySparkValueError(
-                error_class="VALUE_NOT_ALLOWED",
-                message_parameters={
+                errorClass="VALUE_NOT_ALLOWED",
+                messageParameters={
                     "arg_name": "inclusive",
                     "allowed_values": str(allowed_inclusive_values),
                 },

--- a/python/pyspark/pandas/tests/frame/test_reindexing.py
+++ b/python/pyspark/pandas/tests/frame/test_reindexing.py
@@ -172,8 +172,8 @@ class FrameReindexingMixin:
 
         self.check_error(
             exception=ctx.exception,
-            error_class="VALUE_NOT_ALLOWED",
-            message_parameters={
+            errorClass="VALUE_NOT_ALLOWED",
+            messageParameters={
                 "arg_name": "inclusive",
                 "allowed_values": str(["left", "right", "both", "neither"]),
             },

--- a/python/pyspark/pandas/tests/series/test_compute.py
+++ b/python/pyspark/pandas/tests/series/test_compute.py
@@ -544,8 +544,8 @@ class SeriesComputeMixin:
 
         self.check_error(
             exception=ctx.exception,
-            error_class="VALUE_NOT_ALLOWED",
-            message_parameters={
+            errorClass="VALUE_NOT_ALLOWED",
+            messageParameters={
                 "arg_name": "inclusive",
                 "allowed_values": str(["left", "right", "both", "neither"]),
             },

--- a/python/pyspark/pandas/tests/test_utils.py
+++ b/python/pyspark/pandas/tests/test_utils.py
@@ -118,8 +118,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_PANDAS_DATAFRAME",
-            message_parameters={
+            errorClass="DIFFERENT_PANDAS_DATAFRAME",
+            messageParameters={
                 "left": pdf1.to_string(),
                 "left_dtype": str(pdf1.dtypes),
                 "right": pdf2.to_string(),
@@ -136,8 +136,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_PANDAS_SERIES",
-            message_parameters={
+            errorClass="DIFFERENT_PANDAS_SERIES",
+            messageParameters={
                 "left": series1.to_string(),
                 "left_dtype": str(series1.dtype),
                 "right": series2.to_string(),
@@ -154,8 +154,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_PANDAS_INDEX",
-            message_parameters={
+            errorClass="DIFFERENT_PANDAS_INDEX",
+            messageParameters={
                 "left": index1,
                 "left_dtype": str(index1.dtype),
                 "right": index2,
@@ -174,8 +174,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_PANDAS_MULTIINDEX",
-            message_parameters={
+            errorClass="DIFFERENT_PANDAS_MULTIINDEX",
+            messageParameters={
                 "left": multiindex1,
                 "left_dtype": str(multiindex1.dtype),
                 "right": multiindex2,

--- a/python/pyspark/pandas/utils.py
+++ b/python/pyspark/pandas/utils.py
@@ -947,13 +947,13 @@ def spark_column_equals(left: Column, right: Column) -> bool:
 
         if not isinstance(left, ConnectColumn):
             raise PySparkTypeError(
-                error_class="NOT_COLUMN",
-                message_parameters={"arg_name": "left", "arg_type": type(left).__name__},
+                errorClass="NOT_COLUMN",
+                messageParameters={"arg_name": "left", "arg_type": type(left).__name__},
             )
         if not isinstance(right, ConnectColumn):
             raise PySparkTypeError(
-                error_class="NOT_COLUMN",
-                message_parameters={"arg_name": "right", "arg_type": type(right).__name__},
+                errorClass="NOT_COLUMN",
+                messageParameters={"arg_name": "right", "arg_type": type(right).__name__},
             )
         return repr(left).replace("`", "") == repr(right).replace("`", "")
     else:

--- a/python/pyspark/profiler.py
+++ b/python/pyspark/profiler.py
@@ -447,8 +447,8 @@ class MemoryProfiler(Profiler):
             return ret
         else:
             raise PySparkRuntimeError(
-                error_class="MISSING_LIBRARY_FOR_PROFILER",
-                message_parameters={},
+                errorClass="MISSING_LIBRARY_FOR_PROFILER",
+                messageParameters={},
             )
 
     def stats(self) -> CodeMapDict:

--- a/python/pyspark/sql/avro/functions.py
+++ b/python/pyspark/sql/avro/functions.py
@@ -83,21 +83,21 @@ def from_avro(
 
     if not isinstance(data, (Column, str)):
         raise PySparkTypeError(
-            error_class="INVALID_TYPE",
-            message_parameters={
+            errorClass="INVALID_TYPE",
+            messageParameters={
                 "arg_name": "data",
                 "arg_type": "pyspark.sql.Column or str",
             },
         )
     if not isinstance(jsonFormatSchema, str):
         raise PySparkTypeError(
-            error_class="INVALID_TYPE",
-            message_parameters={"arg_name": "jsonFormatSchema", "arg_type": "str"},
+            errorClass="INVALID_TYPE",
+            messageParameters={"arg_name": "jsonFormatSchema", "arg_type": "str"},
         )
     if options is not None and not isinstance(options, dict):
         raise PySparkTypeError(
-            error_class="INVALID_TYPE",
-            message_parameters={"arg_name": "options", "arg_type": "dict, optional"},
+            errorClass="INVALID_TYPE",
+            messageParameters={"arg_name": "options", "arg_type": "dict, optional"},
         )
 
     sc = get_active_spark_context()
@@ -153,16 +153,16 @@ def to_avro(data: "ColumnOrName", jsonFormatSchema: str = "") -> Column:
 
     if not isinstance(data, (Column, str)):
         raise PySparkTypeError(
-            error_class="INVALID_TYPE",
-            message_parameters={
+            errorClass="INVALID_TYPE",
+            messageParameters={
                 "arg_name": "data",
                 "arg_type": "pyspark.sql.Column or str",
             },
         )
     if not isinstance(jsonFormatSchema, str):
         raise PySparkTypeError(
-            error_class="INVALID_TYPE",
-            message_parameters={"arg_name": "jsonFormatSchema", "arg_type": "str"},
+            errorClass="INVALID_TYPE",
+            messageParameters={"arg_name": "jsonFormatSchema", "arg_type": "str"},
         )
 
     sc = get_active_spark_context()

--- a/python/pyspark/sql/catalog.py
+++ b/python/pyspark/sql/catalog.py
@@ -853,8 +853,8 @@ class Catalog:
         else:
             if not isinstance(schema, StructType):
                 raise PySparkTypeError(
-                    error_class="NOT_STRUCT",
-                    message_parameters={
+                    errorClass="NOT_STRUCT",
+                    messageParameters={
                         "arg_name": "schema",
                         "arg_type": type(schema).__name__,
                     },

--- a/python/pyspark/sql/classic/column.py
+++ b/python/pyspark/sql/classic/column.py
@@ -69,8 +69,8 @@ def _to_java_column(col: "ColumnOrName") -> "JavaObject":
         jcol = _create_column_from_name(col)
     else:
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "col", "arg_type": type(col).__name__},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "col", "arg_type": type(col).__name__},
         )
     return jcol
 
@@ -332,8 +332,8 @@ class Column(ParentColumn):
     # container operators
     def __contains__(self, item: Any) -> None:
         raise PySparkValueError(
-            error_class="CANNOT_APPLY_IN_FOR_COLUMN",
-            message_parameters={},
+            errorClass="CANNOT_APPLY_IN_FOR_COLUMN",
+            messageParameters={},
         )
 
     # bitwise operators
@@ -375,14 +375,14 @@ class Column(ParentColumn):
     def withField(self, fieldName: str, col: ParentColumn) -> ParentColumn:
         if not isinstance(fieldName, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "fieldName", "arg_type": type(fieldName).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "fieldName", "arg_type": type(fieldName).__name__},
             )
 
         if not isinstance(col, Column):
             raise PySparkTypeError(
-                error_class="NOT_COLUMN",
-                message_parameters={"arg_name": "col", "arg_type": type(col).__name__},
+                errorClass="NOT_COLUMN",
+                messageParameters={"arg_name": "col", "arg_type": type(col).__name__},
             )
 
         return Column(self._jc.withField(fieldName, col._jc))
@@ -395,8 +395,8 @@ class Column(ParentColumn):
     def __getattr__(self, item: Any) -> ParentColumn:
         if item.startswith("__"):
             raise PySparkAttributeError(
-                error_class="CANNOT_ACCESS_TO_DUNDER",
-                message_parameters={},
+                errorClass="CANNOT_ACCESS_TO_DUNDER",
+                messageParameters={},
             )
         return self[item]
 
@@ -404,8 +404,8 @@ class Column(ParentColumn):
         if isinstance(k, slice):
             if k.step is not None:
                 raise PySparkValueError(
-                    error_class="SLICE_WITH_STEP",
-                    message_parameters={},
+                    errorClass="SLICE_WITH_STEP",
+                    messageParameters={},
                 )
             return self.substr(k.start, k.stop)
         else:
@@ -413,7 +413,7 @@ class Column(ParentColumn):
 
     def __iter__(self) -> None:
         raise PySparkTypeError(
-            error_class="NOT_ITERABLE", message_parameters={"objectName": "Column"}
+            errorClass="NOT_ITERABLE", messageParameters={"objectName": "Column"}
         )
 
     # string methods
@@ -449,8 +449,8 @@ class Column(ParentColumn):
     ) -> ParentColumn:
         if type(startPos) != type(length):
             raise PySparkTypeError(
-                error_class="NOT_SAME_TYPE",
-                message_parameters={
+                errorClass="NOT_SAME_TYPE",
+                messageParameters={
                     "arg_name1": "startPos",
                     "arg_name2": "length",
                     "arg_type1": type(startPos).__name__,
@@ -463,8 +463,8 @@ class Column(ParentColumn):
             jc = self._jc.substr(startPos._jc, cast(ParentColumn, length)._jc)
         else:
             raise PySparkTypeError(
-                error_class="NOT_COLUMN_OR_INT",
-                message_parameters={"arg_name": "startPos", "arg_type": type(startPos).__name__},
+                errorClass="NOT_COLUMN_OR_INT",
+                messageParameters={"arg_name": "startPos", "arg_type": type(startPos).__name__},
             )
         return Column(jc)
 
@@ -522,8 +522,8 @@ class Column(ParentColumn):
         else:
             if metadata is not None:
                 raise PySparkValueError(
-                    error_class="ONLY_ALLOWED_FOR_SINGLE_COLUMN",
-                    message_parameters={"arg_name": "metadata"},
+                    errorClass="ONLY_ALLOWED_FOR_SINGLE_COLUMN",
+                    messageParameters={"arg_name": "metadata"},
                 )
             return Column(getattr(self._jc, "as")(_to_seq(sc, list(alias))))
 
@@ -541,8 +541,8 @@ class Column(ParentColumn):
             jc = self._jc.cast(jdt)
         else:
             raise PySparkTypeError(
-                error_class="NOT_DATATYPE_OR_STR",
-                message_parameters={"arg_name": "dataType", "arg_type": type(dataType).__name__},
+                errorClass="NOT_DATATYPE_OR_STR",
+                messageParameters={"arg_name": "dataType", "arg_type": type(dataType).__name__},
             )
         return Column(jc)
 
@@ -557,8 +557,8 @@ class Column(ParentColumn):
             jc = self._jc.try_cast(jdt)
         else:
             raise PySparkTypeError(
-                error_class="NOT_DATATYPE_OR_STR",
-                message_parameters={"arg_name": "dataType", "arg_type": type(dataType).__name__},
+                errorClass="NOT_DATATYPE_OR_STR",
+                messageParameters={"arg_name": "dataType", "arg_type": type(dataType).__name__},
             )
         return Column(jc)
 
@@ -575,8 +575,8 @@ class Column(ParentColumn):
     def when(self, condition: ParentColumn, value: Any) -> ParentColumn:
         if not isinstance(condition, Column):
             raise PySparkTypeError(
-                error_class="NOT_COLUMN",
-                message_parameters={"arg_name": "condition", "arg_type": type(condition).__name__},
+                errorClass="NOT_COLUMN",
+                messageParameters={"arg_name": "condition", "arg_type": type(condition).__name__},
             )
         v = value._jc if isinstance(value, Column) else value
         jc = self._jc.when(condition._jc, v)
@@ -592,16 +592,16 @@ class Column(ParentColumn):
 
         if not isinstance(window, WindowSpec):
             raise PySparkTypeError(
-                error_class="NOT_WINDOWSPEC",
-                message_parameters={"arg_name": "window", "arg_type": type(window).__name__},
+                errorClass="NOT_WINDOWSPEC",
+                messageParameters={"arg_name": "window", "arg_type": type(window).__name__},
             )
         jc = self._jc.over(window._jspec)
         return Column(jc)
 
     def __nonzero__(self) -> None:
         raise PySparkValueError(
-            error_class="CANNOT_CONVERT_COLUMN_INTO_BOOL",
-            message_parameters={},
+            errorClass="CANNOT_CONVERT_COLUMN_INTO_BOOL",
+            messageParameters={},
         )
 
     __bool__ = __nonzero__

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -214,8 +214,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
                 )
             except Exception as e:
                 raise PySparkValueError(
-                    error_class="CANNOT_PARSE_DATATYPE",
-                    message_parameters={"error": str(e)},
+                    errorClass="CANNOT_PARSE_DATATYPE",
+                    messageParameters={"error": str(e)},
                 )
         return self._schema
 
@@ -230,8 +230,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     ) -> None:
         if extended is not None and mode is not None:
             raise PySparkValueError(
-                error_class="CANNOT_SET_TOGETHER",
-                message_parameters={"arg_list": "extended and mode"},
+                errorClass="CANNOT_SET_TOGETHER",
+                messageParameters={"arg_list": "extended and mode"},
             )
 
         # For the no argument case: df.explain()
@@ -253,16 +253,16 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         if not (is_no_argument or is_extended_case or is_extended_as_mode or is_mode_case):
             if (extended is not None) and (not isinstance(extended, (bool, str))):
                 raise PySparkTypeError(
-                    error_class="NOT_BOOL_OR_STR",
-                    message_parameters={
+                    errorClass="NOT_BOOL_OR_STR",
+                    messageParameters={
                         "arg_name": "extended",
                         "arg_type": type(extended).__name__,
                     },
                 )
             if (mode is not None) and (not isinstance(mode, str)):
                 raise PySparkTypeError(
-                    error_class="NOT_STR",
-                    message_parameters={"arg_name": "mode", "arg_type": type(mode).__name__},
+                    errorClass="NOT_STR",
+                    messageParameters={"arg_name": "mode", "arg_type": type(mode).__name__},
                 )
 
         # Sets an explain mode depending on a given argument
@@ -298,14 +298,14 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     ) -> str:
         if not isinstance(n, int) or isinstance(n, bool):
             raise PySparkTypeError(
-                error_class="NOT_INT",
-                message_parameters={"arg_name": "n", "arg_type": type(n).__name__},
+                errorClass="NOT_INT",
+                messageParameters={"arg_name": "n", "arg_type": type(n).__name__},
             )
 
         if not isinstance(vertical, bool):
             raise PySparkTypeError(
-                error_class="NOT_BOOL",
-                message_parameters={"arg_name": "vertical", "arg_type": type(vertical).__name__},
+                errorClass="NOT_BOOL",
+                messageParameters={"arg_name": "vertical", "arg_type": type(vertical).__name__},
             )
 
         if isinstance(truncate, bool) and truncate:
@@ -315,8 +315,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
                 int_truncate = int(truncate)
             except ValueError:
                 raise PySparkTypeError(
-                    error_class="NOT_BOOL",
-                    message_parameters={
+                    errorClass="NOT_BOOL",
+                    messageParameters={
                         "arg_name": "truncate",
                         "arg_type": type(truncate).__name__,
                     },
@@ -361,13 +361,13 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def withWatermark(self, eventTime: str, delayThreshold: str) -> ParentDataFrame:
         if not eventTime or type(eventTime) is not str:
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "eventTime", "arg_type": type(eventTime).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "eventTime", "arg_type": type(eventTime).__name__},
             )
         if not delayThreshold or type(delayThreshold) is not str:
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={
+                errorClass="NOT_STR",
+                messageParameters={
                     "arg_name": "delayThreshold",
                     "arg_type": type(delayThreshold).__name__,
                 },
@@ -383,8 +383,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
 
         if not isinstance(name, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "name", "arg_type": type(name).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "name", "arg_type": type(name).__name__},
             )
 
         allowed_types = (str, float, int, Column, list)
@@ -396,8 +396,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         for p in parameters:
             if not isinstance(p, allowed_types):
                 raise PySparkTypeError(
-                    error_class="DISALLOWED_TYPE_FOR_CONTAINER",
-                    message_parameters={
+                    errorClass="DISALLOWED_TYPE_FOR_CONTAINER",
+                    messageParameters={
                         "arg_name": "parameters",
                         "arg_type": type(parameters).__name__,
                         "allowed_types": allowed_types_repr,
@@ -407,8 +407,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             if isinstance(p, list):
                 if not all(isinstance(e, allowed_primitive_types) for e in p):
                     raise PySparkTypeError(
-                        error_class="DISALLOWED_TYPE_FOR_CONTAINER",
-                        message_parameters={
+                        errorClass="DISALLOWED_TYPE_FOR_CONTAINER",
+                        messageParameters={
                             "arg_name": "parameters",
                             "arg_type": type(parameters).__name__,
                             "allowed_types": allowed_types_repr,
@@ -532,8 +532,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             return DataFrame(self._jdf.repartition(self._jcols(*cols)), self.sparkSession)
         else:
             raise PySparkTypeError(
-                error_class="NOT_COLUMN_OR_STR",
-                message_parameters={
+                errorClass="NOT_COLUMN_OR_STR",
+                messageParameters={
                     "arg_name": "numPartitions",
                     "arg_type": type(numPartitions).__name__,
                 },
@@ -553,8 +553,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         if isinstance(numPartitions, int):
             if len(cols) == 0:
                 raise PySparkValueError(
-                    error_class="CANNOT_BE_EMPTY",
-                    message_parameters={"item": "partition-by expression"},
+                    errorClass="CANNOT_BE_EMPTY",
+                    messageParameters={"item": "partition-by expression"},
                 )
             else:
                 return DataFrame(
@@ -566,8 +566,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             return DataFrame(self._jdf.repartitionByRange(self._jcols(*cols)), self.sparkSession)
         else:
             raise PySparkTypeError(
-                error_class="NOT_COLUMN_OR_INT_OR_STR",
-                message_parameters={
+                errorClass="NOT_COLUMN_OR_INT_OR_STR",
+                messageParameters={
                     "arg_name": "numPartitions",
                     "arg_type": type(numPartitions).__name__,
                 },
@@ -616,8 +616,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         ):
             argtypes = [type(arg).__name__ for arg in [withReplacement, fraction, seed]]
             raise PySparkTypeError(
-                error_class="NOT_BOOL_OR_FLOAT_OR_INT",
-                message_parameters={
+                errorClass="NOT_BOOL_OR_FLOAT_OR_INT",
+                messageParameters={
                     "arg_name": "withReplacement (optional), "
                     + "fraction (required) and seed (optional)",
                     "arg_type": ", ".join(argtypes),
@@ -642,19 +642,19 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             col = Column(col)
         elif not isinstance(col, Column):
             raise PySparkTypeError(
-                error_class="NOT_COLUMN_OR_STR",
-                message_parameters={"arg_name": "col", "arg_type": type(col).__name__},
+                errorClass="NOT_COLUMN_OR_STR",
+                messageParameters={"arg_name": "col", "arg_type": type(col).__name__},
             )
         if not isinstance(fractions, dict):
             raise PySparkTypeError(
-                error_class="NOT_DICT",
-                message_parameters={"arg_name": "fractions", "arg_type": type(fractions).__name__},
+                errorClass="NOT_DICT",
+                messageParameters={"arg_name": "fractions", "arg_type": type(fractions).__name__},
             )
         for k, v in fractions.items():
             if not isinstance(k, (float, int, str)):
                 raise PySparkTypeError(
-                    error_class="DISALLOWED_TYPE_FOR_CONTAINER",
-                    message_parameters={
+                    errorClass="DISALLOWED_TYPE_FOR_CONTAINER",
+                    messageParameters={
                         "arg_name": "fractions",
                         "arg_type": type(fractions).__name__,
                         "allowed_types": "float, int, str",
@@ -674,8 +674,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         for w in weights:
             if w < 0.0:
                 raise PySparkValueError(
-                    error_class="VALUE_NOT_POSITIVE",
-                    message_parameters={"arg_name": "weights", "arg_value": str(w)},
+                    errorClass="VALUE_NOT_POSITIVE",
+                    messageParameters={"arg_name": "weights", "arg_value": str(w)},
                 )
         seed = seed if seed is not None else random.randint(0, sys.maxsize)
         df_array = self._jdf.randomSplit(
@@ -694,8 +694,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def colRegex(self, colName: str) -> Column:
         if not isinstance(colName, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "colName", "arg_type": type(colName).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "colName", "arg_type": type(colName).__name__},
             )
         jc = self._jdf.colRegex(colName)
         return Column(jc)
@@ -915,7 +915,7 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             if isinstance(c, int) and not isinstance(c, bool):
                 if c < 1:
                     raise PySparkIndexError(
-                        error_class="INDEX_NOT_POSITIVE", message_parameters={"index": str(c)}
+                        errorClass="INDEX_NOT_POSITIVE", messageParameters={"index": str(c)}
                     )
                 # ordinal is 1-based
                 _cols.append(self[c - 1])
@@ -931,8 +931,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         """Return a JVM Seq of Columns that describes the sort order"""
         if not cols:
             raise PySparkValueError(
-                error_class="CANNOT_BE_EMPTY",
-                message_parameters={"item": "column"},
+                errorClass="CANNOT_BE_EMPTY",
+                messageParameters={"item": "column"},
             )
         if len(cols) == 1 and isinstance(cols[0], list):
             cols = cols[0]
@@ -948,8 +948,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
                     _c = self[-c - 1].desc()
                 else:
                     raise PySparkIndexError(
-                        error_class="ZERO_INDEX",
-                        message_parameters={},
+                        errorClass="ZERO_INDEX",
+                        messageParameters={},
                     )
             else:
                 _c = c  # type: ignore[assignment]
@@ -963,8 +963,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             jcols = [jc if asc else jc.desc() for asc, jc in zip(ascending, jcols)]
         else:
             raise PySparkTypeError(
-                error_class="NOT_BOOL_OR_LIST",
-                message_parameters={"arg_name": "ascending", "arg_type": type(ascending).__name__},
+                errorClass="NOT_BOOL_OR_LIST",
+                messageParameters={"arg_name": "ascending", "arg_type": type(ascending).__name__},
             )
         return self._jseq(jcols)
 
@@ -1020,14 +1020,14 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             return Column(jc)
         else:
             raise PySparkTypeError(
-                error_class="NOT_COLUMN_OR_FLOAT_OR_INT_OR_LIST_OR_STR",
-                message_parameters={"arg_name": "item", "arg_type": type(item).__name__},
+                errorClass="NOT_COLUMN_OR_FLOAT_OR_INT_OR_LIST_OR_STR",
+                messageParameters={"arg_name": "item", "arg_type": type(item).__name__},
             )
 
     def __getattr__(self, name: str) -> Column:
         if name not in self.columns:
             raise PySparkAttributeError(
-                error_class="ATTRIBUTE_NOT_SUPPORTED", message_parameters={"attr_name": name}
+                errorClass="ATTRIBUTE_NOT_SUPPORTED", messageParameters={"attr_name": name}
             )
         jc = self._jdf.apply(name)
         return Column(jc)
@@ -1070,8 +1070,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             jdf = self._jdf.filter(condition._jc)
         else:
             raise PySparkTypeError(
-                error_class="NOT_COLUMN_OR_STR",
-                message_parameters={"arg_name": "condition", "arg_type": type(condition).__name__},
+                errorClass="NOT_COLUMN_OR_STR",
+                messageParameters={"arg_name": "condition", "arg_type": type(condition).__name__},
             )
         return DataFrame(jdf, self.sparkSession)
 
@@ -1175,13 +1175,13 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
 
         if len(exprs) == 0:
             raise PySparkValueError(
-                error_class="CANNOT_BE_EMPTY",
-                message_parameters={"item": "exprs"},
+                errorClass="CANNOT_BE_EMPTY",
+                messageParameters={"item": "exprs"},
             )
         if not all(isinstance(c, Column) for c in exprs):
             raise PySparkTypeError(
-                error_class="NOT_LIST_OF_COLUMN",
-                message_parameters={"arg_name": "exprs"},
+                errorClass="NOT_LIST_OF_COLUMN",
+                messageParameters={"arg_name": "exprs"},
             )
 
         if isinstance(observation, Observation):
@@ -1195,8 +1195,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             )
         else:
             raise PySparkTypeError(
-                error_class="NOT_LIST_OF_COLUMN",
-                message_parameters={
+                errorClass="NOT_LIST_OF_COLUMN",
+                messageParameters={
                     "arg_name": "observation",
                     "arg_type": type(observation).__name__,
                 },
@@ -1262,8 +1262,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     ) -> ParentDataFrame:
         if how is not None and how not in ["any", "all"]:
             raise PySparkValueError(
-                error_class="VALUE_NOT_ANY_OR_ALL",
-                message_parameters={"arg_name": "how", "arg_type": how},
+                errorClass="VALUE_NOT_ANY_OR_ALL",
+                messageParameters={"arg_name": "how", "arg_type": how},
             )
 
         if subset is None:
@@ -1272,8 +1272,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             subset = [subset]
         elif not isinstance(subset, (list, tuple)):
             raise PySparkTypeError(
-                error_class="NOT_LIST_OR_STR_OR_TUPLE",
-                message_parameters={"arg_name": "subset", "arg_type": type(subset).__name__},
+                errorClass="NOT_LIST_OR_STR_OR_TUPLE",
+                messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
             )
 
         if thresh is None:
@@ -1300,8 +1300,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     ) -> ParentDataFrame:
         if not isinstance(value, (float, int, str, bool, dict)):
             raise PySparkTypeError(
-                error_class="NOT_BOOL_OR_DICT_OR_FLOAT_OR_INT_OR_STR",
-                message_parameters={"arg_name": "value", "arg_type": type(value).__name__},
+                errorClass="NOT_BOOL_OR_DICT_OR_FLOAT_OR_INT_OR_STR",
+                messageParameters={"arg_name": "value", "arg_type": type(value).__name__},
             )
 
         # Note that bool validates isinstance(int), but we don't want to
@@ -1319,8 +1319,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
                 subset = [subset]
             elif not isinstance(subset, (list, tuple)):
                 raise PySparkTypeError(
-                    error_class="NOT_LIST_OR_TUPLE",
-                    message_parameters={"arg_name": "subset", "arg_type": type(subset).__name__},
+                    errorClass="NOT_LIST_OR_TUPLE",
+                    messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
                 )
 
             return DataFrame(self._jdf.na().fill(value, self._jseq(subset)), self.sparkSession)
@@ -1375,8 +1375,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
                 value = None
             else:
                 raise PySparkTypeError(
-                    error_class="ARGUMENT_REQUIRED",
-                    message_parameters={"arg_name": "value", "condition": "`to_replace` is dict"},
+                    errorClass="ARGUMENT_REQUIRED",
+                    messageParameters={"arg_name": "value", "condition": "`to_replace` is dict"},
                 )
 
         # Helper functions
@@ -1403,8 +1403,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         valid_types = (bool, float, int, str, list, tuple)
         if not isinstance(to_replace, valid_types + (dict,)):
             raise PySparkTypeError(
-                error_class="NOT_BOOL_OR_DICT_OR_FLOAT_OR_INT_OR_LIST_OR_STR_OR_TUPLE",
-                message_parameters={
+                errorClass="NOT_BOOL_OR_DICT_OR_FLOAT_OR_INT_OR_LIST_OR_STR_OR_TUPLE",
+                messageParameters={
                     "arg_name": "to_replace",
                     "arg_type": type(to_replace).__name__,
                 },
@@ -1416,8 +1416,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             and not isinstance(to_replace, dict)
         ):
             raise PySparkTypeError(
-                error_class="NOT_BOOL_OR_FLOAT_OR_INT_OR_LIST_OR_NONE_OR_STR_OR_TUPLE",
-                message_parameters={
+                errorClass="NOT_BOOL_OR_FLOAT_OR_INT_OR_LIST_OR_NONE_OR_STR_OR_TUPLE",
+                messageParameters={
                     "arg_name": "value",
                     "arg_type": type(value).__name__,
                 },
@@ -1426,8 +1426,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         if isinstance(to_replace, (list, tuple)) and isinstance(value, (list, tuple)):
             if len(to_replace) != len(value):
                 raise PySparkValueError(
-                    error_class="LENGTH_SHOULD_BE_THE_SAME",
-                    message_parameters={
+                    errorClass="LENGTH_SHOULD_BE_THE_SAME",
+                    messageParameters={
                         "arg1": "to_replace",
                         "arg2": "value",
                         "arg1_length": str(len(to_replace)),
@@ -1437,8 +1437,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
 
         if not (subset is None or isinstance(subset, (list, tuple, str))):
             raise PySparkTypeError(
-                error_class="NOT_LIST_OR_STR_OR_TUPLE",
-                message_parameters={"arg_name": "subset", "arg_type": type(subset).__name__},
+                errorClass="NOT_LIST_OR_STR_OR_TUPLE",
+                messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
             )
 
         # Reshape input arguments if necessary
@@ -1464,8 +1464,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             for all_of_type in [all_of_bool, all_of_str, all_of_numeric]
         ):
             raise PySparkValueError(
-                error_class="MIXED_TYPE_REPLACEMENT",
-                message_parameters={},
+                errorClass="MIXED_TYPE_REPLACEMENT",
+                messageParameters={},
             )
 
         if subset is None:
@@ -1502,8 +1502,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     ) -> Union[List[float], List[List[float]]]:
         if not isinstance(col, (str, list, tuple)):
             raise PySparkTypeError(
-                error_class="NOT_LIST_OR_STR_OR_TUPLE",
-                message_parameters={"arg_name": "col", "arg_type": type(col).__name__},
+                errorClass="NOT_LIST_OR_STR_OR_TUPLE",
+                messageParameters={"arg_name": "col", "arg_type": type(col).__name__},
             )
 
         isStr = isinstance(col, str)
@@ -1516,8 +1516,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         for c in col:
             if not isinstance(c, str):
                 raise PySparkTypeError(
-                    error_class="DISALLOWED_TYPE_FOR_CONTAINER",
-                    message_parameters={
+                    errorClass="DISALLOWED_TYPE_FOR_CONTAINER",
+                    messageParameters={
                         "arg_name": "col",
                         "arg_type": type(col).__name__,
                         "allowed_types": "str",
@@ -1528,8 +1528,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
 
         if not isinstance(probabilities, (list, tuple)):
             raise PySparkTypeError(
-                error_class="NOT_LIST_OR_TUPLE",
-                message_parameters={
+                errorClass="NOT_LIST_OR_TUPLE",
+                messageParameters={
                     "arg_name": "probabilities",
                     "arg_type": type(probabilities).__name__,
                 },
@@ -1539,8 +1539,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         for p in probabilities:
             if not isinstance(p, (float, int)) or p < 0 or p > 1:
                 raise PySparkTypeError(
-                    error_class="NOT_LIST_OF_FLOAT_OR_INT",
-                    message_parameters={
+                    errorClass="NOT_LIST_OF_FLOAT_OR_INT",
+                    messageParameters={
                         "arg_name": "probabilities",
                         "arg_type": type(p).__name__,
                     },
@@ -1549,16 +1549,16 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
 
         if not isinstance(relativeError, (float, int)):
             raise PySparkTypeError(
-                error_class="NOT_FLOAT_OR_INT",
-                message_parameters={
+                errorClass="NOT_FLOAT_OR_INT",
+                messageParameters={
                     "arg_name": "relativeError",
                     "arg_type": type(relativeError).__name__,
                 },
             )
         if relativeError < 0:
             raise PySparkValueError(
-                error_class="NEGATIVE_VALUE",
-                message_parameters={
+                errorClass="NEGATIVE_VALUE",
+                messageParameters={
                     "arg_name": "relativeError",
                     "arg_value": str(relativeError),
                 },
@@ -1572,46 +1572,46 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def corr(self, col1: str, col2: str, method: Optional[str] = None) -> float:
         if not isinstance(col1, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "col1", "arg_type": type(col1).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "col1", "arg_type": type(col1).__name__},
             )
         if not isinstance(col2, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "col2", "arg_type": type(col2).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "col2", "arg_type": type(col2).__name__},
             )
         if not method:
             method = "pearson"
         if not method == "pearson":
             raise PySparkValueError(
-                error_class="VALUE_NOT_PEARSON",
-                message_parameters={"arg_name": "method", "arg_value": method},
+                errorClass="VALUE_NOT_PEARSON",
+                messageParameters={"arg_name": "method", "arg_value": method},
             )
         return self._jdf.stat().corr(col1, col2, method)
 
     def cov(self, col1: str, col2: str) -> float:
         if not isinstance(col1, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "col1", "arg_type": type(col1).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "col1", "arg_type": type(col1).__name__},
             )
         if not isinstance(col2, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "col2", "arg_type": type(col2).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "col2", "arg_type": type(col2).__name__},
             )
         return self._jdf.stat().cov(col1, col2)
 
     def crosstab(self, col1: str, col2: str) -> ParentDataFrame:
         if not isinstance(col1, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "col1", "arg_type": type(col1).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "col1", "arg_type": type(col1).__name__},
             )
         if not isinstance(col2, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "col2", "arg_type": type(col2).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "col2", "arg_type": type(col2).__name__},
             )
         return DataFrame(self._jdf.stat().crosstab(col1, col2), self.sparkSession)
 
@@ -1622,8 +1622,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             cols = list(cols)
         if not isinstance(cols, list):
             raise PySparkTypeError(
-                error_class="NOT_LIST_OR_TUPLE",
-                message_parameters={"arg_name": "cols", "arg_type": type(cols).__name__},
+                errorClass="NOT_LIST_OR_TUPLE",
+                messageParameters={"arg_name": "cols", "arg_type": type(cols).__name__},
             )
         if not support:
             support = 0.01
@@ -1654,8 +1654,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
 
         if not isinstance(colsMap, dict):
             raise PySparkTypeError(
-                error_class="NOT_DICT",
-                message_parameters={"arg_name": "colsMap", "arg_type": type(colsMap).__name__},
+                errorClass="NOT_DICT",
+                messageParameters={"arg_name": "colsMap", "arg_type": type(colsMap).__name__},
             )
 
         col_names = list(colsMap.keys())
@@ -1669,8 +1669,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def withColumn(self, colName: str, col: Column) -> ParentDataFrame:
         if not isinstance(col, Column):
             raise PySparkTypeError(
-                error_class="NOT_COLUMN",
-                message_parameters={"arg_name": "col", "arg_type": type(col).__name__},
+                errorClass="NOT_COLUMN",
+                messageParameters={"arg_name": "col", "arg_type": type(col).__name__},
             )
         return DataFrame(self._jdf.withColumn(colName, col._jc), self.sparkSession)
 
@@ -1680,8 +1680,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def withColumnsRenamed(self, colsMap: Dict[str, str]) -> ParentDataFrame:
         if not isinstance(colsMap, dict):
             raise PySparkTypeError(
-                error_class="NOT_DICT",
-                message_parameters={"arg_name": "colsMap", "arg_type": type(colsMap).__name__},
+                errorClass="NOT_DICT",
+                messageParameters={"arg_name": "colsMap", "arg_type": type(colsMap).__name__},
             )
 
         col_names: List[str] = []
@@ -1702,8 +1702,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
 
         if not isinstance(metadata, dict):
             raise PySparkTypeError(
-                error_class="NOT_DICT",
-                message_parameters={"arg_name": "metadata", "arg_type": type(metadata).__name__},
+                errorClass="NOT_DICT",
+                messageParameters={"arg_name": "metadata", "arg_type": type(metadata).__name__},
             )
         sc = get_active_spark_context()
         jmeta = cast(JVMView, sc._jvm).org.apache.spark.sql.types.Metadata.fromJson(
@@ -1730,8 +1730,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
                 java_columns.append(c._jc)
             else:
                 raise PySparkTypeError(
-                    error_class="NOT_COLUMN_OR_STR",
-                    message_parameters={"arg_name": "col", "arg_type": type(c).__name__},
+                    errorClass="NOT_COLUMN_OR_STR",
+                    messageParameters={"arg_name": "col", "arg_type": type(c).__name__},
                 )
 
         jdf = self._jdf
@@ -1747,8 +1747,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         for col in cols:
             if not isinstance(col, str):
                 raise PySparkTypeError(
-                    error_class="NOT_LIST_OF_STR",
-                    message_parameters={"arg_name": "cols", "arg_type": type(col).__name__},
+                    errorClass="NOT_LIST_OF_STR",
+                    messageParameters={"arg_name": "cols", "arg_type": type(col).__name__},
                 )
         jdf = self._jdf.toDF(self._jseq(cols))
         return DataFrame(jdf, self.sparkSession)
@@ -1765,8 +1765,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def sameSemantics(self, other: ParentDataFrame) -> bool:
         if not isinstance(other, DataFrame):
             raise PySparkTypeError(
-                error_class="NOT_DATAFRAME",
-                message_parameters={"arg_name": "other", "arg_type": type(other).__name__},
+                errorClass="NOT_DATAFRAME",
+                messageParameters={"arg_name": "other", "arg_type": type(other).__name__},
             )
         return self._jdf.sameSemantics(other._jdf)
 
@@ -1843,8 +1843,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     @property
     def executionInfo(self) -> Optional["ExecutionInfo"]:
         raise PySparkValueError(
-            error_class="CLASSIC_OPERATION_NOT_SUPPORTED_ON_DF",
-            message_parameters={"member": "queryExecution"},
+            errorClass="CLASSIC_OPERATION_NOT_SUPPORTED_ON_DF",
+            messageParameters={"member": "queryExecution"},
         )
 
 

--- a/python/pyspark/sql/column.py
+++ b/python/pyspark/sql/column.py
@@ -315,8 +315,8 @@ class Column:
     @dispatch_col_method
     def __contains__(self, item: Any) -> None:
         raise PySparkValueError(
-            error_class="CANNOT_APPLY_IN_FOR_COLUMN",
-            message_parameters={},
+            errorClass="CANNOT_APPLY_IN_FOR_COLUMN",
+            messageParameters={},
         )
 
     # bitwise operators

--- a/python/pyspark/sql/conf.py
+++ b/python/pyspark/sql/conf.py
@@ -136,8 +136,8 @@ class RuntimeConfig:
         """Assert that an object is of type str."""
         if not isinstance(obj, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={
+                errorClass="NOT_STR",
+                messageParameters={
                     "arg_name": identifier,
                     "arg_type": type(obj).__name__,
                 },

--- a/python/pyspark/sql/connect/avro/functions.py
+++ b/python/pyspark/sql/connect/avro/functions.py
@@ -39,21 +39,21 @@ def from_avro(
 ) -> Column:
     if not isinstance(data, (Column, str)):
         raise PySparkTypeError(
-            error_class="INVALID_TYPE",
-            message_parameters={
+            errorClass="INVALID_TYPE",
+            messageParameters={
                 "arg_name": "data",
                 "arg_type": "pyspark.sql.Column or str",
             },
         )
     if not isinstance(jsonFormatSchema, str):
         raise PySparkTypeError(
-            error_class="INVALID_TYPE",
-            message_parameters={"arg_name": "jsonFormatSchema", "arg_type": "str"},
+            errorClass="INVALID_TYPE",
+            messageParameters={"arg_name": "jsonFormatSchema", "arg_type": "str"},
         )
     if options is not None and not isinstance(options, dict):
         raise PySparkTypeError(
-            error_class="INVALID_TYPE",
-            message_parameters={"arg_name": "options", "arg_type": "dict, optional"},
+            errorClass="INVALID_TYPE",
+            messageParameters={"arg_name": "options", "arg_type": "dict, optional"},
         )
 
     if options is None:
@@ -70,16 +70,16 @@ from_avro.__doc__ = PyAvroFunctions.from_avro.__doc__
 def to_avro(data: "ColumnOrName", jsonFormatSchema: str = "") -> Column:
     if not isinstance(data, (Column, str)):
         raise PySparkTypeError(
-            error_class="INVALID_TYPE",
-            message_parameters={
+            errorClass="INVALID_TYPE",
+            messageParameters={
                 "arg_name": "data",
                 "arg_type": "pyspark.sql.Column or str",
             },
         )
     if not isinstance(jsonFormatSchema, str):
         raise PySparkTypeError(
-            error_class="INVALID_TYPE",
-            message_parameters={"arg_name": "jsonFormatSchema", "arg_type": "str"},
+            errorClass="INVALID_TYPE",
+            messageParameters={"arg_name": "jsonFormatSchema", "arg_type": "str"},
         )
 
     if jsonFormatSchema == "":

--- a/python/pyspark/sql/connect/catalog.py
+++ b/python/pyspark/sql/connect/catalog.py
@@ -253,8 +253,8 @@ class Catalog:
     ) -> DataFrame:
         if schema is not None and not isinstance(schema, StructType):
             raise PySparkTypeError(
-                error_class="NOT_STRUCT",
-                message_parameters={
+                errorClass="NOT_STRUCT",
+                messageParameters={
                     "arg_name": "schema",
                     "arg_type": type(schema).__name__,
                 },

--- a/python/pyspark/sql/connect/client/artifact.py
+++ b/python/pyspark/sql/connect/client/artifact.py
@@ -114,8 +114,8 @@ class Artifact:
             return self.storage.size
         else:
             raise PySparkRuntimeError(
-                error_class="UNSUPPORTED_OPERATION",
-                message_parameters={"operation": f"{self.storage} storage"},
+                errorClass="UNSUPPORTED_OPERATION",
+                messageParameters={"operation": f"{self.storage} storage"},
             )
 
 
@@ -219,8 +219,8 @@ class ArtifactManager:
                     # This has a limitation - hash(#) in the file name would not work.
                     if "#" in local_path:
                         raise PySparkValueError(
-                            error_class="VALUE_ALLOWED",
-                            message_parameters={
+                            errorClass="VALUE_ALLOWED",
+                            messageParameters={
                                 "arg_name": "artifact path",
                                 "disallowed_value": "#",
                             },
@@ -234,13 +234,13 @@ class ArtifactManager:
                 artifact = new_jar_artifact(name, LocalFile(local_path))
             else:
                 raise PySparkRuntimeError(
-                    error_class="UNSUPPORTED_OPERATION",
-                    message_parameters={"operation": f"{local_path} file format"},
+                    errorClass="UNSUPPORTED_OPERATION",
+                    messageParameters={"operation": f"{local_path} file format"},
                 )
             return [artifact]
         raise PySparkRuntimeError(
-            error_class="UNSUPPORTED_OPERATION",
-            message_parameters={"operation": f"{parsed.scheme} scheme"},
+            errorClass="UNSUPPORTED_OPERATION",
+            messageParameters={"operation": f"{parsed.scheme} scheme"},
         )
 
     def _parse_forward_to_fs_artifacts(self, local_path: str, dest_path: str) -> List[Artifact]:

--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -254,8 +254,8 @@ class ChannelBuilder:
                 uuid.UUID(session_id, version=4)
             except ValueError as ve:
                 raise PySparkValueError(
-                    error_class="INVALID_SESSION_UUID_ID",
-                    message_parameters={"arg_name": "session_id", "origin": str(ve)},
+                    errorClass="INVALID_SESSION_UUID_ID",
+                    messageParameters={"arg_name": "session_id", "origin": str(ve)},
                 )
         return session_id
 
@@ -352,8 +352,8 @@ class DefaultChannelBuilder(ChannelBuilder):
         # Explicitly check the scheme of the URL.
         if url[:5] != "sc://":
             raise PySparkValueError(
-                error_class="INVALID_CONNECT_URL",
-                message_parameters={
+                errorClass="INVALID_CONNECT_URL",
+                messageParameters={
                     "detail": "The URL must start with 'sc://'. Please update the URL to "
                     "follow the correct format, e.g., 'sc://hostname:port'.",
                 },
@@ -364,8 +364,8 @@ class DefaultChannelBuilder(ChannelBuilder):
         self.url = urllib.parse.urlparse(tmp_url)
         if len(self.url.path) > 0 and self.url.path != "/":
             raise PySparkValueError(
-                error_class="INVALID_CONNECT_URL",
-                message_parameters={
+                errorClass="INVALID_CONNECT_URL",
+                messageParameters={
                     "detail": f"The path component '{self.url.path}' must be empty. Please update "
                     f"the URL to follow the correct format, e.g., 'sc://hostname:port'.",
                 },
@@ -379,8 +379,8 @@ class DefaultChannelBuilder(ChannelBuilder):
                 kv = p.split("=")
                 if len(kv) != 2:
                     raise PySparkValueError(
-                        error_class="INVALID_CONNECT_URL",
-                        message_parameters={
+                        errorClass="INVALID_CONNECT_URL",
+                        messageParameters={
                             "detail": f"Parameter '{p}' should be provided as a "
                             f"key-value pair separated by an equal sign (=). Please update "
                             f"the parameter to follow the correct format, e.g., 'key=value'.",
@@ -397,8 +397,8 @@ class DefaultChannelBuilder(ChannelBuilder):
             self._port = int(netloc[1])
         else:
             raise PySparkValueError(
-                error_class="INVALID_CONNECT_URL",
-                message_parameters={
+                errorClass="INVALID_CONNECT_URL",
+                messageParameters={
                     "detail": f"Target destination '{self.url.netloc}' should match the "
                     f"'<host>:<port>' pattern. Please update the destination to follow "
                     f"the correct format, e.g., 'hostname:port'.",
@@ -1059,8 +1059,8 @@ class SparkConnectClient(object):
                 yield response
             else:
                 raise PySparkValueError(
-                    error_class="UNKNOWN_RESPONSE",
-                    message_parameters={
+                    errorClass="UNKNOWN_RESPONSE",
+                    messageParameters={
                         "response": str(response),
                     },
                 )
@@ -1149,8 +1149,8 @@ class SparkConnectClient(object):
             explain_mode = kwargs.get("explain_mode")
             if explain_mode not in ["simple", "extended", "codegen", "cost", "formatted"]:
                 raise PySparkValueError(
-                    error_class="UNKNOWN_EXPLAIN_MODE",
-                    message_parameters={
+                    errorClass="UNKNOWN_EXPLAIN_MODE",
+                    messageParameters={
                         "explain_mode": str(explain_mode),
                     },
                 )
@@ -1207,8 +1207,8 @@ class SparkConnectClient(object):
             req.get_storage_level.relation.CopyFrom(cast(pb2.Relation, kwargs.get("relation")))
         else:
             raise PySparkValueError(
-                error_class="UNSUPPORTED_OPERATION",
-                message_parameters={
+                errorClass="UNSUPPORTED_OPERATION",
+                messageParameters={
                     "operation": method,
                 },
             )
@@ -1441,8 +1441,8 @@ class SparkConnectClient(object):
                     properties.update(**response)
                 else:
                     raise PySparkValueError(
-                        error_class="UNKNOWN_RESPONSE",
-                        message_parameters={
+                        errorClass="UNKNOWN_RESPONSE",
+                        messageParameters={
                             "response": response,
                         },
                     )
@@ -1546,8 +1546,8 @@ class SparkConnectClient(object):
             req.operation_id = id_or_tag
         else:
             raise PySparkValueError(
-                error_class="UNKNOWN_INTERRUPT_TYPE",
-                message_parameters={
+                errorClass="UNKNOWN_INTERRUPT_TYPE",
+                messageParameters={
                     "interrupt_type": str(interrupt_type),
                 },
             )
@@ -1635,20 +1635,20 @@ class SparkConnectClient(object):
         spark_job_tags_sep = ","
         if tag is None:
             raise PySparkValueError(
-                error_class="CANNOT_BE_NONE", message_paramters={"arg_name": "Spark Connect tag"}
+                errorClass="CANNOT_BE_NONE", message_paramters={"arg_name": "Spark Connect tag"}
             )
         if spark_job_tags_sep in tag:
             raise PySparkValueError(
-                error_class="VALUE_ALLOWED",
-                message_parameters={
+                errorClass="VALUE_ALLOWED",
+                messageParameters={
                     "arg_name": "Spark Connect tag",
                     "disallowed_value": spark_job_tags_sep,
                 },
             )
         if len(tag) == 0:
             raise PySparkValueError(
-                error_class="VALUE_NOT_NON_EMPTY_STR",
-                message_parameters={"arg_name": "Spark Connect tag", "arg_value": tag},
+                errorClass="VALUE_NOT_NON_EMPTY_STR",
+                messageParameters={"arg_name": "Spark Connect tag", "arg_value": tag},
             )
 
     def _handle_error(self, error: Exception) -> NoReturn:
@@ -1677,7 +1677,7 @@ class SparkConnectClient(object):
             elif isinstance(error, ValueError):
                 if "Cannot invoke RPC" in str(error) and "closed" in str(error):
                     raise SparkConnectException(
-                        error_class="NO_ACTIVE_SESSION", message_parameters=dict()
+                        errorClass="NO_ACTIVE_SESSION", messageParameters=dict()
                     ) from None
             raise error
         finally:

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -266,8 +266,8 @@ class ExecutePlanResponseReattachableIterator(Generator):
             ):
                 if self._last_returned_response_id is not None:
                     raise PySparkRuntimeError(
-                        error_class="RESPONSE_ALREADY_RECEIVED",
-                        message_parameters={},
+                        errorClass="RESPONSE_ALREADY_RECEIVED",
+                        messageParameters={},
                     )
                 # Try a new ExecutePlan, and throw upstream for retry.
                 self._iterator = iter(

--- a/python/pyspark/sql/connect/client/retries.py
+++ b/python/pyspark/sql/connect/client/retries.py
@@ -203,8 +203,8 @@ class Retrying:
     def _last_exception(self) -> BaseException:
         if self._exception is None:
             raise PySparkRuntimeError(
-                error_class="NO_ACTIVE_EXCEPTION",
-                message_parameters={},
+                errorClass="NO_ACTIVE_EXCEPTION",
+                messageParameters={},
             )
         return self._exception
 
@@ -233,7 +233,7 @@ class Retrying:
 
         # Exceeded retries
         logger.debug(f"Given up on retrying. error: {repr(exception)}")
-        raise RetriesExceeded(error_class="RETRIES_EXCEEDED", message_parameters={}) from exception
+        raise RetriesExceeded(errorClass="RETRIES_EXCEEDED", messageParameters={}) from exception
 
     def __iter__(self) -> Generator[AttemptManager, None, None]:
         """

--- a/python/pyspark/sql/connect/column.py
+++ b/python/pyspark/sql/connect/column.py
@@ -113,8 +113,8 @@ class Column(ParentColumn):
     def __init__(self, expr: "Expression") -> None:
         if not isinstance(expr, Expression):
             raise PySparkTypeError(
-                error_class="NOT_EXPRESSION",
-                message_parameters={"arg_name": "expr", "arg_type": type(expr).__name__},
+                errorClass="NOT_EXPRESSION",
+                messageParameters={"arg_name": "expr", "arg_type": type(expr).__name__},
             )
         self._expr = expr
 
@@ -244,8 +244,8 @@ class Column(ParentColumn):
     # container operators
     def __contains__(self, item: Any) -> None:
         raise PySparkValueError(
-            error_class="CANNOT_APPLY_IN_FOR_COLUMN",
-            message_parameters={},
+            errorClass="CANNOT_APPLY_IN_FOR_COLUMN",
+            messageParameters={},
         )
 
     # bitwise operators
@@ -298,20 +298,20 @@ class Column(ParentColumn):
     def when(self, condition: ParentColumn, value: Any) -> ParentColumn:
         if not isinstance(condition, Column):
             raise PySparkTypeError(
-                error_class="NOT_COLUMN",
-                message_parameters={"arg_name": "condition", "arg_type": type(condition).__name__},
+                errorClass="NOT_COLUMN",
+                messageParameters={"arg_name": "condition", "arg_type": type(condition).__name__},
             )
 
         if not isinstance(self._expr, CaseWhen):
             raise PySparkTypeError(
-                error_class="INVALID_WHEN_USAGE",
-                message_parameters={},
+                errorClass="INVALID_WHEN_USAGE",
+                messageParameters={},
             )
 
         if self._expr._else_value is not None:
             raise PySparkTypeError(
-                error_class="INVALID_WHEN_USAGE",
-                message_parameters={},
+                errorClass="INVALID_WHEN_USAGE",
+                messageParameters={},
             )
 
         return Column(
@@ -353,8 +353,8 @@ class Column(ParentColumn):
     ) -> ParentColumn:
         if type(startPos) != type(length):
             raise PySparkTypeError(
-                error_class="NOT_SAME_TYPE",
-                message_parameters={
+                errorClass="NOT_SAME_TYPE",
+                messageParameters={
                     "arg_name1": "startPos",
                     "arg_name2": "length",
                     "arg_type1": type(startPos).__name__,
@@ -367,8 +367,8 @@ class Column(ParentColumn):
             start_expr = _to_expr(startPos)
         else:
             raise PySparkTypeError(
-                error_class="NOT_COLUMN_OR_INT",
-                message_parameters={"arg_name": "startPos", "arg_type": type(length).__name__},
+                errorClass="NOT_COLUMN_OR_INT",
+                messageParameters={"arg_name": "startPos", "arg_type": type(length).__name__},
             )
         return Column(UnresolvedFunction("substr", [self._expr, start_expr, length_expr]))
 
@@ -413,8 +413,8 @@ class Column(ParentColumn):
             return Column(CastExpression(expr=self._expr, data_type=dataType))
         else:
             raise PySparkTypeError(
-                error_class="NOT_DATATYPE_OR_STR",
-                message_parameters={"arg_name": "dataType", "arg_type": type(dataType).__name__},
+                errorClass="NOT_DATATYPE_OR_STR",
+                messageParameters={"arg_name": "dataType", "arg_type": type(dataType).__name__},
             )
 
     astype = cast
@@ -430,8 +430,8 @@ class Column(ParentColumn):
             )
         else:
             raise PySparkTypeError(
-                error_class="NOT_DATATYPE_OR_STR",
-                message_parameters={"arg_name": "dataType", "arg_type": type(dataType).__name__},
+                errorClass="NOT_DATATYPE_OR_STR",
+                messageParameters={"arg_name": "dataType", "arg_type": type(dataType).__name__},
             )
 
     def __repr__(self) -> str:
@@ -442,8 +442,8 @@ class Column(ParentColumn):
 
         if not isinstance(window, WindowSpec):
             raise PySparkTypeError(
-                error_class="NOT_WINDOWSPEC",
-                message_parameters={"arg_name": "window", "arg_type": type(window).__name__},
+                errorClass="NOT_WINDOWSPEC",
+                messageParameters={"arg_name": "window", "arg_type": type(window).__name__},
             )
 
         return Column(WindowExpression(windowFunction=self._expr, windowSpec=window))
@@ -486,14 +486,14 @@ class Column(ParentColumn):
     def withField(self, fieldName: str, col: ParentColumn) -> ParentColumn:
         if not isinstance(fieldName, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "fieldName", "arg_type": type(fieldName).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "fieldName", "arg_type": type(fieldName).__name__},
             )
 
         if not isinstance(col, Column):
             raise PySparkTypeError(
-                error_class="NOT_COLUMN",
-                message_parameters={"arg_name": "col", "arg_type": type(col).__name__},
+                errorClass="NOT_COLUMN",
+                messageParameters={"arg_name": "col", "arg_type": type(col).__name__},
             )
 
         return Column(WithField(self._expr, fieldName, col._expr))
@@ -503,8 +503,8 @@ class Column(ParentColumn):
         for fieldName in fieldNames:
             if not isinstance(fieldName, str):
                 raise PySparkTypeError(
-                    error_class="NOT_STR",
-                    message_parameters={
+                    errorClass="NOT_STR",
+                    messageParameters={
                         "arg_name": "fieldName",
                         "arg_type": type(fieldName).__name__,
                     },
@@ -517,8 +517,8 @@ class Column(ParentColumn):
 
         if dropField is None:
             raise PySparkValueError(
-                error_class="CANNOT_BE_EMPTY",
-                message_parameters={
+                errorClass="CANNOT_BE_EMPTY",
+                messageParameters={
                     "item": "dropFields",
                 },
             )
@@ -528,11 +528,11 @@ class Column(ParentColumn):
     def __getattr__(self, item: Any) -> ParentColumn:
         if item == "_jc":
             raise PySparkAttributeError(
-                error_class="JVM_ATTRIBUTE_NOT_SUPPORTED", message_parameters={"attr_name": "_jc"}
+                errorClass="JVM_ATTRIBUTE_NOT_SUPPORTED", messageParameters={"attr_name": "_jc"}
             )
         if item.startswith("__"):
             raise PySparkAttributeError(
-                error_class="ATTRIBUTE_NOT_SUPPORTED", message_parameters={"attr_name": item}
+                errorClass="ATTRIBUTE_NOT_SUPPORTED", messageParameters={"attr_name": item}
             )
         return self[item]
 
@@ -540,8 +540,8 @@ class Column(ParentColumn):
         if isinstance(k, slice):
             if k.step is not None:
                 raise PySparkValueError(
-                    error_class="SLICE_WITH_STEP",
-                    message_parameters={},
+                    errorClass="SLICE_WITH_STEP",
+                    messageParameters={},
                 )
             return self.substr(k.start, k.stop)
         else:
@@ -549,14 +549,14 @@ class Column(ParentColumn):
 
     def __iter__(self) -> None:
         raise PySparkTypeError(
-            error_class="NOT_ITERABLE",
-            message_parameters={"objectName": "Column"},
+            errorClass="NOT_ITERABLE",
+            messageParameters={"objectName": "Column"},
         )
 
     def __nonzero__(self) -> None:
         raise PySparkValueError(
-            error_class="CANNOT_CONVERT_COLUMN_INTO_BOOL",
-            message_parameters={},
+            errorClass="CANNOT_CONVERT_COLUMN_INTO_BOOL",
+            messageParameters={},
         )
 
     __bool__ = __nonzero__

--- a/python/pyspark/sql/connect/conf.py
+++ b/python/pyspark/sql/connect/conf.py
@@ -100,8 +100,8 @@ class RuntimeConf:
             return False
         else:
             raise PySparkValueError(
-                error_class="VALUE_NOT_ALLOWED",
-                message_parameters={"arg_name": "result", "allowed_values": "'true' or 'false'"},
+                errorClass="VALUE_NOT_ALLOWED",
+                messageParameters={"arg_name": "result", "allowed_values": "'true' or 'false'"},
             )
 
     isModifiable.__doc__ = PySparkRuntimeConfig.isModifiable.__doc__
@@ -110,8 +110,8 @@ class RuntimeConf:
         """Assert that an object is of type str."""
         if not isinstance(obj, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={
+                errorClass="NOT_STR",
+                messageParameters={
                     "arg_name": identifier,
                     "arg_type": type(obj).__name__,
                 },

--- a/python/pyspark/sql/connect/conversion.py
+++ b/python/pyspark/sql/connect/conversion.py
@@ -155,8 +155,8 @@ class LocalDataToArrowConversion:
                     else:
                         if len(value) != len(field_names):
                             raise PySparkValueError(
-                                error_class="AXIS_LENGTH_MISMATCH",
-                                message_parameters={
+                                errorClass="AXIS_LENGTH_MISMATCH",
+                                messageParameters={
                                     "expected_length": str(len(field_names)),
                                     "actual_length": str(len(value)),
                                 },
@@ -306,7 +306,7 @@ class LocalDataToArrowConversion:
                 ):
                     return VariantVal(value["value"], value["metadata"])
                 else:
-                    raise PySparkValueError(error_class="MALFORMED_VARIANT")
+                    raise PySparkValueError(errorClass="MALFORMED_VARIANT")
 
             return convert_variant
 
@@ -352,8 +352,8 @@ class LocalDataToArrowConversion:
             else:
                 if len(item) != len(column_names):
                     raise PySparkValueError(
-                        error_class="AXIS_LENGTH_MISMATCH",
-                        message_parameters={
+                        errorClass="AXIS_LENGTH_MISMATCH",
+                        messageParameters={
                             "expected_length": str(len(column_names)),
                             "actual_length": str(len(item)),
                         },
@@ -522,7 +522,7 @@ class ArrowTableToRowsConversion:
                 ):
                     return VariantVal(value["value"], value["metadata"])
                 else:
-                    raise PySparkValueError(error_class="MALFORMED_VARIANT")
+                    raise PySparkValueError(errorClass="MALFORMED_VARIANT")
 
             return convert_variant
 

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -124,15 +124,15 @@ class DataFrame(ParentDataFrame):
         self._plan = plan
         if self._plan is None:
             raise PySparkRuntimeError(
-                error_class="MISSING_VALID_PLAN",
-                message_parameters={"operator": "__init__"},
+                errorClass="MISSING_VALID_PLAN",
+                messageParameters={"operator": "__init__"},
             )
 
         self._session: "SparkSession" = session  # type: ignore[assignment]
         if self._session is None:
             raise PySparkRuntimeError(
-                error_class="NO_ACTIVE_SESSION",
-                message_parameters={"operator": "__init__"},
+                errorClass="NO_ACTIVE_SESSION",
+                messageParameters={"operator": "__init__"},
             )
 
         # Check whether _repr_html is supported or not, we use it to avoid calling RPC twice
@@ -231,8 +231,8 @@ class DataFrame(ParentDataFrame):
             cols = cols[0]
         if any(not isinstance(c, (str, Column)) for c in cols):
             raise PySparkTypeError(
-                error_class="NOT_LIST_OF_COLUMN_OR_STR",
-                message_parameters={"arg_name": "columns"},
+                errorClass="NOT_LIST_OF_COLUMN_OR_STR",
+                messageParameters={"arg_name": "columns"},
             )
         return DataFrame(
             plan.Project(self._plan, [F._to_col(c) for c in cols]),
@@ -254,8 +254,8 @@ class DataFrame(ParentDataFrame):
     def agg(self, *exprs: Union[Column, Dict[str, str]]) -> ParentDataFrame:
         if not exprs:
             raise PySparkValueError(
-                error_class="CANNOT_BE_EMPTY",
-                message_parameters={"item": "exprs"},
+                errorClass="CANNOT_BE_EMPTY",
+                messageParameters={"item": "exprs"},
             )
 
         if len(exprs) == 1 and isinstance(exprs[0], dict):
@@ -277,8 +277,8 @@ class DataFrame(ParentDataFrame):
 
         if not isinstance(colName, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "colName", "arg_type": type(colName).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "colName", "arg_type": type(colName).__name__},
             )
         return ConnectColumn(UnresolvedRegex(colName, self._plan._plan_id))
 
@@ -312,15 +312,15 @@ class DataFrame(ParentDataFrame):
     def _check_same_session(self, other: ParentDataFrame) -> None:
         if self._session.session_id != other._session.session_id:  # type: ignore[attr-defined]
             raise SessionNotSameException(
-                error_class="SESSION_NOT_SAME",
-                message_parameters={},
+                errorClass="SESSION_NOT_SAME",
+                messageParameters={},
             )
 
     def coalesce(self, numPartitions: int) -> ParentDataFrame:
         if not numPartitions > 0:
             raise PySparkValueError(
-                error_class="VALUE_NOT_POSITIVE",
-                message_parameters={"arg_name": "numPartitions", "arg_value": str(numPartitions)},
+                errorClass="VALUE_NOT_POSITIVE",
+                messageParameters={"arg_name": "numPartitions", "arg_value": str(numPartitions)},
             )
         res = DataFrame(
             plan.Repartition(self._plan, num_partitions=numPartitions, shuffle=False),
@@ -343,8 +343,8 @@ class DataFrame(ParentDataFrame):
         if isinstance(numPartitions, int):
             if not numPartitions > 0:
                 raise PySparkValueError(
-                    error_class="VALUE_NOT_POSITIVE",
-                    message_parameters={
+                    errorClass="VALUE_NOT_POSITIVE",
+                    messageParameters={
                         "arg_name": "numPartitions",
                         "arg_value": str(numPartitions),
                     },
@@ -369,8 +369,8 @@ class DataFrame(ParentDataFrame):
             )
         else:
             raise PySparkTypeError(
-                error_class="NOT_COLUMN_OR_STR",
-                message_parameters={
+                errorClass="NOT_COLUMN_OR_STR",
+                messageParameters={
                     "arg_name": "numPartitions",
                     "arg_type": type(numPartitions).__name__,
                 },
@@ -393,16 +393,16 @@ class DataFrame(ParentDataFrame):
         if isinstance(numPartitions, int):
             if not numPartitions > 0:
                 raise PySparkValueError(
-                    error_class="VALUE_NOT_POSITIVE",
-                    message_parameters={
+                    errorClass="VALUE_NOT_POSITIVE",
+                    messageParameters={
                         "arg_name": "numPartitions",
                         "arg_value": str(numPartitions),
                     },
                 )
             if len(cols) == 0:
                 raise PySparkValueError(
-                    error_class="CANNOT_BE_EMPTY",
-                    message_parameters={"item": "cols"},
+                    errorClass="CANNOT_BE_EMPTY",
+                    messageParameters={"item": "cols"},
                 )
             else:
                 res = DataFrame(
@@ -420,8 +420,8 @@ class DataFrame(ParentDataFrame):
             )
         else:
             raise PySparkTypeError(
-                error_class="NOT_COLUMN_OR_INT_OR_STR",
-                message_parameters={
+                errorClass="NOT_COLUMN_OR_INT_OR_STR",
+                messageParameters={
                     "arg_name": "numPartitions",
                     "arg_type": type(numPartitions).__name__,
                 },
@@ -503,8 +503,8 @@ class DataFrame(ParentDataFrame):
         _cols = list(cols)
         if any(not isinstance(c, (str, Column)) for c in _cols):
             raise PySparkTypeError(
-                error_class="NOT_COLUMN_OR_STR",
-                message_parameters={"arg_name": "cols", "arg_type": type(cols).__name__},
+                errorClass="NOT_COLUMN_OR_STR",
+                messageParameters={"arg_name": "cols", "arg_type": type(cols).__name__},
             )
 
         return DataFrame(
@@ -548,14 +548,14 @@ class DataFrame(ParentDataFrame):
             elif isinstance(c, int) and not isinstance(c, bool):
                 if c < 1:
                     raise PySparkIndexError(
-                        error_class="INDEX_NOT_POSITIVE", message_parameters={"index": str(c)}
+                        errorClass="INDEX_NOT_POSITIVE", messageParameters={"index": str(c)}
                     )
                 # ordinal is 1-based
                 _cols.append(self[c - 1])
             else:
                 raise PySparkTypeError(
-                    error_class="NOT_COLUMN_OR_STR",
-                    message_parameters={"arg_name": "cols", "arg_type": type(c).__name__},
+                    errorClass="NOT_COLUMN_OR_STR",
+                    messageParameters={"arg_name": "cols", "arg_type": type(c).__name__},
                 )
 
         return GroupedData(df=self, group_type="groupby", grouping_cols=_cols)
@@ -580,14 +580,14 @@ class DataFrame(ParentDataFrame):
             elif isinstance(c, int) and not isinstance(c, bool):
                 if c < 1:
                     raise PySparkIndexError(
-                        error_class="INDEX_NOT_POSITIVE", message_parameters={"index": str(c)}
+                        errorClass="INDEX_NOT_POSITIVE", messageParameters={"index": str(c)}
                     )
                 # ordinal is 1-based
                 _cols.append(self[c - 1])
             else:
                 raise PySparkTypeError(
-                    error_class="NOT_COLUMN_OR_STR",
-                    message_parameters={"arg_name": "cols", "arg_type": type(c).__name__},
+                    errorClass="NOT_COLUMN_OR_STR",
+                    messageParameters={"arg_name": "cols", "arg_type": type(c).__name__},
                 )
 
         return GroupedData(df=self, group_type="rollup", grouping_cols=_cols)
@@ -610,14 +610,14 @@ class DataFrame(ParentDataFrame):
             elif isinstance(c, int) and not isinstance(c, bool):
                 if c < 1:
                     raise PySparkIndexError(
-                        error_class="INDEX_NOT_POSITIVE", message_parameters={"index": str(c)}
+                        errorClass="INDEX_NOT_POSITIVE", messageParameters={"index": str(c)}
                     )
                 # ordinal is 1-based
                 _cols.append(self[c - 1])
             else:
                 raise PySparkTypeError(
-                    error_class="NOT_COLUMN_OR_STR",
-                    message_parameters={"arg_name": "cols", "arg_type": type(c).__name__},
+                    errorClass="NOT_COLUMN_OR_STR",
+                    messageParameters={"arg_name": "cols", "arg_type": type(c).__name__},
                 )
 
         return GroupedData(df=self, group_type="cube", grouping_cols=_cols)
@@ -635,8 +635,8 @@ class DataFrame(ParentDataFrame):
                     gset.append(self[c])
                 else:
                     raise PySparkTypeError(
-                        error_class="NOT_COLUMN_OR_STR",
-                        message_parameters={
+                        errorClass="NOT_COLUMN_OR_STR",
+                        messageParameters={
                             "arg_name": "groupingSets",
                             "arg_type": type(c).__name__,
                         },
@@ -651,8 +651,8 @@ class DataFrame(ParentDataFrame):
                 gcols.append(self[c])
             else:
                 raise PySparkTypeError(
-                    error_class="NOT_COLUMN_OR_STR",
-                    message_parameters={"arg_name": "cols", "arg_type": type(c).__name__},
+                    errorClass="NOT_COLUMN_OR_STR",
+                    messageParameters={"arg_name": "cols", "arg_type": type(c).__name__},
                 )
 
         return GroupedData(
@@ -747,8 +747,8 @@ class DataFrame(ParentDataFrame):
         """Return a JVM Seq of Columns that describes the sort order"""
         if cols is None:
             raise PySparkValueError(
-                error_class="CANNOT_BE_EMPTY",
-                message_parameters={"item": "cols"},
+                errorClass="CANNOT_BE_EMPTY",
+                messageParameters={"item": "cols"},
             )
 
         if len(cols) == 1 and isinstance(cols[0], list):
@@ -765,8 +765,8 @@ class DataFrame(ParentDataFrame):
                     _c = self[-c - 1].desc()
                 else:
                     raise PySparkIndexError(
-                        error_class="ZERO_INDEX",
-                        message_parameters={},
+                        errorClass="ZERO_INDEX",
+                        messageParameters={},
                     )
             else:
                 _c = c  # type: ignore[assignment]
@@ -780,8 +780,8 @@ class DataFrame(ParentDataFrame):
             _cols = [c if asc else c.desc() for asc, c in zip(ascending, _cols)]
         else:
             raise PySparkTypeError(
-                error_class="NOT_BOOL_OR_LIST",
-                message_parameters={"arg_name": "ascending", "arg_type": type(ascending).__name__},
+                errorClass="NOT_BOOL_OR_LIST",
+                messageParameters={"arg_name": "ascending", "arg_type": type(ascending).__name__},
             )
 
         return [F._sort_col(c) for c in _cols]
@@ -847,8 +847,8 @@ class DataFrame(ParentDataFrame):
         ):
             argtypes = [type(arg).__name__ for arg in [withReplacement, fraction, seed]]
             raise PySparkTypeError(
-                error_class="NOT_BOOL_OR_FLOAT_OR_INT",
-                message_parameters={
+                errorClass="NOT_BOOL_OR_FLOAT_OR_INT",
+                messageParameters={
                     "arg_name": "withReplacement (optional), "
                     + "fraction (required) and seed (optional)",
                     "arg_type": ", ".join(argtypes),
@@ -885,8 +885,8 @@ class DataFrame(ParentDataFrame):
     def withColumnsRenamed(self, colsMap: Dict[str, str]) -> ParentDataFrame:
         if not isinstance(colsMap, dict):
             raise PySparkTypeError(
-                error_class="NOT_DICT",
-                message_parameters={"arg_name": "colsMap", "arg_type": type(colsMap).__name__},
+                errorClass="NOT_DICT",
+                messageParameters={"arg_name": "colsMap", "arg_type": type(colsMap).__name__},
             )
 
         return DataFrame(plan.WithColumnsRenamed(self._plan, colsMap), self._session)
@@ -896,13 +896,13 @@ class DataFrame(ParentDataFrame):
     ) -> str:
         if not isinstance(n, int) or isinstance(n, bool):
             raise PySparkTypeError(
-                error_class="NOT_INT",
-                message_parameters={"arg_name": "n", "arg_type": type(n).__name__},
+                errorClass="NOT_INT",
+                messageParameters={"arg_name": "n", "arg_type": type(n).__name__},
             )
         if not isinstance(vertical, bool):
             raise PySparkTypeError(
-                error_class="NOT_BOOL",
-                message_parameters={"arg_name": "vertical", "arg_type": type(vertical).__name__},
+                errorClass="NOT_BOOL",
+                messageParameters={"arg_name": "vertical", "arg_type": type(vertical).__name__},
             )
 
         _truncate: int = -1
@@ -913,8 +913,8 @@ class DataFrame(ParentDataFrame):
                 _truncate = int(truncate)
             except ValueError:
                 raise PySparkTypeError(
-                    error_class="NOT_BOOL",
-                    message_parameters={
+                    errorClass="NOT_BOOL",
+                    messageParameters={
                         "arg_name": "truncate",
                         "arg_type": type(truncate).__name__,
                     },
@@ -934,8 +934,8 @@ class DataFrame(ParentDataFrame):
     def withColumns(self, colsMap: Dict[str, Column]) -> ParentDataFrame:
         if not isinstance(colsMap, dict):
             raise PySparkTypeError(
-                error_class="NOT_DICT",
-                message_parameters={"arg_name": "colsMap", "arg_type": type(colsMap).__name__},
+                errorClass="NOT_DICT",
+                messageParameters={"arg_name": "colsMap", "arg_type": type(colsMap).__name__},
             )
 
         names: List[str] = []
@@ -956,8 +956,8 @@ class DataFrame(ParentDataFrame):
     def withColumn(self, colName: str, col: Column) -> ParentDataFrame:
         if not isinstance(col, Column):
             raise PySparkTypeError(
-                error_class="NOT_COLUMN",
-                message_parameters={"arg_name": "col", "arg_type": type(col).__name__},
+                errorClass="NOT_COLUMN",
+                messageParameters={"arg_name": "col", "arg_type": type(col).__name__},
             )
         return DataFrame(
             plan.WithColumns(
@@ -971,8 +971,8 @@ class DataFrame(ParentDataFrame):
     def withMetadata(self, columnName: str, metadata: Dict[str, Any]) -> ParentDataFrame:
         if not isinstance(metadata, dict):
             raise PySparkTypeError(
-                error_class="NOT_DICT",
-                message_parameters={"arg_name": "metadata", "arg_type": type(metadata).__name__},
+                errorClass="NOT_DICT",
+                messageParameters={"arg_name": "metadata", "arg_type": type(metadata).__name__},
             )
 
         return DataFrame(
@@ -1021,13 +1021,13 @@ class DataFrame(ParentDataFrame):
         # TODO: reuse error handling code in sql.DataFrame.withWatermark()
         if not eventTime or type(eventTime) is not str:
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "eventTime", "arg_type": type(eventTime).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "eventTime", "arg_type": type(eventTime).__name__},
             )
         if not delayThreshold or type(delayThreshold) is not str:
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={
+                errorClass="NOT_STR",
+                messageParameters={
                     "arg_name": "delayThreshold",
                     "arg_type": type(delayThreshold).__name__,
                 },
@@ -1050,8 +1050,8 @@ class DataFrame(ParentDataFrame):
 
         if not isinstance(name, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "name", "arg_type": type(name).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "name", "arg_type": type(name).__name__},
             )
 
         allowed_types = (str, float, int, Column, list)
@@ -1063,8 +1063,8 @@ class DataFrame(ParentDataFrame):
         for p in parameters:
             if not isinstance(p, allowed_types):
                 raise PySparkTypeError(
-                    error_class="INVALID_ITEM_FOR_CONTAINER",
-                    message_parameters={
+                    errorClass="INVALID_ITEM_FOR_CONTAINER",
+                    messageParameters={
                         "arg_name": "parameters",
                         "allowed_types": allowed_types_repr,
                         "item_type": type(p).__name__,
@@ -1073,8 +1073,8 @@ class DataFrame(ParentDataFrame):
             if isinstance(p, list):
                 if not all(isinstance(e, allowed_primitive_types) for e in p):
                     raise PySparkTypeError(
-                        error_class="INVALID_ITEM_FOR_CONTAINER",
-                        message_parameters={
+                        errorClass="INVALID_ITEM_FOR_CONTAINER",
+                        messageParameters={
                             "arg_name": "parameters",
                             "allowed_types": allowed_types_repr,
                             "item_type": type(p).__name__ + "[" + type(p[0]).__name__ + "]",
@@ -1096,15 +1096,15 @@ class DataFrame(ParentDataFrame):
         for w in weights:
             if w < 0.0:
                 raise PySparkValueError(
-                    error_class="VALUE_NOT_POSITIVE",
-                    message_parameters={"arg_name": "weights", "arg_value": str(w)},
+                    errorClass="VALUE_NOT_POSITIVE",
+                    messageParameters={"arg_name": "weights", "arg_value": str(w)},
                 )
         seed = seed if seed is not None else random.randint(0, sys.maxsize)
         total = sum(weights)
         if total <= 0:
             raise PySparkValueError(
-                error_class="VALUE_NOT_POSITIVE",
-                message_parameters={"arg_name": "sum(weights)", "arg_value": str(total)},
+                errorClass="VALUE_NOT_POSITIVE",
+                messageParameters={"arg_name": "sum(weights)", "arg_value": str(total)},
             )
         proportions = list(map(lambda x: x / total, weights))
         normalizedCumWeights = [0.0]
@@ -1142,13 +1142,13 @@ class DataFrame(ParentDataFrame):
 
         if len(exprs) == 0:
             raise PySparkValueError(
-                error_class="CANNOT_BE_EMPTY",
-                message_parameters={"item": "exprs"},
+                errorClass="CANNOT_BE_EMPTY",
+                messageParameters={"item": "exprs"},
             )
         if not all(isinstance(c, Column) for c in exprs):
             raise PySparkTypeError(
-                error_class="NOT_LIST_OF_COLUMN",
-                message_parameters={"arg_name": "exprs"},
+                errorClass="NOT_LIST_OF_COLUMN",
+                messageParameters={"arg_name": "exprs"},
             )
 
         if isinstance(observation, Observation):
@@ -1160,8 +1160,8 @@ class DataFrame(ParentDataFrame):
             )
         else:
             raise PySparkTypeError(
-                error_class="NOT_OBSERVATION_OR_STR",
-                message_parameters={
+                errorClass="NOT_OBSERVATION_OR_STR",
+                messageParameters={
                     "arg_name": "observation",
                     "arg_type": type(observation).__name__,
                 },
@@ -1259,8 +1259,8 @@ class DataFrame(ParentDataFrame):
     def where(self, condition: Union[Column, str]) -> ParentDataFrame:
         if not isinstance(condition, (str, Column)):
             raise PySparkTypeError(
-                error_class="NOT_COLUMN_OR_STR",
-                message_parameters={"arg_name": "condition", "arg_type": type(condition).__name__},
+                errorClass="NOT_COLUMN_OR_STR",
+                messageParameters={"arg_name": "condition", "arg_type": type(condition).__name__},
             )
         return self.filter(condition)
 
@@ -1275,28 +1275,28 @@ class DataFrame(ParentDataFrame):
     ) -> ParentDataFrame:
         if not isinstance(value, (float, int, str, bool, dict)):
             raise PySparkTypeError(
-                error_class="NOT_BOOL_OR_DICT_OR_FLOAT_OR_INT_OR_STR",
-                message_parameters={"arg_name": "value", "arg_type": type(value).__name__},
+                errorClass="NOT_BOOL_OR_DICT_OR_FLOAT_OR_INT_OR_STR",
+                messageParameters={"arg_name": "value", "arg_type": type(value).__name__},
             )
         if isinstance(value, dict):
             if len(value) == 0:
                 raise PySparkValueError(
-                    error_class="CANNOT_BE_EMPTY",
-                    message_parameters={"item": "value"},
+                    errorClass="CANNOT_BE_EMPTY",
+                    messageParameters={"item": "value"},
                 )
             for c, v in value.items():
                 if not isinstance(c, str):
                     raise PySparkTypeError(
-                        error_class="NOT_STR",
-                        message_parameters={
+                        errorClass="NOT_STR",
+                        messageParameters={
                             "arg_name": "key type of dict",
                             "arg_type": type(c).__name__,
                         },
                     )
                 if not isinstance(v, (bool, int, float, str)):
                     raise PySparkTypeError(
-                        error_class="NOT_BOOL_OR_FLOAT_OR_INT_OR_STR",
-                        message_parameters={
+                        errorClass="NOT_BOOL_OR_FLOAT_OR_INT_OR_STR",
+                        messageParameters={
                             "arg_name": "value type of dict",
                             "arg_type": type(v).__name__,
                         },
@@ -1310,14 +1310,14 @@ class DataFrame(ParentDataFrame):
                 for c in subset:
                     if not isinstance(c, str):
                         raise PySparkTypeError(
-                            error_class="NOT_LIST_OR_STR_OR_TUPLE",
-                            message_parameters={"arg_name": "cols", "arg_type": type(c).__name__},
+                            errorClass="NOT_LIST_OR_STR_OR_TUPLE",
+                            messageParameters={"arg_name": "cols", "arg_type": type(c).__name__},
                         )
                 _cols = list(subset)
             else:
                 raise PySparkTypeError(
-                    error_class="NOT_LIST_OR_TUPLE",
-                    message_parameters={"arg_name": "subset", "arg_type": type(subset).__name__},
+                    errorClass="NOT_LIST_OR_TUPLE",
+                    messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
                 )
 
         if isinstance(value, dict):
@@ -1342,8 +1342,8 @@ class DataFrame(ParentDataFrame):
         if how is not None:
             if not isinstance(how, str):
                 raise PySparkTypeError(
-                    error_class="NOT_STR",
-                    message_parameters={"arg_name": "how", "arg_type": type(how).__name__},
+                    errorClass="NOT_STR",
+                    messageParameters={"arg_name": "how", "arg_type": type(how).__name__},
                 )
             if how == "all":
                 min_non_nulls = 1
@@ -1351,15 +1351,15 @@ class DataFrame(ParentDataFrame):
                 min_non_nulls = None
             else:
                 raise PySparkValueError(
-                    error_class="CANNOT_BE_EMPTY",
-                    message_parameters={"arg_name": "how", "arg_value": str(how)},
+                    errorClass="CANNOT_BE_EMPTY",
+                    messageParameters={"arg_name": "how", "arg_value": str(how)},
                 )
 
         if thresh is not None:
             if not isinstance(thresh, int):
                 raise PySparkTypeError(
-                    error_class="NOT_INT",
-                    message_parameters={"arg_name": "thresh", "arg_type": type(thresh).__name__},
+                    errorClass="NOT_INT",
+                    messageParameters={"arg_name": "thresh", "arg_type": type(thresh).__name__},
                 )
 
             # 'thresh' overwrites 'how'
@@ -1373,14 +1373,14 @@ class DataFrame(ParentDataFrame):
                 for c in subset:
                     if not isinstance(c, str):
                         raise PySparkTypeError(
-                            error_class="NOT_LIST_OR_STR_OR_TUPLE",
-                            message_parameters={"arg_name": "cols", "arg_type": type(c).__name__},
+                            errorClass="NOT_LIST_OR_STR_OR_TUPLE",
+                            messageParameters={"arg_name": "cols", "arg_type": type(c).__name__},
                         )
                 _cols = list(subset)
             else:
                 raise PySparkTypeError(
-                    error_class="NOT_LIST_OR_STR_OR_TUPLE",
-                    message_parameters={"arg_name": "subset", "arg_type": type(subset).__name__},
+                    errorClass="NOT_LIST_OR_STR_OR_TUPLE",
+                    messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
                 )
 
         return DataFrame(
@@ -1403,8 +1403,8 @@ class DataFrame(ParentDataFrame):
                 value = None
             else:
                 raise PySparkTypeError(
-                    error_class="ARGUMENT_REQUIRED",
-                    message_parameters={"arg_name": "value", "condition": "`to_replace` is dict"},
+                    errorClass="ARGUMENT_REQUIRED",
+                    messageParameters={"arg_name": "value", "condition": "`to_replace` is dict"},
                 )
 
         # Helper functions
@@ -1431,8 +1431,8 @@ class DataFrame(ParentDataFrame):
         valid_types = (bool, float, int, str, list, tuple)
         if not isinstance(to_replace, valid_types + (dict,)):
             raise PySparkTypeError(
-                error_class="NOT_BOOL_OR_DICT_OR_FLOAT_OR_INT_OR_LIST_OR_STR_OR_TUPLE",
-                message_parameters={
+                errorClass="NOT_BOOL_OR_DICT_OR_FLOAT_OR_INT_OR_LIST_OR_STR_OR_TUPLE",
+                messageParameters={
                     "arg_name": "to_replace",
                     "arg_type": type(to_replace).__name__,
                 },
@@ -1444,15 +1444,15 @@ class DataFrame(ParentDataFrame):
             and not isinstance(to_replace, dict)
         ):
             raise PySparkTypeError(
-                error_class="NOT_BOOL_OR_FLOAT_OR_INT_OR_LIST_OR_NONE_OR_STR_OR_TUPLE",
-                message_parameters={"arg_name": "value", "arg_type": type(value).__name__},
+                errorClass="NOT_BOOL_OR_FLOAT_OR_INT_OR_LIST_OR_NONE_OR_STR_OR_TUPLE",
+                messageParameters={"arg_name": "value", "arg_type": type(value).__name__},
             )
 
         if isinstance(to_replace, (list, tuple)) and isinstance(value, (list, tuple)):
             if len(to_replace) != len(value):
                 raise PySparkValueError(
-                    error_class="LENGTH_SHOULD_BE_THE_SAME",
-                    message_parameters={
+                    errorClass="LENGTH_SHOULD_BE_THE_SAME",
+                    messageParameters={
                         "arg1": "to_replace",
                         "arg2": "value",
                         "arg1_length": str(len(to_replace)),
@@ -1462,8 +1462,8 @@ class DataFrame(ParentDataFrame):
 
         if not (subset is None or isinstance(subset, (list, tuple, str))):
             raise PySparkTypeError(
-                error_class="NOT_LIST_OR_STR_OR_TUPLE",
-                message_parameters={"arg_name": "subset", "arg_type": type(subset).__name__},
+                errorClass="NOT_LIST_OR_STR_OR_TUPLE",
+                messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
             )
 
         # Reshape input arguments if necessary
@@ -1489,8 +1489,8 @@ class DataFrame(ParentDataFrame):
             for all_of_type in [all_of_bool, all_of_str, all_of_numeric]
         ):
             raise PySparkValueError(
-                error_class="MIXED_TYPE_REPLACEMENT",
-                message_parameters={},
+                errorClass="MIXED_TYPE_REPLACEMENT",
+                messageParameters={},
             )
 
         def _convert_int_to_float(v: Any) -> Any:
@@ -1524,8 +1524,8 @@ class DataFrame(ParentDataFrame):
         for s in _statistics:
             if not isinstance(s, str):
                 raise PySparkTypeError(
-                    error_class="NOT_LIST_OF_STR",
-                    message_parameters={"arg_name": "statistics", "arg_type": type(s).__name__},
+                    errorClass="NOT_LIST_OF_STR",
+                    messageParameters={"arg_name": "statistics", "arg_type": type(s).__name__},
                 )
         return DataFrame(
             plan.StatSummary(child=self._plan, statistics=_statistics),
@@ -1550,13 +1550,13 @@ class DataFrame(ParentDataFrame):
     def cov(self, col1: str, col2: str) -> float:
         if not isinstance(col1, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "col1", "arg_type": type(col1).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "col1", "arg_type": type(col1).__name__},
             )
         if not isinstance(col2, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "col2", "arg_type": type(col2).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "col2", "arg_type": type(col2).__name__},
             )
         table, _ = DataFrame(
             plan.StatCov(child=self._plan, col1=col1, col2=col2),
@@ -1567,20 +1567,20 @@ class DataFrame(ParentDataFrame):
     def corr(self, col1: str, col2: str, method: Optional[str] = None) -> float:
         if not isinstance(col1, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "col1", "arg_type": type(col1).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "col1", "arg_type": type(col1).__name__},
             )
         if not isinstance(col2, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "col2", "arg_type": type(col2).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "col2", "arg_type": type(col2).__name__},
             )
         if not method:
             method = "pearson"
         if not method == "pearson":
             raise PySparkValueError(
-                error_class="VALUE_NOT_PEARSON",
-                message_parameters={"arg_name": "method", "arg_value": method},
+                errorClass="VALUE_NOT_PEARSON",
+                messageParameters={"arg_name": "method", "arg_value": method},
             )
         table, _ = DataFrame(
             plan.StatCorr(child=self._plan, col1=col1, col2=col2, method=method),
@@ -1596,8 +1596,8 @@ class DataFrame(ParentDataFrame):
     ) -> Union[List[float], List[List[float]]]:
         if not isinstance(col, (str, list, tuple)):
             raise PySparkTypeError(
-                error_class="NOT_LIST_OR_STR_OR_TUPLE",
-                message_parameters={"arg_name": "col", "arg_type": type(col).__name__},
+                errorClass="NOT_LIST_OR_STR_OR_TUPLE",
+                messageParameters={"arg_name": "col", "arg_type": type(col).__name__},
             )
 
         isStr = isinstance(col, str)
@@ -1610,14 +1610,14 @@ class DataFrame(ParentDataFrame):
         for c in col:
             if not isinstance(c, str):
                 raise PySparkTypeError(
-                    error_class="NOT_LIST_OF_STR",
-                    message_parameters={"arg_name": "columns", "arg_type": type(c).__name__},
+                    errorClass="NOT_LIST_OF_STR",
+                    messageParameters={"arg_name": "columns", "arg_type": type(c).__name__},
                 )
 
         if not isinstance(probabilities, (list, tuple)):
             raise PySparkTypeError(
-                error_class="NOT_LIST_OR_TUPLE",
-                message_parameters={
+                errorClass="NOT_LIST_OR_TUPLE",
+                messageParameters={
                     "arg_name": "probabilities",
                     "arg_type": type(probabilities).__name__,
                 },
@@ -1627,8 +1627,8 @@ class DataFrame(ParentDataFrame):
         for p in probabilities:
             if not isinstance(p, (float, int)) or p < 0 or p > 1:
                 raise PySparkTypeError(
-                    error_class="NOT_LIST_OF_FLOAT_OR_INT",
-                    message_parameters={
+                    errorClass="NOT_LIST_OF_FLOAT_OR_INT",
+                    messageParameters={
                         "arg_name": "probabilities",
                         "arg_type": type(p).__name__,
                     },
@@ -1636,16 +1636,16 @@ class DataFrame(ParentDataFrame):
 
         if not isinstance(relativeError, (float, int)):
             raise PySparkTypeError(
-                error_class="NOT_FLOAT_OR_INT",
-                message_parameters={
+                errorClass="NOT_FLOAT_OR_INT",
+                messageParameters={
                     "arg_name": "relativeError",
                     "arg_type": type(relativeError).__name__,
                 },
             )
         if relativeError < 0:
             raise PySparkValueError(
-                error_class="NEGATIVE_VALUE",
-                message_parameters={
+                errorClass="NEGATIVE_VALUE",
+                messageParameters={
                     "arg_name": "relativeError",
                     "arg_value": str(relativeError),
                 },
@@ -1667,13 +1667,13 @@ class DataFrame(ParentDataFrame):
     def crosstab(self, col1: str, col2: str) -> ParentDataFrame:
         if not isinstance(col1, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "col1", "arg_type": type(col1).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "col1", "arg_type": type(col1).__name__},
             )
         if not isinstance(col2, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "col2", "arg_type": type(col2).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "col2", "arg_type": type(col2).__name__},
             )
         return DataFrame(
             plan.StatCrosstab(child=self._plan, col1=col1, col2=col2),
@@ -1687,8 +1687,8 @@ class DataFrame(ParentDataFrame):
             cols = list(cols)
         if not isinstance(cols, list):
             raise PySparkTypeError(
-                error_class="NOT_LIST_OR_TUPLE",
-                message_parameters={"arg_name": "cols", "arg_type": type(cols).__name__},
+                errorClass="NOT_LIST_OR_TUPLE",
+                messageParameters={"arg_name": "cols", "arg_type": type(cols).__name__},
             )
         if not support:
             support = 0.01
@@ -1702,21 +1702,21 @@ class DataFrame(ParentDataFrame):
     ) -> ParentDataFrame:
         if not isinstance(col, (str, Column)):
             raise PySparkTypeError(
-                error_class="NOT_COLUMN_OR_STR",
-                message_parameters={"arg_name": "col", "arg_type": type(col).__name__},
+                errorClass="NOT_COLUMN_OR_STR",
+                messageParameters={"arg_name": "col", "arg_type": type(col).__name__},
             )
         if not isinstance(fractions, dict):
             raise PySparkTypeError(
-                error_class="NOT_DICT",
-                message_parameters={"arg_name": "fractions", "arg_type": type(fractions).__name__},
+                errorClass="NOT_DICT",
+                messageParameters={"arg_name": "fractions", "arg_type": type(fractions).__name__},
             )
 
         _fractions = []
         for k, v in fractions.items():
             if not isinstance(k, (float, int, str)):
                 raise PySparkTypeError(
-                    error_class="DISALLOWED_TYPE_FOR_CONTAINER",
-                    message_parameters={
+                    errorClass="DISALLOWED_TYPE_FOR_CONTAINER",
+                    messageParameters={
                         "arg_name": "fractions",
                         "arg_type": type(fractions).__name__,
                         "allowed_types": "float, int, str",
@@ -1755,12 +1755,12 @@ class DataFrame(ParentDataFrame):
     def __getattr__(self, name: str) -> "Column":
         if name in ["_jseq", "_jdf", "_jmap", "_jcols", "rdd", "toJSON"]:
             raise PySparkAttributeError(
-                error_class="JVM_ATTRIBUTE_NOT_SUPPORTED", message_parameters={"attr_name": name}
+                errorClass="JVM_ATTRIBUTE_NOT_SUPPORTED", messageParameters={"attr_name": name}
             )
 
         if name not in self.columns:
             raise PySparkAttributeError(
-                error_class="ATTRIBUTE_NOT_SUPPORTED", message_parameters={"attr_name": name}
+                errorClass="ATTRIBUTE_NOT_SUPPORTED", messageParameters={"attr_name": name}
             )
 
         return self._col(name)
@@ -1812,8 +1812,8 @@ class DataFrame(ParentDataFrame):
             return F.col(self.columns[item])
         else:
             raise PySparkTypeError(
-                error_class="NOT_COLUMN_OR_INT_OR_LIST_OR_STR_OR_TUPLE",
-                message_parameters={"arg_name": "item", "arg_type": type(item).__name__},
+                errorClass="NOT_COLUMN_OR_INT_OR_LIST_OR_STR_OR_TUPLE",
+                messageParameters={"arg_name": "item", "arg_type": type(item).__name__},
             )
 
     def _col(self, name: str) -> Column:
@@ -1914,8 +1914,8 @@ class DataFrame(ParentDataFrame):
         for col_ in cols:
             if not isinstance(col_, str):
                 raise PySparkTypeError(
-                    error_class="NOT_LIST_OF_STR",
-                    message_parameters={"arg_name": "cols", "arg_type": type(col_).__name__},
+                    errorClass="NOT_LIST_OF_STR",
+                    messageParameters={"arg_name": "cols", "arg_type": type(col_).__name__},
                 )
         return DataFrame(plan.ToDF(self._plan, list(cols)), self._session)
 
@@ -1933,8 +1933,8 @@ class DataFrame(ParentDataFrame):
     ) -> str:
         if extended is not None and mode is not None:
             raise PySparkValueError(
-                error_class="CANNOT_SET_TOGETHER",
-                message_parameters={"arg_list": "extended and mode"},
+                errorClass="CANNOT_SET_TOGETHER",
+                messageParameters={"arg_list": "extended and mode"},
             )
 
         # For the no argument case: df.explain()
@@ -1956,8 +1956,8 @@ class DataFrame(ParentDataFrame):
         if not (is_no_argument or is_extended_case or is_extended_as_mode or is_mode_case):
             argtypes = [str(type(arg)) for arg in [extended, mode] if arg is not None]
             raise PySparkTypeError(
-                error_class="NOT_BOOL_OR_STR",
-                message_parameters={
+                errorClass="NOT_BOOL_OR_STR",
+                messageParameters={
                     "arg_name": "extended (optional) and mode (optional)",
                     "arg_type": ", ".join(argtypes),
                 },
@@ -2166,8 +2166,8 @@ class DataFrame(ParentDataFrame):
     def sameSemantics(self, other: ParentDataFrame) -> bool:
         if not isinstance(other, DataFrame):
             raise PySparkTypeError(
-                error_class="NOT_DATAFRAME",
-                message_parameters={"arg_name": "other", "arg_type": type(other).__name__},
+                errorClass="NOT_DATAFRAME",
+                messageParameters={"arg_name": "other", "arg_type": type(other).__name__},
             )
         self._check_same_session(other)
         return self._session.client.same_semantics(
@@ -2222,15 +2222,15 @@ class DataFrame(ParentDataFrame):
 
         def toJSON(self, use_unicode: bool = True) -> "RDD[str]":
             raise PySparkNotImplementedError(
-                error_class="NOT_IMPLEMENTED",
-                message_parameters={"feature": "toJSON()"},
+                errorClass="NOT_IMPLEMENTED",
+                messageParameters={"feature": "toJSON()"},
             )
 
         @property
         def rdd(self) -> "RDD[Row]":
             raise PySparkNotImplementedError(
-                error_class="NOT_IMPLEMENTED",
-                message_parameters={"feature": "rdd"},
+                errorClass="NOT_IMPLEMENTED",
+                messageParameters={"feature": "rdd"},
             )
 
     @property

--- a/python/pyspark/sql/connect/expressions.py
+++ b/python/pyspark/sql/connect/expressions.py
@@ -113,8 +113,8 @@ class Expression:
         metadata = kwargs.pop("metadata", None)
         if len(alias) > 1 and metadata is not None:
             raise PySparkValueError(
-                error_class="ONLY_ALLOWED_FOR_SINGLE_COLUMN",
-                message_parameters={"arg_name": "metadata"},
+                errorClass="ONLY_ALLOWED_FOR_SINGLE_COLUMN",
+                messageParameters={"arg_name": "metadata"},
             )
         assert not kwargs, "Unexpected kwargs where passed: %s" % kwargs
         return ColumnAlias(self, list(alias), metadata)
@@ -188,8 +188,8 @@ class ColumnAlias(Expression):
         else:
             if self._metadata:
                 raise PySparkValueError(
-                    error_class="CANNOT_PROVIDE_METADATA",
-                    message_parameters={},
+                    errorClass="CANNOT_PROVIDE_METADATA",
+                    messageParameters={},
                 )
             exp = self._create_proto_expression()
             exp.alias.name.extend(self._alias)
@@ -286,8 +286,8 @@ class LiteralExpression(Expression):
                 assert isinstance(value, list)
             else:
                 raise PySparkTypeError(
-                    error_class="UNSUPPORTED_DATA_TYPE",
-                    message_parameters={"data_type": str(dataType)},
+                    errorClass="UNSUPPORTED_DATA_TYPE",
+                    messageParameters={"data_type": str(dataType)},
                 )
 
         self._value = value
@@ -308,8 +308,8 @@ class LiteralExpression(Expression):
                 return LongType()
             else:
                 raise PySparkValueError(
-                    error_class="VALUE_NOT_BETWEEN",
-                    message_parameters={
+                    errorClass="VALUE_NOT_BETWEEN",
+                    messageParameters={
                         "arg_name": "value",
                         "min": str(JVM_LONG_MIN),
                         "max": str(JVM_SHORT_MAX),
@@ -340,20 +340,20 @@ class LiteralExpression(Expression):
             # right now, it's dedicated for pyspark.ml params like array<...>, array<array<...>>
             if len(value) == 0:
                 raise PySparkValueError(
-                    error_class="CANNOT_BE_EMPTY",
-                    message_parameters={"item": "value"},
+                    errorClass="CANNOT_BE_EMPTY",
+                    messageParameters={"item": "value"},
                 )
             first = value[0]
             if first is None:
                 raise PySparkTypeError(
-                    error_class="CANNOT_INFER_ARRAY_TYPE",
-                    message_parameters={},
+                    errorClass="CANNOT_INFER_ARRAY_TYPE",
+                    messageParameters={},
                 )
             return ArrayType(LiteralExpression._infer_type(first), True)
 
         raise PySparkTypeError(
-            error_class="UNSUPPORTED_DATA_TYPE",
-            message_parameters={"data_type": type(value).__name__},
+            errorClass="UNSUPPORTED_DATA_TYPE",
+            messageParameters={"data_type": type(value).__name__},
         )
 
     @classmethod
@@ -416,8 +416,8 @@ class LiteralExpression(Expression):
             return [LiteralExpression._to_value(v, elementType) for v in literal.array.elements]
 
         raise PySparkTypeError(
-            error_class="UNSUPPORTED_LITERAL",
-            message_parameters={"literal": str(literal)},
+            errorClass="UNSUPPORTED_LITERAL",
+            messageParameters={"literal": str(literal)},
         )
 
     def to_plan(self, session: "SparkConnectClient") -> "proto.Expression":
@@ -466,8 +466,8 @@ class LiteralExpression(Expression):
                 )
         else:
             raise PySparkTypeError(
-                error_class="UNSUPPORTED_DATA_TYPE",
-                message_parameters={"data_type": str(self._dataType)},
+                errorClass="UNSUPPORTED_DATA_TYPE",
+                messageParameters={"data_type": str(self._dataType)},
             )
 
         return expr
@@ -1035,8 +1035,8 @@ class WindowExpression(Expression):
                     expr.window.frame_spec.lower.value.literal.integer = start
                 else:
                     raise PySparkValueError(
-                        error_class="VALUE_NOT_BETWEEN",
-                        message_parameters={
+                        errorClass="VALUE_NOT_BETWEEN",
+                        messageParameters={
                             "arg_name": "start",
                             "min": str(JVM_INT_MIN),
                             "max": str(JVM_INT_MAX),
@@ -1052,8 +1052,8 @@ class WindowExpression(Expression):
                     expr.window.frame_spec.upper.value.literal.integer = end
                 else:
                     raise PySparkValueError(
-                        error_class="VALUE_NOT_BETWEEN",
-                        message_parameters={
+                        errorClass="VALUE_NOT_BETWEEN",
+                        messageParameters={
                             "arg_name": "end",
                             "min": str(JVM_INT_MIN),
                             "max": str(JVM_INT_MAX),

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -158,15 +158,15 @@ def _get_lambda_parameters(f: Callable) -> ValuesView[inspect.Parameter]:
     # Validate that the function arity is between 1 and 3.
     if not (1 <= len(parameters) <= 3):
         raise PySparkValueError(
-            error_class="WRONG_NUM_ARGS_FOR_HIGHER_ORDER_FUNCTION",
-            message_parameters={"func_name": f.__name__, "num_args": str(len(parameters))},
+            errorClass="WRONG_NUM_ARGS_FOR_HIGHER_ORDER_FUNCTION",
+            messageParameters={"func_name": f.__name__, "num_args": str(len(parameters))},
         )
 
     # Verify that all arguments can be used as positional arguments.
     if not all(p.kind in supported_parameter_types for p in parameters):
         raise PySparkValueError(
-            error_class="UNSUPPORTED_PARAM_TYPE_FOR_HIGHER_ORDER_FUNCTION",
-            message_parameters={"func_name": f.__name__},
+            errorClass="UNSUPPORTED_PARAM_TYPE_FOR_HIGHER_ORDER_FUNCTION",
+            messageParameters={"func_name": f.__name__},
         )
 
     return parameters
@@ -197,8 +197,8 @@ def _create_lambda(f: Callable) -> LambdaFunction:
 
     if not isinstance(result, Column):
         raise PySparkValueError(
-            error_class="HIGHER_ORDER_FUNCTION_SHOULD_RETURN_COLUMN",
-            message_parameters={"func_name": f.__name__, "return_type": type(result).__name__},
+            errorClass="HIGHER_ORDER_FUNCTION_SHOULD_RETURN_COLUMN",
+            messageParameters={"func_name": f.__name__, "return_type": type(result).__name__},
         )
 
     return LambdaFunction(result._expr, arg_exprs)  # type: ignore[arg-type]
@@ -262,14 +262,14 @@ def lit(col: Any) -> Column:
     elif isinstance(col, list):
         if any(isinstance(c, Column) for c in col):
             raise PySparkValueError(
-                error_class="COLUMN_IN_LIST", message_parameters={"func_name": "lit"}
+                errorClass="COLUMN_IN_LIST", messageParameters={"func_name": "lit"}
             )
         return array(*[lit(c) for c in col])
     elif isinstance(col, np.ndarray) and col.ndim == 1:
         if _from_numpy_type(col.dtype) is None:
             raise PySparkTypeError(
-                error_class="UNSUPPORTED_NUMPY_ARRAY_SCALAR",
-                message_parameters={"dtype": col.dtype.name},
+                errorClass="UNSUPPORTED_NUMPY_ARRAY_SCALAR",
+                messageParameters={"dtype": col.dtype.name},
             )
 
         # NumpyArrayConverter for Py4J can not support ndarray with int8 values.
@@ -327,8 +327,8 @@ def broadcast(df: "ParentDataFrame") -> "ParentDataFrame":
 
     if not isinstance(df, DataFrame):
         raise PySparkTypeError(
-            error_class="NOT_DATAFRAME",
-            message_parameters={"arg_name": "df", "arg_type": type(df).__name__},
+            errorClass="NOT_DATAFRAME",
+            messageParameters={"arg_name": "df", "arg_type": type(df).__name__},
         )
     return df.hint("broadcast")
 
@@ -355,8 +355,8 @@ expr.__doc__ = pysparkfuncs.expr.__doc__
 def greatest(*cols: "ColumnOrName") -> Column:
     if len(cols) < 2:
         raise PySparkValueError(
-            error_class="WRONG_NUM_COLUMNS",
-            message_parameters={"func_name": "greatest", "num_cols": "2"},
+            errorClass="WRONG_NUM_COLUMNS",
+            messageParameters={"func_name": "greatest", "num_cols": "2"},
         )
     return _invoke_function_over_columns("greatest", *cols)
 
@@ -374,8 +374,8 @@ input_file_name.__doc__ = pysparkfuncs.input_file_name.__doc__
 def least(*cols: "ColumnOrName") -> Column:
     if len(cols) < 2:
         raise PySparkValueError(
-            error_class="WRONG_NUM_COLUMNS",
-            message_parameters={"func_name": "least", "num_cols": "2"},
+            errorClass="WRONG_NUM_COLUMNS",
+            messageParameters={"func_name": "least", "num_cols": "2"},
         )
     return _invoke_function_over_columns("least", *cols)
 
@@ -444,8 +444,8 @@ def when(condition: Column, value: Any) -> Column:
     # Explicitly not using ColumnOrName type here to make reading condition less opaque
     if not isinstance(condition, Column):
         raise PySparkTypeError(
-            error_class="NOT_COLUMN",
-            message_parameters={"arg_name": "condition", "arg_type": type(condition).__name__},
+            errorClass="NOT_COLUMN",
+            messageParameters={"arg_name": "condition", "arg_type": type(condition).__name__},
         )
 
     value_col = value if isinstance(value, Column) else lit(value)
@@ -1197,8 +1197,8 @@ def percentile(
 ) -> Column:
     if not isinstance(frequency, (int, Column)):
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_INT",
-            message_parameters={
+            errorClass="NOT_COLUMN_OR_INT",
+            messageParameters={
                 "arg_name": "frequency",
                 "arg_type": type(frequency).__name__,
             },
@@ -1839,8 +1839,8 @@ def from_csv(
         _schema = lit(schema)
     else:
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "schema", "arg_type": type(schema).__name__},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "schema", "arg_type": type(schema).__name__},
         )
 
     if options is None:
@@ -1863,8 +1863,8 @@ def from_json(
         _schema = lit(schema.json())
     else:
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_DATATYPE_OR_STR",
-            message_parameters={"arg_name": "schema", "arg_type": type(schema).__name__},
+            errorClass="NOT_COLUMN_OR_DATATYPE_OR_STR",
+            messageParameters={"arg_name": "schema", "arg_type": type(schema).__name__},
         )
 
     if options is None:
@@ -1887,8 +1887,8 @@ def from_xml(
         _schema = lit(schema.json())
     else:
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_STR_OR_STRUCT",
-            message_parameters={"arg_name": "schema", "arg_type": type(schema).__name__},
+            errorClass="NOT_COLUMN_OR_STR_OR_STRUCT",
+            messageParameters={"arg_name": "schema", "arg_type": type(schema).__name__},
         )
 
     if options is None:
@@ -1947,8 +1947,8 @@ inline_outer.__doc__ = pysparkfuncs.inline_outer.__doc__
 def json_tuple(col: "ColumnOrName", *fields: str) -> Column:
     if len(fields) == 0:
         raise PySparkValueError(
-            error_class="CANNOT_BE_EMPTY",
-            message_parameters={"item": "field"},
+            errorClass="CANNOT_BE_EMPTY",
+            messageParameters={"item": "field"},
         )
     return _invoke_function("json_tuple", _to_col(col), *[lit(field) for field in fields])
 
@@ -2128,8 +2128,8 @@ def schema_of_csv(csv: Union[str, Column], options: Optional[Dict[str, str]] = N
         _csv = lit(csv)
     else:
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "csv", "arg_type": type(csv).__name__},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "csv", "arg_type": type(csv).__name__},
         )
 
     if options is None:
@@ -2146,8 +2146,8 @@ def schema_of_json(json: Union[str, Column], options: Optional[Dict[str, str]] =
         _json = lit(json)
     else:
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "json", "arg_type": type(json).__name__},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "json", "arg_type": type(json).__name__},
         )
 
     if options is None:
@@ -2164,8 +2164,8 @@ def schema_of_xml(xml: Union[str, Column], options: Optional[Dict[str, str]] = N
         _xml = lit(xml)
     else:
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "xml", "arg_type": type(xml).__name__},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "xml", "arg_type": type(xml).__name__},
         )
 
     if options is None:
@@ -2204,8 +2204,8 @@ def slice(
         _start = lit(start)
     else:
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_INT_OR_STR",
-            message_parameters={"arg_name": "start", "arg_type": type(start).__name__},
+            errorClass="NOT_COLUMN_OR_INT_OR_STR",
+            messageParameters={"arg_name": "start", "arg_type": type(start).__name__},
         )
 
     if isinstance(length, (Column, str)):
@@ -2214,8 +2214,8 @@ def slice(
         _length = lit(length)
     else:
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_INT_OR_STR",
-            message_parameters={"arg_name": "length", "arg_type": type(length).__name__},
+            errorClass="NOT_COLUMN_OR_INT_OR_STR",
+            messageParameters={"arg_name": "length", "arg_type": type(length).__name__},
         )
 
     return _invoke_function_over_columns("slice", col, _start, _length)
@@ -2423,13 +2423,13 @@ def overlay(
 ) -> Column:
     if not isinstance(pos, (int, str, Column)):
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_INT_OR_STR",
-            message_parameters={"arg_name": "pos", "arg_type": type(pos).__name__},
+            errorClass="NOT_COLUMN_OR_INT_OR_STR",
+            messageParameters={"arg_name": "pos", "arg_type": type(pos).__name__},
         )
     if len is not None and not isinstance(len, (int, str, Column)):
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_INT_OR_STR",
-            message_parameters={"arg_name": "len", "arg_type": type(len).__name__},
+            errorClass="NOT_COLUMN_OR_INT_OR_STR",
+            messageParameters={"arg_name": "len", "arg_type": type(len).__name__},
         )
 
     if isinstance(pos, int):
@@ -3406,24 +3406,24 @@ def window(
 ) -> Column:
     if windowDuration is None or not isinstance(windowDuration, str):
         raise PySparkTypeError(
-            error_class="NOT_STR",
-            message_parameters={
+            errorClass="NOT_STR",
+            messageParameters={
                 "arg_name": "windowDuration",
                 "arg_type": type(windowDuration).__name__,
             },
         )
     if slideDuration is not None and not isinstance(slideDuration, str):
         raise PySparkTypeError(
-            error_class="NOT_STR",
-            message_parameters={
+            errorClass="NOT_STR",
+            messageParameters={
                 "arg_name": "slideDuration",
                 "arg_type": type(slideDuration).__name__,
             },
         )
     if startTime is not None and not isinstance(startTime, str):
         raise PySparkTypeError(
-            error_class="NOT_STR",
-            message_parameters={"arg_name": "startTime", "arg_type": type(startTime).__name__},
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "startTime", "arg_type": type(startTime).__name__},
         )
 
     time_col = _to_col(timeColumn)
@@ -3457,8 +3457,8 @@ window_time.__doc__ = pysparkfuncs.window_time.__doc__
 def session_window(timeColumn: "ColumnOrName", gapDuration: Union[Column, str]) -> Column:
     if gapDuration is None or not isinstance(gapDuration, (Column, str)):
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "gapDuration", "arg_type": type(gapDuration).__name__},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "gapDuration", "arg_type": type(gapDuration).__name__},
         )
 
     time_col = _to_col(timeColumn)
@@ -3739,8 +3739,8 @@ def assert_true(col: "ColumnOrName", errMsg: Optional[Union[Column, str]] = None
         return _invoke_function_over_columns("assert_true", col)
     if not isinstance(errMsg, (str, Column)):
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "errMsg", "arg_type": type(errMsg).__name__},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "errMsg", "arg_type": type(errMsg).__name__},
         )
     _err_msg = lit(errMsg) if isinstance(errMsg, str) else _to_col(errMsg)
     return _invoke_function("assert_true", _to_col(col), _err_msg)
@@ -3752,8 +3752,8 @@ assert_true.__doc__ = pysparkfuncs.assert_true.__doc__
 def raise_error(errMsg: Union[Column, str]) -> Column:
     if not isinstance(errMsg, (str, Column)):
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "errMsg", "arg_type": type(errMsg).__name__},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "errMsg", "arg_type": type(errMsg).__name__},
         )
     _err_msg = lit(errMsg) if isinstance(errMsg, str) else _to_col(errMsg)
     return _invoke_function("raise_error", _err_msg)
@@ -3800,8 +3800,8 @@ sha1.__doc__ = pysparkfuncs.sha1.__doc__
 def sha2(col: "ColumnOrName", numBits: int) -> Column:
     if numBits not in [0, 224, 256, 384, 512]:
         raise PySparkValueError(
-            error_class="VALUE_NOT_ALLOWED",
-            message_parameters={
+            errorClass="VALUE_NOT_ALLOWED",
+            messageParameters={
                 "arg_name": "numBits",
                 "allowed_values": "[0, 224, 256, 384, 512]",
             },

--- a/python/pyspark/sql/connect/functions/partitioning.py
+++ b/python/pyspark/sql/connect/functions/partitioning.py
@@ -38,8 +38,8 @@ def bucket(numBuckets: Union[Column, int], col: "ColumnOrName") -> Column:
         _numBuckets = numBuckets
     else:
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_INT",
-            message_parameters={
+            errorClass="NOT_COLUMN_OR_INT",
+            messageParameters={
                 "arg_name": "numBuckets",
                 "arg_type": type(numBuckets).__name__,
             },

--- a/python/pyspark/sql/connect/group.py
+++ b/python/pyspark/sql/connect/group.py
@@ -172,8 +172,8 @@ class GroupedData:
             invalid_cols = [c for c in cols if c not in numerical_cols]
             if len(invalid_cols) > 0:
                 raise PySparkTypeError(
-                    error_class="NOT_NUMERIC_COLUMNS",
-                    message_parameters={"invalid_columns": str(invalid_cols)},
+                    errorClass="NOT_NUMERIC_COLUMNS",
+                    messageParameters={"invalid_columns": str(invalid_cols)},
                 )
             agg_cols = cols
         else:
@@ -224,32 +224,32 @@ class GroupedData:
         if self._group_type != "groupby":
             if self._group_type == "pivot":
                 raise PySparkNotImplementedError(
-                    error_class="UNSUPPORTED_OPERATION",
-                    message_parameters={"operation": "Repeated PIVOT operation"},
+                    errorClass="UNSUPPORTED_OPERATION",
+                    messageParameters={"operation": "Repeated PIVOT operation"},
                 )
             else:
                 raise PySparkNotImplementedError(
-                    error_class="UNSUPPORTED_OPERATION",
-                    message_parameters={"operation": f"PIVOT after {self._group_type.upper()}"},
+                    errorClass="UNSUPPORTED_OPERATION",
+                    messageParameters={"operation": f"PIVOT after {self._group_type.upper()}"},
                 )
 
         if not isinstance(pivot_col, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "pivot_col", "arg_type": type(pivot_col).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "pivot_col", "arg_type": type(pivot_col).__name__},
             )
 
         if values is not None:
             if not isinstance(values, list):
                 raise PySparkTypeError(
-                    error_class="NOT_LIST",
-                    message_parameters={"arg_name": "values", "arg_type": type(values).__name__},
+                    errorClass="NOT_LIST",
+                    messageParameters={"arg_name": "values", "arg_type": type(values).__name__},
                 )
             for v in values:
                 if not isinstance(v, (bool, float, int, str)):
                     raise PySparkTypeError(
-                        error_class="NOT_BOOL_OR_FLOAT_OR_INT_OR_STR",
-                        message_parameters={"arg_name": "value", "arg_type": type(v).__name__},
+                        errorClass="NOT_BOOL_OR_FLOAT_OR_INT_OR_STR",
+                        messageParameters={"arg_name": "value", "arg_type": type(v).__name__},
                     )
 
         return GroupedData(
@@ -273,8 +273,8 @@ class GroupedData:
             )
         ):
             raise PySparkTypeError(
-                error_class="INVALID_UDF_EVAL_TYPE",
-                message_parameters={"eval_type": "SQL_GROUPED_MAP_PANDAS_UDF"},
+                errorClass="INVALID_UDF_EVAL_TYPE",
+                messageParameters={"eval_type": "SQL_GROUPED_MAP_PANDAS_UDF"},
             )
 
         warnings.warn(

--- a/python/pyspark/sql/connect/observation.py
+++ b/python/pyspark/sql/connect/observation.py
@@ -37,13 +37,13 @@ class Observation:
         if name is not None:
             if not isinstance(name, str):
                 raise PySparkTypeError(
-                    error_class="NOT_STR",
-                    message_parameters={"arg_name": "name", "arg_type": type(name).__name__},
+                    errorClass="NOT_STR",
+                    messageParameters={"arg_name": "name", "arg_type": type(name).__name__},
                 )
             if name == "":
                 raise PySparkValueError(
-                    error_class="VALUE_NOT_NON_EMPTY_STR",
-                    message_parameters={"arg_name": "name", "arg_value": name},
+                    errorClass="VALUE_NOT_NON_EMPTY_STR",
+                    messageParameters={"arg_name": "name", "arg_value": name},
                 )
         self._name = name
         self._result: Optional[Dict[str, Any]] = None
@@ -52,15 +52,15 @@ class Observation:
 
     def _on(self, df: DataFrame, *exprs: Column) -> DataFrame:
         if self._result is not None:
-            raise PySparkAssertionError(error_class="REUSE_OBSERVATION", message_parameters={})
+            raise PySparkAssertionError(errorClass="REUSE_OBSERVATION", messageParameters={})
 
         if self._name is None:
             self._name = str(uuid.uuid4())
 
         if df.isStreaming:
             raise IllegalArgumentException(
-                error_class="UNSUPPORTED_OPERATION",
-                message_parameters={"operation": "Streaming DataFrame with Observation"},
+                errorClass="UNSUPPORTED_OPERATION",
+                messageParameters={"operation": "Streaming DataFrame with Observation"},
             )
 
         self._result = {}
@@ -71,7 +71,7 @@ class Observation:
     @property
     def get(self) -> Dict[str, Any]:
         if self._result is None:
-            raise PySparkAssertionError(error_class="NO_OBSERVE_BEFORE_GET", message_parameters={})
+            raise PySparkAssertionError(errorClass="NO_OBSERVE_BEFORE_GET", messageParameters={})
 
         return self._result
 

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -888,8 +888,8 @@ class Join(LogicalPlan):
             join_type = proto.Join.JoinType.JOIN_TYPE_CROSS
         else:
             raise AnalysisException(
-                error_class="UNSUPPORTED_JOIN_TYPE",
-                message_parameters={"join_type": how},
+                errorClass="UNSUPPORTED_JOIN_TYPE",
+                messageParameters={"join_type": how},
             )
         self.how = join_type
 
@@ -1056,8 +1056,8 @@ class SetOperation(LogicalPlan):
             plan.set_op.set_op_type = proto.SetOperation.SET_OP_TYPE_EXCEPT
         else:
             raise PySparkValueError(
-                error_class="UNSUPPORTED_OPERATION",
-                message_parameters={"operation": self.set_op},
+                errorClass="UNSUPPORTED_OPERATION",
+                messageParameters={"operation": self.set_op},
             )
 
         plan.set_op.is_all = self.is_all
@@ -1693,8 +1693,8 @@ class WriteOperation(LogicalPlan):
                     )
                 else:
                     raise PySparkValueError(
-                        error_class="UNSUPPORTED_OPERATION",
-                        message_parameters={"operation": tsm},
+                        errorClass="UNSUPPORTED_OPERATION",
+                        messageParameters={"operation": tsm},
                     )
         elif self.path is not None:
             plan.write_operation.path = self.path
@@ -1711,8 +1711,8 @@ class WriteOperation(LogicalPlan):
                 plan.write_operation.mode = proto.WriteOperation.SaveMode.SAVE_MODE_IGNORE
             else:
                 raise PySparkValueError(
-                    error_class="UNSUPPORTED_OPERATION",
-                    message_parameters={"operation": self.mode},
+                    errorClass="UNSUPPORTED_OPERATION",
+                    messageParameters={"operation": self.mode},
                 )
         return plan
 
@@ -1804,8 +1804,8 @@ class WriteOperationV2(LogicalPlan):
                 plan.write_operation_v2.mode = proto.WriteOperationV2.Mode.MODE_CREATE_OR_REPLACE
             else:
                 raise PySparkValueError(
-                    error_class="UNSUPPORTED_OPERATION",
-                    message_parameters={"operation": self.mode},
+                    errorClass="UNSUPPORTED_OPERATION",
+                    messageParameters={"operation": self.mode},
                 )
         return plan
 
@@ -2352,8 +2352,8 @@ class PythonUDTF:
             udtf.command = CloudPickleSerializer().dumps(self._func)
         except pickle.PicklingError:
             raise PySparkPicklingError(
-                error_class="UDTF_SERIALIZATION_ERROR",
-                message_parameters={
+                errorClass="UDTF_SERIALIZATION_ERROR",
+                messageParameters={
                     "name": self._name,
                     "message": "Please check the stack trace and "
                     "make sure the function is serializable.",

--- a/python/pyspark/sql/connect/readwriter.py
+++ b/python/pyspark/sql/connect/readwriter.py
@@ -83,8 +83,8 @@ class DataFrameReader(OptionUtils):
             self._schema = schema
         else:
             raise PySparkTypeError(
-                error_class="NOT_STR_OR_STRUCT",
-                message_parameters={
+                errorClass="NOT_STR_OR_STRUCT",
+                messageParameters={
                     "arg_name": "schema",
                     "arg_type": type(schema).__name__,
                 },
@@ -479,7 +479,7 @@ class DataFrameReader(OptionUtils):
     @property
     def _jreader(self) -> None:
         raise PySparkAttributeError(
-            error_class="JVM_ATTRIBUTE_NOT_SUPPORTED", message_parameters={"attr_name": "_jreader"}
+            errorClass="JVM_ATTRIBUTE_NOT_SUPPORTED", messageParameters={"attr_name": "_jreader"}
         )
 
 
@@ -557,8 +557,8 @@ class DataFrameWriter(OptionUtils):
     ) -> "DataFrameWriter":
         if not isinstance(numBuckets, int):
             raise PySparkValueError(
-                error_class="CANNOT_SET_TOGETHER",
-                message_parameters={
+                errorClass="CANNOT_SET_TOGETHER",
+                messageParameters={
                     "arg_list": f"`col` of type {type(col).__name__} and `cols`",
                 },
             )
@@ -566,8 +566,8 @@ class DataFrameWriter(OptionUtils):
         if isinstance(col, (list, tuple)):
             if cols:
                 raise PySparkValueError(
-                    error_class="NOT_INT",
-                    message_parameters={
+                    errorClass="NOT_INT",
+                    messageParameters={
                         "arg_list": "numBuckets",
                     },
                 )
@@ -577,16 +577,16 @@ class DataFrameWriter(OptionUtils):
         for c in cols:
             if not isinstance(c, str):
                 raise PySparkTypeError(
-                    error_class="NOT_LIST_OF_STR",
-                    message_parameters={
+                    errorClass="NOT_LIST_OF_STR",
+                    messageParameters={
                         "arg_name": "cols",
                         "arg_type": type(c).__name__,
                     },
                 )
         if not isinstance(col, str):
             raise PySparkTypeError(
-                error_class="NOT_LIST_OF_STR",
-                message_parameters={
+                errorClass="NOT_LIST_OF_STR",
+                messageParameters={
                     "arg_name": "col",
                     "arg_type": type(col).__name__,
                 },
@@ -612,8 +612,8 @@ class DataFrameWriter(OptionUtils):
         if isinstance(col, (list, tuple)):
             if cols:
                 raise PySparkValueError(
-                    error_class="CANNOT_SET_TOGETHER",
-                    message_parameters={
+                    errorClass="CANNOT_SET_TOGETHER",
+                    messageParameters={
                         "arg_list": f"`col` of type {type(col).__name__} and `cols`",
                     },
                 )
@@ -623,16 +623,16 @@ class DataFrameWriter(OptionUtils):
         for c in cols:
             if not isinstance(c, str):
                 raise PySparkTypeError(
-                    error_class="NOT_LIST_OF_STR",
-                    message_parameters={
+                    errorClass="NOT_LIST_OF_STR",
+                    messageParameters={
                         "arg_name": "cols",
                         "arg_type": type(c).__name__,
                     },
                 )
         if not isinstance(col, str):
             raise PySparkTypeError(
-                error_class="NOT_LIST_OF_STR",
-                message_parameters={
+                errorClass="NOT_LIST_OF_STR",
+                messageParameters={
                     "arg_name": "col",
                     "arg_type": type(col).__name__,
                 },

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -196,7 +196,7 @@ class SparkSession:
 
         def enableHiveSupport(self) -> "SparkSession.Builder":
             raise PySparkNotImplementedError(
-                error_class="NOT_IMPLEMENTED", message_parameters={"feature": "enableHiveSupport"}
+                errorClass="NOT_IMPLEMENTED", messageParameters={"feature": "enableHiveSupport"}
             )
 
         def _apply_options(self, session: "SparkSession") -> None:
@@ -221,7 +221,7 @@ class SparkSession:
                 not has_channel_builder and not has_spark_remote
             ):
                 raise PySparkValueError(
-                    error_class="SESSION_NEED_CONN_STR_OR_BUILDER", message_parameters={}
+                    errorClass="SESSION_NEED_CONN_STR_OR_BUILDER", messageParameters={}
                 )
 
             if has_channel_builder:
@@ -311,8 +311,8 @@ class SparkSession:
         session = SparkSession.getActiveSession()
         if session is None:
             raise PySparkRuntimeError(
-                error_class="NO_ACTIVE_SESSION",
-                message_parameters={},
+                errorClass="NO_ACTIVE_SESSION",
+                messageParameters={},
             )
         if session._session_id != session_id:
             raise PySparkAssertionError(
@@ -330,8 +330,8 @@ class SparkSession:
             session = cls._get_default_session()
             if session is None:
                 raise PySparkRuntimeError(
-                    error_class="NO_ACTIVE_OR_DEFAULT_SESSION",
-                    message_parameters={},
+                    errorClass="NO_ACTIVE_OR_DEFAULT_SESSION",
+                    messageParameters={},
                 )
         return session
 
@@ -340,8 +340,8 @@ class SparkSession:
     def table(self, tableName: str) -> ParentDataFrame:
         if not isinstance(tableName, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "tableName", "arg_type": type(tableName).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "tableName", "arg_type": type(tableName).__name__},
             )
 
         return self.read.table(tableName)
@@ -383,8 +383,8 @@ class SparkSession:
         """
         if not data:
             raise PySparkValueError(
-                error_class="CANNOT_INFER_EMPTY_SCHEMA",
-                message_parameters={},
+                errorClass="CANNOT_INFER_EMPTY_SCHEMA",
+                messageParameters={},
             )
 
         (
@@ -423,8 +423,8 @@ class SparkSession:
         assert data is not None
         if isinstance(data, DataFrame):
             raise PySparkTypeError(
-                error_class="INVALID_TYPE",
-                message_parameters={"arg_name": "data", "arg_type": "DataFrame"},
+                errorClass="INVALID_TYPE",
+                messageParameters={"arg_name": "data", "arg_type": "DataFrame"},
             )
 
         if samplingRatio is not None:
@@ -456,8 +456,8 @@ class SparkSession:
 
         elif schema is not None:
             raise PySparkTypeError(
-                error_class="NOT_LIST_OR_NONE_OR_STRUCT",
-                message_parameters={
+                errorClass="NOT_LIST_OR_NONE_OR_STRUCT",
+                messageParameters={
                     "arg_name": "schema",
                     "arg_type": type(schema).__name__,
                 },
@@ -465,16 +465,16 @@ class SparkSession:
 
         if isinstance(data, np.ndarray) and data.ndim not in [1, 2]:
             raise PySparkValueError(
-                error_class="INVALID_NDARRAY_DIMENSION",
-                message_parameters={"dimensions": "1 or 2"},
+                errorClass="INVALID_NDARRAY_DIMENSION",
+                messageParameters={"dimensions": "1 or 2"},
             )
         elif isinstance(data, Sized) and len(data) == 0:
             if _schema is not None:
                 return DataFrame(LocalRelation(table=None, schema=_schema.json()), self)
             else:
                 raise PySparkValueError(
-                    error_class="CANNOT_INFER_EMPTY_SCHEMA",
-                    message_parameters={},
+                    errorClass="CANNOT_INFER_EMPTY_SCHEMA",
+                    messageParameters={},
                 )
 
         _table: Optional[pa.Table] = None
@@ -500,8 +500,8 @@ class SparkSession:
                         if isinstance(field_type, pa.StructType):
                             if len(field_type) == 0:
                                 raise PySparkValueError(
-                                    error_class="CANNOT_INFER_EMPTY_SCHEMA",
-                                    message_parameters={},
+                                    errorClass="CANNOT_INFER_EMPTY_SCHEMA",
+                                    messageParameters={},
                                 )
                             arrow_type = field_type.field(0).type
                             spark_type = MapType(StringType(), from_arrow_type(arrow_type))
@@ -526,8 +526,8 @@ class SparkSession:
                 _cols = [str(x) if not isinstance(x, str) else x for x in schema.fieldNames()]
             elif isinstance(schema, DataType):
                 raise PySparkTypeError(
-                    error_class="UNSUPPORTED_DATA_TYPE_FOR_ARROW",
-                    message_parameters={"data_type": str(schema)},
+                    errorClass="UNSUPPORTED_DATA_TYPE_FOR_ARROW",
+                    messageParameters={"data_type": str(schema)},
                 )
             else:
                 # Any timestamps must be coerced to be compatible with Spark
@@ -596,8 +596,8 @@ class SparkSession:
             if data.ndim == 1:
                 if 1 != len(_cols):
                     raise PySparkValueError(
-                        error_class="AXIS_LENGTH_MISMATCH",
-                        message_parameters={
+                        errorClass="AXIS_LENGTH_MISMATCH",
+                        messageParameters={
                             "expected_length": str(len(_cols)),
                             "actual_length": "1",
                         },
@@ -607,8 +607,8 @@ class SparkSession:
             else:
                 if data.shape[1] != len(_cols):
                     raise PySparkValueError(
-                        error_class="AXIS_LENGTH_MISMATCH",
-                        message_parameters={
+                        errorClass="AXIS_LENGTH_MISMATCH",
+                        messageParameters={
                             "expected_length": str(len(_cols)),
                             "actual_length": str(data.shape[1]),
                         },
@@ -649,7 +649,7 @@ class SparkSession:
                     # For cases like createDataFrame([("Alice", None, 80.1)], schema)
                     # we can not infer the schema from the data itself.
                     raise PySparkValueError(
-                        error_class="CANNOT_DETERMINE_TYPE", message_parameters={}
+                        errorClass="CANNOT_DETERMINE_TYPE", messageParameters={}
                     )
 
             from pyspark.sql.connect.conversion import LocalDataToArrowConversion
@@ -663,8 +663,8 @@ class SparkSession:
         # whether the Arrow Schema is compatible with the user provided Schema.
         if _num_cols is not None and _num_cols != _table.shape[1]:
             raise PySparkValueError(
-                error_class="AXIS_LENGTH_MISMATCH",
-                message_parameters={
+                errorClass="AXIS_LENGTH_MISMATCH",
+                messageParameters={
                     "expected_length": str(_num_cols),
                     "actual_length": str(_table.shape[1]),
                 },
@@ -704,8 +704,8 @@ class SparkSession:
                 _args = [F.lit(v) for v in args]
             else:
                 raise PySparkTypeError(
-                    error_class="INVALID_TYPE",
-                    message_parameters={"arg_name": "args", "arg_type": type(args).__name__},
+                    errorClass="INVALID_TYPE",
+                    messageParameters={"arg_name": "args", "arg_type": type(args).__name__},
                 )
 
         _views: List[SubqueryAlias] = []
@@ -894,7 +894,7 @@ class SparkSession:
     def __getattr__(self, name: str) -> Any:
         if name in ["_jsc", "_jconf", "_jvm", "_jsparkSession", "sparkContext", "newSession"]:
             raise PySparkAttributeError(
-                error_class="JVM_ATTRIBUTE_NOT_SUPPORTED", message_parameters={"attr_name": name}
+                errorClass="JVM_ATTRIBUTE_NOT_SUPPORTED", messageParameters={"attr_name": name}
             )
         return object.__getattribute__(self, name)
 
@@ -941,8 +941,8 @@ class SparkSession:
     ) -> None:
         if sum([file, pyfile, archive]) > 1:
             raise PySparkValueError(
-                error_class="INVALID_MULTIPLE_ARGUMENT_CONDITIONS",
-                message_parameters={
+                errorClass="INVALID_MULTIPLE_ARGUMENT_CONDITIONS",
+                messageParameters={
                     "arg_names": "'pyfile', 'archive' and/or 'file'",
                     "condition": "True together",
                 },
@@ -963,8 +963,8 @@ class SparkSession:
     def copyFromLocalToFs(self, local_path: str, dest_path: str) -> None:
         if urllib.parse.urlparse(dest_path).scheme:
             raise PySparkValueError(
-                error_class="NO_SCHEMA_AND_DRIVER_DEFAULT_SCHEME",
-                message_parameters={"arg_name": "dest_path"},
+                errorClass="NO_SCHEMA_AND_DRIVER_DEFAULT_SCHEME",
+                messageParameters={"arg_name": "dest_path"},
             )
         self._client.copy_from_local_to_fs(local_path, dest_path)
 
@@ -1032,8 +1032,8 @@ class SparkSession:
                     os.environ["SPARK_REMOTE"] = origin_remote
         else:
             raise PySparkRuntimeError(
-                error_class="SESSION_OR_CONTEXT_EXISTS",
-                message_parameters={},
+                errorClass="SESSION_OR_CONTEXT_EXISTS",
+                messageParameters={},
             )
 
     @property

--- a/python/pyspark/sql/connect/streaming/query.py
+++ b/python/pyspark/sql/connect/streaming/query.py
@@ -84,8 +84,8 @@ class StreamingQuery:
         if timeout is not None:
             if not isinstance(timeout, (int, float)) or timeout <= 0:
                 raise PySparkValueError(
-                    error_class="VALUE_NOT_POSITIVE",
-                    message_parameters={"arg_name": "timeout", "arg_value": type(timeout).__name__},
+                    errorClass="VALUE_NOT_POSITIVE",
+                    messageParameters={"arg_name": "timeout", "arg_value": type(timeout).__name__},
                 )
             cmd.await_termination.timeout_ms = int(timeout * 1000)
             terminated = self._execute_streaming_query_cmd(cmd).await_termination.terminated
@@ -219,8 +219,8 @@ class StreamingQueryManager:
         if timeout is not None:
             if not isinstance(timeout, (int, float)) or timeout <= 0:
                 raise PySparkValueError(
-                    error_class="VALUE_NOT_POSITIVE",
-                    message_parameters={"arg_name": "timeout", "arg_value": type(timeout).__name__},
+                    errorClass="VALUE_NOT_POSITIVE",
+                    messageParameters={"arg_name": "timeout", "arg_value": type(timeout).__name__},
                 )
             cmd.await_any_termination.timeout_ms = int(timeout * 1000)
             terminated = self._execute_streaming_query_manager_cmd(
@@ -401,8 +401,8 @@ class StreamingQueryListenerBus:
             return QueryIdleEvent.fromJson(json.loads(event.event_json))
         else:
             raise PySparkValueError(
-                error_class="UNKNOWN_VALUE_FOR",
-                message_parameters={"var": f"proto.StreamingQueryEventType: {event.event_type}"},
+                errorClass="UNKNOWN_VALUE_FOR",
+                messageParameters={"var": f"proto.StreamingQueryEventType: {event.event_type}"},
             )
 
     def post_to_all(

--- a/python/pyspark/sql/connect/streaming/readwriter.py
+++ b/python/pyspark/sql/connect/streaming/readwriter.py
@@ -69,8 +69,8 @@ class DataStreamReader(OptionUtils):
             self._schema = schema
         else:
             raise PySparkTypeError(
-                error_class="NOT_STR_OR_STRUCT",
-                message_parameters={"arg_name": "schema", "arg_type": type(schema).__name__},
+                errorClass="NOT_STR_OR_STRUCT",
+                messageParameters={"arg_name": "schema", "arg_type": type(schema).__name__},
             )
         return self
 
@@ -103,8 +103,8 @@ class DataStreamReader(OptionUtils):
         self.options(**options)
         if path is not None and (type(path) != str or len(path.strip()) == 0):
             raise PySparkValueError(
-                error_class="VALUE_NOT_NON_EMPTY_STR",
-                message_parameters={"arg_name": "path", "arg_value": str(path)},
+                errorClass="VALUE_NOT_NON_EMPTY_STR",
+                messageParameters={"arg_name": "path", "arg_value": str(path)},
             )
 
         plan = DataSource(
@@ -171,8 +171,8 @@ class DataStreamReader(OptionUtils):
             return self.load(path=path, format="json")
         else:
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
             )
 
     json.__doc__ = PySparkDataStreamReader.json.__doc__
@@ -193,8 +193,8 @@ class DataStreamReader(OptionUtils):
             return self.load(path=path, format="orc")
         else:
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
             )
 
     orc.__doc__ = PySparkDataStreamReader.orc.__doc__
@@ -226,8 +226,8 @@ class DataStreamReader(OptionUtils):
             return self.load(path=path, format="parquet")
         else:
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
             )
 
     parquet.__doc__ = PySparkDataStreamReader.parquet.__doc__
@@ -250,8 +250,8 @@ class DataStreamReader(OptionUtils):
             return self.load(path=path, format="text")
         else:
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
             )
 
     text.__doc__ = PySparkDataStreamReader.text.__doc__
@@ -326,8 +326,8 @@ class DataStreamReader(OptionUtils):
             return self.load(path=path, format="csv")
         else:
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
             )
 
     csv.__doc__ = PySparkDataStreamReader.csv.__doc__
@@ -380,8 +380,8 @@ class DataStreamReader(OptionUtils):
             return self.load(path=path, format="xml")
         else:
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
             )
 
     xml.__doc__ = PySparkDataStreamReader.xml.__doc__
@@ -448,8 +448,8 @@ class DataStreamWriter:
     def queryName(self, queryName: str) -> "DataStreamWriter":
         if not queryName or type(queryName) != str or len(queryName.strip()) == 0:
             raise PySparkValueError(
-                error_class="VALUE_NOT_NON_EMPTY_STR",
-                message_parameters={"arg_name": "queryName", "arg_value": str(queryName)},
+                errorClass="VALUE_NOT_NON_EMPTY_STR",
+                messageParameters={"arg_name": "queryName", "arg_value": str(queryName)},
             )
         self._write_proto.query_name = queryName
         return self
@@ -484,20 +484,20 @@ class DataStreamWriter:
 
         if params.count(None) == 4:
             raise PySparkValueError(
-                error_class="ONLY_ALLOW_SINGLE_TRIGGER",
-                message_parameters={},
+                errorClass="ONLY_ALLOW_SINGLE_TRIGGER",
+                messageParameters={},
             )
         elif params.count(None) < 3:
             raise PySparkValueError(
-                error_class="ONLY_ALLOW_SINGLE_TRIGGER",
-                message_parameters={},
+                errorClass="ONLY_ALLOW_SINGLE_TRIGGER",
+                messageParameters={},
             )
 
         if processingTime is not None:
             if type(processingTime) != str or len(processingTime.strip()) == 0:
                 raise PySparkValueError(
-                    error_class="VALUE_NOT_NON_EMPTY_STR",
-                    message_parameters={
+                    errorClass="VALUE_NOT_NON_EMPTY_STR",
+                    messageParameters={
                         "arg_name": "processingTime",
                         "arg_value": str(processingTime),
                     },
@@ -507,24 +507,24 @@ class DataStreamWriter:
         elif once is not None:
             if once is not True:
                 raise PySparkValueError(
-                    error_class="VALUE_NOT_TRUE",
-                    message_parameters={"arg_name": "once", "arg_value": str(once)},
+                    errorClass="VALUE_NOT_TRUE",
+                    messageParameters={"arg_name": "once", "arg_value": str(once)},
                 )
             self._write_proto.once = True
 
         elif continuous is not None:
             if type(continuous) != str or len(continuous.strip()) == 0:
                 raise PySparkValueError(
-                    error_class="VALUE_NOT_NON_EMPTY_STR",
-                    message_parameters={"arg_name": "continuous", "arg_value": str(continuous)},
+                    errorClass="VALUE_NOT_NON_EMPTY_STR",
+                    messageParameters={"arg_name": "continuous", "arg_value": str(continuous)},
                 )
             self._write_proto.continuous_checkpoint_interval = continuous.strip()
 
         else:
             if availableNow is not True:
                 raise PySparkValueError(
-                    error_class="VALUE_NOT_TRUE",
-                    message_parameters={"arg_name": "availableNow", "arg_value": str(availableNow)},
+                    errorClass="VALUE_NOT_TRUE",
+                    messageParameters={"arg_name": "availableNow", "arg_value": str(availableNow)},
                 )
             self._write_proto.available_now = True
 
@@ -553,8 +553,8 @@ class DataStreamWriter:
             )
         except pickle.PicklingError:
             raise PySparkPicklingError(
-                error_class="STREAMING_CONNECT_SERIALIZATION_ERROR",
-                message_parameters={"name": "foreach"},
+                errorClass="STREAMING_CONNECT_SERIALIZATION_ERROR",
+                messageParameters={"name": "foreach"},
             )
         self._write_proto.foreach_writer.python_function.python_ver = "%d.%d" % sys.version_info[:2]
         return self
@@ -568,8 +568,8 @@ class DataStreamWriter:
             )
         except pickle.PicklingError:
             raise PySparkPicklingError(
-                error_class="STREAMING_CONNECT_SERIALIZATION_ERROR",
-                message_parameters={"name": "foreachBatch"},
+                errorClass="STREAMING_CONNECT_SERIALIZATION_ERROR",
+                messageParameters={"name": "foreachBatch"},
             )
         self._write_proto.foreach_batch.python_function.python_ver = get_python_ver()
         return self

--- a/python/pyspark/sql/connect/types.py
+++ b/python/pyspark/sql/connect/types.py
@@ -101,26 +101,26 @@ class UnparsedDataType(DataType):
 
     def jsonValue(self) -> Dict[str, Any]:
         raise PySparkAssertionError(
-            error_class="INVALID_CALL_ON_UNRESOLVED_OBJECT",
-            message_parameters={"func_name": "jsonValue"},
+            errorClass="INVALID_CALL_ON_UNRESOLVED_OBJECT",
+            messageParameters={"func_name": "jsonValue"},
         )
 
     def needConversion(self) -> bool:
         raise PySparkAssertionError(
-            error_class="INVALID_CALL_ON_UNRESOLVED_OBJECT",
-            message_parameters={"func_name": "needConversion"},
+            errorClass="INVALID_CALL_ON_UNRESOLVED_OBJECT",
+            messageParameters={"func_name": "needConversion"},
         )
 
     def toInternal(self, obj: Any) -> Any:
         raise PySparkAssertionError(
-            error_class="INVALID_CALL_ON_UNRESOLVED_OBJECT",
-            message_parameters={"func_name": "toInternal"},
+            errorClass="INVALID_CALL_ON_UNRESOLVED_OBJECT",
+            messageParameters={"func_name": "toInternal"},
         )
 
     def fromInternal(self, obj: Any) -> Any:
         raise PySparkAssertionError(
-            error_class="INVALID_CALL_ON_UNRESOLVED_OBJECT",
-            message_parameters={"func_name": "fromInternal"},
+            errorClass="INVALID_CALL_ON_UNRESOLVED_OBJECT",
+            messageParameters={"func_name": "fromInternal"},
         )
 
 
@@ -199,8 +199,8 @@ def pyspark_types_to_proto_types(data_type: DataType) -> pb2.DataType:
         ret.unparsed.data_type_string = data_type_string
     else:
         raise PySparkValueError(
-            error_class="UNSUPPORTED_OPERATION",
-            message_parameters={"operation": f"data type {data_type}"},
+            errorClass="UNSUPPORTED_OPERATION",
+            messageParameters={"operation": f"data type {data_type}"},
         )
     return ret
 
@@ -303,8 +303,8 @@ def proto_schema_to_pyspark_data_type(schema: pb2.DataType) -> DataType:
         return UserDefinedType.fromJson(json_value)
     else:
         raise PySparkValueError(
-            error_class="UNSUPPORTED_OPERATION",
-            message_parameters={"operation": f"data type {schema}"},
+            errorClass="UNSUPPORTED_OPERATION",
+            messageParameters={"operation": f"data type {schema}"},
         )
 
 

--- a/python/pyspark/sql/connect/udf.py
+++ b/python/pyspark/sql/connect/udf.py
@@ -130,14 +130,14 @@ class UserDefinedFunction:
     ):
         if not callable(func):
             raise PySparkTypeError(
-                error_class="NOT_CALLABLE",
-                message_parameters={"arg_name": "func", "arg_type": type(func).__name__},
+                errorClass="NOT_CALLABLE",
+                messageParameters={"arg_name": "func", "arg_type": type(func).__name__},
             )
 
         if not isinstance(returnType, (DataType, str)):
             raise PySparkTypeError(
-                error_class="NOT_DATATYPE_OR_STR",
-                message_parameters={
+                errorClass="NOT_DATATYPE_OR_STR",
+                messageParameters={
                     "arg_name": "returnType",
                     "arg_type": type(returnType).__name__,
                 },
@@ -145,8 +145,8 @@ class UserDefinedFunction:
 
         if not isinstance(evalType, int):
             raise PySparkTypeError(
-                error_class="NOT_INT",
-                message_parameters={"arg_name": "evalType", "arg_type": type(evalType).__name__},
+                errorClass="NOT_INT",
+                messageParameters={"arg_name": "evalType", "arg_type": type(evalType).__name__},
             )
 
         self.func = func
@@ -268,8 +268,8 @@ class UDFRegistration:
         if hasattr(f, "asNondeterministic"):
             if returnType is not None:
                 raise PySparkTypeError(
-                    error_class="CANNOT_SPECIFY_RETURN_TYPE_FOR_UDF",
-                    message_parameters={"arg_name": "f", "return_type": str(returnType)},
+                    errorClass="CANNOT_SPECIFY_RETURN_TYPE_FOR_UDF",
+                    messageParameters={"arg_name": "f", "return_type": str(returnType)},
                 )
             f = cast("UserDefinedFunctionLike", f)
             if f.evalType not in [
@@ -280,8 +280,8 @@ class UDFRegistration:
                 PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF,
             ]:
                 raise PySparkTypeError(
-                    error_class="INVALID_UDF_EVAL_TYPE",
-                    message_parameters={
+                    errorClass="INVALID_UDF_EVAL_TYPE",
+                    messageParameters={
                         "eval_type": "SQL_BATCHED_UDF, SQL_ARROW_BATCHED_UDF, "
                         "SQL_SCALAR_PANDAS_UDF, SQL_SCALAR_PANDAS_ITER_UDF or "
                         "SQL_GROUPED_AGG_PANDAS_UDF"

--- a/python/pyspark/sql/connect/udtf.py
+++ b/python/pyspark/sql/connect/udtf.py
@@ -194,16 +194,16 @@ class UDTFRegistration:
     ) -> "UserDefinedTableFunction":
         if not isinstance(f, UserDefinedTableFunction):
             raise PySparkTypeError(
-                error_class="CANNOT_REGISTER_UDTF",
-                message_parameters={
+                errorClass="CANNOT_REGISTER_UDTF",
+                messageParameters={
                     "name": name,
                 },
             )
 
         if f.evalType not in [PythonEvalType.SQL_TABLE_UDF, PythonEvalType.SQL_ARROW_TABLE_UDF]:
             raise PySparkTypeError(
-                error_class="INVALID_UDTF_EVAL_TYPE",
-                message_parameters={
+                errorClass="INVALID_UDTF_EVAL_TYPE",
+                messageParameters={
                     "name": name,
                     "eval_type": "SQL_TABLE_UDF, SQL_ARROW_TABLE_UDF",
                 },

--- a/python/pyspark/sql/connect/utils.py
+++ b/python/pyspark/sql/connect/utils.py
@@ -47,16 +47,16 @@ def require_minimum_grpc_version() -> None:
         import grpc
     except ImportError as error:
         raise PySparkImportError(
-            error_class="PACKAGE_NOT_INSTALLED",
-            message_parameters={
+            errorClass="PACKAGE_NOT_INSTALLED",
+            messageParameters={
                 "package_name": "grpcio",
                 "minimum_version": str(minimum_grpc_version),
             },
         ) from error
     if LooseVersion(grpc.__version__) < LooseVersion(minimum_grpc_version):
         raise PySparkImportError(
-            error_class="UNSUPPORTED_PACKAGE_VERSION",
-            message_parameters={
+            errorClass="UNSUPPORTED_PACKAGE_VERSION",
+            messageParameters={
                 "package_name": "grpcio",
                 "minimum_version": str(minimum_grpc_version),
                 "current_version": str(grpc.__version__),
@@ -72,8 +72,8 @@ def require_minimum_grpcio_status_version() -> None:
         import grpc_status  # noqa
     except ImportError as error:
         raise PySparkImportError(
-            error_class="PACKAGE_NOT_INSTALLED",
-            message_parameters={
+            errorClass="PACKAGE_NOT_INSTALLED",
+            messageParameters={
                 "package_name": "grpcio-status",
                 "minimum_version": str(minimum_grpc_version),
             },
@@ -88,8 +88,8 @@ def require_minimum_googleapis_common_protos_version() -> None:
         import google.rpc  # noqa
     except ImportError as error:
         raise PySparkImportError(
-            error_class="PACKAGE_NOT_INSTALLED",
-            message_parameters={
+            errorClass="PACKAGE_NOT_INSTALLED",
+            messageParameters={
                 "package_name": "googleapis-common-protos",
                 "minimum_version": str(minimum_common_protos_version),
             },

--- a/python/pyspark/sql/datasource.py
+++ b/python/pyspark/sql/datasource.py
@@ -115,8 +115,8 @@ class DataSource(ABC):
         ...   return StructType().add("a", "int").add("b", "string")
         """
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "schema"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "schema"},
         )
 
     def reader(self, schema: StructType) -> "DataSourceReader":
@@ -136,8 +136,8 @@ class DataSource(ABC):
             A reader instance for this data source.
         """
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "reader"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "reader"},
         )
 
     def writer(self, schema: StructType, overwrite: bool) -> "DataSourceWriter":
@@ -159,8 +159,8 @@ class DataSource(ABC):
             A writer instance for this data source.
         """
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "writer"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "writer"},
         )
 
     def streamWriter(self, schema: StructType, overwrite: bool) -> "DataSourceStreamWriter":
@@ -182,8 +182,8 @@ class DataSource(ABC):
             A writer instance for writing data into a streaming sink.
         """
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "streamWriter"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "streamWriter"},
         )
 
     def simpleStreamReader(self, schema: StructType) -> "SimpleDataSourceStreamReader":
@@ -206,8 +206,8 @@ class DataSource(ABC):
             A reader instance for this data source.
         """
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "simpleStreamReader"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "simpleStreamReader"},
         )
 
     def streamReader(self, schema: StructType) -> "DataSourceStreamReader":
@@ -228,8 +228,8 @@ class DataSource(ABC):
             A reader instance for this streaming data source.
         """
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "streamReader"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "streamReader"},
         )
 
 
@@ -328,8 +328,8 @@ class DataSourceReader(ABC):
         ...     return [RangeInputPartition(1, 3), RangeInputPartition(5, 10)]
         """
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "partitions"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "partitions"},
         )
 
     @abstractmethod
@@ -398,8 +398,8 @@ class DataSourceStreamReader(ABC):
         ...     return {"parititon-1": {"index": 3, "closed": True}, "partition-2": {"index": 5}}
         """
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "initialOffset"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "initialOffset"},
         )
 
     def latestOffset(self) -> dict:
@@ -418,8 +418,8 @@ class DataSourceStreamReader(ABC):
         ...     return {"parititon-1": {"index": 3, "closed": True}, "partition-2": {"index": 5}}
         """
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "latestOffset"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "latestOffset"},
         )
 
     def partitions(self, start: dict, end: dict) -> Sequence[InputPartition]:
@@ -443,8 +443,8 @@ class DataSourceStreamReader(ABC):
             must be an instance of `InputPartition` or a subclass of it.
         """
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "partitions"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "partitions"},
         )
 
     @abstractmethod
@@ -475,8 +475,8 @@ class DataSourceStreamReader(ABC):
             in the final DataFrame.
         """
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "read"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "read"},
         )
 
     def commit(self, end: dict) -> None:
@@ -534,8 +534,8 @@ class SimpleDataSourceStreamReader(ABC):
         ...     return {"parititon-1": {"index": 3, "closed": True}, "partition-2": {"index": 5}}
         """
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "initialOffset"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "initialOffset"},
         )
 
     def read(self, start: dict) -> Tuple[Iterator[Tuple], dict]:
@@ -555,8 +555,8 @@ class SimpleDataSourceStreamReader(ABC):
             The dict is the end offset of this read attempt and the start of next read attempt.
         """
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "read"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "read"},
         )
 
     def readBetweenOffsets(self, start: dict, end: dict) -> Iterator[Tuple]:
@@ -578,8 +578,8 @@ class SimpleDataSourceStreamReader(ABC):
             All the records between start offset and end offset.
         """
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "readBetweenOffsets"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "readBetweenOffsets"},
         )
 
     def commit(self, end: dict) -> None:

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -218,7 +218,7 @@ def lit(col: Any) -> Column:
     elif isinstance(col, list):
         if any(isinstance(c, Column) for c in col):
             raise PySparkValueError(
-                error_class="COLUMN_IN_LIST", message_parameters={"func_name": "lit"}
+                errorClass="COLUMN_IN_LIST", messageParameters={"func_name": "lit"}
             )
         return array(*[lit(item) for item in col])
     else:
@@ -6573,8 +6573,8 @@ def greatest(*cols: "ColumnOrName") -> Column:
     """
     if len(cols) < 2:
         raise PySparkValueError(
-            error_class="WRONG_NUM_COLUMNS",
-            message_parameters={"func_name": "greatest", "num_cols": "2"},
+            errorClass="WRONG_NUM_COLUMNS",
+            messageParameters={"func_name": "greatest", "num_cols": "2"},
         )
     return _invoke_function_over_seq_of_columns("greatest", cols)
 
@@ -6608,8 +6608,8 @@ def least(*cols: "ColumnOrName") -> Column:
     """
     if len(cols) < 2:
         raise PySparkValueError(
-            error_class="WRONG_NUM_COLUMNS",
-            message_parameters={"func_name": "least", "num_cols": "2"},
+            errorClass="WRONG_NUM_COLUMNS",
+            messageParameters={"func_name": "least", "num_cols": "2"},
         )
     return _invoke_function_over_seq_of_columns("least", cols)
 
@@ -6661,8 +6661,8 @@ def when(condition: Column, value: Any) -> Column:
     # Explicitly not using ColumnOrName type here to make reading condition less opaque
     if not isinstance(condition, Column):
         raise PySparkTypeError(
-            error_class="NOT_COLUMN",
-            message_parameters={"arg_name": "condition", "arg_type": type(condition).__name__},
+            errorClass="NOT_COLUMN",
+            messageParameters={"arg_name": "condition", "arg_type": type(condition).__name__},
         )
     v = value._jc if isinstance(value, Column) else value
 
@@ -9563,8 +9563,8 @@ def window(
     def check_string_field(field, fieldName):  # type: ignore[no-untyped-def]
         if not field or type(field) is not str:
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": fieldName, "arg_type": type(field).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": fieldName, "arg_type": type(field).__name__},
             )
 
     time_col = _to_java_column(timeColumn)
@@ -9692,8 +9692,8 @@ def session_window(timeColumn: "ColumnOrName", gapDuration: Union[Column, str]) 
     def check_field(field: Union[Column, str], fieldName: str) -> None:
         if field is None or not isinstance(field, (str, Column)):
             raise PySparkTypeError(
-                error_class="NOT_COLUMN_OR_STR",
-                message_parameters={"arg_name": fieldName, "arg_type": type(field).__name__},
+                errorClass="NOT_COLUMN_OR_STR",
+                messageParameters={"arg_name": fieldName, "arg_type": type(field).__name__},
             )
 
     time_col = _to_java_column(timeColumn)
@@ -10062,8 +10062,8 @@ def sha2(col: "ColumnOrName", numBits: int) -> Column:
 
     if numBits not in [0, 224, 256, 384, 512]:
         raise PySparkValueError(
-            error_class="VALUE_NOT_ALLOWED",
-            message_parameters={
+            errorClass="VALUE_NOT_ALLOWED",
+            messageParameters={
                 "arg_name": "numBits",
                 "allowed_values": "[0, 224, 256, 384, 512]",
             },
@@ -10203,8 +10203,8 @@ def assert_true(col: "ColumnOrName", errMsg: Optional[Union[Column, str]] = None
         return _invoke_function_over_columns("assert_true", col)
     if not isinstance(errMsg, (str, Column)):
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "errMsg", "arg_type": type(errMsg).__name__},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "errMsg", "arg_type": type(errMsg).__name__},
         )
 
     errMsg = (
@@ -10245,8 +10245,8 @@ def raise_error(errMsg: Union[Column, str]) -> Column:
 
     if not isinstance(errMsg, (str, Column)):
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "errMsg", "arg_type": type(errMsg).__name__},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "errMsg", "arg_type": type(errMsg).__name__},
         )
 
     errMsg = (
@@ -10804,13 +10804,13 @@ def overlay(
 
     if not isinstance(pos, (int, str, Column)):
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_INT_OR_STR",
-            message_parameters={"arg_name": "pos", "arg_type": type(pos).__name__},
+            errorClass="NOT_COLUMN_OR_INT_OR_STR",
+            messageParameters={"arg_name": "pos", "arg_type": type(pos).__name__},
         )
     if len is not None and not isinstance(len, (int, str, Column)):
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_INT_OR_STR",
-            message_parameters={"arg_name": "len", "arg_type": type(len).__name__},
+            errorClass="NOT_COLUMN_OR_INT_OR_STR",
+            messageParameters={"arg_name": "len", "arg_type": type(len).__name__},
         )
 
     pos = _create_column_from_literal(pos) if isinstance(pos, int) else _to_java_column(pos)
@@ -15714,8 +15714,8 @@ def json_tuple(col: "ColumnOrName", *fields: str) -> Column:
 
     if len(fields) == 0:
         raise PySparkValueError(
-            error_class="CANNOT_BE_EMPTY",
-            message_parameters={"item": "field"},
+            errorClass="CANNOT_BE_EMPTY",
+            messageParameters={"item": "field"},
         )
     sc = _get_active_spark_context()
     return _invoke_function("json_tuple", _to_java_column(col), _to_seq(sc, fields))
@@ -16220,8 +16220,8 @@ def schema_of_json(json: Union[Column, str], options: Optional[Dict[str, str]] =
         col = _to_java_column(json)
     else:
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "json", "arg_type": type(json).__name__},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "json", "arg_type": type(json).__name__},
         )
 
     return _invoke_function("schema_of_json", col, _options_to_str(options))
@@ -16373,8 +16373,8 @@ def from_xml(
         schema = _to_java_column(schema)
     elif not isinstance(schema, str):
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_STR_OR_STRUCT",
-            message_parameters={"arg_name": "schema", "arg_type": type(schema).__name__},
+            errorClass="NOT_COLUMN_OR_STR_OR_STRUCT",
+            messageParameters={"arg_name": "schema", "arg_type": type(schema).__name__},
         )
     return _invoke_function("from_xml", _to_java_column(col), schema, _options_to_str(options))
 
@@ -16452,8 +16452,8 @@ def schema_of_xml(xml: Union[Column, str], options: Optional[Dict[str, str]] = N
         col = _to_java_column(xml)
     else:
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "xml", "arg_type": type(xml).__name__},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "xml", "arg_type": type(xml).__name__},
         )
 
     return _invoke_function("schema_of_xml", col, _options_to_str(options))
@@ -16576,8 +16576,8 @@ def schema_of_csv(csv: Union[Column, str], options: Optional[Dict[str, str]] = N
         col = _to_java_column(csv)
     else:
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "csv", "arg_type": type(csv).__name__},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "csv", "arg_type": type(csv).__name__},
         )
 
     return _invoke_function("schema_of_csv", col, _options_to_str(options))
@@ -18124,8 +18124,8 @@ def from_csv(
         schema = _to_java_column(schema)
     else:
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "schema", "arg_type": type(schema).__name__},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "schema", "arg_type": type(schema).__name__},
         )
 
     return _invoke_function("from_csv", _to_java_column(col), schema, _options_to_str(options))
@@ -18170,15 +18170,15 @@ def _get_lambda_parameters(f: Callable) -> ValuesView[inspect.Parameter]:
     # function arity is between 1 and 3
     if not (1 <= len(parameters) <= 3):
         raise PySparkValueError(
-            error_class="WRONG_NUM_ARGS_FOR_HIGHER_ORDER_FUNCTION",
-            message_parameters={"func_name": f.__name__, "num_args": str(len(parameters))},
+            errorClass="WRONG_NUM_ARGS_FOR_HIGHER_ORDER_FUNCTION",
+            messageParameters={"func_name": f.__name__, "num_args": str(len(parameters))},
         )
 
     # and all arguments can be used as positional
     if not all(p.kind in supported_parameter_types for p in parameters):
         raise PySparkValueError(
-            error_class="UNSUPPORTED_PARAM_TYPE_FOR_HIGHER_ORDER_FUNCTION",
-            message_parameters={"func_name": f.__name__},
+            errorClass="UNSUPPORTED_PARAM_TYPE_FOR_HIGHER_ORDER_FUNCTION",
+            messageParameters={"func_name": f.__name__},
         )
 
     return parameters
@@ -18214,8 +18214,8 @@ def _create_lambda(f: Callable) -> Callable:
 
     if not isinstance(result, Column):
         raise PySparkValueError(
-            error_class="HIGHER_ORDER_FUNCTION_SHOULD_RETURN_COLUMN",
-            message_parameters={"func_name": f.__name__, "return_type": type(result).__name__},
+            errorClass="HIGHER_ORDER_FUNCTION_SHOULD_RETURN_COLUMN",
+            messageParameters={"func_name": f.__name__, "return_type": type(result).__name__},
         )
 
     jexpr = result._jc.expr()

--- a/python/pyspark/sql/functions/partitioning.py
+++ b/python/pyspark/sql/functions/partitioning.py
@@ -210,8 +210,8 @@ def bucket(numBuckets: Union[Column, int], col: "ColumnOrName") -> Column:
 
     if not isinstance(numBuckets, (int, Column)):
         raise PySparkTypeError(
-            error_class="NOT_COLUMN_OR_INT",
-            message_parameters={
+            errorClass="NOT_COLUMN_OR_INT",
+            messageParameters={
                 "arg_name": "numBuckets",
                 "arg_type": type(numBuckets).__name__,
             },

--- a/python/pyspark/sql/metrics.py
+++ b/python/pyspark/sql/metrics.py
@@ -263,8 +263,8 @@ class CollectedMetrics:
 
         except ImportError:
             raise PySparkValueError(
-                error_class="PACKAGE_NOT_INSTALLED",
-                message_parameters={"package_name": "graphviz", "minimum_version": "0.20"},
+                errorClass="PACKAGE_NOT_INSTALLED",
+                messageParameters={"package_name": "graphviz", "minimum_version": "0.20"},
             )
 
 

--- a/python/pyspark/sql/observation.py
+++ b/python/pyspark/sql/observation.py
@@ -88,13 +88,13 @@ class Observation:
         if name is not None:
             if not isinstance(name, str):
                 raise PySparkTypeError(
-                    error_class="NOT_STR",
-                    message_parameters={"arg_name": "name", "arg_type": type(name).__name__},
+                    errorClass="NOT_STR",
+                    messageParameters={"arg_name": "name", "arg_type": type(name).__name__},
                 )
             if name == "":
                 raise PySparkValueError(
-                    error_class="VALUE_NOT_NON_EMPTY_STR",
-                    message_parameters={"arg_name": "name", "arg_value": name},
+                    errorClass="VALUE_NOT_NON_EMPTY_STR",
+                    messageParameters={"arg_name": "name", "arg_value": name},
                 )
         self._name = name
         self._jvm: Optional[JVMView] = None
@@ -118,7 +118,7 @@ class Observation:
         from pyspark.sql.classic.column import _to_seq
 
         if self._jo is not None:
-            raise PySparkAssertionError(error_class="REUSE_OBSERVATION", message_parameters={})
+            raise PySparkAssertionError(errorClass="REUSE_OBSERVATION", messageParameters={})
 
         self._jvm = df._sc._jvm
         assert self._jvm is not None
@@ -144,7 +144,7 @@ class Observation:
             the observed metrics
         """
         if self._jo is None:
-            raise PySparkAssertionError(error_class="NO_OBSERVE_BEFORE_GET", message_parameters={})
+            raise PySparkAssertionError(errorClass="NO_OBSERVE_BEFORE_GET", messageParameters={})
 
         jmap = self._jo.getAsJava()
         # return a pure Python dict, not jmap which is a py4j JavaMap

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -673,8 +673,8 @@ class SparkConversionMixin:
                     if isinstance(field_type, pa.StructType):
                         if len(field_type) == 0:
                             raise PySparkValueError(
-                                error_class="CANNOT_INFER_EMPTY_SCHEMA",
-                                message_parameters={},
+                                errorClass="CANNOT_INFER_EMPTY_SCHEMA",
+                                messageParameters={},
                             )
                         arrow_type = field_type.field(0).type
                         spark_type = MapType(
@@ -697,8 +697,8 @@ class SparkConversionMixin:
             spark_types = [_deduplicate_field_names(f.dataType) for f in schema.fields]
         elif isinstance(schema, DataType):
             raise PySparkTypeError(
-                error_class="UNSUPPORTED_DATA_TYPE_FOR_ARROW",
-                message_parameters={"data_type": str(schema)},
+                errorClass="UNSUPPORTED_DATA_TYPE_FOR_ARROW",
+                messageParameters={"data_type": str(schema)},
             )
         else:
             # Any timestamps must be coerced to be compatible with Spark

--- a/python/pyspark/sql/pandas/functions.py
+++ b/python/pyspark/sql/pandas/functions.py
@@ -400,8 +400,8 @@ def pandas_udf(f=None, returnType=None, functionType=None):
 
     if return_type is None:
         raise PySparkTypeError(
-            error_class="CANNOT_BE_NONE",
-            message_parameters={"arg_name": "returnType"},
+            errorClass="CANNOT_BE_NONE",
+            messageParameters={"arg_name": "returnType"},
         )
 
     if eval_type not in [
@@ -418,8 +418,8 @@ def pandas_udf(f=None, returnType=None, functionType=None):
         None,
     ]:  # None means it should infer the type from type hints.
         raise PySparkTypeError(
-            error_class="INVALID_PANDAS_UDF_TYPE",
-            message_parameters={
+            errorClass="INVALID_PANDAS_UDF_TYPE",
+            messageParameters={
                 "arg_name": "functionType",
                 "arg_type": str(eval_type),
             },
@@ -485,8 +485,8 @@ def _validate_pandas_udf(f, evalType) -> int:
         and argspec.varargs is None
     ):
         raise PySparkValueError(
-            error_class="INVALID_PANDAS_UDF",
-            message_parameters={
+            errorClass="INVALID_PANDAS_UDF",
+            messageParameters={
                 "detail": "0-arg pandas_udfs are not supported. "
                 "Instead, create a 1-arg pandas_udf and ignore the arg in your function.",
             },
@@ -494,8 +494,8 @@ def _validate_pandas_udf(f, evalType) -> int:
 
     if evalType == PythonEvalType.SQL_GROUPED_MAP_PANDAS_UDF and len(argspec.args) not in (1, 2):
         raise PySparkValueError(
-            error_class="INVALID_PANDAS_UDF",
-            message_parameters={
+            errorClass="INVALID_PANDAS_UDF",
+            messageParameters={
                 "detail": "pandas_udf with function type GROUPED_MAP or the function in "
                 "groupby.applyInPandas must take either one argument (data) or "
                 "two arguments (key, data).",
@@ -504,8 +504,8 @@ def _validate_pandas_udf(f, evalType) -> int:
 
     if evalType == PythonEvalType.SQL_GROUPED_MAP_ARROW_UDF and len(argspec.args) not in (1, 2):
         raise PySparkValueError(
-            error_class="INVALID_PANDAS_UDF",
-            message_parameters={
+            errorClass="INVALID_PANDAS_UDF",
+            messageParameters={
                 "detail": "the function in groupby.applyInArrow must take either one argument "
                 "(data) or two arguments (key, data).",
             },
@@ -513,8 +513,8 @@ def _validate_pandas_udf(f, evalType) -> int:
 
     if evalType == PythonEvalType.SQL_COGROUPED_MAP_PANDAS_UDF and len(argspec.args) not in (2, 3):
         raise PySparkValueError(
-            error_class="INVALID_PANDAS_UDF",
-            message_parameters={
+            errorClass="INVALID_PANDAS_UDF",
+            messageParameters={
                 "detail": "the function in cogroup.applyInPandas must take either two arguments "
                 "(left, right) or three arguments (key, left, right).",
             },
@@ -522,8 +522,8 @@ def _validate_pandas_udf(f, evalType) -> int:
 
     if evalType == PythonEvalType.SQL_COGROUPED_MAP_ARROW_UDF and len(argspec.args) not in (2, 3):
         raise PySparkValueError(
-            error_class="INVALID_PANDAS_UDF",
-            message_parameters={
+            errorClass="INVALID_PANDAS_UDF",
+            messageParameters={
                 "detail": "the function in cogroup.applyInArrow must take either two arguments "
                 "(left, right) or three arguments (key, left, right).",
             },

--- a/python/pyspark/sql/pandas/group_ops.py
+++ b/python/pyspark/sql/pandas/group_ops.py
@@ -101,8 +101,8 @@ class PandasGroupedOpsMixin:
             )
         ):
             raise PySparkTypeError(
-                error_class="INVALID_UDF_EVAL_TYPE",
-                message_parameters={"eval_type": "SQL_GROUPED_MAP_PANDAS_UDF"},
+                errorClass="INVALID_UDF_EVAL_TYPE",
+                messageParameters={"eval_type": "SQL_GROUPED_MAP_PANDAS_UDF"},
             )
 
         warnings.warn(

--- a/python/pyspark/sql/pandas/serializers.py
+++ b/python/pyspark/sql/pandas/serializers.py
@@ -75,8 +75,8 @@ class ArrowCollectSerializer(Serializer):
         if num == -1:
             error_msg = UTF8Deserializer().loads(stream)
             raise PySparkRuntimeError(
-                error_class="ERROR_OCCURRED_WHILE_CALLING",
-                message_parameters={
+                errorClass="ERROR_OCCURRED_WHILE_CALLING",
+                messageParameters={
                     "func_name": "ArrowCollectSerializer.load_stream",
                     "error_msg": error_msg,
                 },
@@ -667,8 +667,8 @@ class ArrowStreamPandasUDTFSerializer(ArrowStreamPandasUDFSerializer):
             # arrow's error message. This also works better with Spark Connect
             # where the exception messages are by default truncated.
             raise PySparkRuntimeError(
-                error_class="UDTF_ARROW_TYPE_CAST_ERROR",
-                message_parameters={
+                errorClass="UDTF_ARROW_TYPE_CAST_ERROR",
+                messageParameters={
                     "col_name": series.name,
                     "col_type": str(series.dtype),
                     "arrow_type": arrow_type,
@@ -711,8 +711,8 @@ class CogroupArrowUDFSerializer(ArrowStreamGroupUDFSerializer):
 
             elif dataframes_in_group != 0:
                 raise PySparkValueError(
-                    error_class="INVALID_NUMBER_OF_DATAFRAMES_IN_GROUP",
-                    message_parameters={"dataframes_in_group": str(dataframes_in_group)},
+                    errorClass="INVALID_NUMBER_OF_DATAFRAMES_IN_GROUP",
+                    messageParameters={"dataframes_in_group": str(dataframes_in_group)},
                 )
 
 
@@ -739,8 +739,8 @@ class CogroupPandasUDFSerializer(ArrowStreamPandasUDFSerializer):
 
             elif dataframes_in_group != 0:
                 raise PySparkValueError(
-                    error_class="INVALID_NUMBER_OF_DATAFRAMES_IN_GROUP",
-                    message_parameters={"dataframes_in_group": str(dataframes_in_group)},
+                    errorClass="INVALID_NUMBER_OF_DATAFRAMES_IN_GROUP",
+                    messageParameters={"dataframes_in_group": str(dataframes_in_group)},
                 )
 
 

--- a/python/pyspark/sql/pandas/typehints.py
+++ b/python/pyspark/sql/pandas/typehints.py
@@ -52,16 +52,16 @@ def infer_eval_type(
     ]
     if len(parameters_sig) != len(sig.parameters):
         raise PySparkValueError(
-            error_class="TYPE_HINT_SHOULD_BE_SPECIFIED",
-            message_parameters={"target": "all parameters", "sig": str(sig)},
+            errorClass="TYPE_HINT_SHOULD_BE_SPECIFIED",
+            messageParameters={"target": "all parameters", "sig": str(sig)},
         )
 
     # Check if the return has a type hint
     return_annotation = type_hints.get("return", sig.return_annotation)
     if sig.empty is return_annotation:
         raise PySparkValueError(
-            error_class="TYPE_HINT_SHOULD_BE_SPECIFIED",
-            message_parameters={"target": "the return type", "sig": str(sig)},
+            errorClass="TYPE_HINT_SHOULD_BE_SPECIFIED",
+            messageParameters={"target": "the return type", "sig": str(sig)},
         )
 
     # Series, Frame or Union[DataFrame, Series], ... -> Series or Frame
@@ -140,8 +140,8 @@ def infer_eval_type(
         return PandasUDFType.GROUPED_AGG
     else:
         raise PySparkNotImplementedError(
-            error_class="UNSUPPORTED_SIGNATURE",
-            message_parameters={"signature": str(sig)},
+            errorClass="UNSUPPORTED_SIGNATURE",
+            messageParameters={"signature": str(sig)},
         )
 
 

--- a/python/pyspark/sql/pandas/types.py
+++ b/python/pyspark/sql/pandas/types.py
@@ -143,8 +143,8 @@ def to_arrow_type(
         field_names = dt.names
         if error_on_duplicated_field_names_in_struct and len(set(field_names)) != len(field_names):
             raise UnsupportedOperationException(
-                error_class="DUPLICATED_FIELD_NAME_IN_ARROW_STRUCT",
-                message_parameters={"field_names": str(field_names)},
+                errorClass="DUPLICATED_FIELD_NAME_IN_ARROW_STRUCT",
+                messageParameters={"field_names": str(field_names)},
             )
         fields = [
             pa.field(
@@ -171,8 +171,8 @@ def to_arrow_type(
         arrow_type = pa.struct(fields)
     else:
         raise PySparkTypeError(
-            error_class="UNSUPPORTED_DATA_TYPE_FOR_ARROW_CONVERSION",
-            message_parameters={"data_type": str(dt)},
+            errorClass="UNSUPPORTED_DATA_TYPE_FOR_ARROW_CONVERSION",
+            messageParameters={"data_type": str(dt)},
         )
     return arrow_type
 
@@ -263,8 +263,8 @@ def from_arrow_type(at: "pa.DataType", prefer_timestamp_ntz: bool = False) -> Da
         if LooseVersion(pa.__version__) < LooseVersion("14.0.0"):
             # PyArrow versions before 14.0.0 do not support casting FixedSizeListArray to ListArray
             raise PySparkTypeError(
-                error_class="UNSUPPORTED_DATA_TYPE_FOR_ARROW_CONVERSION",
-                message_parameters={"data_type": str(at)},
+                errorClass="UNSUPPORTED_DATA_TYPE_FOR_ARROW_CONVERSION",
+                messageParameters={"data_type": str(at)},
             )
         spark_type = ArrayType(from_arrow_type(at.value_type, prefer_timestamp_ntz))
     elif types.is_large_list(at):
@@ -291,8 +291,8 @@ def from_arrow_type(at: "pa.DataType", prefer_timestamp_ntz: bool = False) -> Da
         spark_type = NullType()
     else:
         raise PySparkTypeError(
-            error_class="UNSUPPORTED_DATA_TYPE_FOR_ARROW_CONVERSION",
-            message_parameters={"data_type": str(at)},
+            errorClass="UNSUPPORTED_DATA_TYPE_FOR_ARROW_CONVERSION",
+            messageParameters={"data_type": str(at)},
         )
     return spark_type
 
@@ -888,8 +888,8 @@ def _create_converter_to_pandas(
 
             if error_on_duplicated_field_names and len(set(field_names)) != len(field_names):
                 raise UnsupportedOperationException(
-                    error_class="DUPLICATED_FIELD_NAME_IN_ARROW_STRUCT",
-                    message_parameters={"field_names": str(field_names)},
+                    errorClass="DUPLICATED_FIELD_NAME_IN_ARROW_STRUCT",
+                    messageParameters={"field_names": str(field_names)},
                 )
 
             dedup_field_names = _dedup_names(field_names)
@@ -970,8 +970,8 @@ def _create_converter_to_pandas(
 
             else:
                 raise PySparkValueError(
-                    error_class="UNKNOWN_VALUE_FOR",
-                    message_parameters={"var": str(_struct_in_pandas)},
+                    errorClass="UNKNOWN_VALUE_FOR",
+                    messageParameters={"var": str(_struct_in_pandas)},
                 )
 
         elif isinstance(dt, TimestampType):
@@ -1032,7 +1032,7 @@ def _create_converter_to_pandas(
                 ):
                     return VariantVal(value["value"], value["metadata"])
                 else:
-                    raise PySparkValueError(error_class="MALFORMED_VARIANT")
+                    raise PySparkValueError(errorClass="MALFORMED_VARIANT")
 
             return convert_variant
 
@@ -1185,8 +1185,8 @@ def _create_converter_from_pandas(
 
             if error_on_duplicated_field_names and len(set(field_names)) != len(field_names):
                 raise UnsupportedOperationException(
-                    error_class="DUPLICATED_FIELD_NAME_IN_ARROW_STRUCT",
-                    message_parameters={"field_names": str(field_names)},
+                    errorClass="DUPLICATED_FIELD_NAME_IN_ARROW_STRUCT",
+                    messageParameters={"field_names": str(field_names)},
                 )
 
             dedup_field_names = _dedup_names(field_names)

--- a/python/pyspark/sql/pandas/utils.py
+++ b/python/pyspark/sql/pandas/utils.py
@@ -41,16 +41,16 @@ def require_minimum_pandas_version() -> None:
         raised_error = error
     if not have_pandas:
         raise PySparkImportError(
-            error_class="PACKAGE_NOT_INSTALLED",
-            message_parameters={
+            errorClass="PACKAGE_NOT_INSTALLED",
+            messageParameters={
                 "package_name": "Pandas",
                 "minimum_version": str(minimum_pandas_version),
             },
         ) from raised_error
     if LooseVersion(pandas.__version__) < LooseVersion(minimum_pandas_version):
         raise PySparkImportError(
-            error_class="UNSUPPORTED_PACKAGE_VERSION",
-            message_parameters={
+            errorClass="UNSUPPORTED_PACKAGE_VERSION",
+            messageParameters={
                 "package_name": "Pandas",
                 "minimum_version": str(minimum_pandas_version),
                 "current_version": str(pandas.__version__),
@@ -74,16 +74,16 @@ def require_minimum_pyarrow_version() -> None:
         raised_error = error
     if not have_arrow:
         raise PySparkImportError(
-            error_class="PACKAGE_NOT_INSTALLED",
-            message_parameters={
+            errorClass="PACKAGE_NOT_INSTALLED",
+            messageParameters={
                 "package_name": "PyArrow",
                 "minimum_version": str(minimum_pyarrow_version),
             },
         ) from raised_error
     if LooseVersion(pyarrow.__version__) < LooseVersion(minimum_pyarrow_version):
         raise PySparkImportError(
-            error_class="UNSUPPORTED_PACKAGE_VERSION",
-            message_parameters={
+            errorClass="UNSUPPORTED_PACKAGE_VERSION",
+            messageParameters={
                 "package_name": "PyArrow",
                 "minimum_version": str(minimum_pyarrow_version),
                 "current_version": str(pyarrow.__version__),
@@ -91,6 +91,6 @@ def require_minimum_pyarrow_version() -> None:
         )
     if os.environ.get("ARROW_PRE_0_15_IPC_FORMAT", "0") == "1":
         raise PySparkRuntimeError(
-            error_class="ARROW_LEGACY_IPC_FORMAT",
-            message_parameters={},
+            errorClass="ARROW_LEGACY_IPC_FORMAT",
+            messageParameters={},
         )

--- a/python/pyspark/sql/profiler.py
+++ b/python/pyspark/sql/profiler.py
@@ -324,8 +324,8 @@ class Profile:
                 self.profiler_collector.show_memory_profiles(id)
         else:
             raise PySparkValueError(
-                error_class="VALUE_NOT_ALLOWED",
-                message_parameters={
+                errorClass="VALUE_NOT_ALLOWED",
+                messageParameters={
                     "arg_name": "type",
                     "allowed_values": str(["perf", "memory"]),
                 },
@@ -354,8 +354,8 @@ class Profile:
                 self.profiler_collector.dump_memory_profiles(path, id)
         else:
             raise PySparkValueError(
-                error_class="VALUE_NOT_ALLOWED",
-                message_parameters={
+                errorClass="VALUE_NOT_ALLOWED",
+                messageParameters={
                     "arg_name": "type",
                     "allowed_values": str(["perf", "memory"]),
                 },
@@ -415,8 +415,8 @@ class Profile:
             result = self.profiler_collector._memory_profile_results.get(id)
         else:
             raise PySparkValueError(
-                error_class="VALUE_NOT_ALLOWED",
-                message_parameters={
+                errorClass="VALUE_NOT_ALLOWED",
+                messageParameters={
                     "arg_name": "type",
                     "allowed_values": str(["perf", "memory"]),
                 },
@@ -429,8 +429,8 @@ class Profile:
             render = renderer
         if render is None:
             raise PySparkValueError(
-                error_class="VALUE_NOT_ALLOWED",
-                message_parameters={
+                errorClass="VALUE_NOT_ALLOWED",
+                messageParameters={
                     "arg_name": "(type, renderer)",
                     "allowed_values": str(list(_renderers.keys())),
                 },
@@ -461,8 +461,8 @@ class Profile:
                 self.profiler_collector.clear_memory_profiles(id)
         else:
             raise PySparkValueError(
-                error_class="VALUE_NOT_ALLOWED",
-                message_parameters={
+                errorClass="VALUE_NOT_ALLOWED",
+                messageParameters={
                     "arg_name": "type",
                     "allowed_values": str(["perf", "memory"]),
                 },
@@ -474,8 +474,8 @@ def _render_flameprof(stats: pstats.Stats) -> Any:
         from flameprof import render
     except ImportError:
         raise PySparkValueError(
-            error_class="PACKAGE_NOT_INSTALLED",
-            message_parameters={"package_name": "flameprof", "minimum_version": "0.4"},
+            errorClass="PACKAGE_NOT_INSTALLED",
+            messageParameters={"package_name": "flameprof", "minimum_version": "0.4"},
         )
 
     buf = StringIO()

--- a/python/pyspark/sql/readwriter.py
+++ b/python/pyspark/sql/readwriter.py
@@ -155,8 +155,8 @@ class DataFrameReader(OptionUtils):
             self._jreader = self._jreader.schema(schema)
         else:
             raise PySparkTypeError(
-                error_class="NOT_STR_OR_STRUCT",
-                message_parameters={
+                errorClass="NOT_STR_OR_STRUCT",
+                messageParameters={
                     "arg_name": "schema",
                     "arg_type": type(schema).__name__,
                 },
@@ -486,8 +486,8 @@ class DataFrameReader(OptionUtils):
             return self._df(self._jreader.json(jrdd))
         else:
             raise PySparkTypeError(
-                error_class="NOT_STR_OR_LIST_OF_RDD",
-                message_parameters={
+                errorClass="NOT_STR_OR_LIST_OF_RDD",
+                messageParameters={
                     "arg_name": "path",
                     "arg_type": type(path).__name__,
                 },
@@ -862,8 +862,8 @@ class DataFrameReader(OptionUtils):
             return self._df(self._jreader.csv(jdataset))
         else:
             raise PySparkTypeError(
-                error_class="NOT_STR_OR_LIST_OF_RDD",
-                message_parameters={
+                errorClass="NOT_STR_OR_LIST_OF_RDD",
+                messageParameters={
                     "arg_name": "path",
                     "arg_type": type(path).__name__,
                 },
@@ -989,8 +989,8 @@ class DataFrameReader(OptionUtils):
             return self._df(self._jreader.xml(jdataset))
         else:
             raise PySparkTypeError(
-                error_class="NOT_STR_OR_LIST_OF_RDD",
-                message_parameters={
+                errorClass="NOT_STR_OR_LIST_OF_RDD",
+                messageParameters={
                     "arg_name": "path",
                     "arg_type": type(path).__name__,
                 },
@@ -1513,8 +1513,8 @@ class DataFrameWriter(OptionUtils):
 
         if not isinstance(numBuckets, int):
             raise PySparkTypeError(
-                error_class="NOT_INT",
-                message_parameters={
+                errorClass="NOT_INT",
+                messageParameters={
                     "arg_name": "numBuckets",
                     "arg_type": type(numBuckets).__name__,
                 },
@@ -1523,8 +1523,8 @@ class DataFrameWriter(OptionUtils):
         if isinstance(col, (list, tuple)):
             if cols:
                 raise PySparkValueError(
-                    error_class="CANNOT_SET_TOGETHER",
-                    message_parameters={
+                    errorClass="CANNOT_SET_TOGETHER",
+                    messageParameters={
                         "arg_list": f"`col` of type {type(col).__name__} and `cols`",
                     },
                 )
@@ -1534,16 +1534,16 @@ class DataFrameWriter(OptionUtils):
         for c in cols:
             if not isinstance(c, str):
                 raise PySparkTypeError(
-                    error_class="NOT_LIST_OF_STR",
-                    message_parameters={
+                    errorClass="NOT_LIST_OF_STR",
+                    messageParameters={
                         "arg_name": "cols",
                         "arg_type": type(c).__name__,
                     },
                 )
         if not isinstance(col, str):
             raise PySparkTypeError(
-                error_class="NOT_LIST_OF_STR",
-                message_parameters={
+                errorClass="NOT_LIST_OF_STR",
+                messageParameters={
                     "arg_name": "col",
                     "arg_type": type(col).__name__,
                 },
@@ -1607,8 +1607,8 @@ class DataFrameWriter(OptionUtils):
         if isinstance(col, (list, tuple)):
             if cols:
                 raise PySparkValueError(
-                    error_class="CANNOT_SET_TOGETHER",
-                    message_parameters={
+                    errorClass="CANNOT_SET_TOGETHER",
+                    messageParameters={
                         "arg_list": f"`col` of type {type(col).__name__} and `cols`",
                     },
                 )
@@ -1618,16 +1618,16 @@ class DataFrameWriter(OptionUtils):
         for c in cols:
             if not isinstance(c, str):
                 raise PySparkTypeError(
-                    error_class="NOT_LIST_OF_STR",
-                    message_parameters={
+                    errorClass="NOT_LIST_OF_STR",
+                    messageParameters={
                         "arg_name": "cols",
                         "arg_type": type(c).__name__,
                     },
                 )
         if not isinstance(col, str):
             raise PySparkTypeError(
-                error_class="NOT_LIST_OF_STR",
-                message_parameters={
+                errorClass="NOT_LIST_OF_STR",
+                messageParameters={
                     "arg_name": "col",
                     "arg_type": type(col).__name__,
                 },

--- a/python/pyspark/sql/session.py
+++ b/python/pyspark/sql/session.py
@@ -325,8 +325,8 @@ class SparkSession(SparkConversionMixin):
                 "spark.remote" in self._options or "SPARK_REMOTE" in os.environ
             ):
                 raise PySparkRuntimeError(
-                    error_class="CANNOT_CONFIGURE_SPARK_CONNECT_MASTER",
-                    message_parameters={
+                    errorClass="CANNOT_CONFIGURE_SPARK_CONNECT_MASTER",
+                    messageParameters={
                         "master_url": self._options.get("spark.master", os.environ.get("MASTER")),
                         "connect_url": self._options.get(
                             "spark.remote", os.environ.get("SPARK_REMOTE")
@@ -340,8 +340,8 @@ class SparkSession(SparkConversionMixin):
                     "SPARK_LOCAL_REMOTE" in os.environ and not remote.startswith("local")
                 ):
                     raise PySparkRuntimeError(
-                        error_class="CANNOT_CONFIGURE_SPARK_CONNECT",
-                        message_parameters={
+                        errorClass="CANNOT_CONFIGURE_SPARK_CONNECT",
+                        messageParameters={
                             "existing_url": os.environ["SPARK_REMOTE"],
                             "new_url": remote,
                         },
@@ -483,8 +483,8 @@ class SparkSession(SparkConversionMixin):
 
                 if url is None:
                     raise PySparkRuntimeError(
-                        error_class="CONNECT_URL_NOT_SET",
-                        message_parameters={},
+                        errorClass="CONNECT_URL_NOT_SET",
+                        messageParameters={},
                     )
 
                 os.environ["SPARK_CONNECT_MODE_ENABLED"] = "1"
@@ -510,8 +510,8 @@ class SparkSession(SparkConversionMixin):
 
                             if url is None:
                                 raise PySparkRuntimeError(
-                                    error_class="CONNECT_URL_NOT_SET",
-                                    message_parameters={},
+                                    errorClass="CONNECT_URL_NOT_SET",
+                                    messageParameters={},
                                 )
 
                             if url.startswith("local"):
@@ -535,8 +535,8 @@ class SparkSession(SparkConversionMixin):
                             )
                         else:
                             raise PySparkRuntimeError(
-                                error_class="SESSION_ALREADY_EXIST",
-                                message_parameters={},
+                                errorClass="SESSION_ALREADY_EXIST",
+                                messageParameters={},
                             )
 
                 session = SparkSession._instantiatedSession
@@ -580,8 +580,8 @@ class SparkSession(SparkConversionMixin):
                 url = opts.get("spark.remote", os.environ.get("SPARK_REMOTE"))
                 if url.startswith("local"):
                     raise PySparkRuntimeError(
-                        error_class="UNSUPPORTED_LOCAL_CONNECTION_STRING",
-                        message_parameters={},
+                        errorClass="UNSUPPORTED_LOCAL_CONNECTION_STRING",
+                        messageParameters={},
                     )
 
                 # Mark this Spark Session as Spark Connect. This prevents that local PySpark is
@@ -591,8 +591,8 @@ class SparkSession(SparkConversionMixin):
                 return cast(SparkSession, RemoteSparkSession.builder.config(map=opts).create())
             else:
                 raise PySparkRuntimeError(
-                    error_class="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
-                    message_parameters={"feature": "SparkSession.builder.create"},
+                    errorClass="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
+                    messageParameters={"feature": "SparkSession.builder.create"},
                 )
 
     # TODO(SPARK-38912): Replace classproperty with @classmethod + @property once support for
@@ -758,8 +758,8 @@ class SparkSession(SparkConversionMixin):
             session = cls._instantiatedSession
             if session is None:
                 raise PySparkRuntimeError(
-                    error_class="NO_ACTIVE_OR_DEFAULT_SESSION",
-                    message_parameters={},
+                    errorClass="NO_ACTIVE_OR_DEFAULT_SESSION",
+                    messageParameters={},
                 )
         return session
 
@@ -1038,8 +1038,8 @@ class SparkSession(SparkConversionMixin):
         """
         if not data:
             raise PySparkValueError(
-                error_class="CANNOT_INFER_EMPTY_SCHEMA",
-                message_parameters={},
+                errorClass="CANNOT_INFER_EMPTY_SCHEMA",
+                messageParameters={},
             )
         infer_dict_as_struct = self._jconf.inferDictAsStruct()
         infer_array_from_first_element = self._jconf.legacyInferArrayTypeFromFirstElement()
@@ -1061,8 +1061,8 @@ class SparkSession(SparkConversionMixin):
         )
         if _has_nulltype(schema):
             raise PySparkValueError(
-                error_class="CANNOT_DETERMINE_TYPE",
-                message_parameters={},
+                errorClass="CANNOT_DETERMINE_TYPE",
+                messageParameters={},
             )
         return schema
 
@@ -1090,8 +1090,8 @@ class SparkSession(SparkConversionMixin):
         first = rdd.first()
         if isinstance(first, Sized) and len(first) == 0:
             raise PySparkValueError(
-                error_class="CANNOT_INFER_EMPTY_SCHEMA",
-                message_parameters={},
+                errorClass="CANNOT_INFER_EMPTY_SCHEMA",
+                messageParameters={},
             )
 
         infer_dict_as_struct = self._jconf.inferDictAsStruct()
@@ -1122,8 +1122,8 @@ class SparkSession(SparkConversionMixin):
                         break
                 else:
                     raise PySparkValueError(
-                        error_class="CANNOT_DETERMINE_TYPE",
-                        message_parameters={},
+                        errorClass="CANNOT_DETERMINE_TYPE",
+                        messageParameters={},
                     )
         else:
             if samplingRatio < 0.99:
@@ -1164,8 +1164,8 @@ class SparkSession(SparkConversionMixin):
 
         else:
             raise PySparkTypeError(
-                error_class="NOT_LIST_OR_NONE_OR_STRUCT",
-                message_parameters={
+                errorClass="NOT_LIST_OR_NONE_OR_STRUCT",
+                messageParameters={
                     "arg_name": "schema",
                     "arg_type": type(schema).__name__,
                 },
@@ -1201,8 +1201,8 @@ class SparkSession(SparkConversionMixin):
 
         else:
             raise PySparkTypeError(
-                error_class="NOT_LIST_OR_NONE_OR_STRUCT",
-                message_parameters={
+                errorClass="NOT_LIST_OR_NONE_OR_STRUCT",
+                messageParameters={
                     "arg_name": "schema",
                     "arg_type": type(schema).__name__,
                 },
@@ -1516,8 +1516,8 @@ class SparkSession(SparkConversionMixin):
         self._jvm.SparkSession.setActiveSession(self._jsparkSession)
         if isinstance(data, DataFrame):
             raise PySparkTypeError(
-                error_class="INVALID_TYPE",
-                message_parameters={"arg_name": "data", "arg_type": "DataFrame"},
+                errorClass="INVALID_TYPE",
+                messageParameters={"arg_name": "data", "arg_type": "DataFrame"},
             )
 
         if isinstance(schema, str):
@@ -1555,8 +1555,8 @@ class SparkSession(SparkConversionMixin):
             require_minimum_pandas_version()
             if data.ndim not in [1, 2]:
                 raise PySparkValueError(
-                    error_class="INVALID_NDARRAY_DIMENSION",
-                    message_parameters={"dimensions": "1 or 2"},
+                    errorClass="INVALID_NDARRAY_DIMENSION",
+                    messageParameters={"dimensions": "1 or 2"},
                 )
 
             if data.ndim == 1 or data.shape[1] == 1:
@@ -1793,8 +1793,8 @@ class SparkSession(SparkConversionMixin):
                 )
             else:
                 raise PySparkTypeError(
-                    error_class="INVALID_TYPE",
-                    message_parameters={"arg_name": "args", "arg_type": type(args).__name__},
+                    errorClass="INVALID_TYPE",
+                    messageParameters={"arg_name": "args", "arg_type": type(args).__name__},
                 )
             return DataFrame(self._jsparkSession.sql(sqlQuery, litArgs), self)
         finally:
@@ -1841,8 +1841,8 @@ class SparkSession(SparkConversionMixin):
         """
         if not isinstance(tableName, str):
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "tableName", "arg_type": type(tableName).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "tableName", "arg_type": type(tableName).__name__},
             )
 
         return DataFrame(self._jsparkSession.table(tableName), self)
@@ -2058,8 +2058,8 @@ class SparkSession(SparkConversionMixin):
         an exception.
         """
         raise PySparkRuntimeError(
-            error_class="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
-            message_parameters={"feature": "SparkSession.client"},
+            errorClass="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
+            messageParameters={"feature": "SparkSession.client"},
         )
 
     def addArtifacts(
@@ -2091,8 +2091,8 @@ class SparkSession(SparkConversionMixin):
         an exception.
         """
         raise PySparkRuntimeError(
-            error_class="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
-            message_parameters={"feature": "SparkSession.addArtifact(s)"},
+            errorClass="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
+            messageParameters={"feature": "SparkSession.addArtifact(s)"},
         )
 
     addArtifact = addArtifacts
@@ -2121,8 +2121,8 @@ class SparkSession(SparkConversionMixin):
         >>> spark.clearProgressHandlers()
         """
         raise PySparkRuntimeError(
-            error_class="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
-            message_parameters={"feature": "SparkSession.registerProgressHandler"},
+            errorClass="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
+            messageParameters={"feature": "SparkSession.registerProgressHandler"},
         )
 
     def removeProgressHandler(self, handler: "ProgressHandler") -> None:
@@ -2137,8 +2137,8 @@ class SparkSession(SparkConversionMixin):
           The handler to remove if present in the list of progress handlers.
         """
         raise PySparkRuntimeError(
-            error_class="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
-            message_parameters={"feature": "SparkSession.removeProgressHandler"},
+            errorClass="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
+            messageParameters={"feature": "SparkSession.removeProgressHandler"},
         )
 
     def clearProgressHandlers(self) -> None:
@@ -2148,8 +2148,8 @@ class SparkSession(SparkConversionMixin):
         .. versionadded:: 4.0
         """
         raise PySparkRuntimeError(
-            error_class="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
-            message_parameters={"feature": "SparkSession.clearProgressHandlers"},
+            errorClass="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
+            messageParameters={"feature": "SparkSession.clearProgressHandlers"},
         )
 
     def copyFromLocalToFs(self, local_path: str, dest_path: str) -> None:
@@ -2176,8 +2176,8 @@ class SparkSession(SparkConversionMixin):
         Spark Session, it throws an exception.
         """
         raise PySparkRuntimeError(
-            error_class="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
-            message_parameters={"feature": "SparkSession.copyFromLocalToFs"},
+            errorClass="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
+            messageParameters={"feature": "SparkSession.copyFromLocalToFs"},
         )
 
     def interruptAll(self) -> List[str]:
@@ -2196,8 +2196,8 @@ class SparkSession(SparkConversionMixin):
         There is still a possibility of operation finishing just as it is interrupted.
         """
         raise PySparkRuntimeError(
-            error_class="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
-            message_parameters={"feature": "SparkSession.interruptAll"},
+            errorClass="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
+            messageParameters={"feature": "SparkSession.interruptAll"},
         )
 
     def interruptTag(self, tag: str) -> List[str]:
@@ -2216,8 +2216,8 @@ class SparkSession(SparkConversionMixin):
         There is still a possibility of operation finishing just as it is interrupted.
         """
         raise PySparkRuntimeError(
-            error_class="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
-            message_parameters={"feature": "SparkSession.interruptTag"},
+            errorClass="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
+            messageParameters={"feature": "SparkSession.interruptTag"},
         )
 
     def interruptOperation(self, op_id: str) -> List[str]:
@@ -2236,8 +2236,8 @@ class SparkSession(SparkConversionMixin):
         There is still a possibility of operation finishing just as it is interrupted.
         """
         raise PySparkRuntimeError(
-            error_class="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
-            message_parameters={"feature": "SparkSession.interruptOperation"},
+            errorClass="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
+            messageParameters={"feature": "SparkSession.interruptOperation"},
         )
 
     def addTag(self, tag: str) -> None:
@@ -2260,8 +2260,8 @@ class SparkSession(SparkConversionMixin):
             The tag to be added. Cannot contain ',' (comma) character or be an empty string.
         """
         raise PySparkRuntimeError(
-            error_class="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
-            message_parameters={"feature": "SparkSession.addTag"},
+            errorClass="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
+            messageParameters={"feature": "SparkSession.addTag"},
         )
 
     def removeTag(self, tag: str) -> None:
@@ -2277,8 +2277,8 @@ class SparkSession(SparkConversionMixin):
             The tag to be removed. Cannot contain ',' (comma) character or be an empty string.
         """
         raise PySparkRuntimeError(
-            error_class="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
-            message_parameters={"feature": "SparkSession.removeTag"},
+            errorClass="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
+            messageParameters={"feature": "SparkSession.removeTag"},
         )
 
     def getTags(self) -> Set[str]:
@@ -2294,8 +2294,8 @@ class SparkSession(SparkConversionMixin):
             Set of tags of interrupted operations.
         """
         raise PySparkRuntimeError(
-            error_class="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
-            message_parameters={"feature": "SparkSession.getTags"},
+            errorClass="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
+            messageParameters={"feature": "SparkSession.getTags"},
         )
 
     def clearTags(self) -> None:
@@ -2305,8 +2305,8 @@ class SparkSession(SparkConversionMixin):
         .. versionadded:: 3.5.0
         """
         raise PySparkRuntimeError(
-            error_class="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
-            message_parameters={"feature": "SparkSession.clearTags"},
+            errorClass="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
+            messageParameters={"feature": "SparkSession.clearTags"},
         )
 
 

--- a/python/pyspark/sql/sql_formatter.py
+++ b/python/pyspark/sql/sql_formatter.py
@@ -63,8 +63,8 @@ class SQLStringFormatter(string.Formatter):
                 return jexpr.sql()
             else:
                 raise PySparkValueError(
-                    error_class="VALUE_NOT_PLAIN_COLUMN_REFERENCE",
-                    message_parameters={"val": str(val), "field_name": field_name},
+                    errorClass="VALUE_NOT_PLAIN_COLUMN_REFERENCE",
+                    messageParameters={"val": str(val), "field_name": field_name},
                 )
         elif isinstance(val, DataFrame):
             for df, n in self._temp_views:

--- a/python/pyspark/sql/streaming/python_streaming_source_runner.py
+++ b/python/pyspark/sql/streaming/python_streaming_source_runner.py
@@ -130,8 +130,8 @@ def main(infile: IO, outfile: IO) -> None:
 
         if not isinstance(data_source, DataSource):
             raise PySparkAssertionError(
-                error_class="DATA_SOURCE_TYPE_MISMATCH",
-                message_parameters={
+                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                messageParameters={
                     "expected": "a Python data source instance of type 'DataSource'",
                     "actual": f"'{type(data_source).__name__}'",
                 },
@@ -142,8 +142,8 @@ def main(infile: IO, outfile: IO) -> None:
         schema = _parse_datatype_json_string(schema_json)
         if not isinstance(schema, StructType):
             raise PySparkAssertionError(
-                error_class="DATA_SOURCE_TYPE_MISMATCH",
-                message_parameters={
+                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                messageParameters={
                     "expected": "an output schema of type 'StructType'",
                     "actual": f"'{type(schema).__name__}'",
                 },
@@ -177,8 +177,8 @@ def main(infile: IO, outfile: IO) -> None:
                     commit_func(reader, infile, outfile)
                 else:
                     raise IllegalArgumentException(
-                        error_class="UNSUPPORTED_OPERATION",
-                        message_parameters={
+                        errorClass="UNSUPPORTED_OPERATION",
+                        messageParameters={
                             "operation": "Function call id not recognized by stream reader"
                         },
                     )
@@ -186,8 +186,8 @@ def main(infile: IO, outfile: IO) -> None:
         except Exception as e:
             error_msg = "data source {} throw exception: {}".format(data_source.name, e)
             raise PySparkRuntimeError(
-                error_class="PYTHON_STREAMING_DATA_SOURCE_RUNTIME_ERROR",
-                message_parameters={"msg": error_msg},
+                errorClass="PYTHON_STREAMING_DATA_SOURCE_RUNTIME_ERROR",
+                messageParameters={"msg": error_msg},
             )
         finally:
             reader.stop()

--- a/python/pyspark/sql/streaming/query.py
+++ b/python/pyspark/sql/streaming/query.py
@@ -214,8 +214,8 @@ class StreamingQuery:
         if timeout is not None:
             if not isinstance(timeout, (int, float)) or timeout <= 0:
                 raise PySparkValueError(
-                    error_class="VALUE_NOT_POSITIVE",
-                    message_parameters={"arg_name": "timeout", "arg_value": type(timeout).__name__},
+                    errorClass="VALUE_NOT_POSITIVE",
+                    messageParameters={"arg_name": "timeout", "arg_value": type(timeout).__name__},
                 )
             return self._jsq.awaitTermination(int(timeout * 1000))
         else:
@@ -589,8 +589,8 @@ class StreamingQueryManager:
         if timeout is not None:
             if not isinstance(timeout, (int, float)) or timeout < 0:
                 raise PySparkValueError(
-                    error_class="VALUE_NOT_POSITIVE",
-                    message_parameters={"arg_name": "timeout", "arg_value": type(timeout).__name__},
+                    errorClass="VALUE_NOT_POSITIVE",
+                    messageParameters={"arg_name": "timeout", "arg_value": type(timeout).__name__},
                 )
             return self._jsqm.awaitAnyTermination(int(timeout * 1000))
         else:

--- a/python/pyspark/sql/streaming/readwriter.py
+++ b/python/pyspark/sql/streaming/readwriter.py
@@ -171,8 +171,8 @@ class DataStreamReader(OptionUtils):
             self._jreader = self._jreader.schema(schema)
         else:
             raise PySparkTypeError(
-                error_class="NOT_STR_OR_STRUCT",
-                message_parameters={"arg_name": "schema", "arg_type": type(schema).__name__},
+                errorClass="NOT_STR_OR_STRUCT",
+                messageParameters={"arg_name": "schema", "arg_type": type(schema).__name__},
             )
         return self
 
@@ -299,8 +299,8 @@ class DataStreamReader(OptionUtils):
         if path is not None:
             if type(path) != str or len(path.strip()) == 0:
                 raise PySparkValueError(
-                    error_class="VALUE_NOT_NON_EMPTY_STR",
-                    message_parameters={"arg_name": "path", "arg_value": str(path)},
+                    errorClass="VALUE_NOT_NON_EMPTY_STR",
+                    messageParameters={"arg_name": "path", "arg_value": str(path)},
                 )
             return self._df(self._jreader.load(path))
         else:
@@ -413,8 +413,8 @@ class DataStreamReader(OptionUtils):
             return self._df(self._jreader.json(path))
         else:
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
             )
 
     def orc(
@@ -464,8 +464,8 @@ class DataStreamReader(OptionUtils):
             return self._df(self._jreader.orc(path))
         else:
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
             )
 
     def parquet(
@@ -526,8 +526,8 @@ class DataStreamReader(OptionUtils):
             return self._df(self._jreader.parquet(path))
         else:
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
             )
 
     def text(
@@ -595,8 +595,8 @@ class DataStreamReader(OptionUtils):
             return self._df(self._jreader.text(path))
         else:
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
             )
 
     def csv(
@@ -718,8 +718,8 @@ class DataStreamReader(OptionUtils):
             return self._df(self._jreader.csv(path))
         else:
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
             )
 
     def xml(
@@ -817,8 +817,8 @@ class DataStreamReader(OptionUtils):
             return self._df(self._jreader.xml(path))
         else:
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "path", "arg_type": type(path).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "path", "arg_type": type(path).__name__},
             )
 
     def table(self, tableName: str) -> "DataFrame":
@@ -866,8 +866,8 @@ class DataStreamReader(OptionUtils):
             return self._df(self._jreader.table(tableName))
         else:
             raise PySparkTypeError(
-                error_class="NOT_STR",
-                message_parameters={"arg_name": "tableName", "arg_type": type(tableName).__name__},
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "tableName", "arg_type": type(tableName).__name__},
             )
 
 
@@ -948,8 +948,8 @@ class DataStreamWriter:
         """
         if not outputMode or type(outputMode) != str or len(outputMode.strip()) == 0:
             raise PySparkValueError(
-                error_class="VALUE_NOT_NON_EMPTY_STR",
-                message_parameters={"arg_name": "outputMode", "arg_value": str(outputMode)},
+                errorClass="VALUE_NOT_NON_EMPTY_STR",
+                messageParameters={"arg_name": "outputMode", "arg_value": str(outputMode)},
             )
         self._jwrite = self._jwrite.outputMode(outputMode)
         return self
@@ -1153,8 +1153,8 @@ class DataStreamWriter:
         """
         if not queryName or type(queryName) != str or len(queryName.strip()) == 0:
             raise PySparkValueError(
-                error_class="VALUE_NOT_NON_EMPTY_STR",
-                message_parameters={"arg_name": "queryName", "arg_value": str(queryName)},
+                errorClass="VALUE_NOT_NON_EMPTY_STR",
+                messageParameters={"arg_name": "queryName", "arg_value": str(queryName)},
             )
         self._jwrite = self._jwrite.queryName(queryName)
         return self
@@ -1235,13 +1235,13 @@ class DataStreamWriter:
 
         if params.count(None) == 4:
             raise PySparkValueError(
-                error_class="ONLY_ALLOW_SINGLE_TRIGGER",
-                message_parameters={},
+                errorClass="ONLY_ALLOW_SINGLE_TRIGGER",
+                messageParameters={},
             )
         elif params.count(None) < 3:
             raise PySparkValueError(
-                error_class="ONLY_ALLOW_SINGLE_TRIGGER",
-                message_parameters={},
+                errorClass="ONLY_ALLOW_SINGLE_TRIGGER",
+                messageParameters={},
             )
 
         jTrigger = None
@@ -1249,8 +1249,8 @@ class DataStreamWriter:
         if processingTime is not None:
             if type(processingTime) != str or len(processingTime.strip()) == 0:
                 raise PySparkValueError(
-                    error_class="VALUE_NOT_NON_EMPTY_STR",
-                    message_parameters={
+                    errorClass="VALUE_NOT_NON_EMPTY_STR",
+                    messageParameters={
                         "arg_name": "processingTime",
                         "arg_value": str(processingTime),
                     },
@@ -1263,8 +1263,8 @@ class DataStreamWriter:
         elif once is not None:
             if once is not True:
                 raise PySparkValueError(
-                    error_class="VALUE_NOT_TRUE",
-                    message_parameters={"arg_name": "once", "arg_value": str(once)},
+                    errorClass="VALUE_NOT_TRUE",
+                    messageParameters={"arg_name": "once", "arg_value": str(once)},
                 )
 
             jTrigger = self._spark._sc._jvm.org.apache.spark.sql.streaming.Trigger.Once()
@@ -1272,8 +1272,8 @@ class DataStreamWriter:
         elif continuous is not None:
             if type(continuous) != str or len(continuous.strip()) == 0:
                 raise PySparkValueError(
-                    error_class="VALUE_NOT_NON_EMPTY_STR",
-                    message_parameters={"arg_name": "continuous", "arg_value": str(continuous)},
+                    errorClass="VALUE_NOT_NON_EMPTY_STR",
+                    messageParameters={"arg_name": "continuous", "arg_value": str(continuous)},
                 )
             interval = continuous.strip()
             jTrigger = self._spark._sc._jvm.org.apache.spark.sql.streaming.Trigger.Continuous(
@@ -1282,8 +1282,8 @@ class DataStreamWriter:
         else:
             if availableNow is not True:
                 raise PySparkValueError(
-                    error_class="VALUE_NOT_TRUE",
-                    message_parameters={"arg_name": "availableNow", "arg_value": str(availableNow)},
+                    errorClass="VALUE_NOT_TRUE",
+                    messageParameters={"arg_name": "availableNow", "arg_value": str(availableNow)},
                 )
             jTrigger = self._spark._sc._jvm.org.apache.spark.sql.streaming.Trigger.AvailableNow()
 
@@ -1314,22 +1314,22 @@ class DataStreamWriter:
 
             if not hasattr(f, "process"):
                 raise PySparkAttributeError(
-                    error_class="ATTRIBUTE_NOT_CALLABLE",
-                    message_parameters={"attr_name": "process", "obj_name": "f"},
+                    errorClass="ATTRIBUTE_NOT_CALLABLE",
+                    messageParameters={"attr_name": "process", "obj_name": "f"},
                 )
 
             if not callable(getattr(f, "process")):
                 raise PySparkAttributeError(
-                    error_class="ATTRIBUTE_NOT_CALLABLE",
-                    message_parameters={"attr_name": "process", "obj_name": "f"},
+                    errorClass="ATTRIBUTE_NOT_CALLABLE",
+                    messageParameters={"attr_name": "process", "obj_name": "f"},
                 )
 
             def doesMethodExist(method_name: str) -> bool:
                 exists = hasattr(f, method_name)
                 if exists and not callable(getattr(f, method_name)):
                     raise PySparkAttributeError(
-                        error_class="ATTRIBUTE_NOT_CALLABLE",
-                        message_parameters={"attr_name": method_name, "obj_name": "f"},
+                        errorClass="ATTRIBUTE_NOT_CALLABLE",
+                        messageParameters={"attr_name": method_name, "obj_name": "f"},
                     )
                 return exists
 
@@ -1344,8 +1344,8 @@ class DataStreamWriter:
                     int_epoch_id = int(epoch_id)
                 else:
                     raise PySparkRuntimeError(
-                        error_class="CANNOT_GET_BATCH_ID",
-                        message_parameters={"obj_name": "TaskContext"},
+                        errorClass="CANNOT_GET_BATCH_ID",
+                        messageParameters={"obj_name": "TaskContext"},
                     )
 
                 # Check if the data should be processed

--- a/python/pyspark/sql/streaming/state.py
+++ b/python/pyspark/sql/streaming/state.py
@@ -100,8 +100,8 @@ class GroupState:
             return tuple(self._value)
         else:
             raise PySparkValueError(
-                error_class="STATE_NOT_EXISTS",
-                message_parameters={},
+                errorClass="STATE_NOT_EXISTS",
+                messageParameters={},
             )
 
     @property
@@ -134,8 +134,8 @@ class GroupState:
         """
         if newValue is None:
             raise PySparkTypeError(
-                error_class="CANNOT_BE_NONE",
-                message_parameters={"arg_name": "newValue"},
+                errorClass="CANNOT_BE_NONE",
+                messageParameters={"arg_name": "newValue"},
             )
 
         converted = []
@@ -177,8 +177,8 @@ class GroupState:
         if isinstance(durationMs, str):
             # TODO(SPARK-40437): Support string representation of durationMs.
             raise PySparkTypeError(
-                error_class="NOT_INT",
-                message_parameters={
+                errorClass="NOT_INT",
+                messageParameters={
                     "arg_name": "durationMs",
                     "arg_type": type(durationMs).__name__,
                 },
@@ -186,8 +186,8 @@ class GroupState:
 
         if self._timeout_conf != GroupStateTimeout.ProcessingTimeTimeout:
             raise PySparkRuntimeError(
-                error_class="CANNOT_WITHOUT",
-                message_parameters={
+                errorClass="CANNOT_WITHOUT",
+                messageParameters={
                     "condition1": "set timeout duration",
                     "condition2": "enabling processing time timeout in applyInPandasWithState",
                 },
@@ -195,8 +195,8 @@ class GroupState:
 
         if durationMs <= 0:
             raise PySparkValueError(
-                error_class="VALUE_NOT_POSITIVE",
-                message_parameters={
+                errorClass="VALUE_NOT_POSITIVE",
+                messageParameters={
                     "arg_name": "durationMs",
                     "arg_value": type(durationMs).__name__,
                 },
@@ -212,8 +212,8 @@ class GroupState:
         """
         if self._timeout_conf != GroupStateTimeout.EventTimeTimeout:
             raise PySparkRuntimeError(
-                error_class="CANNOT_WITHOUT",
-                message_parameters={
+                errorClass="CANNOT_WITHOUT",
+                messageParameters={
                     "condition1": "set timeout duration",
                     "condition2": "enabling processing time timeout in applyInPandasWithState",
                 },
@@ -224,8 +224,8 @@ class GroupState:
 
         if timestampMs <= 0:
             raise PySparkValueError(
-                error_class="VALUE_NOT_POSITIVE",
-                message_parameters={
+                errorClass="VALUE_NOT_POSITIVE",
+                messageParameters={
                     "arg_name": "timestampMs",
                     "arg_value": type(timestampMs).__name__,
                 },
@@ -236,8 +236,8 @@ class GroupState:
             and timestampMs < self._event_time_watermark_ms
         ):
             raise PySparkValueError(
-                error_class="INVALID_TIMEOUT_TIMESTAMP",
-                message_parameters={
+                errorClass="INVALID_TIMEOUT_TIMESTAMP",
+                messageParameters={
                     "timestamp": str(timestampMs),
                     "watermark": str(self._event_time_watermark_ms),
                 },
@@ -252,8 +252,8 @@ class GroupState:
         """
         if not self._watermark_present:
             raise PySparkRuntimeError(
-                error_class="CANNOT_WITHOUT",
-                message_parameters={
+                errorClass="CANNOT_WITHOUT",
+                messageParameters={
                     "condition1": "get event time watermark timestamp",
                     "condition2": "setting watermark before applyInPandasWithState",
                 },

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -217,8 +217,8 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_INT_OR_LIST_OR_STR_OR_TUPLE",
-            message_parameters={
+            errorClass="NOT_COLUMN_OR_INT_OR_LIST_OR_STR_OR_TUPLE",
+            messageParameters={
                 "arg_name": "item",
                 "arg_type": "float",
             },
@@ -229,8 +229,8 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_INT_OR_LIST_OR_STR_OR_TUPLE",
-            message_parameters={
+            errorClass="NOT_COLUMN_OR_INT_OR_LIST_OR_STR_OR_TUPLE",
+            messageParameters={
                 "arg_name": "item",
                 "arg_type": "NoneType",
             },
@@ -241,8 +241,8 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_INT_OR_LIST_OR_STR_OR_TUPLE",
-            message_parameters={
+            errorClass="NOT_COLUMN_OR_INT_OR_LIST_OR_STR_OR_TUPLE",
+            messageParameters={
                 "arg_name": "item",
                 "arg_type": "DataFrame",
             },
@@ -651,8 +651,8 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
 
             self.check_error(
                 exception=pe.exception,
-                error_class="INVALID_TYPE",
-                message_parameters={"arg_name": "args", "arg_type": "set"},
+                errorClass="INVALID_TYPE",
+                messageParameters={"arg_name": "args", "arg_type": "set"},
             )
 
     def test_deduplicate(self):
@@ -924,8 +924,8 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="CANNOT_BE_EMPTY",
-            message_parameters={"item": "exprs"},
+            errorClass="CANNOT_BE_EMPTY",
+            messageParameters={"item": "exprs"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -933,8 +933,8 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_LIST_OF_COLUMN",
-            message_parameters={"arg_name": "exprs"},
+            errorClass="NOT_LIST_OF_COLUMN",
+            messageParameters={"arg_name": "exprs"},
         )
 
     def test_with_columns(self):
@@ -1030,8 +1030,8 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="INVALID_ITEM_FOR_CONTAINER",
-            message_parameters={
+            errorClass="INVALID_ITEM_FOR_CONTAINER",
+            messageParameters={
                 "arg_name": "parameters",
                 "allowed_types": "str, float, int, Column, list[str], list[float], list[int]",
                 "item_type": "dict",
@@ -1094,8 +1094,8 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             self.connect.sql("SELECT 1")._explain_string(mode="unknown")
         self.check_error(
             exception=pe.exception,
-            error_class="UNKNOWN_EXPLAIN_MODE",
-            message_parameters={"explain_mode": "unknown"},
+            errorClass="UNKNOWN_EXPLAIN_MODE",
+            messageParameters={"explain_mode": "unknown"},
         )
 
     def test_count(self) -> None:
@@ -1237,8 +1237,8 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_DICT",
-            message_parameters={
+            errorClass="NOT_DICT",
+            messageParameters={
                 "arg_name": "metadata",
                 "arg_type": "list",
             },

--- a/python/pyspark/sql/tests/connect/test_connect_column.py
+++ b/python/pyspark/sql/tests/connect/test_connect_column.py
@@ -139,8 +139,8 @@ class SparkConnectColumnTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_SAME_TYPE",
-            message_parameters={
+            errorClass="NOT_SAME_TYPE",
+            messageParameters={
                 "arg_name1": "startPos",
                 "arg_name2": "length",
                 "arg_type1": "Column",
@@ -153,8 +153,8 @@ class SparkConnectColumnTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_INT",
-            message_parameters={
+            errorClass="NOT_COLUMN_OR_INT",
+            messageParameters={
                 "arg_name": "startPos",
                 "arg_type": "float",
             },
@@ -519,8 +519,8 @@ class SparkConnectColumnTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="VALUE_NOT_BETWEEN",
-            message_parameters={"arg_name": "value", "min": "-9223372036854775808", "max": "32767"},
+            errorClass="VALUE_NOT_BETWEEN",
+            messageParameters={"arg_name": "value", "min": "-9223372036854775808", "max": "32767"},
         )
 
         with self.assertRaises(PySparkValueError) as pe:
@@ -528,8 +528,8 @@ class SparkConnectColumnTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="VALUE_NOT_BETWEEN",
-            message_parameters={"arg_name": "value", "min": "-9223372036854775808", "max": "32767"},
+            errorClass="VALUE_NOT_BETWEEN",
+            messageParameters={"arg_name": "value", "min": "-9223372036854775808", "max": "32767"},
         )
 
     def test_cast(self):
@@ -566,8 +566,8 @@ class SparkConnectColumnTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_DATATYPE_OR_STR",
-            message_parameters={"arg_name": "dataType", "arg_type": "int"},
+            errorClass="NOT_DATATYPE_OR_STR",
+            messageParameters={"arg_name": "dataType", "arg_type": "int"},
         )
 
     def test_isin(self):
@@ -923,8 +923,8 @@ class SparkConnectColumnTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_STR",
-            message_parameters={"arg_name": "fieldName", "arg_type": "Column"},
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "fieldName", "arg_type": "Column"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -932,8 +932,8 @@ class SparkConnectColumnTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN",
-            message_parameters={"arg_name": "col", "arg_type": "int"},
+            errorClass="NOT_COLUMN",
+            messageParameters={"arg_name": "col", "arg_type": "int"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -941,8 +941,8 @@ class SparkConnectColumnTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_STR",
-            message_parameters={"arg_name": "fieldName", "arg_type": "int"},
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "fieldName", "arg_type": "int"},
         )
 
         with self.assertRaises(PySparkValueError) as pe:
@@ -950,8 +950,8 @@ class SparkConnectColumnTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="CANNOT_BE_EMPTY",
-            message_parameters={"item": "dropFields"},
+            errorClass="CANNOT_BE_EMPTY",
+            messageParameters={"item": "dropFields"},
         )
 
     def test_column_string_ops(self):

--- a/python/pyspark/sql/tests/connect/test_connect_creation.py
+++ b/python/pyspark/sql/tests/connect/test_connect_creation.py
@@ -97,8 +97,8 @@ class SparkConnectCreationTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="AXIS_LENGTH_MISMATCH",
-            message_parameters={"expected_length": "5", "actual_length": "4"},
+            errorClass="AXIS_LENGTH_MISMATCH",
+            messageParameters={"expected_length": "5", "actual_length": "4"},
         )
 
         with self.assertRaises(ParseException):
@@ -109,8 +109,8 @@ class SparkConnectCreationTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="AXIS_LENGTH_MISMATCH",
-            message_parameters={"expected_length": "3", "actual_length": "4"},
+            errorClass="AXIS_LENGTH_MISMATCH",
+            messageParameters={"expected_length": "3", "actual_length": "4"},
         )
 
         # test 1 dim ndarray
@@ -150,8 +150,8 @@ class SparkConnectCreationTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="AXIS_LENGTH_MISMATCH",
-            message_parameters={"expected_length": "5", "actual_length": "4"},
+            errorClass="AXIS_LENGTH_MISMATCH",
+            messageParameters={"expected_length": "5", "actual_length": "4"},
         )
 
         with self.assertRaises(ParseException):
@@ -162,8 +162,8 @@ class SparkConnectCreationTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="AXIS_LENGTH_MISMATCH",
-            message_parameters={"expected_length": "3", "actual_length": "4"},
+            errorClass="AXIS_LENGTH_MISMATCH",
+            messageParameters={"expected_length": "3", "actual_length": "4"},
         )
 
     def test_with_local_rows(self):
@@ -339,8 +339,8 @@ class SparkConnectCreationTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="CANNOT_INFER_EMPTY_SCHEMA",
-            message_parameters={},
+            errorClass="CANNOT_INFER_EMPTY_SCHEMA",
+            messageParameters={},
         )
 
     def test_create_dataframe_from_arrays(self):

--- a/python/pyspark/sql/tests/connect/test_connect_error.py
+++ b/python/pyspark/sql/tests/connect/test_connect_error.py
@@ -136,24 +136,24 @@ class SparkConnectErrorTests(SparkConnectSQLTestCase):
             df.union(df2).collect()
         self.check_error(
             exception=e1.exception,
-            error_class="SESSION_NOT_SAME",
-            message_parameters={},
+            errorClass="SESSION_NOT_SAME",
+            messageParameters={},
         )
 
         with self.assertRaises(SessionNotSameException) as e2:
             df.unionByName(df2).collect()
         self.check_error(
             exception=e2.exception,
-            error_class="SESSION_NOT_SAME",
-            message_parameters={},
+            errorClass="SESSION_NOT_SAME",
+            messageParameters={},
         )
 
         with self.assertRaises(SessionNotSameException) as e3:
             df.join(df2).collect()
         self.check_error(
             exception=e3.exception,
-            error_class="SESSION_NOT_SAME",
-            message_parameters={},
+            errorClass="SESSION_NOT_SAME",
+            messageParameters={},
         )
 
     def test_unsupported_functions(self):
@@ -174,8 +174,8 @@ class SparkConnectErrorTests(SparkConnectSQLTestCase):
 
             self.check_error(
                 exception=pe.exception,
-                error_class="JVM_ATTRIBUTE_NOT_SUPPORTED",
-                message_parameters={"attr_name": attr},
+                errorClass="JVM_ATTRIBUTE_NOT_SUPPORTED",
+                messageParameters={"attr_name": attr},
             )
 
         # Unsupported jvm attributes for DataFrame.
@@ -187,8 +187,8 @@ class SparkConnectErrorTests(SparkConnectSQLTestCase):
 
             self.check_error(
                 exception=pe.exception,
-                error_class="JVM_ATTRIBUTE_NOT_SUPPORTED",
-                message_parameters={"attr_name": attr},
+                errorClass="JVM_ATTRIBUTE_NOT_SUPPORTED",
+                messageParameters={"attr_name": attr},
             )
 
         # Unsupported jvm attributes for Column.
@@ -197,8 +197,8 @@ class SparkConnectErrorTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="JVM_ATTRIBUTE_NOT_SUPPORTED",
-            message_parameters={"attr_name": "_jc"},
+            errorClass="JVM_ATTRIBUTE_NOT_SUPPORTED",
+            messageParameters={"attr_name": "_jc"},
         )
 
         # Unsupported jvm attributes for DataFrameReader.
@@ -207,8 +207,8 @@ class SparkConnectErrorTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="JVM_ATTRIBUTE_NOT_SUPPORTED",
-            message_parameters={"attr_name": "_jreader"},
+            errorClass="JVM_ATTRIBUTE_NOT_SUPPORTED",
+            messageParameters={"attr_name": "_jreader"},
         )
 
     def test_column_cannot_be_constructed_from_string(self):
@@ -221,8 +221,8 @@ class SparkConnectErrorTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=e1.exception,
-            error_class="NOT_LIST_OF_COLUMN_OR_STR",
-            message_parameters={"arg_name": "columns"},
+            errorClass="NOT_LIST_OF_COLUMN_OR_STR",
+            messageParameters={"arg_name": "columns"},
         )
 
     def test_ym_interval_in_collect(self):

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -180,8 +180,8 @@ class SparkConnectFunctionTests(ReusedConnectTestCase, PandasOnSparkTestUtils, S
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_DATAFRAME",
-            message_parameters={"arg_name": "df", "arg_type": "Column"},
+            errorClass="NOT_DATAFRAME",
+            messageParameters={"arg_name": "df", "arg_type": "Column"},
         )
 
     def test_normal_functions(self):
@@ -375,8 +375,8 @@ class SparkConnectFunctionTests(ReusedConnectTestCase, PandasOnSparkTestUtils, S
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN",
-            message_parameters={"arg_name": "condition", "arg_type": "bool"},
+            errorClass="NOT_COLUMN",
+            messageParameters={"arg_name": "condition", "arg_type": "bool"},
         )
 
     def test_sorting_functions_with_column(self):
@@ -880,8 +880,8 @@ class SparkConnectFunctionTests(ReusedConnectTestCase, PandasOnSparkTestUtils, S
 
         self.check_error(
             exception=pe.exception,
-            error_class="VALUE_NOT_BETWEEN",
-            message_parameters={"arg_name": "end", "min": "-2147483648", "max": "2147483647"},
+            errorClass="VALUE_NOT_BETWEEN",
+            messageParameters={"arg_name": "end", "min": "-2147483648", "max": "2147483647"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -889,8 +889,8 @@ class SparkConnectFunctionTests(ReusedConnectTestCase, PandasOnSparkTestUtils, S
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_WINDOWSPEC",
-            message_parameters={"arg_name": "window", "arg_type": "Column"},
+            errorClass="NOT_WINDOWSPEC",
+            messageParameters={"arg_name": "window", "arg_type": "Column"},
         )
 
         # invalid window function
@@ -1217,8 +1217,8 @@ class SparkConnectFunctionTests(ReusedConnectTestCase, PandasOnSparkTestUtils, S
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_INT_OR_STR",
-            message_parameters={"arg_name": "start", "arg_type": "float"},
+            errorClass="NOT_COLUMN_OR_INT_OR_STR",
+            messageParameters={"arg_name": "start", "arg_type": "float"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -1226,8 +1226,8 @@ class SparkConnectFunctionTests(ReusedConnectTestCase, PandasOnSparkTestUtils, S
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_INT_OR_STR",
-            message_parameters={"arg_name": "length", "arg_type": "float"},
+            errorClass="NOT_COLUMN_OR_INT_OR_STR",
+            messageParameters={"arg_name": "length", "arg_type": "float"},
         )
 
         # test sort_array
@@ -1843,8 +1843,8 @@ class SparkConnectFunctionTests(ReusedConnectTestCase, PandasOnSparkTestUtils, S
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_DATATYPE_OR_STR",
-            message_parameters={"arg_name": "schema", "arg_type": "list"},
+            errorClass="NOT_COLUMN_OR_DATATYPE_OR_STR",
+            messageParameters={"arg_name": "schema", "arg_type": "list"},
         )
 
         # test get_json_object
@@ -1980,8 +1980,8 @@ class SparkConnectFunctionTests(ReusedConnectTestCase, PandasOnSparkTestUtils, S
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_STR_OR_STRUCT",
-            message_parameters={"arg_name": "schema", "arg_type": "list"},
+            errorClass="NOT_COLUMN_OR_STR_OR_STRUCT",
+            messageParameters={"arg_name": "schema", "arg_type": "list"},
         )
 
         # test schema_of_xml
@@ -2373,8 +2373,8 @@ class SparkConnectFunctionTests(ReusedConnectTestCase, PandasOnSparkTestUtils, S
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_STR",
-            message_parameters={"arg_name": "slideDuration", "arg_type": "int"},
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "slideDuration", "arg_type": "int"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -2382,8 +2382,8 @@ class SparkConnectFunctionTests(ReusedConnectTestCase, PandasOnSparkTestUtils, S
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_STR",
-            message_parameters={"arg_name": "startTime", "arg_type": "int"},
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "startTime", "arg_type": "int"},
         )
 
         # test session_window

--- a/python/pyspark/sql/tests/connect/test_connect_plan.py
+++ b/python/pyspark/sql/tests/connect/test_connect_plan.py
@@ -668,8 +668,8 @@ class SparkConnectPlanTests(PlanOnlyTestFixture):
 
         self.check_error(
             exception=pe.exception,
-            error_class="VALUE_NOT_POSITIVE",
-            message_parameters={"arg_name": "numPartitions", "arg_value": "-1"},
+            errorClass="VALUE_NOT_POSITIVE",
+            messageParameters={"arg_name": "numPartitions", "arg_value": "-1"},
         )
 
         with self.assertRaises(PySparkValueError) as pe:
@@ -677,8 +677,8 @@ class SparkConnectPlanTests(PlanOnlyTestFixture):
 
         self.check_error(
             exception=pe.exception,
-            error_class="VALUE_NOT_POSITIVE",
-            message_parameters={"arg_name": "numPartitions", "arg_value": "-1"},
+            errorClass="VALUE_NOT_POSITIVE",
+            messageParameters={"arg_name": "numPartitions", "arg_value": "-1"},
         )
 
     def test_repartition_by_expression(self):

--- a/python/pyspark/sql/tests/connect/test_connect_session.py
+++ b/python/pyspark/sql/tests/connect/test_connect_session.py
@@ -82,7 +82,7 @@ class SparkConnectSessionTests(ReusedConnectTestCase):
         self.assertGreaterEqual(len(handler_called), 0)
 
     def _check_no_active_session_error(self, e: PySparkException):
-        self.check_error(exception=e, error_class="NO_ACTIVE_SESSION", message_parameters=dict())
+        self.check_error(exception=e, errorClass="NO_ACTIVE_SESSION", messageParameters=dict())
 
     def test_stop_session(self):
         df = self.spark.sql("select 1 as a, 2 as b")

--- a/python/pyspark/sql/tests/connect/test_connect_stat.py
+++ b/python/pyspark/sql/tests/connect/test_connect_stat.py
@@ -195,8 +195,8 @@ class SparkConnectStatTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_STR",
-            message_parameters={
+            errorClass="NOT_STR",
+            messageParameters={
                 "arg_name": "col1",
                 "arg_type": "int",
             },
@@ -207,8 +207,8 @@ class SparkConnectStatTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_STR",
-            message_parameters={
+            errorClass="NOT_STR",
+            messageParameters={
                 "arg_name": "col2",
                 "arg_type": "int",
             },
@@ -241,8 +241,8 @@ class SparkConnectStatTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_LIST_OR_STR_OR_TUPLE",
-            message_parameters={
+            errorClass="NOT_LIST_OR_STR_OR_TUPLE",
+            messageParameters={
                 "arg_name": "col",
                 "arg_type": "int",
             },
@@ -253,8 +253,8 @@ class SparkConnectStatTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_LIST_OR_TUPLE",
-            message_parameters={
+            errorClass="NOT_LIST_OR_TUPLE",
+            messageParameters={
                 "arg_name": "probabilities",
                 "arg_type": "float",
             },
@@ -266,8 +266,8 @@ class SparkConnectStatTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_LIST_OF_FLOAT_OR_INT",
-            message_parameters={"arg_name": "probabilities", "arg_type": "float"},
+            errorClass="NOT_LIST_OF_FLOAT_OR_INT",
+            messageParameters={"arg_name": "probabilities", "arg_type": "float"},
         )
         with self.assertRaises(PySparkTypeError) as pe:
             self.connect.read.table(self.tbl_name2).stat.approxQuantile(
@@ -276,8 +276,8 @@ class SparkConnectStatTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_FLOAT_OR_INT",
-            message_parameters={
+            errorClass="NOT_FLOAT_OR_INT",
+            messageParameters={
                 "arg_name": "relativeError",
                 "arg_type": "str",
             },
@@ -289,8 +289,8 @@ class SparkConnectStatTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NEGATIVE_VALUE",
-            message_parameters={
+            errorClass="NEGATIVE_VALUE",
+            messageParameters={
                 "arg_name": "relativeError",
                 "arg_value": "-0.1",
             },
@@ -316,8 +316,8 @@ class SparkConnectStatTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_LIST_OR_TUPLE",
-            message_parameters={
+            errorClass="NOT_LIST_OR_TUPLE",
+            messageParameters={
                 "arg_name": "cols",
                 "arg_type": "str",
             },
@@ -347,8 +347,8 @@ class SparkConnectStatTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="DISALLOWED_TYPE_FOR_CONTAINER",
-            message_parameters={
+            errorClass="DISALLOWED_TYPE_FOR_CONTAINER",
+            messageParameters={
                 "arg_name": "fractions",
                 "arg_type": "dict",
                 "allowed_types": "float, int, str",
@@ -538,8 +538,8 @@ class SparkConnectStatTests(SparkConnectSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_BOOL_OR_FLOAT_OR_INT_OR_STR",
-            message_parameters={
+            errorClass="NOT_BOOL_OR_FLOAT_OR_INT_OR_STR",
+            messageParameters={
                 "arg_name": "value",
                 "arg_type": "bytes",
             },

--- a/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
@@ -163,7 +163,7 @@ class CogroupedApplyInPandasTestsMixin:
     def check_apply_in_pandas_not_returning_pandas_dataframe(self):
         self._test_merge_error(
             fn=lambda lft, rgt: lft.size + rgt.size,
-            error_class=PythonException,
+            errorClass=PythonException,
             error_message_regex="Return type of the user-defined function "
             "should be pandas.DataFrame, but is int",
         )
@@ -203,7 +203,7 @@ class CogroupedApplyInPandasTestsMixin:
 
         self._test_merge_error(
             fn=merge_pandas,
-            error_class=PythonException,
+            errorClass=PythonException,
             error_message_regex="Column names of the returned pandas.DataFrame "
             "do not match specified schema. Unexpected: add, more.\n",
         )
@@ -224,7 +224,7 @@ class CogroupedApplyInPandasTestsMixin:
 
         self._test_merge_error(
             fn=merge_pandas,
-            error_class=PythonException,
+            errorClass=PythonException,
             error_message_regex="Number of columns of the returned pandas.DataFrame "
             "doesn't match specified schema. Expected: 4 Actual: 6\n",
         )
@@ -264,7 +264,7 @@ class CogroupedApplyInPandasTestsMixin:
                     self._test_merge_error(
                         fn=lambda lft, rgt: pd.DataFrame({"id": [1], "k": ["2.0"]}),
                         output_schema="id long, k double",
-                        error_class=PythonException,
+                        errorClass=PythonException,
                         error_message_regex=expected,
                     )
 
@@ -277,7 +277,7 @@ class CogroupedApplyInPandasTestsMixin:
                     self._test_merge_error(
                         fn=lambda lft, rgt: pd.DataFrame({"id": [1], "k": [2.0]}),
                         output_schema="id long, k string",
-                        error_class=PythonException,
+                        errorClass=PythonException,
                         error_message_regex=expected,
                     )
 
@@ -341,7 +341,7 @@ class CogroupedApplyInPandasTestsMixin:
             output_schema=(
                 StructType().add("id", LongType()).add("v", ArrayType(YearMonthIntervalType()))
             ),
-            error_class=NotImplementedError,
+            errorClass=NotImplementedError,
             error_message_regex="Invalid return type.*ArrayType.*YearMonthIntervalType",
         )
 
@@ -353,7 +353,7 @@ class CogroupedApplyInPandasTestsMixin:
         self.__test_merge_error(
             fn=lambda: 1,
             output_schema=StructType([StructField("d", DoubleType())]),
-            error_class=ValueError,
+            errorClass=ValueError,
             error_message_regex="Invalid function",
         )
 
@@ -558,7 +558,7 @@ class CogroupedApplyInPandasTestsMixin:
 
     def _test_merge_error(
         self,
-        error_class,
+        errorClass,
         error_message_regex,
         left=None,
         right=None,
@@ -577,7 +577,7 @@ class CogroupedApplyInPandasTestsMixin:
                 by=by,
                 fn=fn,
                 output_schema=output_schema,
-                error_class=error_class,
+                errorClass=errorClass,
                 error_message_regex=error_message_regex,
             )
         with self.subTest("with key"):
@@ -587,13 +587,13 @@ class CogroupedApplyInPandasTestsMixin:
                 by=by,
                 fn=fn_with_key,
                 output_schema=output_schema,
-                error_class=error_class,
+                errorClass=errorClass,
                 error_message_regex=error_message_regex,
             )
 
     def __test_merge_error(
         self,
-        error_class,
+        errorClass,
         error_message_regex,
         left=None,
         right=None,
@@ -602,7 +602,7 @@ class CogroupedApplyInPandasTestsMixin:
         output_schema="id long, k int, v int, v2 int",
     ):
         # Test fn as is, cf. _test_merge_error
-        with self.assertRaisesRegex(error_class, error_message_regex):
+        with self.assertRaisesRegex(errorClass, error_message_regex):
             self.__test_merge(left, right, by, fn, output_schema)
 
 

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -219,8 +219,8 @@ class GroupedApplyInPandasTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="INVALID_UDF_EVAL_TYPE",
-            message_parameters={
+            errorClass="INVALID_UDF_EVAL_TYPE",
+            messageParameters={
                 "eval_type": "SQL_BATCHED_UDF, SQL_ARROW_BATCHED_UDF, SQL_SCALAR_PANDAS_UDF, "
                 "SQL_SCALAR_PANDAS_ITER_UDF or SQL_GROUPED_AGG_PANDAS_UDF"
             },

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf.py
@@ -142,8 +142,8 @@ class PandasUDFTestsMixin:
 
             self.check_error(
                 exception=pe.exception,
-                error_class="INVALID_RETURN_TYPE_FOR_PANDAS_UDF",
-                message_parameters={
+                errorClass="INVALID_RETURN_TYPE_FOR_PANDAS_UDF",
+                messageParameters={
                     "eval_type": "SQL_GROUPED_MAP_PANDAS_UDF "
                     "or SQL_GROUPED_MAP_PANDAS_UDF_WITH_STATE",
                     "return_type": "DoubleType()",
@@ -165,8 +165,8 @@ class PandasUDFTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="CANNOT_BE_NONE",
-            message_parameters={"arg_name": "returnType"},
+            errorClass="CANNOT_BE_NONE",
+            messageParameters={"arg_name": "returnType"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -177,8 +177,8 @@ class PandasUDFTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="INVALID_PANDAS_UDF_TYPE",
-            message_parameters={"arg_name": "functionType", "arg_type": "100"},
+            errorClass="INVALID_PANDAS_UDF_TYPE",
+            messageParameters={"arg_name": "functionType", "arg_type": "100"},
         )
 
         with self.assertRaisesRegex(ValueError, "0-arg pandas_udfs.*not.*supported"):
@@ -197,8 +197,8 @@ class PandasUDFTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_DATATYPE_OR_STR",
-            message_parameters={"arg_name": "returnType", "arg_type": "int"},
+            errorClass="NOT_DATATYPE_OR_STR",
+            messageParameters={"arg_name": "returnType", "arg_type": "int"},
         )
 
     def test_stopiteration_in_udf(self):

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_grouped_agg.py
@@ -189,8 +189,8 @@ class GroupedAggPandasUDFTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={
                 "feature": "Invalid return type with grouped aggregate Pandas UDFs: "
                 "ArrayType(ArrayType(YearMonthIntervalType(0, 1), True), True)"
             },
@@ -204,8 +204,8 @@ class GroupedAggPandasUDFTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={
                 "feature": "Invalid return type with grouped aggregate Pandas UDFs: "
                 "StructType([StructField('mean', DoubleType(), True), "
                 "StructField('std', DoubleType(), True)])"
@@ -220,8 +220,8 @@ class GroupedAggPandasUDFTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={
                 "feature": "Invalid return type with grouped aggregate Pandas UDFs: "
                 "ArrayType(YearMonthIntervalType(0, 1), True)"
             },

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -765,8 +765,8 @@ class ScalarPandasUDFTestsMixin:
 
             self.check_error(
                 exception=ae.exception,
-                error_class="DATATYPE_MISMATCH.UNSUPPORTED_UDF_INPUT_TYPE",
-                message_parameters={
+                errorClass="DATATYPE_MISMATCH.UNSUPPORTED_UDF_INPUT_TYPE",
+                messageParameters={
                     "sqlExpr": '"<lambda>(v)"',
                     "dataType": "VARIANT",
                 },
@@ -786,8 +786,8 @@ class ScalarPandasUDFTestsMixin:
 
             self.check_error(
                 exception=ae.exception,
-                error_class="DATATYPE_MISMATCH.UNSUPPORTED_UDF_OUTPUT_TYPE",
-                message_parameters={
+                errorClass="DATATYPE_MISMATCH.UNSUPPORTED_UDF_OUTPUT_TYPE",
+                messageParameters={
                     "sqlExpr": '"<lambda>()"',
                     "dataType": "VARIANT",
                 },

--- a/python/pyspark/sql/tests/streaming/test_streaming_listener.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_listener.py
@@ -51,7 +51,7 @@ class StreamingListenerTestsMixin:
         self.assertTrue(isinstance(event, QueryProgressEvent))
         self.check_streaming_query_progress(event.progress, is_stateful)
 
-    def check_terminated_event(self, event, exception=None, error_class=None):
+    def check_terminated_event(self, event, exception=None, errorClass=None):
         """Check QueryTerminatedEvent"""
         self.assertTrue(isinstance(event, QueryTerminatedEvent))
         self.assertTrue(isinstance(event.id, uuid.UUID))
@@ -61,8 +61,8 @@ class StreamingListenerTestsMixin:
         else:
             self.assertEqual(event.exception, None)
 
-        if error_class:
-            self.assertTrue(error_class in event.errorClassOnException)
+        if errorClass:
+            self.assertTrue(errorClass in event.errorClassOnException)
         else:
             self.assertEqual(event.errorClassOnException, None)
 

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -701,8 +701,8 @@ class ArrowTestsMixin:
 
                 self.check_error(
                     exception=pe.exception,
-                    error_class="UNSUPPORTED_DATA_TYPE_FOR_ARROW",
-                    message_parameters={"data_type": "IntegerType()"},
+                    errorClass="UNSUPPORTED_DATA_TYPE_FOR_ARROW",
+                    messageParameters={"data_type": "IntegerType()"},
                 )
 
     def test_createDataFrame_does_not_modify_input(self):

--- a/python/pyspark/sql/tests/test_arrow_python_udf.py
+++ b/python/pyspark/sql/tests/test_arrow_python_udf.py
@@ -186,8 +186,8 @@ class PythonUDFArrowTestsMixin(BaseUDFTestsMixin):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={
                 "feature": "Invalid return type with Arrow-optimized Python UDF: VarcharType(10)"
             },
         )

--- a/python/pyspark/sql/tests/test_column.py
+++ b/python/pyspark/sql/tests/test_column.py
@@ -53,8 +53,8 @@ class ColumnTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "col", "arg_type": "int"},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "col", "arg_type": "int"},
         )
 
         class A:
@@ -68,8 +68,8 @@ class ColumnTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "col", "arg_type": "NoneType"},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "col", "arg_type": "NoneType"},
         )
         self.assertRaises(TypeError, lambda: to_json(1))
 
@@ -177,8 +177,8 @@ class ColumnTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN",
-            message_parameters={"arg_name": "col", "arg_type": "int"},
+            errorClass="NOT_COLUMN",
+            messageParameters={"arg_name": "col", "arg_type": "int"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -186,8 +186,8 @@ class ColumnTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_STR",
-            message_parameters={"arg_name": "fieldName", "arg_type": "Column"},
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "fieldName", "arg_type": "Column"},
         )
 
     def test_drop_fields(self):
@@ -224,8 +224,8 @@ class ColumnTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="ONLY_ALLOWED_FOR_SINGLE_COLUMN",
-            message_parameters={"arg_name": "metadata"},
+            errorClass="ONLY_ALLOWED_FOR_SINGLE_COLUMN",
+            messageParameters={"arg_name": "metadata"},
         )
 
     def test_cast_str_representation(self):
@@ -245,8 +245,8 @@ class ColumnTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_DATATYPE_OR_STR",
-            message_parameters={"arg_name": "dataType", "arg_type": "int"},
+            errorClass="NOT_DATATYPE_OR_STR",
+            messageParameters={"arg_name": "dataType", "arg_type": "int"},
         )
 
     def test_over_negative(self):
@@ -255,8 +255,8 @@ class ColumnTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_WINDOWSPEC",
-            message_parameters={"arg_name": "window", "arg_type": "int"},
+            errorClass="NOT_WINDOWSPEC",
+            messageParameters={"arg_name": "window", "arg_type": "int"},
         )
 
     def test_eqnullsafe_classmethod_usage(self):

--- a/python/pyspark/sql/tests/test_conf.py
+++ b/python/pyspark/sql/tests/test_conf.py
@@ -69,8 +69,8 @@ class ConfTestsMixin:
 
             self.check_error(
                 exception=pe.exception,
-                error_class="NOT_STR",
-                message_parameters={
+                errorClass="NOT_STR",
+                messageParameters={
                     "arg_name": "key",
                     "arg_type": "int",
                 },

--- a/python/pyspark/sql/tests/test_creation.py
+++ b/python/pyspark/sql/tests/test_creation.py
@@ -137,8 +137,8 @@ class DataFrameCreationTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_LIST_OR_NONE_OR_STRUCT",
-            message_parameters={"arg_name": "schema", "arg_type": "int"},
+            errorClass="NOT_LIST_OR_NONE_OR_STRUCT",
+            messageParameters={"arg_name": "schema", "arg_type": "int"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -146,8 +146,8 @@ class DataFrameCreationTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="INVALID_TYPE",
-            message_parameters={"arg_name": "data", "arg_type": "DataFrame"},
+            errorClass="INVALID_TYPE",
+            messageParameters={"arg_name": "data", "arg_type": "DataFrame"},
         )
 
     def test_partial_inference_failure(self):
@@ -156,8 +156,8 @@ class DataFrameCreationTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="CANNOT_DETERMINE_TYPE",
-            message_parameters={},
+            errorClass="CANNOT_DETERMINE_TYPE",
+            messageParameters={},
         )
 
     @unittest.skipIf(
@@ -191,8 +191,8 @@ class DataFrameCreationTestsMixin:
 
             self.check_error(
                 exception=pe.exception,
-                error_class="CANNOT_INFER_EMPTY_SCHEMA",
-                message_parameters={},
+                errorClass="CANNOT_INFER_EMPTY_SCHEMA",
+                messageParameters={},
             )
 
             # Dict has different types of values should fail

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -62,8 +62,8 @@ class DataFrameTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_STR",
-            message_parameters={"arg_name": "tableName", "arg_type": "NoneType"},
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "tableName", "arg_type": "NoneType"},
         )
 
     def test_dataframe_star(self):
@@ -217,8 +217,8 @@ class DataFrameTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_DICT",
-            message_parameters={"arg_name": "colsMap", "arg_type": "tuple"},
+            errorClass="NOT_DICT",
+            messageParameters={"arg_name": "colsMap", "arg_type": "tuple"},
         )
 
     def test_with_columns_renamed_with_duplicated_names(self):
@@ -414,8 +414,8 @@ class DataFrameTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_BOOL_OR_FLOAT_OR_INT",
-            message_parameters={
+            errorClass="NOT_BOOL_OR_FLOAT_OR_INT",
+            messageParameters={
                 "arg_name": "withReplacement (optional), fraction (required) and seed (optional)",
                 "arg_type": "NoneType, NoneType, NoneType",
             },
@@ -447,8 +447,8 @@ class DataFrameTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_LIST_OF_STR",
-            message_parameters={"arg_name": "cols", "arg_type": "NoneType"},
+            errorClass="NOT_LIST_OF_STR",
+            messageParameters={"arg_name": "cols", "arg_type": "NoneType"},
         )
 
     def test_toDF_with_schema_string(self):
@@ -684,8 +684,8 @@ class DataFrameTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_DATAFRAME",
-            message_parameters={"arg_name": "other", "arg_type": "int"},
+            errorClass="NOT_DATAFRAME",
+            messageParameters={"arg_name": "other", "arg_type": "int"},
         )
 
     def test_input_files(self):
@@ -720,8 +720,8 @@ class DataFrameTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_INT",
-            message_parameters={"arg_name": "n", "arg_type": "bool"},
+            errorClass="NOT_INT",
+            messageParameters={"arg_name": "n", "arg_type": "bool"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -729,8 +729,8 @@ class DataFrameTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_BOOL",
-            message_parameters={"arg_name": "vertical", "arg_type": "str"},
+            errorClass="NOT_BOOL",
+            messageParameters={"arg_name": "vertical", "arg_type": "str"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -738,8 +738,8 @@ class DataFrameTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_BOOL",
-            message_parameters={"arg_name": "truncate", "arg_type": "str"},
+            errorClass="NOT_BOOL",
+            messageParameters={"arg_name": "truncate", "arg_type": "str"},
         )
 
     def test_df_merge_into(self):
@@ -871,8 +871,8 @@ class DataFrameTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_STR",
-            message_parameters={"arg_name": "colName", "arg_type": "int"},
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "colName", "arg_type": "int"},
         )
 
     def test_where(self):
@@ -881,8 +881,8 @@ class DataFrameTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "condition", "arg_type": "int"},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "condition", "arg_type": "int"},
         )
 
     def test_duplicate_field_names(self):
@@ -929,8 +929,8 @@ class DataFrameTests(DataFrameTestsMixin, ReusedSQLTestCase):
 
         self.check_error(
             exception=pe.exception,
-            error_class="CLASSIC_OPERATION_NOT_SUPPORTED_ON_DF",
-            message_parameters={"member": "queryExecution"},
+            errorClass="CLASSIC_OPERATION_NOT_SUPPORTED_ON_DF",
+            messageParameters={"member": "queryExecution"},
         )
 
 

--- a/python/pyspark/sql/tests/test_dataframe_query_context.py
+++ b/python/pyspark/sql/tests/test_dataframe_query_context.py
@@ -38,8 +38,8 @@ class DataFrameQueryContextTestsMixin:
                 df.withColumn("div_zero", df.id / 0).collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="DIVIDE_BY_ZERO",
-                message_parameters={"config": '"spark.sql.ansi.enabled"'},
+                errorClass="DIVIDE_BY_ZERO",
+                messageParameters={"config": '"spark.sql.ansi.enabled"'},
                 query_context_type=QueryContextType.DataFrame,
                 fragment="__truediv__",
             )
@@ -49,8 +49,8 @@ class DataFrameQueryContextTestsMixin:
                 df.withColumn("plus_invalid_type", df.id + "string").collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="CAST_INVALID_INPUT",
-                message_parameters={
+                errorClass="CAST_INVALID_INPUT",
+                messageParameters={
                     "expression": "'string'",
                     "sourceType": '"STRING"',
                     "targetType": '"BIGINT"',
@@ -65,8 +65,8 @@ class DataFrameQueryContextTestsMixin:
                 df.withColumn("minus_invalid_type", df.id - "string").collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="CAST_INVALID_INPUT",
-                message_parameters={
+                errorClass="CAST_INVALID_INPUT",
+                messageParameters={
                     "expression": "'string'",
                     "sourceType": '"STRING"',
                     "targetType": '"BIGINT"',
@@ -81,8 +81,8 @@ class DataFrameQueryContextTestsMixin:
                 df.withColumn("multiply_invalid_type", df.id * "string").collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="CAST_INVALID_INPUT",
-                message_parameters={
+                errorClass="CAST_INVALID_INPUT",
+                messageParameters={
                     "expression": "'string'",
                     "sourceType": '"STRING"',
                     "targetType": '"BIGINT"',
@@ -97,8 +97,8 @@ class DataFrameQueryContextTestsMixin:
                 df.withColumn("mod_invalid_type", df.id % "string").collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="CAST_INVALID_INPUT",
-                message_parameters={
+                errorClass="CAST_INVALID_INPUT",
+                messageParameters={
                     "expression": "'string'",
                     "sourceType": '"STRING"',
                     "targetType": '"BIGINT"',
@@ -113,8 +113,8 @@ class DataFrameQueryContextTestsMixin:
                 df.withColumn("equalTo_invalid_type", df.id == "string").collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="CAST_INVALID_INPUT",
-                message_parameters={
+                errorClass="CAST_INVALID_INPUT",
+                messageParameters={
                     "expression": "'string'",
                     "sourceType": '"STRING"',
                     "targetType": '"BIGINT"',
@@ -129,8 +129,8 @@ class DataFrameQueryContextTestsMixin:
                 df.withColumn("lt_invalid_type", df.id < "string").collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="CAST_INVALID_INPUT",
-                message_parameters={
+                errorClass="CAST_INVALID_INPUT",
+                messageParameters={
                     "expression": "'string'",
                     "sourceType": '"STRING"',
                     "targetType": '"BIGINT"',
@@ -145,8 +145,8 @@ class DataFrameQueryContextTestsMixin:
                 df.withColumn("leq_invalid_type", df.id <= "string").collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="CAST_INVALID_INPUT",
-                message_parameters={
+                errorClass="CAST_INVALID_INPUT",
+                messageParameters={
                     "expression": "'string'",
                     "sourceType": '"STRING"',
                     "targetType": '"BIGINT"',
@@ -161,8 +161,8 @@ class DataFrameQueryContextTestsMixin:
                 df.withColumn("geq_invalid_type", df.id >= "string").collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="CAST_INVALID_INPUT",
-                message_parameters={
+                errorClass="CAST_INVALID_INPUT",
+                messageParameters={
                     "expression": "'string'",
                     "sourceType": '"STRING"',
                     "targetType": '"BIGINT"',
@@ -177,8 +177,8 @@ class DataFrameQueryContextTestsMixin:
                 df.withColumn("gt_invalid_type", df.id > "string").collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="CAST_INVALID_INPUT",
-                message_parameters={
+                errorClass="CAST_INVALID_INPUT",
+                messageParameters={
                     "expression": "'string'",
                     "sourceType": '"STRING"',
                     "targetType": '"BIGINT"',
@@ -193,8 +193,8 @@ class DataFrameQueryContextTestsMixin:
                 df.withColumn("eqNullSafe_invalid_type", df.id.eqNullSafe("string")).collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="CAST_INVALID_INPUT",
-                message_parameters={
+                errorClass="CAST_INVALID_INPUT",
+                messageParameters={
                     "expression": "'string'",
                     "sourceType": '"STRING"',
                     "targetType": '"BIGINT"',
@@ -209,8 +209,8 @@ class DataFrameQueryContextTestsMixin:
                 df.withColumn("bitwiseOR_invalid_type", df.id.bitwiseOR("string")).collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="CAST_INVALID_INPUT",
-                message_parameters={
+                errorClass="CAST_INVALID_INPUT",
+                messageParameters={
                     "expression": "'string'",
                     "sourceType": '"STRING"',
                     "targetType": '"BIGINT"',
@@ -225,8 +225,8 @@ class DataFrameQueryContextTestsMixin:
                 df.withColumn("bitwiseAND_invalid_type", df.id.bitwiseAND("string")).collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="CAST_INVALID_INPUT",
-                message_parameters={
+                errorClass="CAST_INVALID_INPUT",
+                messageParameters={
                     "expression": "'string'",
                     "sourceType": '"STRING"',
                     "targetType": '"BIGINT"',
@@ -241,8 +241,8 @@ class DataFrameQueryContextTestsMixin:
                 df.withColumn("bitwiseXOR_invalid_type", df.id.bitwiseXOR("string")).collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="CAST_INVALID_INPUT",
-                message_parameters={
+                errorClass="CAST_INVALID_INPUT",
+                messageParameters={
                     "expression": "'string'",
                     "sourceType": '"STRING"',
                     "targetType": '"BIGINT"',
@@ -259,8 +259,8 @@ class DataFrameQueryContextTestsMixin:
                 ).withColumn("plus_ten", df.id + 10).withColumn("minus_ten", df.id - 10).collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="DIVIDE_BY_ZERO",
-                message_parameters={"config": '"spark.sql.ansi.enabled"'},
+                errorClass="DIVIDE_BY_ZERO",
+                messageParameters={"config": '"spark.sql.ansi.enabled"'},
                 query_context_type=QueryContextType.DataFrame,
                 fragment="__truediv__",
             )
@@ -274,8 +274,8 @@ class DataFrameQueryContextTestsMixin:
                 ).collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="CAST_INVALID_INPUT",
-                message_parameters={
+                errorClass="CAST_INVALID_INPUT",
+                messageParameters={
                     "expression": "'string'",
                     "sourceType": '"STRING"',
                     "targetType": '"BIGINT"',
@@ -294,8 +294,8 @@ class DataFrameQueryContextTestsMixin:
                 ).collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="CAST_INVALID_INPUT",
-                message_parameters={
+                errorClass="CAST_INVALID_INPUT",
+                messageParameters={
                     "expression": "'string'",
                     "sourceType": '"STRING"',
                     "targetType": '"BIGINT"',
@@ -312,8 +312,8 @@ class DataFrameQueryContextTestsMixin:
                 ).withColumn("plus_ten", df.id + 10).withColumn("minus_ten", df.id - 10).collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="CAST_INVALID_INPUT",
-                message_parameters={
+                errorClass="CAST_INVALID_INPUT",
+                messageParameters={
                     "expression": "'string'",
                     "sourceType": '"STRING"',
                     "targetType": '"BIGINT"',
@@ -328,8 +328,8 @@ class DataFrameQueryContextTestsMixin:
                 df.select(df.id - 10, df.id + 4, df.id / 0, df.id * 5).collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="DIVIDE_BY_ZERO",
-                message_parameters={"config": '"spark.sql.ansi.enabled"'},
+                errorClass="DIVIDE_BY_ZERO",
+                messageParameters={"config": '"spark.sql.ansi.enabled"'},
                 query_context_type=QueryContextType.DataFrame,
                 fragment="__truediv__",
             )
@@ -339,8 +339,8 @@ class DataFrameQueryContextTestsMixin:
                 df.select(df.id - 10, df.id + "string", df.id / 10, df.id * 5).collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="CAST_INVALID_INPUT",
-                message_parameters={
+                errorClass="CAST_INVALID_INPUT",
+                messageParameters={
                     "expression": "'string'",
                     "sourceType": '"STRING"',
                     "targetType": '"BIGINT"',
@@ -355,8 +355,8 @@ class DataFrameQueryContextTestsMixin:
                 df.select(df.id - "string", df.id + 4, df.id / 10, df.id * 5).collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="CAST_INVALID_INPUT",
-                message_parameters={
+                errorClass="CAST_INVALID_INPUT",
+                messageParameters={
                     "expression": "'string'",
                     "sourceType": '"STRING"',
                     "targetType": '"BIGINT"',
@@ -371,8 +371,8 @@ class DataFrameQueryContextTestsMixin:
                 df.select(df.id - 10, df.id + 4, df.id / 10, df.id * "string").collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="CAST_INVALID_INPUT",
-                message_parameters={
+                errorClass="CAST_INVALID_INPUT",
+                messageParameters={
                     "expression": "'string'",
                     "sourceType": '"STRING"',
                     "targetType": '"BIGINT"',
@@ -389,8 +389,8 @@ class DataFrameQueryContextTestsMixin:
                 df.select(a, df.id + 4, b, df.id * 5).collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="DIVIDE_BY_ZERO",
-                message_parameters={"config": '"spark.sql.ansi.enabled"'},
+                errorClass="DIVIDE_BY_ZERO",
+                messageParameters={"config": '"spark.sql.ansi.enabled"'},
                 query_context_type=QueryContextType.DataFrame,
                 fragment="__truediv__",
             )
@@ -402,8 +402,8 @@ class DataFrameQueryContextTestsMixin:
                 df.select(df.id / 10, a, b, df.id * 5).collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="CAST_INVALID_INPUT",
-                message_parameters={
+                errorClass="CAST_INVALID_INPUT",
+                messageParameters={
                     "expression": "'string'",
                     "sourceType": '"STRING"',
                     "targetType": '"BIGINT"',
@@ -420,8 +420,8 @@ class DataFrameQueryContextTestsMixin:
                 df.select(a, df.id / 10, b, df.id * 5).collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="CAST_INVALID_INPUT",
-                message_parameters={
+                errorClass="CAST_INVALID_INPUT",
+                messageParameters={
                     "expression": "'string'",
                     "sourceType": '"STRING"',
                     "targetType": '"BIGINT"',
@@ -438,8 +438,8 @@ class DataFrameQueryContextTestsMixin:
                 df.select(a, df.id / 10, b, df.id + 5).collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="CAST_INVALID_INPUT",
-                message_parameters={
+                errorClass="CAST_INVALID_INPUT",
+                messageParameters={
                     "expression": "'string'",
                     "sourceType": '"STRING"',
                     "targetType": '"BIGINT"',
@@ -456,8 +456,8 @@ class DataFrameQueryContextTestsMixin:
                 self.spark.sql("select 10/0").collect()
             self.check_error(
                 exception=pe.exception,
-                error_class="DIVIDE_BY_ZERO",
-                message_parameters={"config": '"spark.sql.ansi.enabled"'},
+                errorClass="DIVIDE_BY_ZERO",
+                messageParameters={"config": '"spark.sql.ansi.enabled"'},
                 query_context_type=QueryContextType.SQL,
             )
 
@@ -466,8 +466,8 @@ class DataFrameQueryContextTestsMixin:
                 self.spark.sql("select * from non-existing-table")
             self.check_error(
                 exception=pe.exception,
-                error_class="INVALID_IDENTIFIER",
-                message_parameters={"ident": "non-existing-table"},
+                errorClass="INVALID_IDENTIFIER",
+                messageParameters={"ident": "non-existing-table"},
                 query_context_type=None,
             )
 

--- a/python/pyspark/sql/tests/test_datasources.py
+++ b/python/pyspark/sql/tests/test_datasources.py
@@ -296,8 +296,8 @@ class DataSourcesTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "schema"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "schema"},
         )
 
         with self.assertRaises(PySparkNotImplementedError) as pe:
@@ -305,8 +305,8 @@ class DataSourcesTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "reader"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "reader"},
         )
 
         with self.assertRaises(PySparkNotImplementedError) as pe:
@@ -314,8 +314,8 @@ class DataSourcesTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "writer"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "writer"},
         )
 
     def test_input_partition(self):

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -166,8 +166,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "col", "arg_type": "int"},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "col", "arg_type": "int"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -175,8 +175,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_DICT",
-            message_parameters={"arg_name": "fractions", "arg_type": "list"},
+            errorClass="NOT_DICT",
+            messageParameters={"arg_name": "fractions", "arg_type": "list"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -184,8 +184,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DISALLOWED_TYPE_FOR_CONTAINER",
-            message_parameters={
+            errorClass="DISALLOWED_TYPE_FOR_CONTAINER",
+            messageParameters={
                 "arg_name": "fractions",
                 "arg_type": "dict",
                 "allowed_types": "float, int, str",
@@ -203,8 +203,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_STR",
-            message_parameters={"arg_name": "col1", "arg_type": "int"},
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "col1", "arg_type": "int"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -212,8 +212,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_STR",
-            message_parameters={"arg_name": "col2", "arg_type": "bool"},
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "col2", "arg_type": "bool"},
         )
 
     def test_crosstab(self):
@@ -349,8 +349,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_SAME_TYPE",
-            message_parameters={
+            errorClass="NOT_SAME_TYPE",
+            messageParameters={
                 "arg_name1": "startPos",
                 "arg_name2": "length",
                 "arg_type1": "int",
@@ -363,8 +363,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_INT",
-            message_parameters={
+            errorClass="NOT_COLUMN_OR_INT",
+            messageParameters={
                 "arg_name": "startPos",
                 "arg_type": "str",
             },
@@ -683,8 +683,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="WRONG_NUM_COLUMNS",
-            message_parameters={"func_name": "least", "num_cols": "2"},
+            errorClass="WRONG_NUM_COLUMNS",
+            messageParameters={"func_name": "least", "num_cols": "2"},
         )
 
     def test_overlay(self):
@@ -729,8 +729,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_INT_OR_STR",
-            message_parameters={"arg_name": "pos", "arg_type": "float"},
+            errorClass="NOT_COLUMN_OR_INT_OR_STR",
+            messageParameters={"arg_name": "pos", "arg_type": "float"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -738,8 +738,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_INT_OR_STR",
-            message_parameters={"arg_name": "len", "arg_type": "float"},
+            errorClass="NOT_COLUMN_OR_INT_OR_STR",
+            messageParameters={"arg_name": "len", "arg_type": "float"},
         )
 
     def test_percentile(self):
@@ -859,8 +859,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="UNSUPPORTED_PARAM_TYPE_FOR_HIGHER_ORDER_FUNCTION",
-            message_parameters={"func_name": "<lambda>"},
+            errorClass="UNSUPPORTED_PARAM_TYPE_FOR_HIGHER_ORDER_FUNCTION",
+            messageParameters={"func_name": "<lambda>"},
         )
 
         # Should fail with kwargs
@@ -869,8 +869,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="UNSUPPORTED_PARAM_TYPE_FOR_HIGHER_ORDER_FUNCTION",
-            message_parameters={"func_name": "<lambda>"},
+            errorClass="UNSUPPORTED_PARAM_TYPE_FOR_HIGHER_ORDER_FUNCTION",
+            messageParameters={"func_name": "<lambda>"},
         )
 
         # Should fail with nullary function
@@ -879,8 +879,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="WRONG_NUM_ARGS_FOR_HIGHER_ORDER_FUNCTION",
-            message_parameters={"func_name": "<lambda>", "num_args": "0"},
+            errorClass="WRONG_NUM_ARGS_FOR_HIGHER_ORDER_FUNCTION",
+            messageParameters={"func_name": "<lambda>", "num_args": "0"},
         )
 
         # Should fail with quaternary function
@@ -889,8 +889,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="WRONG_NUM_ARGS_FOR_HIGHER_ORDER_FUNCTION",
-            message_parameters={"func_name": "<lambda>", "num_args": "4"},
+            errorClass="WRONG_NUM_ARGS_FOR_HIGHER_ORDER_FUNCTION",
+            messageParameters={"func_name": "<lambda>", "num_args": "4"},
         )
 
         # Should fail if function doesn't return Column
@@ -899,8 +899,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="HIGHER_ORDER_FUNCTION_SHOULD_RETURN_COLUMN",
-            message_parameters={"func_name": "<lambda>", "return_type": "int"},
+            errorClass="HIGHER_ORDER_FUNCTION_SHOULD_RETURN_COLUMN",
+            messageParameters={"func_name": "<lambda>", "return_type": "int"},
         )
 
     def test_nested_higher_order_function(self):
@@ -1098,8 +1098,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "errMsg", "arg_type": "int"},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "errMsg", "arg_type": "int"},
         )
 
     def test_raise_error(self):
@@ -1119,8 +1119,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "errMsg", "arg_type": "NoneType"},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "errMsg", "arg_type": "NoneType"},
         )
 
     def test_sum_distinct(self):
@@ -1179,8 +1179,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="COLUMN_IN_LIST",
-            message_parameters={"func_name": "lit"},
+            errorClass="COLUMN_IN_LIST",
+            messageParameters={"func_name": "lit"},
         )
 
     # Test added for SPARK-39832; change Python API to accept both col & str as input
@@ -1255,8 +1255,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="UNSUPPORTED_NUMPY_ARRAY_SCALAR",
-            message_parameters={
+            errorClass="UNSUPPORTED_NUMPY_ARRAY_SCALAR",
+            messageParameters={
                 "dtype": "uint64",
             },
         )
@@ -1336,8 +1336,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=ex.exception,
-            error_class="INVALID_VARIANT_CAST",
-            message_parameters={"value": "1", "dataType": '"BINARY"'},
+            errorClass="INVALID_VARIANT_CAST",
+            messageParameters={"value": "1", "dataType": '"BINARY"'},
         )
 
         check(df.select(F.try_variant_get(v, "$.a", "int")), [1, None])
@@ -1351,8 +1351,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "json", "arg_type": "int"},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "json", "arg_type": "int"},
         )
 
     def test_try_parse_json(self):
@@ -1369,8 +1369,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "csv", "arg_type": "int"},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "csv", "arg_type": "int"},
         )
 
     def test_from_csv(self):
@@ -1380,8 +1380,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "schema", "arg_type": "int"},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "schema", "arg_type": "int"},
         )
 
     def test_schema_of_xml(self):
@@ -1390,8 +1390,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "xml", "arg_type": "int"},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "xml", "arg_type": "int"},
         )
 
     def test_from_xml(self):
@@ -1401,8 +1401,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_STR_OR_STRUCT",
-            message_parameters={"arg_name": "schema", "arg_type": "int"},
+            errorClass="NOT_COLUMN_OR_STR_OR_STRUCT",
+            messageParameters={"arg_name": "schema", "arg_type": "int"},
         )
 
     def test_greatest(self):
@@ -1412,8 +1412,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="WRONG_NUM_COLUMNS",
-            message_parameters={"func_name": "greatest", "num_cols": "2"},
+            errorClass="WRONG_NUM_COLUMNS",
+            messageParameters={"func_name": "greatest", "num_cols": "2"},
         )
 
     def test_when(self):
@@ -1422,8 +1422,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN",
-            message_parameters={"arg_name": "condition", "arg_type": "str"},
+            errorClass="NOT_COLUMN",
+            messageParameters={"arg_name": "condition", "arg_type": "str"},
         )
 
     def test_window(self):
@@ -1432,8 +1432,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_STR",
-            message_parameters={"arg_name": "windowDuration", "arg_type": "int"},
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "windowDuration", "arg_type": "int"},
         )
 
     def test_session_window(self):
@@ -1442,8 +1442,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "gapDuration", "arg_type": "int"},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "gapDuration", "arg_type": "int"},
         )
 
     def test_current_user(self):
@@ -1461,8 +1461,8 @@ class FunctionsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_INT",
-            message_parameters={"arg_name": "numBuckets", "arg_type": "str"},
+            errorClass="NOT_COLUMN_OR_INT",
+            messageParameters={"arg_name": "numBuckets", "arg_type": "str"},
         )
 
     def test_to_timestamp_ltz(self):
@@ -1546,8 +1546,8 @@ class FunctionsTestsMixin:
         for i in range(3):
             self.check_error(
                 exception=from_avro_pes[i].exception,
-                error_class="INVALID_TYPE",
-                message_parameters={"arg_name": parameters[i], "arg_type": expected_type[i]},
+                errorClass="INVALID_TYPE",
+                messageParameters={"arg_name": parameters[i], "arg_type": expected_type[i]},
             )
 
         # test to_avro type checks for each parameter
@@ -1559,8 +1559,8 @@ class FunctionsTestsMixin:
         for i in range(2):
             self.check_error(
                 exception=to_avro_pes[i].exception,
-                error_class="INVALID_TYPE",
-                message_parameters={"arg_name": parameters[i], "arg_type": expected_type[i]},
+                errorClass="INVALID_TYPE",
+                messageParameters={"arg_name": parameters[i], "arg_type": expected_type[i]},
             )
 
 

--- a/python/pyspark/sql/tests/test_observation.py
+++ b/python/pyspark/sql/tests/test_observation.py
@@ -50,8 +50,8 @@ class DataFrameObservationTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NO_OBSERVE_BEFORE_GET",
-            message_parameters={},
+            errorClass="NO_OBSERVE_BEFORE_GET",
+            messageParameters={},
         )
 
         observed = (
@@ -85,8 +85,8 @@ class DataFrameObservationTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="REUSE_OBSERVATION",
-            message_parameters={},
+            errorClass="REUSE_OBSERVATION",
+            messageParameters={},
         )
 
         # observation requires name (if given) to be non empty string
@@ -101,8 +101,8 @@ class DataFrameObservationTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="CANNOT_BE_EMPTY",
-            message_parameters={"item": "exprs"},
+            errorClass="CANNOT_BE_EMPTY",
+            messageParameters={"item": "exprs"},
         )
 
         # dataframe.observe requires non-None Columns
@@ -113,8 +113,8 @@ class DataFrameObservationTestsMixin:
 
                 self.check_error(
                     exception=pe.exception,
-                    error_class="NOT_LIST_OF_COLUMN",
-                    message_parameters={"arg_name": "exprs"},
+                    errorClass="NOT_LIST_OF_COLUMN",
+                    messageParameters={"arg_name": "exprs"},
                 )
 
     def test_observe_str(self):

--- a/python/pyspark/sql/tests/test_repartition.py
+++ b/python/pyspark/sql/tests/test_repartition.py
@@ -37,8 +37,8 @@ class DataFrameRepartitionTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_STR",
-            message_parameters={"arg_name": "numPartitions", "arg_type": "list"},
+            errorClass="NOT_COLUMN_OR_STR",
+            messageParameters={"arg_name": "numPartitions", "arg_type": "list"},
         )
 
     def test_repartition_by_range(self):
@@ -80,8 +80,8 @@ class DataFrameRepartitionTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_COLUMN_OR_INT_OR_STR",
-            message_parameters={"arg_name": "numPartitions", "arg_type": "list"},
+            errorClass="NOT_COLUMN_OR_INT_OR_STR",
+            messageParameters={"arg_name": "numPartitions", "arg_type": "list"},
         )
 
 

--- a/python/pyspark/sql/tests/test_session.py
+++ b/python/pyspark/sql/tests/test_session.py
@@ -87,8 +87,8 @@ class SparkSessionTests3(unittest.TestCase, PySparkErrorTestUtils):
 
         self.check_error(
             exception=pe1.exception,
-            error_class="NO_ACTIVE_OR_DEFAULT_SESSION",
-            message_parameters={},
+            errorClass="NO_ACTIVE_OR_DEFAULT_SESSION",
+            messageParameters={},
         )
 
         spark = SparkSession.builder.master("local").getOrCreate()
@@ -241,8 +241,8 @@ class SparkSessionTests3(unittest.TestCase, PySparkErrorTestUtils):
 
                 self.check_error(
                     exception=pe1.exception,
-                    error_class="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
-                    message_parameters={"feature": f"SparkSession.{name}"},
+                    errorClass="ONLY_SUPPORTED_WITH_SPARK_CONNECT",
+                    messageParameters={"feature": f"SparkSession.{name}"},
                 )
 
 
@@ -410,8 +410,8 @@ class SparkSessionBuilderTests(unittest.TestCase, PySparkErrorTestUtils):
 
         self.check_error(
             exception=pe1.exception,
-            error_class="CANNOT_CONFIGURE_SPARK_CONNECT_MASTER",
-            message_parameters={"master_url": "x", "connect_url": "y"},
+            errorClass="CANNOT_CONFIGURE_SPARK_CONNECT_MASTER",
+            messageParameters={"master_url": "x", "connect_url": "y"},
         )
 
         with unittest.mock.patch.dict(
@@ -422,8 +422,8 @@ class SparkSessionBuilderTests(unittest.TestCase, PySparkErrorTestUtils):
 
             self.check_error(
                 exception=pe2.exception,
-                error_class="CANNOT_CONFIGURE_SPARK_CONNECT",
-                message_parameters={
+                errorClass="CANNOT_CONFIGURE_SPARK_CONNECT",
+                messageParameters={
                     "existing_url": "remote_url",
                     "new_url": "different_remote_url",
                 },
@@ -435,8 +435,8 @@ class SparkSessionBuilderTests(unittest.TestCase, PySparkErrorTestUtils):
 
         self.check_error(
             exception=pe2.exception,
-            error_class="CANNOT_CONFIGURE_SPARK_CONNECT_MASTER",
-            message_parameters={"connect_url": "2", "master_url": "1"},
+            errorClass="CANNOT_CONFIGURE_SPARK_CONNECT_MASTER",
+            messageParameters={"connect_url": "2", "master_url": "1"},
         )
 
         try:
@@ -447,8 +447,8 @@ class SparkSessionBuilderTests(unittest.TestCase, PySparkErrorTestUtils):
 
             self.check_error(
                 exception=pe2.exception,
-                error_class="CANNOT_CONFIGURE_SPARK_CONNECT",
-                message_parameters={
+                errorClass="CANNOT_CONFIGURE_SPARK_CONNECT",
+                messageParameters={
                     "new_url": "1",
                     "existing_url": "2",
                 },
@@ -464,8 +464,8 @@ class SparkSessionBuilderTests(unittest.TestCase, PySparkErrorTestUtils):
 
         self.check_error(
             exception=pe2.exception,
-            error_class="UNSUPPORTED_LOCAL_CONNECTION_STRING",
-            message_parameters={},
+            errorClass="UNSUPPORTED_LOCAL_CONNECTION_STRING",
+            messageParameters={},
         )
 
 
@@ -494,8 +494,8 @@ class SparkSessionProfileTests(unittest.TestCase, PySparkErrorTestUtils):
             self.profile.show(type="invalid")
         self.check_error(
             exception=e.exception,
-            error_class="VALUE_NOT_ALLOWED",
-            message_parameters={
+            errorClass="VALUE_NOT_ALLOWED",
+            messageParameters={
                 "arg_name": "type",
                 "allowed_values": str(["perf", "memory"]),
             },
@@ -521,8 +521,8 @@ class SparkSessionProfileTests(unittest.TestCase, PySparkErrorTestUtils):
             self.profile.dump("path/to/dump", type="invalid")
         self.check_error(
             exception=e.exception,
-            error_class="VALUE_NOT_ALLOWED",
-            message_parameters={
+            errorClass="VALUE_NOT_ALLOWED",
+            messageParameters={
                 "arg_name": "type",
                 "allowed_values": str(["perf", "memory"]),
             },
@@ -548,8 +548,8 @@ class SparkSessionProfileTests(unittest.TestCase, PySparkErrorTestUtils):
             self.profile.clear(type="invalid")
         self.check_error(
             exception=e.exception,
-            error_class="VALUE_NOT_ALLOWED",
-            message_parameters={
+            errorClass="VALUE_NOT_ALLOWED",
+            messageParameters={
                 "arg_name": "type",
                 "allowed_values": str(["perf", "memory"]),
             },

--- a/python/pyspark/sql/tests/test_stat.py
+++ b/python/pyspark/sql/tests/test_stat.py
@@ -120,8 +120,8 @@ class DataFrameStatTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_LIST_OR_STR_OR_TUPLE",
-            message_parameters={"arg_name": "subset", "arg_type": "int"},
+            errorClass="NOT_LIST_OR_STR_OR_TUPLE",
+            messageParameters={"arg_name": "subset", "arg_type": "int"},
         )
 
     def test_fillna(self):
@@ -200,8 +200,8 @@ class DataFrameStatTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_BOOL_OR_DICT_OR_FLOAT_OR_INT_OR_STR",
-            message_parameters={"arg_name": "value", "arg_type": "list"},
+            errorClass="NOT_BOOL_OR_DICT_OR_FLOAT_OR_INT_OR_STR",
+            messageParameters={"arg_name": "value", "arg_type": "list"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -209,8 +209,8 @@ class DataFrameStatTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_LIST_OR_TUPLE",
-            message_parameters={"arg_name": "subset", "arg_type": "int"},
+            errorClass="NOT_LIST_OR_TUPLE",
+            messageParameters={"arg_name": "subset", "arg_type": "int"},
         )
 
     def test_replace(self):
@@ -399,8 +399,8 @@ class DataFrameStatTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="ARGUMENT_REQUIRED",
-            message_parameters={"arg_name": "value", "condition": "`to_replace` is dict"},
+            errorClass="ARGUMENT_REQUIRED",
+            messageParameters={"arg_name": "value", "condition": "`to_replace` is dict"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -408,8 +408,8 @@ class DataFrameStatTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_BOOL_OR_DICT_OR_FLOAT_OR_INT_OR_LIST_OR_STR_OR_TUPLE",
-            message_parameters={"arg_name": "to_replace", "arg_type": "function"},
+            errorClass="NOT_BOOL_OR_DICT_OR_FLOAT_OR_INT_OR_LIST_OR_STR_OR_TUPLE",
+            messageParameters={"arg_name": "to_replace", "arg_type": "function"},
         )
 
     def test_unpivot(self):

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -134,8 +134,8 @@ class TypesTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_LIST_OR_NONE_OR_STRUCT",
-            message_parameters={"arg_name": "schema", "arg_type": "int"},
+            errorClass="NOT_LIST_OR_NONE_OR_STRUCT",
+            messageParameters={"arg_name": "schema", "arg_type": "int"},
         )
 
         df = self.spark.createDataFrame(rdd)
@@ -1602,8 +1602,8 @@ class TypesTestsMixin:
             _merge_type(ArrayType(LongType()), ArrayType(DoubleType()))
         self.check_error(
             exception=pe.exception,
-            error_class="CANNOT_MERGE_TYPE",
-            message_parameters={"data_type1": "LongType", "data_type2": "DoubleType"},
+            errorClass="CANNOT_MERGE_TYPE",
+            messageParameters={"data_type1": "LongType", "data_type2": "DoubleType"},
         )
 
         self.assertEqual(
@@ -1620,8 +1620,8 @@ class TypesTestsMixin:
             _merge_type(MapType(StringType(), LongType()), MapType(StringType(), DoubleType()))
         self.check_error(
             exception=pe.exception,
-            error_class="CANNOT_MERGE_TYPE",
-            message_parameters={"data_type1": "LongType", "data_type2": "DoubleType"},
+            errorClass="CANNOT_MERGE_TYPE",
+            messageParameters={"data_type1": "LongType", "data_type2": "DoubleType"},
         )
 
         self.assertEqual(
@@ -1638,8 +1638,8 @@ class TypesTestsMixin:
             )
         self.check_error(
             exception=pe.exception,
-            error_class="CANNOT_MERGE_TYPE",
-            message_parameters={"data_type1": "LongType", "data_type2": "DoubleType"},
+            errorClass="CANNOT_MERGE_TYPE",
+            messageParameters={"data_type1": "LongType", "data_type2": "DoubleType"},
         )
 
         self.assertEqual(
@@ -1679,8 +1679,8 @@ class TypesTestsMixin:
             )
         self.check_error(
             exception=pe.exception,
-            error_class="CANNOT_MERGE_TYPE",
-            message_parameters={"data_type1": "LongType", "data_type2": "DoubleType"},
+            errorClass="CANNOT_MERGE_TYPE",
+            messageParameters={"data_type1": "LongType", "data_type2": "DoubleType"},
         )
 
         self.assertEqual(
@@ -1722,8 +1722,8 @@ class TypesTestsMixin:
             )
         self.check_error(
             exception=pe.exception,
-            error_class="CANNOT_MERGE_TYPE",
-            message_parameters={"data_type1": "LongType", "data_type2": "DoubleType"},
+            errorClass="CANNOT_MERGE_TYPE",
+            messageParameters={"data_type1": "LongType", "data_type2": "DoubleType"},
         )
 
         self.assertEqual(
@@ -1833,8 +1833,8 @@ class TypesTestsMixin:
 
             self.check_error(
                 exception=pe.exception,
-                error_class="CANNOT_INFER_TYPE_FOR_FIELD",
-                message_parameters={"field_name": "myarray"},
+                errorClass="CANNOT_INFER_TYPE_FOR_FIELD",
+                messageParameters={"field_name": "myarray"},
             )
 
     def test_repr(self):
@@ -1886,8 +1886,8 @@ class TypesTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="INVALID_INTERVAL_CASTING",
-            message_parameters={"start_field": "None", "end_field": "3"},
+            errorClass="INVALID_INTERVAL_CASTING",
+            messageParameters={"start_field": "None", "end_field": "3"},
         )
 
         with self.assertRaises(PySparkRuntimeError) as pe:
@@ -1895,8 +1895,8 @@ class TypesTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="INVALID_INTERVAL_CASTING",
-            message_parameters={"start_field": "123", "end_field": "123"},
+            errorClass="INVALID_INTERVAL_CASTING",
+            messageParameters={"start_field": "123", "end_field": "123"},
         )
 
         with self.assertRaises(PySparkRuntimeError) as pe:
@@ -1904,8 +1904,8 @@ class TypesTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="INVALID_INTERVAL_CASTING",
-            message_parameters={"start_field": "0", "end_field": "321"},
+            errorClass="INVALID_INTERVAL_CASTING",
+            messageParameters={"start_field": "0", "end_field": "321"},
         )
 
     def test_daytime_interval_type(self):
@@ -1973,8 +1973,8 @@ class TypesTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="INVALID_INTERVAL_CASTING",
-            message_parameters={"start_field": "None", "end_field": "3"},
+            errorClass="INVALID_INTERVAL_CASTING",
+            messageParameters={"start_field": "None", "end_field": "3"},
         )
 
         with self.assertRaises(PySparkRuntimeError) as pe:
@@ -1982,8 +1982,8 @@ class TypesTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="INVALID_INTERVAL_CASTING",
-            message_parameters={"start_field": "123", "end_field": "123"},
+            errorClass="INVALID_INTERVAL_CASTING",
+            messageParameters={"start_field": "123", "end_field": "123"},
         )
 
         with self.assertRaises(PySparkRuntimeError) as pe:
@@ -1991,8 +1991,8 @@ class TypesTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="INVALID_INTERVAL_CASTING",
-            message_parameters={"start_field": "0", "end_field": "321"},
+            errorClass="INVALID_INTERVAL_CASTING",
+            messageParameters={"start_field": "0", "end_field": "321"},
         )
 
     def test_yearmonth_interval_type(self):
@@ -2377,8 +2377,8 @@ class DataTypeVerificationTests(unittest.TestCase, PySparkErrorTestUtils):
 
         self.check_error(
             exception=pe.exception,
-            error_class="FIELD_NOT_NULLABLE_WITH_NAME",
-            message_parameters={
+            errorClass="FIELD_NOT_NULLABLE_WITH_NAME",
+            messageParameters={
                 "field_name": "test_name",
             },
         )
@@ -2389,8 +2389,8 @@ class DataTypeVerificationTests(unittest.TestCase, PySparkErrorTestUtils):
 
         self.check_error(
             exception=pe.exception,
-            error_class="FIELD_DATA_TYPE_UNACCEPTABLE_WITH_NAME",
-            message_parameters={
+            errorClass="FIELD_DATA_TYPE_UNACCEPTABLE_WITH_NAME",
+            messageParameters={
                 "data_type": "IntegerType()",
                 "field_name": "field b in field a",
                 "obj": "'data'",

--- a/python/pyspark/sql/tests/test_udf.py
+++ b/python/pyspark/sql/tests/test_udf.py
@@ -128,8 +128,8 @@ class BaseUDFTestsMixin(object):
 
         self.check_error(
             exception=pe.exception,
-            error_class="CANNOT_SPECIFY_RETURN_TYPE_FOR_UDF",
-            message_parameters={"arg_name": "f", "return_type": "StringType()"},
+            errorClass="CANNOT_SPECIFY_RETURN_TYPE_FOR_UDF",
+            messageParameters={"arg_name": "f", "return_type": "StringType()"},
         )
 
     def test_nondeterministic_udf(self):
@@ -341,8 +341,8 @@ class BaseUDFTestsMixin(object):
 
         self.check_error(
             exception=ae.exception,
-            error_class="DATATYPE_MISMATCH.UNSUPPORTED_UDF_INPUT_TYPE",
-            message_parameters={"sqlExpr": '"<lambda>(v)"', "dataType": "VARIANT"},
+            errorClass="DATATYPE_MISMATCH.UNSUPPORTED_UDF_INPUT_TYPE",
+            messageParameters={"sqlExpr": '"<lambda>(v)"', "dataType": "VARIANT"},
         )
 
     def test_udf_with_complex_variant_input(self):
@@ -357,8 +357,8 @@ class BaseUDFTestsMixin(object):
 
         self.check_error(
             exception=ae.exception,
-            error_class="DATATYPE_MISMATCH.UNSUPPORTED_UDF_INPUT_TYPE",
-            message_parameters={
+            errorClass="DATATYPE_MISMATCH.UNSUPPORTED_UDF_INPUT_TYPE",
+            messageParameters={
                 "sqlExpr": '"<lambda>(struct_of_v)"',
                 "dataType": "STRUCT<v: VARIANT NOT NULL>",
             },
@@ -376,8 +376,8 @@ class BaseUDFTestsMixin(object):
 
         self.check_error(
             exception=ae.exception,
-            error_class="DATATYPE_MISMATCH.UNSUPPORTED_UDF_OUTPUT_TYPE",
-            message_parameters={"sqlExpr": '"<lambda>()"', "dataType": "VARIANT"},
+            errorClass="DATATYPE_MISMATCH.UNSUPPORTED_UDF_OUTPUT_TYPE",
+            messageParameters={"sqlExpr": '"<lambda>()"', "dataType": "VARIANT"},
         )
 
     def test_udf_with_complex_variant_output(self):
@@ -392,8 +392,8 @@ class BaseUDFTestsMixin(object):
 
         self.check_error(
             exception=ae.exception,
-            error_class="DATATYPE_MISMATCH.UNSUPPORTED_UDF_OUTPUT_TYPE",
-            message_parameters={"sqlExpr": '"<lambda>()"', "dataType": "MAP<STRING, VARIANT>"},
+            errorClass="DATATYPE_MISMATCH.UNSUPPORTED_UDF_OUTPUT_TYPE",
+            messageParameters={"sqlExpr": '"<lambda>()"', "dataType": "MAP<STRING, VARIANT>"},
         )
 
     def test_udf_with_aggregate_function(self):
@@ -516,8 +516,8 @@ class BaseUDFTestsMixin(object):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_CALLABLE",
-            message_parameters={"arg_name": "func", "arg_type": "str"},
+            errorClass="NOT_CALLABLE",
+            messageParameters={"arg_name": "func", "arg_type": "str"},
         )
 
     def test_non_existed_udf(self):
@@ -1141,8 +1141,8 @@ class BaseUDFTestsMixin(object):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_CALLABLE",
-            message_parameters={"arg_name": "func", "arg_type": "str"},
+            errorClass="NOT_CALLABLE",
+            messageParameters={"arg_name": "func", "arg_type": "str"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -1150,8 +1150,8 @@ class BaseUDFTestsMixin(object):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_DATATYPE_OR_STR",
-            message_parameters={"arg_name": "returnType", "arg_type": "int"},
+            errorClass="NOT_DATATYPE_OR_STR",
+            messageParameters={"arg_name": "returnType", "arg_type": "int"},
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
@@ -1159,8 +1159,8 @@ class BaseUDFTestsMixin(object):
 
         self.check_error(
             exception=pe.exception,
-            error_class="NOT_INT",
-            message_parameters={"arg_name": "evalType", "arg_type": "str"},
+            errorClass="NOT_INT",
+            messageParameters={"arg_name": "evalType", "arg_type": "str"},
         )
 
 

--- a/python/pyspark/sql/tests/test_udf_profiler.py
+++ b/python/pyspark/sql/tests/test_udf_profiler.py
@@ -582,8 +582,8 @@ class UDFProfiler2TestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="VALUE_NOT_ALLOWED",
-            message_parameters={
+            errorClass="VALUE_NOT_ALLOWED",
+            messageParameters={
                 "arg_name": "type",
                 "allowed_values": "['perf', 'memory']",
             },
@@ -594,8 +594,8 @@ class UDFProfiler2TestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="VALUE_NOT_ALLOWED",
-            message_parameters={
+            errorClass="VALUE_NOT_ALLOWED",
+            messageParameters={
                 "arg_name": "(type, renderer)",
                 "allowed_values": "[('perf', None), ('perf', 'flameprof')]",
             },
@@ -606,8 +606,8 @@ class UDFProfiler2TestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="VALUE_NOT_ALLOWED",
-            message_parameters={
+            errorClass="VALUE_NOT_ALLOWED",
+            messageParameters={
                 "arg_name": "(type, renderer)",
                 "allowed_values": "[('perf', None), ('perf', 'flameprof')]",
             },

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -579,8 +579,8 @@ class BaseUDTFTestsMixin:
 
         self.check_error(
             exception=e.exception,
-            error_class="UDTF_RETURN_TYPE_MISMATCH",
-            message_parameters={"name": "TestUDTF", "return_type": "IntegerType()"},
+            errorClass="UDTF_RETURN_TYPE_MISMATCH",
+            messageParameters={"name": "TestUDTF", "return_type": "IntegerType()"},
         )
 
         @udtf(returnType=MapType(StringType(), IntegerType()))
@@ -593,8 +593,8 @@ class BaseUDTFTestsMixin:
 
         self.check_error(
             exception=e.exception,
-            error_class="UDTF_RETURN_TYPE_MISMATCH",
-            message_parameters={
+            errorClass="UDTF_RETURN_TYPE_MISMATCH",
+            messageParameters={
                 "name": "TestUDTF",
                 "return_type": "MapType(StringType(), IntegerType(), True)",
             },
@@ -935,8 +935,8 @@ class BaseUDTFTestsMixin:
 
         self.check_error(
             exception=e.exception,
-            error_class="CANNOT_REGISTER_UDTF",
-            message_parameters={
+            errorClass="CANNOT_REGISTER_UDTF",
+            messageParameters={
                 "name": "test_udf",
             },
         )
@@ -949,8 +949,8 @@ class BaseUDTFTestsMixin:
 
         self.check_error(
             exception=e.exception,
-            error_class="CANNOT_REGISTER_UDTF",
-            message_parameters={
+            errorClass="CANNOT_REGISTER_UDTF",
+            messageParameters={
                 "name": "test_udtf",
             },
         )
@@ -991,8 +991,8 @@ class BaseUDTFTestsMixin:
 
         self.check_error(
             exception=e.exception,
-            error_class="INVALID_UDTF_NO_EVAL",
-            message_parameters={"name": "TestUDTF"},
+            errorClass="INVALID_UDTF_NO_EVAL",
+            messageParameters={"name": "TestUDTF"},
         )
 
     def test_udtf_with_no_handler_class(self):
@@ -1004,8 +1004,8 @@ class BaseUDTFTestsMixin:
 
         self.check_error(
             exception=e.exception,
-            error_class="INVALID_UDTF_HANDLER_TYPE",
-            message_parameters={"type": "function"},
+            errorClass="INVALID_UDTF_HANDLER_TYPE",
+            messageParameters={"type": "function"},
         )
 
         with self.assertRaises(PySparkTypeError) as e:
@@ -1013,8 +1013,8 @@ class BaseUDTFTestsMixin:
 
         self.check_error(
             exception=e.exception,
-            error_class="INVALID_UDTF_HANDLER_TYPE",
-            message_parameters={"type": "int"},
+            errorClass="INVALID_UDTF_HANDLER_TYPE",
+            messageParameters={"type": "int"},
         )
 
     def test_udtf_with_table_argument_query(self):
@@ -1541,8 +1541,8 @@ class BaseUDTFTestsMixin:
 
         self.check_error(
             exception=e.exception,
-            error_class="INVALID_UDTF_BOTH_RETURN_TYPE_AND_ANALYZE",
-            message_parameters={"name": "TestUDTF"},
+            errorClass="INVALID_UDTF_BOTH_RETURN_TYPE_AND_ANALYZE",
+            messageParameters={"name": "TestUDTF"},
         )
 
     def test_udtf_with_neither_return_type_nor_analyze(self):
@@ -1555,8 +1555,8 @@ class BaseUDTFTestsMixin:
 
         self.check_error(
             exception=e.exception,
-            error_class="INVALID_UDTF_RETURN_TYPE",
-            message_parameters={"name": "TestUDTF"},
+            errorClass="INVALID_UDTF_RETURN_TYPE",
+            messageParameters={"name": "TestUDTF"},
         )
 
     def test_udtf_with_analyze_non_staticmethod(self):
@@ -1572,8 +1572,8 @@ class BaseUDTFTestsMixin:
 
         self.check_error(
             exception=e.exception,
-            error_class="INVALID_UDTF_RETURN_TYPE",
-            message_parameters={"name": "TestUDTF"},
+            errorClass="INVALID_UDTF_RETURN_TYPE",
+            messageParameters={"name": "TestUDTF"},
         )
 
         with self.assertRaises(PySparkAttributeError) as e:
@@ -1581,8 +1581,8 @@ class BaseUDTFTestsMixin:
 
         self.check_error(
             exception=e.exception,
-            error_class="INVALID_UDTF_BOTH_RETURN_TYPE_AND_ANALYZE",
-            message_parameters={"name": "TestUDTF"},
+            errorClass="INVALID_UDTF_BOTH_RETURN_TYPE_AND_ANALYZE",
+            messageParameters={"name": "TestUDTF"},
         )
 
     def test_udtf_with_analyze_returning_non_struct(self):

--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -175,8 +175,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_ROWS",
-            message_parameters={"error_msg": error_msg},
+            errorClass="DIFFERENT_ROWS",
+            messageParameters={"error_msg": error_msg},
         )
 
         with self.assertRaises(PySparkAssertionError) as pe:
@@ -184,8 +184,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_ROWS",
-            message_parameters={"error_msg": error_msg},
+            errorClass="DIFFERENT_ROWS",
+            messageParameters={"error_msg": error_msg},
         )
 
     def test_assert_approx_equal_arraytype_float_custom_rtol_pass(self):
@@ -332,8 +332,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_ROWS",
-            message_parameters={"error_msg": error_msg},
+            errorClass="DIFFERENT_ROWS",
+            messageParameters={"error_msg": error_msg},
         )
 
         rows_str1 = ""
@@ -358,8 +358,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_ROWS",
-            message_parameters={"error_msg": error_msg},
+            errorClass="DIFFERENT_ROWS",
+            messageParameters={"error_msg": error_msg},
         )
 
     def test_assert_equal_maptype(self):
@@ -653,8 +653,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_ROWS",
-            message_parameters={"error_msg": error_msg},
+            errorClass="DIFFERENT_ROWS",
+            messageParameters={"error_msg": error_msg},
         )
 
         with self.assertRaises(PySparkAssertionError) as pe:
@@ -662,8 +662,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_ROWS",
-            message_parameters={"error_msg": error_msg},
+            errorClass="DIFFERENT_ROWS",
+            messageParameters={"error_msg": error_msg},
         )
 
     def test_assert_equal_nulldf(self):
@@ -688,8 +688,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
-            message_parameters={
+            errorClass="INVALID_TYPE_DF_EQUALITY_ARG",
+            messageParameters={
                 "expected_type": "Union[DataFrame, ps.DataFrame, List[Row]]",
                 "arg_name": "actual",
                 "actual_type": None,
@@ -701,8 +701,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
-            message_parameters={
+            errorClass="INVALID_TYPE_DF_EQUALITY_ARG",
+            messageParameters={
                 "expected_type": "Union[DataFrame, ps.DataFrame, List[Row]]",
                 "arg_name": "actual",
                 "actual_type": None,
@@ -724,8 +724,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
-            message_parameters={
+            errorClass="INVALID_TYPE_DF_EQUALITY_ARG",
+            messageParameters={
                 "expected_type": "Union[DataFrame, ps.DataFrame, List[Row]]",
                 "arg_name": "expected",
                 "actual_type": None,
@@ -737,8 +737,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
-            message_parameters={
+            errorClass="INVALID_TYPE_DF_EQUALITY_ARG",
+            messageParameters={
                 "expected_type": "Union[DataFrame, ps.DataFrame, List[Row]]",
                 "arg_name": "expected",
                 "actual_type": None,
@@ -803,8 +803,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_PANDAS_DATAFRAME",
-            message_parameters={
+            errorClass="DIFFERENT_PANDAS_DATAFRAME",
+            messageParameters={
                 "left": df1.to_string(),
                 "left_dtype": str(df1.dtypes),
                 "right": df2.to_string(),
@@ -817,8 +817,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_PANDAS_DATAFRAME",
-            message_parameters={
+            errorClass="DIFFERENT_PANDAS_DATAFRAME",
+            messageParameters={
                 "left": df1.to_string(),
                 "left_dtype": str(df1.dtypes),
                 "right": df2.to_string(),
@@ -846,8 +846,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_PANDAS_DATAFRAME",
-            message_parameters={
+            errorClass="DIFFERENT_PANDAS_DATAFRAME",
+            messageParameters={
                 "left": df1.to_string(),
                 "left_dtype": str(df1.dtypes),
                 "right": df2.to_string(),
@@ -860,8 +860,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_PANDAS_DATAFRAME",
-            message_parameters={
+            errorClass="DIFFERENT_PANDAS_DATAFRAME",
+            messageParameters={
                 "left": df1.to_string(),
                 "left_dtype": str(df1.dtypes),
                 "right": df2.to_string(),
@@ -888,8 +888,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_PANDAS_DATAFRAME",
-            message_parameters={
+            errorClass="DIFFERENT_PANDAS_DATAFRAME",
+            messageParameters={
                 "left": df1.to_string(),
                 "left_dtype": str(df1.dtypes),
                 "right": df2.to_string(),
@@ -902,8 +902,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_PANDAS_DATAFRAME",
-            message_parameters={
+            errorClass="DIFFERENT_PANDAS_DATAFRAME",
+            messageParameters={
                 "left": df1.to_string(),
                 "left_dtype": str(df1.dtypes),
                 "right": df2.to_string(),
@@ -953,8 +953,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
-            message_parameters={
+            errorClass="INVALID_TYPE_DF_EQUALITY_ARG",
+            messageParameters={
                 "expected_type": f"{ps.DataFrame.__name__}, "
                 f"{pd.DataFrame.__name__}, "
                 f"{ps.Series.__name__}, "
@@ -971,8 +971,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
-            message_parameters={
+            errorClass="INVALID_TYPE_DF_EQUALITY_ARG",
+            messageParameters={
                 "expected_type": f"{ps.DataFrame.__name__}, "
                 f"{pd.DataFrame.__name__}, "
                 f"{ps.Series.__name__}, "
@@ -993,8 +993,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
-            message_parameters={
+            errorClass="INVALID_TYPE_DF_EQUALITY_ARG",
+            messageParameters={
                 "expected_type": "Union[DataFrame, ps.DataFrame, List[Row]]",
                 "arg_name": "actual",
                 "actual_type": type(dict1),
@@ -1006,8 +1006,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
-            message_parameters={
+            errorClass="INVALID_TYPE_DF_EQUALITY_ARG",
+            messageParameters={
                 "expected_type": "Union[DataFrame, ps.DataFrame, List[Row]]",
                 "arg_name": "actual",
                 "actual_type": type(dict1),
@@ -1072,8 +1072,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_ROWS",
-            message_parameters={"error_msg": error_msg},
+            errorClass="DIFFERENT_ROWS",
+            messageParameters={"error_msg": error_msg},
         )
 
     def test_remove_non_word_characters_long(self):
@@ -1167,8 +1167,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_ROWS",
-            message_parameters={"error_msg": error_msg},
+            errorClass="DIFFERENT_ROWS",
+            messageParameters={"error_msg": error_msg},
         )
 
         with self.assertRaises(PySparkAssertionError) as pe:
@@ -1176,8 +1176,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_ROWS",
-            message_parameters={"error_msg": error_msg},
+            errorClass="DIFFERENT_ROWS",
+            messageParameters={"error_msg": error_msg},
         )
 
     def test_assert_notequal_schema(self):
@@ -1205,8 +1205,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_SCHEMA",
-            message_parameters={"error_msg": expected_error_msg},
+            errorClass="DIFFERENT_SCHEMA",
+            messageParameters={"error_msg": expected_error_msg},
         )
 
     def test_diff_schema_lens(self):
@@ -1235,8 +1235,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_SCHEMA",
-            message_parameters={"error_msg": expected_error_msg},
+            errorClass="DIFFERENT_SCHEMA",
+            messageParameters={"error_msg": expected_error_msg},
         )
 
     def test_schema_ignore_nullable(self):
@@ -1285,8 +1285,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_SCHEMA",
-            message_parameters={"error_msg": expected_error_msg},
+            errorClass="DIFFERENT_SCHEMA",
+            messageParameters={"error_msg": expected_error_msg},
         )
 
     def test_schema_struct_unequal(self):
@@ -1306,8 +1306,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_SCHEMA",
-            message_parameters={"error_msg": expected_error_msg},
+            errorClass="DIFFERENT_SCHEMA",
+            messageParameters={"error_msg": expected_error_msg},
         )
 
     def test_schema_more_nested_struct_unequal(self):
@@ -1350,8 +1350,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_SCHEMA",
-            message_parameters={"error_msg": expected_error_msg},
+            errorClass="DIFFERENT_SCHEMA",
+            messageParameters={"error_msg": expected_error_msg},
         )
 
     def test_schema_unsupported_type(self):
@@ -1363,8 +1363,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="UNSUPPORTED_DATA_TYPE",
-            message_parameters={"data_type": type(s1)},
+            errorClass="UNSUPPORTED_DATA_TYPE",
+            messageParameters={"data_type": type(s1)},
         )
 
     def test_spark_sql(self):
@@ -1522,8 +1522,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_ROWS",
-            message_parameters={"error_msg": error_msg},
+            errorClass="DIFFERENT_ROWS",
+            messageParameters={"error_msg": error_msg},
         )
 
         with self.assertRaises(PySparkAssertionError) as pe:
@@ -1531,8 +1531,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_ROWS",
-            message_parameters={"error_msg": error_msg},
+            errorClass="DIFFERENT_ROWS",
+            messageParameters={"error_msg": error_msg},
         )
 
     def test_list_row_unequal_schema(self):
@@ -1569,8 +1569,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_ROWS",
-            message_parameters={"error_msg": error_msg},
+            errorClass="DIFFERENT_ROWS",
+            messageParameters={"error_msg": error_msg},
         )
 
         with self.assertRaises(PySparkAssertionError) as pe:
@@ -1578,8 +1578,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_ROWS",
-            message_parameters={"error_msg": error_msg},
+            errorClass="DIFFERENT_ROWS",
+            messageParameters={"error_msg": error_msg},
         )
 
     def test_list_row_unequal_schema(self):
@@ -1617,8 +1617,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_ROWS",
-            message_parameters={"error_msg": error_msg},
+            errorClass="DIFFERENT_ROWS",
+            messageParameters={"error_msg": error_msg},
         )
 
         with self.assertRaises(PySparkAssertionError) as pe:
@@ -1626,8 +1626,8 @@ class UtilsTestsMixin:
 
         self.check_error(
             exception=pe.exception,
-            error_class="DIFFERENT_ROWS",
-            message_parameters={"error_msg": error_msg},
+            errorClass="DIFFERENT_ROWS",
+            messageParameters={"error_msg": error_msg},
         )
 
     def test_dataframe_include_diff_rows(self):

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -543,8 +543,8 @@ class DayTimeIntervalType(AnsiIntervalType):
         fields = DayTimeIntervalType._fields
         if startField not in fields.keys() or endField not in fields.keys():
             raise PySparkRuntimeError(
-                error_class="INVALID_INTERVAL_CASTING",
-                message_parameters={"start_field": str(startField), "end_field": str(endField)},
+                errorClass="INVALID_INTERVAL_CASTING",
+                messageParameters={"start_field": str(startField), "end_field": str(endField)},
             )
         self.startField = startField
         self.endField = endField
@@ -606,8 +606,8 @@ class YearMonthIntervalType(AnsiIntervalType):
         fields = YearMonthIntervalType._fields
         if startField not in fields.keys() or endField not in fields.keys():
             raise PySparkRuntimeError(
-                error_class="INVALID_INTERVAL_CASTING",
-                message_parameters={"start_field": str(startField), "end_field": str(endField)},
+                errorClass="INVALID_INTERVAL_CASTING",
+                messageParameters={"start_field": str(startField), "end_field": str(endField)},
             )
         self.startField = startField
         self.endField = endField
@@ -633,14 +633,14 @@ class YearMonthIntervalType(AnsiIntervalType):
 
     def toInternal(self, obj: Any) -> Any:
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "YearMonthIntervalType.toInternal"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "YearMonthIntervalType.toInternal"},
         )
 
     def fromInternal(self, obj: Any) -> Any:
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "YearMonthIntervalType.fromInternal"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "YearMonthIntervalType.fromInternal"},
         )
 
     def __repr__(self) -> str:
@@ -665,14 +665,14 @@ class CalendarIntervalType(DataType, metaclass=DataTypeSingleton):
 
     def toInternal(self, obj: Any) -> Any:
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "CalendarIntervalType.toInternal"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "CalendarIntervalType.toInternal"},
         )
 
     def fromInternal(self, obj: Any) -> Any:
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "CalendarIntervalType.fromInternal"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "CalendarIntervalType.fromInternal"},
         )
 
 
@@ -1095,8 +1095,8 @@ class StructField(DataType):
 
     def typeName(self) -> str:  # type: ignore[override]
         raise PySparkTypeError(
-            error_class="INVALID_TYPENAME_CALL",
-            message_parameters={},
+            errorClass="INVALID_TYPENAME_CALL",
+            messageParameters={},
         )
 
     def _build_formatted_string(
@@ -1256,8 +1256,8 @@ class StructType(DataType):
         else:
             if isinstance(field, str) and data_type is None:
                 raise PySparkValueError(
-                    error_class="ARGUMENT_REQUIRED",
-                    message_parameters={
+                    errorClass="ARGUMENT_REQUIRED",
+                    messageParameters={
                         "arg_name": "data_type",
                         "condition": "passing name of struct_field to create",
                     },
@@ -1288,23 +1288,21 @@ class StructType(DataType):
             for field in self:
                 if field.name == key:
                     return field
-            raise PySparkKeyError(
-                error_class="KEY_NOT_EXISTS", message_parameters={"key": str(key)}
-            )
+            raise PySparkKeyError(errorClass="KEY_NOT_EXISTS", messageParameters={"key": str(key)})
         elif isinstance(key, int):
             try:
                 return self.fields[key]
             except IndexError:
                 raise PySparkIndexError(
-                    error_class="INDEX_OUT_OF_RANGE",
-                    message_parameters={"arg_name": "StructType", "index": str(key)},
+                    errorClass="INDEX_OUT_OF_RANGE",
+                    messageParameters={"arg_name": "StructType", "index": str(key)},
                 )
         elif isinstance(key, slice):
             return StructType(self.fields[key])
         else:
             raise PySparkTypeError(
-                error_class="NOT_INT_OR_SLICE_OR_STR",
-                message_parameters={"arg_name": "key", "arg_type": type(key).__name__},
+                errorClass="NOT_INT_OR_SLICE_OR_STR",
+                messageParameters={"arg_name": "key", "arg_type": type(key).__name__},
             )
 
     def simpleString(self) -> str:
@@ -1500,8 +1498,8 @@ class StructType(DataType):
                 )
             else:
                 raise PySparkValueError(
-                    error_class="UNEXPECTED_TUPLE_WITH_STRUCT",
-                    message_parameters={"tuple": str(obj)},
+                    errorClass="UNEXPECTED_TUPLE_WITH_STRUCT",
+                    messageParameters={"tuple": str(obj)},
                 )
         else:
             if isinstance(obj, dict):
@@ -1513,8 +1511,8 @@ class StructType(DataType):
                 return tuple(d.get(n) for n in self.names)
             else:
                 raise PySparkValueError(
-                    error_class="UNEXPECTED_TUPLE_WITH_STRUCT",
-                    message_parameters={"tuple": str(obj)},
+                    errorClass="UNEXPECTED_TUPLE_WITH_STRUCT",
+                    messageParameters={"tuple": str(obj)},
                 )
 
     def fromInternal(self, obj: Tuple) -> "Row":
@@ -1571,8 +1569,8 @@ class VariantType(AtomicType):
 
     def toInternal(self, obj: Any) -> Any:
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "VariantType.toInternal"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "VariantType.toInternal"},
         )
 
 
@@ -1592,8 +1590,8 @@ class UserDefinedType(DataType):
         Underlying SQL storage type for this UDT.
         """
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "sqlType()"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "sqlType()"},
         )
 
     @classmethod
@@ -1602,8 +1600,8 @@ class UserDefinedType(DataType):
         The Python module of the UDT.
         """
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "module()"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "module()"},
         )
 
     @classmethod
@@ -1640,8 +1638,8 @@ class UserDefinedType(DataType):
         Converts a user-type object into a SQL datum.
         """
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "toInternal()"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "toInternal()"},
         )
 
     def deserialize(self, datum: Any) -> Any:
@@ -1649,8 +1647,8 @@ class UserDefinedType(DataType):
         Converts a SQL datum into a user-type object.
         """
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": "fromInternal()"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "fromInternal()"},
         )
 
     def simpleString(self) -> str:
@@ -2021,8 +2019,8 @@ def _parse_datatype_json_value(
             return VarcharType(int(m.group(1)))  # type: ignore[union-attr]
         else:
             raise PySparkValueError(
-                error_class="CANNOT_PARSE_DATATYPE",
-                message_parameters={"error": str(json_value)},
+                errorClass="CANNOT_PARSE_DATATYPE",
+                messageParameters={"error": str(json_value)},
             )
     else:
         tpe = json_value["type"]
@@ -2040,8 +2038,8 @@ def _parse_datatype_json_value(
             return UserDefinedType.fromJson(json_value)
         else:
             raise PySparkValueError(
-                error_class="UNSUPPORTED_DATA_TYPE",
-                message_parameters={"data_type": str(tpe)},
+                errorClass="UNSUPPORTED_DATA_TYPE",
+                messageParameters={"data_type": str(tpe)},
             )
 
 
@@ -2050,16 +2048,16 @@ def _assert_valid_type_for_collation(
 ) -> None:
     if fieldPath in collationMap and fieldType != "string":
         raise PySparkTypeError(
-            error_class="INVALID_JSON_DATA_TYPE_FOR_COLLATIONS",
-            message_parameters={"jsonType": fieldType},
+            errorClass="INVALID_JSON_DATA_TYPE_FOR_COLLATIONS",
+            messageParameters={"jsonType": fieldType},
         )
 
 
 def _assert_valid_collation_provider(provider: str) -> None:
     if provider.lower() not in StringType.providers:
         raise PySparkValueError(
-            error_class="COLLATION_INVALID_PROVIDER",
-            message_parameters={
+            errorClass="COLLATION_INVALID_PROVIDER",
+            messageParameters={
                 "provider": provider,
                 "supportedProviders": ", ".join(StringType.providers),
             },
@@ -2310,8 +2308,8 @@ def _infer_type(
             return ArrayType(_array_type_mappings[obj.typecode](), False)
         else:
             raise PySparkTypeError(
-                error_class="UNSUPPORTED_DATA_TYPE",
-                message_parameters={"data_type": f"array({obj.typecode})"},
+                errorClass="UNSUPPORTED_DATA_TYPE",
+                messageParameters={"data_type": f"array({obj.typecode})"},
             )
     else:
         try:
@@ -2323,8 +2321,8 @@ def _infer_type(
             )
         except TypeError:
             raise PySparkTypeError(
-                error_class="UNSUPPORTED_DATA_TYPE",
-                message_parameters={"data_type": type(obj).__name__},
+                errorClass="UNSUPPORTED_DATA_TYPE",
+                messageParameters={"data_type": type(obj).__name__},
             )
 
 
@@ -2358,8 +2356,8 @@ def _infer_schema(
 
     else:
         raise PySparkTypeError(
-            error_class="CANNOT_INFER_SCHEMA_FOR_TYPE",
-            message_parameters={"data_type": type(row).__name__},
+            errorClass="CANNOT_INFER_SCHEMA_FOR_TYPE",
+            messageParameters={"data_type": type(row).__name__},
         )
 
     fields = []
@@ -2380,8 +2378,8 @@ def _infer_schema(
             )
         except TypeError:
             raise PySparkTypeError(
-                error_class="CANNOT_INFER_TYPE_FOR_FIELD",
-                message_parameters={"field_name": k},
+                errorClass="CANNOT_INFER_TYPE_FOR_FIELD",
+                messageParameters={"field_name": k},
             )
     return StructType(fields)
 
@@ -2468,8 +2466,8 @@ def _merge_type(
     elif type(a) is not type(b):
         # TODO: type cast (such as int -> long)
         raise PySparkTypeError(
-            error_class="CANNOT_MERGE_TYPE",
-            message_parameters={"data_type1": type(a).__name__, "data_type2": type(b).__name__},
+            errorClass="CANNOT_MERGE_TYPE",
+            messageParameters={"data_type1": type(a).__name__, "data_type2": type(b).__name__},
         )
 
     # same type
@@ -2559,8 +2557,8 @@ def _create_converter(dataType: DataType) -> Callable:
             d = obj.__dict__
         else:
             raise PySparkTypeError(
-                error_class="UNSUPPORTED_DATA_TYPE",
-                message_parameters={"data_type": type(obj).__name__},
+                errorClass="UNSUPPORTED_DATA_TYPE",
+                messageParameters={"data_type": type(obj).__name__},
             )
 
         if convert_fields:
@@ -2695,14 +2693,14 @@ def _make_type_verifier(
             else:
                 if name is not None:
                     raise PySparkValueError(
-                        error_class="FIELD_NOT_NULLABLE_WITH_NAME",
-                        message_parameters={
+                        errorClass="FIELD_NOT_NULLABLE_WITH_NAME",
+                        messageParameters={
                             "field_name": str(name),
                         },
                     )
                 raise PySparkValueError(
-                    error_class="FIELD_NOT_NULLABLE",
-                    message_parameters={},
+                    errorClass="FIELD_NOT_NULLABLE",
+                    messageParameters={},
                 )
         else:
             return False
@@ -2719,8 +2717,8 @@ def _make_type_verifier(
         if type(obj) not in _acceptable_types[_type]:
             if name is not None:
                 raise PySparkTypeError(
-                    error_class="FIELD_DATA_TYPE_UNACCEPTABLE_WITH_NAME",
-                    message_parameters={
+                    errorClass="FIELD_DATA_TYPE_UNACCEPTABLE_WITH_NAME",
+                    messageParameters={
                         "field_name": str(name),
                         "data_type": str(dataType),
                         "obj": repr(obj),
@@ -2728,8 +2726,8 @@ def _make_type_verifier(
                     },
                 )
             raise PySparkTypeError(
-                error_class="FIELD_DATA_TYPE_UNACCEPTABLE",
-                message_parameters={
+                errorClass="FIELD_DATA_TYPE_UNACCEPTABLE",
+                messageParameters={
                     "data_type": str(dataType),
                     "obj": repr(obj),
                     "obj_type": str(type(obj)),
@@ -2748,16 +2746,16 @@ def _make_type_verifier(
             if not (hasattr(obj, "__UDT__") and obj.__UDT__ == dataType):
                 if name is not None:
                     raise PySparkValueError(
-                        error_class="FIELD_TYPE_MISMATCH_WITH_NAME",
-                        message_parameters={
+                        errorClass="FIELD_TYPE_MISMATCH_WITH_NAME",
+                        messageParameters={
                             "field_name": str(name),
                             "obj": str(obj),
                             "data_type": str(dataType),
                         },
                     )
                 raise PySparkValueError(
-                    error_class="FIELD_TYPE_MISMATCH",
-                    message_parameters={
+                    errorClass="FIELD_TYPE_MISMATCH",
+                    messageParameters={
                         "obj": str(obj),
                         "data_type": str(dataType),
                     },
@@ -2775,8 +2773,8 @@ def _make_type_verifier(
             upper_bound = 127
             if obj < lower_bound or obj > upper_bound:
                 raise PySparkValueError(
-                    error_class="VALUE_OUT_OF_BOUNDS",
-                    message_parameters={
+                    errorClass="VALUE_OUT_OF_BOUNDS",
+                    messageParameters={
                         "arg_name": "obj",
                         "lower_bound": str(lower_bound),
                         "upper_bound": str(upper_bound),
@@ -2795,8 +2793,8 @@ def _make_type_verifier(
             upper_bound = 32767
             if obj < lower_bound or obj > upper_bound:
                 raise PySparkValueError(
-                    error_class="VALUE_OUT_OF_BOUNDS",
-                    message_parameters={
+                    errorClass="VALUE_OUT_OF_BOUNDS",
+                    messageParameters={
                         "arg_name": "obj",
                         "lower_bound": str(lower_bound),
                         "upper_bound": str(upper_bound),
@@ -2815,8 +2813,8 @@ def _make_type_verifier(
             upper_bound = 2147483647
             if obj < lower_bound or obj > upper_bound:
                 raise PySparkValueError(
-                    error_class="VALUE_OUT_OF_BOUNDS",
-                    message_parameters={
+                    errorClass="VALUE_OUT_OF_BOUNDS",
+                    messageParameters={
                         "arg_name": "obj",
                         "lower_bound": str(lower_bound),
                         "upper_bound": str(upper_bound),
@@ -2835,8 +2833,8 @@ def _make_type_verifier(
             upper_bound = 9223372036854775807
             if obj < lower_bound or obj > upper_bound:
                 raise PySparkValueError(
-                    error_class="VALUE_OUT_OF_BOUNDS",
-                    message_parameters={
+                    errorClass="VALUE_OUT_OF_BOUNDS",
+                    messageParameters={
                         "arg_name": "obj",
                         "lower_bound": str(lower_bound),
                         "upper_bound": str(upper_bound),
@@ -2890,16 +2888,16 @@ def _make_type_verifier(
                 if len(obj) != len(verifiers):
                     if name is not None:
                         raise PySparkValueError(
-                            error_class="FIELD_STRUCT_LENGTH_MISMATCH_WITH_NAME",
-                            message_parameters={
+                            errorClass="FIELD_STRUCT_LENGTH_MISMATCH_WITH_NAME",
+                            messageParameters={
                                 "field_name": str(name),
                                 "object_length": str(len(obj)),
                                 "field_length": str(len(verifiers)),
                             },
                         )
                     raise PySparkValueError(
-                        error_class="FIELD_STRUCT_LENGTH_MISMATCH",
-                        message_parameters={
+                        errorClass="FIELD_STRUCT_LENGTH_MISMATCH",
+                        messageParameters={
                             "object_length": str(len(obj)),
                             "field_length": str(len(verifiers)),
                         },
@@ -2913,8 +2911,8 @@ def _make_type_verifier(
             else:
                 if name is not None:
                     raise PySparkTypeError(
-                        error_class="FIELD_DATA_TYPE_UNACCEPTABLE_WITH_NAME",
-                        message_parameters={
+                        errorClass="FIELD_DATA_TYPE_UNACCEPTABLE_WITH_NAME",
+                        messageParameters={
                             "field_name": str(name),
                             "data_type": str(dataType),
                             "obj": repr(obj),
@@ -2922,8 +2920,8 @@ def _make_type_verifier(
                         },
                     )
                 raise PySparkTypeError(
-                    error_class="FIELD_DATA_TYPE_UNACCEPTABLE",
-                    message_parameters={
+                    errorClass="FIELD_DATA_TYPE_UNACCEPTABLE",
+                    messageParameters={
                         "data_type": str(dataType),
                         "obj": repr(obj),
                         "obj_type": str(type(obj)),
@@ -3036,8 +3034,8 @@ class Row(tuple):
     def __new__(cls, *args: Optional[str], **kwargs: Optional[Any]) -> "Row":
         if args and kwargs:
             raise PySparkValueError(
-                error_class="CANNOT_SET_TOGETHER",
-                message_parameters={"arg_list": "args and kwargs"},
+                errorClass="CANNOT_SET_TOGETHER",
+                messageParameters={"arg_list": "args and kwargs"},
             )
         if kwargs:
             # create row objects
@@ -3078,8 +3076,8 @@ class Row(tuple):
         """
         if not hasattr(self, "__fields__"):
             raise PySparkTypeError(
-                error_class="CANNOT_CONVERT_TYPE",
-                message_parameters={
+                errorClass="CANNOT_CONVERT_TYPE",
+                messageParameters={
                     "from_type": "Row",
                     "to_type": "dict",
                 },
@@ -3112,8 +3110,8 @@ class Row(tuple):
         """create new Row object"""
         if len(args) > len(self):
             raise PySparkValueError(
-                error_class="TOO_MANY_VALUES",
-                message_parameters={
+                errorClass="TOO_MANY_VALUES",
+                messageParameters={
                     "expected": str(len(self)),
                     "item": "fields",
                     "actual": str(len(args)),
@@ -3130,16 +3128,14 @@ class Row(tuple):
             idx = self.__fields__.index(item)
             return super(Row, self).__getitem__(idx)
         except IndexError:
-            raise PySparkKeyError(
-                error_class="KEY_NOT_EXISTS", message_parameters={"key": str(item)}
-            )
+            raise PySparkKeyError(errorClass="KEY_NOT_EXISTS", messageParameters={"key": str(item)})
         except ValueError:
             raise PySparkValueError(item)
 
     def __getattr__(self, item: str) -> Any:
         if item.startswith("__"):
             raise PySparkAttributeError(
-                error_class="ATTRIBUTE_NOT_SUPPORTED", message_parameters={"attr_name": item}
+                errorClass="ATTRIBUTE_NOT_SUPPORTED", messageParameters={"attr_name": item}
             )
         try:
             # it will be slow when it has many fields,
@@ -3148,18 +3144,18 @@ class Row(tuple):
             return self[idx]
         except IndexError:
             raise PySparkAttributeError(
-                error_class="ATTRIBUTE_NOT_SUPPORTED", message_parameters={"attr_name": item}
+                errorClass="ATTRIBUTE_NOT_SUPPORTED", messageParameters={"attr_name": item}
             )
         except ValueError:
             raise PySparkAttributeError(
-                error_class="ATTRIBUTE_NOT_SUPPORTED", message_parameters={"attr_name": item}
+                errorClass="ATTRIBUTE_NOT_SUPPORTED", messageParameters={"attr_name": item}
             )
 
     def __setattr__(self, key: Any, value: Any) -> None:
         if key != "__fields__":
             raise PySparkRuntimeError(
-                error_class="READ_ONLY",
-                message_parameters={"object": "Row"},
+                errorClass="READ_ONLY",
+                messageParameters={"object": "Row"},
             )
         self.__dict__[key] = value
 
@@ -3292,8 +3288,8 @@ class NumpyArrayConverter:
             jtpe = self._from_numpy_type_to_java_type(obj.dtype, gateway)
             if jtpe is None:
                 raise PySparkTypeError(
-                    error_class="UNSUPPORTED_NUMPY_ARRAY_SCALAR",
-                    message_parameters={"dtype": str(obj.dtype)},
+                    errorClass="UNSUPPORTED_NUMPY_ARRAY_SCALAR",
+                    messageParameters={"dtype": str(obj.dtype)},
                 )
         jarr = gateway.new_array(jtpe, len(obj))
         for i in range(len(plist)):

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -175,14 +175,14 @@ class UserDefinedFunction:
     ):
         if not callable(func):
             raise PySparkTypeError(
-                error_class="NOT_CALLABLE",
-                message_parameters={"arg_name": "func", "arg_type": type(func).__name__},
+                errorClass="NOT_CALLABLE",
+                messageParameters={"arg_name": "func", "arg_type": type(func).__name__},
             )
 
         if not isinstance(returnType, (DataType, str)):
             raise PySparkTypeError(
-                error_class="NOT_DATATYPE_OR_STR",
-                message_parameters={
+                errorClass="NOT_DATATYPE_OR_STR",
+                messageParameters={
                     "arg_name": "returnType",
                     "arg_type": type(returnType).__name__,
                 },
@@ -190,8 +190,8 @@ class UserDefinedFunction:
 
         if not isinstance(evalType, int):
             raise PySparkTypeError(
-                error_class="NOT_INT",
-                message_parameters={"arg_name": "evalType", "arg_type": type(evalType).__name__},
+                errorClass="NOT_INT",
+                messageParameters={"arg_name": "evalType", "arg_type": type(evalType).__name__},
             )
 
         self.func = func
@@ -212,8 +212,8 @@ class UserDefinedFunction:
                 to_arrow_type(returnType)
             except TypeError:
                 raise PySparkNotImplementedError(
-                    error_class="NOT_IMPLEMENTED",
-                    message_parameters={
+                    errorClass="NOT_IMPLEMENTED",
+                    messageParameters={
                         "feature": f"Invalid return type with Arrow-optimized Python UDF: "
                         f"{returnType}"
                     },
@@ -226,8 +226,8 @@ class UserDefinedFunction:
                 to_arrow_type(returnType)
             except TypeError:
                 raise PySparkNotImplementedError(
-                    error_class="NOT_IMPLEMENTED",
-                    message_parameters={
+                    errorClass="NOT_IMPLEMENTED",
+                    messageParameters={
                         "feature": f"Invalid return type with scalar Pandas UDFs: " f"{returnType}"
                     },
                 )
@@ -240,16 +240,16 @@ class UserDefinedFunction:
                     to_arrow_type(returnType)
                 except TypeError:
                     raise PySparkNotImplementedError(
-                        error_class="NOT_IMPLEMENTED",
-                        message_parameters={
+                        errorClass="NOT_IMPLEMENTED",
+                        messageParameters={
                             "feature": f"Invalid return type with grouped map Pandas UDFs or "
                             f"at groupby.applyInPandas(WithState): {returnType}"
                         },
                     )
             else:
                 raise PySparkTypeError(
-                    error_class="INVALID_RETURN_TYPE_FOR_PANDAS_UDF",
-                    message_parameters={
+                    errorClass="INVALID_RETURN_TYPE_FOR_PANDAS_UDF",
+                    messageParameters={
                         "eval_type": "SQL_GROUPED_MAP_PANDAS_UDF or "
                         "SQL_GROUPED_MAP_PANDAS_UDF_WITH_STATE",
                         "return_type": str(returnType),
@@ -264,15 +264,15 @@ class UserDefinedFunction:
                     to_arrow_type(returnType)
                 except TypeError:
                     raise PySparkNotImplementedError(
-                        error_class="NOT_IMPLEMENTED",
-                        message_parameters={
+                        errorClass="NOT_IMPLEMENTED",
+                        messageParameters={
                             "feature": f"Invalid return type in mapInPandas: " f"{returnType}"
                         },
                     )
             else:
                 raise PySparkTypeError(
-                    error_class="INVALID_RETURN_TYPE_FOR_PANDAS_UDF",
-                    message_parameters={
+                    errorClass="INVALID_RETURN_TYPE_FOR_PANDAS_UDF",
+                    messageParameters={
                         "eval_type": "SQL_MAP_PANDAS_ITER_UDF or SQL_MAP_ARROW_ITER_UDF",
                         "return_type": str(returnType),
                     },
@@ -283,16 +283,16 @@ class UserDefinedFunction:
                     to_arrow_type(returnType)
                 except TypeError:
                     raise PySparkNotImplementedError(
-                        error_class="NOT_IMPLEMENTED",
-                        message_parameters={
+                        errorClass="NOT_IMPLEMENTED",
+                        messageParameters={
                             "feature": "Invalid return type with grouped map Arrow UDFs or "
                             f"at groupby.applyInArrow: {returnType}"
                         },
                     )
             else:
                 raise PySparkTypeError(
-                    error_class="INVALID_RETURN_TYPE_FOR_ARROW_UDF",
-                    message_parameters={
+                    errorClass="INVALID_RETURN_TYPE_FOR_ARROW_UDF",
+                    messageParameters={
                         "eval_type": "SQL_GROUPED_MAP_ARROW_UDF",
                         "return_type": str(returnType),
                     },
@@ -303,16 +303,16 @@ class UserDefinedFunction:
                     to_arrow_type(returnType)
                 except TypeError:
                     raise PySparkNotImplementedError(
-                        error_class="NOT_IMPLEMENTED",
-                        message_parameters={
+                        errorClass="NOT_IMPLEMENTED",
+                        messageParameters={
                             "feature": f"Invalid return type in cogroup.applyInPandas: "
                             f"{returnType}"
                         },
                     )
             else:
                 raise PySparkTypeError(
-                    error_class="INVALID_RETURN_TYPE_FOR_PANDAS_UDF",
-                    message_parameters={
+                    errorClass="INVALID_RETURN_TYPE_FOR_PANDAS_UDF",
+                    messageParameters={
                         "eval_type": "SQL_COGROUPED_MAP_PANDAS_UDF",
                         "return_type": str(returnType),
                     },
@@ -323,16 +323,16 @@ class UserDefinedFunction:
                     to_arrow_type(returnType)
                 except TypeError:
                     raise PySparkNotImplementedError(
-                        error_class="NOT_IMPLEMENTED",
-                        message_parameters={
+                        errorClass="NOT_IMPLEMENTED",
+                        messageParameters={
                             "feature": "Invalid return type in cogroup.applyInArrow: "
                             f"{returnType}"
                         },
                     )
             else:
                 raise PySparkTypeError(
-                    error_class="INVALID_RETURN_TYPE_FOR_ARROW_UDF",
-                    message_parameters={
+                    errorClass="INVALID_RETURN_TYPE_FOR_ARROW_UDF",
+                    messageParameters={
                         "eval_type": "SQL_COGROUPED_MAP_ARROW_UDF",
                         "return_type": str(returnType),
                     },
@@ -342,8 +342,8 @@ class UserDefinedFunction:
                 # StructType is not yet allowed as a return type, explicitly check here to fail fast
                 if isinstance(returnType, StructType):
                     raise PySparkNotImplementedError(
-                        error_class="NOT_IMPLEMENTED",
-                        message_parameters={
+                        errorClass="NOT_IMPLEMENTED",
+                        messageParameters={
                             "feature": f"Invalid return type with grouped aggregate Pandas UDFs: "
                             f"{returnType}"
                         },
@@ -351,8 +351,8 @@ class UserDefinedFunction:
                 to_arrow_type(returnType)
             except TypeError:
                 raise PySparkNotImplementedError(
-                    error_class="NOT_IMPLEMENTED",
-                    message_parameters={
+                    errorClass="NOT_IMPLEMENTED",
+                    messageParameters={
                         "feature": f"Invalid return type with grouped aggregate Pandas UDFs: "
                         f"{returnType}"
                     },
@@ -433,8 +433,8 @@ class UserDefinedFunction:
                 # When both profilers are enabled, they interfere with each other,
                 # that makes the result profile misleading.
                 raise PySparkRuntimeError(
-                    error_class="CANNOT_SET_TOGETHER",
-                    message_parameters={
+                    errorClass="CANNOT_SET_TOGETHER",
+                    messageParameters={
                         "arg_list": "'spark.python.profile' and "
                         "'spark.python.profile.memory' configuration"
                     },
@@ -651,8 +651,8 @@ class UDFRegistration:
         if hasattr(f, "asNondeterministic"):
             if returnType is not None:
                 raise PySparkTypeError(
-                    error_class="CANNOT_SPECIFY_RETURN_TYPE_FOR_UDF",
-                    message_parameters={"arg_name": "f", "return_type": str(returnType)},
+                    errorClass="CANNOT_SPECIFY_RETURN_TYPE_FOR_UDF",
+                    messageParameters={"arg_name": "f", "return_type": str(returnType)},
                 )
             f = cast("UserDefinedFunctionLike", f)
             if f.evalType not in [
@@ -663,8 +663,8 @@ class UDFRegistration:
                 PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF,
             ]:
                 raise PySparkTypeError(
-                    error_class="INVALID_UDF_EVAL_TYPE",
-                    message_parameters={
+                    errorClass="INVALID_UDF_EVAL_TYPE",
+                    messageParameters={
                         "eval_type": "SQL_BATCHED_UDF, SQL_ARROW_BATCHED_UDF, "
                         "SQL_SCALAR_PANDAS_UDF, SQL_SCALAR_PANDAS_ITER_UDF or "
                         "SQL_GROUPED_AGG_PANDAS_UDF"

--- a/python/pyspark/sql/udtf.py
+++ b/python/pyspark/sql/udtf.py
@@ -247,12 +247,12 @@ def _validate_udtf_handler(cls: Any, returnType: Optional[Union[StructType, str]
 
     if not isinstance(cls, type):
         raise PySparkTypeError(
-            error_class="INVALID_UDTF_HANDLER_TYPE", message_parameters={"type": type(cls).__name__}
+            errorClass="INVALID_UDTF_HANDLER_TYPE", messageParameters={"type": type(cls).__name__}
         )
 
     if not hasattr(cls, "eval"):
         raise PySparkAttributeError(
-            error_class="INVALID_UDTF_NO_EVAL", message_parameters={"name": cls.__name__}
+            errorClass="INVALID_UDTF_NO_EVAL", messageParameters={"name": cls.__name__}
         )
 
     has_analyze = hasattr(cls, "analyze")
@@ -261,12 +261,12 @@ def _validate_udtf_handler(cls: Any, returnType: Optional[Union[StructType, str]
     )
     if returnType is None and not has_analyze_staticmethod:
         raise PySparkAttributeError(
-            error_class="INVALID_UDTF_RETURN_TYPE", message_parameters={"name": cls.__name__}
+            errorClass="INVALID_UDTF_RETURN_TYPE", messageParameters={"name": cls.__name__}
         )
     if returnType is not None and has_analyze:
         raise PySparkAttributeError(
-            error_class="INVALID_UDTF_BOTH_RETURN_TYPE_AND_ANALYZE",
-            message_parameters={"name": cls.__name__},
+            errorClass="INVALID_UDTF_BOTH_RETURN_TYPE_AND_ANALYZE",
+            messageParameters={"name": cls.__name__},
         )
 
 
@@ -316,8 +316,8 @@ class UserDefinedTableFunction:
                 parsed = self._returnType
             if not isinstance(parsed, StructType):
                 raise PySparkTypeError(
-                    error_class="UDTF_RETURN_TYPE_MISMATCH",
-                    message_parameters={
+                    errorClass="UDTF_RETURN_TYPE_MISMATCH",
+                    messageParameters={
                         "name": self._name,
                         "return_type": f"{parsed}",
                     },
@@ -342,8 +342,8 @@ class UserDefinedTableFunction:
         except pickle.PicklingError as e:
             if "CONTEXT_ONLY_VALID_ON_DRIVER" in str(e):
                 raise PySparkPicklingError(
-                    error_class="UDTF_SERIALIZATION_ERROR",
-                    message_parameters={
+                    errorClass="UDTF_SERIALIZATION_ERROR",
+                    messageParameters={
                         "name": self._name,
                         "message": "it appears that you are attempting to reference SparkSession "
                         "inside a UDTF. SparkSession can only be used on the driver, "
@@ -352,8 +352,8 @@ class UserDefinedTableFunction:
                     },
                 ) from None
             raise PySparkPicklingError(
-                error_class="UDTF_SERIALIZATION_ERROR",
-                message_parameters={
+                errorClass="UDTF_SERIALIZATION_ERROR",
+                messageParameters={
                     "name": self._name,
                     "message": "Please check the stack trace and make sure the "
                     "function is serializable.",
@@ -463,16 +463,16 @@ class UDTFRegistration:
         """
         if not isinstance(f, UserDefinedTableFunction):
             raise PySparkTypeError(
-                error_class="CANNOT_REGISTER_UDTF",
-                message_parameters={
+                errorClass="CANNOT_REGISTER_UDTF",
+                messageParameters={
                     "name": name,
                 },
             )
 
         if f.evalType not in [PythonEvalType.SQL_TABLE_UDF, PythonEvalType.SQL_ARROW_TABLE_UDF]:
             raise PySparkTypeError(
-                error_class="INVALID_UDTF_EVAL_TYPE",
-                message_parameters={
+                errorClass="INVALID_UDTF_EVAL_TYPE",
+                messageParameters={
                     "name": name,
                     "eval_type": "SQL_TABLE_UDF, SQL_ARROW_TABLE_UDF",
                 },

--- a/python/pyspark/sql/utils.py
+++ b/python/pyspark/sql/utils.py
@@ -109,8 +109,8 @@ def require_test_compiled() -> None:
 
     if len(paths) == 0:
         raise PySparkRuntimeError(
-            error_class="TEST_CLASS_NOT_COMPILED",
-            message_parameters={"test_class_path": test_class_path},
+            errorClass="TEST_CLASS_NOT_COMPILED",
+            messageParameters={"test_class_path": test_class_path},
         )
 
 
@@ -306,8 +306,8 @@ def get_active_spark_context() -> "SparkContext":
     sc = SparkContext._active_spark_context
     if sc is None or sc._jvm is None:
         raise PySparkRuntimeError(
-            error_class="SESSION_OR_CONTEXT_NOT_EXISTS",
-            message_parameters={},
+            errorClass="SESSION_OR_CONTEXT_NOT_EXISTS",
+            messageParameters={},
         )
     return sc
 
@@ -348,8 +348,8 @@ def dispatch_df_method(f: FuncT) -> FuncT:
                 return getattr(ClassicDataFrame, f.__name__)(*args, **kwargs)
 
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": f"DataFrame.{f.__name__}"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": f"DataFrame.{f.__name__}"},
         )
 
     return cast(FuncT, wrapped)
@@ -375,8 +375,8 @@ def dispatch_col_method(f: FuncT) -> FuncT:
                 return getattr(ClassicColumn, f.__name__)(*args, **kwargs)
 
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": f"Column.{f.__name__}"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": f"Column.{f.__name__}"},
         )
 
     return cast(FuncT, wrapped)
@@ -400,8 +400,8 @@ def dispatch_window_method(f: FuncT) -> FuncT:
             return getattr(ClassicWindow, f.__name__)(*args, **kwargs)
 
         raise PySparkNotImplementedError(
-            error_class="NOT_IMPLEMENTED",
-            message_parameters={"feature": f"Window.{f.__name__}"},
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": f"Window.{f.__name__}"},
         )
 
     return cast(FuncT, wrapped)

--- a/python/pyspark/sql/worker/commit_data_source_write.py
+++ b/python/pyspark/sql/worker/commit_data_source_write.py
@@ -69,8 +69,8 @@ def main(infile: IO, outfile: IO) -> None:
             message = pickleSer._read_with_length(infile)
             if message is not None and not isinstance(message, WriterCommitMessage):
                 raise PySparkAssertionError(
-                    error_class="DATA_SOURCE_TYPE_MISMATCH",
-                    message_parameters={
+                    errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                    messageParameters={
                         "expected": "an instance of WriterCommitMessage",
                         "actual": f"'{type(message).__name__}'",
                     },

--- a/python/pyspark/sql/worker/create_data_source.py
+++ b/python/pyspark/sql/worker/create_data_source.py
@@ -75,8 +75,8 @@ def main(infile: IO, outfile: IO) -> None:
         data_source_cls = read_command(pickleSer, infile)
         if not (isinstance(data_source_cls, type) and issubclass(data_source_cls, DataSource)):
             raise PySparkAssertionError(
-                error_class="DATA_SOURCE_TYPE_MISMATCH",
-                message_parameters={
+                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                messageParameters={
                     "expected": "a subclass of DataSource",
                     "actual": f"'{type(data_source_cls).__name__}'",
                 },
@@ -85,8 +85,8 @@ def main(infile: IO, outfile: IO) -> None:
         # Check the name method is a class method.
         if not inspect.ismethod(data_source_cls.name):
             raise PySparkTypeError(
-                error_class="DATA_SOURCE_TYPE_MISMATCH",
-                message_parameters={
+                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                messageParameters={
                     "expected": "'name()' method to be a classmethod",
                     "actual": f"'{type(data_source_cls.name).__name__}'",
                 },
@@ -98,8 +98,8 @@ def main(infile: IO, outfile: IO) -> None:
         # Check if the provider name matches the data source's name.
         if provider.lower() != data_source_cls.name().lower():
             raise PySparkAssertionError(
-                error_class="DATA_SOURCE_TYPE_MISMATCH",
-                message_parameters={
+                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                messageParameters={
                     "expected": f"provider with name {data_source_cls.name()}",
                     "actual": f"'{provider}'",
                 },
@@ -111,8 +111,8 @@ def main(infile: IO, outfile: IO) -> None:
             user_specified_schema = _parse_datatype_json_string(utf8_deserializer.loads(infile))
             if not isinstance(user_specified_schema, StructType):
                 raise PySparkAssertionError(
-                    error_class="DATA_SOURCE_TYPE_MISMATCH",
-                    message_parameters={
+                    errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                    messageParameters={
                         "expected": "the user-defined schema to be a 'StructType'",
                         "actual": f"'{type(data_source_cls).__name__}'",
                     },
@@ -131,8 +131,8 @@ def main(infile: IO, outfile: IO) -> None:
             data_source = data_source_cls(options=options)  # type: ignore
         except Exception as e:
             raise PySparkRuntimeError(
-                error_class="DATA_SOURCE_CREATE_ERROR",
-                message_parameters={"error": str(e)},
+                errorClass="DATA_SOURCE_CREATE_ERROR",
+                messageParameters={"error": str(e)},
             )
 
         # Get the schema of the data source.
@@ -149,8 +149,8 @@ def main(infile: IO, outfile: IO) -> None:
                     is_ddl_string = True
             except NotImplementedError:
                 raise PySparkRuntimeError(
-                    error_class="NOT_IMPLEMENTED",
-                    message_parameters={"feature": "DataSource.schema"},
+                    errorClass="NOT_IMPLEMENTED",
+                    messageParameters={"feature": "DataSource.schema"},
                 )
         else:
             schema = user_specified_schema  # type: ignore

--- a/python/pyspark/sql/worker/plan_data_source_read.py
+++ b/python/pyspark/sql/worker/plan_data_source_read.py
@@ -89,8 +89,8 @@ def records_to_arrow_batches(
             # Validate the output row schema.
             if hasattr(result, "__len__") and len(result) != num_cols:
                 raise PySparkRuntimeError(
-                    error_class="DATA_SOURCE_RETURN_SCHEMA_MISMATCH",
-                    message_parameters={
+                    errorClass="DATA_SOURCE_RETURN_SCHEMA_MISMATCH",
+                    messageParameters={
                         "expected": str(num_cols),
                         "actual": str(len(result)),
                     },
@@ -99,8 +99,8 @@ def records_to_arrow_batches(
             # Validate the output row type.
             if not isinstance(result, (list, tuple)):
                 raise PySparkRuntimeError(
-                    error_class="DATA_SOURCE_INVALID_RETURN_TYPE",
-                    message_parameters={
+                    errorClass="DATA_SOURCE_INVALID_RETURN_TYPE",
+                    messageParameters={
                         "type": type(result).__name__,
                         "name": data_source.name(),
                         "supported_types": "tuple, list, `pyspark.sql.types.Row`",
@@ -113,8 +113,8 @@ def records_to_arrow_batches(
                 # Check if the names are the same as the schema.
                 if set(result.__fields__) != col_name_set:
                     raise PySparkRuntimeError(
-                        error_class="DATA_SOURCE_RETURN_SCHEMA_MISMATCH",
-                        message_parameters={
+                        errorClass="DATA_SOURCE_RETURN_SCHEMA_MISMATCH",
+                        messageParameters={
                             "expected": str(column_names),
                             "actual": str(result.__fields__),
                         },
@@ -164,8 +164,8 @@ def main(infile: IO, outfile: IO) -> None:
         data_source = read_command(pickleSer, infile)
         if not isinstance(data_source, DataSource):
             raise PySparkAssertionError(
-                error_class="DATA_SOURCE_TYPE_MISMATCH",
-                message_parameters={
+                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                messageParameters={
                     "expected": "a Python data source instance of type 'DataSource'",
                     "actual": f"'{type(data_source).__name__}'",
                 },
@@ -176,8 +176,8 @@ def main(infile: IO, outfile: IO) -> None:
         input_schema = _parse_datatype_json_string(input_schema_json)
         if not isinstance(input_schema, StructType):
             raise PySparkAssertionError(
-                error_class="DATA_SOURCE_TYPE_MISMATCH",
-                message_parameters={
+                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                messageParameters={
                     "expected": "an input schema of type 'StructType'",
                     "actual": f"'{type(input_schema).__name__}'",
                 },
@@ -192,8 +192,8 @@ def main(infile: IO, outfile: IO) -> None:
         schema = _parse_datatype_json_string(schema_json)
         if not isinstance(schema, StructType):
             raise PySparkAssertionError(
-                error_class="DATA_SOURCE_TYPE_MISMATCH",
-                message_parameters={
+                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                messageParameters={
                     "expected": "an output schema of type 'StructType'",
                     "actual": f"'{type(schema).__name__}'",
                 },
@@ -218,8 +218,8 @@ def main(infile: IO, outfile: IO) -> None:
             # Validate the reader.
             if not isinstance(reader, DataSourceReader):
                 raise PySparkAssertionError(
-                    error_class="DATA_SOURCE_TYPE_MISMATCH",
-                    message_parameters={
+                    errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                    messageParameters={
                         "expected": "an instance of DataSourceReader",
                         "actual": f"'{type(reader).__name__}'",
                     },
@@ -261,8 +261,8 @@ def main(infile: IO, outfile: IO) -> None:
             # Validate the output iterator.
             if not isinstance(output_iter, Iterator):
                 raise PySparkRuntimeError(
-                    error_class="DATA_SOURCE_INVALID_RETURN_TYPE",
-                    message_parameters={
+                    errorClass="DATA_SOURCE_INVALID_RETURN_TYPE",
+                    messageParameters={
                         "type": type(output_iter).__name__,
                         "name": data_source.name(),
                         "supported_types": "iterator",
@@ -282,8 +282,8 @@ def main(infile: IO, outfile: IO) -> None:
                 partitions = reader.partitions()  # type: ignore[call-arg]
                 if not isinstance(partitions, list):
                     raise PySparkRuntimeError(
-                        error_class="DATA_SOURCE_TYPE_MISMATCH",
-                        message_parameters={
+                        errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                        messageParameters={
                             "expected": "'partitions' to return a list",
                             "actual": f"'{type(partitions).__name__}'",
                         },
@@ -291,8 +291,8 @@ def main(infile: IO, outfile: IO) -> None:
                 if not all(isinstance(p, InputPartition) for p in partitions):
                     partition_types = ", ".join([f"'{type(p).__name__}'" for p in partitions])
                     raise PySparkRuntimeError(
-                        error_class="DATA_SOURCE_TYPE_MISMATCH",
-                        message_parameters={
+                        errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                        messageParameters={
                             "expected": "elements in 'partitions' to be of type 'InputPartition'",
                             "actual": partition_types,
                         },

--- a/python/pyspark/sql/worker/python_streaming_sink_runner.py
+++ b/python/pyspark/sql/worker/python_streaming_sink_runner.py
@@ -70,8 +70,8 @@ def main(infile: IO, outfile: IO) -> None:
 
         if not isinstance(data_source, DataSource):
             raise PySparkAssertionError(
-                error_class="DATA_SOURCE_TYPE_MISMATCH",
-                message_parameters={
+                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                messageParameters={
                     "expected": "a Python data source instance of type 'DataSource'",
                     "actual": f"'{type(data_source).__name__}'",
                 },
@@ -81,8 +81,8 @@ def main(infile: IO, outfile: IO) -> None:
         schema = _parse_datatype_json_string(schema_json)
         if not isinstance(schema, StructType):
             raise PySparkAssertionError(
-                error_class="DATA_SOURCE_TYPE_MISMATCH",
-                message_parameters={
+                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                messageParameters={
                     "expected": "an output schema of type 'StructType'",
                     "actual": f"'{type(schema).__name__}'",
                 },
@@ -101,8 +101,8 @@ def main(infile: IO, outfile: IO) -> None:
                 message = pickleSer._read_with_length(infile)
                 if message is not None and not isinstance(message, WriterCommitMessage):
                     raise PySparkAssertionError(
-                        error_class="DATA_SOURCE_TYPE_MISMATCH",
-                        message_parameters={
+                        errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                        messageParameters={
                             "expected": "an instance of WriterCommitMessage",
                             "actual": f"'{type(message).__name__}'",
                         },
@@ -124,8 +124,8 @@ def main(infile: IO, outfile: IO) -> None:
         except Exception as e:
             error_msg = "data source {} throw exception: {}".format(data_source.name, e)
             raise PySparkRuntimeError(
-                error_class="PYTHON_STREAMING_DATA_SOURCE_RUNTIME_ERROR",
-                message_parameters={"action": "commitOrAbort", "error": error_msg},
+                errorClass="PYTHON_STREAMING_DATA_SOURCE_RUNTIME_ERROR",
+                messageParameters={"action": "commitOrAbort", "error": error_msg},
             )
     except BaseException as e:
         handle_worker_exception(e, outfile)

--- a/python/pyspark/sql/worker/write_into_data_source.py
+++ b/python/pyspark/sql/worker/write_into_data_source.py
@@ -88,8 +88,8 @@ def main(infile: IO, outfile: IO) -> None:
         data_source_cls = read_command(pickleSer, infile)
         if not (isinstance(data_source_cls, type) and issubclass(data_source_cls, DataSource)):
             raise PySparkAssertionError(
-                error_class="DATA_SOURCE_TYPE_MISMATCH",
-                message_parameters={
+                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                messageParameters={
                     "expected": "a subclass of DataSource",
                     "actual": f"'{type(data_source_cls).__name__}'",
                 },
@@ -98,8 +98,8 @@ def main(infile: IO, outfile: IO) -> None:
         # Check the name method is a class method.
         if not inspect.ismethod(data_source_cls.name):
             raise PySparkTypeError(
-                error_class="DATA_SOURCE_TYPE_MISMATCH",
-                message_parameters={
+                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                messageParameters={
                     "expected": "'name()' method to be a classmethod",
                     "actual": f"'{type(data_source_cls.name).__name__}'",
                 },
@@ -111,8 +111,8 @@ def main(infile: IO, outfile: IO) -> None:
         # Check if the provider name matches the data source's name.
         if provider.lower() != data_source_cls.name().lower():
             raise PySparkAssertionError(
-                error_class="DATA_SOURCE_TYPE_MISMATCH",
-                message_parameters={
+                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                messageParameters={
                     "expected": f"provider with name {data_source_cls.name()}",
                     "actual": f"'{provider}'",
                 },
@@ -122,8 +122,8 @@ def main(infile: IO, outfile: IO) -> None:
         schema = _parse_datatype_json_string(utf8_deserializer.loads(infile))
         if not isinstance(schema, StructType):
             raise PySparkAssertionError(
-                error_class="DATA_SOURCE_TYPE_MISMATCH",
-                message_parameters={
+                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                messageParameters={
                     "expected": "the schema to be a 'StructType'",
                     "actual": f"'{type(data_source_cls).__name__}'",
                 },
@@ -133,8 +133,8 @@ def main(infile: IO, outfile: IO) -> None:
         return_type = _parse_datatype_json_string(utf8_deserializer.loads(infile))
         if not isinstance(return_type, StructType):
             raise PySparkAssertionError(
-                error_class="DATA_SOURCE_TYPE_MISMATCH",
-                message_parameters={
+                errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                messageParameters={
                     "expected": "a return type of type 'StructType'",
                     "actual": f"'{type(return_type).__name__}'",
                 },
@@ -169,8 +169,8 @@ def main(infile: IO, outfile: IO) -> None:
             writer = data_source.writer(schema, overwrite)  # type: ignore[assignment]
             if not isinstance(writer, DataSourceWriter):
                 raise PySparkAssertionError(
-                    error_class="DATA_SOURCE_TYPE_MISMATCH",
-                    message_parameters={
+                    errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                    messageParameters={
                         "expected": "an instance of DataSourceWriter",
                         "actual": f"'{type(writer).__name__}'",
                     },
@@ -199,8 +199,8 @@ def main(infile: IO, outfile: IO) -> None:
             # Check the commit message has the right type.
             if not isinstance(res, WriterCommitMessage):
                 raise PySparkRuntimeError(
-                    error_class="DATA_SOURCE_TYPE_MISMATCH",
-                    message_parameters={
+                    errorClass="DATA_SOURCE_TYPE_MISMATCH",
+                    messageParameters={
                         "expected": (
                             "'WriterCommitMessage' as the return type of " "the `write` method"
                         ),

--- a/python/pyspark/taskcontext.py
+++ b/python/pyspark/taskcontext.py
@@ -361,8 +361,8 @@ class BarrierTaskContext(TaskContext):
         """
         if not isinstance(cls._taskContext, BarrierTaskContext):
             raise PySparkRuntimeError(
-                error_class="NOT_IN_BARRIER_STAGE",
-                message_parameters={},
+                errorClass="NOT_IN_BARRIER_STAGE",
+                messageParameters={},
             )
         return cls._taskContext
 
@@ -395,8 +395,8 @@ class BarrierTaskContext(TaskContext):
         """
         if self._port is None or self._secret is None:
             raise PySparkRuntimeError(
-                error_class="CALL_BEFORE_INITIALIZE",
-                message_parameters={
+                errorClass="CALL_BEFORE_INITIALIZE",
+                messageParameters={
                     "func_name": "barrier",
                     "object": "BarrierTaskContext",
                 },
@@ -424,8 +424,8 @@ class BarrierTaskContext(TaskContext):
             raise TypeError("Argument `message` must be of type `str`")
         elif self._port is None or self._secret is None:
             raise PySparkRuntimeError(
-                error_class="CALL_BEFORE_INITIALIZE",
-                message_parameters={
+                errorClass="CALL_BEFORE_INITIALIZE",
+                messageParameters={
                     "func_name": "allGather",
                     "object": "BarrierTaskContext",
                 },
@@ -455,8 +455,8 @@ class BarrierTaskContext(TaskContext):
         """
         if self._port is None or self._secret is None:
             raise PySparkRuntimeError(
-                error_class="CALL_BEFORE_INITIALIZE",
-                message_parameters={
+                errorClass="CALL_BEFORE_INITIALIZE",
+                messageParameters={
                     "func_name": "getTaskInfos",
                     "object": "BarrierTaskContext",
                 },

--- a/python/pyspark/testing/pandasutils.py
+++ b/python/pyspark/testing/pandasutils.py
@@ -86,8 +86,8 @@ def _assert_pandas_equal(
             )
         except AssertionError:
             raise PySparkAssertionError(
-                error_class="DIFFERENT_PANDAS_DATAFRAME",
-                message_parameters={
+                errorClass="DIFFERENT_PANDAS_DATAFRAME",
+                messageParameters={
                     "left": left.to_string(),
                     "left_dtype": str(left.dtypes),
                     "right": right.to_string(),
@@ -106,8 +106,8 @@ def _assert_pandas_equal(
             )
         except AssertionError:
             raise PySparkAssertionError(
-                error_class="DIFFERENT_PANDAS_SERIES",
-                message_parameters={
+                errorClass="DIFFERENT_PANDAS_SERIES",
+                messageParameters={
                     "left": left.to_string(),
                     "left_dtype": str(left.dtype),
                     "right": right.to_string(),
@@ -119,8 +119,8 @@ def _assert_pandas_equal(
             assert_index_equal(left, right, check_exact=checkExact)
         except AssertionError:
             raise PySparkAssertionError(
-                error_class="DIFFERENT_PANDAS_INDEX",
-                message_parameters={
+                errorClass="DIFFERENT_PANDAS_INDEX",
+                messageParameters={
                     "left": left,
                     "left_dtype": str(left.dtype),
                     "right": right,
@@ -159,8 +159,8 @@ def _assert_pandas_almost_equal(
     if isinstance(left, pd.DataFrame) and isinstance(right, pd.DataFrame):
         if left.shape != right.shape:
             raise PySparkAssertionError(
-                error_class="DIFFERENT_PANDAS_DATAFRAME",
-                message_parameters={
+                errorClass="DIFFERENT_PANDAS_DATAFRAME",
+                messageParameters={
                     "left": left.to_string(),
                     "left_dtype": str(left.dtypes),
                     "right": right.to_string(),
@@ -170,8 +170,8 @@ def _assert_pandas_almost_equal(
         for lcol, rcol in zip(left.columns, right.columns):
             if lcol != rcol:
                 raise PySparkAssertionError(
-                    error_class="DIFFERENT_PANDAS_DATAFRAME",
-                    message_parameters={
+                    errorClass="DIFFERENT_PANDAS_DATAFRAME",
+                    messageParameters={
                         "left": left.to_string(),
                         "left_dtype": str(left.dtypes),
                         "right": right.to_string(),
@@ -181,8 +181,8 @@ def _assert_pandas_almost_equal(
             for lnull, rnull in zip(left[lcol].isnull(), right[rcol].isnull()):
                 if lnull != rnull:
                     raise PySparkAssertionError(
-                        error_class="DIFFERENT_PANDAS_DATAFRAME",
-                        message_parameters={
+                        errorClass="DIFFERENT_PANDAS_DATAFRAME",
+                        messageParameters={
                             "left": left.to_string(),
                             "left_dtype": str(left.dtypes),
                             "right": right.to_string(),
@@ -192,8 +192,8 @@ def _assert_pandas_almost_equal(
             for lval, rval in zip(left[lcol].dropna(), right[rcol].dropna()):
                 if not compare_vals_approx(lval, rval):
                     raise PySparkAssertionError(
-                        error_class="DIFFERENT_PANDAS_DATAFRAME",
-                        message_parameters={
+                        errorClass="DIFFERENT_PANDAS_DATAFRAME",
+                        messageParameters={
                             "left": left.to_string(),
                             "left_dtype": str(left.dtypes),
                             "right": right.to_string(),
@@ -202,8 +202,8 @@ def _assert_pandas_almost_equal(
                     )
         if left.columns.names != right.columns.names:
             raise PySparkAssertionError(
-                error_class="DIFFERENT_PANDAS_DATAFRAME",
-                message_parameters={
+                errorClass="DIFFERENT_PANDAS_DATAFRAME",
+                messageParameters={
                     "left": left.to_string(),
                     "left_dtype": str(left.dtypes),
                     "right": right.to_string(),
@@ -213,8 +213,8 @@ def _assert_pandas_almost_equal(
     elif isinstance(left, pd.Series) and isinstance(right, pd.Series):
         if left.name != right.name or len(left) != len(right):
             raise PySparkAssertionError(
-                error_class="DIFFERENT_PANDAS_SERIES",
-                message_parameters={
+                errorClass="DIFFERENT_PANDAS_SERIES",
+                messageParameters={
                     "left": left.to_string(),
                     "left_dtype": str(left.dtype),
                     "right": right.to_string(),
@@ -224,8 +224,8 @@ def _assert_pandas_almost_equal(
         for lnull, rnull in zip(left.isnull(), right.isnull()):
             if lnull != rnull:
                 raise PySparkAssertionError(
-                    error_class="DIFFERENT_PANDAS_SERIES",
-                    message_parameters={
+                    errorClass="DIFFERENT_PANDAS_SERIES",
+                    messageParameters={
                         "left": left.to_string(),
                         "left_dtype": str(left.dtype),
                         "right": right.to_string(),
@@ -235,8 +235,8 @@ def _assert_pandas_almost_equal(
         for lval, rval in zip(left.dropna(), right.dropna()):
             if not compare_vals_approx(lval, rval):
                 raise PySparkAssertionError(
-                    error_class="DIFFERENT_PANDAS_SERIES",
-                    message_parameters={
+                    errorClass="DIFFERENT_PANDAS_SERIES",
+                    messageParameters={
                         "left": left.to_string(),
                         "left_dtype": str(left.dtype),
                         "right": right.to_string(),
@@ -246,8 +246,8 @@ def _assert_pandas_almost_equal(
     elif isinstance(left, pd.MultiIndex) and isinstance(right, pd.MultiIndex):
         if len(left) != len(right):
             raise PySparkAssertionError(
-                error_class="DIFFERENT_PANDAS_MULTIINDEX",
-                message_parameters={
+                errorClass="DIFFERENT_PANDAS_MULTIINDEX",
+                messageParameters={
                     "left": left,
                     "left_dtype": str(left.dtype),
                     "right": right,
@@ -257,8 +257,8 @@ def _assert_pandas_almost_equal(
         for lval, rval in zip(left, right):
             if not compare_vals_approx(lval, rval):
                 raise PySparkAssertionError(
-                    error_class="DIFFERENT_PANDAS_MULTIINDEX",
-                    message_parameters={
+                    errorClass="DIFFERENT_PANDAS_MULTIINDEX",
+                    messageParameters={
                         "left": left,
                         "left_dtype": str(left.dtype),
                         "right": right,
@@ -268,8 +268,8 @@ def _assert_pandas_almost_equal(
     elif isinstance(left, pd.Index) and isinstance(right, pd.Index):
         if len(left) != len(right):
             raise PySparkAssertionError(
-                error_class="DIFFERENT_PANDAS_INDEX",
-                message_parameters={
+                errorClass="DIFFERENT_PANDAS_INDEX",
+                messageParameters={
                     "left": left,
                     "left_dtype": str(left.dtype),
                     "right": right,
@@ -279,8 +279,8 @@ def _assert_pandas_almost_equal(
         for lnull, rnull in zip(left.isnull(), right.isnull()):
             if lnull != rnull:
                 raise PySparkAssertionError(
-                    error_class="DIFFERENT_PANDAS_INDEX",
-                    message_parameters={
+                    errorClass="DIFFERENT_PANDAS_INDEX",
+                    messageParameters={
                         "left": left,
                         "left_dtype": str(left.dtype),
                         "right": right,
@@ -290,8 +290,8 @@ def _assert_pandas_almost_equal(
         for lval, rval in zip(left.dropna(), right.dropna()):
             if not compare_vals_approx(lval, rval):
                 raise PySparkAssertionError(
-                    error_class="DIFFERENT_PANDAS_INDEX",
-                    message_parameters={
+                    errorClass="DIFFERENT_PANDAS_INDEX",
+                    messageParameters={
                         "left": left,
                         "left_dtype": str(left.dtype),
                         "right": right,
@@ -301,8 +301,8 @@ def _assert_pandas_almost_equal(
     else:
         if not isinstance(left, (pd.DataFrame, pd.Series, pd.Index)):
             raise PySparkAssertionError(
-                error_class="INVALID_TYPE_DF_EQUALITY_ARG",
-                message_parameters={
+                errorClass="INVALID_TYPE_DF_EQUALITY_ARG",
+                messageParameters={
                     "expected_type": f"{pd.DataFrame.__name__}, "
                     f"{pd.Series.__name__}, "
                     f"{pd.Index.__name__}, ",
@@ -312,8 +312,8 @@ def _assert_pandas_almost_equal(
             )
         elif not isinstance(right, (pd.DataFrame, pd.Series, pd.Index)):
             raise PySparkAssertionError(
-                error_class="INVALID_TYPE_DF_EQUALITY_ARG",
-                message_parameters={
+                errorClass="INVALID_TYPE_DF_EQUALITY_ARG",
+                messageParameters={
                     "expected_type": f"{pd.DataFrame.__name__}, "
                     f"{pd.Series.__name__}, "
                     f"{pd.Index.__name__}, ",
@@ -424,8 +424,8 @@ class PandasOnSparkTestUtils:
 
             if not isinstance(left, (DataFrame, Series, Index)):
                 raise PySparkAssertionError(
-                    error_class="INVALID_TYPE_DF_EQUALITY_ARG",
-                    message_parameters={
+                    errorClass="INVALID_TYPE_DF_EQUALITY_ARG",
+                    messageParameters={
                         "expected_type": f"{DataFrame.__name__}, {Series.__name__}, "
                         f"{Index.__name__}",
                         "arg_name": "actual",
@@ -436,8 +436,8 @@ class PandasOnSparkTestUtils:
                 right, (DataFrame, pd.DataFrame, Series, pd.Series, Index, pd.Index)
             ):
                 raise PySparkAssertionError(
-                    error_class="INVALID_TYPE_DF_EQUALITY_ARG",
-                    message_parameters={
+                    errorClass="INVALID_TYPE_DF_EQUALITY_ARG",
+                    messageParameters={
                         "expected_type": f"{DataFrame.__name__}, "
                         f"{pd.DataFrame.__name__}, "
                         f"{Series.__name__}, "

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -284,8 +284,8 @@ class PySparkErrorTestUtils:
     def check_error(
         self,
         exception: PySparkException,
-        error_class: str,
-        message_parameters: Optional[Dict[str, str]] = None,
+        errorClass: str,
+        messageParameters: Optional[Dict[str, str]] = None,
         query_context_type: Optional[QueryContextType] = None,
         fragment: Optional[str] = None,
     ):
@@ -302,14 +302,14 @@ class PySparkErrorTestUtils:
         )
 
         # Test error class
-        expected = error_class
+        expected = errorClass
         actual = exception.getErrorClass()
         self.assertEqual(
             expected, actual, f"Expected error class was '{expected}', got '{actual}'."
         )
 
         # Test message parameters
-        expected = message_parameters
+        expected = messageParameters
         actual = exception.getMessageParameters()
         self.assertEqual(
             expected, actual, f"Expected message parameters was '{expected}', got '{actual}'"
@@ -443,13 +443,13 @@ def assertSchemaEqual(
     """
     if not isinstance(actual, StructType):
         raise PySparkAssertionError(
-            error_class="UNSUPPORTED_DATA_TYPE",
-            message_parameters={"data_type": type(actual)},
+            errorClass="UNSUPPORTED_DATA_TYPE",
+            messageParameters={"data_type": type(actual)},
         )
     if not isinstance(expected, StructType):
         raise PySparkAssertionError(
-            error_class="UNSUPPORTED_DATA_TYPE",
-            message_parameters={"data_type": type(expected)},
+            errorClass="UNSUPPORTED_DATA_TYPE",
+            messageParameters={"data_type": type(expected)},
         )
 
     def compare_schemas_ignore_nullable(s1: StructType, s2: StructType):
@@ -504,8 +504,8 @@ def assertSchemaEqual(
         generated_diff = difflib.ndiff(str(actual).splitlines(), str(expected).splitlines())
         error_msg = "\n".join(generated_diff)
         raise PySparkAssertionError(
-            error_class="DIFFERENT_SCHEMA",
-            message_parameters={"error_msg": error_msg},
+            errorClass="DIFFERENT_SCHEMA",
+            messageParameters={"error_msg": error_msg},
         )
 
 
@@ -778,8 +778,8 @@ def assertDataFrameEqual(
         return True
     elif actual is None:
         raise PySparkAssertionError(
-            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
-            message_parameters={
+            errorClass="INVALID_TYPE_DF_EQUALITY_ARG",
+            messageParameters={
                 "expected_type": "Union[DataFrame, ps.DataFrame, List[Row]]",
                 "arg_name": "actual",
                 "actual_type": None,
@@ -787,8 +787,8 @@ def assertDataFrameEqual(
         )
     elif expected is None:
         raise PySparkAssertionError(
-            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
-            message_parameters={
+            errorClass="INVALID_TYPE_DF_EQUALITY_ARG",
+            messageParameters={
                 "expected_type": "Union[DataFrame, ps.DataFrame, List[Row]]",
                 "arg_name": "expected",
                 "actual_type": None,
@@ -831,8 +831,8 @@ def assertDataFrameEqual(
 
     if not isinstance(actual, (DataFrame, list)):
         raise PySparkAssertionError(
-            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
-            message_parameters={
+            errorClass="INVALID_TYPE_DF_EQUALITY_ARG",
+            messageParameters={
                 "expected_type": "Union[DataFrame, ps.DataFrame, List[Row]]",
                 "arg_name": "actual",
                 "actual_type": type(actual),
@@ -840,8 +840,8 @@ def assertDataFrameEqual(
         )
     elif not isinstance(expected, (DataFrame, list)):
         raise PySparkAssertionError(
-            error_class="INVALID_TYPE_DF_EQUALITY_ARG",
-            message_parameters={
+            errorClass="INVALID_TYPE_DF_EQUALITY_ARG",
+            messageParameters={
                 "expected_type": "Union[DataFrame, ps.DataFrame, List[Row]]",
                 "arg_name": "expected",
                 "actual_type": type(expected),
@@ -948,7 +948,7 @@ def assertDataFrameEqual(
             error_msg += "\n" + "\n".join(generated_diff)
             data = diff_rows if includeDiffRows else None
             raise PySparkAssertionError(
-                error_class="DIFFERENT_ROWS", message_parameters={"error_msg": error_msg}, data=data
+                errorClass="DIFFERENT_ROWS", messageParameters={"error_msg": error_msg}, data=data
             )
 
     # only compare schema if expected is not a List
@@ -962,15 +962,15 @@ def assertDataFrameEqual(
             error_msg = "\n".join(generated_diff)
 
             raise PySparkAssertionError(
-                error_class="DIFFERENT_SCHEMA",
-                message_parameters={"error_msg": error_msg},
+                errorClass="DIFFERENT_SCHEMA",
+                messageParameters={"error_msg": error_msg},
             )
 
     if not isinstance(actual, list):
         if actual.isStreaming:
             raise PySparkAssertionError(
-                error_class="UNSUPPORTED_OPERATION",
-                message_parameters={"operation": "assertDataFrameEqual on streaming DataFrame"},
+                errorClass="UNSUPPORTED_OPERATION",
+                messageParameters={"operation": "assertDataFrameEqual on streaming DataFrame"},
             )
         actual_list = actual.collect()
     else:
@@ -979,8 +979,8 @@ def assertDataFrameEqual(
     if not isinstance(expected, list):
         if expected.isStreaming:
             raise PySparkAssertionError(
-                error_class="UNSUPPORTED_OPERATION",
-                message_parameters={"operation": "assertDataFrameEqual on streaming DataFrame"},
+                errorClass="UNSUPPORTED_OPERATION",
+                messageParameters={"operation": "assertDataFrameEqual on streaming DataFrame"},
             )
         expected_list = expected.collect()
     else:

--- a/python/pyspark/tests/test_profiler.py
+++ b/python/pyspark/tests/test_profiler.py
@@ -96,16 +96,16 @@ class ProfilerTests2(unittest.TestCase, PySparkErrorTestUtils):
                 sc.show_profiles()
             self.check_error(
                 exception=pe.exception,
-                error_class="INCORRECT_CONF_FOR_PROFILE",
-                message_parameters={},
+                errorClass="INCORRECT_CONF_FOR_PROFILE",
+                messageParameters={},
             )
 
             with self.assertRaises(PySparkRuntimeError) as pe:
                 sc.dump_profiles("/tmp/abc")
             self.check_error(
                 exception=pe.exception,
-                error_class="INCORRECT_CONF_FOR_PROFILE",
-                message_parameters={},
+                errorClass="INCORRECT_CONF_FOR_PROFILE",
+                messageParameters={},
             )
         finally:
             sc.stop()
@@ -128,8 +128,8 @@ class ProfilerTests2(unittest.TestCase, PySparkErrorTestUtils):
 
             self.check_error(
                 exception=pe.exception,
-                error_class="CANNOT_SET_TOGETHER",
-                message_parameters={
+                errorClass="CANNOT_SET_TOGETHER",
+                messageParameters={
                     "arg_list": "'spark.python.profile' and "
                     "'spark.python.profile.memory' configuration"
                 },

--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -144,8 +144,8 @@ def fail_on_stopiteration(f: Callable) -> Callable:
             return f(*args, **kwargs)
         except StopIteration as exc:
             raise PySparkRuntimeError(
-                error_class="STOP_ITERATION_OCCURRED",
-                message_parameters={
+                errorClass="STOP_ITERATION_OCCURRED",
+                messageParameters={
                     "exc": str(exc),
                 },
             )
@@ -721,8 +721,8 @@ def local_connect_and_auth(port: Optional[Union[str, int]], auth_secret: str) ->
                 sock.close()
                 sock = None
     raise PySparkRuntimeError(
-        error_class="CANNOT_OPEN_SOCKET",
-        message_parameters={
+        errorClass="CANNOT_OPEN_SOCKET",
+        messageParameters={
             "errors": str(errors),
         },
     )
@@ -739,8 +739,8 @@ def _do_server_auth(conn: "io.IOBase", auth_secret: str) -> None:
     if reply != "ok":
         conn.close()
         raise PySparkRuntimeError(
-            error_class="UNEXPECTED_RESPONSE_FROM_SERVER",
-            message_parameters={},
+            errorClass="UNEXPECTED_RESPONSE_FROM_SERVER",
+            messageParameters={},
         )
 
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -121,8 +121,8 @@ def wrap_scalar_pandas_udf(f, args_offsets, kwargs_offsets, return_type):
         if not hasattr(result, "__len__"):
             pd_type = "pandas.DataFrame" if type(return_type) == StructType else "pandas.Series"
             raise PySparkTypeError(
-                error_class="UDF_RETURN_TYPE",
-                message_parameters={
+                errorClass="UDF_RETURN_TYPE",
+                messageParameters={
                     "expected": pd_type,
                     "actual": type(result).__name__,
                 },
@@ -132,8 +132,8 @@ def wrap_scalar_pandas_udf(f, args_offsets, kwargs_offsets, return_type):
     def verify_result_length(result, length):
         if len(result) != length:
             raise PySparkRuntimeError(
-                error_class="SCHEMA_MISMATCH_FOR_PANDAS_UDF",
-                message_parameters={
+                errorClass="SCHEMA_MISMATCH_FOR_PANDAS_UDF",
+                messageParameters={
                     "expected": str(length),
                     "actual": str(len(result)),
                 },
@@ -174,8 +174,8 @@ def wrap_arrow_batch_udf(f, args_offsets, kwargs_offsets, return_type):
     def verify_result_length(result, length):
         if len(result) != length:
             raise PySparkRuntimeError(
-                error_class="SCHEMA_MISMATCH_FOR_PANDAS_UDF",
-                message_parameters={
+                errorClass="SCHEMA_MISMATCH_FOR_PANDAS_UDF",
+                messageParameters={
                     "expected": str(length),
                     "actual": str(len(result)),
                 },
@@ -195,8 +195,8 @@ def wrap_pandas_batch_iter_udf(f, return_type):
     def verify_result(result):
         if not isinstance(result, Iterator) and not hasattr(result, "__iter__"):
             raise PySparkTypeError(
-                error_class="UDF_RETURN_TYPE",
-                message_parameters={
+                errorClass="UDF_RETURN_TYPE",
+                messageParameters={
                     "expected": "iterator of {}".format(iter_type_label),
                     "actual": type(result).__name__,
                 },
@@ -208,8 +208,8 @@ def wrap_pandas_batch_iter_udf(f, return_type):
 
         if not isinstance(elem, pd.DataFrame if type(return_type) == StructType else pd.Series):
             raise PySparkTypeError(
-                error_class="UDF_RETURN_TYPE",
-                message_parameters={
+                errorClass="UDF_RETURN_TYPE",
+                messageParameters={
                     "expected": "iterator of {}".format(iter_type_label),
                     "actual": "iterator of {}".format(type(elem).__name__),
                 },
@@ -232,8 +232,8 @@ def verify_pandas_result(result, return_type, assign_cols_by_name, truncate_retu
     if type(return_type) == StructType:
         if not isinstance(result, pd.DataFrame):
             raise PySparkTypeError(
-                error_class="UDF_RETURN_TYPE",
-                message_parameters={
+                errorClass="UDF_RETURN_TYPE",
+                messageParameters={
                     "expected": "pandas.DataFrame",
                     "actual": type(result).__name__,
                 },
@@ -263,8 +263,8 @@ def verify_pandas_result(result, return_type, assign_cols_by_name, truncate_retu
                 extra = f" Unexpected: {', '.join(extra)}." if extra else ""
 
                 raise PySparkRuntimeError(
-                    error_class="RESULT_COLUMNS_MISMATCH_FOR_PANDAS_UDF",
-                    message_parameters={
+                    errorClass="RESULT_COLUMNS_MISMATCH_FOR_PANDAS_UDF",
+                    messageParameters={
                         "missing": missing,
                         "extra": extra,
                     },
@@ -272,8 +272,8 @@ def verify_pandas_result(result, return_type, assign_cols_by_name, truncate_retu
             # otherwise the number of columns of result have to match the return type
             elif len(result_columns) != len(return_type):
                 raise PySparkRuntimeError(
-                    error_class="RESULT_LENGTH_MISMATCH_FOR_PANDAS_UDF",
-                    message_parameters={
+                    errorClass="RESULT_LENGTH_MISMATCH_FOR_PANDAS_UDF",
+                    messageParameters={
                         "expected": str(len(return_type)),
                         "actual": str(len(result.columns)),
                     },
@@ -281,8 +281,8 @@ def verify_pandas_result(result, return_type, assign_cols_by_name, truncate_retu
     else:
         if not isinstance(result, pd.Series):
             raise PySparkTypeError(
-                error_class="UDF_RETURN_TYPE",
-                message_parameters={"expected": "pandas.Series", "actual": type(result).__name__},
+                errorClass="UDF_RETURN_TYPE",
+                messageParameters={"expected": "pandas.Series", "actual": type(result).__name__},
             )
 
 
@@ -292,8 +292,8 @@ def wrap_arrow_batch_iter_udf(f, return_type):
     def verify_result(result):
         if not isinstance(result, Iterator) and not hasattr(result, "__iter__"):
             raise PySparkTypeError(
-                error_class="UDF_RETURN_TYPE",
-                message_parameters={
+                errorClass="UDF_RETURN_TYPE",
+                messageParameters={
                     "expected": "iterator of pyarrow.RecordBatch",
                     "actual": type(result).__name__,
                 },
@@ -305,8 +305,8 @@ def wrap_arrow_batch_iter_udf(f, return_type):
 
         if not isinstance(elem, pa.RecordBatch):
             raise PySparkTypeError(
-                error_class="UDF_RETURN_TYPE",
-                message_parameters={
+                errorClass="UDF_RETURN_TYPE",
+                messageParameters={
                     "expected": "iterator of pyarrow.RecordBatch",
                     "actual": "iterator of {}".format(type(elem).__name__),
                 },
@@ -375,8 +375,8 @@ def verify_arrow_result(table, assign_cols_by_name, expected_cols_and_types):
 
     if not isinstance(table, pa.Table):
         raise PySparkTypeError(
-            error_class="UDF_RETURN_TYPE",
-            message_parameters={
+            errorClass="UDF_RETURN_TYPE",
+            messageParameters={
                 "expected": "pyarrow.Table",
                 "actual": type(table).__name__,
             },
@@ -402,8 +402,8 @@ def verify_arrow_result(table, assign_cols_by_name, expected_cols_and_types):
                 extra = f" Unexpected: {', '.join(extra)}." if extra else ""
 
                 raise PySparkRuntimeError(
-                    error_class="RESULT_COLUMNS_MISMATCH_FOR_ARROW_UDF",
-                    message_parameters={
+                    errorClass="RESULT_COLUMNS_MISMATCH_FOR_ARROW_UDF",
+                    messageParameters={
                         "missing": missing,
                         "extra": extra,
                     },
@@ -432,8 +432,8 @@ def verify_arrow_result(table, assign_cols_by_name, expected_cols_and_types):
 
         if type_mismatch:
             raise PySparkRuntimeError(
-                error_class="RESULT_TYPE_MISMATCH_FOR_ARROW_UDF",
-                message_parameters={
+                errorClass="RESULT_TYPE_MISMATCH_FOR_ARROW_UDF",
+                messageParameters={
                     "mismatch": ", ".join(
                         "column '{}' (expected {}, actual {})".format(name, expected, actual)
                         for name, expected, actual in type_mismatch
@@ -531,8 +531,8 @@ def wrap_grouped_map_pandas_udf_with_state(f, return_type):
         def verify_element(result):
             if not isinstance(result, pd.DataFrame):
                 raise PySparkTypeError(
-                    error_class="UDF_RETURN_TYPE",
-                    message_parameters={
+                    errorClass="UDF_RETURN_TYPE",
+                    messageParameters={
                         "expected": "iterator of pandas.DataFrame",
                         "actual": "iterator of {}".format(type(result).__name__),
                     },
@@ -544,8 +544,8 @@ def wrap_grouped_map_pandas_udf_with_state(f, return_type):
                 or (len(result.columns) == 0 and result.empty)
             ):
                 raise PySparkRuntimeError(
-                    error_class="RESULT_LENGTH_MISMATCH_FOR_PANDAS_UDF",
-                    message_parameters={
+                    errorClass="RESULT_LENGTH_MISMATCH_FOR_PANDAS_UDF",
+                    messageParameters={
                         "expected": str(len(return_type)),
                         "actual": str(len(result.columns)),
                     },
@@ -555,8 +555,8 @@ def wrap_grouped_map_pandas_udf_with_state(f, return_type):
 
         if isinstance(result_iter, pd.DataFrame):
             raise PySparkTypeError(
-                error_class="UDF_RETURN_TYPE",
-                message_parameters={
+                errorClass="UDF_RETURN_TYPE",
+                messageParameters={
                     "expected": "iterable of pandas.DataFrame",
                     "actual": type(result_iter).__name__,
                 },
@@ -566,8 +566,8 @@ def wrap_grouped_map_pandas_udf_with_state(f, return_type):
             iter(result_iter)
         except TypeError:
             raise PySparkTypeError(
-                error_class="UDF_RETURN_TYPE",
-                message_parameters={"expected": "iterable", "actual": type(result_iter).__name__},
+                errorClass="UDF_RETURN_TYPE",
+                messageParameters={"expected": "iterable", "actual": type(result_iter).__name__},
             )
 
         result_iter_with_validation = (verify_element(x) for x in result_iter)
@@ -608,8 +608,8 @@ def wrap_window_agg_pandas_udf(
         return wrap_unbounded_window_agg_pandas_udf(f, args_offsets, kwargs_offsets, return_type)
     else:
         raise PySparkRuntimeError(
-            error_class="INVALID_WINDOW_BOUND_TYPE",
-            message_parameters={
+            errorClass="INVALID_WINDOW_BOUND_TYPE",
+            messageParameters={
                 "window_bound_type": window_bound_type,
             },
         )
@@ -931,8 +931,8 @@ def read_udtf(pickleSer, infile, eval_type):
     if has_pickled_analyze_result:
         if len(udtf_init_args.args) > 2:
             raise PySparkRuntimeError(
-                error_class="UDTF_CONSTRUCTOR_INVALID_IMPLEMENTS_ANALYZE_METHOD",
-                message_parameters={"name": udtf_name},
+                errorClass="UDTF_CONSTRUCTOR_INVALID_IMPLEMENTS_ANALYZE_METHOD",
+                messageParameters={"name": udtf_name},
             )
         elif len(udtf_init_args.args) == 2:
             prev_handler = handler
@@ -944,8 +944,8 @@ def read_udtf(pickleSer, infile, eval_type):
             handler = construct_udtf
     elif len(udtf_init_args.args) > 1:
         raise PySparkRuntimeError(
-            error_class="UDTF_CONSTRUCTOR_INVALID_NO_ANALYZE_METHOD",
-            message_parameters={"name": udtf_name},
+            errorClass="UDTF_CONSTRUCTOR_INVALID_NO_ANALYZE_METHOD",
+            messageParameters={"name": udtf_name},
         )
 
     class UDTFWithPartitions:
@@ -1062,8 +1062,8 @@ def read_udtf(pickleSer, infile, eval_type):
             udtf = handler()
     except Exception as e:
         raise PySparkRuntimeError(
-            error_class="UDTF_EXEC_ERROR",
-            message_parameters={"method_name": "__init__", "error": str(e)},
+            errorClass="UDTF_EXEC_ERROR",
+            messageParameters={"method_name": "__init__", "error": str(e)},
         )
 
     # Validate the UDTF
@@ -1080,15 +1080,15 @@ def read_udtf(pickleSer, infile, eval_type):
         inspect.signature(udtf.eval).bind(*args_offsets, **kwargs_offsets)
     except TypeError as e:
         raise PySparkRuntimeError(
-            error_class="UDTF_EVAL_METHOD_ARGUMENTS_DO_NOT_MATCH_SIGNATURE",
-            message_parameters={"name": udtf_name, "reason": str(e)},
+            errorClass="UDTF_EVAL_METHOD_ARGUMENTS_DO_NOT_MATCH_SIGNATURE",
+            messageParameters={"name": udtf_name, "reason": str(e)},
         ) from None
 
     def build_null_checker(return_type: StructType) -> Optional[Callable[[Any], None]]:
         def raise_(result_column_index):
             raise PySparkRuntimeError(
-                error_class="UDTF_EXEC_ERROR",
-                message_parameters={
+                errorClass="UDTF_EXEC_ERROR",
+                messageParameters={
                     "method_name": "eval' or 'terminate",
                     "error": f"Column {result_column_index} within a returned row had a "
                     + "value of None, either directly or within array/struct/map "
@@ -1202,8 +1202,8 @@ def read_udtf(pickleSer, infile, eval_type):
             def verify_result(result):
                 if not isinstance(result, pd.DataFrame):
                     raise PySparkTypeError(
-                        error_class="INVALID_ARROW_UDTF_RETURN_TYPE",
-                        message_parameters={
+                        errorClass="INVALID_ARROW_UDTF_RETURN_TYPE",
+                        messageParameters={
                             "return_type": type(result).__name__,
                             "value": str(result),
                             "func": f.__name__,
@@ -1217,8 +1217,8 @@ def read_udtf(pickleSer, infile, eval_type):
                 if len(result) > 0 or len(result.columns) > 0:
                     if len(result.columns) != return_type_size:
                         raise PySparkRuntimeError(
-                            error_class="UDTF_RETURN_SCHEMA_MISMATCH",
-                            message_parameters={
+                            errorClass="UDTF_RETURN_SCHEMA_MISMATCH",
+                            messageParameters={
                                 "expected": str(return_type_size),
                                 "actual": str(len(result.columns)),
                                 "func": f.__name__,
@@ -1239,8 +1239,8 @@ def read_udtf(pickleSer, infile, eval_type):
                     raise
                 except Exception as e:
                     raise PySparkRuntimeError(
-                        error_class="UDTF_EXEC_ERROR",
-                        message_parameters={"method_name": f.__name__, "error": str(e)},
+                        errorClass="UDTF_EXEC_ERROR",
+                        messageParameters={"method_name": f.__name__, "error": str(e)},
                     )
 
             def check_return_value(res):
@@ -1249,8 +1249,8 @@ def read_udtf(pickleSer, infile, eval_type):
                 if res is not None:
                     if not isinstance(res, Iterable):
                         raise PySparkRuntimeError(
-                            error_class="UDTF_RETURN_NOT_ITERABLE",
-                            message_parameters={
+                            errorClass="UDTF_RETURN_NOT_ITERABLE",
+                            messageParameters={
                                 "type": type(res).__name__,
                                 "func": f.__name__,
                             },
@@ -1319,8 +1319,8 @@ def read_udtf(pickleSer, infile, eval_type):
                 if result is not None:
                     if hasattr(result, "__len__") and len(result) != return_type_size:
                         raise PySparkRuntimeError(
-                            error_class="UDTF_RETURN_SCHEMA_MISMATCH",
-                            message_parameters={
+                            errorClass="UDTF_RETURN_SCHEMA_MISMATCH",
+                            messageParameters={
                                 "expected": str(return_type_size),
                                 "actual": str(len(result)),
                                 "func": f.__name__,
@@ -1329,8 +1329,8 @@ def read_udtf(pickleSer, infile, eval_type):
 
                     if not (isinstance(result, (list, dict, tuple)) or hasattr(result, "__dict__")):
                         raise PySparkRuntimeError(
-                            error_class="UDTF_INVALID_OUTPUT_ROW_TYPE",
-                            message_parameters={
+                            errorClass="UDTF_INVALID_OUTPUT_ROW_TYPE",
+                            messageParameters={
                                 "type": type(result).__name__,
                                 "func": f.__name__,
                             },
@@ -1347,8 +1347,8 @@ def read_udtf(pickleSer, infile, eval_type):
                     raise
                 except Exception as e:
                     raise PySparkRuntimeError(
-                        error_class="UDTF_EXEC_ERROR",
-                        message_parameters={"method_name": f.__name__, "error": str(e)},
+                        errorClass="UDTF_EXEC_ERROR",
+                        messageParameters={"method_name": f.__name__, "error": str(e)},
                     )
 
                 if res is None:
@@ -1359,8 +1359,8 @@ def read_udtf(pickleSer, infile, eval_type):
 
                 if not isinstance(res, Iterable):
                     raise PySparkRuntimeError(
-                        error_class="UDTF_RETURN_NOT_ITERABLE",
-                        message_parameters={
+                        errorClass="UDTF_RETURN_NOT_ITERABLE",
+                        messageParameters={
                             "type": type(res).__name__,
                             "func": f.__name__,
                         },
@@ -1545,14 +1545,14 @@ def read_udfs(pickleSer, infile, eval_type):
                     pass
                 else:
                     raise PySparkRuntimeError(
-                        error_class="STOP_ITERATION_OCCURRED_FROM_SCALAR_ITER_PANDAS_UDF",
-                        message_parameters={},
+                        errorClass="STOP_ITERATION_OCCURRED_FROM_SCALAR_ITER_PANDAS_UDF",
+                        messageParameters={},
                     )
 
                 if num_output_rows != num_input_rows:
                     raise PySparkRuntimeError(
-                        error_class="RESULT_LENGTH_MISMATCH_FOR_SCALAR_ITER_PANDAS_UDF",
-                        message_parameters={
+                        errorClass="RESULT_LENGTH_MISMATCH_FOR_SCALAR_ITER_PANDAS_UDF",
+                        messageParameters={
                             "output_length": str(num_output_rows),
                             "input_length": str(num_input_rows),
                         },

--- a/python/pyspark/worker_util.py
+++ b/python/pyspark/worker_util.py
@@ -75,8 +75,8 @@ def check_python_version(infile: IO) -> None:
     worker_version = "%d.%d" % sys.version_info[:2]
     if version != worker_version:
         raise PySparkRuntimeError(
-            error_class="PYTHON_VERSION_MISMATCH",
-            message_parameters={
+            errorClass="PYTHON_VERSION_MISMATCH",
+            messageParameters={
                 "worker_version": worker_version,
                 "driver_version": str(version),
             },


### PR DESCRIPTION

### What changes were proposed in this pull request?

This PR proposes to make the parameter naming of `PySparkException` consistent with JVM

### Why are the changes needed?

The parameter names of `PySparkException` are different from `SparkException` so there is an inconsistency when searching those parameters from error logs.

SparkException:
https://github.com/apache/spark/blob/6508b1f5e18731359354af0a7bcc1382bc4f356b/common/utils/src/main/scala/org/apache/spark/SparkException.scala#L27-L33

PySparkException:
https://github.com/apache/spark/blob/6508b1f5e18731359354af0a7bcc1382bc4f356b/python/pyspark/errors/exceptions/base.py#L29-L40

### Does this PR introduce _any_ user-facing change?

The error parameter names are changed from:
- `error_class` -> `errorClass`
- `message_parameters` -> `messageParameters`
- `query_contexts` -> `context`

### How was this patch tested?

The existing CI should pass

### Was this patch authored or co-authored using generative AI tooling?

No.