### PR TITLE
[SPARK-49008][PYTHON] Use `ParamSpec` to propagate `func` signature in `transform`

### DIFF
--- a/python/pyspark/sql/_typing.pyi
+++ b/python/pyspark/sql/_typing.pyi
@@ -26,7 +26,7 @@ from typing import (
     TypeVar,
     Union,
 )
-from typing_extensions import Literal, Protocol
+from typing_extensions import Concatenate, Literal, ParamSpec, Protocol
 
 import datetime
 import decimal
@@ -36,6 +36,10 @@ from pyspark._typing import PrimitiveType
 from pyspark.profiler import CodeMapDict
 import pyspark.sql.types
 from pyspark.sql.column import Column
+
+__all__ = ["Concatenate"]
+
+P = ParamSpec("P")
 
 ColumnOrName = Union[Column, str]
 ColumnOrNameOrOrdinal = Union[Column, str, int]

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -32,7 +32,6 @@ from typing import (
     overload,
     TYPE_CHECKING,
 )
-from typing_extensions import Concatenate, ParamSpec
 
 from pyspark import _NoValue
 from pyspark._globals import _NoValueType
@@ -72,11 +71,12 @@ if TYPE_CHECKING:
     from pyspark.sql.plot import PySparkPlotAccessor
     from pyspark.sql.metrics import ExecutionInfo
 
+    from typing_extensions import Concatenate, ParamSpec
+
+    P = ParamSpec("P")
+
 
 __all__ = ["DataFrame", "DataFrameNaFunctions", "DataFrameStatFunctions"]
-
-
-P = ParamSpec("P")
 
 
 class DataFrame:
@@ -5843,9 +5843,9 @@ class DataFrame:
     @dispatch_df_method
     def transform(
         self,
-        func: Callable[Concatenate["DataFrame", P], "DataFrame"],
-        *args: P.args,
-        **kwargs: P.kwargs,
+        func: "Callable[Concatenate[DataFrame, P], DataFrame]",
+        *args: "P.args",
+        **kwargs: "P.kwargs",
     ) -> "DataFrame":
         """Returns a new :class:`DataFrame`. Concise syntax for chaining custom transformations.
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -56,8 +56,10 @@ if TYPE_CHECKING:
     from pyspark.sql._typing import (
         ColumnOrName,
         ColumnOrNameOrOrdinal,
+        Concatenate,
         LiteralType,
         OptionalPrimitiveType,
+        P,
     )
     from pyspark.sql.context import SQLContext
     from pyspark.sql.session import SparkSession
@@ -70,10 +72,6 @@ if TYPE_CHECKING:
     )
     from pyspark.sql.plot import PySparkPlotAccessor
     from pyspark.sql.metrics import ExecutionInfo
-
-    from typing_extensions import Concatenate, ParamSpec
-
-    P = ParamSpec("P")
 
 
 __all__ = ["DataFrame", "DataFrameNaFunctions", "DataFrameStatFunctions"]

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -32,6 +32,7 @@ from typing import (
     overload,
     TYPE_CHECKING,
 )
+from typing_extensions import Concatenate, ParamSpec
 
 from pyspark import _NoValue
 from pyspark._globals import _NoValueType
@@ -73,6 +74,9 @@ if TYPE_CHECKING:
 
 
 __all__ = ["DataFrame", "DataFrameNaFunctions", "DataFrameStatFunctions"]
+
+
+P = ParamSpec("P")
 
 
 class DataFrame:
@@ -5837,7 +5841,12 @@ class DataFrame:
         ...
 
     @dispatch_df_method
-    def transform(self, func: Callable[..., "DataFrame"], *args: Any, **kwargs: Any) -> "DataFrame":
+    def transform(
+        self,
+        func: Callable[Concatenate["DataFrame", P], "DataFrame"],
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> "DataFrame":
         """Returns a new :class:`DataFrame`. Concise syntax for chaining custom transformations.
 
         .. versionadded:: 3.0.0


### PR DESCRIPTION
### What changes were proposed in this pull request?
Propagate function signature of `func` in `DataFrame(...).transform(...)`.


### Why are the changes needed?
Propagating the function signature for `func` in `DataFrame(...).transform(...)` enables type checkers like `mypy` to enforce that `func` is being correctly called through `transform`.


### Does this PR introduce _any_ user-facing change?
Yes, it allows the user to better leverage type checking tools when using `DataFrame(...).transform(...)`.


### How was this patch tested?
Ran example script that passes `add_num` to `transform` with inappropriate arguments:
- first running mypy on `master`, showing that no mypy errors are raised
- then running mypy with the changes in this PR on the `type-hint-transform-args-kwargs` branch
   - this shows that the expected mypy errors are raised

<details><summary>screenshot of no mypy errors on master</summary>
<p>

<img width="904" alt="no_mypy_errors_master" src="https://github.com/user-attachments/assets/a2bb01b2-8ca8-41d6-a50a-fe95d7a1cfd7">
</p>
</details> 

<details><summary>screenshot of expected mypy errors with PR changes</summary>
<p>

<img width="1348" alt="mypy_errors_pr_changes" src="https://github.com/user-attachments/assets/8d7920cf-e9ad-42a0-b435-1f55b0469f29">
</p>
</details> 


<details><summary>example script</summary>
<p>

```python

from pyspark.sql import DataFrame, functions as F, SparkSession

spark = (
    SparkSession
    .builder
    .appName("Python Spark SQL basic example")
    .getOrCreate()
)


df = spark.createDataFrame([("a", 0), ("b", 1)], schema=["col1", "col2"])


def add_num(df: DataFrame, in_colname: str, *, num: int) -> DataFrame:
    return df.withColumn("new_col", F.col(in_colname) + num)


if __name__=="__main__":
    df.transform(add_num, "col2", 2).show()                   # enforces kw
    df.transform(add_num, in_colname="col2", num="a").show()  # enforces type for kwarg
    df.transform(add_num, in_colname=2, num=2).show()         # enforces type for arg
    df.transform(add_num, "col2").show()                      # enforces required args
``` 

</p>
</details> 


### Was this patch authored or co-authored using generative AI tooling?
No
