### PR TITLE
[SPARK-49140][SQL] Widening type promotion from int/long to decimal and support custom decimal logic type for int in `AvroDeserializer`

### DIFF
--- a/connector/avro/src/main/java/org/apache/spark/sql/avro/CustomDecimal.scala
+++ b/connector/avro/src/main/java/org/apache/spark/sql/avro/CustomDecimal.scala
@@ -27,8 +27,9 @@ private[spark] object CustomDecimal {
 }
 
 // A customized logical type, which will be registered to Avro. This logical type is similar to
-// Avro's builtin Decimal type, but is meant to be registered for long type. It indicates that
-// the long type should be converted to Spark's Decimal type, with provided precision and scale.
+// Avro's builtin Decimal type, but is meant to be registered for long type or int type. It
+// indicates that the long type or int type should be converted to Spark's Decimal type, with
+// provided precision and scale.
 private[spark] class CustomDecimal(schema: Schema) extends LogicalType(CustomDecimal.TYPE_NAME) {
   val scale : Int = {
     val obj = schema.getObjectProp("scale")
@@ -57,9 +58,9 @@ private[spark] class CustomDecimal(schema: Schema) extends LogicalType(CustomDec
 
   override def validate(schema: Schema): Unit = {
     super.validate(schema)
-    if (schema.getType != Schema.Type.LONG) {
+    if (schema.getType != Schema.Type.LONG && schema.getType != Schema.Type.INT) {
       throw new IllegalArgumentException(
-        s"${CustomDecimal.TYPE_NAME} can only be used with an underlying long type")
+        s"${CustomDecimal.TYPE_NAME} can only be used with an underlying long type or int type")
     }
     if (precision <= 0) {
       throw new IllegalArgumentException(s"Invalid decimal precision: $precision" +

--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/AvroDeserializer.scala
@@ -386,9 +386,27 @@ private[sql] class AvroDeserializer(
       case (LONG, _: DayTimeIntervalType) => (updater, ordinal, value) =>
         updater.setLong(ordinal, value.asInstanceOf[Long])
 
-      case (LONG, _: DecimalType) => (updater, ordinal, value) =>
-        val d = avroType.getLogicalType.asInstanceOf[CustomDecimal]
-        updater.setDecimal(ordinal, Decimal(value.asInstanceOf[Long], d.precision, d.scale))
+      case (INT, dt: DecimalType) => avroType.getLogicalType match {
+        case null => (updater, ordinal, value) =>
+          updater.setDecimal(ordinal,
+            Decimal(value.asInstanceOf[Int], dt.precision, dt.scale))
+        case _: CustomDecimal => (updater, ordinal, value) =>
+          val d = avroType.getLogicalType.asInstanceOf[CustomDecimal]
+          updater.setDecimal(ordinal, Decimal(value.asInstanceOf[Int], d.precision, d.scale))
+        case other => throw new IncompatibleSchemaException(errorPrefix +
+          s"Avro logical type $other cannot be converted to SQL type ${DecimalType.simpleString}.")
+      }
+
+      case (LONG, dt: DecimalType) => avroType.getLogicalType match {
+        case null => (updater, ordinal, value) =>
+          updater.setDecimal(ordinal,
+            Decimal(value.asInstanceOf[Long], dt.precision, dt.scale))
+        case _: CustomDecimal => (updater, ordinal, value) =>
+          val d = avroType.getLogicalType.asInstanceOf[CustomDecimal]
+          updater.setDecimal(ordinal, Decimal(value.asInstanceOf[Long], d.precision, d.scale))
+        case other => throw new IncompatibleSchemaException(errorPrefix +
+          s"Avro logical type $other cannot be converted to SQL type ${DecimalType.simpleString}.")
+      }
 
       case _ => throw new IncompatibleSchemaException(incompatibleMsg)
     }

--- a/connector/avro/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
+++ b/connector/avro/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala
@@ -86,6 +86,8 @@ object SchemaConverters {
       stableIdPrefixForUnionType: String): SchemaType = {
     avroSchema.getType match {
       case INT => avroSchema.getLogicalType match {
+        case d: CustomDecimal =>
+          SchemaType(DecimalType(d.precision, d.scale), nullable = false)
         case _: Date => SchemaType(DateType, nullable = false)
         case _ =>
           val catalystTypeAttrValue = avroSchema.getProp(CATALYST_TYPE_PROP_NAME)

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -954,6 +954,37 @@ abstract class AvroSuite
     }
   }
 
+  test("SPARK-49140: Widening type promotions from int / long to decimal in AvroDeserializer") {
+    withTempPath { tempPath =>
+      // int -> decimal
+      val intPath = s"$tempPath/int_data"
+      val intDf = Seq(1, Int.MinValue, Int.MaxValue).toDF("col")
+      intDf.write.format("avro").save(intPath)
+
+      Seq((10, 0), (10, 2)).foreach { case (precision, scale) =>
+        checkAnswer(
+          spark.read.schema(s"col Decimal($precision, $scale)").format("avro").load(intPath),
+          Seq(Row(java.math.BigDecimal.valueOf(1, scale)),
+            Row(java.math.BigDecimal.valueOf(-2147483648, scale)),
+            Row(java.math.BigDecimal.valueOf(2147483647, scale)))
+        )
+      }
+
+      // long -> decimal
+      val longPath = s"$tempPath/long_data"
+      val longDf = Seq(1F, Long.MinValue, Long.MaxValue).toDF("col")
+      longDf.write.format("avro").save(longPath)
+      Seq((20, 0), (20, 2)).foreach { case (precision, scale) =>
+        checkAnswer(
+          spark.read.schema(s"col Decimal($precision, $scale)").format("avro").load(longPath),
+          Seq(Row(java.math.BigDecimal.valueOf(1, scale)),
+            Row(java.math.BigDecimal.valueOf(-9223372036854775808L, scale)),
+            Row(java.math.BigDecimal.valueOf(9223372036854775807L, scale)))
+        )
+      }
+    }
+  }
+
   test("SPARK-43380: Fix Avro data type conversion" +
     " of DayTimeIntervalType to avoid producing incorrect results") {
     withTempPath { path =>

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -961,7 +961,7 @@ abstract class AvroSuite
       val intDf = Seq(1, Int.MinValue, Int.MaxValue).toDF("col")
       intDf.write.format("avro").save(intPath)
 
-      Seq((10, 0), (10, 2)).foreach { case (precision, scale) =>
+      Seq((10, 0), (12, 0)).foreach { case (precision, scale) =>
         checkAnswer(
           spark.read.schema(s"col Decimal($precision, $scale)").format("avro").load(intPath),
           Seq(Row(java.math.BigDecimal.valueOf(1, scale)),
@@ -974,7 +974,7 @@ abstract class AvroSuite
       val longPath = s"$tempPath/long_data"
       val longDf = Seq(1L, Long.MinValue, Long.MaxValue).toDF("col")
       longDf.write.format("avro").save(longPath)
-      Seq((20, 0), (20, 2)).foreach { case (precision, scale) =>
+      Seq((20, 0), (22, 0)).foreach { case (precision, scale) =>
         checkAnswer(
           spark.read.schema(s"col Decimal($precision, $scale)").format("avro").load(longPath),
           Seq(Row(java.math.BigDecimal.valueOf(1L, scale)),

--- a/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
+++ b/connector/avro/src/test/scala/org/apache/spark/sql/avro/AvroSuite.scala
@@ -972,12 +972,12 @@ abstract class AvroSuite
 
       // long -> decimal
       val longPath = s"$tempPath/long_data"
-      val longDf = Seq(1F, Long.MinValue, Long.MaxValue).toDF("col")
+      val longDf = Seq(1L, Long.MinValue, Long.MaxValue).toDF("col")
       longDf.write.format("avro").save(longPath)
       Seq((20, 0), (20, 2)).foreach { case (precision, scale) =>
         checkAnswer(
           spark.read.schema(s"col Decimal($precision, $scale)").format("avro").load(longPath),
-          Seq(Row(java.math.BigDecimal.valueOf(1, scale)),
+          Seq(Row(java.math.BigDecimal.valueOf(1L, scale)),
             Row(java.math.BigDecimal.valueOf(-9223372036854775808L, scale)),
             Row(java.math.BigDecimal.valueOf(9223372036854775807L, scale)))
         )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR aims to:

1.  Widening type promotion from int/long to decimal  in `AvroDeserializer`. Supported as following(Avro Type -> Spark Type):

- Int -> DecimalType;
- Long -> DecimalType ;

2. Support custom decimal logic type for int
We already support long in #41409.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Similar to Parquet reader, we'd better to enable type promotion/widening for Avro deserializer.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, Users can use wider types more flexibly.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Pass GA and add some new test cases.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.