### PR TITLE
[SPARK-49198][CONNECT] Prune more jars required for Spark Connect shell

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -171,62 +171,28 @@
       </plugin>
       <plugin>
         <!--
-          Here we download ammonite dependency required for Spark Connect REPL and copy
-          Spark Connect client to target's jars/connect-repl directory. Both jars will
-          only be loaded when we run Spark Connect shell, see also
-          AbstractCommandBuilder.buildClassPath and SPARK-48936.
+          Copy Spark Connect client jar and its dependencies for Spark Connect REPL.
         -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <executions>
           <execution>
-            <id>get-ammonite-jar</id>
+            <id>copy-connect-client-repl-jars</id>
             <phase>package</phase>
             <goals>
               <goal>exec</goal>
             </goals>
             <configuration>
-              <executable>${basedir}/../build/mvn</executable>
+              <executable>cp</executable>
               <arguments>
-                <argument>dependency:copy</argument>
-                <argument>-Dartifact=com.lihaoyi:ammonite_${scala.version}:${ammonite.version}</argument>
-                <argument>-DoutputDirectory=${basedir}/target/scala-${scala.binary.version}/jars/connect-repl</argument>
+                <argument>-r</argument>
+                <argument>${basedir}/../connector/connect/client/jvm/target/connect-repl</argument>
+                <argument>${basedir}/target/scala-${scala.binary.version}/jars/</argument>
               </arguments>
             </configuration>
           </execution>
           <execution>
-            <id>get-ammonite-pom</id>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <executable>${basedir}/../build/mvn</executable>
-              <arguments>
-                <argument>dependency:copy</argument>
-                <argument>-Dartifact=com.lihaoyi:ammonite_${scala.version}:${ammonite.version}:pom</argument>
-                <argument>-DoutputDirectory=${basedir}/target/scala-${scala.binary.version}/jars/connect-repl</argument>
-              </arguments>
-            </configuration>
-          </execution>
-          <execution>
-            <id>get-ammonite-deps</id>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <executable>${basedir}/../build/mvn</executable>
-              <arguments>
-                <argument>dependency:copy-dependencies</argument>
-                <argument>-DoutputDirectory=${basedir}/target/scala-${scala.binary.version}/jars/connect-repl</argument>
-                <argument>--file</argument>
-                <argument>${basedir}/target/scala-${scala.binary.version}/jars/connect-repl/ammonite_${scala.version}-${ammonite.version}.pom</argument>
-              </arguments>
-            </configuration>
-          </execution>
-          <execution>
-            <id>get-connect-client-jar</id>
+            <id>copy-connect-client-jar</id>
             <phase>package</phase>
             <goals>
               <goal>exec</goal>

--- a/connector/connect/client/jvm/pom.xml
+++ b/connector/connect/client/jvm/pom.xml
@@ -195,6 +195,28 @@
         </configuration>
       </plugin>
       <plugin>
+        <!--
+          Here we download Spark Connect cleint dependencies for REPL and copy
+          Spark Connect client to target's jars/connect-repl directory (at assembly/pom.xml).
+          Those jars will only be loaded when we run Spark Connect shell, see also SPARK-49198
+        -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>get-ammonite-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${basedir}/target/connect-repl</outputDirectory>
+              <includeScope>provided</includeScope>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR propose to specify `includeScope=runtime` for `copy-dependencies` to prune unrelated jars out. In addition, this Pr has a couple of more improvement by replacing `org.codehaus.mojo:exec-maven-plugin` to `org.apache.maven.plugins:maven-dependency-plugin` for `get-ammonite-jar` and `get-ammonite-pom` which avoid directly calling `mvn` executable.

### Why are the changes needed?

To reduce the number of jars (https://github.com/apache/spark/pull/47402#issuecomment-2277042654) 

### Does this PR introduce _any_ user-facing change?

No the main change (https://github.com/apache/spark/pull/47402) has not been released out yet.
But it will reduce the size of the jars in the package.

### How was this patch tested?


```bash
./build/mvn -Phive -DskipTests clean package
cd assembly/target/scala-2.13/jars/connect-repl/
ls -al | wc -l
```

### Was this patch authored or co-authored using generative AI tooling?

No.
