### PR TITLE
[SPARK-49011][SQL] Improve exceptions thrown from parser/interpreter

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -185,7 +185,7 @@ class AstBuilder extends DataTypeAstBuilder
               el.multipartIdentifier().getText.toLowerCase(Locale.ROOT) =>
         withOrigin(bl) {
           throw SqlScriptingException.labelsMismatch(
-          CurrentOrigin.get, bl.multipartIdentifier().getText, el.multipartIdentifier().getText)
+            CurrentOrigin.get, bl.multipartIdentifier().getText, el.multipartIdentifier().getText)
         }
       case (None, Some(el: EndLabelContext)) =>
         withOrigin(el) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -48,7 +48,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils.{convertSpecialDate, con
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, SupportsNamespaces, TableCatalog}
 import org.apache.spark.sql.connector.catalog.TableChange.ColumnPosition
 import org.apache.spark.sql.connector.expressions.{ApplyTransform, BucketTransform, DaysTransform, Expression => V2Expression, FieldReference, HoursTransform, IdentityTransform, LiteralValue, MonthsTransform, Transform, YearsTransform}
-import org.apache.spark.sql.errors.{DataTypeErrorsBase, QueryCompilationErrors, QueryParsingErrors, SqlScriptingException}
+import org.apache.spark.sql.errors.{DataTypeErrorsBase, QueryCompilationErrors, QueryParsingErrors, SqlScriptingErrors}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.LEGACY_BANG_EQUALS_NOT
 import org.apache.spark.sql.types._
