### PR TITLE
[SPARK-47047] TransformWithState integration with statedata source integration - Value State

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StateDataSource.scala
@@ -52,6 +52,8 @@ class StateDataSource extends TableProvider with DataSourceRegister {
 
   override def shortName(): String = "statestore"
 
+  private lazy val TRANSFORM_WITH_STATE_OPERATOR_SHORT_NAME = "transformWithStateExec"
+
   override def getTable(
       schema: StructType,
       partitioning: Array[Transform],
@@ -66,6 +68,18 @@ class StateDataSource extends TableProvider with DataSourceRegister {
     val stateStoreMetadata = allStateStoreMetadata.filter { entry =>
       entry.operatorId == sourceOptions.operatorId &&
         entry.stateStoreName == sourceOptions.storeName
+    }
+
+    if (sourceOptions.stateVarName.isDefined) {
+      // Perform checks for transformWithState operator in case state variable name is provided
+      allStateStoreMetadata.foreach { entry =>
+        if (entry.operatorName != TRANSFORM_WITH_STATE_OPERATOR_SHORT_NAME) {
+          val errorMsg = "Providing state variable names is only supported with the " +
+            s"transformWithState operator. Found operator=${entry.operatorName}"
+          throw StateDataSourceErrors.invalidOptionValue(sourceOptions.stateVarName.get,
+            errorMsg)
+        }
+      }
     }
 
     new StateTable(session, schema, sourceOptions, stateConf, stateStoreMetadata)
@@ -153,12 +167,14 @@ case class StateSourceOptions(
     joinSide: JoinSideValues,
     readChangeFeed: Boolean,
     fromSnapshotOptions: Option[FromSnapshotOptions],
-    readChangeFeedOptions: Option[ReadChangeFeedOptions]) {
+    readChangeFeedOptions: Option[ReadChangeFeedOptions],
+    stateVarName: Option[String]) {
   def stateCheckpointLocation: Path = new Path(resolvedCpLocation, DIR_NAME_STATE)
 
   override def toString: String = {
     var desc = s"StateSourceOptions(checkpointLocation=$resolvedCpLocation, batchId=$batchId, " +
-      s"operatorId=$operatorId, storeName=$storeName, joinSide=$joinSide"
+      s"operatorId=$operatorId, storeName=$storeName, joinSide=$joinSide, " +
+      s"stateVarName=${stateVarName.getOrElse("None")}"
     if (fromSnapshotOptions.isDefined) {
       desc += s", snapshotStartBatchId=${fromSnapshotOptions.get.snapshotStartBatchId}"
       desc += s", snapshotPartitionId=${fromSnapshotOptions.get.snapshotPartitionId}"
@@ -182,6 +198,7 @@ object StateSourceOptions extends DataSourceOptions {
   val READ_CHANGE_FEED = newOption("readChangeFeed")
   val CHANGE_START_BATCH_ID = newOption("changeStartBatchId")
   val CHANGE_END_BATCH_ID = newOption("changeEndBatchId")
+  val STATE_VAR_NAME = newOption("stateVarName")
 
   object JoinSideValues extends Enumeration {
     type JoinSideValues = Value
@@ -217,6 +234,10 @@ object StateSourceOptions extends DataSourceOptions {
     if (storeName.isEmpty) {
       throw StateDataSourceErrors.invalidOptionValueIsEmpty(STORE_NAME)
     }
+
+    // Check if the state variable name is provided. Used with the transformWithState operator.
+    val stateVarName = Option(options.get(STATE_VAR_NAME))
+      .map(_.trim)
 
     val joinSide = try {
       Option(options.get(JOIN_SIDE))
@@ -321,7 +342,7 @@ object StateSourceOptions extends DataSourceOptions {
 
     StateSourceOptions(
       resolvedCpLocation, batchId.get, operatorId, storeName, joinSide,
-      readChangeFeed, fromSnapshotOptions, readChangeFeedOptions)
+      readChangeFeed, fromSnapshotOptions, readChangeFeedOptions, stateVarName)
   }
 
   private def resolvedCheckpointLocation(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StatePartitionReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StatePartitionReader.scala
@@ -36,7 +36,8 @@ class StatePartitionReaderFactory(
     storeConf: StateStoreConf,
     hadoopConf: SerializableConfiguration,
     schema: StructType,
-    stateStoreMetadata: Array[StateMetadataTableEntry]) extends PartitionReaderFactory {
+    stateStoreMetadata: Array[StateMetadataTableEntry],
+    stateVarName: Option[String] = None) extends PartitionReaderFactory {
 
   override def createReader(partition: InputPartition): PartitionReader[InternalRow] = {
     val stateStoreInputPartition = partition.asInstanceOf[StateStoreInputPartition]
@@ -45,7 +46,7 @@ class StatePartitionReaderFactory(
         stateStoreInputPartition, schema, stateStoreMetadata)
     } else {
       new StatePartitionReader(storeConf, hadoopConf,
-        stateStoreInputPartition, schema, stateStoreMetadata)
+        stateStoreInputPartition, schema, stateStoreMetadata, stateVarName)
     }
   }
 }
@@ -59,10 +60,19 @@ abstract class StatePartitionReaderBase(
     hadoopConf: SerializableConfiguration,
     partition: StateStoreInputPartition,
     schema: StructType,
-    stateStoreMetadata: Array[StateMetadataTableEntry])
+    stateStoreMetadata: Array[StateMetadataTableEntry],
+    stateVarName: Option[String] = None)
   extends PartitionReader[InternalRow] with Logging {
-  private val keySchema = SchemaUtil.getSchemaAsDataType(schema, "key").asInstanceOf[StructType]
-  private val valueSchema = SchemaUtil.getSchemaAsDataType(schema, "value").asInstanceOf[StructType]
+  protected val keySchema = SchemaUtil.getSchemaAsDataType(
+    schema, "key").asInstanceOf[StructType]
+  protected val valueSchema = SchemaUtil.getSchemaAsDataType(
+    schema, "value").asInstanceOf[StructType]
+
+  // TODO better way to avoid this?
+  protected val transformWithState: Boolean =
+    stateStoreMetadata.head.operatorName == "transformWithStateExec"
+
+  protected var keyStateEncoderType: KeyStateEncoderSpec = _
 
   protected lazy val provider: StateStoreProvider = {
     val stateStoreId = StateStoreId(partition.sourceOptions.stateCheckpointLocation.toString,
@@ -77,14 +87,13 @@ abstract class StatePartitionReaderBase(
       0
     } else {
       require(stateStoreMetadata.length == 1)
-      require(stateStoreMetadata.head.version == 1)
-      stateStoreMetadata.head.numColsPrefixKey.get
+      stateStoreMetadata.head.numColsPrefixKey
     }
 
     // TODO: currently we don't support RangeKeyScanStateEncoderSpec. Support for this will be
     // added in the future along with state metadata changes.
     // Filed JIRA here: https://issues.apache.org/jira/browse/SPARK-47524
-    val keyStateEncoderType = if (numColsPrefixKey > 0) {
+    keyStateEncoderType = if (numColsPrefixKey > 0) {
       PrefixKeyScanStateEncoderSpec(keySchema, numColsPrefixKey)
     } else {
       NoPrefixKeyStateEncoderSpec(keySchema)
@@ -92,7 +101,7 @@ abstract class StatePartitionReaderBase(
 
     StateStoreProvider.createAndInit(
       stateStoreProviderId, keySchema, valueSchema, keyStateEncoderType,
-      useColumnFamilies = false, storeConf, hadoopConf.value,
+      useColumnFamilies = transformWithState, storeConf, hadoopConf.value,
       useMultipleValuesPerKey = false)
   }
 
@@ -127,8 +136,10 @@ class StatePartitionReader(
     hadoopConf: SerializableConfiguration,
     partition: StateStoreInputPartition,
     schema: StructType,
-    stateStoreMetadata: Array[StateMetadataTableEntry])
-  extends StatePartitionReaderBase(storeConf, hadoopConf, partition, schema, stateStoreMetadata) {
+    stateStoreMetadata: Array[StateMetadataTableEntry],
+    stateVarName: Option[String] = None)
+  extends StatePartitionReaderBase(storeConf, hadoopConf,
+    partition, schema, stateStoreMetadata, stateVarName) {
 
   private lazy val store: ReadStateStore = {
     partition.sourceOptions.fromSnapshotOptions match {
@@ -146,11 +157,23 @@ class StatePartitionReader(
     }
   }
 
+  // TODO we can remove this create new col family after integration with VCF
+  private var stateStore: Option[StateStore] = None
   override lazy val iter: Iterator[InternalRow] = {
-    store.iterator().map(pair => unifyStateRowPair((pair.key, pair.value)))
+    if (transformWithState) {
+      stateStore = Option(provider.getStore(partition.sourceOptions.batchId + 1))
+      assert(stateVarName.isDefined, "state variable name has to be defined for TWS")
+      stateStore.get.createColFamilyIfAbsent(
+        stateVarName.get, keySchema, valueSchema, keyStateEncoderType)
+      stateStore.get.iterator(stateVarName.get)
+        .map(pair => unifyStateRowPair((pair.key, pair.value)))
+    } else {
+      store.iterator().map(pair => unifyStateRowPair((pair.key, pair.value)))
+    }
   }
 
   override def close(): Unit = {
+    if (stateStore.isDefined) stateStore.get.abort()
     store.abort()
     super.close()
   }
@@ -164,6 +187,7 @@ class StatePartitionReader(
   }
 }
 
+// TODO do we need to do integration with readChangeFeed?
 /**
  * An implementation of [[StatePartitionReaderBase]] for the readChangeFeed mode of State Data
  * Source. It reads the change of state over batches of a particular partition.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StatePartitionReader.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StatePartitionReader.scala
@@ -77,7 +77,8 @@ abstract class StatePartitionReaderBase(
       0
     } else {
       require(stateStoreMetadata.length == 1)
-      stateStoreMetadata.head.numColsPrefixKey
+      require(stateStoreMetadata.head.version == 1)
+      stateStoreMetadata.head.numColsPrefixKey.get
     }
 
     // TODO: currently we don't support RangeKeyScanStateEncoderSpec. Support for this will be

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StateScanBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/StateScanBuilder.scala
@@ -123,7 +123,7 @@ class StateScan(
 
     case JoinSideValues.none =>
       new StatePartitionReaderFactory(stateStoreConf, hadoopConfBroadcast.value, schema,
-        stateStoreMetadata)
+        stateStoreMetadata, sourceOptions.stateVarName)
   }
 
   override def toBatch: Batch = this

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/metadata/StateMetadataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/metadata/StateMetadataSource.scala
@@ -40,6 +40,7 @@ import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.SerializableConfiguration
 
 case class StateMetadataTableEntry(
+    version: Int,
     operatorId: Long,
     operatorName: String,
     stateStoreName: String,
@@ -243,7 +244,7 @@ class StateMetadataPartitionReader(
               -1 // numColsPrefixKey is not available in OperatorStateMetadataV2
             )
           }
-        }
       }
-    }.iterator
+    }
+  }.iterator
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/metadata/StateMetadataSource.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/state/metadata/StateMetadataSource.scala
@@ -40,7 +40,6 @@ import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.SerializableConfiguration
 
 case class StateMetadataTableEntry(
-    version: Int,
     operatorId: Long,
     operatorName: String,
     stateStoreName: String,
@@ -63,7 +62,7 @@ case class StateMetadataTableEntry(
 }
 
 object StateMetadataTableEntry {
-  private[sql] val schema = {
+  private[sql] val schema: StructType = {
     new StructType()
       .add("operatorId", LongType)
       .add("operatorName", StringType)
@@ -76,35 +75,35 @@ object StateMetadataTableEntry {
 }
 
 class StateMetadataSource extends TableProvider with DataSourceRegister {
+
   override def shortName(): String = "state-metadata"
 
   override def getTable(
       schema: StructType,
       partitioning: Array[Transform],
       properties: util.Map[String, String]): Table = {
-    new StateMetadataTable
+    new StateMetadataTable(schema)
   }
 
   override def inferSchema(options: CaseInsensitiveStringMap): StructType = {
-    // The schema of state metadata table is static.
-   StateMetadataTableEntry.schema
+    if (!options.containsKey("path")) {
+      throw StateDataSourceErrors.requiredOptionUnspecified(PATH)
+    }
+
+    StateMetadataTableEntry.schema
   }
 }
 
 
-class StateMetadataTable extends Table with SupportsRead with SupportsMetadataColumns {
+class StateMetadataTable(override val schema: StructType) extends Table
+  with SupportsRead with SupportsMetadataColumns {
   override def name(): String = "state-metadata-table"
-
-  override def schema(): StructType = StateMetadataTableEntry.schema
 
   override def capabilities(): util.Set[TableCapability] = Set(TableCapability.BATCH_READ).asJava
 
   override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
     () => {
-      if (!options.containsKey("path")) {
-        throw StateDataSourceErrors.requiredOptionUnspecified(PATH)
-      }
-      new StateMetadataScan(options.get("path"))
+      new StateMetadataScan(options.get("path"), schema)
     }
   }
 
@@ -119,8 +118,10 @@ class StateMetadataTable extends Table with SupportsRead with SupportsMetadataCo
 
 case class StateMetadataInputPartition(checkpointLocation: String) extends InputPartition
 
-class StateMetadataScan(checkpointLocation: String) extends Scan {
-  override def readSchema: StructType = StateMetadataTableEntry.schema
+class StateMetadataScan(
+    checkpointLocation: String,
+    schema: StructType) extends Scan {
+  override def readSchema: StructType = schema
 
   override def toBatch: Batch = {
     new Batch {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
@@ -37,12 +37,11 @@ import org.apache.spark.sql.execution.streaming.state.OperatorStateMetadataUtils
  */
 trait StateStoreMetadata {
   def storeName: String
-  def numColsPrefixKey: Int
   def numPartitions: Int
 }
 
-case class StateStoreMetadataV1(storeName: String, numColsPrefixKey: Int, numPartitions: Int)
-  extends StateStoreMetadata
+case class StateStoreMetadataV1(storeName: String, numColsPrefixKey: Int,
+  numPartitions: Int) extends StateStoreMetadata
 
 case class StateStoreMetadataV2(
     storeName: String,
@@ -139,6 +138,9 @@ object OperatorStateMetadataUtils extends Logging {
     version match {
       case 1 =>
         Serialization.read[OperatorStateMetadataV1](in)
+      case 2 =>
+        Serialization.read[OperatorStateMetadataV2](in)
+
       case 2 =>
         Serialization.read[OperatorStateMetadataV2](in)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
@@ -140,10 +140,6 @@ object OperatorStateMetadataUtils extends Logging {
         Serialization.read[OperatorStateMetadataV1](in)
       case 2 =>
         Serialization.read[OperatorStateMetadataV2](in)
-
-      case 2 =>
-        Serialization.read[OperatorStateMetadataV2](in)
-
       case _ =>
         throw new IllegalArgumentException(s"Failed to deserialize operator metadata with " +
           s"version=$version")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateSchemaCompatibilityChecker.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateSchemaCompatibilityChecker.scala
@@ -51,12 +51,45 @@ class StateSchemaCompatibilityChecker(
     oldSchemaFilePath: Option[Path] = None,
     newSchemaFilePath: Option[Path] = None) extends Logging {
 
-  private val schemaFileLocation = if (oldSchemaFilePath.isEmpty) {
-    val storeCpLocation = providerId.storeId.storeCheckpointLocation()
-    schemaFile(storeCpLocation)
-  } else {
-    oldSchemaFilePath.get
-  }
+  private val schemaFileLocation =
+    if (oldSchemaFilePath.isEmpty) {
+      val storeCpLocation = providerId.storeId.storeCheckpointLocation()
+      val f = CheckpointFileManager.create(storeCpLocation.getParent, hadoopConf)
+
+      val schemaDir = schemaFile(new Path(storeCpLocation.getParent,
+        providerId.storeId.storeName))
+      if (f.exists(schemaDir)) {
+        val schemaSeq = f.list(schemaDir).toSeq
+        assert(!schemaSeq.isEmpty, "Schema file directory is empty!")
+
+        // get latest schema files with highest batch Id for version 3 schema file
+        val regexPattern = """(\d+)_.*""".r
+        var schemaFileOfLatestBatch = schemaSeq.head.getPath
+        var latestBatchId = 0L
+        schemaSeq.foreach { fileStatus =>
+          val filePath = fileStatus.getPath
+          filePath.getName match {
+            case regexPattern(batchId) =>
+              if (batchId.toLong > latestBatchId) {
+                latestBatchId = batchId.toLong
+                schemaFileOfLatestBatch = filePath
+              }
+            case "schema" =>
+              // if we are not using schema format version 3,
+              // schema fileName should be "schema"
+              filePath
+            case _ =>
+              throw new IllegalStateException("Schema files are not in correct file name format; " +
+                "Likely schema files are corrupted.")
+          }
+        }
+        schemaFileOfLatestBatch
+      } else {
+        schemaFile(storeCpLocation)
+      }
+    } else {
+      oldSchemaFilePath.get
+    }
 
   private val fm = CheckpointFileManager.create(schemaFileLocation, hadoopConf)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
@@ -26,6 +26,7 @@ import org.apache.spark.SparkRuntimeException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{Dataset, Encoders, Row}
 import org.apache.spark.sql.catalyst.util.stringToFile
+import org.apache.spark.sql.execution.datasources.v2.state.StateSourceOptions
 import org.apache.spark.sql.execution.streaming._
 import org.apache.spark.sql.execution.streaming.state._
 import org.apache.spark.sql.functions.timestamp_seconds
@@ -347,6 +348,28 @@ class StatefulProcessorWithCompositeTypes extends RunningCountStatefulProcessor 
       "listState", Encoders.product[TestClass])
     _mapState = getHandle.getMapState[POJOTestClass, String](
       "mapState", Encoders.bean(classOf[POJOTestClass]), Encoders.STRING)
+  }
+}
+
+/** Stateful processor of single value state var with non-primitive type */
+class StatefulProcessorWithMultipleValueVars extends RunningCountStatefulProcessor {
+  @transient private var _valueState: ValueState[TestClass] = _
+
+  override def init(
+      outputMode: OutputMode,
+      timeMode: TimeMode): Unit = {
+    _valueState = getHandle.getValueState[TestClass](
+      "valueState", Encoders.product[TestClass])
+  }
+
+  override def handleInputRows(
+      key: String,
+      inputRows: Iterator[String],
+      timerValues: TimerValues,
+      expiredTimerInfo: ExpiredTimerInfo): Iterator[(String, String)] = {
+    val count = _valueState.getOption().getOrElse(TestClass(0L, "dummyKey")).id + 1
+    _valueState.update(TestClass(count, "dummyKey"))
+    Iterator((key, count.toString))
   }
 }
 
@@ -980,6 +1003,52 @@ class TransformWithStateSuite extends StateStoreMetricsTest
             }
           }
         )
+      }
+    }
+  }
+
+  test("state data source integration - value state with single variable") {
+    withTempDir { tempDir =>
+      withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+        classOf[RocksDBStateStoreProvider].getName,
+        SQLConf.SHUFFLE_PARTITIONS.key ->
+          TransformWithStateSuiteUtils.NUM_SHUFFLE_PARTITIONS.toString) {
+        val inputData = MemoryStream[String]
+        val result = inputData.toDS()
+          .groupByKey(x => x)
+          .transformWithState(new StatefulProcessorWithMultipleValueVars(),
+            TimeMode.None(),
+            OutputMode.Update())
+
+        testStream(result, OutputMode.Update())(
+          StartStream(checkpointLocation = tempDir.getAbsolutePath),
+          AddData(inputData, "a"),
+          CheckNewAnswer(("a", "1")),
+          AddData(inputData, "b"),
+          CheckNewAnswer(("b", "1")),
+          StopStream
+        )
+
+        val stateReaderDf = spark.read
+          .format("statestore")
+          .option(StateSourceOptions.PATH, tempDir.getAbsolutePath)
+          .option(StateSourceOptions.STATE_VAR_NAME, "valueState")
+          .load()
+
+        val resultDf = stateReaderDf.selectExpr(
+          "key.value AS groupingKey",
+          "value.id AS valueId", "value.name AS valueName",
+          "partition_id")
+
+        checkAnswer(resultDf,
+          Seq(Row("a", 1L, "dummyKey", 0), Row("b", 1L, "dummyKey", 1)))
+
+        // TODO this should fail, but currently we'll explicitly call createColFamily
+        spark.read
+          .format("statestore")
+          .option(StateSourceOptions.PATH, tempDir.getAbsolutePath)
+          .option(StateSourceOptions.STATE_VAR_NAME, "non-exist")
+          .load()
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This change introduces integration change for TransformWithState with state data source for Value State.
Coauthored by @anishshri-db and includes his change in the WIP PR here: https://github.com/apache/spark/pull/47238

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is needed as base change for the integration for state data source, specifically for value state.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
User can now interact with value state for TWS of reading state data source as:
```
spark.read
.format("statestore")
.option(StateSourceOptions.STATE_VAR_NAME, [STATE_VAR_NAME])
.load()
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Add unit tests in `TransformWithStateSuite` and `TransformWithValueStateTTLSuite`.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.