### PR TITLE
[SPARK-49039][UI] Reset checkbox when executor metrics are loaded in the Stages tab

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/stagepage.js
@@ -654,6 +654,7 @@ $(document).ready(function () {
             }
             executorSummaryTableSelector.column(13).visible(dataToShow.showBytesSpilledData);
             executorSummaryTableSelector.column(14).visible(dataToShow.showBytesSpilledData);
+            reselectCheckboxesBasedOnTaskTableState();
           });
 
         // Prepare data for speculation metrics


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to reset checkbox when executor metrics are loaded in the Stages tab.

### Why are the changes needed?
The variable `executorSummaryTableSelector` in the `reselectCheckboxesBasedOnTaskTableState` function may not be initialized, which results in inconsistent UI display.

Sometimes `allexecutors` api calls are slow, which causes `executorSummaryTableSelector` to be initialized lazily.
```js
$.getJSON(createRESTEndPointForExecutorsPage(appId),
```

<img width="800" alt="image" src="https://github.com/user-attachments/assets/780705ee-71b2-4063-bee9-cac3a3d35f27">


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
local test

<img width="1299" alt="image" src="https://github.com/user-attachments/assets/b3ee9cc3-088f-490f-a52b-259e8b07c016">



### Was this patch authored or co-authored using generative AI tooling?
No
