### PR TITLE
[SPARK-49005][K8S][3.4] Use `17-jammy` tag instead of `17-jre` to prevent Python 3.12

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ARG java_image_tag=17-jre
+ARG java_image_tag=17-jammy
 
 FROM eclipse-temurin:${java_image_tag}
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `17-jammy` tag instead of `17-jre` to prevent Python 12.

### Why are the changes needed?

Two days ago, `eclipse-temurin:17` switched its baseline OS to `Ubuntu 24.04` which brings `Python 3.12`.

```
$ docker run -it --rm eclipse-temurin:17-jre cat /etc/os-release | grep VERSION_ID
VERSION_ID="24.04"

$ docker run -it --rm eclipse-temurin:17-jammy cat /etc/os-release | grep VERSION_ID
VERSION_ID="22.04"
```

Since Python 3.12 supported is added only to Apache Spark 4.0.0, we need to keep using the previous OS, `Ubuntu 22.04`.

- #43184
- #43192

### Does this PR introduce _any_ user-facing change?

No. This aims to recover to the same OS for consistent behavior.

### How was this patch tested?

Pass the CIs with K8s IT. Currently, it's broken at Python image building phase.

- https://github.com/apache/spark/actions/workflows/build_branch34.yml

### Was this patch authored or co-authored using generative AI tooling?

No.