### PR TITLE
[SPARK-48997][SS] Implement individual unloads for maintenance thread pool thread failures

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -872,8 +872,8 @@ object StateStore extends Logging {
               //
               // However, we assume that repeated failures on the same partition and global issues
               // are rare. The benefit to unloading just the partition with an exception is that
-              // is that transient issues on a given provider do not affect any other providers;
-              // so, in most cases, this should be a more performant solution.
+              // transient issues on a given provider do not affect any other providers; so, in
+              // most cases, this should be a more performant solution.
               unload(id)
           } finally {
             val duration = System.currentTimeMillis() - startTime

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.execution.streaming.state
 
 import java.util.UUID
 import java.util.concurrent.{ScheduledFuture, TimeUnit}
-import java.util.concurrent.atomic.AtomicReference
 import javax.annotation.concurrent.GuardedBy
 
 import scala.collection.mutable
@@ -612,10 +611,6 @@ object StateStore extends Logging {
 
   private val maintenanceThreadPoolLock = new Object
 
-  // Shared exception between threads in thread pool that the scheduling thread
-  // checks to see if an exception has been thrown in the maintenance task
-  private val threadPoolException = new AtomicReference[Throwable](null)
-
   // This set is to keep track of the partitions that are queued
   // for maintenance or currently have maintenance running on them
   // to prevent the same partition from being processed concurrently.
@@ -623,10 +618,9 @@ object StateStore extends Logging {
   private val maintenancePartitions = new mutable.HashSet[StateStoreProviderId]
 
   /**
-   * Runs the `task` periodically and automatically cancels it if there is an exception. `onError`
-   * will be called when an exception happens.
+   * Runs the `task` periodically and automatically cancels it if there is an exception.
    */
-  class MaintenanceTask(periodMs: Long, task: => Unit, onError: => Unit) {
+  class MaintenanceTask(periodMs: Long, task: => Unit) {
     private val executor =
       ThreadUtils.newDaemonSingleThreadScheduledExecutor("state-store-maintenance-task")
 
@@ -637,7 +631,6 @@ object StateStore extends Logging {
         } catch {
           case NonFatal(e) =>
             logWarning("Error running maintenance thread", e)
-            onError
             throw e
         }
       }
@@ -793,7 +786,6 @@ object StateStore extends Logging {
   /** Stop maintenance thread and reset the maintenance task */
   def stopMaintenanceTask(): Unit = loadedProviders.synchronized {
     if (maintenanceThreadPool != null) {
-      threadPoolException.set(null)
       maintenanceThreadPoolLock.synchronized {
         maintenancePartitions.clear()
       }
@@ -822,16 +814,7 @@ object StateStore extends Logging {
       if (SparkEnv.get != null && !isMaintenanceRunning) {
         maintenanceTask = new MaintenanceTask(
           storeConf.maintenanceInterval,
-          task = { doMaintenance() },
-          onError = { loadedProviders.synchronized {
-              logInfo("Stopping maintenance task since an error was encountered.")
-              stopMaintenanceTask()
-              // SPARK-44504 - Unload explicitly to force closing underlying DB instance
-              // and releasing allocated resources, especially for RocksDBStateStoreProvider.
-              loadedProviders.keySet.foreach { key => unload(key) }
-              loadedProviders.clear()
-            }
-          }
+          task = { doMaintenance() }
         )
         maintenanceThreadPool = new MaintenanceThreadPool(numMaintenanceThreads)
         logInfo("State Store maintenance task started")
@@ -862,12 +845,6 @@ object StateStore extends Logging {
     loadedProviders.synchronized {
       loadedProviders.toSeq
     }.foreach { case (id, provider) =>
-      // check exception
-      if (threadPoolException.get() != null) {
-        val exception = threadPoolException.get()
-        logWarning("Error in maintenanceThreadPool", exception)
-        throw exception
-      }
       if (processThisPartition(id)) {
         maintenanceThreadPool.execute(() => {
           val startTime = System.currentTimeMillis()
@@ -881,7 +858,7 @@ object StateStore extends Logging {
             case NonFatal(e) =>
               logWarning(log"Error managing ${MDC(LogKeys.STATE_STORE_PROVIDER, provider)}, " +
                 log"stopping management thread", e)
-              threadPoolException.set(e)
+              unload(id)
           } finally {
             val duration = System.currentTimeMillis() - startTime
             val logMsg =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -861,7 +861,7 @@ object StateStore extends Logging {
           } catch {
             case NonFatal(e) =>
               logWarning(log"Error managing ${MDC(LogKeys.STATE_STORE_PROVIDER, provider)}, " +
-                log"stopping management thread", e)
+                log"unloading state store provider", e)
               // When we get a non-fatal exception, we just unload the provider.
               //
               // By not bubbling the exception to the maintenance task thread or the query execution

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -61,8 +61,7 @@ class MaintenanceErrorOnCertainPartitionsProvider extends HDFSBackedStateStorePr
    useColumnFamilies: Boolean,
    storeConfs: StateStoreConf,
    hadoopConf: Configuration,
-   useMultipleValuesPerKey: Boolean = false
-  ): Unit = {
+   useMultipleValuesPerKey: Boolean = false): Unit = {
     id = stateStoreId
 
     super.init(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -50,6 +50,10 @@ import org.apache.spark.tags.ExtendedSQLTest
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.Utils
 
+// MaintenanceErrorOnCertainPartitionsProvider is a test-only provider that throws an
+// exception during maintenance for partitions 0 and 1 (these are arbitrary choices). It is
+// used to test that an exception in a single provider's maintenance does not affect other
+// providers that do not experience exceptions.
 class MaintenanceErrorOnCertainPartitionsProvider extends HDFSBackedStateStoreProvider {
   private var id: StateStoreId = null
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -58,14 +58,14 @@ class MaintenanceErrorOnCertainPartitionsProvider extends HDFSBackedStateStorePr
   private var id: StateStoreId = null
 
   override def init(
-   stateStoreId: StateStoreId,
-   keySchema: StructType,
-   valueSchema: StructType,
-   keyStateEncoderSpec: KeyStateEncoderSpec,
-   useColumnFamilies: Boolean,
-   storeConfs: StateStoreConf,
-   hadoopConf: Configuration,
-   useMultipleValuesPerKey: Boolean = false): Unit = {
+    stateStoreId: StateStoreId,
+    keySchema: StructType,
+    valueSchema: StructType,
+    keyStateEncoderSpec: KeyStateEncoderSpec,
+    useColumnFamilies: Boolean,
+    storeConfs: StateStoreConf,
+    hadoopConf: Configuration,
+    useMultipleValuesPerKey: Boolean = false): Unit = {
     id = stateStoreId
 
     super.init(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -58,14 +58,14 @@ class MaintenanceErrorOnCertainPartitionsProvider extends HDFSBackedStateStorePr
   private var id: StateStoreId = null
 
   override def init(
-    stateStoreId: StateStoreId,
-    keySchema: StructType,
-    valueSchema: StructType,
-    keyStateEncoderSpec: KeyStateEncoderSpec,
-    useColumnFamilies: Boolean,
-    storeConfs: StateStoreConf,
-    hadoopConf: Configuration,
-    useMultipleValuesPerKey: Boolean = false): Unit = {
+      stateStoreId: StateStoreId,
+      keySchema: StructType,
+      valueSchema: StructType,
+      keyStateEncoderSpec: KeyStateEncoderSpec,
+      useColumnFamilies: Boolean,
+      storeConfs: StateStoreConf,
+      hadoopConf: Configuration,
+      useMultipleValuesPerKey: Boolean = false): Unit = {
     id = stateStoreId
 
     super.init(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently, an exception in the maintenance thread pool today can cause the entire executor to exit (or in some cases, deadlock). This PR changes the maintenance thread pool exception logic to _only_ unload the providers that throw exceptions—the entire thread pool is not stopped.

Historically, the way that we bubbled exceptions to the maintenance thread task (which manages the pool) was in the following way:

- A thread in the maintenance thread pool sees an exception and it sets `threadPoolException` to be non-null
- The next time that `doMaintenance()` gets called by the maintenance task (which is scheduled periodically), it checks to see whether that exception is non-null
- If it is non-null, it throws that exception
- It then _catches_ that exception, and stops the thread pool

But now that we don't need to stop the entire maintenance thread pool and unload _all_ of the providers, when an exception is encountered in a maintenance thread pool thread, we can just have that thread unload itself. Then, we can remove the `onError` callback because it will no longer be needed.

### Why are the changes needed?
Please see the JIRA for a full description of the error conditions. We don't want executors to exit because of maintenance thread pool thread failures.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- All existing UTs must pass. One test was removed, though (see below).
- Added a new UT where a fake state store provider is used; this state store provider throws exceptions for partitions 0 and 1. The UT asserts that these two providers become unloaded, but any other ones are _not_. 

There was an existing test, `SPARK-44438: maintenance task should be shutdown on error`, which actually mentions that the `SparkUncaughtExceptionHandler` should not be invoked even if there is an exception. However, this test does _not_ load more than 1 provider. Thus, the only loaded provider is the one that experiences the exception. We know that the root-cause of this issue is that if there exists _another_ provider that is waiting on a lock (i.e. on an RPC in `verifyStateStoreInstanceActive`), then that provider will receive an `InterruptedException`, which will lead to the `SparkUncaughtExceptionHandler` firing.

### Was this patch authored or co-authored using generative AI tooling?

No.
