### PR TITLE
[SPARK-48346][SQL] Support for IF ELSE statements in SQL scripts

### DIFF
--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -75,7 +75,7 @@ setStatementWithOptionalVarKeyword
 ifElseStatement
     : IF booleanExpression THEN conditionalBodies+=compoundBody
         (ELSE IF booleanExpression THEN conditionalBodies+=compoundBody)*
-        (ELSE unconditionalBody=compoundBody)? END IF
+        (ELSE elseBody=compoundBody)? END IF
     ;
 
 singleStatement

--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -73,9 +73,9 @@ setStatementWithOptionalVarKeyword
     ;
 
 ifElseStatement
-    : IF booleanExpression THEN compoundBody
-        (ELSE IF booleanExpression THEN compoundBody)*
-        (ELSE compoundBody)? END IF
+    : IF booleanExpression THEN conditionalBodies+=compoundBody
+        (ELSE IF booleanExpression THEN conditionalBodies+=compoundBody)*
+        (ELSE unconditionalBody=compoundBody)? END IF
     ;
 
 singleStatement

--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -63,12 +63,19 @@ compoundStatement
     : statement
     | setStatementWithOptionalVarKeyword
     | beginEndCompoundBlock
+    | ifElseStatement
     ;
 
 setStatementWithOptionalVarKeyword
     : SET variable? assignmentList                              #setVariableWithOptionalKeyword
     | SET variable? LEFT_PAREN multipartIdentifierList RIGHT_PAREN EQ
         LEFT_PAREN query RIGHT_PAREN                            #setVariableWithOptionalKeyword
+    ;
+
+ifElseStatement
+    : IF booleanExpression THEN compoundBody
+        (ELSE IF booleanExpression THEN compoundBody)*
+        (ELSE compoundBody)? END IF
     ;
 
 singleStatement

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -218,7 +218,7 @@ class AstBuilder extends DataTypeAstBuilder
             OneRowRelation()))
       }),
       conditionalBodies = ctx.conditionalBodies.asScala.toList.map(body => visitCompoundBody(body)),
-      unconditionalBody = Option(ctx.unconditionalBody).map(body => visitCompoundBody(body))
+      elseBody = Option(ctx.elseBody).map(body => visitCompoundBody(body))
     )
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -209,7 +209,7 @@ class AstBuilder extends DataTypeAstBuilder
         }
     }
 
