### PR TITLE
[SPARK-49143][K8S][DOCS] Update `YuniKorn` docs with v1.5.2

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -1939,10 +1939,10 @@ Install Apache YuniKorn:
 ```bash
 helm repo add yunikorn https://apache.github.io/yunikorn-release
 helm repo update
-helm install yunikorn yunikorn/yunikorn --namespace yunikorn --version 1.5.1 --create-namespace --set embedAdmissionController=false
+helm install yunikorn yunikorn/yunikorn --namespace yunikorn --version 1.5.2 --create-namespace --set embedAdmissionController=false
 ```
 
-The above steps will install YuniKorn v1.5.1 on an existing Kubernetes cluster.
+The above steps will install YuniKorn v1.5.2 on an existing Kubernetes cluster.
 
 ##### Get started
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `YuniKorn` docs with v1.5.2 for Apache Spark 4.0.0.

### Why are the changes needed?

Apache YuniKorn v1.5.2 was released on 2024-07-26 with 17 bug fixes.

  - https://yunikorn.apache.org/release-announce/1.5.2

I installed YuniKorn v1.5.2 on K8s 1.29 and tested manually.

**K8s v1.29**
```
$ kubectl version
Client Version: v1.30.3
Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
Server Version: v1.29.2
```

**YuniKorn v1.5.2**
```
$ helm list -n yunikorn
NAME    	NAMESPACE	REVISION	UPDATED                             	STATUS  CHART         	APP VERSION
yunikorn	yunikorn 	1       	2024-08-07 08:39:25.300224 -0700 PDT	deployedyunikorn-1.5.2
```

```
$ build/sbt -Pkubernetes -Pkubernetes-integration-tests -Dspark.kubernetes.test.deployMode=docker-desktop "kubernetes-integration-tests/testOnly *.YuniKornSuite" -Dtest.exclude.tags=minikube,local,decom,r -Dtest.default.exclude.tags=
...
[info] YuniKornSuite:
...
[info] All tests passed.
[success] Total time: 421 s (07:01), completed Aug 7, 2024, 8:55:20 AM
```

```
$ kubectl describe pod -l spark-role=driver -n spark-a9b4df9b5e0345238458ecd3a9c305d1
...
Events:
  Type    Reason             Age   From      Message
  ----    ------             ----  ----      -------
  Normal  Scheduling         2s    yunikorn  spark-a9b4df9b5e0345238458ecd3a9c305d1/spark-test-app-19b49ac94d58405585668894e30b03f2-driver is queued and waiting for allocation
  Normal  Scheduled          2s    yunikorn  Successfully assigned spark-a9b4df9b5e0345238458ecd3a9c305d1/spark-test-app-19b49ac94d58405585668894e30b03f2-driver to node docker-desktop
  Normal  PodBindSuccessful  2s    yunikorn  Pod spark-a9b4df9b5e0345238458ecd3a9c305d1/spark-test-app-19b49ac94d58405585668894e30b03f2-driver is successfully bound to node docker-desktop
...
```