### PR TITLE
[SPARK-49193][SQL] Improve the performance of RowSetUtils.toColumnBasedSet

### DIFF
--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/RowSetUtils.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/RowSetUtils.scala
@@ -135,6 +135,7 @@ object RowSetUtils {
 
       case _ =>
         var i = 0
+        val rowSize = rows.length
         val values = new java.util.ArrayList[String](rowSize)
         rows.foreach { row =>
           nulls.set(i, row.isNullAt(ordinal))

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/RowSetUtils.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/RowSetUtils.scala
@@ -134,9 +134,9 @@ object RowSetUtils {
         TColumn.binaryVal(new TBinaryColumn(values, nulls))
 
       case _ =>
-        val rowSize = rows.length
+        var i = 0
         val values = new java.util.ArrayList[String](rowSize)
-        rows.zipWithIndex.foreach { case (row, i) =>
+        rows.foreach { row =>
           nulls.set(i, row.isNullAt(ordinal))
           val value = if (row.isNullAt(ordinal)) {
             ""
@@ -144,6 +144,7 @@ object RowSetUtils {
             toHiveString((row.get(ordinal), typ), nested = true, timeFormatters, binaryFormatter)
           }
           values.add(value)
+          i += 1
         }
         TColumn.stringVal(new TStringColumn(values, nulls))
     }

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/RowSetUtils.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/RowSetUtils.scala
@@ -134,11 +134,9 @@ object RowSetUtils {
         TColumn.binaryVal(new TBinaryColumn(values, nulls))
 
       case _ =>
-        var i = 0
         val rowSize = rows.length
         val values = new java.util.ArrayList[String](rowSize)
-        while (i < rowSize) {
-          val row = rows(i)
+        rows.zipWithIndex.foreach { case (row, i) =>
           nulls.set(i, row.isNullAt(ordinal))
           val value = if (row.isNullAt(ordinal)) {
             ""
@@ -146,7 +144,6 @@ object RowSetUtils {
             toHiveString((row.get(ordinal), typ), nested = true, timeFormatters, binaryFormatter)
           }
           values.add(value)
-          i += 1
         }
         TColumn.stringVal(new TStringColumn(values, nulls))
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace `while` loop with `foreach` in `RowSetUtils.toTColumn`.

### Why are the changes needed?

Improve the performance of `RowSetUtils.toColumnBasedSet`:
<img width="1196" alt="image" src="https://github.com/user-attachments/assets/f481de39-e0bf-41c5-8fee-09dc1a93c4e1">


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual test.
```scala
import org.apache.hive.service.rpc.thrift.TProtocolVersion
import org.apache.spark.sql.execution.HiveResult

val df = spark.sql("select id, cast(id as string), cast(id as timestamp) from range(200000)")
val dataTypes = df.schema.fields.map(_.dataType)
val rows = df.collect().toList
val start1 = System.currentTimeMillis()
RowSetUtils.toTRowSet(1, rows, dataTypes, TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V11, HiveResult.getTimeFormatters)
val start2 = System.currentTimeMillis()
RowSetUtils.toTRowSet(1, rows, dataTypes, TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V5, HiveResult.getTimeFormatters)
val start3 = System.currentTimeMillis()
println(s"toColumnBasedSet time: ${start2 - start1}, toRowBasedSet time: ${start3 - start2}")
```

Before this PR:
```
toColumnBasedSet time: 17307, toRowBasedSet time: 71
```

After this PR:
```
toColumnBasedSet time: 128, toRowBasedSet time: 70
```

### Was this patch authored or co-authored using generative AI tooling?

No.