-  override def visitIfElseStatement(ctx: IfElseStatementContext): IfElseStatement ={
+  override def visitIfElseStatement(ctx: IfElseStatementContext): IfElseStatement = {
     IfElseStatement(
       conditions = ctx.booleanExpression().asScala.toList.map(boolExpr => withOrigin(boolExpr) {
         SingleStatement(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -217,7 +217,8 @@ class AstBuilder extends DataTypeAstBuilder
             Seq(Alias(expression(boolExpr), "condition")()),
             OneRowRelation()))
       }),
-      bodies = ctx.compoundBody().asScala.toList.map(body => visitCompoundBody(body))
+      conditionalBodies = ctx.conditionalBodies.asScala.toList.map(body => visitCompoundBody(body)),
+      unconditionalBody = Option(ctx.unconditionalBody).map(body => visitCompoundBody(body))
     )
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingLogicalOperators.scala
@@ -63,8 +63,14 @@ case class CompoundBody(
  * Logical operator for IF ELSE statement.
  * @param conditions Collection of conditions. First condition corresponds to IF clause,
  *                   while others (if any) correspond to following ELSE IF clauses.
- * @param bodies Collection of bodies.
+ * @param conditionalBodies Collection of bodies that have a corresponding condition,
+ *                          in IF or ELSE IF branches.
+ * @param unconditionalBody Body that is executed if none of the conditions are met,
+ *                          i.e. ELSE branch.
  */
 case class IfElseStatement(
     conditions: Seq[SingleStatement],
-    bodies: Seq[CompoundBody]) extends CompoundPlanStatement
+    conditionalBodies: Seq[CompoundBody],
+    unconditionalBody: Option[CompoundBody]) extends CompoundPlanStatement {
+  assert(conditions.length == conditionalBodies.length)
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingLogicalOperators.scala
@@ -65,12 +65,12 @@ case class CompoundBody(
  *                   while others (if any) correspond to following ELSE IF clauses.
  * @param conditionalBodies Collection of bodies that have a corresponding condition,
  *                          in IF or ELSE IF branches.
- * @param unconditionalBody Body that is executed if none of the conditions are met,
+ * @param elseBody Body that is executed if none of the conditions are met,
  *                          i.e. ELSE branch.
  */
 case class IfElseStatement(
     conditions: Seq[SingleStatement],
     conditionalBodies: Seq[CompoundBody],
-    unconditionalBody: Option[CompoundBody]) extends CompoundPlanStatement {
+    elseBody: Option[CompoundBody]) extends CompoundPlanStatement {
   assert(conditions.length == conditionalBodies.length)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingLogicalOperators.scala
@@ -58,3 +58,13 @@ case class SingleStatement(parsedPlan: LogicalPlan)
 case class CompoundBody(
     collection: Seq[CompoundPlanStatement],
     label: Option[String]) extends CompoundPlanStatement
+
+/**
+ * Logical operator for IF ELSE statement.
+ * @param conditions Collection of conditions. First condition corresponds to IF clause,
+ *                   while others (if any) correspond to following ELSE IF clauses.
+ * @param bodies Collection of bodies.
+ */
+case class IfElseStatement(
+    conditions: Seq[SingleStatement],
+    bodies: Seq[CompoundBody]) extends CompoundPlanStatement

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -348,6 +348,129 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     assert(e.getMessage.contains("Syntax error"))
   }
 
+  test("if") {
+    val sqlScriptText =
+      """
+        |BEGIN
+        | IF 1=1 THEN
+        |   SELECT 42;
+        | END IF;
+        |END
+        |""".stripMargin
+    val tree = parseScript(sqlScriptText)
+    assert(tree.collection.length == 1)
+    assert(tree.collection.head.isInstanceOf[IfElseStatement])
+    val ifStmt = tree.collection.head.asInstanceOf[IfElseStatement]
+    assert(ifStmt.conditions.length == 1)
+    assert(ifStmt.conditions.head.isInstanceOf[SingleStatement])
+    assert(ifStmt.conditions.head.getText == "1=1")
+  }
+
+  test("if else") {
+    val sqlScriptText =
+      """BEGIN
+        |IF 1 = 1 THEN
+        |  SELECT 1;
+        |ELSE
+        |  SELECT 2;
+        |END IF;
+        |END
+        """.stripMargin
+    val tree = parseScript(sqlScriptText)
+    assert(tree.collection.length == 1)
+    assert(tree.collection.head.isInstanceOf[IfElseStatement])
+
+    val ifStmt = tree.collection.head.asInstanceOf[IfElseStatement]
+    assert(ifStmt.conditions.length == 1)
+    assert(ifStmt.bodies.length == 2)
+
+    assert(ifStmt.conditions.head.isInstanceOf[SingleStatement])
+    assert(ifStmt.conditions.head.getText == "1 = 1")
+
+    assert(ifStmt.bodies.head.collection.length == 1)
+    assert(ifStmt.bodies.head.collection.head.isInstanceOf[SingleStatement])
+    assert(ifStmt.bodies.head.collection.head.asInstanceOf[SingleStatement].getText == "SELECT 1")
+
+    assert(ifStmt.bodies(1).collection.length == 1)
+    assert(ifStmt.bodies(1).collection.head.isInstanceOf[SingleStatement])
+    assert(ifStmt.bodies(1).collection.head.asInstanceOf[SingleStatement].getText == "SELECT 2")
+  }
+
+  test("if else if") {
+    val sqlScriptText =
+      """BEGIN
+        |IF 1 = 1 THEN
+        |  SELECT 1;
+        |ELSE IF 2 = 2 THEN
+        |  SELECT 2;
+        |ELSE
+        |  SELECT 3;
+        |END IF;
+        |END
+      """.stripMargin
+    val tree = parseScript(sqlScriptText)
+    assert(tree.collection.length == 1)
+    assert(tree.collection.head.isInstanceOf[IfElseStatement])
+
+    val ifStmt = tree.collection.head.asInstanceOf[IfElseStatement]
+    assert(ifStmt.conditions.length == 2)
+    assert(ifStmt.bodies.length == 3)
+
+    assert(ifStmt.conditions.head.isInstanceOf[SingleStatement])
+    assert(ifStmt.conditions.head.getText == "1 = 1")
+
+    assert(ifStmt.bodies.head.collection.head.isInstanceOf[SingleStatement])
+    assert(ifStmt.bodies.head.collection.head.asInstanceOf[SingleStatement].getText == "SELECT 1")
+
+    assert(ifStmt.conditions(1).isInstanceOf[SingleStatement])
+    assert(ifStmt.conditions(1).getText == "2 = 2")
+
+    assert(ifStmt.bodies(1).collection.head.isInstanceOf[SingleStatement])
+    assert(ifStmt.bodies(1).collection.head.asInstanceOf[SingleStatement].getText == "SELECT 2")
+
+    assert(ifStmt.bodies(2).collection.head.isInstanceOf[SingleStatement])
+    assert(ifStmt.bodies(2).collection.head.asInstanceOf[SingleStatement].getText == "SELECT 3")
+  }
+
+  test("if multi else if") {
+    val sqlScriptText =
+      """BEGIN
+        |IF 1 = 1 THEN
+        |  SELECT 1;
+        |ELSE IF 2 = 2 THEN
+        |  SELECT 2;
+        |ELSE IF 3 = 3 THEN
+        |  SELECT 3;
+        |END IF;
+        |END
+      """.stripMargin
+    val tree = parseScript(sqlScriptText)
+    assert(tree.collection.length == 1)
+    assert(tree.collection.head.isInstanceOf[IfElseStatement])
+
+    val ifStmt = tree.collection.head.asInstanceOf[IfElseStatement]
+    assert(ifStmt.conditions.length == 3)
+    assert(ifStmt.bodies.length == 3)
+
+    assert(ifStmt.conditions.head.isInstanceOf[SingleStatement])
+    assert(ifStmt.conditions.head.getText == "1 = 1")
+
+    assert(ifStmt.bodies.head.collection.head.isInstanceOf[SingleStatement])
+    assert(ifStmt.bodies.head.collection.head.asInstanceOf[SingleStatement].getText == "SELECT 1")
+
+    assert(ifStmt.conditions(1).isInstanceOf[SingleStatement])
+    assert(ifStmt.conditions(1).getText == "2 = 2")
+
+    assert(ifStmt.bodies(1).collection.head.isInstanceOf[SingleStatement])
+    assert(ifStmt.bodies(1).collection.head.asInstanceOf[SingleStatement].getText == "SELECT 2")
+
+    assert(ifStmt.conditions(2).isInstanceOf[SingleStatement])
+    assert(ifStmt.conditions(2).getText == "3 = 3")
+
+    assert(ifStmt.bodies(2).collection.head.isInstanceOf[SingleStatement])
+    assert(ifStmt.bodies(2).collection.head.asInstanceOf[SingleStatement].getText == "SELECT 3")
+  }
+
   // Helper methods
   def cleanupStatementString(statementStr: String): String = {
     statementStr

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -383,7 +383,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     val ifStmt = tree.collection.head.asInstanceOf[IfElseStatement]
     assert(ifStmt.conditions.length == 1)
     assert(ifStmt.conditionalBodies.length == 1)
-    assert(ifStmt.unconditionalBody.isDefined)
+    assert(ifStmt.elseBody.isDefined)
 
     assert(ifStmt.conditions.head.isInstanceOf[SingleStatement])
     assert(ifStmt.conditions.head.getText == "1 = 1")
@@ -393,9 +393,9 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     assert(ifStmt.conditionalBodies.head.collection.head.asInstanceOf[SingleStatement]
       .getText == "SELECT 1")
 
-    assert(ifStmt.unconditionalBody.get.collection.length == 1)
-    assert(ifStmt.unconditionalBody.get.collection.head.isInstanceOf[SingleStatement])
-    assert(ifStmt.unconditionalBody.get.collection.head.asInstanceOf[SingleStatement]
+    assert(ifStmt.elseBody.get.collection.length == 1)
+    assert(ifStmt.elseBody.get.collection.head.isInstanceOf[SingleStatement])
+    assert(ifStmt.elseBody.get.collection.head.asInstanceOf[SingleStatement]
       .getText == "SELECT 2")
   }
 
@@ -418,7 +418,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     val ifStmt = tree.collection.head.asInstanceOf[IfElseStatement]
     assert(ifStmt.conditions.length == 2)
     assert(ifStmt.conditionalBodies.length == 2)
-    assert(ifStmt.unconditionalBody.isDefined)
+    assert(ifStmt.elseBody.isDefined)
 
     assert(ifStmt.conditions.head.isInstanceOf[SingleStatement])
     assert(ifStmt.conditions.head.getText == "1 = 1")
@@ -434,8 +434,8 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     assert(ifStmt.conditionalBodies(1).collection.head.asInstanceOf[SingleStatement]
       .getText == "SELECT 2")
 
-    assert(ifStmt.unconditionalBody.get.collection.head.isInstanceOf[SingleStatement])
-    assert(ifStmt.unconditionalBody.get.collection.head.asInstanceOf[SingleStatement]
+    assert(ifStmt.elseBody.get.collection.head.isInstanceOf[SingleStatement])
+    assert(ifStmt.elseBody.get.collection.head.asInstanceOf[SingleStatement]
       .getText == "SELECT 3")
   }
 
@@ -458,7 +458,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     val ifStmt = tree.collection.head.asInstanceOf[IfElseStatement]
     assert(ifStmt.conditions.length == 3)
     assert(ifStmt.conditionalBodies.length == 3)
-    assert(ifStmt.unconditionalBody.isEmpty)
+    assert(ifStmt.elseBody.isEmpty)
 
     assert(ifStmt.conditions.head.isInstanceOf[SingleStatement])
     assert(ifStmt.conditions.head.getText == "1 = 1")
@@ -502,7 +502,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     val ifStmt = tree.collection.head.asInstanceOf[IfElseStatement]
     assert(ifStmt.conditions.length == 1)
     assert(ifStmt.conditionalBodies.length == 1)
-    assert(ifStmt.unconditionalBody.isEmpty)
+    assert(ifStmt.elseBody.isEmpty)
 
     assert(ifStmt.conditions.head.isInstanceOf[SingleStatement])
     assert(ifStmt.conditions.head.getText == "1=1")
@@ -512,7 +512,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
 
     assert(nestedIfStmt.conditions.length == 1)
     assert(nestedIfStmt.conditionalBodies.length == 1)
-    assert(nestedIfStmt.unconditionalBody.isDefined)
+    assert(nestedIfStmt.elseBody.isDefined)
 
     assert(nestedIfStmt.conditions.head.isInstanceOf[SingleStatement])
     assert(nestedIfStmt.conditions.head.getText == "2=1")
@@ -521,8 +521,8 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     assert(nestedIfStmt.conditionalBodies.head.collection.head.asInstanceOf[SingleStatement]
       .getText == "SELECT 41")
 
-    assert(nestedIfStmt.unconditionalBody.get.collection.head.isInstanceOf[SingleStatement])
-    assert(nestedIfStmt.unconditionalBody.get.collection.head.asInstanceOf[SingleStatement]
+    assert(nestedIfStmt.elseBody.get.collection.head.isInstanceOf[SingleStatement])
+    assert(nestedIfStmt.elseBody.get.collection.head.asInstanceOf[SingleStatement]
       .getText == "SELECT 42")
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -58,6 +58,12 @@ trait NonLeafStatementExec extends CompoundStatementExec {
    */
   def getTreeIterator: Iterator[CompoundStatementExec]
 
+  /**
+   * Evaluate the boolean condition represented by the statement.
+   * @param session SparkSession that SQL script is executed within.
+   * @param statement Statement representing the boolean condition to evaluate.
+   * @return Whether the condition evaluates to True.
+   */
   protected def evaluateBooleanCondition(
       session: SparkSession,
       statement: LeafStatementExec): Boolean = statement match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreter.scala
@@ -77,12 +77,15 @@ case class SqlScriptingInterpreter() {
           .reverse
         new CompoundBodyExec(
           body.collection.map(st => transformTreeIntoExecutable(st, evaluator)) ++ dropVariables)
-      case IfElseStatement(conditions, bodies) =>
+      case IfElseStatement(conditions, conditionalBodies, unconditionalBody) =>
         val conditionsExec = conditions.map(condition =>
           new SingleStatementExec(condition.parsedPlan, condition.origin, isInternal = false))
-        val bodiesExec = bodies.map(body =>
+        val conditionalBodiesExec = conditionalBodies.map(body =>
           transformTreeIntoExecutable(body, evaluator).asInstanceOf[CompoundBodyExec])
-        new IfElseStatementExec(conditionsExec, bodiesExec, evaluator)
+        val unconditionalBodiesExec = unconditionalBody.map(body =>
+          transformTreeIntoExecutable(body, evaluator).asInstanceOf[CompoundBodyExec])
+        new IfElseStatementExec(
+          conditionsExec, conditionalBodiesExec, unconditionalBodiesExec, evaluator)
       case sparkStatement: SingleStatement =>
         new SingleStatementExec(
           sparkStatement.parsedPlan,

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreter.scala
@@ -77,12 +77,12 @@ case class SqlScriptingInterpreter() {
           .reverse
         new CompoundBodyExec(
           body.collection.map(st => transformTreeIntoExecutable(st, evaluator)) ++ dropVariables)
-      case IfElseStatement(conditions, conditionalBodies, unconditionalBody) =>
+      case IfElseStatement(conditions, conditionalBodies, elseBody) =>
         val conditionsExec = conditions.map(condition =>
           new SingleStatementExec(condition.parsedPlan, condition.origin, isInternal = false))
         val conditionalBodiesExec = conditionalBodies.map(body =>
           transformTreeIntoExecutable(body, evaluator).asInstanceOf[CompoundBodyExec])
-        val unconditionalBodiesExec = unconditionalBody.map(body =>
+        val unconditionalBodiesExec = elseBody.map(body =>
           transformTreeIntoExecutable(body, evaluator).asInstanceOf[CompoundBodyExec])
         new IfElseStatementExec(
           conditionsExec, conditionalBodiesExec, unconditionalBodiesExec, evaluator)

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
@@ -47,13 +47,13 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite {
   case class TestIfElse(
       conditions: Seq[TestSingleStatement],
       conditionalBodies: Seq[TestBody],
-      unconditionalBody: Option[TestBody],
+      elseBody: Option[TestBody],
       booleanEvaluator: StatementBooleanEvaluator)
     extends IfElseStatementExec(
-      conditions, conditionalBodies, unconditionalBody, booleanEvaluator)
+      conditions, conditionalBodies, elseBody, booleanEvaluator)
 
   // Repeat retValue reps times, then return !retValue once.
-  case class RepEval(retValue: Boolean, reps: Int) extends StatementBooleanEvaluator {
+  case class RepEval(retValue: Boolean, reps: Int) extends StatementBooleanEvaluator(null) {
     private var callCount: Int = 0;
     override def eval(statement: LeafStatementExec): Boolean = {
       callCount += 1
@@ -106,7 +106,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite {
         conditionalBodies = Seq(
           TestBody(Seq(TestLeafStatement("body1")))
         ),
-        unconditionalBody = Some(TestBody(Seq(TestLeafStatement("body2")))),
+        elseBody = Some(TestBody(Seq(TestLeafStatement("body2")))),
         booleanEvaluator = RepEval(retValue = false, reps = 0)
       )
     )).getTreeIterator
@@ -123,7 +123,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite {
         conditionalBodies = Seq(
           TestBody(Seq(TestLeafStatement("body1")))
         ),
-        unconditionalBody = Some(TestBody(Seq(TestLeafStatement("body2")))),
+        elseBody = Some(TestBody(Seq(TestLeafStatement("body2")))),
         booleanEvaluator = RepEval(retValue = false, reps = 1)
       )
     )).getTreeIterator
@@ -142,7 +142,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite {
           TestBody(Seq(TestLeafStatement("body1"))),
           TestBody(Seq(TestLeafStatement("body2")))
         ),
-        unconditionalBody = Some(TestBody(Seq(TestLeafStatement("body3")))),
+        elseBody = Some(TestBody(Seq(TestLeafStatement("body3")))),
         booleanEvaluator = RepEval(retValue = false, reps = 0)
       )
     )).getTreeIterator
@@ -161,7 +161,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite {
           TestBody(Seq(TestLeafStatement("body1"))),
           TestBody(Seq(TestLeafStatement("body2")))
         ),
-        unconditionalBody = Some(TestBody(Seq(TestLeafStatement("body3")))),
+        elseBody = Some(TestBody(Seq(TestLeafStatement("body3")))),
         booleanEvaluator = RepEval(retValue = false, reps = 1)
       )
     )).getTreeIterator
@@ -182,7 +182,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite {
           TestBody(Seq(TestLeafStatement("body2"))),
           TestBody(Seq(TestLeafStatement("body3")))
         ),
-        unconditionalBody = Some(TestBody(Seq(TestLeafStatement("body4")))),
+        elseBody = Some(TestBody(Seq(TestLeafStatement("body4")))),
         booleanEvaluator = RepEval(retValue = false, reps = 2)
       )
     )).getTreeIterator
@@ -201,7 +201,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite {
           TestBody(Seq(TestLeafStatement("body1"))),
           TestBody(Seq(TestLeafStatement("body2")))
         ),
-        unconditionalBody = Some(TestBody(Seq(TestLeafStatement("body3")))),
+        elseBody = Some(TestBody(Seq(TestLeafStatement("body3")))),
         booleanEvaluator = RepEval(retValue = false, reps = 2)
       )
     )).getTreeIterator
