### PR TITLE
[SPARK-48980][ML] Avoid per-row param read in `LSH/DCT/NGram/PolynomialExpansion`

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/BucketedRandomProjectionLSH.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/BucketedRandomProjectionLSH.scala
@@ -90,6 +90,15 @@ class BucketedRandomProjectionLSHModel private[ml](
     hashVec.values.map(h => Vectors.dense(h.floor))
   }
 
+  override protected[ml] def createHashFunction: Vector => Array[Vector] = {
+    val hashVec = new DenseVector(Array.ofDim[Double](randMatrix.numRows))
+    val localBucketLength = $(bucketLength)
+    (elems: Vector) => {
+      BLAS.gemv(1.0 / localBucketLength, randMatrix, elems, 0.0, hashVec)
+      hashVec.values.map(h => Vectors.dense(h.floor))
+    }
+  }
+
   @Since("2.1.0")
   override protected[ml] def keyDistance(x: Vector, y: Vector): Double = {
     Math.sqrt(Vectors.sqdist(x, y))

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/BucketedRandomProjectionLSH.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/BucketedRandomProjectionLSH.scala
@@ -91,9 +91,9 @@ class BucketedRandomProjectionLSHModel private[ml](
   }
 
   override protected[ml] def createHashFunction: Vector => Array[Vector] = {
-    val hashVec = new DenseVector(Array.ofDim[Double](randMatrix.numRows))
     val localBucketLength = $(bucketLength)
     (elems: Vector) => {
+      val hashVec = new DenseVector(Array.ofDim[Double](randMatrix.numRows))
       BLAS.gemv(1.0 / localBucketLength, randMatrix, elems, 0.0, hashVec)
       hashVec.values.map(h => Vectors.dense(h.floor))
     }

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/DCT.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/DCT.scala
@@ -62,11 +62,18 @@ class DCT @Since("1.5.0") (@Since("1.5.0") override val uid: String)
 
   setDefault(inverse -> false)
 
-  override protected def createTransformFunc: Vector => Vector = { vec =>
-    val result = vec.toArray
-    val jTransformer = new DoubleDCT_1D(result.length)
-    if ($(inverse)) jTransformer.inverse(result, true) else jTransformer.forward(result, true)
-    Vectors.dense(result)
+  override protected def createTransformFunc: Vector => Vector = {
+    val localInverse = $(inverse)
+    (vec: Vector) => {
+      val result = vec.toArray
+      val jTransformer = new DoubleDCT_1D(result.length)
+      if (localInverse) {
+        jTransformer.inverse(result, true)
+      } else {
+        jTransformer.forward(result, true)
+      }
+      Vectors.dense(result)
+    }
   }
 
   override protected def validateInputType(inputType: DataType): Unit = {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/LSH.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/LSH.scala
@@ -76,6 +76,11 @@ private[ml] abstract class LSHModel[T <: LSHModel[T]]
    */
   protected[ml] def hashFunction(elems: Vector): Array[Vector]
 
+  /*
+   * Creates the transform function using the given param map.
+   */
+  protected[ml] def createHashFunction: Vector => Array[Vector] = hashFunction
+
   /**
    * Calculate the distance between two different keys using the distance metric corresponding
    * to the hashFunction.
@@ -96,7 +101,7 @@ private[ml] abstract class LSHModel[T <: LSHModel[T]]
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
-    val transformUDF = udf(hashFunction(_: Vector))
+    val transformUDF = udf(createHashFunction)
     dataset.withColumn($(outputCol), transformUDF(dataset($(inputCol))))
   }
 

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/NGram.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/NGram.scala
@@ -61,7 +61,8 @@ class NGram @Since("1.5.0") (@Since("1.5.0") override val uid: String)
   setDefault(n -> 2)
 
   override protected def createTransformFunc: Seq[String] => Seq[String] = {
-    _.iterator.sliding($(n)).withPartial(false).map(_.mkString(" ")).toSeq
+    val localN = $(n)
+    seq => seq.iterator.sliding(localN).withPartial(false).map(_.mkString(" ")).toSeq
   }
 
   override protected def validateInputType(inputType: DataType): Unit = {

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/PolynomialExpansion.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/PolynomialExpansion.scala
@@ -64,8 +64,9 @@ class PolynomialExpansion @Since("1.4.0") (@Since("1.4.0") override val uid: Str
   @Since("1.4.0")
   def setDegree(value: Int): this.type = set(degree, value)
 
-  override protected def createTransformFunc: Vector => Vector = { v =>
-    PolynomialExpansion.expand(v, $(degree))
+  override protected def createTransformFunc: Vector => Vector = {
+    val localDegree = $(degree)
+    v => PolynomialExpansion.expand(v, localDegree)
   }
 
   override protected def validateInputType(inputType: DataType): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Avoid per-row param read in `LSH/DCT/NGram/PolynomialExpansion`

### Why are the changes needed?
avoid reading param per row in `transform`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
No