### PR TITLE
[SPARK-49108][EXAMPLE] Add `submit_pi.sh` REST API example

### DIFF
--- a/examples/src/main/scripts/submit_pi.sh
+++ b/examples/src/main/scripts/submit_pi.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Usage: Use Spark Cluster and 'pi.py' Python script
+#        In case of standalone clusters on K8s, we can use the local file.
+#        - local:///opt/spark/examples/src/main/python/pi.py
+#        Otherwise, use any cluster-accessible file via HTTP/HTTPS, S3, or HDFS
+#        - https://raw.githubusercontent.com/apache/spark/master/examples/src/main/python/pi.py
+#
+#    submit_pi.sh <spark_master_hostname> <location_of_python_script>
+#
+
+SPARK_MASTER=${1:-localhost}
+PYTHON_FILE=${2:-https://raw.githubusercontent.com/apache/spark/master/examples/src/main/python/pi.py}
+
+curl -XPOST http://$SPARK_MASTER:6066/v1/submissions/create \
+--data '{
+  "appResource": "",
+  "sparkProperties": {
+    "spark.submit.deployMode": "cluster",
+    "spark.app.name": "SparkPi",
+    "spark.driver.cores": "1",
+    "spark.driver.memory": "1g",
+    "spark.executor.cores": "1",
+    "spark.executor.memory": "1g",
+    "spark.cores.max": "2"
+  },
+  "clientSparkVersion": "",
+  "mainClass": "org.apache.spark.deploy.SparkSubmit",
+  "environmentVariables": {
+    "MASTER": "spark://'$SPARK_MASTER':7077"
+  },
+  "action": "CreateSubmissionRequest",
+  "appArgs": [ "'$PYTHON_FILE'", "2000" ]
+}'


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to provide `submit_pi.sh` example via REST API.

### Why are the changes needed?

To provide the REST API feature more clearly via a working example.

### Does this PR introduce _any_ user-facing change?

No, this is a new example.

### How was this patch tested?

Manual review.

1. Start Spark Cluster and Submit the job via `submit_pi.sh` script.
```
$ SPARK_MASTER_OPTS="-Dspark.master.rest.enabled=true" sbin/start-master.sh
$ sbin/start-worker.sh spark://$(hostname):7077

$ ./examples/src/main/scripts/submit_pi.sh
{
  "action" : "CreateSubmissionResponse",
  "message" : "Driver successfully submitted as driver-20240804234519-0000",
  "serverSparkVersion" : "4.0.0-SNAPSHOT",
  "submissionId" : "driver-20240804234519-0000",
  "success" : true
}%
```

2. Visit Spark Master UI and Spark job `Executor` UI.
- http://localhost:8080

<img width="712" alt="Screenshot 2024-08-04 at 23 45 50" src="https://github.com/user-attachments/assets/9e1c583b-a954-484c-8728-e4e51d7f08ed">

3. After completion, check the status via REST API.
```
$ curl http://localhost:6066/v1/submissions/status/driver-20240804234519-0000
{
  "action" : "SubmissionStatusResponse",
  "driverState" : "FINISHED",
  "serverSparkVersion" : "4.0.0-SNAPSHOT",
  "submissionId" : "driver-20240804234519-0000",
  "success" : true,
  "workerHostPort" : "127.0.0.1:61480",
  "workerId" : "worker-20240804234513-127.0.0.1-61480"
}
```


### Was this patch authored or co-authored using generative AI tooling?

No.