### PR TITLE
[SPARK-49135][SQL] Replace `limit(2)` with `limit(1)` in `NonLeafStatementExec`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -76,7 +76,7 @@ trait NonLeafStatementExec extends CompoundStatementExec {
       val df = Dataset.ofRows(session, statement.parsedPlan)
       df.schema.fields match {
         case Array(field) if field.dataType == BooleanType =>
-          df.limit(2).collect() match {
+          df.limit(1).collect() match {
             case Array(row) => row.getBoolean(0)
             case _ => false
           }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to replace `limit(2)` with `limit(1)` in `NonLeafStatementExec`.


### Why are the changes needed?
Fix bug.
According to its logic, `limit(1)` is sufficient to obtain the required data.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA (Existed UT)


### Was this patch authored or co-authored using generative AI tooling?
No.
