### PR TITLE
[SPARK-49178][CORE][SQL][CONNECT][ML][R] Optimize performance of `Row#getSeq` to match the performance when using Spark 3.5 with Scala 2.12.

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/arrow/ArrowEncoderSuite.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/connect/client/arrow/ArrowEncoderSuite.scala
@@ -23,7 +23,7 @@ import java.util
 import java.util.{Collections, Objects}
 
 import scala.beans.BeanProperty
-import scala.collection.mutable
+import scala.collection.{immutable, mutable}
 import scala.reflect.classTag
 
 import org.apache.arrow.memory.{BufferAllocator, RootAllocator}
@@ -511,9 +511,9 @@ class ArrowEncoderSuite extends ConnectFunSuite with BeforeAndAfterAll {
     val encoder = toRowEncoder(schema)
     val iterator = roundTrip(encoder, Iterator.single(Row(Seq())))
     val Seq(Row(raw)) = iterator.toSeq
-    val seq = raw.asInstanceOf[mutable.ArraySeq[String]]
+    val seq = raw.asInstanceOf[immutable.ArraySeq[String]]
     assert(seq.isEmpty)
-    assert(seq.array.getClass == classOf[Array[String]])
+    assert(seq.unsafeArray.getClass == classOf[Array[String]])
     iterator.close()
   }
 

--- a/core/src/main/scala/org/apache/spark/api/r/SerDe.scala
+++ b/core/src/main/scala/org/apache/spark/api/r/SerDe.scala
@@ -21,7 +21,7 @@ import java.io.{DataInputStream, DataOutputStream}
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Time, Timestamp}
 
-import scala.collection.mutable
+import scala.collection.{immutable, mutable}
 
 import org.apache.spark.util.collection.Utils
 
