### PR TITLE
[SPARK-49038][SQL] Fix regression in Spark UI SQL operator metrics calculation to filter out invalid accumulator values correctly

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
@@ -96,9 +96,12 @@ class SQLMetric(
 
   def +=(v: Long): Unit = add(v)
 
-  // _value may be uninitialized, in many cases being -1. We should not expose it to the user
-  // and instead return 0.
-  override def value: Long = if (isZero) 0 else _value
+  // We use -1 as initial value of the SIZE and TIMIMG accumulators (0 is a valid metric value).
+  // We need to return it as it is so that the SQL UI can filter out the invalid accumulator
+  // values in `SQLMetrics.stringValue` when calculating min, max, etc.
+  // However, users accessing the values in the physical plan programmatically still gets -1. They
+  // may use `SQLMetric.isZero` before consuming this value.
+  override def value: Long = _value
 
   // Provide special identifier as metadata so we can tell that this is a `SQLMetric` later
   override def toInfo(update: Option[Any], value: Option[Any]): AccumulableInfo = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningSuite.scala
@@ -1746,7 +1746,7 @@ abstract class DynamicPartitionPruningV1Suite extends DynamicPartitionPruningDat
         val allFilesNum = scan1.metrics("numFiles").value
         val allFilesSize = scan1.metrics("filesSize").value
         assert(scan1.metrics("numPartitions").value === numPartitions)
-        assert(scan1.metrics("pruningTime").value === 0)
+        assert(scan1.metrics("pruningTime").value === -1)
 
         // No dynamic partition pruning, so no static metrics
         // Only files from fid = 5 partition are scanned
@@ -1760,7 +1760,7 @@ abstract class DynamicPartitionPruningV1Suite extends DynamicPartitionPruningDat
         assert(0 < partFilesNum && partFilesNum < allFilesNum)
         assert(0 < partFilesSize && partFilesSize < allFilesSize)
         assert(scan2.metrics("numPartitions").value === 1)
-        assert(scan2.metrics("pruningTime").value === 0)
+        assert(scan2.metrics("pruningTime").value === -1)
 
         // Dynamic partition pruning is used
         // Static metrics are as-if reading the whole fact table

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -2291,8 +2291,16 @@ class AdaptiveQueryExecSuite
         assert(aqeReads.length == 2)
         aqeReads.foreach { c =>
           val stats = c.child.asInstanceOf[QueryStageExec].getRuntimeStatistics
-          assert(stats.sizeInBytes >= 0)
-          assert(stats.rowCount.get >= 0)
+          val rowCount = stats.rowCount.get
+          val sizeInBytes = stats.sizeInBytes
+          assert(rowCount >= 0)
+          if (rowCount == 0) {
+            // For empty relation, the query stage doesn't serialize any bytes.
+            // The SQLMetric keeps initial value.
+            assert(sizeInBytes == -1)
+          } else {
+            assert(sizeInBytes > 0)
+          }
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -815,7 +815,11 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
 
     testMetricsInSparkPlanOperator(exchanges.head,
       Map("dataSize" -> 3200, "shuffleRecordsWritten" -> 100))
-    testMetricsInSparkPlanOperator(exchanges(1), Map("dataSize" -> 0, "shuffleRecordsWritten" -> 0))
+    // `testData2.filter($"b" === 0)` is an empty relation.
+    // The exchange doesn't serialize any bytes.
+    // The SQLMetric keeps initial value.
+    testMetricsInSparkPlanOperator(exchanges(1),
+      Map("dataSize" -> -1, "shuffleRecordsWritten" -> 0))
   }
 
   test("Add numRows to metric of BroadcastExchangeExec") {
@@ -936,20 +940,20 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
   }
 
   test("Creating metrics with initial values") {
-    assert(SQLMetrics.createSizeMetric(sparkContext, name = "m").value === 0)
-    assert(SQLMetrics.createSizeMetric(sparkContext, name = "m", initValue = -1).value === 0)
+    assert(SQLMetrics.createSizeMetric(sparkContext, name = "m").value === -1)
+    assert(SQLMetrics.createSizeMetric(sparkContext, name = "m", initValue = -1).value === -1)
 
     assert(SQLMetrics.createSizeMetric(sparkContext, name = "m").isZero)
     assert(SQLMetrics.createSizeMetric(sparkContext, name = "m", initValue = -1).isZero)
 
-    assert(SQLMetrics.createTimingMetric(sparkContext, name = "m").value === 0)
-    assert(SQLMetrics.createTimingMetric(sparkContext, name = "m", initValue = -1).value === 0)
+    assert(SQLMetrics.createTimingMetric(sparkContext, name = "m").value === -1)
+    assert(SQLMetrics.createTimingMetric(sparkContext, name = "m", initValue = -1).value === -1)
 
     assert(SQLMetrics.createTimingMetric(sparkContext, name = "m").isZero)
     assert(SQLMetrics.createTimingMetric(sparkContext, name = "m", initValue = -1).isZero)
 
-    assert(SQLMetrics.createNanoTimingMetric(sparkContext, name = "m").value === 0)
-    assert(SQLMetrics.createNanoTimingMetric(sparkContext, name = "m", initValue = -1).value === 0)
+    assert(SQLMetrics.createNanoTimingMetric(sparkContext, name = "m").value === -1)
+    assert(SQLMetrics.createNanoTimingMetric(sparkContext, name = "m", initValue = -1).value === -1)
 
     assert(SQLMetrics.createNanoTimingMetric(sparkContext, name = "m").isZero)
     assert(SQLMetrics.createNanoTimingMetric(sparkContext, name = "m", initValue = -1).isZero)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/metric/SQLMetricsSuite.scala
@@ -961,7 +961,7 @@ class SQLMetricsSuite extends SharedSparkSession with SQLMetricsTestUtils
     val expectedOutput =
       "total (min, med, max (stageId: taskId))\n21 ms (0 ms, 4 ms, 10 ms (stage 2.0: task 4))"
 
-    assert(SQLMetrics.stringValue(metricTypeTiming, values, maxMetrics).equals(expectedOutput))
+    assert(SQLMetrics.stringValue(metricTypeTiming, values, maxMetrics) === expectedOutput)
   }
 
   test("Creating metrics with initial values") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch fixes an issue in the driver hosted Spark UI `SQL` tab DAG view where the invalid SQL metric values are not filtered out correctly and hence showing incorrect `minimum` and `median` metric values in the UI. This regression got introduced in #39311 .

### Why are the changes needed?
`SIZE`, `TIMING` and `NS_TIMING` metrics are [created](https://github.com/apache/spark/blob/9f22fa4d2acfcbc42d6d76a28778885cbdad733d/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala#L155-L182) with initial value `-1` (given `0` is a valid metric value for them). The `SQLMetrics.stringValue` method filters out the invalid values using condition: `value >= 0` before calculating the `min`, `med` and `max` values. But #39311 introduced in Spark `3.4.0` introduced a regression where the `SQLMetric.value` is always `>= 0`. This means that the invalid accumulators with value `-1` are no longer invalid to get filtered out correctly. This needs to be fixed.

### Does this PR introduce _any_ user-facing change?
Yes, as end users can access accumulator values directly. Users accessing the values in the physical plan programmatically should use `SQLMetric.isZero` before consuming its value.

### How was this patch tested?
Existing tests; Created new jar for Spark `3.5.1` and confirms that the incorrect data is shown correctly in Spark UI now.

Old UI view: 
[old_spark_ui_view_3_5_1.pdf](https://github.com/user-attachments/files/16411445/old_spark_ui_view_3_5_1.pdf)

Fixed UI view: 
[new_spark_ui_view_3_5_1.pdf](https://github.com/user-attachments/files/16411447/new_spark_ui_view_3_5_1.pdf)

### Was this patch authored or co-authored using generative AI tooling?
No
