### PR TITLE
[SPARK-49175][PYTHON][MIRROR] Use UnsupportedType to check DataType validation for Arrow UDF

### DIFF
--- a/python/docs/source/user_guide/sql/arrow_pandas.rst
+++ b/python/docs/source/user_guide/sql/arrow_pandas.rst
@@ -384,7 +384,7 @@ Supported SQL Types
 .. currentmodule:: pyspark.sql.types
 
 Currently, all Spark SQL data types are supported by Arrow-based conversion except
-:class:`ArrayType` of :class:`TimestampType`.
+:class:`YearMonthIntervalType`.
 :class:`MapType` and :class:`ArrayType` of nested :class:`StructType` are only supported
 when using PyArrow 2.0.0 and above.
 

--- a/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_cogrouped_map.py
@@ -25,7 +25,6 @@ from pyspark.sql.types import (
     LongType,
     StructType,
     StructField,
-    YearMonthIntervalType,
     Row,
 )
 from pyspark.sql.window import Window
@@ -36,6 +35,7 @@ from pyspark.testing.sqlutils import (
     have_pyarrow,
     pandas_requirement_message,
     pyarrow_requirement_message,
+    UnsupportedType,
 )
 
 if have_pandas:
@@ -339,10 +339,10 @@ class CogroupedApplyInPandasTestsMixin:
         self._test_merge_error(
             fn=lambda l, r: l,
             output_schema=(
-                StructType().add("id", LongType()).add("v", ArrayType(YearMonthIntervalType()))
+                StructType().add("id", LongType()).add("v", ArrayType(UnsupportedType()))
             ),
             errorClass=NotImplementedError,
-            error_message_regex="Invalid return type.*ArrayType.*YearMonthIntervalType",
+            error_message_regex="Invalid return type.*ArrayType.*UnsupportedType",
         )
 
     def test_wrong_args(self):

--- a/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_grouped_map.py
@@ -50,7 +50,6 @@ from pyspark.sql.types import (
     StructField,
     NullType,
     MapType,
-    YearMonthIntervalType,
 )
 from pyspark.errors import PythonException, PySparkTypeError, PySparkValueError
 from pyspark.testing.sqlutils import (
@@ -59,6 +58,7 @@ from pyspark.testing.sqlutils import (
     have_pyarrow,
     pandas_requirement_message,
     pyarrow_requirement_message,
+    UnsupportedType,
 )
 
 if have_pandas:
@@ -406,11 +406,11 @@ class GroupedApplyInPandasTestsMixin:
     def check_wrong_return_type(self):
         with self.assertRaisesRegex(
             NotImplementedError,
-            "Invalid return type.*grouped map Pandas UDF.*ArrayType.*YearMonthIntervalType",
+            "Invalid return type.*grouped map Pandas UDF.*ArrayType.*UnsupportedType",
         ):
             pandas_udf(
                 lambda pdf: pdf,
-                StructType().add("id", LongType()).add("v", ArrayType(YearMonthIntervalType())),
+                StructType().add("id", LongType()).add("v", ArrayType(UnsupportedType())),
                 PandasUDFType.GROUPED_MAP,
             )
 
@@ -466,8 +466,8 @@ class GroupedApplyInPandasTestsMixin:
     def check_unsupported_types(self):
         common_err_msg = "Invalid return type.*grouped map Pandas UDF.*"
         unsupported_types = [
-            StructField("array_struct", ArrayType(YearMonthIntervalType())),
-            StructField("map", MapType(StringType(), YearMonthIntervalType())),
+            StructField("array_struct", ArrayType(UnsupportedType())),
+            StructField("map", MapType(StringType(), UnsupportedType())),
         ]
 
         for unsupported_type in unsupported_types:

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_grouped_agg.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_grouped_agg.py
@@ -31,7 +31,7 @@ from pyspark.sql.functions import (
     pandas_udf,
     PandasUDFType,
 )
-from pyspark.sql.types import ArrayType, YearMonthIntervalType
+from pyspark.sql.types import ArrayType
 from pyspark.errors import AnalysisException, PySparkNotImplementedError, PythonException
 from pyspark.testing.sqlutils import (
     ReusedSQLTestCase,
@@ -39,6 +39,7 @@ from pyspark.testing.sqlutils import (
     have_pyarrow,
     pandas_requirement_message,
     pyarrow_requirement_message,
+    UnsupportedType,
 )
 from pyspark.testing.utils import assertDataFrameEqual
 
@@ -183,7 +184,7 @@ class GroupedAggPandasUDFTestsMixin:
         with self.assertRaises(PySparkNotImplementedError) as pe:
             pandas_udf(
                 lambda x: x,
-                ArrayType(ArrayType(YearMonthIntervalType())),
+                ArrayType(ArrayType(UnsupportedType())),
                 PandasUDFType.GROUPED_AGG,
             )
 
@@ -192,7 +193,7 @@ class GroupedAggPandasUDFTestsMixin:
             errorClass="NOT_IMPLEMENTED",
             messageParameters={
                 "feature": "Invalid return type with grouped aggregate Pandas UDFs: "
-                "ArrayType(ArrayType(YearMonthIntervalType(0, 1), True), True)"
+                "ArrayType(ArrayType(UnsupportedType(), True), True)"
             },
         )
 
@@ -214,7 +215,7 @@ class GroupedAggPandasUDFTestsMixin:
 
         with self.assertRaises(PySparkNotImplementedError) as pe:
 
-            @pandas_udf(ArrayType(YearMonthIntervalType()), PandasUDFType.GROUPED_AGG)
+            @pandas_udf(ArrayType(UnsupportedType()), PandasUDFType.GROUPED_AGG)
             def mean_and_std_udf(v):  # noqa: F811
                 return {v.mean(): v.std()}
 
@@ -223,7 +224,7 @@ class GroupedAggPandasUDFTestsMixin:
             errorClass="NOT_IMPLEMENTED",
             messageParameters={
                 "feature": "Invalid return type with grouped aggregate Pandas UDFs: "
-                "ArrayType(YearMonthIntervalType(0, 1), True)"
+                "ArrayType(UnsupportedType(), True)"
             },
         )
 