@@ -296,6 +296,7 @@ private[spark] object SerDe {
       // type "scala.collection.mutable.ArraySeq"
       val value = obj match {
         case wa: mutable.ArraySeq[_] => wa.array
+        case im: immutable.ArraySeq[_] => im.unsafeArray
         case other => other
       }
 

--- a/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
+++ b/mllib/src/test/scala/org/apache/spark/ml/recommendation/ALSSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.ml.recommendation
 import java.io.File
 import java.util.Random
 
-import scala.collection.mutable
+import scala.collection.{immutable, mutable}
 import scala.collection.mutable.ArrayBuffer
 import scala.jdk.CollectionConverters._
 
@@ -1014,7 +1014,7 @@ class ALSSuite extends MLTest with DefaultReadWriteTest with Logging {
       assert(recs === expected(id))
     }
     topK.collect().foreach { row =>
-      val recs = row.getAs[mutable.ArraySeq[Row]]("recommendations")
+      val recs = row.getAs[immutable.ArraySeq[Row]]("recommendations")
       assert(recs(0).fieldIndex(dstColName) == 0)
       assert(recs(0).fieldIndex("rating") == 1)
     }

--- a/sql/api/src/main/scala/org/apache/spark/sql/Row.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Row.scala
@@ -319,7 +319,10 @@ trait Row extends Serializable {
    *
    * @throws ClassCastException when data type does not match.
    */
-  def getSeq[T](i: Int): Seq[T] = getAs[Seq[T]](i)
+  def getSeq[T](i: Int): Seq[T] = {
+    val res = getAs[scala.collection.Seq[T]](i)
+    if (res != null) res.toSeq else null
+  }
 
   /**
    * Returns the value at position i of array type as `java.util.List`.

--- a/sql/api/src/main/scala/org/apache/spark/sql/Row.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Row.scala
@@ -319,10 +319,7 @@ trait Row extends Serializable {
    *
    * @throws ClassCastException when data type does not match.
    */
-  def getSeq[T](i: Int): Seq[T] = {
-    val res = getAs[scala.collection.Seq[T]](i)
-    if (res != null) res.toSeq else null
-  }
+  def getSeq[T](i: Int): Seq[T] = getAs[Seq[T]](i)
 
   /**
    * Returns the value at position i of array type as `java.util.List`.

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/encoders/RowEncoder.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/encoders/RowEncoder.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.catalyst.encoders
 
-import scala.collection.mutable
+import scala.collection.immutable
 import scala.reflect.classTag
 
 import org.apache.spark.sql.{AnalysisException, Row}
@@ -106,7 +106,7 @@ object RowEncoder extends DataTypeErrorsBase {
       UDTEncoder(udt, udtClass.asInstanceOf[Class[_ <: UserDefinedType[_]]])
     case ArrayType(elementType, containsNull) =>
       IterableEncoder(
-        classTag[mutable.ArraySeq[_]],
+        classTag[immutable.ArraySeq[_]],
         encoderForDataType(elementType, lenient),
         containsNull,
         lenientSerialization = true)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
@@ -315,7 +315,7 @@ class RowEncoderSuite extends CodegenInterpretedPlanTest {
 
   private def roundTripArray[T](dt: DataType, nullable: Boolean, data: Array[T]): Unit = {
     val schema = new StructType().add("a", ArrayType(dt, nullable))
-    test(s"RowEncoder should return mutable.ArraySeq with properly typed array for $schema") {
+    test(s"RowEncoder should return immutable.ArraySeq with properly typed array for $schema") {
       val encoder = ExpressionEncoder(schema).resolveAndBind()
       val result = fromRow(encoder, toRow(encoder, Row(data))).getAs[immutable.ArraySeq[_]](0)
       assert(result.unsafeArray.getClass === data.getClass)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
@@ -17,8 +17,7 @@
 
 package org.apache.spark.sql.catalyst.encoders
 
-import scala.collection.immutable
-import scala.collection.mutable
+import scala.collection.{immutable, mutable}
 import scala.util.Random
 
 import org.apache.spark.SparkRuntimeException

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/encoders/RowEncoderSuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.catalyst.encoders
 
+import scala.collection.immutable
 import scala.collection.mutable
 import scala.util.Random
 
@@ -317,8 +318,8 @@ class RowEncoderSuite extends CodegenInterpretedPlanTest {
     val schema = new StructType().add("a", ArrayType(dt, nullable))
     test(s"RowEncoder should return mutable.ArraySeq with properly typed array for $schema") {
       val encoder = ExpressionEncoder(schema).resolveAndBind()
-      val result = fromRow(encoder, toRow(encoder, Row(data))).getAs[mutable.ArraySeq[_]](0)
-      assert(result.array.getClass === data.getClass)
+      val result = fromRow(encoder, toRow(encoder, Row(data))).getAs[immutable.ArraySeq[_]](0)
+      assert(result.unsafeArray.getClass === data.getClass)
       assert(result === data)
     }
   }

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaHigherOrderFunctionsSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaHigherOrderFunctionsSuite.java
@@ -53,7 +53,8 @@ public class JavaHigherOrderFunctionsSuite {
                 Object expectedValue = expectedRow.get(j);
                 Object actualValue = actualRow.get(j);
                 if (expectedValue != null && expectedValue.getClass().isArray()) {
-                    actualValue = actualValue.getClass().getMethod("unsafeArray").invoke(actualValue);
+                    actualValue = actualValue.getClass().getMethod("unsafeArray")
+                        .invoke(actualValue);
                     Assertions.assertArrayEquals((Object[]) expectedValue, (Object[]) actualValue);
                 } else {
                     Assertions.assertEquals(expectedValue, actualValue);

--- a/sql/core/src/test/java/test/org/apache/spark/sql/JavaHigherOrderFunctionsSuite.java
+++ b/sql/core/src/test/java/test/org/apache/spark/sql/JavaHigherOrderFunctionsSuite.java
@@ -53,7 +53,7 @@ public class JavaHigherOrderFunctionsSuite {
                 Object expectedValue = expectedRow.get(j);
                 Object actualValue = actualRow.get(j);
                 if (expectedValue != null && expectedValue.getClass().isArray()) {
-                    actualValue = actualValue.getClass().getMethod("array").invoke(actualValue);
+                    actualValue = actualValue.getClass().getMethod("unsafeArray").invoke(actualValue);
                     Assertions.assertArrayEquals((Object[]) expectedValue, (Object[]) actualValue);
                 } else {
                     Assertions.assertEquals(expectedValue, actualValue);

--- a/sql/core/src/test/scala/org/apache/spark/sql/VariantSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/VariantSuite.scala
@@ -21,7 +21,7 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
-import scala.collection.mutable
+import scala.collection.immutable
 import scala.jdk.CollectionConverters._
 import scala.util.Random
 
@@ -167,7 +167,7 @@ class VariantSuite extends QueryTest with SharedSparkSession with ExpressionEval
         if (v == null) {
           "null"
         } else {
-          v.asInstanceOf[mutable.ArraySeq[Any]]
+          v.asInstanceOf[immutable.ArraySeq[Any]]
            .map(_.asInstanceOf[VariantVal].debugString()).mkString(",")
         }
       }.sorted


### PR DESCRIPTION
### What changes were proposed in this pull request?
The primary change in this PR is in the function `RowEncoder#encoderForDataType`, where the encoding type for `ArrayType` data has been changed from `immutable.ArraySeq[_]` to `immutable.ArraySeq[_]` in order to optimize the performance of `Row#getSeq` to match the performance when using Spark 3.5 with Scala 2.12.

Following the modification of `RowEncoder.scala`, the data transferred between the JVM and R may now include `immutable.ArraySeq`. As a result, this pr also fix `r/SerDe.scala` to adjust to this scenario and guarantees that all existing test cases can pass successfully.

The changes to other test files are because, after this pr, Seq type data will be encoded as `immutable.ArraySeq` type, so it is necessary to use `getAs[immutable.Seq]` instead of `getAs[mutable.Seq]` to retrieve them, but if `getSeq` is used to retrieve the data, there will be no changes.

### Why are the changes needed?
Optimize the performance of `Row#getSeq` to match the performance when using Spark 3.5 with Scala 2.12.

Consider the following scenario:

```scala
    val data = (0 until arraySize).toArray
    val row = Seq(data).toDF().collect().head

    val benchmark = new Benchmark(
      s"Test get seq with $arraySize from row",
      valuesPerIteration,
      output = output)

    benchmark.addCase("Get Seq") { _: Int =>

      for (_ <- 0L until valuesPerIteration) {
        val ret = row.getSeq(0)
      }
    }

    benchmark.run()
```

Run tests on the aforementioned code with `arraySize` set to 10, 100, 1000, 10000, and 100000, respectively, and with `valuesPerIteration` set to 100000, getting the following results:

- branch-3.5(with Scala 2.12):

```
OpenJDK 64-Bit Server VM 1.8.0_422-b05 on Linux 5.15.0-1068-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 10 from row:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                               1              1           0        194.8           5.1       1.0X

OpenJDK 64-Bit Server VM 1.8.0_422-b05 on Linux 5.15.0-1068-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 100 from row:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                               1              1           0         96.8          10.3       1.0X

OpenJDK 64-Bit Server VM 1.8.0_422-b05 on Linux 5.15.0-1068-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 1000 from row:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                               1              1           0         97.0          10.3       1.0X

OpenJDK 64-Bit Server VM 1.8.0_422-b05 on Linux 5.15.0-1068-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 10000 from row:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                               1              1           0         96.8          10.3       1.0X

OpenJDK 64-Bit Server VM 1.8.0_422-b05 on Linux 5.15.0-1068-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 100000 from row:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                               1              1           0         96.9          10.3       1.0X

```

- master (with Scala 2.13):

```
OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 10 from row:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                               9             10           0         10.5          94.8       1.0X

OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 100 from row:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                              65             65           1          1.5         646.4       1.0X

OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 1000 from row:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                             614            615           1          0.2        6140.2       1.0X

OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 10000 from row:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                            6122           6128           8          0.0       61223.1       1.0X

OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 100000 from row:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                           61247          61268          30          0.0      612468.1       1.0X
```

We can observe that in branch-3.5(with Scala 2.12), the latency of `Row#getSeq` is constant, whereas in master(with Scala 2.13), the latency of `Row#getSeq` exhibits a linearly increasing trend with the length of the array.

This is due to the following code:

https://github.com/apache/spark/blob/c121bb557447709c19fc01b68b3a34b8838abc6d/sql/api/src/main/scala/org/apache/spark/sql/Row.scala#L317-L325

The default Scala version in branch-3.5 is 2.12, where `Seq` represents `scala.collection.Seq`. Therefore, the `res.toSeq` in the code above is a redundant operation that does not trigger a collection copy.

However, the default Scala version in master is 2.13, where `Seq` represents `scala.collection.immutable.Seq`, and `getAs[scala.collection.Seq[T]](i)` returns a `scala.collection.mutable.ArraySeq[T]` type. As a result, the `res.toSeq` in the code above triggers a collection copy from `mutable.ArraySeq[T]` to `immutable.ArraySeq[T]`.

This has caused a performance regression for the `Row#getSeq` API between master and Spark 3.5 with Scala 2.12


### Does this PR introduce _any_ user-facing change?
Yes.

If users utilize the `Row#getSeq` API to fetch data, there will be no user-facing change.

However, if users previously used the `Row#getAs[mutable.Seq]` API to obtain data, they will need to change it to `Row#getAs[immutable.Seq]`.

### How was this patch tested?
- Pass GitHub Actions
- Test the previously described scenario with this PR:


```
penJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 10 from row:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                               0              0           0        338.5           3.0       1.0X

OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 100 from row:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                               0              0           0        338.2           3.0       1.0X

OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 1000 from row:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                               0              0           0        337.4           3.0       1.0X

OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 10000 from row:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                               0              0           0        338.1           3.0       1.0X

OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 100000 from row:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                               0              0           0        337.9           3.0       1.0X
```

We can see that, with this PR, the latency of the `Row#getSeq` API has returned to being constant.


### Was this patch authored or co-authored using generative AI tooling?
No