### PR TITLE
Set correct `since` for named_struct

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
@@ -436,7 +436,7 @@ object CreateStruct {
       > SELECT _FUNC_("a", 1, "b", 2, "c", 3);
        {"a":1,"b":2,"c":3}
   """,
-  since = "1.5.0",
+  since = "3.5.0",
   group = "struct_funcs")
 // scalastyle:on line.size.limit
 case class CreateNamedStruct(children: Seq[Expression]) extends Expression with NoThrow {


### PR DESCRIPTION
SQL API docs show incorrect `since` field as 1.5.0: https://spark.apache.org/docs/latest/api/sql/#named_struct

While the named structs were actually added since 3.5.0: https://issues.apache.org/jira/browse/SPARK-43926

https://github.com/apache/spark/commit/de8ec74f2826db3815275b4fccef186f22c85833

### What changes were proposed in this pull request?
The correct since field is set on the `named_struct` method to be reflected in documentation.

### Why are the changes needed?
Documentation should reflect the actual feature availability.

### Does this PR introduce _any_ user-facing change?
It is a documentation fix.

### How was this patch tested?
No tests are needed.

### Was this patch authored or co-authored using generative AI tooling?
No