### PR TITLE
[SPARK-49136][SQL] Eagerly initialize DriverManager on Driver

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala
@@ -283,6 +283,14 @@ class JdbcOptionsInWrite(
 }
 
 object JDBCOptions {
+
+  /**
+   * Load DriverManager first to avoid any race condition between
+   * DriverManager static initialization block and specific driver class's
+   * static initialization block. e.g. com.mysql.jdbc.Driver
+   */
+  DriverManager.getDrivers
+
   private val curId = new java.util.concurrent.atomic.AtomicLong(0L)
   private val jdbcOptionNames = collection.mutable.Set[String]()
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This is similar to SPARK-23186, which eagerly initializes DriverManager on the executor side to mitigate some JDBC drivers' deadlock issue on initializing.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We got a report from our customer that there is a deadlock issue when using the Spark JDBC connector with StarRocks connector, the Spark driver thread dump shows it is caused by `com.mysql.jdbc.Driver` initializing deadlock, more tech details are explained at [STORM-2527](https://issues.apache.org/jira/browse/STORM-2527) and SPARK-23186.

```
"SparkSQLSessionManager-exec-pool: Thread-8176" #8176 daemon prio=5 os_prio=0 tid=0x0000000003ee0000 nid=0x932 in Object.wait() [0x00007f0a22c2e000]
   java.lang.Thread.State: RUNNABLE
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at com.starrocks.connector.spark.sql.connect.StarRocksConnector.createJdbcConnection(StarRocksConnector.java:94)
	at com.starrocks.connector.spark.sql.connect.StarRocksConnector.extractColumnValuesBySql(StarRocksConnector.java:111)
	at com.starrocks.connector.spark.sql.connect.StarRocksConnector.getSchema(StarRocksConnector.java:46)
	at com.starrocks.connector.spark.sql.StarRocksTableProvider.getStarRocksSchema(StarRocksTableProvider.java:82)
	at com.starrocks.connector.spark.sql.StarRocksTableProvider.inferSchema(StarRocksTableProvider.java:64)
	at org.apache.spark.sql.execution.datasources.v2.DataSourceV2Utils$.getTableFromProvider(DataSourceV2Utils.scala:90)
	at org.apache.spark.sql.execution.datasources.v2.DataSourceV2Utils$.loadV2Source(DataSourceV2Utils.scala:140)
...

"SparkSQLSessionManager-exec-pool: Thread-8693" #8693 daemon prio=5 os_prio=0 tid=0x00007f0a78a0a000 nid=0x26d2 in Object.wait() [0x00007f0a2161b000]
   java.lang.Thread.State: RUNNABLE
	at org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions.$anonfun$driverClass$2(JDBCOptions.scala:107)
	at org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions$$Lambda$3369/1410955143.apply(Unknown Source)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions.<init>(JDBCOptions.scala:107)
	at org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions.<init>(JDBCOptions.scala:39)
	at org.apache.spark.sql.execution.datasources.jdbc.JdbcRelationProvider.createRelation(JdbcRelationProvider.scala:34)
	at org.apache.spark.sql.execution.datasources.DataSource.resolveRelation(DataSource.scala:346)
	at org.apache.spark.sql.execution.datasources.CreateTempViewUsing.$anonfun$run$2(ddl.scala:114)
	at org.apache.spark.sql.execution.datasources.CreateTempViewUsing$$Lambda$3355/398586231.apply(Unknown Source)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.spark.sql.execution.datasources.CreateTempViewUsing.run(ddl.scala:106)
...

"SparkSQLSessionManager-exec-pool: Thread-8185" #8185 daemon prio=5 os_prio=0 tid=0x00007f0a5c3d0000 nid=0x11ce in Object.wait() [0x00007f0a24345000]
   java.lang.Thread.State: RUNNABLE
	at org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions.$anonfun$driverClass$2(JDBCOptions.scala:107)
	at org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions$$Lambda$3369/1410955143.apply(Unknown Source)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions.<init>(JDBCOptions.scala:107)
	at org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions.<init>(JDBCOptions.scala:39)
	at org.apache.spark.sql.execution.datasources.jdbc.JdbcRelationProvider.createRelation(JdbcRelationProvider.scala:34)
	at org.apache.spark.sql.execution.datasources.DataSource.resolveRelation(DataSource.scala:346)
	at org.apache.spark.sql.execution.datasources.CreateTempViewUsing.$anonfun$run$2(ddl.scala:114)
	at org.apache.spark.sql.execution.datasources.CreateTempViewUsing$$Lambda$3355/398586231.apply(Unknown Source)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.spark.sql.execution.datasources.CreateTempViewUsing.run(ddl.scala:106)
...
```

PS: the tread dump comes from a Kyuubi Spark engine (similar to the Spark Thrift Server) - that serves multiple Spark sessions to accept and run queries, thus I suppose this patch would benefit STS and Spark Connect use cases.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, this would mitigate a potential Spark driver-side JDBC driver initializing deadlock issue.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Tested in our customer env for a few days, the deadlock has gone after eagerly initializing DriverManager.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No