### PR TITLE
[SPARK-48925] Add interface which prevents DataSourceV2Strategy to do planning for scan nodes

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ExternallyPlannedV1Scan.java
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/ExternallyPlannedV1Scan.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources;
+
+import org.apache.spark.annotation.Evolving;
+
+/**
+ * The interface which prevents spark built-in strategies to do planning of DataSourceV2Relation
+ * which has V1Scan.
+ * This will guarantee extra (external) strategies to do planning of relation (scan).
+ *
+ * @since 4.0.0
+ */
+@Evolving
+public interface ExternallyPlannedV1Scan {
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add new interface (`ExternallyPlannedV1Scan`) for `V1Scan` which will prevent `DataSourceV2Strategy` to do planning of optimized scan node.

### Why are the changes needed?
Sometimes, we want to extend Spark with new strategies (it can be done by adding strategy to `extraStrategies` property of `SparkSession`), and we want that strategy to plan `DataSourceV2ScanRelation` node. Even extra strategies are applied before other strategies (and have extra priority), often those strategies tries to do some push downs (or optimization) with `Filter` and `Project` logical plans. If that push down fails, then `DataSourceV2Strategy` will do planning, because it can handle Filter/Project for every expression. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
No tests made, existing tests covers we did not make regression for current planning logic.

### Was this patch authored or co-authored using generative AI tooling?
No
