### PR TITLE
[SPARK-49000][SQL] Fix aggregate behaviour with DISTINCT literals

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -618,32 +618,14 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
               }
             }
 
-            if (distinctExpressions.isEmpty) {
-              // If there is no distinct column expression, we use `planAggregateWithoutDistinct`.
-              // Essentially, when dealing with literals instead of columns, we can ignore DISTINCT.
-              // For example, this rule is applied to the following query:
-              //   SELECT COUNT(DISTINCT 1) FROM t
-              // Where t is a table with any columns.
-              AggUtils.planAggregateWithoutDistinct(
-                normalizedGroupingExpressions,
-                aggExpressions,
-                resultExpressions,
-                planLater(child))
-            } else {
-              // If there is a distinct column expression, we use `planAggregateWithOneDistinct`.
-              // This is the regular case where we have a single DISTINCT expression in aggregate.
-              // For example, this rule is applied to the following query:
-              //   SELECT COUNT(DISTINCT c) FROM t
-              // Where t is a table with column c.
-              AggUtils.planAggregateWithOneDistinct(
-                normalizedGroupingExpressions,
-                functionsWithDistinct,
-                functionsWithoutDistinct,
-                distinctExpressions,
-                normalizedNamedDistinctExpressions,
-                resultExpressions,
-                planLater(child))
-            }
+            AggUtils.planAggregateWithOneDistinct(
+              normalizedGroupingExpressions,
+              functionsWithDistinct,
+              functionsWithoutDistinct,
+              distinctExpressions,
+              normalizedNamedDistinctExpressions,
+              resultExpressions,
+              planLater(child))
           }
 
         aggregateOperator

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -2340,6 +2340,39 @@ class DataFrameAggregateSuite extends QueryTest
      checkAnswer(sql("select count(distinct 2), count(distinct 2,3)"), Row(1, 1))
   }
 
