### PR TITLE
[MINOR][INFRA] Add `bin/docker-image-tool.sh` to KUBERNETES label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -199,6 +199,7 @@ YARN:
 KUBERNETES:
   - changed-files:
     - any-glob-to-any-file: [
+     'bin/docker-image-tool.sh',
      'resource-managers/kubernetes/**/*'
     ]
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to add `bin/docker-image-tool.sh` to KUBERNETES label rule.


### Why are the changes needed?
To label PRs better.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
N/A.

### Was this patch authored or co-authored using generative AI tooling?
No.