### PR TITLE
[SPARK-49010][SQL][XML] Add unit tests for XML schema inference case sensitivity

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlInferSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlInferSchemaSuite.scala
@@ -935,6 +935,7 @@ trait XmlSchemaInferenceCaseSensitivityTests extends QueryTest {
               .xml(dir.getCanonicalPath)
             assert(xml.schema == testcase.expectedCaseSensitiveSchema)
             checkAnswer(xml, testcase.expectedCaseSensitiveAns)
+          }
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlInferSchemaSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/xml/XmlInferSchemaSuite.scala
@@ -17,6 +17,8 @@
 package org.apache.spark.sql.execution.datasources.xml
 
 import java.io.File
+import java.nio.file.Files
+import java.util.UUID
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Encoders, QueryTest, Row}
@@ -35,7 +37,11 @@ import org.apache.spark.sql.types.{
   StructType
 }
 
-class XmlInferSchemaSuite extends QueryTest with SharedSparkSession with TestXmlData {
+class XmlInferSchemaSuite
+    extends QueryTest
+    with SharedSparkSession
+    with TestXmlData
+    with XmlSchemaInferenceCaseSensitivityTests {
 
   private val baseOptions = Map("rowTag" -> "ROW")
 
@@ -49,6 +55,9 @@ class XmlInferSchemaSuite extends QueryTest with SharedSparkSession with TestXml
     val dataset = spark.createDataset(spark.sparkContext.parallelize(xmlString))(Encoders.STRING)
     spark.read.options(baseOptions ++ options).xml(dataset)
   }
+
+  override protected def customSQLConf
+      : Map[String, String] = Map.empty
 
   // TODO: add tests for type widening
   test("Type conflict in primitive field values") {
@@ -630,3 +639,305 @@ class XmlInferSchemaSuite extends QueryTest with SharedSparkSession with TestXml
     checkAnswer(xmlDF, expectedAns)
   }
 }
