### PR TITLE
[SPARK-49041][PYTHON][CONNECT] Raise proper error for `dropDuplicates` when wrong `subset` is given

### DIFF
--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -270,6 +270,43 @@ class DataFrameTestsMixin:
         self.assertEqual(df.drop_duplicates("name").count(), 1)
         self.assertEqual(df.drop_duplicates("name", "age").count(), 2)
 
+        # Should raise proper error when taking non-string values
+        with self.assertRaises(PySparkTypeError) as pe:
+            df.dropDuplicates([None]).show()
+
+        self.check_error(
+            exception=pe.exception,
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "subset", "arg_type": "NoneType"},
+        )
+
+        with self.assertRaises(PySparkTypeError) as pe:
+            df.dropDuplicates(None).show()
+
+        self.check_error(
+            exception=pe.exception,
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "subset", "arg_type": "NoneType"},
+        )
+
+        with self.assertRaises(PySparkTypeError) as pe:
+            df.dropDuplicates([1]).show()
+
+        self.check_error(
+            exception=pe.exception,
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "subset", "arg_type": "int"},
+        )
+
+        with self.assertRaises(PySparkTypeError) as pe:
+            df.dropDuplicates(1).show()
+
+        self.check_error(
+            exception=pe.exception,
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "subset", "arg_type": "int"},
+        )
+
     def test_drop_duplicates_with_ambiguous_reference(self):
         df1 = self.spark.createDataFrame([(14, "Tom"), (23, "Alice"), (16, "Bob")], ["age", "name"])
         df2 = self.spark.createDataFrame([Row(height=80, name="Tom"), Row(height=85, name="Bob")])


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to raise proper error for `dropDuplicates` when wrong `subset` is given

### Why are the changes needed?

Current error message is hard to understand since it raises unrelated `INTERNAL_ERROR`:

**Classic**:
```python
>>> df.dropDuplicates(None)
[INTERNAL_ERROR] Undefined error message parameter for error class: '_LEGACY_ERROR_TEMP_1201', MessageTemplate: Cannot resolve column name "<colName>" among (<fieldNames>)., Parameters: Map(colName -> null, fieldNames -> name, age) SQLSTATE: XX000
```

**Connect**:
```python
>>> df.dropDuplicates(None)
TypeError: bad argument type for built-in operation
```

### Does this PR introduce _any_ user-facing change?

No API changes, but the user-facing error message is improved both in classic & connect:


```python
>>> df.dropDuplicates(None)
[NOT_STR] Argument `subset` should be a str, got NoneType.
```


### How was this patch tested?

Added UTs.


### Was this patch authored or co-authored using generative AI tooling?

No.
