### PR TITLE
[SPARK-49095][SQL] Update `DecimalType`and `decimal fields` compatible logic of `Avro` data source to avoid loss of decimal precision

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -60,6 +60,8 @@ license: |
 - Since Spark 4.0, By default views tolerate column type changes in the query and compensate with casts. To restore the previous behavior, allowing up-casts only, set `spark.sql.legacy.viewSchemaCompensation` to `false`.
 - Since Spark 4.0, Views allow control over how they react to underlying query changes. By default views tolerate column type changes in the query and compensate with casts. To disable this feature set `spark.sql.legacy.viewSchemaBindingMode` to `false`. This also removes the clause from `DESCRIBE EXTENDED` and `SHOW CREATE TABLE`.
 - Since Spark 4.0, The Storage-Partitioned Join feature flag `spark.sql.sources.v2.bucketing.pushPartValues.enabled` is set to `true`. To restore the previous behavior, set `spark.sql.sources.v2.bucketing.pushPartValues.enabled` to `false`.
+- Since Spark 4.0, when reading decimal fields from Avro data source, it requires that not only the `precision - scale` value of the `DecimalType` should be greater than or equal to that of decimal fields, but also the scale of the `DecimalType` should be greater than or equal to the scale of decimal fields. Otherwise, an `AnalysisException` will be thrown. To restore the legacy behavior, set `spark.sql.legacy.avro.allowIncompatibleDecimalType` to `true`.
+
 
 ## Upgrading from Spark SQL 3.5.1 to 3.5.2
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4841,6 +4841,19 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val LEGACY_AVRO_ALLOW_INCOMPATIBLE_DECIMAL_TYPE =
+    buildConf("spark.sql.legacy.avro.allowIncompatibleDecimalType")
+      .internal()
+      .doc("When set to false, when reading decimal fields from Avro data source, it requires " +
+        "that not only the `precision - scale` value of the `DecimalType` should be greater " +
+        "than or equal to that of decimal fields, but also the scale of the `DecimalType` " +
+        "should be greater than or equal to the scale of decimal fields. When set to true, it " +
+        "restores the legacy behavior, allowing the scale of `DecimalType` to be less than " +
+        "the scale of decimal fields, which may cause a loss of precision in the decimal part.")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val LEGACY_NON_IDENTIFIER_OUTPUT_CATALOG_NAME =
     buildConf("spark.sql.legacy.v1IdentifierNoCatalog")
       .internal()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR aims to enhance comparison logic to avoid precision loss in decimal parts of `Decimal` in Avro data source. It refers to the related logic of convert `Decimal` type in `Parquet` data source #44513 .

Before:
- As long as the length of the integer part(`precision - scale`) matches, it can be converted.

After:
- Both the integer(`precision - scale`) and decimal part(`scale`) lengths must match.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fixed the issue causing missing data accuracy.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, stricter matching requirements for conversions between Spark `DecimalType` and `Avro` Decimal type.

Previously, decimal(12,10) -> decimal(5,3) was allowed, but there would be some loss of precision in the decimal part, such as: 13.1234567890 -> 13.123
After that, the exception `avroIncompatibleReadError` will be thrown, because 3 is not greater than or equal 10. Unless both the integer and the decimal part are greater than or equal. For example, decimal(15, 13) is OK because 13>=10 and 15-13>=12-10

But users can restore the legacy behavior, set `spark.sql.legacy.avro.allowIncompatibleDecimalType` to `true`.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Pass GA and add new test cases.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.