### PR TITLE
[SPARK-48752][FOLLOWUP][PYTHON][DOCS] Use explicit name for line number in log

### DIFF
--- a/python/docs/source/development/logger.rst
+++ b/python/docs/source/development/logger.rst
@@ -50,7 +50,7 @@ Example log entry:
       "msg": "[DIVIDE_BY_ZERO] Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set \"spark.sql.ansi.enabled\" to \"false\" to bypass this error. SQLSTATE: 22012\n== DataFrame ==\n\"divide\" was called from\n/.../spark/python/test_error_context.py:17\n",
       "context": {
         "file": "/path/to/file.py",
-        "line_no": "17",
+        "line_number": "17",
         "fragment": "divide"
         "error_class": "DIVIDE_BY_ZERO"
       },

--- a/python/docs/source/development/logger.rst
+++ b/python/docs/source/development/logger.rst
@@ -50,7 +50,7 @@ Example log entry:
       "msg": "[DIVIDE_BY_ZERO] Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead. If necessary set \"spark.sql.ansi.enabled\" to \"false\" to bypass this error. SQLSTATE: 22012\n== DataFrame ==\n\"divide\" was called from\n/.../spark/python/test_error_context.py:17\n",
       "context": {
         "file": "/path/to/file.py",
-        "line_number": "17",
+        "line": "17",
         "fragment": "divide"
         "error_class": "DIVIDE_BY_ZERO"
       },

--- a/python/pyspark/errors/exceptions/base.py
+++ b/python/pyspark/errors/exceptions/base.py
@@ -137,11 +137,11 @@ class PySparkException(Exception):
             if query_context.contextType().name == "DataFrame":
                 logger = PySparkLogger.getLogger("DataFrameQueryContextLogger")
                 call_site = query_context.callSite().split(":")
-                line_no = call_site[1] if len(call_site) == 2 else ""
+                line_number = call_site[1] if len(call_site) == 2 else ""
                 logger.exception(
                     self.getMessage(),
                     file=call_site[0],
-                    line_no=line_no,
+                    line_number=line_number,
                     fragment=query_context.fragment(),
                     error_class=self.getErrorClass(),
                 )

--- a/python/pyspark/errors/exceptions/base.py
+++ b/python/pyspark/errors/exceptions/base.py
@@ -137,11 +137,11 @@ class PySparkException(Exception):
             if query_context.contextType().name == "DataFrame":
                 logger = PySparkLogger.getLogger("DataFrameQueryContextLogger")
                 call_site = query_context.callSite().split(":")
-                line_number = call_site[1] if len(call_site) == 2 else ""
+                line = call_site[1] if len(call_site) == 2 else ""
                 logger.exception(
                     self.getMessage(),
                     file=call_site[0],
-                    line_number=line_number,
+                    line=line,
                     fragment=query_context.fragment(),
                     error_class=self.getErrorClass(),
                 )


### PR DESCRIPTION

### What changes were proposed in this pull request?

This PR followups for https://github.com/apache/spark/pull/47145 to rename the log field naming

### Why are the changes needed?

`line_no` is not very intuitive so we better renaming to `line_number` explicitly.


### Does this PR introduce _any_ user-facing change?

No API change, but user-facing log message will be improved


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
The existing CI should pass


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
