### PR TITLE
[SPARK-49185][PS][PYTHON][CONNECT] Reimplement `kde` plot with Spark SQL

### DIFF
--- a/python/pyspark/pandas/plot/core.py
+++ b/python/pyspark/pandas/plot/core.py
@@ -474,27 +474,27 @@ class KdePlotBase(NumericPlotBase):
 
         bandwidth = float(bw_method)
         points = [float(i) for i in ind]
-        logStandardDeviationPlusHalfLog2Pi = math.log(bandwidth) + 0.5 * math.log(2 * math.pi)
+        log_std_plus_half_log2_pi = math.log(bandwidth) + 0.5 * math.log(2 * math.pi)
 
-        def normPdf(
+        def norm_pdf(
             mean: Column,
-            standardDeviation: Column,
-            logStandardDeviationPlusHalfLog2Pi: Column,
+            std: Column,
+            log_std_plus_half_log2_pi: Column,
             x: Column,
         ) -> Column:
             x0 = x - mean
-            x1 = x0 / standardDeviation
-            logDensity = -0.5 * x1 * x1 - logStandardDeviationPlusHalfLog2Pi
-            return F.exp(logDensity)
+            x1 = x0 / std
+            log_density = -0.5 * x1 * x1 - log_std_plus_half_log2_pi
+            return F.exp(log_density)
 
         dataCol = F.col(sdf.columns[0]).cast("double")
 
         estimated = [
             F.avg(
-                normPdf(
+                norm_pdf(
                     dataCol,
                     F.lit(bandwidth),
-                    F.lit(logStandardDeviationPlusHalfLog2Pi),
+                    F.lit(log_std_plus_half_log2_pi),
                     F.lit(point),
                 )
             )

--- a/python/pyspark/pandas/tests/connect/plot/test_parity_frame_plot_matplotlib.py
+++ b/python/pyspark/pandas/tests/connect/plot/test_parity_frame_plot_matplotlib.py
@@ -28,10 +28,6 @@ class DataFramePlotMatplotlibParityTests(
     def test_hist_plot(self):
         super().test_hist_plot()
 
-    @unittest.skip("Test depends on Spark ML which is not supported from Spark Connect.")
-    def test_kde_plot(self):
-        super().test_kde_plot()
-
 
 if __name__ == "__main__":
     from pyspark.pandas.tests.connect.plot.test_parity_frame_plot_matplotlib import *  # noqa: F401

--- a/python/pyspark/pandas/tests/connect/plot/test_parity_frame_plot_plotly.py
+++ b/python/pyspark/pandas/tests/connect/plot/test_parity_frame_plot_plotly.py
@@ -32,10 +32,6 @@ class DataFramePlotPlotlyParityTests(
     def test_hist_plot(self):
         super().test_hist_plot()
 
-    @unittest.skip("Test depends on Spark ML which is not supported from Spark Connect.")
-    def test_kde_plot(self):
-        super().test_kde_plot()
-
 
 if __name__ == "__main__":
     from pyspark.pandas.tests.connect.plot.test_parity_frame_plot_plotly import *  # noqa: F401

--- a/python/pyspark/pandas/tests/connect/plot/test_parity_series_plot_matplotlib.py
+++ b/python/pyspark/pandas/tests/connect/plot/test_parity_series_plot_matplotlib.py
@@ -37,10 +37,6 @@ class SeriesPlotMatplotlibParityTests(
         super().test_hist_plot()
 
     @unittest.skip("Test depends on Spark ML which is not supported from Spark Connect.")
-    def test_kde_plot(self):
-        super().test_kde_plot()
-
-    @unittest.skip("Test depends on Spark ML which is not supported from Spark Connect.")
     def test_single_value_hist(self):
         super().test_single_value_hist()
 

--- a/python/pyspark/pandas/tests/connect/plot/test_parity_series_plot_plotly.py
+++ b/python/pyspark/pandas/tests/connect/plot/test_parity_series_plot_plotly.py
@@ -28,10 +28,6 @@ class SeriesPlotPlotlyParityTests(
     def test_hist_plot(self):
         super().test_hist_plot()
 
-    @unittest.skip("Test depends on Spark ML which is not supported from Spark Connect.")
-    def test_kde_plot(self):
-        super().test_kde_plot()
-
 
 if __name__ == "__main__":
     from pyspark.pandas.tests.connect.plot.test_parity_series_plot_plotly import *  # noqa: F401

--- a/python/pyspark/pandas/tests/connect/test_connect_plotting.py
+++ b/python/pyspark/pandas/tests/connect/test_connect_plotting.py
@@ -45,34 +45,10 @@ class ConnectPlottingTests(PandasOnSparkTestUtils, TestUtils, ReusedConnectTestC
             self.psdf1.plot.hist(bins=3)
 
         with self.assertRaises(PandasNotImplementedError):
-            self.psdf1.plot.kde()
-
-        with self.assertRaises(PandasNotImplementedError):
-            self.psdf1.plot.kde(bw_method=3)
-
-        with self.assertRaises(PandasNotImplementedError):
-            self.psdf1.plot.density()
-
-        with self.assertRaises(PandasNotImplementedError):
-            self.psdf1.plot.density(bw_method=3)
-
-        with self.assertRaises(PandasNotImplementedError):
             self.psdf1.shield.plot.hist()
 
         with self.assertRaises(PandasNotImplementedError):
             self.psdf1.shield.plot.hist(bins=3)
-
-        with self.assertRaises(PandasNotImplementedError):
-            self.psdf1.shield.plot.kde()
-
-        with self.assertRaises(PandasNotImplementedError):
-            self.psdf1.shield.plot.kde(bw_method=3)
-
-        with self.assertRaises(PandasNotImplementedError):
-            self.psdf1.shield.plot.density()
-
-        with self.assertRaises(PandasNotImplementedError):
-            self.psdf1.shield.plot.density(bw_method=3)
 
     def test_unsupported_kinds(self):
         with self.assertRaises(PandasNotImplementedError):
@@ -82,34 +58,10 @@ class ConnectPlottingTests(PandasOnSparkTestUtils, TestUtils, ReusedConnectTestC
             self.psdf1.plot(kind="hist", bins=3)
 
         with self.assertRaises(PandasNotImplementedError):
-            self.psdf1.plot(kind="kde")
-
-        with self.assertRaises(PandasNotImplementedError):
-            self.psdf1.plot(kind="kde", bw_method=3)
-
-        with self.assertRaises(PandasNotImplementedError):
-            self.psdf1.plot(kind="density")
-
-        with self.assertRaises(PandasNotImplementedError):
-            self.psdf1.plot(kind="density", bw_method=3)
-
-        with self.assertRaises(PandasNotImplementedError):
             self.psdf1.shield.plot(kind="hist")
 
         with self.assertRaises(PandasNotImplementedError):
             self.psdf1.shield.plot(kind="hist", bins=3)
-
-        with self.assertRaises(PandasNotImplementedError):
-            self.psdf1.shield.plot(kind="kde")
-
-        with self.assertRaises(PandasNotImplementedError):
-            self.psdf1.shield.plot(kind="kde", bw_method=3)
-
-        with self.assertRaises(PandasNotImplementedError):
-            self.psdf1.shield.plot(kind="density")
-
-        with self.assertRaises(PandasNotImplementedError):
-            self.psdf1.shield.plot(kind="density", bw_method=3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What changes were proposed in this pull request?
Reimplement kde plot with Spark SQL


### Why are the changes needed?
Existing `kde` plot is not supported with Spark Connect, due to it's based on mllib which is not compatible with spark connect.


### Does this PR introduce _any_ user-facing change?
yes, following APIs are enabled:

- `{Frame, Series}.plot.kde`
- `{Frame, Series}.plot.density`
- `{Frame, Series}.plot(kind="kde", ...)`
- `{Frame, Series}.plot(kind="density", ...)`

### How was this patch tested?
1, enabled tests
2, manually check
```
import pyspark.pandas as ps
df = ps.DataFrame({'x': [1, 2, 2.5, 3, 3.5, 4, 5], 'y': [4, 4, 4.5, 5, 5.5, 6, 6],})
df.plot.kde(bw_method=0.3)
```

before (Spark Classic):
![image](https://github.com/user-attachments/assets/01d5c180-e84c-4e31-b5ed-071a8b4d1227)

after (Spark Connect):
![image](https://github.com/user-attachments/assets/472b0fec-2029-4250-a623-1fe345e4bde8)


### Was this patch authored or co-authored using generative AI tooling?
No
