### PR TITLE
[SPARK-49128][CORE] Support custom History Server UI title

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryPage.scala
@@ -105,7 +105,7 @@ private[history] class HistoryPage(parent: HistoryServer) extends WebUIPage("") 
       <script type="module" src={UIUtils.prependBaseUri(
         request, "/static/utils.js")}></script> ++
       summary ++ appList ++ pageLink
-    UIUtils.basicSparkPage(request, content, "History Server", true)
+    UIUtils.basicSparkPage(request, content, parent.title, true)
   }
 
   def shouldDisplayApplications(requestedIncomplete: Boolean): Boolean = {

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -61,6 +61,8 @@ class HistoryServer(
     poolSize = 1000)
   with Logging with UIRoot with ApplicationCacheOperations {
 
+  val title = conf.get(History.HISTORY_SERVER_UI_TITLE)
+
   // How many applications to retain
   private val retainedApplications = conf.get(History.RETAINED_APPLICATIONS)
 

--- a/core/src/main/scala/org/apache/spark/internal/config/History.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/History.scala
@@ -109,6 +109,12 @@ private[spark] object History {
     .bytesConf(ByteUnit.BYTE)
     .createWithDefaultString("10g")
 
+  val HISTORY_SERVER_UI_TITLE = ConfigBuilder("spark.history.ui.title")
+    .version("4.0.0")
+    .doc("Specifies the title of the History Server UI page.")
+    .stringConf
+    .createWithDefault("History Server")
+
   val HISTORY_SERVER_UI_PORT = ConfigBuilder("spark.history.ui.port")
     .doc("Web UI port to bind Spark History Server")
     .version("1.0.0")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support custom History Server UI title via a new configuration, `spark.history.ui.title`.

### Why are the changes needed?

Like Spark Master UI, it's helpful to provide an easily distinguishable information when there are multiple Spark history server.

- https://github.com/apache/spark/pull/47491

### Does this PR introduce _any_ user-facing change?

No, this is a new feature.

### How was this patch tested?

Pass the CIs with newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.