### PR TITLE
[SPARK-49195][CONNECT] Embed script level parsing logic into SparkSubmitCommandBuilder

### DIFF
--- a/bin/spark-shell
+++ b/bin/spark-shell
@@ -44,42 +44,11 @@ Scala REPL options, Spark Classic only:
 # through spark.driver.extraClassPath is not automatically propagated.
 SPARK_SUBMIT_OPTS="$SPARK_SUBMIT_OPTS -Dscala.usejavacp=true"
 
-# In order to start Spark Connect shell, we should identify if spark.remote
-# or --remote is set. Spark Connect does not support loading configurations
-# yet.
-connect_shell=false
-cur_arg="$0"
-for arg in "${@:1}"
-do
-  # --conf spark.remote=... or -c spark.remote=...
-  if [[ $cur_arg == "--conf" || $cur_arg == "-c" ]]; then
-    if [[ $arg == "spark.remote"* ]]; then
-      connect_shell=true
-    fi
-  fi
-
-  # --conf=spark.remote=... or -c=spark.remote=...
-  if [[ $arg == "--conf=spark.remote"* || $arg == "-c=spark.remote"* ]]; then
-    connect_shell=true
-  fi
-
-  # --remote= or --remote
-  if [[ $arg == "--remote"* ]]; then
-    connect_shell=true
-  fi
-  cur_arg=$arg
-done
-
-if [ -n "${SPARK_REMOTE}" ]; then
-  connect_shell=true
-fi
-
 function main() {
-  if $connect_shell; then
-     export SPARK_SUBMIT_OPTS
-     export SPARK_CONNECT_SHELL=1
-     "${SPARK_HOME}"/bin/spark-submit --class org.apache.spark.sql.application.ConnectRepl --name "Connect shell" "$@"
-  elif $cygwin; then
+  export SPARK_SCALA_SHELL=1
+  # In case of Spark Connect shell, the main class (and resource) is replaced in
+  # SparkSubmitCommandBuilder.
+  if $cygwin; then
     # Workaround for issue involving JLine and Cygwin
     # (see http://sourceforge.net/p/jline/bugs/40/).
     # If you're using the Mintty terminal emulator in Cygwin, may need to set the

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/application/ConnectRepl.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/application/ConnectRepl.scala
@@ -86,7 +86,6 @@ Spark session available as 'spark'.
           remoteString.get) ++ configs.flatMap { case (k, v) => Seq("--conf", s"$k=$v") }
         val pb = new ProcessBuilder(args: _*)
         // So don't exclude spark-sql jar in classpath
-        pb.environment().put("SPARK_CONNECT_SHELL", "0")
         pb.environment().remove(SparkConnectClient.SPARK_REMOTE)
         pb.start()
       }

--- a/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/AbstractCommandBuilder.java
@@ -60,6 +60,11 @@ abstract class AbstractCommandBuilder {
   // properties files multiple times.
   private Map<String, String> effectiveConfig;
 
+  /**
+   * Indicate if the current app submission has to use Spark Connect.
+   */
+  protected boolean isRemote = System.getenv().containsKey("SPARK_REMOTE");
+
   AbstractCommandBuilder() {
     this.appArgs = new ArrayList<>();
     this.childEnv = new HashMap<>();
@@ -206,8 +211,7 @@ abstract class AbstractCommandBuilder {
           addToClassPath(cp, f.toString());
         }
       }
-      boolean isConnectShell = "1".equals(getenv("SPARK_CONNECT_SHELL"));
-      if (isConnectShell) {
+      if (isRemote && "1".equals(getenv("SPARK_SCALA_SHELL"))) {
         for (File f: new File(jarsDir).listFiles()) {
           // Exclude Spark Classic SQL and Spark Connect server jars
           // if we're in Spark Connect Shell. Also exclude Spark SQL API and

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkClassCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkClassCommandBuilder.java
@@ -82,6 +82,10 @@ class SparkClassCommandBuilder extends AbstractCommandBuilder {
         javaOptsKeys.add("SPARK_BEELINE_OPTS");
         yield "SPARK_BEELINE_MEMORY";
       }
+      case "org.apache.spark.sql.application.ConnectRepl" -> {
+        isRemote = true;
+        yield "SPARK_DRIVER_MEMORY";
+      }
       default -> "SPARK_DRIVER_MEMORY";
     };
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR embeds the configuration validation logic in scripts (added in https://github.com/apache/spark/pull/47402) to `SparkSubmitCommandBuilder` to be consistent.

### Why are the changes needed?

To have the consistent one place that handles configurations.

Those configuration validation at the script level was a temporary workaround that we should remove it away.

### Does this PR introduce _any_ user-facing change?

No, refactoring.

### How was this patch tested?

Manually tested:


```
./bin/spark-shell --remote "local[*]"
...
spark.range(10).show()
```

```
./sbin/start-connect-server.sh --wait
...
./bin/spark-shell --remote "sc://localhost"
...
spark.range(10).show()
```

```
./bin/spark-shell --remote "local[*]" --conf spark.sql.ansi.enabled=false
...
spark.conf.get("spark.sql.ansi.enabled")
```


```
./bin/spark-shell --remote "local[*]" --conf spark.sql.ansi.enabled=false --conf spark.abcabc=abc --conf spark.sql.debug=true
...
spark.conf.get("spark.sql.debug")
spark.conf.get("spark.sql.ansi.enabled")
```

```
./sbin/start-connect-server.sh --wait
...
./bin/spark-shell --remote "sc://localhost" --conf spark.sql.ansi.enabled=false --conf spark.abcabc=abc --conf spark.sql.debug=true
...
spark.conf.get("spark.sql.debug")
spark.conf.get("spark.sql.ansi.enabled")
```

```
SPARK_REMOTE="sc://localhost" ./bin/spark-shell
...
spark.range(1).collect()
```


### Was this patch authored or co-authored using generative AI tooling?

No.