### PR TITLE
[SPARK-47410][SQL][FOLLOWUP] Limit part of StringType API to private[sql]

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/types/StringType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/StringType.scala
@@ -36,16 +36,16 @@ class StringType private(val collationId: Int) extends AtomicType with Serializa
    * non-binary. If this field is true, byte level operations can be used against this datatype
    * (e.g. for equality and hashing).
    */
-  def supportsBinaryEquality: Boolean =
+  private[sql] def supportsBinaryEquality: Boolean =
     CollationFactory.fetchCollation(collationId).supportsBinaryEquality
 
-  def supportsLowercaseEquality: Boolean =
+  private[sql] def supportsLowercaseEquality: Boolean =
     CollationFactory.fetchCollation(collationId).supportsLowercaseEquality
 
-  def isUTF8BinaryCollation: Boolean =
+  private[sql] def isUTF8BinaryCollation: Boolean =
     collationId == CollationFactory.UTF8_BINARY_COLLATION_ID
 
-  def isUTF8LcaseCollation: Boolean =
+  private[sql] def isUTF8LcaseCollation: Boolean =
     collationId == CollationFactory.UTF8_LCASE_COLLATION_ID
 
   /**
@@ -55,7 +55,7 @@ class StringType private(val collationId: Int) extends AtomicType with Serializa
    * it follows spark internal implementation. If this field is true, byte level operations
    * can be used against this datatype (e.g. for equality, hashing and ordering).
    */
-  def supportsBinaryOrdering: Boolean =
+  private[sql] def supportsBinaryOrdering: Boolean =
     CollationFactory.fetchCollation(collationId).supportsBinaryOrdering
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Limit `supportsBinaryEquality`, `supportsLowercaseEquality`, etc. to `private[sql]`.


### Why are the changes needed?
Methods such as `supportsBinaryEquality`, `supportsLowercaseEquality`, etc. should only be used internally.


### Does this PR introduce _any_ user-facing change?
Yes, users should no longer be able to access certain StringType fields.


### How was this patch tested?
N/A


### Was this patch authored or co-authored using generative AI tooling?
No.
