### PR TITLE
Multiple spark application can be submitted within the current process

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/submit/KubernetesClientUtils.scala
@@ -53,10 +53,10 @@ object KubernetesClientUtils extends Logging {
   }
 
   @Since("3.1.0")
-  val configMapNameExecutor: String = configMapName(s"spark-exec-${KubernetesUtils.uniqueID()}")
+  def configMapNameExecutor: String = configMapName(s"spark-exec-${KubernetesUtils.uniqueID()}")
 
   @Since("3.1.0")
-  val configMapNameDriver: String = configMapName(s"spark-drv-${KubernetesUtils.uniqueID()}")
+  def configMapNameDriver: String = configMapName(s"spark-drv-${KubernetesUtils.uniqueID()}")
 
   private def buildStringFromPropertiesMap(configMapName: String,
       propertiesMap: Map[String, String]): String = {


### PR DESCRIPTION
Multiple spark application can be submitted within the current process

What changes were proposed in this pull request?
Why are the changes needed?
Multiple spark application can be submitted within the current process

Does this PR introduce any user-facing change?
No

How was this patch tested?
assert(KubernetesClientUtils.configMapNameDriver!=KubernetesClientUtils.configMapNameDriver)

Was this patch authored or co-authored using generative AI tooling?
No