### PR TITLE
[SPARK-49018][SQL] Fix approx_count_distinct not working correctly with collation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/HyperLogLogPlusPlusHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/HyperLogLogPlusPlusHelper.scala
@@ -94,10 +94,8 @@ class HyperLogLogPlusPlusHelper(relativeSD: Double) extends Serializable {
     val value = dataType match {
       case FloatType => FLOAT_NORMALIZER.apply(_value)
       case DoubleType => DOUBLE_NORMALIZER.apply(_value)
-      case s: StringType => _value match {
-        case v: UTF8String => CollationFactory.getCollationKeyBytes(
-          v, s.collationId)
-      }
+      case s: StringType if _value.isInstanceOf[UTF8String] =>
+        CollationFactory.getCollationKeyBytes(_value.asInstanceOf[UTF8String], s.collationId)
       case _ => _value
     }
     // Create the hashed value 'x'.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/HyperLogLogPlusPlusHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/HyperLogLogPlusPlusHelper.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.XxHash64Function
 import org.apache.spark.sql.catalyst.optimizer.NormalizeFloatingNumbers.{DOUBLE_NORMALIZER, FLOAT_NORMALIZER}
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
 
 // A helper class for HyperLogLogPlusPlus.
 class HyperLogLogPlusPlusHelper(relativeSD: Double) extends Serializable {
@@ -93,6 +94,8 @@ class HyperLogLogPlusPlusHelper(relativeSD: Double) extends Serializable {
     val value = dataType match {
       case FloatType => FLOAT_NORMALIZER.apply(_value)
       case DoubleType => DOUBLE_NORMALIZER.apply(_value)
+      case _: StringType => CollationFactory.getCollationKeyBytes(
+        _value.asInstanceOf[UTF8String], dataType.asInstanceOf[StringType].collationId)
       case _ => _value
     }
     // Create the hashed value 'x'.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/HyperLogLogPlusPlusHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/HyperLogLogPlusPlusHelper.scala
@@ -94,8 +94,8 @@ class HyperLogLogPlusPlusHelper(relativeSD: Double) extends Serializable {
     val value = dataType match {
       case FloatType => FLOAT_NORMALIZER.apply(_value)
       case DoubleType => DOUBLE_NORMALIZER.apply(_value)
-      case s: StringType if _value.isInstanceOf[UTF8String] =>
-        CollationFactory.getCollationKeyBytes(_value.asInstanceOf[UTF8String], s.collationId)
+      case st: StringType if !st.supportsBinaryEquality && _value.isInstanceOf[UTF8String] =>
+        CollationFactory.getCollationKeyBytes(_value.asInstanceOf[UTF8String], st.collationId)
       case _ => _value
     }
     // Create the hashed value 'x'.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/HyperLogLogPlusPlusHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/HyperLogLogPlusPlusHelper.scala
@@ -94,8 +94,10 @@ class HyperLogLogPlusPlusHelper(relativeSD: Double) extends Serializable {
     val value = dataType match {
       case FloatType => FLOAT_NORMALIZER.apply(_value)
       case DoubleType => DOUBLE_NORMALIZER.apply(_value)
-      case _: StringType => CollationFactory.getCollationKeyBytes(
-        _value.asInstanceOf[UTF8String], dataType.asInstanceOf[StringType].collationId)
+      case s: StringType => _value match {
+        case v: UTF8String => CollationFactory.getCollationKeyBytes(
+          v, s.collationId)
+      }
       case _ => _value
     }
     // Create the hashed value 'x'.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/HyperLogLogPlusPlusHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/HyperLogLogPlusPlusHelper.scala
@@ -94,7 +94,7 @@ class HyperLogLogPlusPlusHelper(relativeSD: Double) extends Serializable {
     val value = dataType match {
       case FloatType => FLOAT_NORMALIZER.apply(_value)
       case DoubleType => DOUBLE_NORMALIZER.apply(_value)
-      case st: StringType if !st.supportsBinaryEquality && _value.isInstanceOf[UTF8String] =>
+      case st: StringType if !st.supportsBinaryEquality =>
         CollationFactory.getCollationKeyBytes(_value.asInstanceOf[UTF8String], st.collationId)
       case _ => _value
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSQLExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSQLExpressionsSuite.scala
@@ -2320,7 +2320,6 @@ class CollationSQLExpressionsSuite
   }
 
   test("Support HyperLogLogPlusPlus expression with collation") {
-
     case class HyperLogLogPlusPlusTestCase(
       collation: String,
       input: Seq[String],
@@ -2339,6 +2338,7 @@ class CollationSQLExpressionsSuite
     )
 
     testCases.foreach( t => {
+      // Using explicit collate clause
       val query =
         s"""
            |SELECT approx_count_distinct(col) FROM VALUES
@@ -2346,6 +2346,7 @@ class CollationSQLExpressionsSuite
            |""".stripMargin
       checkAnswer(sql(query), t.output)
 
+      // Using default collation
       withSQLConf(SqlApiConf.DEFAULT_COLLATION -> t.collation) {
         val query =
           s"""

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSQLExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSQLExpressionsSuite.scala
@@ -2319,56 +2319,43 @@ class CollationSQLExpressionsSuite
     )
   }
 
-  // scalastyle:off nonascii
-  test("approx_count_distinct returns correct with collation") {
+  test("Support HyperLogLogPlusPlus expression with collation") {
 
-    case class ACDTestCase(
+    case class HyperLogLogPlusPlusTestCase(
       collation: String,
       input: Seq[String],
       output: Seq[Row]
     )
 
     val testCases = Seq(
-      ACDTestCase("utf8_lcase", Seq("a", "a", "A"), Seq(Row(1))),
-      ACDTestCase("utf8_lcase", Seq("aCfew", "acFEw", "ACFEW"), Seq(Row(1))),
-      ACDTestCase("utf8_lcase", Seq("a"), Seq(Row(1))),
-      ACDTestCase("utf8_lcase", Seq("B"), Seq(Row(1))),
-      ACDTestCase("utf8_lcase", Seq("aCfew", "aCfew", "aCfew", "aCfew", "aCfew"), Seq(Row(1))),
-      ACDTestCase("utf8_lcase", Seq("Aaa", "AAA", "AAA", "aAa", "aAA", "aaa"), Seq(Row(1))),
-      ACDTestCase("UNICODE_CI_AI", Seq("č", "c", "Ć", "C", "Z", "Ž"), Seq(Row(2))),
-      ACDTestCase("UNICODE_CI_AI", Seq("Ž"), Seq(Row(1))),
-      ACDTestCase("UNICODE_CI_AI", Seq("z"), Seq(Row(1))),
-      ACDTestCase("UNICODE_CI_AI", Seq("fAFfewfćČĆfečwćCsŠ", "fAffEWfćČCfeCwcćss"), Seq(Row(1))),
-      ACDTestCase("UNICODE_CI_AI", Seq("fAFfe", "fAFfe", "fAFfe", "fAFfe", "fAFfe"), Seq(Row(1))),
-      ACDTestCase("UNICODE_CI_AI", Seq("fAcfewfćČĆfečwćCsŠ", "fAffEWfćČCfeCwcćss"), Seq(Row(2))),
-      ACDTestCase("UNICODE_CI_AI", Seq("Ćcc", "CCc", "CCC", "ĆĆČ", "CČĆ", "ČcĆ", "Ćčč", "ČČČ",
-        "CĆC", "ććć", "ccc"), Seq(Row(1))),
-      ACDTestCase("UNICODE_CI_AI", Seq("sŠŠ", "SŠS", "SŠS", "ššS", "ššs", "SšS", "ššš", "ŠŠs",
-        "ŠsŠ", "ssŠ", "SSS"), Seq(Row(1))),
-      ACDTestCase("UNICODE_CI_AI", Seq("zŽŽ", "ŽZŽ", "ZŽZ", "ZZZ", "ZžZ", "žžž", "žžZ", "ZžZ",
-        "ŽzZ", "zZZ", "ZZZ"), Seq(Row(1))),
-      ACDTestCase("UNICODE_CI_AI", Seq("zŽŽ", "ŽZŽ", "ZŽZ", "ZZZ", "ZžZ", "žžž", "žžZ", "ZžZ",
-        "ŽzZ", "zZZ", "ZZZ", "ZZŠ"), Seq(Row(2)))
+      HyperLogLogPlusPlusTestCase("utf8_binary", Seq("a", "a", "A", "z", "zz", "ZZ", "w", "AA",
+        "aA", "Aa", "aa"), Seq(Row(10))),
+      HyperLogLogPlusPlusTestCase("utf8_lcase", Seq("a", "a", "A", "z", "zz", "ZZ", "w", "AA",
+        "aA", "Aa", "aa"), Seq(Row(5))),
+      HyperLogLogPlusPlusTestCase("UNICODE", Seq("a", "a", "A", "z", "zz", "ZZ", "w", "AA",
+        "aA", "Aa", "aa"), Seq(Row(10))),
+      HyperLogLogPlusPlusTestCase("UNICODE_CI", Seq("a", "a", "A", "z", "zz", "ZZ", "w", "AA",
+        "aA", "Aa", "aa"), Seq(Row(5)))
     )
 
     testCases.foreach( t => {
-      val insertQuery = s"INSERT INTO t VALUES ${t.input.map(s => s"'${s}'").mkString(", ") }"
-      val testQuery = "SELECT approx_count_distinct(s) FROM t"
-
-      sql(s"CREATE TABLE t(s string collate ${t.collation})")
-      sql(insertQuery)
-      checkAnswer(sql(testQuery), t.output)
-      sql("DROP TABLE t")
+      val query =
+        s"""
+           |SELECT approx_count_distinct(col) FROM VALUES
+           |${t.input.map(s => s"('${s}' collate ${t.collation})").mkString(", ") } tab(col)
+           |""".stripMargin
+      checkAnswer(sql(query), t.output)
 
       withSQLConf(SqlApiConf.DEFAULT_COLLATION -> t.collation) {
-        sql("CREATE TABLE t(s string)")
-        sql(insertQuery)
-        checkAnswer(sql(testQuery), t.output)
-        sql("DROP TABLE t")
+        val query =
+          s"""
+             |SELECT approx_count_distinct(col) FROM VALUES
+             |${t.input.map(s => s"('${s}')").mkString(", ") } tab(col)
+             |""".stripMargin
+        checkAnswer(sql(query), t.output)
       }
     })
   }
-  // scalastyle:on nonascii
 
   // TODO: Add more tests for other SQL expressions
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix for approx_count_distinct not working correctly with collated strings.


### Why are the changes needed?
approx_count_distinct was not working with any collation.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
New test added to CollationSQLExpressionSuite.


### Was this patch authored or co-authored using generative AI tooling?
No.
