### PR TITLE
[SPARK-49107][SQL] `ROUTINE_ALREADY_EXISTS` supports RoutineType

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3688,8 +3688,8 @@
   },
   "ROUTINE_ALREADY_EXISTS" : {
     "message" : [
-      "Cannot create the routine <routineName> because it already exists.",
-      "Choose a different name, drop or replace the existing routine, or add the IF NOT EXISTS clause to tolerate a pre-existing routine."
+      "Cannot create the <newRoutineType> <routineName> because a <existingRoutineType> of that name already exists.",
+      "Choose a different name, drop or replace the existing <existingRoutineType>, or add the IF NOT EXISTS clause to tolerate a pre-existing <newRoutineType>."
     ],
     "sqlState" : "42723"
   },

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/analysis/alreadyExistException.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/analysis/alreadyExistException.scala
@@ -146,7 +146,9 @@ class FunctionAlreadyExistsException(errorClass: String, messageParameters: Map[
 
   def this(function: Seq[String]) = {
     this (errorClass = "ROUTINE_ALREADY_EXISTS",
-      Map("routineName" -> quoteNameParts(function)))
+      Map("routineName" -> quoteNameParts(function),
+        "newRoutineType" -> "routine",
+        "existingRoutineType" -> "routine"))
   }
 
   def this(db: String, func: String) = {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalogSuite.scala
@@ -1583,7 +1583,9 @@ abstract class SessionCatalogSuite extends AnalysisTest with Eventually {
       }
       checkError(e,
         errorClass = "ROUTINE_ALREADY_EXISTS",
-        parameters = Map("routineName" -> "`temp1`"))
+        parameters = Map("routineName" -> "`temp1`",
+          "newRoutineType" -> "routine",
+          "existingRoutineType" -> "routine"))
       // Temporary function is overridden
       catalog.registerFunction(
         newFunc("temp1", None), overrideIfExists = true, functionBuilder = Some(tempFunc3))

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/HiveDDLSuite.scala
@@ -3277,7 +3277,9 @@ class HiveDDLSuite
       }
       checkError(e,
         errorClass = "ROUTINE_ALREADY_EXISTS",
-        parameters = Map("routineName" -> "`f1`"))
+        parameters = Map("routineName" -> "`f1`",
+          "newRoutineType" -> "routine",
+          "existingRoutineType" -> "routine"))
       assert(!spark.sparkContext.listJars().exists(_.contains(jarName)))
 
       sql("CREATE OR REPLACE TEMPORARY FUNCTION f1 AS " +


### PR DESCRIPTION
### What changes were proposed in this pull request?
`ROUTINE_ALREADY_EXISTS` supports RoutineType:

- existingRoutineType
- newRoutineType


### Why are the changes needed?
To make `ROUTINE_ALREADY_EXISTS` able to contain the type information


### Does this PR introduce _any_ user-facing change?
minor change in error message


### How was this patch tested?
updated tests


### Was this patch authored or co-authored using generative AI tooling?
no