+  test("aggregating single distinct column with empty and non-empty table") {
+    val tableName = "t"
+    withTable(tableName) {
+      sql(s"create table $tableName(col int) using parquet")
+
+      checkAnswer(sql(s"select count(1) from $tableName"), Row(0))
+      checkAnswer(sql(s"select count(col) from $tableName"), Row(0))
+      checkAnswer(sql(s"select count(distinct 1) from $tableName"), Row(0))
+      checkAnswer(sql(s"select count(distinct col) from $tableName"), Row(0))
+
+      sql(s"insert into $tableName(col) values(1)")
+
+      checkAnswer(sql(s"select count(1) from $tableName"), Row(1))
+      checkAnswer(sql(s"select count(col) from $tableName"), Row(1))
+      checkAnswer(sql(s"select count(distinct 1) from $tableName"), Row(1))
+      checkAnswer(sql(s"select count(distinct col) from $tableName"), Row(1))
+
+      sql(s"insert into $tableName(col) values(2)")
+
+      checkAnswer(sql(s"select count(1) from $tableName"), Row(2))
+      checkAnswer(sql(s"select count(col) from $tableName"), Row(2))
+      checkAnswer(sql(s"select count(distinct 1) from $tableName"), Row(1))
+      checkAnswer(sql(s"select count(distinct col) from $tableName"), Row(2))
+
+      sql(s"insert into $tableName(col) values(3)")
+
+      checkAnswer(sql(s"select count(1) from $tableName"), Row(3))
+      checkAnswer(sql(s"select count(col) from $tableName"), Row(3))
+      checkAnswer(sql(s"select count(distinct 1) from $tableName"), Row(1))
+      checkAnswer(sql(s"select count(distinct col) from $tableName"), Row(3))
+    }
+  }
+
   test("aggregating single distinct column with table") {
     val tableName = "t"
     withTable(tableName) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameAggregateSuite.scala
@@ -2343,33 +2343,61 @@ class DataFrameAggregateSuite extends QueryTest
   test("aggregating single distinct column with empty and non-empty table") {
     val tableName = "t"
     withTable(tableName) {
+      // Original table now has 0 rows.
       sql(s"create table $tableName(col int) using parquet")
 
+      // Count function.
       checkAnswer(sql(s"select count(1) from $tableName"), Row(0))
       checkAnswer(sql(s"select count(col) from $tableName"), Row(0))
       checkAnswer(sql(s"select count(distinct 1) from $tableName"), Row(0))
       checkAnswer(sql(s"select count(distinct col) from $tableName"), Row(0))
+      // Sum function.
+      checkAnswer(sql(s"select sum(1) from $tableName"), Row(null))
+      checkAnswer(sql(s"select sum(col) from $tableName"), Row(null))
+      checkAnswer(sql(s"select sum(distinct 1) from $tableName"), Row(null))
+      checkAnswer(sql(s"select sum(distinct col) from $tableName"), Row(null))
 
+      // Original table now has 1 row.
       sql(s"insert into $tableName(col) values(1)")
 
+      // Count function.
       checkAnswer(sql(s"select count(1) from $tableName"), Row(1))
       checkAnswer(sql(s"select count(col) from $tableName"), Row(1))
       checkAnswer(sql(s"select count(distinct 1) from $tableName"), Row(1))
       checkAnswer(sql(s"select count(distinct col) from $tableName"), Row(1))
+      // Sum function.
+      checkAnswer(sql(s"select sum(1) from $tableName"), Row(1))
+      checkAnswer(sql(s"select sum(col) from $tableName"), Row(1))
+      checkAnswer(sql(s"select sum(distinct 1) from $tableName"), Row(1))
+      checkAnswer(sql(s"select sum(distinct col) from $tableName"), Row(1))
 
+      // Original table now has 2 rows.
       sql(s"insert into $tableName(col) values(2)")
 
+      // Count function.
       checkAnswer(sql(s"select count(1) from $tableName"), Row(2))
       checkAnswer(sql(s"select count(col) from $tableName"), Row(2))
       checkAnswer(sql(s"select count(distinct 1) from $tableName"), Row(1))
       checkAnswer(sql(s"select count(distinct col) from $tableName"), Row(2))
+      // Sum function.
+      checkAnswer(sql(s"select sum(1) from $tableName"), Row(2))
+      checkAnswer(sql(s"select sum(col) from $tableName"), Row(3))
+      checkAnswer(sql(s"select sum(distinct 1) from $tableName"), Row(1))
+      checkAnswer(sql(s"select sum(distinct col) from $tableName"), Row(3))
 
+      // Original table now has 3 rows.
       sql(s"insert into $tableName(col) values(3)")
 
+      // Count function.
       checkAnswer(sql(s"select count(1) from $tableName"), Row(3))
       checkAnswer(sql(s"select count(col) from $tableName"), Row(3))
       checkAnswer(sql(s"select count(distinct 1) from $tableName"), Row(1))
       checkAnswer(sql(s"select count(distinct col) from $tableName"), Row(3))
+      // Sum function.
+      checkAnswer(sql(s"select sum(1) from $tableName"), Row(3))
+      checkAnswer(sql(s"select sum(col) from $tableName"), Row(6))
+      checkAnswer(sql(s"select sum(distinct 1) from $tableName"), Row(1))
+      checkAnswer(sql(s"select sum(distinct col) from $tableName"), Row(6))
     }
   }
 
@@ -2405,7 +2433,7 @@ class DataFrameAggregateSuite extends QueryTest
       checkAnswer(sql(s"""select count("hello") from $tableName"""), Row(0))
       checkAnswer(sql(s"""select max(distinct "hello") from $tableName"""), Row(null))
       checkAnswer(sql(s"""select count(distinct "hello") from $tableName"""), Row(0))
-      // Or any other literal for that matter.
+      // Or any other kind of literal for that matter.
       checkAnswer(sql(s"select max(1) from $tableName"), Row(null))
       checkAnswer(sql(s"select count(1) from $tableName"), Row(0))
       checkAnswer(sql(s"""select max(distinct 1) from $tableName"""), Row(null))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix SparkStrategy for Aggregates dealing with DISTINCT literals.


### Why are the changes needed?
Aggregation with DISTINCT literal gives wrong results. For example:
`select count(distinct 1) from t` returns 1, while the correct result should be 0.
For reference:
`select count(1) from t` returns 0, which is the correct and expected result.


### Does this PR introduce _any_ user-facing change?
Yes, this fixes a critical bug in Spark.


### How was this patch tested?
New e2e SQL tests for aggregates with DISTINCT literals.


### Was this patch authored or co-authored using generative AI tooling?
No.
