### PR TITLE
[MINOR][PS][DOCS] Add `DataFrame.plot.kde` to API reference

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/frame.rst
+++ b/python/docs/source/reference/pyspark.pandas/frame.rst
@@ -326,14 +326,15 @@ specific plotting methods of the form ``DataFrame.plot.<kind>``.
    :template: autosummary/accessor_method.rst
 
    DataFrame.plot.area
-   DataFrame.plot.barh
    DataFrame.plot.bar
-   DataFrame.plot.hist
+   DataFrame.plot.barh
    DataFrame.plot.box
+   DataFrame.plot.density
+   DataFrame.plot.hist
+   DataFrame.plot.kde
    DataFrame.plot.line
    DataFrame.plot.pie
    DataFrame.plot.scatter
-   DataFrame.plot.density
 
 .. autosummary::
    :toctree: api/

--- a/python/docs/source/reference/pyspark.pandas/series.rst
+++ b/python/docs/source/reference/pyspark.pandas/series.rst
@@ -461,8 +461,8 @@ specific plotting methods of the form ``Series.plot.<kind>``.
    Series.plot.box
    Series.plot.density
    Series.plot.hist
-   Series.plot.line
    Series.plot.kde
+   Series.plot.line
    Series.plot.pie
 
 .. autosummary::

--- a/python/docs/source/reference/pyspark.pandas/series.rst
+++ b/python/docs/source/reference/pyspark.pandas/series.rst
@@ -462,8 +462,8 @@ specific plotting methods of the form ``Series.plot.<kind>``.
    Series.plot.density
    Series.plot.hist
    Series.plot.line
-   Series.plot.pie
    Series.plot.kde
+   Series.plot.pie
 
 .. autosummary::
    :toctree: api/


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, add `DataFrame.plot.kde` to API reference;
2, sort the plotting function alphabetically;


### Why are the changes needed?
`DataFrame.plot.kde` is a public function in Pandas https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.plot.kde.html

And it was already implemented in PS, but never exposed to users.


### Does this PR introduce _any_ user-facing change?
Yes, doc-only changes


### How was this patch tested?
CI

### Was this patch authored or co-authored using generative AI tooling?
No