### PR TITLE
[SPARK-48936][CONNECT][FOLLOW-UP] Makes spark-shell with Spark connect work with SPARK_REMOTE environment variable

### DIFF
--- a/bin/spark-shell
+++ b/bin/spark-shell
@@ -70,6 +70,10 @@ do
   cur_arg=$arg
 done
 
+if [ -n "${SPARK_REMOTE}" ]; then
+  connect_shell=true
+fi
+
 function main() {
   if $connect_shell; then
      export SPARK_SUBMIT_OPTS

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/application/ConnectRepl.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/application/ConnectRepl.scala
@@ -67,14 +67,12 @@ Spark session available as 'spark'.
           p._1.startsWith("spark.") &&
             p._2.nonEmpty &&
             // Don't include spark.remote that we manually set later.
-            !p._1.startsWith("spark.remote") &&
-            // We use Driver class path in spark-shell. Exclude it.
-            !p._1.startsWith("spark.driver.extraClassPath"))
+            !p._1.startsWith("spark.remote"))
         .toMap
 
     val remoteString: Option[String] =
       Option(System.getProperty("spark.remote")) // Set from Spark Submit
-        .orElse(sys.env.get("SPARK_REMOTE"))
+        .orElse(sys.env.get(SparkConnectClient.SPARK_REMOTE))
 
     if (remoteString.exists(_.startsWith("local"))) {
       server = Some {
@@ -85,6 +83,7 @@ Spark session available as 'spark'.
         val pb = new ProcessBuilder(args: _*)
         // So don't exclude spark-sql jar in classpath
         pb.environment().put("SPARK_CONNECT_SHELL", "0")
+        pb.environment().remove(SparkConnectClient.SPARK_REMOTE)
         pb.start()
       }
       // Let the server start. We will directly request to set the configurations

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/SparkConnectClient.scala
@@ -399,7 +399,7 @@ private[sql] class SparkConnectClient(
 
 object SparkConnectClient {
 
-  private val SPARK_REMOTE: String = "SPARK_REMOTE"
+  private[sql] val SPARK_REMOTE: String = "SPARK_REMOTE"
 
   private val DEFAULT_USER_AGENT: String = "_SPARK_CONNECT_SCALA"
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/47402 that makes:

```bash
SPARK_REMOTE="..." bin/spark-shell
```

works.

### Why are the changes needed?

To be consistent with PySpark shell.

### Does this PR introduce _any_ user-facing change?

The main change has not been released out yet. After this change, users can do:

```
SPARK_REMOTE="..." bin/spark-shell
```

### How was this patch tested?

Manually tesed.

### Was this patch authored or co-authored using generative AI tooling?

No.