--- a/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
+++ b/python/pyspark/sql/tests/pandas/test_pandas_udf_scalar.py
@@ -46,7 +46,6 @@ from pyspark.sql.types import (
     MapType,
     DateType,
     BinaryType,
-    YearMonthIntervalType,
     VariantType,
     VariantVal,
 )
@@ -59,6 +58,7 @@ from pyspark.testing.sqlutils import (
     have_pyarrow,
     pandas_requirement_message,
     pyarrow_requirement_message,
+    UnsupportedType,
 )
 from pyspark.testing.utils import assertDataFrameEqual
 
@@ -732,9 +732,9 @@ class ScalarPandasUDFTestsMixin:
         for udf_type in [PandasUDFType.SCALAR, PandasUDFType.SCALAR_ITER]:
             with self.assertRaisesRegex(
                 NotImplementedError,
-                "Invalid return type.*scalar Pandas UDF.*ArrayType.*YearMonthIntervalType",
+                "Invalid return type.*scalar Pandas UDF.*ArrayType.*UnsupportedType",
             ):
-                pandas_udf(lambda x: x, ArrayType(YearMonthIntervalType()), udf_type)
+                pandas_udf(lambda x: x, ArrayType(UnsupportedType()), udf_type)
 
     def test_vectorized_udf_return_scalar(self):
         with self.quiet():

--- a/python/pyspark/testing/sqlutils.py
+++ b/python/pyspark/testing/sqlutils.py
@@ -49,7 +49,7 @@ except Exception as e:
     test_not_compiled_message = str(e)
 
 from pyspark.sql import SparkSession
-from pyspark.sql.types import ArrayType, DoubleType, UserDefinedType, Row
+from pyspark.sql.types import ArrayType, DoubleType, UserDefinedType, Row, DataType
 from pyspark.testing.utils import ReusedPySparkTestCase, PySparkErrorTestUtils
 
 
@@ -71,6 +71,10 @@ class UTCOffsetTimezone(datetime.tzinfo):
 
     def dst(self, dt):
         return self.ZERO
+
+
+class UnsupportedType(DataType):
+    """Unsupported DataType for Type Checking"""
 
 
 class ExamplePointUDT(UserDefinedType):

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3090,7 +3090,7 @@ object SQLConf {
         "2. pyspark.sql.SparkSession.createDataFrame when its input is a Pandas DataFrame " +
         "or a NumPy ndarray. " +
         "The following data type is unsupported: " +
-        "ArrayType of TimestampType.")
+        "YearMonthIntervalType.")
       .version("3.0.0")
       .fallbackConf(ARROW_EXECUTION_ENABLED)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use UnsupportedType instead of YearMonthIntervalType for type checking in Arrow UDF.

### Does this PR introduce _any_ user-facing change?
Yes. Change the doc as `ArrayType<TimeStampType>` has already supported in #41240. 

### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No.