@@ -158,12 +158,12 @@ class AstBuilder extends DataTypeAstBuilder
     declareVarStatement match {
       case Some(c: CreateVariable) =>
         if (allowVarDeclare) {
-          throw SqlScriptingException.variableDeclarationOnlyAtBeginning(
+          throw SqlScriptingErrors.variableDeclarationOnlyAtBeginning(
             c.origin,
             toSQLId(c.name.asInstanceOf[UnresolvedIdentifier].nameParts),
             c.origin.line.get.toString)
         } else {
-          throw SqlScriptingException.variableDeclarationNotAllowedInScope(
+          throw SqlScriptingErrors.variableDeclarationNotAllowedInScope(
             c.origin,
             toSQLId(c.name.asInstanceOf[UnresolvedIdentifier].nameParts),
             c.origin.line.get.toString)
@@ -184,12 +184,12 @@ class AstBuilder extends DataTypeAstBuilder
           bl.multipartIdentifier().getText.toLowerCase(Locale.ROOT) !=
               el.multipartIdentifier().getText.toLowerCase(Locale.ROOT) =>
         withOrigin(bl) {
-          throw SqlScriptingException.labelsMismatch(
+          throw SqlScriptingErrors.labelsMismatch(
             CurrentOrigin.get, bl.multipartIdentifier().getText, el.multipartIdentifier().getText)
         }
       case (None, Some(el: EndLabelContext)) =>
         withOrigin(el) {
-          throw SqlScriptingException.endLabelWithoutBeginLabel(
+          throw SqlScriptingErrors.endLabelWithoutBeginLabel(
             CurrentOrigin.get, el.multipartIdentifier().getText)
         }
       case _ =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -19,15 +19,12 @@ package org.apache.spark.sql.catalyst.parser
 
 import java.util.Locale
 import java.util.concurrent.TimeUnit
-
 import scala.collection.mutable.{ArrayBuffer, ListBuffer, Set}
 import scala.jdk.CollectionConverters._
 import scala.util.{Left, Right}
-
 import org.antlr.v4.runtime.{ParserRuleContext, Token}
 import org.antlr.v4.runtime.misc.Interval
 import org.antlr.v4.runtime.tree.{ParseTree, RuleNode, TerminalNode}
-
 import org.apache.spark.{SparkArithmeticException, SparkException, SparkIllegalArgumentException, SparkThrowable}
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys.PARTITION_SPECIFICATION
@@ -47,7 +44,7 @@ import org.apache.spark.sql.catalyst.util.{CharVarcharUtils, DateTimeUtils, Inte
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.{convertSpecialDate, convertSpecialTimestamp, convertSpecialTimestampNTZ, getZoneId, stringToDate, stringToTimestamp, stringToTimestampWithoutTimeZone}
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, SupportsNamespaces, TableCatalog}
 import org.apache.spark.sql.connector.catalog.TableChange.ColumnPosition
-import org.apache.spark.sql.connector.expressions.{ApplyTransform, BucketTransform, DaysTransform, Expression => V2Expression, FieldReference, HoursTransform, IdentityTransform, LiteralValue, MonthsTransform, Transform, YearsTransform}
+import org.apache.spark.sql.connector.expressions.{ApplyTransform, BucketTransform, DaysTransform, FieldReference, HoursTransform, IdentityTransform, LiteralValue, MonthsTransform, Transform, YearsTransform, Expression => V2Expression}
 import org.apache.spark.sql.errors.{DataTypeErrorsBase, QueryCompilationErrors, QueryParsingErrors, SqlScriptingException}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.LEGACY_BANG_EQUALS_NOT

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -19,12 +19,15 @@ package org.apache.spark.sql.catalyst.parser
 
 import java.util.Locale
 import java.util.concurrent.TimeUnit
+
 import scala.collection.mutable.{ArrayBuffer, ListBuffer, Set}
 import scala.jdk.CollectionConverters._
 import scala.util.{Left, Right}
+
 import org.antlr.v4.runtime.{ParserRuleContext, Token}
 import org.antlr.v4.runtime.misc.Interval
 import org.antlr.v4.runtime.tree.{ParseTree, RuleNode, TerminalNode}
+
 import org.apache.spark.{SparkArithmeticException, SparkException, SparkIllegalArgumentException, SparkThrowable}
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys.PARTITION_SPECIFICATION
@@ -44,7 +47,7 @@ import org.apache.spark.sql.catalyst.util.{CharVarcharUtils, DateTimeUtils, Inte
 import org.apache.spark.sql.catalyst.util.DateTimeUtils.{convertSpecialDate, convertSpecialTimestamp, convertSpecialTimestampNTZ, getZoneId, stringToDate, stringToTimestamp, stringToTimestampWithoutTimeZone}
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, SupportsNamespaces, TableCatalog}
 import org.apache.spark.sql.connector.catalog.TableChange.ColumnPosition
-import org.apache.spark.sql.connector.expressions.{ApplyTransform, BucketTransform, DaysTransform, FieldReference, HoursTransform, IdentityTransform, LiteralValue, MonthsTransform, Transform, YearsTransform, Expression => V2Expression}
+import org.apache.spark.sql.connector.expressions.{ApplyTransform, BucketTransform, DaysTransform, Expression => V2Expression, FieldReference, HoursTransform, IdentityTransform, LiteralValue, MonthsTransform, Transform, YearsTransform}
 import org.apache.spark.sql.errors.{DataTypeErrorsBase, QueryCompilationErrors, QueryParsingErrors, SqlScriptingException}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.LEGACY_BANG_EQUALS_NOT

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
@@ -17,30 +17,14 @@
 
 package org.apache.spark.sql.errors
 
-import scala.jdk.CollectionConverters.MapHasAsJava
-
-import org.apache.spark.{SparkThrowable, SparkThrowableHelper}
 import org.apache.spark.sql.catalyst.trees.Origin
-import org.apache.spark.sql.errors.SqlScriptingException.errorMessageWithLineNumber
-
-class SqlScriptingException protected (
-    origin: Origin,
-    errorClass: String,
-    cause: Throwable,
-    messageParameters: Map[String, String] = Map.empty)
-  extends Exception(errorMessageWithLineNumber(origin, errorClass, messageParameters), cause)
-    with SparkThrowable {
-
-  override def getErrorClass: String = errorClass
-  override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
-
-}
+import org.apache.spark.sql.exceptions.SqlScriptingException
 
 /**
  * Object for grouping error messages thrown during parsing/interpreting phase
  * of the SQL Scripting Language interpreter.
  */
-private[sql] object SqlScriptingException {
+private[sql] object SqlScriptingErrors {
 
   def labelsMismatch(origin: Origin, beginLabel: String, endLabel: String): Throwable = {
     new SqlScriptingException(
@@ -79,13 +63,4 @@ private[sql] object SqlScriptingException {
       cause = null,
       messageParameters = Map("varName" -> varName, "lineNumber" -> lineNumber))
   }
-
-  private def errorMessageWithLineNumber(
-    origin: Origin,
-    errorClass: String,
-    messageParameters: Map[String, String]): String = {
-    val prefix = origin.line.map(l => s"[LINE:$l] ").getOrElse("")
-    prefix + SparkThrowableHelper.getMessage(errorClass, messageParameters)
-  }
-
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
@@ -28,7 +28,7 @@ private[sql] object SqlScriptingErrors {
 
   def labelsMismatch(origin: Origin, beginLabel: String, endLabel: String): Throwable = {
     new SqlScriptingException(
-      origin = Option(origin),
+      origin = origin,
       errorClass = "LABELS_MISMATCH",
       cause = null,
       messageParameters = Map("beginLabel" -> beginLabel, "endLabel" -> endLabel))
@@ -36,7 +36,7 @@ private[sql] object SqlScriptingErrors {
 
   def endLabelWithoutBeginLabel(origin: Origin, endLabel: String): Throwable = {
     new SqlScriptingException(
-      origin = Option(origin),
+      origin = origin,
       errorClass = "END_LABEL_WITHOUT_BEGIN_LABEL",
       cause = null,
       messageParameters = Map("endLabel" -> endLabel))
@@ -47,7 +47,7 @@ private[sql] object SqlScriptingErrors {
       varName: String,
       lineNumber: String): Throwable = {
     new SqlScriptingException(
-      origin = Option(origin),
+      origin = origin,
       errorClass = "INVALID_VARIABLE_DECLARATION.NOT_ALLOWED_IN_SCOPE",
       cause = null,
       messageParameters = Map("varName" -> varName, "lineNumber" -> lineNumber))
@@ -58,7 +58,7 @@ private[sql] object SqlScriptingErrors {
       varName: String,
       lineNumber: String): Throwable = {
     new SqlScriptingException(
-      origin = Option(origin),
+      origin = origin,
       errorClass = "INVALID_VARIABLE_DECLARATION.ONLY_AT_BEGINNING",
       cause = null,
       messageParameters = Map("varName" -> varName, "lineNumber" -> lineNumber))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
@@ -28,7 +28,7 @@ private[sql] object SqlScriptingErrors {
 
   def labelsMismatch(origin: Origin, beginLabel: String, endLabel: String): Throwable = {
     new SqlScriptingException(
-      origin = origin,
+      origin = Option(origin),
       errorClass = "LABELS_MISMATCH",
       cause = null,
       messageParameters = Map("beginLabel" -> beginLabel, "endLabel" -> endLabel))
@@ -36,7 +36,7 @@ private[sql] object SqlScriptingErrors {
 
   def endLabelWithoutBeginLabel(origin: Origin, endLabel: String): Throwable = {
     new SqlScriptingException(
-      origin = origin,
+      origin = Option(origin),
       errorClass = "END_LABEL_WITHOUT_BEGIN_LABEL",
       cause = null,
       messageParameters = Map("endLabel" -> endLabel))
@@ -47,7 +47,7 @@ private[sql] object SqlScriptingErrors {
       varName: String,
       lineNumber: String): Throwable = {
     new SqlScriptingException(
-      origin = origin,
+      origin = Option(origin),
       errorClass = "INVALID_VARIABLE_DECLARATION.NOT_ALLOWED_IN_SCOPE",
       cause = null,
       messageParameters = Map("varName" -> varName, "lineNumber" -> lineNumber))
@@ -58,7 +58,7 @@ private[sql] object SqlScriptingErrors {
       varName: String,
       lineNumber: String): Throwable = {
     new SqlScriptingException(
-      origin = origin,
+      origin = Option(origin),
       errorClass = "INVALID_VARIABLE_DECLARATION.ONLY_AT_BEGINNING",
       cause = null,
       messageParameters = Map("varName" -> varName, "lineNumber" -> lineNumber))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingException.scala
@@ -17,7 +17,9 @@
 
 package org.apache.spark.sql.errors
 
-import org.apache.spark.{SparkException, SparkThrowableHelper}
+import scala.jdk.CollectionConverters.MapHasAsJava
+
+import org.apache.spark.{SparkThrowable, SparkThrowableHelper}
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.errors.SqlScriptingException.errorMessageWithLineNumber
 
@@ -26,11 +28,13 @@ class SqlScriptingException protected (
     errorClass: String,
     cause: Throwable,
     messageParameters: Map[String, String] = Map.empty)
-  extends SparkException(
-    message = errorMessageWithLineNumber(origin, errorClass, messageParameters),
-    errorClass = Option(errorClass),
-    cause = cause,
-    messageParameters = messageParameters)
+  extends Exception(errorMessageWithLineNumber(origin, errorClass, messageParameters), cause)
+    with SparkThrowable {
+
+  override def getErrorClass: String = errorClass
+  override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
+
+}
 
 /**
  * Object for grouping error messages thrown during parsing/interpreting phase

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingException.scala
@@ -17,8 +17,9 @@
 
 package org.apache.spark.sql.errors
 
-import org.apache.spark.{SparkException, SparkThrowable, SparkThrowableHelper}
+import org.apache.spark.{SparkException, SparkThrowableHelper}
 import org.apache.spark.sql.catalyst.trees.Origin
+import org.apache.spark.sql.errors.SqlScriptingException.errorMessageWithLineNumber
 
 class SqlScriptingException protected (
     origin: Origin,
@@ -26,8 +27,7 @@ class SqlScriptingException protected (
     cause: Throwable,
     messageParameters: Map[String, String] = Map.empty)
   extends SparkException(
-    message = s"[LINE:${origin.line}] "
-      + SparkThrowableHelper.getMessage(errorClass, messageParameters),
+    message = errorMessageWithLineNumber(origin, errorClass, messageParameters),
     errorClass = Option(errorClass),
     cause = cause,
     messageParameters = messageParameters
@@ -79,6 +79,15 @@ private[sql] object SqlScriptingException {
       errorClass = "INVALID_VARIABLE_DECLARATION.ONLY_AT_BEGINNING",
       cause = null,
       messageParameters = Map("varName" -> varName, "lineNumber" -> lineNumber))
+  }
+
+  private def errorMessageWithLineNumber(
+    origin: Origin,
+    errorClass: String,
+    messageParameters: Map[String, String]
+  ): String = {
+    val prefix = if (origin.line.isEmpty) "" else s"[LINE:${origin.line.get}] "
+    prefix + SparkThrowableHelper.getMessage(errorClass, messageParameters)
   }
 
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingException.scala
@@ -17,37 +17,65 @@
 
 package org.apache.spark.sql.errors
 
-import org.apache.spark.SparkException
+import org.apache.spark.{SparkException, SparkThrowable, SparkThrowableHelper}
+import org.apache.spark.sql.catalyst.trees.Origin
+
+class SqlScriptingException protected (
+    origin: Origin,
+    errorClass: String,
+    cause: Throwable,
+    messageParameters: Map[String, String] = Map.empty)
+  extends SparkException(
+    message = s"[LINE:${origin.line}] "
+      + SparkThrowableHelper.getMessage(errorClass, messageParameters),
+    errorClass = Option(errorClass),
+    cause = cause,
+    messageParameters = messageParameters
+  ) {
+
+}
 
 /**
  * Object for grouping error messages thrown during parsing/interpreting phase
  * of the SQL Scripting Language interpreter.
  */
-private[sql] object SqlScriptingErrors extends QueryErrorsBase {
+private[sql] object SqlScriptingException {
 
-  def labelsMismatch(beginLabel: String, endLabel: String): Throwable = {
-    new SparkException(
+  def labelsMismatch(origin: Origin, beginLabel: String, endLabel: String): Throwable = {
+    new SqlScriptingException(
+      origin = origin,
       errorClass = "LABELS_MISMATCH",
       cause = null,
       messageParameters = Map("beginLabel" -> beginLabel, "endLabel" -> endLabel))
   }
 
-  def endLabelWithoutBeginLabel(endLabel: String): Throwable = {
-    new SparkException(
+  def endLabelWithoutBeginLabel(origin: Origin, endLabel: String): Throwable = {
+    new SqlScriptingException(
+      origin = origin,
       errorClass = "END_LABEL_WITHOUT_BEGIN_LABEL",
       cause = null,
       messageParameters = Map("endLabel" -> endLabel))
   }
 
-  def variableDeclarationNotAllowedInScope(varName: String, lineNumber: String): Throwable = {
-    new SparkException(
+  def variableDeclarationNotAllowedInScope(
+    origin: Origin,
+    varName: String,
+    lineNumber: String
+  ): Throwable = {
+    new SqlScriptingException(
+      origin = origin,
       errorClass = "INVALID_VARIABLE_DECLARATION.NOT_ALLOWED_IN_SCOPE",
       cause = null,
       messageParameters = Map("varName" -> varName, "lineNumber" -> lineNumber))
   }
 
-  def variableDeclarationOnlyAtBeginning(varName: String, lineNumber: String): Throwable = {
-    new SparkException(
+  def variableDeclarationOnlyAtBeginning(
+    origin: Origin,
+    varName: String,
+    lineNumber: String
+  ): Throwable = {
+    new SqlScriptingException(
+      origin = origin,
       errorClass = "INVALID_VARIABLE_DECLARATION.ONLY_AT_BEGINNING",
       cause = null,
       messageParameters = Map("varName" -> varName, "lineNumber" -> lineNumber))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingException.scala
@@ -17,9 +17,8 @@
 
 package org.apache.spark.sql.errors
 
-import org.apache.spark.{SparkException, SparkThrowableHelper}
+import org.apache.spark.{SparkException, SparkThrowable, SparkThrowableHelper}
 import org.apache.spark.sql.catalyst.trees.Origin
-import org.apache.spark.sql.errors.SqlScriptingException.errorMessageWithLineNumber
 
 class SqlScriptingException protected (
     origin: Origin,
@@ -27,7 +26,8 @@ class SqlScriptingException protected (
     cause: Throwable,
     messageParameters: Map[String, String] = Map.empty)
   extends SparkException(
-    message = errorMessageWithLineNumber(origin, errorClass, messageParameters),
+    message = s"[LINE:${origin.line}] "
+      + SparkThrowableHelper.getMessage(errorClass, messageParameters),
     errorClass = Option(errorClass),
     cause = cause,
     messageParameters = messageParameters

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingException.scala
@@ -30,10 +30,7 @@ class SqlScriptingException protected (
     message = errorMessageWithLineNumber(origin, errorClass, messageParameters),
     errorClass = Option(errorClass),
     cause = cause,
-    messageParameters = messageParameters
-  ) {
-
-}
+    messageParameters = messageParameters)
 
 /**
  * Object for grouping error messages thrown during parsing/interpreting phase
@@ -58,10 +55,9 @@ private[sql] object SqlScriptingException {
   }
 
   def variableDeclarationNotAllowedInScope(
-    origin: Origin,
-    varName: String,
-    lineNumber: String
-  ): Throwable = {
+      origin: Origin,
+      varName: String,
+      lineNumber: String): Throwable = {
     new SqlScriptingException(
       origin = origin,
       errorClass = "INVALID_VARIABLE_DECLARATION.NOT_ALLOWED_IN_SCOPE",
@@ -70,10 +66,9 @@ private[sql] object SqlScriptingException {
   }
 
   def variableDeclarationOnlyAtBeginning(
-    origin: Origin,
-    varName: String,
-    lineNumber: String
-  ): Throwable = {
+      origin: Origin,
+      varName: String,
+      lineNumber: String): Throwable = {
     new SqlScriptingException(
       origin = origin,
       errorClass = "INVALID_VARIABLE_DECLARATION.ONLY_AT_BEGINNING",
@@ -84,9 +79,8 @@ private[sql] object SqlScriptingException {
   private def errorMessageWithLineNumber(
     origin: Origin,
     errorClass: String,
-    messageParameters: Map[String, String]
-  ): String = {
-    val prefix = if (origin.line.isEmpty) "" else s"[LINE:${origin.line.get}] "
+    messageParameters: Map[String, String]): String = {
+    val prefix = origin.line.map(l => s"[LINE:$l] ").getOrElse("")
     prefix + SparkThrowableHelper.getMessage(errorClass, messageParameters)
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingException.scala
@@ -17,8 +17,9 @@
 
 package org.apache.spark.sql.errors
 
-import org.apache.spark.{SparkException, SparkThrowable, SparkThrowableHelper}
+import org.apache.spark.{SparkException, SparkThrowableHelper}
 import org.apache.spark.sql.catalyst.trees.Origin
+import org.apache.spark.sql.errors.SqlScriptingException.errorMessageWithLineNumber
 
 class SqlScriptingException protected (
     origin: Origin,
@@ -26,8 +27,7 @@ class SqlScriptingException protected (
     cause: Throwable,
     messageParameters: Map[String, String] = Map.empty)
   extends SparkException(
-    message = s"[LINE:${origin.line}] "
-      + SparkThrowableHelper.getMessage(errorClass, messageParameters),
+    message = errorMessageWithLineNumber(origin, errorClass, messageParameters),
     errorClass = Option(errorClass),
     cause = cause,
     messageParameters = messageParameters

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/exceptions/SqlScriptingException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/exceptions/SqlScriptingException.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.exceptions
+
+import scala.jdk.CollectionConverters.MapHasAsJava
+
+import org.apache.spark.{SparkThrowable, SparkThrowableHelper}
+import org.apache.spark.sql.catalyst.trees.Origin
+import org.apache.spark.sql.exceptions.SqlScriptingException.errorMessageWithLineNumber
+
+class SqlScriptingException (
+    origin: Origin,
+    errorClass: String,
+    cause: Throwable,
+    messageParameters: Map[String, String] = Map.empty)
+  extends Exception(errorMessageWithLineNumber(origin, errorClass, messageParameters), cause)
+    with SparkThrowable {
+
+  override def getErrorClass: String = errorClass
+  override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
+}
+
+private object SqlScriptingException {
+
+  private def errorMessageWithLineNumber(
+      origin: Origin,
+      errorClass: String,
+      messageParameters: Map[String, String]): String = {
+    val prefix = origin.line.map(l => s"[LINE:$l] ").getOrElse("")
+    prefix + SparkThrowableHelper.getMessage(errorClass, messageParameters)
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/exceptions/SqlScriptingException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/exceptions/SqlScriptingException.scala
@@ -26,9 +26,11 @@ import org.apache.spark.sql.exceptions.SqlScriptingException.errorMessageWithLin
 class SqlScriptingException (
     errorClass: String,
     cause: Throwable,
-    origin: Option[Origin],
+    origin: Origin,
     messageParameters: Map[String, String] = Map.empty)
-  extends Exception(errorMessageWithLineNumber(origin, errorClass, messageParameters), cause)
+  extends Exception(
+    errorMessageWithLineNumber(Option(origin), errorClass, messageParameters),
+    cause)
   with SparkThrowable {
 
   override def getErrorClass: String = errorClass

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/exceptions/SqlScriptingException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/exceptions/SqlScriptingException.scala
@@ -41,7 +41,7 @@ private object SqlScriptingException {
       origin: Option[Origin],
       errorClass: String,
       messageParameters: Map[String, String]): String = {
-    val prefix = origin.map(o => o.line.map(l => s"[LINE:$l] ").getOrElse("")).getOrElse("")
+    val prefix = origin.flatMap(o => o.line.map(l => s"[LINE:$l] ")).getOrElse("")
     prefix + SparkThrowableHelper.getMessage(errorClass, messageParameters)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/exceptions/SqlScriptingException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/exceptions/SqlScriptingException.scala
@@ -24,12 +24,12 @@ import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.exceptions.SqlScriptingException.errorMessageWithLineNumber
 
 class SqlScriptingException (
-    origin: Origin,
     errorClass: String,
     cause: Throwable,
-    messageParameters: Map[String, String] = Map.empty)
+    messageParameters: Map[String, String] = Map.empty,
+    origin: Option[Origin] = None)
   extends Exception(errorMessageWithLineNumber(origin, errorClass, messageParameters), cause)
-    with SparkThrowable {
+  with SparkThrowable {
 
   override def getErrorClass: String = errorClass
   override def getMessageParameters: java.util.Map[String, String] = messageParameters.asJava
@@ -38,10 +38,10 @@ class SqlScriptingException (
 private object SqlScriptingException {
 
   private def errorMessageWithLineNumber(
-      origin: Origin,
+      origin: Option[Origin],
       errorClass: String,
       messageParameters: Map[String, String]): String = {
-    val prefix = origin.line.map(l => s"[LINE:$l] ").getOrElse("")
+    val prefix = origin.map(o => o.line.map(l => s"[LINE:$l] ").getOrElse("")).getOrElse("")
     prefix + SparkThrowableHelper.getMessage(errorClass, messageParameters)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/exceptions/SqlScriptingException.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/exceptions/SqlScriptingException.scala
@@ -26,8 +26,8 @@ import org.apache.spark.sql.exceptions.SqlScriptingException.errorMessageWithLin
 class SqlScriptingException (
     errorClass: String,
     cause: Throwable,
-    messageParameters: Map[String, String] = Map.empty,
-    origin: Option[Origin] = None)
+    origin: Option[Origin],
+    messageParameters: Map[String, String] = Map.empty)
   extends Exception(errorMessageWithLineNumber(origin, errorClass, messageParameters), cause)
   with SparkThrowable {
 
@@ -41,7 +41,7 @@ private object SqlScriptingException {
       origin: Option[Origin],
       errorClass: String,
       messageParameters: Map[String, String]): String = {
-    val prefix = origin.flatMap(o => o.line.map(l => s"[LINE:$l] ")).getOrElse("")
+    val prefix = origin.flatMap(o => o.line.map(l => s"{LINE:$l} ")).getOrElse("")
     prefix + SparkThrowableHelper.getMessage(errorClass, messageParameters)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.parser
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.catalyst.plans.logical.CreateVariable
-import org.apache.spark.sql.errors.SqlScriptingException
+import org.apache.spark.sql.exceptions.SqlScriptingException
 
 class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
   import CatalystSqlParser._

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -17,9 +17,10 @@
 
 package org.apache.spark.sql.catalyst.parser
 
-import org.apache.spark.{SparkException, SparkFunSuite}
+import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.catalyst.plans.logical.CreateVariable
+import org.apache.spark.sql.errors.SqlScriptingException
 
 class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
   import CatalystSqlParser._
@@ -206,7 +207,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
         |END lbl_end""".stripMargin
 
     checkError(
-      exception = intercept[SparkException] {
+      exception = intercept[SqlScriptingException] {
         parseScript(sqlScriptText)
       },
       errorClass = "LABELS_MISMATCH",
@@ -225,7 +226,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
         |END lbl""".stripMargin
 
     checkError(
-      exception = intercept[SparkException] {
+      exception = intercept[SqlScriptingException] {
         parseScript(sqlScriptText)
       },
       errorClass = "END_LABEL_WITHOUT_BEGIN_LABEL",
@@ -286,7 +287,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
         |  DECLARE testVariable INTEGER;
         |END""".stripMargin
     checkError(
-        exception = intercept[SparkException] {
+        exception = intercept[SqlScriptingException] {
           parseScript(sqlScriptText)
         },
         errorClass = "INVALID_VARIABLE_DECLARATION.ONLY_AT_BEGINNING",


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduced a new class `SqlScriptingException`, which is thrown during SQL script parsing/interpreting, and contains information about the line number on which the error occured.


### Why are the changes needed?
Users should know which line of their script caused an error.


### Does this PR introduce _any_ user-facing change?
Users will now see a line number on some of their error messages. The format of the new error messages is:
`{LINE:N} errorMessage`
where N is the line number of the error, and errorMessage is the existing error message, before this change.


### How was this patch tested?
No new tests required, existing tests are updated.


### Was this patch authored or co-authored using generative AI tooling?
No
