### PR TITLE
[SPARK-49116][K8S] Fix `InvalidDefaultArgInFrom` in Python/R binding Dockerfiles

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/R/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/R/Dockerfile
@@ -17,7 +17,7 @@
 
 ARG base_img
 
-FROM $base_img
+FROM ${base_img:-spark}
 WORKDIR /
 
 # Reset to root to run installation tasks

--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile
@@ -17,7 +17,7 @@
 
 ARG base_img
 
-FROM $base_img
+FROM ${base_img:-spark}
 WORKDIR /
 
 # Reset to root to run installation tasks


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `InvalidDefaultArgInFrom` in Python/R binding Dockerfiles by providing the default value.

### Why are the changes needed?

When a user builds Apache Spark docker images, he/she meets the following warning currently.
```
 1 warning found (use docker --debug to expand):
 - InvalidDefaultArgInFrom: Default value for ARG $base_img results in empty or invalid base image name (line 20)
```

This is an official guide line to fix it.
- https://docs.docker.com/reference/build-checks/invalid-default-arg-in-from/

### Does this PR introduce _any_ user-facing change?

No.

The provided default value is the same one for the following command. We usually provide REPO and TAG to override this.
```
bin/docker-image-tool.sh -p kubernetes/dockerfiles/spark/bindings/python/Dockerfile -n build
```

### How was this patch tested?

Manual build the distribution and docker images.
```
$ NO_MANUAL=1 ./dev/make-distribution.sh -Pkubernetes
$ bin/docker-image-tool.sh -p kubernetes/dockerfiles/spark/bindings/python/Dockerfile -n build
```

**BEFORE**
```
...
 1 warning found (use docker --debug to expand):
 - InvalidDefaultArgInFrom: Default value for ARG $base_img results in empty or invalid base image name (line 20)

What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview
```

**AFTER**
```
...
What's next:
    View a summary of image vulnerabilities and recommendations → docker scout quickview
```

### Was this patch authored or co-authored using generative AI tooling?

No