### PR TITLE
[SPARK-49014][BUILD] Bump Apache Avro to 1.12.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -22,9 +22,9 @@ arrow-memory-netty-buffer-patch/17.0.0//arrow-memory-netty-buffer-patch-17.0.0.j
 arrow-memory-netty/17.0.0//arrow-memory-netty-17.0.0.jar
 arrow-vector/17.0.0//arrow-vector-17.0.0.jar
 audience-annotations/0.12.0//audience-annotations-0.12.0.jar
-avro-ipc/1.11.3//avro-ipc-1.11.3.jar
-avro-mapred/1.11.3//avro-mapred-1.11.3.jar
-avro/1.11.3//avro-1.11.3.jar
+avro-ipc/1.12.0//avro-ipc-1.12.0.jar
+avro-mapred/1.12.0//avro-mapred-1.12.0.jar
+avro/1.12.0//avro-1.12.0.jar
 azure-data-lake-store-sdk/2.3.9//azure-data-lake-store-sdk-2.3.9.jar
 azure-keyvault-core/1.0.0//azure-keyvault-core-1.0.0.jar
 azure-storage/7.0.1//azure-storage-7.0.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
     -->
     <codahale.metrics.version>4.2.26</codahale.metrics.version>
     <!-- Should be consistent with SparkBuild.scala and docs -->
-    <avro.version>1.11.3</avro.version>
+    <avro.version>1.12.0</avro.version>
     <aws.kinesis.client.version>1.12.0</aws.kinesis.client.version>
     <!-- Should be consistent with Kinesis client dependency -->
     <aws.java.sdk.version>1.11.655</aws.java.sdk.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `Apache Avro` to 1.12.0.

### Why are the changes needed?

Apache Avro 1.12.0 is the latest feature release.
- https://github.com/apache/avro/releases/tag/release-1.12.0

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.