### PR TITLE
[WIP] Implement Levenshtein distance for utf8_lcase collation

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
@@ -1423,7 +1423,7 @@ public class CollationAwareUTF8String {
   }
 
   /**
-   * Next matching pair will include d>=2 next elements of one string, and 0 next elements of another
+   * Next matching pair will include d>=2 next elements of one string,and 0 next elements of another
    * string. This guarantees that we will delete all the d-2 elements from the middle of the
    * substring (i+1,i+d), and that we need the remaining two characters (i+1 and i+d) to
    * match the transformation.rightFirst and transformation.rightSecond, and we have to add
@@ -1448,7 +1448,7 @@ public class CollationAwareUTF8String {
   }
 
   /**
-   * Next matching pair will include d>=2 next elements of one string, and 1 next element of another
+   * Next matching pair will include d>=2 next elements of one string,and 1 next element of another
    * string. This guarantees that we will delete all the d-2 elements from the middle of the
    * substring (i+1,i+d), and that we need the remaining two characters (i+1 and i+d) to
    * match the transformation.rightFirst and transformation.rightSecond, and we have to match

--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
@@ -1290,7 +1290,7 @@ public class CollationAwareUTF8String {
   /// Lowercase levenshtein distance
   private static class Transformation {
     public int left, rightFirst, rightSecond;
-    public Transformation(int left, int rightFirst, int rightSecond) {
+    Transformation(int left, int rightFirst, int rightSecond) {
       this.left = left;
       this.rightFirst = rightFirst;
       this.rightSecond = rightSecond;
@@ -1344,9 +1344,9 @@ public class CollationAwareUTF8String {
     public ArrayList<Integer> codepointsLeft, codepointsRight;
     public ArrayList<Integer> codepointsLeftLowerCase, codepointsRightLowerCase;
 
-    public DP(UTF8String stLeft, UTF8String stRight, ArrayList<Transformation> transformations) {
-      this.codepointsLeft = UTF8ToCodepoints(stLeft);
-      this.codepointsRight = UTF8ToCodepoints(stRight);
+    DP(UTF8String stLeft, UTF8String stRight, ArrayList<Transformation> transformations) {
+      this.codepointsLeft = convertUTF8ToCodepoints(stLeft);
+      this.codepointsRight = convertUTF8ToCodepoints(stRight);
 
       if (codepointsLeft.size() > codepointsRight.size()) {
         ArrayList<Integer> swap = codepointsLeft;
@@ -1364,8 +1364,9 @@ public class CollationAwareUTF8String {
       rowMinimum = new int[n+1];
       for (int i = 0; i <= n; i++) {
         rowMinimum[i] = INF;
-        for (int j = 0; j <= m; j++)
+        for (int j = 0; j <= m; j++) {
           dp[i][j] = INF;
+        }
       }
       dp[0][0] = 0;
       rowMinimum[0] = 0;
@@ -1380,7 +1381,7 @@ public class CollationAwareUTF8String {
     }
 
   }
-  private static ArrayList<Integer> UTF8ToCodepoints(UTF8String st) {
+  private static ArrayList<Integer> convertUTF8ToCodepoints(UTF8String st) {
     Iterator<Integer> targetIter = st.codePointIterator(
             CodePointIteratorType.CODE_POINT_ITERATOR_MAKE_VALID);
     ArrayList<Integer> codepoints = new ArrayList<>();
@@ -1415,8 +1416,10 @@ public class CollationAwareUTF8String {
    * or they are different, and we can replace one of them with a cost of 1, to make them equal.
    */
   private static void pushType2(int i, int j, DP dp) {
-    if(i+1 <= dp.n && j+1 <= dp.m)dp.updateState(i,j,i+1,j+1,
-            dp.codepointsLeftLowerCase.get(i).equals(dp.codepointsRightLowerCase.get(j))?0:1);
+    if (i+1 <= dp.n && j+1 <= dp.m) {
+      dp.updateState(i, j, i + 1, j + 1,
+              dp.codepointsLeftLowerCase.get(i).equals(dp.codepointsRightLowerCase.get(j)) ? 0 : 1);
+    }
   }
 
   /**
@@ -1510,8 +1513,9 @@ public class CollationAwareUTF8String {
 
       if (i < n) {
         int minVal = 1000000000;
-        for (int j = i + 1;j <= n; j++)
+        for (int j = i + 1;j <= n; j++) {
           minVal = Math.min(minVal, dp.rowMinimum[j]);
+        }
         if (minVal > threshold) return -1;
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
@@ -653,7 +653,7 @@ class CollationStringExpressionsSuite
     )
     val testCases = Seq(
       LevenshteinTestCase("kitten", "sitTing", "UTF8_BINARY", None, result = 4),
-      LevenshteinTestCase("kitten", "sitTing", "UTF8_LCASE", None, result = 4),
+      LevenshteinTestCase("kitten", "sitTing", "UTF8_LCASE", None, result = 3),
       LevenshteinTestCase("kitten", "sitTing", "UNICODE", Some(3), result = -1),
       LevenshteinTestCase("kitten", "sitTing", "UNICODE_CI", Some(3), result = -1)
     )


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Supporting Levenshtein distance with utf8_lcase collation.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Levenshtein distance for utf8_lcase collation was not supported.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit tests in CollationSQLExpressionsSuite.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.