### PR TITLE
[SPARK-48975][PROTOBUF] Remove unnecessary `ScalaReflectionLock` definition from `protobuf`

### DIFF
--- a/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/package.scala
+++ b/connector/protobuf/src/main/scala/org/apache/spark/sql/protobuf/package.scala
@@ -17,5 +17,4 @@
 package org.apache.spark.sql
 
 package object protobuf {
-  protected[protobuf] object ScalaReflectionLock
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR removes the unused object definition `ScalaReflectionLock` from the `protobuf` module. `ScalaReflectionLock` is a definition at the access scope of `protobuf` package, which was defined in SPARK-40654 | https://github.com/apache/spark/pull/37972 and become unused in SPARK-41639 | https://github.com/apache/spark/pull/39147.


### Why are the changes needed?
Clean up unused definitions.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No