### PR TITLE
[SPARK-49110][SQL] Fix reading metadata columns for tables with CHAR columns

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -1727,14 +1727,10 @@ case class SubqueryAlias(
   }
 
   override def metadataOutput: Seq[Attribute] = {
-    // Propagate metadata columns from leaf nodes through a chain of `SubqueryAlias`.
-    if (child.isInstanceOf[LeafNode] || child.isInstanceOf[SubqueryAlias]) {
-      val qualifierList = identifier.qualifier :+ alias
-      val nonHiddenMetadataOutput = child.metadataOutput.filter(!_.qualifiedAccessOnly)
-      nonHiddenMetadataOutput.map(_.withQualifier(qualifierList))
-    } else {
-      Nil
-    }
+    // Propagate metadata columns
+    val qualifierList = identifier.qualifier :+ alias
+    val nonHiddenMetadataOutput = child.metadataOutput.filter(!_.qualifiedAccessOnly)
+    nonHiddenMetadataOutput.map(_.withQualifier(qualifierList))
   }
 
   override def maxRows: Option[Long] = child.maxRows


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR modifies `SubqueryAlias` to always propagate the metadata output of its child, even if the child is not a `SubqueryAlias` or a `LeafNode`.


### Why are the changes needed?

This is needed because with these changes it is not possible to read metadata columns when reading a table with a CHAR column when read-side padding is enabled. In the case the plan is `SubqueryAlias(Project(LeafNode)))`, so without this patch the metadata output is not propagated.

### Does this PR introduce _any_ user-facing change?

Yes, there will be more cases in which the metadata columns can be accessed, and users will no longer get an exception in these cases.

### How was this patch tested?

Added a case to `MetadataColumnSuite`.

### Was this patch authored or co-authored using generative AI tooling?

No
