### PR TITLE
[SPARK-49031] Implement validation for the TransformWithStateExec operator using OperatorStateMetadataV2

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3805,7 +3805,7 @@
   },
   "STATEFUL_PROCESSOR_DUPLICATE_STATE_VARIABLE_DEFINED" : {
     "message" : [
-      "State variable with name <stateName> has already been defined in the StatefulProcessor."
+      "State variable with name <stateVarName> has already been defined in the StatefulProcessor."
     ],
     "sqlState" : "42802"
   },
@@ -3872,7 +3872,7 @@
   },
   "STATE_STORE_INVALID_VARIABLE_TYPE_CHANGE" : {
     "message" : [
-      "Cannot change <stateName> to <newType> between query restarts. Please set <stateName> to <oldType>, or restart with a new checkpoint directory."
+      "Cannot change <stateVarName> to <newType> between query restarts. Please set <stateVarName> to <oldType>, or restart with a new checkpoint directory."
     ],
     "sqlState" : "42K06"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3803,6 +3803,12 @@
     ],
     "sqlState" : "42802"
   },
+  "STATEFUL_PROCESSOR_DUPLICATE_STATE_VARIABLE_DEFINED" : {
+    "message" : [
+      "State variable with name <stateName> has already been defined in the StatefulProcessor."
+    ],
+    "sqlState" : "42802"
+  },
   "STATEFUL_PROCESSOR_INCORRECT_TIME_MODE_TO_ASSIGN_TTL" : {
     "message" : [
       "Cannot use TTL for state=<stateName> in timeMode=<timeMode>, use TimeMode.ProcessingTime() instead."
@@ -3830,12 +3836,6 @@
   "STATE_STORE_COLUMN_FAMILY_SCHEMA_INCOMPATIBLE" : {
     "message" : [
       "Incompatible schema transformation with column family=<colFamilyName>, oldSchema=<oldSchema>, newSchema=<newSchema>."
-    ],
-    "sqlState" : "42802"
-  },
-  "STATE_STORE_DUPLICATE_STATE_VARIABLE_DEFINED" : {
-    "message" : [
-      "State variable with name <stateName> has already been defined in the StatefulProcessor."
     ],
     "sqlState" : "42802"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3833,6 +3833,12 @@
     ],
     "sqlState" : "42802"
   },
+  "STATE_STORE_DUPLICATE_STATE_VARIABLE_DEFINED" : {
+    "message" : [
+      "State variable with name <stateName> has already been defined in the StatefulProcessor."
+    ],
+    "sqlState" : "42802"
+  },
   "STATE_STORE_HANDLE_NOT_INITIALIZED" : {
     "message" : [
       "The handle has not been initialized for this StatefulProcessor.",
@@ -3852,9 +3858,21 @@
     ],
     "sqlState" : "42802"
   },
+  "STATE_STORE_INVALID_CONFIG_AFTER_RESTART" : {
+    "message" : [
+      "<configName> <oldConfig> is not equal to <newConfig>. Please set <configName> to <oldConfig>, or restart with a new checkpoint directory."
+    ],
+    "sqlState" : "42K06"
+  },
   "STATE_STORE_INVALID_PROVIDER" : {
     "message" : [
       "The given State Store Provider <inputClass> does not extend org.apache.spark.sql.execution.streaming.state.StateStoreProvider."
+    ],
+    "sqlState" : "42K06"
+  },
+  "STATE_STORE_INVALID_VARIABLE_TYPE_CHANGE" : {
+    "message" : [
+      "Cannot change <stateName> to <newType> between query restarts. Please set <stateName> to <oldType>, or restart with a new checkpoint directory."
     ],
     "sqlState" : "42K06"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3860,7 +3860,7 @@
   },
   "STATE_STORE_INVALID_CONFIG_AFTER_RESTART" : {
     "message" : [
-      "<configName> <oldConfig> is not equal to <newConfig>. Please set <configName> to <oldConfig>, or restart with a new checkpoint directory."
+      "<configName>=<oldConfig> is not equal to <newConfig>. Please set <configName> to <oldConfig>, or restart with a new checkpoint directory."
     ],
     "sqlState" : "42K06"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3860,7 +3860,7 @@
   },
   "STATE_STORE_INVALID_CONFIG_AFTER_RESTART" : {
     "message" : [
-      "<configName>=<oldConfig> is not equal to <newConfig>. Please set <configName> to <oldConfig>, or restart with a new checkpoint directory."
+      "Cannot change <configName> from <oldConfig> to <newConfig> between restarts. Please set <configName> to <oldConfig>, or restart with a new checkpoint directory."
     ],
     "sqlState" : "42K06"
   },

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -224,9 +224,9 @@ class IncrementalExecution(
                   hadoopConf, ssw.operatorStateMetadataVersion).read()
               } catch {
                 case e: Exception =>
-                  logWarning(s"Error reading metadata path for stateful operator. This " +
-                    s"may due to no prior committed batch, or previously run on lower " +
-                    s"versions: ${e.getMessage}")
+                  logWarning(log"Error reading metadata path for stateful operator. This " +
+                    log"may due to no prior committed batch, or previously run on lower " +
+                    log"versions: ${MDC(ERROR, e.getMessage)}")
                 None
               }
               oldMetadata match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -218,19 +218,20 @@ class IncrementalExecution(
               // If we are restarting from a different checkpoint directory
               // there may be a mismatch between the stateful operators in the
               // physical plan and the metadata.
-              try {
-                val oldMetadata = OperatorStateMetadataReader.createReader(
+              val oldMetadata = try {
+                OperatorStateMetadataReader.createReader(
                   new Path(checkpointLocation, ssw.getStateInfo.operatorId.toString),
                   hadoopConf, ssw.operatorStateMetadataVersion).read()
-                oldMetadata match {
-                  case Some(oldMetadata) => ssw.validateNewMetadata(oldMetadata, metadata)
-                  case None =>
-                }
               } catch {
                 case e: Exception =>
                   logWarning(s"Error reading metadata path for stateful operator. This " +
                     s"may due to no prior committed batch, or previously run on lower " +
                     s"versions: ${e.getMessage}")
+                None
+              }
+              oldMetadata match {
+                case Some(oldMetadata) => ssw.validateNewMetadata(oldMetadata, metadata)
+                case None =>
               }
             }
             val metadataWriter = OperatorStateMetadataWriter.createWriter(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/IncrementalExecution.scala
@@ -214,12 +214,14 @@ class IncrementalExecution(
           case ssw: StateStoreWriter =>
             val metadata = ssw.operatorStateMetadata(stateSchemaPaths)
             // validate metadata
-            val oldMetadata = OperatorStateMetadataReader.createReader(
-              new Path(checkpointLocation, ssw.getStateInfo.operatorId.toString),
-              hadoopConf, ssw.operatorStateMetadataVersion).read()
-            oldMetadata match {
-              case Some(oldMetadata) => ssw.validateNewMetadata(oldMetadata, metadata)
-              case None =>
+            if (isFirstBatch && currentBatchId != 0) {
+              val oldMetadata = OperatorStateMetadataReader.createReader(
+                new Path(checkpointLocation, ssw.getStateInfo.operatorId.toString),
+                hadoopConf, ssw.operatorStateMetadataVersion).read()
+              oldMetadata match {
+                case Some(oldMetadata) => ssw.validateNewMetadata(oldMetadata, metadata)
+                case None =>
+              }
             }
             val metadataWriter = OperatorStateMetadataWriter.createWriter(
                 new Path(checkpointLocation, ssw.getStateInfo.operatorId.toString),

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
@@ -301,17 +301,32 @@ class DriverStatefulProcessorHandleImpl(timeMode: TimeMode, keyExprEnc: Expressi
   extends StatefulProcessorHandleImplBase(timeMode, keyExprEnc) {
 
   // Because this is only happening on the driver side, there is only
-  // one task modifying and accessing this map at a time
+  // one task modifying and accessing these maps at a time
   private[sql] val columnFamilySchemas: mutable.Map[String, StateStoreColFamilySchema] =
     new mutable.HashMap[String, StateStoreColFamilySchema]()
 
+  private[sql] val stateVariableInfos: mutable.Map[String, TransformWithStateVariableInfo] =
+    new mutable.HashMap[String, TransformWithStateVariableInfo]()
+
   def getColumnFamilySchemas: Map[String, StateStoreColFamilySchema] = columnFamilySchemas.toMap
+
+  def getStateVariableInfos: Map[String, TransformWithStateVariableInfo] = stateVariableInfos.toMap
+
+  private def checkIfDuplicateVariableDefined(stateName: String): Unit = {
+    if (columnFamilySchemas.contains(stateName)) {
+      throw StateStoreErrors.duplicateStateVariableDefined(stateName)
+    }
+  }
 
   override def getValueState[T](stateName: String, valEncoder: Encoder[T]): ValueState[T] = {
     verifyStateVarOperations("get_value_state", PRE_INIT)
     val colFamilySchema = StateStoreColumnFamilySchemaUtils.
       getValueStateSchema(stateName, keyExprEnc, valEncoder, false)
+    checkIfDuplicateVariableDefined(stateName)
     columnFamilySchemas.put(stateName, colFamilySchema)
+    val stateVariableInfo = TransformWithStateVariableUtils.
+      getValueState(stateName, ttlEnabled = false)
+    stateVariableInfos.put(stateName, stateVariableInfo)
     null.asInstanceOf[ValueState[T]]
   }
 
@@ -322,7 +337,11 @@ class DriverStatefulProcessorHandleImpl(timeMode: TimeMode, keyExprEnc: Expressi
     verifyStateVarOperations("get_value_state", PRE_INIT)
     val colFamilySchema = StateStoreColumnFamilySchemaUtils.
       getValueStateSchema(stateName, keyExprEnc, valEncoder, true)
+    checkIfDuplicateVariableDefined(stateName)
     columnFamilySchemas.put(stateName, colFamilySchema)
+    val stateVariableInfo = TransformWithStateVariableUtils.
+      getValueState(stateName, ttlEnabled = true)
+    stateVariableInfos.put(stateName, stateVariableInfo)
     null.asInstanceOf[ValueState[T]]
   }
 
@@ -330,7 +349,11 @@ class DriverStatefulProcessorHandleImpl(timeMode: TimeMode, keyExprEnc: Expressi
     verifyStateVarOperations("get_list_state", PRE_INIT)
     val colFamilySchema = StateStoreColumnFamilySchemaUtils.
       getListStateSchema(stateName, keyExprEnc, valEncoder, false)
+    checkIfDuplicateVariableDefined(stateName)
     columnFamilySchemas.put(stateName, colFamilySchema)
+    val stateVariableInfo = TransformWithStateVariableUtils.
+      getListState(stateName, ttlEnabled = false)
+    stateVariableInfos.put(stateName, stateVariableInfo)
     null.asInstanceOf[ListState[T]]
   }
 
@@ -341,7 +364,11 @@ class DriverStatefulProcessorHandleImpl(timeMode: TimeMode, keyExprEnc: Expressi
     verifyStateVarOperations("get_list_state", PRE_INIT)
     val colFamilySchema = StateStoreColumnFamilySchemaUtils.
       getListStateSchema(stateName, keyExprEnc, valEncoder, true)
+    checkIfDuplicateVariableDefined(stateName)
     columnFamilySchemas.put(stateName, colFamilySchema)
+    val stateVariableInfo = TransformWithStateVariableUtils.
+      getListState(stateName, ttlEnabled = true)
+    stateVariableInfos.put(stateName, stateVariableInfo)
     null.asInstanceOf[ListState[T]]
   }
 
@@ -352,7 +379,11 @@ class DriverStatefulProcessorHandleImpl(timeMode: TimeMode, keyExprEnc: Expressi
     verifyStateVarOperations("get_map_state", PRE_INIT)
     val colFamilySchema = StateStoreColumnFamilySchemaUtils.
       getMapStateSchema(stateName, keyExprEnc, userKeyEnc, valEncoder, false)
+    checkIfDuplicateVariableDefined(stateName)
     columnFamilySchemas.put(stateName, colFamilySchema)
+    val stateVariableInfo = TransformWithStateVariableUtils.
+      getMapState(stateName, ttlEnabled = false)
+    stateVariableInfos.put(stateName, stateVariableInfo)
     null.asInstanceOf[MapState[K, V]]
   }
 
@@ -365,6 +396,9 @@ class DriverStatefulProcessorHandleImpl(timeMode: TimeMode, keyExprEnc: Expressi
     val colFamilySchema = StateStoreColumnFamilySchemaUtils.
       getMapStateSchema(stateName, keyExprEnc, userKeyEnc, valEncoder, true)
     columnFamilySchemas.put(stateName, colFamilySchema)
+    val stateVariableInfo = TransformWithStateVariableUtils.
+      getMapState(stateName, ttlEnabled = true)
+    stateVariableInfos.put(stateName, stateVariableInfo)
     null.asInstanceOf[MapState[K, V]]
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
@@ -305,16 +305,16 @@ class DriverStatefulProcessorHandleImpl(timeMode: TimeMode, keyExprEnc: Expressi
   private[sql] val columnFamilySchemas: mutable.Map[String, StateStoreColFamilySchema] =
     new mutable.HashMap[String, StateStoreColFamilySchema]()
 
-  private[sql] val stateVariableInfos: mutable.Map[String, TransformWithStateVariableInfo] =
+  private val stateVariableInfos: mutable.Map[String, TransformWithStateVariableInfo] =
     new mutable.HashMap[String, TransformWithStateVariableInfo]()
 
   def getColumnFamilySchemas: Map[String, StateStoreColFamilySchema] = columnFamilySchemas.toMap
 
   def getStateVariableInfos: Map[String, TransformWithStateVariableInfo] = stateVariableInfos.toMap
 
-  private def checkIfDuplicateVariableDefined(stateName: String): Unit = {
-    if (columnFamilySchemas.contains(stateName)) {
-      throw StateStoreErrors.duplicateStateVariableDefined(stateName)
+  private def checkIfDuplicateVariableDefined(stateVarName: String): Unit = {
+    if (columnFamilySchemas.contains(stateVarName)) {
+      throw StateStoreErrors.duplicateStateVariableDefined(stateVarName)
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -443,25 +443,6 @@ case class TransformWithStateExec(
     new Path(new Path(storeNamePath, "_metadata"), "schema")
   }
 
-  private def checkStateVariableEquality(
-      oldStateVariableInfos: List[TransformWithStateVariableInfo]): Unit = {
-    val newStateVariableInfos = getStateVariableInfos()
-    oldStateVariableInfos.foreach { oldInfo =>
-      val newInfo = newStateVariableInfos.get(oldInfo.stateName)
-      newInfo match {
-        case Some(stateVarInfo) =>
-          if (oldInfo.stateVariableType != stateVarInfo.stateVariableType) {
-            throw StateStoreErrors.invalidVariableTypeChange(
-              stateVarInfo.stateName,
-              oldInfo.stateVariableType.toString,
-              stateVarInfo.stateVariableType.toString
-            )
-          }
-        case None =>
-      }
-    }
-  }
-
   override def validateNewMetadata(
       oldOperatorMetadata: OperatorStateMetadata,
       newOperatorMetadata: OperatorStateMetadata): Unit = {
@@ -475,7 +456,6 @@ case class TransformWithStateExec(
           newMetadataV2.operatorPropertiesJson)
         TransformWithStateOperatorProperties.validateOperatorProperties(
           oldOperatorProps, newOperatorProps)
-        checkStateVariableEquality(oldOperatorProps.stateVariables)
       case (_, _) =>
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateVariableUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateVariableUtils.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.streaming
+
+import org.json4s.DefaultFormats
+import org.json4s.JsonAST._
+import org.json4s.JsonDSL._
+import org.json4s.jackson.JsonMethods
+import org.json4s.jackson.JsonMethods.{compact, render}
+
+import org.apache.spark.sql.execution.streaming.StateVariableType.StateVariableType
+
+// Enum of possible State Variable types
+object StateVariableType extends Enumeration {
+  type StateVariableType = Value
+  val ValueState, ListState, MapState = Value
+}
+
+case class TransformWithStateVariableInfo(
+    stateName: String,
+    stateVariableType: StateVariableType,
+    ttlEnabled: Boolean) {
+  def jsonValue: JValue = {
+    ("stateName" -> JString(stateName)) ~
+      ("stateVariableType" -> JString(stateVariableType.toString)) ~
+      ("ttlEnabled" -> JBool(ttlEnabled))
+  }
+
+  def json: String = {
+    compact(render(jsonValue))
+  }
+}
+
+object TransformWithStateVariableInfo {
+
+  def fromJson(json: String): TransformWithStateVariableInfo = {
+    implicit val formats: DefaultFormats.type = DefaultFormats
+    val parsed = JsonMethods.parse(json).extract[Map[String, Any]]
+    fromMap(parsed)
+  }
+
+  def fromMap(map: Map[String, Any]): TransformWithStateVariableInfo = {
+    val stateName = map("stateName").asInstanceOf[String]
+    val stateVariableType = StateVariableType.withName(
+      map("stateVariableType").asInstanceOf[String])
+    val ttlEnabled = map("ttlEnabled").asInstanceOf[Boolean]
+    TransformWithStateVariableInfo(stateName, stateVariableType, ttlEnabled)
+  }
+}
+object TransformWithStateVariableUtils {
+  def getValueState(stateName: String, ttlEnabled: Boolean): TransformWithStateVariableInfo = {
+    TransformWithStateVariableInfo(stateName, StateVariableType.ValueState, ttlEnabled)
+  }
+
+  def getListState(stateName: String, ttlEnabled: Boolean): TransformWithStateVariableInfo = {
+    TransformWithStateVariableInfo(stateName, StateVariableType.ListState, ttlEnabled)
+  }
+
+  def getMapState(stateName: String, ttlEnabled: Boolean): TransformWithStateVariableInfo = {
+      TransformWithStateVariableInfo(stateName, StateVariableType.MapState, ttlEnabled)
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateVariableUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateVariableUtils.scala
@@ -105,6 +105,9 @@ object TransformWithStateOperatorProperties extends Logging {
     )
   }
 
+  // This function is to confirm that the operator properties and state variables have
+  // only changed in an acceptable way after query restart. If the properties have changed
+  // in an unacceptable way, this function will throw an exception.
   def validateOperatorProperties(
       oldOperatorProperties: TransformWithStateOperatorProperties,
       newOperatorProperties: TransformWithStateOperatorProperties): Unit = {
@@ -117,6 +120,7 @@ object TransformWithStateOperatorProperties extends Logging {
       throw StateStoreErrors.invalidConfigChangedAfterRestart(
         "outputMode", oldOperatorProperties.outputMode, newOperatorProperties.outputMode)
     }
+
     val oldStateVariableInfos = oldOperatorProperties.stateVariables
     val newStateVariableInfos = newOperatorProperties.stateVariables.map { stateVarInfo =>
       stateVarInfo.stateName -> stateVarInfo

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateVariableUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateVariableUtils.scala
@@ -117,5 +117,23 @@ object TransformWithStateOperatorProperties extends Logging {
       throw StateStoreErrors.invalidConfigChangedAfterRestart(
         "outputMode", oldOperatorProperties.outputMode, newOperatorProperties.outputMode)
     }
+    val oldStateVariableInfos = oldOperatorProperties.stateVariables
+    val newStateVariableInfos = newOperatorProperties.stateVariables.map { stateVarInfo =>
+      stateVarInfo.stateName -> stateVarInfo
+    }.toMap
+    oldStateVariableInfos.foreach { oldInfo =>
+      val newInfo = newStateVariableInfos.get(oldInfo.stateName)
+      newInfo match {
+        case Some(stateVarInfo) =>
+          if (oldInfo.stateVariableType != stateVarInfo.stateVariableType) {
+            throw StateStoreErrors.invalidVariableTypeChange(
+              stateVarInfo.stateName,
+              oldInfo.stateVariableType.toString,
+              stateVarInfo.stateVariableType.toString
+            )
+          }
+        case None =>
+      }
+    }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateVariableUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateVariableUtils.scala
@@ -26,6 +26,11 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.streaming.StateVariableType.StateVariableType
 import org.apache.spark.sql.execution.streaming.state.StateStoreErrors
 
+/**
+ * This file contains utility classes and functions for managing state variables in
+ * the operatorProperties field of the OperatorStateMetadata for TransformWithState.
+ * We use these utils to read and write state variable information for validation purposes
+ */
 // Enum of possible State Variable types
 object StateVariableType extends Enumeration {
   type StateVariableType = Value

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateVariableUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateVariableUtils.scala
@@ -29,8 +29,22 @@ import org.apache.spark.sql.execution.streaming.state.StateStoreErrors
 /**
  * This file contains utility classes and functions for managing state variables in
  * the operatorProperties field of the OperatorStateMetadata for TransformWithState.
- * We use these utils to read and write state variable information for validation purposes
+ * We use these utils to read and write state variable information for validation purposes.
  */
+object TransformWithStateVariableUtils {
+  def getValueState(stateName: String, ttlEnabled: Boolean): TransformWithStateVariableInfo = {
+    TransformWithStateVariableInfo(stateName, StateVariableType.ValueState, ttlEnabled)
+  }
+
+  def getListState(stateName: String, ttlEnabled: Boolean): TransformWithStateVariableInfo = {
+    TransformWithStateVariableInfo(stateName, StateVariableType.ListState, ttlEnabled)
+  }
+
+  def getMapState(stateName: String, ttlEnabled: Boolean): TransformWithStateVariableInfo = {
+    TransformWithStateVariableInfo(stateName, StateVariableType.MapState, ttlEnabled)
+  }
+}
+
 // Enum of possible State Variable types
 object StateVariableType extends Enumeration {
   type StateVariableType = Value
@@ -68,24 +82,11 @@ object TransformWithStateVariableInfo {
     TransformWithStateVariableInfo(stateName, stateVariableType, ttlEnabled)
   }
 }
-object TransformWithStateVariableUtils {
-  def getValueState(stateName: String, ttlEnabled: Boolean): TransformWithStateVariableInfo = {
-    TransformWithStateVariableInfo(stateName, StateVariableType.ValueState, ttlEnabled)
-  }
-
-  def getListState(stateName: String, ttlEnabled: Boolean): TransformWithStateVariableInfo = {
-    TransformWithStateVariableInfo(stateName, StateVariableType.ListState, ttlEnabled)
-  }
-
-  def getMapState(stateName: String, ttlEnabled: Boolean): TransformWithStateVariableInfo = {
-    TransformWithStateVariableInfo(stateName, StateVariableType.MapState, ttlEnabled)
-  }
-}
 
 case class TransformWithStateOperatorProperties(
-    val timeMode: String,
-    val outputMode: String,
-    val stateVariables: List[TransformWithStateVariableInfo]) {
+    timeMode: String,
+    outputMode: String,
+    stateVariables: List[TransformWithStateVariableInfo]) {
 
   def json: String = {
     val stateVariablesJson = stateVariables.map(_.jsonValue)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
@@ -24,9 +24,7 @@ import scala.reflect.ClassTag
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FSDataInputStream, FSDataOutputStream, Path}
-import org.json4s.{Formats, JString, NoTypeHints}
-import org.json4s.JsonDSL._
-import org.json4s.jackson.JsonMethods.{compact, render}
+import org.json4s.{Formats, NoTypeHints}
 import org.json4s.jackson.Serialization
 
 import org.apache.spark.internal.{Logging, LogKeys, MDC}
@@ -89,40 +87,6 @@ case class OperatorStateMetadataV2(
     stateStoreInfo: Array[StateStoreMetadataV2],
     operatorPropertiesJson: String) extends OperatorStateMetadata {
   override def version: Int = 2
-}
-
-object OperatorPropertiesUtils {
-  class OperatorProperties(
-      val timeMode: String,
-      val outputMode: String) {
-    def json: String = {
-      compact(render(
-        ("timeMode" -> JString(timeMode)) ~
-          ("outputMode" -> JString(outputMode))
-      ))
-    }
-  }
-
-  object OperatorProperties {
-    def fromJson(json: String): OperatorProperties = {
-      implicit val formats: Formats = Serialization.formats(NoTypeHints)
-      Serialization.read[OperatorProperties](json)
-    }
-
-    def validateOperatorProperties(
-        oldOperatorProperties: OperatorProperties,
-        newOperatorProperties: OperatorProperties): Unit = {
-      if (oldOperatorProperties.timeMode != newOperatorProperties.timeMode) {
-        throw StateStoreErrors.invalidConfigChangedAfterRestart(
-          "timeMode", oldOperatorProperties.timeMode, newOperatorProperties.timeMode)
-      }
-
-      if (oldOperatorProperties.outputMode != newOperatorProperties.outputMode) {
-          throw StateStoreErrors.invalidConfigChangedAfterRestart(
-          "outputMode", oldOperatorProperties.outputMode, newOperatorProperties.outputMode)
-      }
-    }
-  }
 }
 
 object OperatorStateMetadataUtils extends Logging {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
@@ -174,7 +174,6 @@ object StateStoreErrors {
     new StateStoreProviderDoesNotSupportFineGrainedReplay(inputClass)
   }
 
-
   def invalidConfigChangedAfterRestart(configName: String, oldConfig: String, newConfig: String):
     StateStoreInvalidConfigAfterRestart = {
     new StateStoreInvalidConfigAfterRestart(configName, oldConfig, newConfig)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
@@ -191,11 +191,11 @@ object StateStoreErrors {
   }
 }
 
-class StateStoreDuplicateStateVariableDefined(stateName: String)
+class StateStoreDuplicateStateVariableDefined(stateVarName: String)
   extends SparkRuntimeException(
     errorClass = "STATEFUL_PROCESSOR_DUPLICATE_STATE_VARIABLE_DEFINED",
     messageParameters = Map(
-      "stateName" -> stateName
+      "stateVarName" -> stateVarName
     )
   )
 
@@ -209,15 +209,16 @@ class StateStoreInvalidConfigAfterRestart(configName: String, oldConfig: String,
     )
   )
 
-class StateStoreInvalidVariableTypeChange(stateName: String, oldType: String, newType: String)
+class StateStoreInvalidVariableTypeChange(stateVarName: String, oldType: String, newType: String)
   extends SparkUnsupportedOperationException(
     errorClass = "STATE_STORE_INVALID_VARIABLE_TYPE_CHANGE",
     messageParameters = Map(
-      "stateName" -> stateName,
+      "stateVarName" -> stateVarName,
       "oldType" -> oldType,
       "newType" -> newType
     )
   )
+
 class StateStoreMultipleColumnFamiliesNotSupportedException(stateStoreProvider: String)
   extends SparkUnsupportedOperationException(
     errorClass = "UNSUPPORTED_FEATURE.STATE_STORE_MULTIPLE_COLUMN_FAMILIES",

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
@@ -193,7 +193,7 @@ object StateStoreErrors {
 
 class StateStoreDuplicateStateVariableDefined(stateName: String)
   extends SparkRuntimeException(
-    errorClass = "STATE_STORE_DUPLICATE_STATE_VARIABLE_DEFINED",
+    errorClass = "STATEFUL_PROCESSOR_DUPLICATE_STATE_VARIABLE_DEFINED",
     messageParameters = Map(
       "stateName" -> stateName
     )

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
@@ -176,17 +176,17 @@ object StateStoreErrors {
 
 
   def invalidConfigChangedAfterRestart(configName: String, oldConfig: String, newConfig: String):
-  StateStoreInvalidConfigAfterRestart = {
+    StateStoreInvalidConfigAfterRestart = {
     new StateStoreInvalidConfigAfterRestart(configName, oldConfig, newConfig)
   }
 
   def duplicateStateVariableDefined(stateName: String):
-  StateStoreDuplicateStateVariableDefined = {
+    StateStoreDuplicateStateVariableDefined = {
     new StateStoreDuplicateStateVariableDefined(stateName)
   }
 
   def invalidVariableTypeChange(stateName: String, oldType: String, newType: String):
-  StateStoreInvalidVariableTypeChange = {
+    StateStoreInvalidVariableTypeChange = {
     new StateStoreInvalidVariableTypeChange(stateName, oldType, newType)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
@@ -173,8 +173,51 @@ object StateStoreErrors {
     StateStoreProviderDoesNotSupportFineGrainedReplay = {
     new StateStoreProviderDoesNotSupportFineGrainedReplay(inputClass)
   }
+
+
+  def invalidConfigChangedAfterRestart(configName: String, oldConfig: String, newConfig: String):
+  StateStoreInvalidConfigAfterRestart = {
+    new StateStoreInvalidConfigAfterRestart(configName, oldConfig, newConfig)
+  }
+
+  def duplicateStateVariableDefined(stateName: String):
+  StateStoreDuplicateStateVariableDefined = {
+    new StateStoreDuplicateStateVariableDefined(stateName)
+  }
+
+  def invalidVariableTypeChange(stateName: String, oldType: String, newType: String):
+  StateStoreInvalidVariableTypeChange = {
+    new StateStoreInvalidVariableTypeChange(stateName, oldType, newType)
+  }
 }
 
+class StateStoreDuplicateStateVariableDefined(stateName: String)
+  extends SparkRuntimeException(
+    errorClass = "STATE_STORE_DUPLICATE_STATE_VARIABLE_DEFINED",
+    messageParameters = Map(
+      "stateName" -> stateName
+    )
+  )
+
+class StateStoreInvalidConfigAfterRestart(configName: String, oldConfig: String, newConfig: String)
+  extends SparkUnsupportedOperationException(
+    errorClass = "STATE_STORE_INVALID_CONFIG_AFTER_RESTART",
+    messageParameters = Map(
+      "configName" -> configName,
+      "oldConfig" -> oldConfig,
+      "newConfig" -> newConfig
+    )
+  )
+
+class StateStoreInvalidVariableTypeChange(stateName: String, oldType: String, newType: String)
+  extends SparkUnsupportedOperationException(
+    errorClass = "STATE_STORE_INVALID_VARIABLE_TYPE_CHANGE",
+    messageParameters = Map(
+      "stateName" -> stateName,
+      "oldType" -> oldType,
+      "newType" -> newType
+    )
+  )
 class StateStoreMultipleColumnFamiliesNotSupportedException(stateStoreProvider: String)
   extends SparkUnsupportedOperationException(
     errorClass = "UNSUPPORTED_FEATURE.STATE_STORE_MULTIPLE_COLUMN_FAMILIES",

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/statefulOperators.scala
@@ -276,6 +276,10 @@ trait StateStoreWriter extends StatefulOperator with PythonSQLMetrics { self: Sp
   /** Name to output in [[StreamingOperatorProgress]] to identify operator type */
   def shortName: String = "defaultName"
 
+  def validateNewMetadata(
+      oldMetadata: OperatorStateMetadata,
+      newMetadata: OperatorStateMetadata): Unit = {}
+
   /**
    * Should the MicroBatchExecution run another batch based on this stateful operator and the
    * new input watermark.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Implementing validation for the TransformWithStateExec operator, so that it can't restart with a different TimeMode and OutputMode, or invalid State Variable transformations.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
If there is an invalid change to the query after a restart, we want the query to fail. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No