### PR TITLE
[WIP][SPARK-49145] Improve readability of log4j console log output

### DIFF
--- a/conf/log4j.properties.template-string
+++ b/conf/log4j.properties.template-string
@@ -1,0 +1,68 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Usage: For String formatted console logs, rename this template to log4j.properties
+
+# Set everything to be logged to the console
+rootLogger.level = info
+rootLogger.appenderRef.stdout.ref = console
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.target = SYSTEM_ERR
+appender.console.layout.type = PatternLayout
+# Log strings follow `appender.console.layout.pattern.` The default pattern is:
+# *timestamp* [*threadName*] {*context*} *loggerName* - *message*
+# For more information about pattern configuration, see the log4j PatternLayout documentation.
+appender.console.layout.pattern = %d{ISO8601} [%t] %notEmpty{%X} %c{1} - %highlight{%m}%n%n
+
+# Set the default spark-shell/spark-sql log level to WARN. When running the
+# spark-shell/spark-sql, the log level for these classes is used to overwrite
+# the root logger's log level, so that the user can have different defaults
+# for the shell and regular Spark apps.
+logger.repl.name = org.apache.spark.repl.Main
+logger.repl.level = warn
+
+logger.thriftserver.name = org.apache.spark.sql.hive.thriftserver.SparkSQLCLIDriver
+logger.thriftserver.level = warn
+
+# Settings to quiet third party logs that are too verbose
+logger.jetty1.name = org.sparkproject.jetty
+logger.jetty1.level = warn
+logger.jetty2.name = org.sparkproject.jetty.util.component.AbstractLifeCycle
+logger.jetty2.level = error
+logger.replexprTyper.name = org.apache.spark.repl.SparkIMain$exprTyper
+logger.replexprTyper.level = info
+logger.replSparkILoopInterpreter.name = org.apache.spark.repl.SparkILoop$SparkILoopInterpreter
+logger.replSparkILoopInterpreter.level = info
+logger.parquet1.name = org.apache.parquet
+logger.parquet1.level = error
+logger.parquet2.name = parquet
+logger.parquet2.level = error
+
+# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
+logger.RetryingHMSHandler.name = org.apache.hadoop.hive.metastore.RetryingHMSHandler
+logger.RetryingHMSHandler.level = fatal
+logger.FunctionRegistry.name = org.apache.hadoop.hive.ql.exec.FunctionRegistry
+logger.FunctionRegistry.level = error
+
+# For deploying Spark ThriftServer
+# SPARK-34128: Suppress undesirable TTransportException warnings involved in THRIFT-4805
+appender.console.filter.1.type = RegexFilter
+appender.console.filter.1.regex = .*Thrift error occurred during processing of message.*
+appender.console.filter.1.onMatch = deny
+appender.console.filter.1.onMismatch = neutral

--- a/conf/log4j2.properties.template
+++ b/conf/log4j2.properties.template
@@ -22,8 +22,8 @@ rootLogger.appenderRef.stdout.ref = console
 appender.console.type = Console
 appender.console.name = console
 appender.console.target = SYSTEM_ERR
-appender.console.layout.type = JsonTemplateLayout
-appender.console.layout.eventTemplateUri = classpath:org/apache/spark/SparkLayout.json
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{ISO8601} [%t] %c{1} - %highlight{%m} %notEmpty{%X}%n%n
 
 # Set the default spark-shell/spark-sql log level to WARN. When running the
 # spark-shell/spark-sql, the log level for these classes is used to overwrite

--- a/conf/log4j2.properties.template-json
+++ b/conf/log4j2.properties.template-json
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+# Usage: For JSON formatted console logs, rename this template to log4j.properties
+
 # Set everything to be logged to the console
 rootLogger.level = info
 rootLogger.appenderRef.stdout.ref = console
@@ -22,8 +24,8 @@ rootLogger.appenderRef.stdout.ref = console
 appender.console.type = Console
 appender.console.name = console
 appender.console.target = SYSTEM_ERR
-appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{ISO8601} [%t] %c{1} - %highlight{%m} %notEmpty{%X}%n%n
+appender.console.layout.type = JsonTemplateLayout
+appender.console.layout.eventTemplateUri = classpath:org/apache/spark/SparkLayout.json
 
 # Set the default spark-shell/spark-sql log level to WARN. When running the
 # spark-shell/spark-sql, the log level for these classes is used to overwrite


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

This issue updates the default `log4j.properties.template` with the following improvements for console logging format:

- Use PatternLayout for improved human readability
- Color-code log levels (INFO/ERROR/WARN) to simplify logging output
- Visually partition the threadName and contextInfo for easy interpretation

See below for sample screenshots of the improved logs.

### Why are the changes needed?
Prior to this update, the OSS Spark logs were difficult to interpret. The logs followed a JSON output format which is not optimal for human consumption:

```

{"ts":"2024-07-26T18:45:17.712Z","level":"INFO","msg":"Running Spark version 4.0.0-SNAPSHOT","context":{"spark_version":"4.0.0-SNAPSHOT"},"logger":"SparkContext"}{"ts":"2024-07-26T18:45:17.715Z","level":"INFO","msg":"OS info Mac OS X, 14.4.1, aarch64","context":{"os_arch":"aarch64","os_name":"Mac OS X","os_version":"14.4.1"},"logger":"SparkContext"}{"ts":"2024-07-26T18:45:17.716Z","level":"INFO","msg":"Java version 17.0.11","context":{"java_version":"17.0.11"},"logger":"SparkContext"}{"ts":"2024-07-26T18:45:17.761Z","level":"WARN","msg":"Unable to load native-hadoop library for your platform... using builtin-java classes where applicable","logger":"NativeCodeLoader"}{"ts":"2024-07-26T18:45:17.783Z","level":"INFO","msg":"==============================================================","logger":"ResourceUtils"}{"ts":"2024-07-26T18:45:17.783Z","level":"INFO","msg":"No custom resources configured for spark.driver.","logger":"ResourceUtils"}{"ts":"2024-07-26T18:45:17.783Z","level":"INFO","msg":"==============================================================","logger":"ResourceUtils"}{"ts":"2024-07-26T18:45:17.784Z","level":"INFO","msg":"Submitted application: Spark Pi","context":{"app_name":"Spark Pi"},"logger":"SparkContext"}...{"ts":"2024-07-26T18:45:18.036Z","level":"INFO","msg":"Start Jetty 0.0.0.0:4040 for SparkUI","context":{"host":"0.0.0.0","port":"4040","server_name":"SparkUI"},"logger":"JettyUtils"}{"ts":"2024-07-26T18:45:18.044Z","level":"INFO","msg":"jetty-11.0.20; built: 2024-01-29T21:04:22.394Z; git: 922f8dc188f7011e60d0361de585fd4ac4d63064; jvm 17.0.11+9-LTS","logger":"Server"}{"ts":"2024-07-26T18:45:18.054Z","level":"INFO","msg":"Started Server@22c75c01{STARTING}[11.0.20,sto=30000] @1114ms","logger":"Server"} 

```

### Does this PR introduce _any_ user-facing change?
Yes, please see below for the updated log output. Note that users can override the provided `log4j.properties.template` as desired.

<img width="1403" alt="Screenshot 2024-08-07 at 10 38 25 AM" src="https://github.com/user-attachments/assets/7d5330f1-33b7-4957-88df-18f16fafe099">

<img width="1404" alt="Screenshot 2024-08-07 at 10 38 55 AM" src="https://github.com/user-attachments/assets/a389c0a0-91b3-45cf-951b-496e5e4a5908">

### How was this patch tested?
Producing console logs via spark-submit, e.g:

`./bin/spark-submit --class org.apache.spark.examples.SparkPi  examples/target/scala-2.13/jars/spark-examples_2.13-4.0.0-SNAPSHOT.jar 100`

### Was this patch authored or co-authored using generative AI tooling?
No
