### PR TITLE
[SPARK-49131][SS] TransformWithState should properly set implicit grouping keys even with lazy iterators

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -232,7 +232,7 @@ case class TransformWithStateExec(
       }
 
       override def next(): InternalRow = {
-        assert(hasStarted, "next called before hasNext")
+        assert(hasStarted, "next() called on handleInputRows iterator before hasNext()")
         mappedIterator.next()
       }
     }
@@ -308,7 +308,7 @@ case class TransformWithStateExec(
       }
 
       override def next(): InternalRow = {
-        assert(hasStarted, "next called before hasNext")
+        assert(hasStarted, "next() called on handleTimerRows iterator before hasNext()")
         mappedIterator.next()
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
@@ -360,7 +360,7 @@ class TransformWithStateSuite extends StateStoreMetricsTest
 
       override def init(outputMode: OutputMode, timeMode: TimeMode): Unit = {
         _myValueState = getHandle.getValueState[Int](
-          "eagerValueState",
+          "myValueState",
           Encoders.scalaInt
         )
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

These changes ensure that implicit grouping key thread locals are set in two places:

1. When `handleInputRows` is called. This allows for the user to get/set keyed state in the body of `handleInputRows` before they create the iterator that they return (see the UT).
2. When methods on the returned iterator from `handleInputRows` are called.


### Why are the changes needed?

Previously, if `handleInputRows` returned a lazy iterator, then the following would happen:

1. The implicit grouping key was set in `processNewData`
2. `handleInputRows` ran, and returned an iterator, call it `iter`
3. The implicit grouping key was unset
4. When the sink finally  causes the iterator to evaluate, the iterator from `handleInputRows` is invoked, but cannot find the implicit grouping key


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- New UT.
- The new UT was verified to fail on current `master`. 
- All existing UTs should pass.

### Was this patch authored or co-authored using generative AI tooling?

No.