### PR TITLE
[SPARK-49178][SQL] Optimize performance of `Row#getSeq` to match the performance when using Spark 3.5 with Scala 2.12

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/Row.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Row.scala
@@ -320,8 +320,12 @@ trait Row extends Serializable {
    * @throws ClassCastException when data type does not match.
    */
   def getSeq[T](i: Int): Seq[T] = {
-    val res = getAs[scala.collection.Seq[T]](i)
-    if (res != null) res.toSeq else null
+    getAs[scala.collection.Seq[T]](i) match {
+      case seq: mutable.ArraySeq[T] =>
+        seq.array.toImmutableArraySeq.asInstanceOf[Seq[T]]
+      case other if other != null => other.toSeq
+      case _ => null
+    }
   }
 
   /**

--- a/sql/api/src/main/scala/org/apache/spark/sql/Row.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/Row.scala
@@ -321,6 +321,9 @@ trait Row extends Serializable {
    */
   def getSeq[T](i: Int): Seq[T] = {
     getAs[scala.collection.Seq[T]](i) match {
+      // SPARK-49178: When the type of `Seq[T]` is `mutable.ArraySeq[T]`,
+      // rewrap `mutable.ArraySeq[T].array` as `immutable.ArraySeq[T]`
+      // to avoid a collection copy.
       case seq: mutable.ArraySeq[T] =>
         seq.array.toImmutableArraySeq.asInstanceOf[Seq[T]]
       case other if other != null => other.toSeq


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR introduces the following optimization to the `Row#getSeq` function: 

- When the actual type of `Seq` is `mutable.ArraySeq[T]`, it rewraps the `mutable.ArraySeq.array` as an `immutable.ArraySeq[T]` to avoid a collection copy. 

This optimization make the performance of `Row#getSeq` in master to match the performance when using Spark 3.5 with Scala 2.12.


### Why are the changes needed?
Optimize the performance of `Row#getSeq` to match the performance when using Spark 3.5 with Scala 2.12.

Consider the following scenario:

```scala
    val data = (0 until arraySize).toArray
    val row = Seq(data).toDF().collect().head

    val benchmark = new Benchmark(
      s"Test get seq with $arraySize from row",
      valuesPerIteration,
      output = output)

    benchmark.addCase("Get Seq") { _: Int =>

      for (_ <- 0L until valuesPerIteration) {
        val ret = row.getSeq(0)
      }
    }

    benchmark.run()
```

Run tests on the aforementioned code with `arraySize` set to 10, 100, 1000, 10000, and 100000, respectively, and with `valuesPerIteration` set to 100000, getting the following results:

- branch-3.5(with Scala 2.12):

```
OpenJDK 64-Bit Server VM 1.8.0_422-b05 on Linux 5.15.0-1068-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 10 from row:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                               1              1           0        194.8           5.1       1.0X

OpenJDK 64-Bit Server VM 1.8.0_422-b05 on Linux 5.15.0-1068-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 100 from row:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                               1              1           0         96.8          10.3       1.0X

OpenJDK 64-Bit Server VM 1.8.0_422-b05 on Linux 5.15.0-1068-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 1000 from row:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                               1              1           0         97.0          10.3       1.0X

OpenJDK 64-Bit Server VM 1.8.0_422-b05 on Linux 5.15.0-1068-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 10000 from row:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                               1              1           0         96.8          10.3       1.0X

OpenJDK 64-Bit Server VM 1.8.0_422-b05 on Linux 5.15.0-1068-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 100000 from row:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                               1              1           0         96.9          10.3       1.0X

```

- master (with Scala 2.13):

```
OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 10 from row:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                               9             10           0         10.5          94.8       1.0X

OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 100 from row:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                              65             65           1          1.5         646.4       1.0X

OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 1000 from row:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                             614            615           1          0.2        6140.2       1.0X

OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 10000 from row:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                            6122           6128           8          0.0       61223.1       1.0X

OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 100000 from row:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                           61247          61268          30          0.0      612468.1       1.0X
```

We can observe that in branch-3.5(with Scala 2.12), the latency of `Row#getSeq` is constant, whereas in master(with Scala 2.13), the latency of `Row#getSeq` exhibits a linearly increasing trend with the length of the array.

This is due to the following code:

https://github.com/apache/spark/blob/c121bb557447709c19fc01b68b3a34b8838abc6d/sql/api/src/main/scala/org/apache/spark/sql/Row.scala#L317-L325

The default Scala version in branch-3.5 is 2.12, where `Seq` represents `scala.collection.Seq`. Therefore, the `res.toSeq` in the code above is a redundant operation that does not trigger a collection copy.

However, the default Scala version in master is 2.13, where `Seq` represents `scala.collection.immutable.Seq`, and `getAs[scala.collection.Seq[T]](i)` returns a `scala.collection.mutable.ArraySeq[T]` type. As a result, the `res.toSeq` in the code above triggers a collection copy from `mutable.ArraySeq[T]` to `immutable.ArraySeq[T]`.

This has caused a performance regression for the `Row#getSeq` API between master and Spark 3.5 with Scala 2.12


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Pass GitHub Actions
- Test the previously described scenario with this PR:


```
OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 10 from row:            Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                               0              1           0        257.7           3.9       1.0X

OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 100 from row:           Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                               1              1           0        167.7           6.0       1.0X

OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 1000 from row:          Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                               1              1           0        165.7           6.0       1.0X

OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 10000 from row:         Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                               1              1           0        167.8           6.0       1.0X

OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
AMD EPYC 7763 64-Core Processor
Test get seq with 100000 from row:        Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
------------------------------------------------------------------------------------------------------------------------
Get Seq                                               1              1           0        168.0           6.0       1.0X
```

We can see that, with this PR, the latency of the `Row#getSeq` API has returned to being constant.


### Was this patch authored or co-authored using generative AI tooling?
No