+
+trait XmlSchemaInferenceCaseSensitivityTests extends QueryTest {
+
+  protected def customSQLConf: Map[String, String] = Map.empty
+
+  private def writeXmlStringToFile(
+      xmlString: String,
+      dir: File,
+      multiline: Boolean = true,
+      fileName: String = UUID.randomUUID().toString): String = {
+    val bytes = if (multiline) xmlString.getBytes() else xmlString.filter(_ >= ' ').getBytes
+    Files.write(new File(dir, fileName).toPath, bytes)
+    dir.getCanonicalPath + s"/$fileName"
+  }
+
+  private val valueTagCaseSensitivityTestcase: XmlSchemaInferenceCaseSensitiveTestCase = {
+    val caseSensitiveValueTag =
+      """
+        |<ROW>
+        |    <a>
+        |       1
+        |       <b>2</b>
+        |    </a>
+        |</ROW>
+        |<ROW>
+        |    <A>
+        |       3
+        |    </A>
+        |</ROW>
+        |""".stripMargin
+    XmlSchemaInferenceCaseSensitiveTestCase(
+      "value tag",
+      caseSensitiveValueTag,
+      expectedCaseSensitiveSchema = new StructType()
+        .add("A", LongType)
+        .add("a", new StructType().add("_VALUE", LongType).add("b", LongType)),
+      expectedCaseSensitiveAns = Seq(
+        Row(null, Row(1, 2)),
+        Row(3, null)
+      ),
+      expectedCaseInsensitiveSchema = new StructType()
+        .add("a", new StructType().add("_VALUE", LongType).add("b", LongType)),
+      expectedCaseInsensitiveAns = Seq(
+        Row(Row(1, 2)),
+        Row(Row(3, null))
+      )
+    )
+  }
+
+  //  array type: a A b and A & a struct<b, c> and A struct<b, c>, a <struct B, c>
+  private val arrayComplexCaseSensitivityTestcase: XmlSchemaInferenceCaseSensitiveTestCase = {
+    val caseSensitiveArrayType =
+      """
+        |<ROW>
+        |    <a>
+        |        1
+        |        <b>2</b>
+        |        <c>3</c>
+        |    </a>
+        |    <A>
+        |        4
+        |    </A>
+        |</ROW>
+        |<ROW>
+        |    <A>5</A>
+        |</ROW>
+        |""".stripMargin
+    XmlSchemaInferenceCaseSensitiveTestCase(
+      "array type - simple",
+      caseSensitiveArrayType,
+      expectedCaseSensitiveSchema = new StructType()
+        .add("A", LongType)
+        .add(
+          "a",
+          new StructType()
+            .add("_VALUE", LongType)
+            .add("b", LongType)
+            .add("c", LongType)
+        ),
+      expectedCaseSensitiveAns = Seq(
+        Row(4, Row(1, 2, 3)),
+        Row(5, null)
+      ),
+      expectedCaseInsensitiveSchema = new StructType()
+        .add(
+          "a",
+          ArrayType(
+            new StructType()
+              .add("_VALUE", LongType)
+              .add("b", LongType)
+              .add("c", LongType)
+          )
+        ),
+      expectedCaseInsensitiveAns = Seq(
+        Row(List(Row(1, 2, 3), Row(4, null, null))),
+        Row(List(Row(5, null, null)))
+      )
+    )
+  }
+
+  private val arraySimpleCaseSensitivityTestcase: XmlSchemaInferenceCaseSensitiveTestCase = {
+    val caseSensitiveArrayType =
+      """
+        |<ROW>
+        |    <a>
+        |        <b>1</b>
+        |        <c>2</c>
+        |    </a>
+        |    <A>
+        |        <B>3</B>
+        |        <c>4</c>
+        |    </A>
+        |</ROW>
+        |""".stripMargin
+    XmlSchemaInferenceCaseSensitiveTestCase(
+      "array type - complex",
+      caseSensitiveArrayType,
+      expectedCaseSensitiveSchema = new StructType()
+        .add("A", new StructType().add("B", LongType).add("c", LongType))
+        .add("a", new StructType().add("b", LongType).add("c", LongType)),
+      expectedCaseSensitiveAns = Seq(
+        Row(Row(3, 4), Row(1, 2))
+      ),
+      expectedCaseInsensitiveSchema = new StructType()
+        .add("a", ArrayType(new StructType().add("b", LongType).add("c", LongType))),
+      expectedCaseInsensitiveAns = Seq(
+        Row(List(Row(1, 2), Row(3, 4)))
+      )
+    )
+  }
+
+  private val primitiveTypeCaseSensitivityTestcase: XmlSchemaInferenceCaseSensitiveTestCase = {
+    val caseInSensitivePrimitiveTypes =
+      """
+        |<ROW>
+        |    <a>1</a>
+        |    <b>2</b>
+        |    <c>3</c>
+        |</ROW>
+        |<ROW>
+        |    <a>4</a>
+        |    <B>5</B>
+        |    <c>6</c>
+        |</ROW>
+        |""".stripMargin
+    XmlSchemaInferenceCaseSensitiveTestCase(
+      "primitive type",
+      caseInSensitivePrimitiveTypes,
+      expectedCaseSensitiveSchema = new StructType()
+        .add("B", LongType)
+        .add("a", LongType)
+        .add("b", LongType)
+        .add("c", LongType),
+      expectedCaseSensitiveAns = Seq(
+        Row(null, 1, 2, 3),
+        Row(5, 4, null, 6)
+      ),
+      expectedCaseInsensitiveSchema = new StructType()
+        .add("a", LongType)
+        .add("b", LongType)
+        .add("c", LongType),
+      expectedCaseInsensitiveAns = Seq(
+        Row(1, 2, 3),
+        Row(4, 5, 6)
+      )
+    )
+  }
+
+  private val attributesCaseSensitivityTestcase: XmlSchemaInferenceCaseSensitiveTestCase = {
+    val caseSensitiveAttr =
+      """
+        |<ROW attr="1">
+        |    <a>1</a>
+        |    <b>2</b>
+        |    <c>3</c>
+        |</ROW>
+        |<ROW aTtr="2">
+        |    <a>4</a>
+        |    <b>5</b>
+        |    <c>6</c>
+        |</ROW>
+        |""".stripMargin
+    XmlSchemaInferenceCaseSensitiveTestCase(
+      "attributes",
+      caseSensitiveAttr,
+      expectedCaseSensitiveSchema = new StructType()
+        .add("_aTtr", LongType)
+        .add("_attr", LongType)
+        .add("a", LongType)
+        .add("b", LongType)
+        .add("c", LongType),
+      expectedCaseSensitiveAns = Seq(
+        Row(null, 1, 1, 2, 3),
+        Row(2, null, 4, 5, 6)
+      ),
+      expectedCaseInsensitiveSchema = new StructType()
+        .add("_attr", LongType)
+        .add("a", LongType)
+        .add("b", LongType)
+        .add("c", LongType),
+      expectedCaseInsensitiveAns = Seq(
+        Row(1, 1, 2, 3),
+        Row(2, 4, 5, 6)
+      )
+    )
+  }
+
+  // struct: A struct<a, c> and a <A, c>
+  private val structCaseSensitivityTestcase: XmlSchemaInferenceCaseSensitiveTestCase = {
+    val caseSensitiveStruct =
+      """
+        |<ROW>
+        |    <A>
+        |        <a>1</a>
+        |        <c>3</c>
+        |    </A>
+        |</ROW>
+        |<ROW>
+        |    <a>
+        |        <A>5</A>
+        |        <c>7</c>
+        |    </a>
+        |</ROW>
+        |""".stripMargin
+    XmlSchemaInferenceCaseSensitiveTestCase(
+      "struct",
+      caseSensitiveStruct,
+      expectedCaseSensitiveSchema = new StructType()
+        .add(
+          "A",
+          new StructType()
+            .add("a", LongType)
+            .add("c", LongType)
+        )
+        .add(
+          "a",
+          new StructType()
+            .add("A", LongType)
+            .add("c", LongType)
+        ),
+      expectedCaseSensitiveAns = Seq(
+        Row(Row(1, 3), null),
+        Row(null, Row(5, 7))
+      ),
+      expectedCaseInsensitiveSchema = new StructType()
+        .add(
+          "A",
+          new StructType()
+            .add("a", LongType)
+            .add("c", LongType)
+        ),
+      expectedCaseInsensitiveAns = Seq(
+        Row(Row(1, 3)),
+        Row(Row(5, 7))
+      )
+    )
+  }
+
+  case class XmlSchemaInferenceCaseSensitiveTestCase(
+      name: String,
+      xmlString: String,
+      expectedCaseSensitiveSchema: StructType,
+      expectedCaseSensitiveAns: Seq[Row],
+      expectedCaseInsensitiveSchema: StructType,
+      expectedCaseInsensitiveAns: Seq[Row]
+  )
+
+  private val testcases: Seq[XmlSchemaInferenceCaseSensitiveTestCase] = Seq(
+    valueTagCaseSensitivityTestcase,
+    arrayComplexCaseSensitivityTestcase,
+    arraySimpleCaseSensitivityTestcase,
+    primitiveTypeCaseSensitivityTestcase,
+    structCaseSensitivityTestcase,
+    attributesCaseSensitivityTestcase
+  )
+
+  testcases.foreach { testcase =>
+    test(s"case sensitivity test - ${testcase.name}") {
+      withTempDir { dir =>
+        withSQLConf(customSQLConf.toSeq: _*) {
+          val baseOptions = Map("rowTag" -> "ROW")
+          writeXmlStringToFile(testcase.xmlString, dir)
+          withSQLConf(SQLConf.CASE_SENSITIVE.key -> "false") {
+            val xml =
+              spark.read
+                .options(baseOptions)
+                .xml(dir.getCanonicalPath)
+            assert(xml.schema == testcase.expectedCaseInsensitiveSchema)
+            checkAnswer(xml, testcase.expectedCaseInsensitiveAns)
+          }
+          withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+            val xml = spark.read
+              .options(baseOptions)
+              .xml(dir.getCanonicalPath)
+            assert(xml.schema == testcase.expectedCaseSensitiveSchema)
+            checkAnswer(xml, testcase.expectedCaseSensitiveAns)
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Currently, XML respects the case sensitivity SQLConf (default to false) in the schema inference but we lack unit tests to verify the behavior. This PR adds more unit tests to it.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This is a test-only change.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
This is a test-only change.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No