### PR TITLE
[SPARK-48834][SQL][TESTS][FOLLOWUP] Add `assume(shouldTestPandasUDFs)` to PythonUDFSuite complex variant input test

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonUDFSuite.scala
@@ -101,6 +101,7 @@ class PythonUDFSuite extends QueryTest with SharedSparkSession {
   }
 
   test("complex variant input to pandas grouped agg UDF") {
+    assume(shouldTestPandasUDFs)
     val df = spark.range(0, 10).selectExpr(
       """array(parse_json(format_string('{"%s": "test"}', id))) as arr_v""")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up of the following in order to add a missed `assume(shouldTestPandasUDFs)`.
- #47253

### Why are the changes needed?

After this PR, all tests of `PythonUDFSuite` will have `assume(shouldTestPythonUDFs)`.
```
$ cd ./sql/core/src/test/scala/org/apache/spark/sql/execution/python/
$ grep -C1 'test(' PythonUDFSuite.scala

  test("SPARK-28445: PythonUDF as grouping key and aggregate expressions") {
    assume(shouldTestPythonUDFs)
--

  test("SPARK-28445: PythonUDF as grouping key and used in aggregate expressions") {
    assume(shouldTestPythonUDFs)
--

  test("SPARK-28445: PythonUDF in aggregate expression has grouping key in its arguments") {
    assume(shouldTestPythonUDFs)
--

  test("SPARK-28445: PythonUDF over grouping key is argument to aggregate function") {
    assume(shouldTestPythonUDFs)
--

  test("SPARK-39962: Global aggregation of Pandas UDF should respect the column order") {
    assume(shouldTestPandasUDFs)
--

  test("variant input to pandas grouped agg UDF") {
    assume(shouldTestPandasUDFs)
--

  test("complex variant input to pandas grouped agg UDF") {
    assume(shouldTestPandasUDFs)
--

  test("variant output to pandas grouped agg UDF") {
    assume(shouldTestPandasUDFs)
--

  test("complex variant output to pandas grouped agg UDF") {
    assume(shouldTestPandasUDFs)
--

  test("SPARK-34265: Instrument Python UDF execution using SQL Metrics") {
    assume(shouldTestPythonUDFs)
--

  test("PythonUDAF pretty name") {
    assume(shouldTestPandasUDFs)
--

  test("SPARK-48706: Negative test case for Python UDF in higher order functions") {
    assume(shouldTestPythonUDFs)
--

  test("SPARK-48666: Python UDF execution against partitioned column") {
    assume(shouldTestPythonUDFs)
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs and manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.