### PR TITLE
[SPARK-49040][SQL] Fix doc `sql-ref-syntax-aux-exec-imm.md`

### DIFF
--- a/docs/sql-ref-syntax-aux-exec-imm.md
+++ b/docs/sql-ref-syntax-aux-exec-imm.md
@@ -61,11 +61,11 @@ EXECUTE IMMEDIATE sql_string
 
 ```sql
 -- A self-contained execution using a literal string
-EXECUTE IMMEDIATE 'SELECT SUM(c1) FROM VALUES(?), (?)' USING 5, 6;
+EXECUTE IMMEDIATE 'SELECT SUM(col1) FROM VALUES(?), (?)' USING 5, 6;
  11
 
 -- A SQL string composed in a SQL variable
-DECLARE sqlStr = 'SELECT SUM(c1) FROM VALUES(?), (?)';
+DECLARE sqlStr = 'SELECT SUM(col1) FROM VALUES(?), (?)';
 DECLARE arg1 = 5;
 DECLARE arg2 = 6;
 EXECUTE IMMEDIATE sqlStr USING arg1, arg2;
@@ -78,9 +78,8 @@ SELECT sum;
  11
 
 -- Using named parameter markers
-SET VAR sqlStr = 'SELECT SUM(c1) FROM VALUES(:first), (:second)';
-EXECUTE IMMEDIATE sqlStr INTO (sum)
-    USING 5 AS first, arg2 AS second;
+SET VAR sqlStr = 'SELECT SUM(col1) FROM VALUES(:first), (:second)';
+EXECUTE IMMEDIATE sqlStr INTO sum USING 5 AS first, arg2 AS second;
 SELECT sum;
  11
 ```


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix the sql in the example of the file `sql-ref-syntax-aux-exec-imm.md` cannot be executed

### Why are the changes needed?
- Before:
  <img width="1333" alt="image" src="https://github.com/user-attachments/assets/fa980b52-d233-42bf-9f84-cc55e52dbb23">

- After:
  <img width="630" alt="image" src="https://github.com/user-attachments/assets/3b4f4326-b628-464f-a0ef-55e66d315653">

### Does this PR introduce _any_ user-facing change?
Yes, the example sql in file `sql-ref-syntax-aux-exec-imm.md` can be copy-paste-run.


### How was this patch tested?
Manually test.


### Was this patch authored or co-authored using generative AI tooling?
No.
