### PR TITLE
[SPARK-47894][CORE][FOLLOWUP] Add a trailing slash to `MasterPage`'s `Environment` page link

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/ui/MasterPage.scala
@@ -172,7 +172,7 @@ private[ui] class MasterPage(parent: MasterWebUI) extends WebUIPage("") {
                 {state.completedDrivers.count(_.state == DriverState.RELAUNCHING)} Relaunching)
               </li>
               <li><strong>Status:</strong> {state.status}
-                (<a href={"/environment"}>Environment</a>,
+                (<a href={"/environment/"}>Environment</a>,
                 <a href={"/logPage/?self&logType=out"}>Log</a>)
               </li>
             </ul>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of #46111 to prevent redundant redirection by adding trailing slashes like #46157 .

### Why are the changes needed?

- To remove redundant redirection.
```
$ curl -v http://localhost:8080/environment
* Host localhost:8080 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8080...
* connect to ::1 port 8080 from ::1 port 50081 failed: Connection refused
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080
> GET /environment HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/1.1 302 Found
< Date: Sat, 03 Aug 2024 02:39:02 GMT
< Location: http://localhost:8080/environment/
< Content-Length: 0
<
* Connection #0 to host localhost left intact
```

- Some browser doesn't preserve all HTTP header information of the original PRs when it redirects.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and do the manual test.

```
$ sbin/start-master.sh
```

### Was this patch authored or co-authored using generative AI tooling?

No.