### PR TITLE
Multiple spark application can be submitted within the current process

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
@@ -53,10 +53,10 @@ object KubernetesClientUtils extends Logging {
   }
 
   @Since("3.1.0")
-  val configMapNameExecutor: String = configMapName(s"spark-exec-${KubernetesUtils.uniqueID()}")
+  def configMapNameExecutor: String = configMapName(s"spark-exec-${KubernetesUtils.uniqueID()}")
 
   @Since("3.1.0")
-  val configMapNameDriver: String = configMapName(s"spark-drv-${KubernetesUtils.uniqueID()}")
+  def configMapNameDriver: String = configMapName(s"spark-drv-${KubernetesUtils.uniqueID()}")
 
   private def buildStringFromPropertiesMap(configMapName: String,
       propertiesMap: Map[String, String]): String = {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtilsSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtilsSuite.scala
@@ -81,6 +81,10 @@ class KubernetesClientUtilsSuite extends SparkFunSuite with BeforeAndAfter {
     assert(output === expectedOutput)
   }
 
+  test("verify that the DriverConfigMapName are different") {
+    assert(!KubernetesClientUtils.configMapNameDriver.equals(KubernetesClientUtils.configMapNameDriver))
+  }
+  
   test("verify that configmap built as expected") {
     val configMapName = s"configmap-name-${UUID.randomUUID.toString}"
     val configMapNameSpace = s"configmap-namespace-${UUID.randomUUID.toString}"

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtilsSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtilsSuite.scala
@@ -82,7 +82,7 @@ class KubernetesClientUtilsSuite extends SparkFunSuite with BeforeAndAfter {
   }
 
   test("verify that the DriverConfigMapName are different") {
-    assert(!KubernetesClientUtils.configMapNameDriver.equals(KubernetesClientUtils.configMapNameDriver))
+    assert(KubernetesClientUtils.configMapNameDriver!=KubernetesClientUtils.configMapNameDriver)
   }
   
   test("verify that configmap built as expected") {


### PR DESCRIPTION
What changes were proposed in this pull request?
Why are the changes needed?
Multiple spark application can be submitted within the current process

Does this PR introduce any user-facing change?
No

How was this patch tested?
test("verify that the DriverConfigMapName are different") {
assert(KubernetesClientUtils.configMapNameDriver!=KubernetesClientUtils.configMapNameDriver)
}

Was this patch authored or co-authored using generative AI tooling?
No