@@ -220,7 +220,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite {
           TestBody(Seq(TestLeafStatement("body1"))),
           TestBody(Seq(TestLeafStatement("body2")))
         ),
-        unconditionalBody = None,
+        elseBody = None,
         booleanEvaluator = RepEval(retValue = false, reps = 1)
       )
     )).getTreeIterator
@@ -239,7 +239,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite {
           TestBody(Seq(TestLeafStatement("body1"))),
           TestBody(Seq(TestLeafStatement("body2")))
         ),
-        unconditionalBody = None,
+        elseBody = None,
         booleanEvaluator = RepEval(retValue = false, reps = 2)
       )
     )).getTreeIterator

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
@@ -50,7 +50,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
 
   case class TestIfElseCondition(condVal: Boolean, description: String)
     extends SingleStatementExec(
-      parsedPlan = Project(Seq(Alias(Literal(condVal), "condition")()), OneRowRelation()),
+      parsedPlan = Project(Seq(Alias(Literal(condVal), description)()), OneRowRelation()),
       Origin(startIndex = Some(0), stopIndex = Some(description.length)),
       isInternal = false)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -32,8 +32,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
   private def verifySqlScriptResult(sqlText: String, expected: Seq[Seq[Row]]): Unit = {
     val interpreter = SqlScriptingInterpreter()
     val compoundBody = spark.sessionState.sqlParser.parseScript(sqlText)
-    val executionPlan = interpreter
-      .buildExecutionPlan(compoundBody, spark)
+    val executionPlan = interpreter.buildExecutionPlan(compoundBody, spark)
     val result = executionPlan.flatMap {
       case statement: SingleStatementExec =>
         if (statement.isExecuted) {
@@ -216,7 +215,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
     verifySqlScriptResult(sqlScript, expected)
   }
 
-  test ("if") {
+  test("if") {
     val commands =
       """
         |BEGIN

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -228,6 +228,23 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
     verifySqlScriptResult(commands, expected)
   }
 
+  test("if nested") {
+    val commands =
+      """
+        |BEGIN
+        | IF 1=1 THEN
+        |   IF 2=1 THEN
+        |     SELECT 41;
+        |   ELSE
+        |     SELECT 42;
+        |   END IF;
+        | END IF;
+        |END
+        |""".stripMargin
+    val expected = Seq(Seq(Row(42)))
+    verifySqlScriptResult(commands, expected)
+  }
+
   test("if else going in if") {
     val commands =
       """

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -32,7 +32,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
   private def verifySqlScriptResult(sqlText: String, expected: Seq[Seq[Row]]): Unit = {
     val interpreter = SqlScriptingInterpreter()
     val compoundBody = spark.sessionState.sqlParser.parseScript(sqlText)
-    val executionPlan = interpreter.buildExecutionPlan(compoundBody)
+    val executionPlan = interpreter.buildExecutionPlan(compoundBody, DataFrameEvaluator(spark))
     val result = executionPlan.flatMap {
       case statement: SingleStatementExec =>
         if (statement.isExecuted) {
@@ -213,5 +213,136 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
       Seq.empty[Row] // drop var - implicit
     )
     verifySqlScriptResult(sqlScript, expected)
+  }
+
+  test ("if") {
+    val commands =
+      """
+        |BEGIN
+        | IF 1=1 THEN
+        |   SELECT 42;
+        | END IF;
+        |END
+        |""".stripMargin
+    val expected = Seq(Seq(Row(42)))
+    verifySqlScriptResult(commands, expected)
+  }
+
+  test("if else going in if") {
+    val commands =
+      """
+        |BEGIN
+        | IF 1=1
+        | THEN
+        |   SELECT 42;
+        | ELSE
+        |   SELECT 43;
+        | END IF;
+        |END
+        |""".stripMargin
+
+    val expected = Seq(Seq(Row(42)))
+    verifySqlScriptResult(commands, expected)
+  }
+
+  test("if else if going in else if") {
+    val commands =
+      """
+        |BEGIN
+        |  IF 1=2
+        |  THEN
+        |    SELECT 42;
+        |  ELSE IF 1=1
+        |  THEN
+        |    SELECT 43;
+        |  ELSE
+        |    SELECT 44;
+        |  END IF;
+        |END
+        |""".stripMargin
+
+    val expected = Seq(Seq(Row(43)))
+    verifySqlScriptResult(commands, expected)
+  }
+
+  test("if else going in else") {
+    val commands =
+      """
+        |BEGIN
+        | IF 1=2
+        | THEN
+        |   SELECT 42;
+        | ELSE
+        |   SELECT 43;
+        | END IF;
+        |END
+        |""".stripMargin
+
+    val expected = Seq(Seq(Row(43)))
+    verifySqlScriptResult(commands, expected)
+  }
+
+  test("if else if going in else") {
+    val commands =
+      """
+        |BEGIN
+        |  IF 1=2
+        |  THEN
+        |    SELECT 42;
+        |  ELSE IF 1=3
+        |  THEN
+        |    SELECT 43;
+        |  ELSE
+        |    SELECT 44;
+        |  END IF;
+        |END
+        |""".stripMargin
+
+    val expected = Seq(Seq(Row(44)))
+    verifySqlScriptResult(commands, expected)
+  }
+
+  test("if with count") {
+    withTable("t") {
+      val commands =
+        """
+          |BEGIN
+          |CREATE TABLE t (a INT, b STRING, c DOUBLE) USING parquet;
+          |INSERT INTO t VALUES (1, 'a', 1.0);
+          |INSERT INTO t VALUES (1, 'a', 1.0);
+          |IF (SELECT COUNT(*) > 2 FROM t) THEN
+          |   SELECT 42;
+          | ELSE
+          |   SELECT 43;
+          | END IF;
+          |END
+          |""".stripMargin
+
+      val expected = Seq(Seq.empty[Row], Seq.empty[Row], Seq.empty[Row], Seq(Row(43)))
+      verifySqlScriptResult(commands, expected)
+    }
+  }
+
+  test("if else if with count") {
+    withTable("t") {
+      val commands =
+        """
+          |BEGIN
+          |  CREATE TABLE t (a INT, b STRING, c DOUBLE) USING parquet;
+          |  INSERT INTO t VALUES (1, 'a', 1.0);
+          |  INSERT INTO t VALUES (1, 'a', 1.0);
+          |  IF (SELECT COUNT(*) > 2 FROM t) THEN
+          |    SELECT 42;
+          |  ELSE IF (SELECT COUNT(*) > 1 FROM t) THEN
+          |    SELECT 43;
+          |  ELSE
+          |    SELECT 44;
+          |  END IF;
+          |END
+          |""".stripMargin
+
+      val expected = Seq(Seq.empty[Row], Seq.empty[Row], Seq.empty[Row], Seq(Row(43)))
+      verifySqlScriptResult(commands, expected)
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -32,7 +32,8 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
   private def verifySqlScriptResult(sqlText: String, expected: Seq[Seq[Row]]): Unit = {
     val interpreter = SqlScriptingInterpreter()
     val compoundBody = spark.sessionState.sqlParser.parseScript(sqlText)
-    val executionPlan = interpreter.buildExecutionPlan(compoundBody, DataFrameEvaluator(spark))
+    val executionPlan = interpreter
+      .buildExecutionPlan(compoundBody, new StatementBooleanEvaluator(spark))
     val result = executionPlan.flatMap {
       case statement: SingleStatementExec =>
         if (statement.isExecuted) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -33,7 +33,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
     val interpreter = SqlScriptingInterpreter()
     val compoundBody = spark.sessionState.sqlParser.parseScript(sqlText)
     val executionPlan = interpreter
-      .buildExecutionPlan(compoundBody, new StatementBooleanEvaluator(spark))
+      .buildExecutionPlan(compoundBody, spark)
     val result = executionPlan.flatMap {
       case statement: SingleStatementExec =>
         if (statement.isExecuted) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes introduction of IF/ELSE statement to SQL scripting language.
To evaluate conditions in IF or ELSE IF clauses, introduction of boolean statement evaluator is required as well.

Changes summary:
- Grammar/parser changes:
  - `ifElseStatement` grammar rule
  - `visitIfElseStatement` rule visitor
  - `IfElseStatement` logical operator
- `IfElseStatementExec` execution node:
  - Internal states - `Condition` and `Body`
  - Iterator implementation - iterate over conditions until the one that evaluates to `true` is found
  - Use `StatementBooleanEvaluator` implementation to evaluate conditions
- `DataFrameEvaluator`:
  - Implementation of `StatementBooleanEvaluator`
  - Evaluates results to `true` if it is single row, single column of boolean type with value `true`
- `SqlScriptingInterpreter` - add logic to transform `IfElseStatement` to `IfElseStatementExec`

### Why are the changes needed?
We are gradually introducing SQL Scripting to Spark, and IF/ELSE is one of the basic control flow constructs in the SQL language. For more details, check [JIRA item](https://issues.apache.org/jira/browse/SPARK-48346).

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
New tests are introduced to all of the three scripting test suites: `SqlScriptingParserSuite`, `SqlScriptingExecutionNodeSuite` and `SqlScriptingInterpreterSuite`.

### Was this patch authored or co-authored using generative AI tooling?
No.
