### PR TITLE
[SPARK-49114][SS][FOLLOWUP] Add missing error classes into json definition file

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -256,6 +256,26 @@
           "Error reading streaming state file of <fileToRead> does not exist. If the stream job is restarted with a new or updated state operation, please create a new checkpoint location or clear the existing checkpoint location."
         ]
       },
+      "HDFS_STORE_PROVIDER_OUT_OF_MEMORY" : {
+        "message" : [
+          "Could not load HDFS state store with id <stateStoreId> because of an out of memory exception."
+        ]
+      },
+      "INVALID_CHANGE_LOG_READER_VERSION" : {
+        "message" : [
+          "The change log reader version cannot be <version>."
+        ]
+      },
+      "INVALID_CHANGE_LOG_WRITER_VERSION" : {
+        "message" : [
+          "The change log writer version cannot be <version>."
+        ]
+      },
+      "ROCKSDB_STORE_PROVIDER_OUT_OF_MEMORY" : {
+        "message" : [
+          "Could not load RocksDB state store with id <stateStoreId> because of an out of memory exception."
+        ]
+      },
       "SNAPSHOT_PARTITION_ID_NOT_FOUND" : {
         "message" : [
           "Partition id <snapshotPartitionId> not found for state of operator <operatorId> at <checkpointLocation>."


### PR DESCRIPTION
### What changes were proposed in this pull request?

Follow up to SPARK-49114 (https://github.com/apache/spark/pull/47616). The PR added sub-categories of "cannot load state store errors", but it missed to add definition of error class into `error-conditions.json` JSON file.

### Why are the changes needed?

Newly added error classes from https://github.com/apache/spark/pull/47616 will be dangling ones without this PR.

### Does this PR introduce _any_ user-facing change?

Yes, user will see the detailed error class to identify the issue better for the case of "cannot load state store" error.

### How was this patch tested?

N/A

### Was this patch authored or co-authored using generative AI tooling?

No.