### PR TITLE
[SPARK-48865][SQL][FOLLOWUP] Add failOnError argument to replace TryEval in TryUrlDecode

### DIFF
--- a/connect/common/src/test/resources/query-tests/explain-results/function_try_url_decode.explain
+++ b/connect/common/src/test/resources/query-tests/explain-results/function_try_url_decode.explain
@@ -1,2 +1,2 @@
-Project [tryeval(static_invoke(UrlCodec.decode(g#0, UTF-8))) AS try_url_decode(g)#0]
+Project [static_invoke(UrlCodec.decode(g#0, UTF-8, false)) AS try_url_decode(g)#0]
 +- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/connect/common/src/test/resources/query-tests/explain-results/function_url_decode.explain
+++ b/connect/common/src/test/resources/query-tests/explain-results/function_url_decode.explain
@@ -1,2 +1,2 @@
-Project [static_invoke(UrlCodec.decode(g#0, UTF-8)) AS url_decode(g)#0]
+Project [static_invoke(UrlCodec.decode(g#0, UTF-8, true)) AS url_decode(g)#0]
 +- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/url-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/url-functions.sql.out
@@ -79,28 +79,28 @@ Project [url_encode(cast(null as string)) AS url_encode(NULL)#x]
 -- !query
 select url_decode('https%3A%2F%2Fspark.apache.org')
 -- !query analysis
-Project [url_decode(https%3A%2F%2Fspark.apache.org) AS url_decode(https%3A%2F%2Fspark.apache.org)#x]
+Project [url_decode(https%3A%2F%2Fspark.apache.org, true) AS url_decode(https%3A%2F%2Fspark.apache.org)#x]
 +- OneRowRelation
 
 
 -- !query
 select url_decode('http%3A%2F%2spark.apache.org')
 -- !query analysis
-Project [url_decode(http%3A%2F%2spark.apache.org) AS url_decode(http%3A%2F%2spark.apache.org)#x]
+Project [url_decode(http%3A%2F%2spark.apache.org, true) AS url_decode(http%3A%2F%2spark.apache.org)#x]
 +- OneRowRelation
 
 
 -- !query
 select url_decode('inva lid://user:pass@host/file\\;param?query\\;p2')
 -- !query analysis
-Project [url_decode(inva lid://user:pass@host/file\;param?query\;p2) AS url_decode(inva lid://user:pass@host/file\;param?query\;p2)#x]
+Project [url_decode(inva lid://user:pass@host/file\;param?query\;p2, true) AS url_decode(inva lid://user:pass@host/file\;param?query\;p2)#x]
 +- OneRowRelation
 
 
 -- !query
 select url_decode(null)
 -- !query analysis
-Project [url_decode(cast(null as string)) AS url_decode(NULL)#x]
+Project [url_decode(cast(null as string), true) AS url_decode(NULL)#x]
 +- OneRowRelation
 
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Add `failOnError` argument for `UrlDecode` to replace `TryEval` in `TryUrlDecode`.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Address https://github.com/apache/spark/pull/47294#discussion_r1681150787

> I'm not a big fan of TryEval as it catches all the exceptions, including the ones not from UrlDecode, but from its input expressions.
> 
> We should add a boolean flag in UrlDecode to control the null-on-error behavior.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
existing unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No