### PR TITLE
[SPARK-49199][BUILD] `build/mvn` should check project local installed Maven ahead

### DIFF
--- a/build/mvn
+++ b/build/mvn
@@ -111,36 +111,36 @@ function version { echo "$@" | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }'
 install_mvn() {
   local MVN_VERSION=`grep "<maven.version>" "${_DIR}/../pom.xml" | head -n1 | awk -F '[<>]' '{print $3}'`
   MVN_BIN="${_DIR}/apache-maven-${MVN_VERSION}/bin/mvn"
-  if [ ! -f "$MVN_BIN" ]; then
-    MVN_BIN="$(command -v mvn)"
-    if [ "$MVN_BIN" ]; then
-      local MVN_DETECTED_VERSION="$(mvn --version | head -n1 | awk '{print $3}')"
-    fi
-    if [ $(version $MVN_DETECTED_VERSION) -ne $(version $MVN_VERSION) ]; then
-      local MVN_TARBALL="apache-maven-${MVN_VERSION}-bin.tar.gz"
-      local FILE_PATH="maven/maven-3/${MVN_VERSION}/binaries/${MVN_TARBALL}"
-      local APACHE_MIRROR=${APACHE_MIRROR:-'https://www.apache.org/dyn/closer.lua'}
-      local MIRROR_URL_QUERY="?action=download"
+  if [ -f "$MVN_BIN" ]; then
+    return
+  fi
+  MVN_BIN="$(command -v mvn)"
+  if [ "$MVN_BIN" ]; then
+    local MVN_DETECTED_VERSION="$(mvn --version | head -n1 | awk '{print $3}')"
+  fi
+  if [ $(version $MVN_DETECTED_VERSION) -ne $(version $MVN_VERSION) ]; then
+    local MVN_TARBALL="apache-maven-${MVN_VERSION}-bin.tar.gz"
+    local FILE_PATH="maven/maven-3/${MVN_VERSION}/binaries/${MVN_TARBALL}"
+    local APACHE_MIRROR=${APACHE_MIRROR:-'https://www.apache.org/dyn/closer.lua'}
+    local MIRROR_URL_QUERY="?action=download"
 
-      if [ $(command -v curl) ]; then
-        if ! curl -L --output /dev/null --silent --head --fail "${APACHE_MIRROR}/${FILE_PATH}${MIRROR_URL_QUERY}" ; then
-          # Fall back to archive.apache.org for older Maven
-          echo "Falling back to archive.apache.org to download Maven"
-          APACHE_MIRROR="https://archive.apache.org/dist"
-          MIRROR_URL_QUERY=""
-        fi
+    if [ $(command -v curl) ]; then
+      if ! curl -L --output /dev/null --silent --head --fail "${APACHE_MIRROR}/${FILE_PATH}${MIRROR_URL_QUERY}" ; then
+        # Fall back to archive.apache.org for older Maven
+        echo "Falling back to archive.apache.org to download Maven"
+        APACHE_MIRROR="https://archive.apache.org/dist"
+        MIRROR_URL_QUERY=""
       fi
-
-      install_app \
-        "${APACHE_MIRROR}" \
-        "${FILE_PATH}" \
-        "${MIRROR_URL_QUERY}" \
-        "sha512" \
-        "${MVN_TARBALL}" \
-        "apache-maven-${MVN_VERSION}/bin/mvn"
-
-      MVN_BIN="${_DIR}/apache-maven-${MVN_VERSION}/bin/mvn"
     fi
+
+    install_app \
+      "${APACHE_MIRROR}" \
+      "${FILE_PATH}" \
+      "${MIRROR_URL_QUERY}" \
+      "sha512" \
+      "${MVN_TARBALL}"
+
+    MVN_BIN="${_DIR}/apache-maven-${MVN_VERSION}/bin/mvn"
   fi
 }
 

--- a/build/mvn
+++ b/build/mvn
@@ -38,8 +38,8 @@ _CALLING_DIR="$(pwd)"
 # Options used during compilation
 _COMPILE_JVM_OPTS="-Xss128m -Xmx4g -XX:ReservedCodeCacheSize=128m"
 
-# Installs any application tarball given a URL, the expected tarball name,
-# and, optionally. Arguments:
+# Installs any application tarball given a URL, the expected tarball name.
+# Arguments:
 # 1 - Mirror host
 # 2 - URL path on host
 # 3 - URL query string

--- a/build/mvn
+++ b/build/mvn
@@ -39,21 +39,18 @@ _CALLING_DIR="$(pwd)"
 _COMPILE_JVM_OPTS="-Xss128m -Xmx4g -XX:ReservedCodeCacheSize=128m"
 
 # Installs any application tarball given a URL, the expected tarball name,
-# and, optionally, a checkable binary path to determine if the binary has
-# already been installed. Arguments:
+# and, optionally. Arguments:
 # 1 - Mirror host
 # 2 - URL path on host
 # 3 - URL query string
 # 4 - checksum suffix
 # 5 - Tarball Name
-# 6 - Checkable Binary
 install_app() {
   local mirror_host="$1"
   local url_path="$2"
   local url_query="$3"
   local checksum_suffix="$4"
   local local_tarball="${_DIR}/$5"
-  local binary="${_DIR}/$6"
   local remote_tarball="${mirror_host}/${url_path}${url_query}"
   local local_checksum="${local_tarball}.${checksum_suffix}"
   local remote_checksum="https://archive.apache.org/dist/${url_path}.${checksum_suffix}"
@@ -61,51 +58,49 @@ install_app() {
   local curl_opts="--retry 3 --retry-all-errors --silent --show-error -L"
   local wget_opts="--no-verbose"
 
-  if [ ! -f "$binary" ]; then
-    # check if we already have the tarball
-    # check if we have curl installed
-    # download application
-    if [ ! -f "${local_tarball}" -a "$(command -v curl)" ]; then
-      echo "exec: curl ${curl_opts} ${remote_tarball}" 1>&2
-      curl ${curl_opts} "${remote_tarball}" > "${local_tarball}"
-      if [ ! -z "${checksum_suffix}" ]; then
-        echo "exec: curl ${curl_opts} ${remote_checksum}" 1>&2
-        curl ${curl_opts} "${remote_checksum}" > "${local_checksum}"
-      fi
+  # check if we already have the tarball
+  # check if we have curl installed
+  # download application
+  if [ ! -f "${local_tarball}" -a "$(command -v curl)" ]; then
+    echo "exec: curl ${curl_opts} ${remote_tarball}" 1>&2
+    curl ${curl_opts} "${remote_tarball}" > "${local_tarball}"
+    if [ ! -z "${checksum_suffix}" ]; then
+      echo "exec: curl ${curl_opts} ${remote_checksum}" 1>&2
+      curl ${curl_opts} "${remote_checksum}" > "${local_checksum}"
     fi
-    # if the file still doesn't exist, lets try `wget` and cross our fingers
-    if [ ! -f "${local_tarball}" -a "$(command -v wget)" ]; then
-      echo "exec: wget ${wget_opts} ${remote_tarball}" 1>&2
-      wget ${wget_opts} -O "${local_tarball}" "${remote_tarball}"
-      if [ ! -z "${checksum_suffix}" ]; then
-        echo "exec: wget ${wget_opts} ${remote_checksum}" 1>&2
-        wget ${wget_opts} -O "${local_checksum}" "${remote_checksum}"
-      fi
-    fi
-    # if both were unsuccessful, exit
-    if [ ! -f "${local_tarball}" ]; then
-      echo -n "ERROR: Cannot download ${remote_tarball} with cURL or wget; please install manually and try again."
-      exit 2
-    fi
-    # Checksum may not have been specified; don't check if doesn't exist
-    if [ "$(command -v shasum)" ]; then
-      if [ -f "${local_checksum}" ]; then
-        echo "  ${local_tarball}" >> ${local_checksum} # two spaces + file are important!
-        # Assuming SHA512 here for now
-        echo "Verifying checksum from ${local_checksum}" 1>&2
-        if ! shasum -a 512 -c "${local_checksum}" > /dev/null ; then
-          echo "Bad checksum from ${remote_checksum}"
-          exit 2
-        fi
-      fi
-    else
-      echo "Skipping checksum because shasum is not installed." 1>&2
-    fi
-
-    cd "${_DIR}" && tar -xzf "${local_tarball}"
-    rm -rf "${local_tarball}"
-    rm -f "${local_checksum}"
   fi
+  # if the file still doesn't exist, lets try `wget` and cross our fingers
+  if [ ! -f "${local_tarball}" -a "$(command -v wget)" ]; then
+    echo "exec: wget ${wget_opts} ${remote_tarball}" 1>&2
+    wget ${wget_opts} -O "${local_tarball}" "${remote_tarball}"
+    if [ ! -z "${checksum_suffix}" ]; then
+      echo "exec: wget ${wget_opts} ${remote_checksum}" 1>&2
+      wget ${wget_opts} -O "${local_checksum}" "${remote_checksum}"
+    fi
+  fi
+  # if both were unsuccessful, exit
+  if [ ! -f "${local_tarball}" ]; then
+    echo -n "ERROR: Cannot download ${remote_tarball} with cURL or wget; please install manually and try again."
+    exit 2
+  fi
+  # Checksum may not have been specified; don't check if doesn't exist
+  if [ "$(command -v shasum)" ]; then
+    if [ -f "${local_checksum}" ]; then
+      echo "  ${local_tarball}" >> ${local_checksum} # two spaces + file are important!
+      # Assuming SHA512 here for now
+      echo "Verifying checksum from ${local_checksum}" 1>&2
+      if ! shasum -a 512 -c "${local_checksum}" > /dev/null ; then
+        echo "Bad checksum from ${remote_checksum}"
+        exit 2
+      fi
+    fi
+  else
+    echo "Skipping checksum because shasum is not installed." 1>&2
+  fi
+
+  cd "${_DIR}" && tar -xzf "${local_tarball}"
+  rm -rf "${local_tarball}"
+  rm -f "${local_checksum}"
 }
 
 # See simple version normalization: http://stackoverflow.com/questions/16989598/bash-comparing-version-numbers
@@ -115,34 +110,37 @@ function version { echo "$@" | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }'
 # install maven under the build/ folder if needed.
 install_mvn() {
   local MVN_VERSION=`grep "<maven.version>" "${_DIR}/../pom.xml" | head -n1 | awk -F '[<>]' '{print $3}'`
-  MVN_BIN="$(command -v mvn)"
-  if [ "$MVN_BIN" ]; then
-    local MVN_DETECTED_VERSION="$(mvn --version | head -n1 | awk '{print $3}')"
-  fi
-  if [ $(version $MVN_DETECTED_VERSION) -ne $(version $MVN_VERSION) ]; then
-    local MVN_TARBALL="apache-maven-${MVN_VERSION}-bin.tar.gz"
-    local FILE_PATH="maven/maven-3/${MVN_VERSION}/binaries/${MVN_TARBALL}"
-    local APACHE_MIRROR=${APACHE_MIRROR:-'https://www.apache.org/dyn/closer.lua'}
-    local MIRROR_URL_QUERY="?action=download"
-
-    if [ $(command -v curl) ]; then
-      if ! curl -L --output /dev/null --silent --head --fail "${APACHE_MIRROR}/${FILE_PATH}${MIRROR_URL_QUERY}" ; then
-        # Fall back to archive.apache.org for older Maven
-        echo "Falling back to archive.apache.org to download Maven"
-        APACHE_MIRROR="https://archive.apache.org/dist"
-        MIRROR_URL_QUERY=""
-      fi
+  MVN_BIN="${_DIR}/apache-maven-${MVN_VERSION}/bin/mvn"
+  if [ ! -f "$MVN_BIN" ]; then
+    MVN_BIN="$(command -v mvn)"
+    if [ "$MVN_BIN" ]; then
+      local MVN_DETECTED_VERSION="$(mvn --version | head -n1 | awk '{print $3}')"
     fi
+    if [ $(version $MVN_DETECTED_VERSION) -ne $(version $MVN_VERSION) ]; then
+      local MVN_TARBALL="apache-maven-${MVN_VERSION}-bin.tar.gz"
+      local FILE_PATH="maven/maven-3/${MVN_VERSION}/binaries/${MVN_TARBALL}"
+      local APACHE_MIRROR=${APACHE_MIRROR:-'https://www.apache.org/dyn/closer.lua'}
+      local MIRROR_URL_QUERY="?action=download"
 
-    install_app \
-      "${APACHE_MIRROR}" \
-      "${FILE_PATH}" \
-      "${MIRROR_URL_QUERY}" \
-      "sha512" \
-      "${MVN_TARBALL}" \
-      "apache-maven-${MVN_VERSION}/bin/mvn"
+      if [ $(command -v curl) ]; then
+        if ! curl -L --output /dev/null --silent --head --fail "${APACHE_MIRROR}/${FILE_PATH}${MIRROR_URL_QUERY}" ; then
+          # Fall back to archive.apache.org for older Maven
+          echo "Falling back to archive.apache.org to download Maven"
+          APACHE_MIRROR="https://archive.apache.org/dist"
+          MIRROR_URL_QUERY=""
+        fi
+      fi
 
-    MVN_BIN="${_DIR}/apache-maven-${MVN_VERSION}/bin/mvn"
+      install_app \
+        "${APACHE_MIRROR}" \
+        "${FILE_PATH}" \
+        "${MIRROR_URL_QUERY}" \
+        "sha512" \
+        "${MVN_TARBALL}" \
+        "apache-maven-${MVN_VERSION}/bin/mvn"
+
+      MVN_BIN="${_DIR}/apache-maven-${MVN_VERSION}/bin/mvn"
+    fi
   fi
 }
 

--- a/build/mvn
+++ b/build/mvn
@@ -38,19 +38,22 @@ _CALLING_DIR="$(pwd)"
 # Options used during compilation
 _COMPILE_JVM_OPTS="-Xss128m -Xmx4g -XX:ReservedCodeCacheSize=128m"
 
-# Installs any application tarball given a URL, the expected tarball name.
-# Arguments:
+# Installs any application tarball given a URL, the expected tarball name,
+# and, optionally, a checkable binary path to determine if the binary has
+# already been installed. Arguments:
 # 1 - Mirror host
 # 2 - URL path on host
 # 3 - URL query string
 # 4 - checksum suffix
 # 5 - Tarball Name
+# 6 - Checkable Binary
 install_app() {
   local mirror_host="$1"
   local url_path="$2"
   local url_query="$3"
   local checksum_suffix="$4"
   local local_tarball="${_DIR}/$5"
+  local binary="${_DIR}/$6"
   local remote_tarball="${mirror_host}/${url_path}${url_query}"
   local local_checksum="${local_tarball}.${checksum_suffix}"
   local remote_checksum="https://archive.apache.org/dist/${url_path}.${checksum_suffix}"
@@ -58,49 +61,51 @@ install_app() {
   local curl_opts="--retry 3 --retry-all-errors --silent --show-error -L"
   local wget_opts="--no-verbose"
 
-  # check if we already have the tarball
-  # check if we have curl installed
-  # download application
-  if [ ! -f "${local_tarball}" -a "$(command -v curl)" ]; then
-    echo "exec: curl ${curl_opts} ${remote_tarball}" 1>&2
-    curl ${curl_opts} "${remote_tarball}" > "${local_tarball}"
-    if [ ! -z "${checksum_suffix}" ]; then
-      echo "exec: curl ${curl_opts} ${remote_checksum}" 1>&2
-      curl ${curl_opts} "${remote_checksum}" > "${local_checksum}"
-    fi
-  fi
-  # if the file still doesn't exist, lets try `wget` and cross our fingers
-  if [ ! -f "${local_tarball}" -a "$(command -v wget)" ]; then
-    echo "exec: wget ${wget_opts} ${remote_tarball}" 1>&2
-    wget ${wget_opts} -O "${local_tarball}" "${remote_tarball}"
-    if [ ! -z "${checksum_suffix}" ]; then
-      echo "exec: wget ${wget_opts} ${remote_checksum}" 1>&2
-      wget ${wget_opts} -O "${local_checksum}" "${remote_checksum}"
-    fi
-  fi
-  # if both were unsuccessful, exit
-  if [ ! -f "${local_tarball}" ]; then
-    echo -n "ERROR: Cannot download ${remote_tarball} with cURL or wget; please install manually and try again."
-    exit 2
-  fi
-  # Checksum may not have been specified; don't check if doesn't exist
-  if [ "$(command -v shasum)" ]; then
-    if [ -f "${local_checksum}" ]; then
-      echo "  ${local_tarball}" >> ${local_checksum} # two spaces + file are important!
-      # Assuming SHA512 here for now
-      echo "Verifying checksum from ${local_checksum}" 1>&2
-      if ! shasum -a 512 -c "${local_checksum}" > /dev/null ; then
-        echo "Bad checksum from ${remote_checksum}"
-        exit 2
+  if [ ! -f "$binary" ]; then
+    # check if we already have the tarball
+    # check if we have curl installed
+    # download application
+    if [ ! -f "${local_tarball}" -a "$(command -v curl)" ]; then
+      echo "exec: curl ${curl_opts} ${remote_tarball}" 1>&2
+      curl ${curl_opts} "${remote_tarball}" > "${local_tarball}"
+      if [ ! -z "${checksum_suffix}" ]; then
+        echo "exec: curl ${curl_opts} ${remote_checksum}" 1>&2
+        curl ${curl_opts} "${remote_checksum}" > "${local_checksum}"
       fi
     fi
-  else
-    echo "Skipping checksum because shasum is not installed." 1>&2
-  fi
+    # if the file still doesn't exist, lets try `wget` and cross our fingers
+    if [ ! -f "${local_tarball}" -a "$(command -v wget)" ]; then
+      echo "exec: wget ${wget_opts} ${remote_tarball}" 1>&2
+      wget ${wget_opts} -O "${local_tarball}" "${remote_tarball}"
+      if [ ! -z "${checksum_suffix}" ]; then
+        echo "exec: wget ${wget_opts} ${remote_checksum}" 1>&2
+        wget ${wget_opts} -O "${local_checksum}" "${remote_checksum}"
+      fi
+    fi
+    # if both were unsuccessful, exit
+    if [ ! -f "${local_tarball}" ]; then
+      echo -n "ERROR: Cannot download ${remote_tarball} with cURL or wget; please install manually and try again."
+      exit 2
+    fi
+    # Checksum may not have been specified; don't check if doesn't exist
+    if [ "$(command -v shasum)" ]; then
+      if [ -f "${local_checksum}" ]; then
+        echo "  ${local_tarball}" >> ${local_checksum} # two spaces + file are important!
+        # Assuming SHA512 here for now
+        echo "Verifying checksum from ${local_checksum}" 1>&2
+        if ! shasum -a 512 -c "${local_checksum}" > /dev/null ; then
+          echo "Bad checksum from ${remote_checksum}"
+          exit 2
+        fi
+      fi
+    else
+      echo "Skipping checksum because shasum is not installed." 1>&2
+    fi
 
-  cd "${_DIR}" && tar -xzf "${local_tarball}"
-  rm -rf "${local_tarball}"
-  rm -f "${local_checksum}"
+    cd "${_DIR}" && tar -xzf "${local_tarball}"
+    rm -rf "${local_tarball}"
+    rm -f "${local_checksum}"
+  fi
 }
 
 # See simple version normalization: http://stackoverflow.com/questions/16989598/bash-comparing-version-numbers
@@ -138,7 +143,8 @@ install_mvn() {
       "${FILE_PATH}" \
       "${MIRROR_URL_QUERY}" \
       "sha512" \
-      "${MVN_TARBALL}"
+      "${MVN_TARBALL}" \
+      "apache-maven-${MVN_VERSION}/bin/mvn"
 
     MVN_BIN="${_DIR}/apache-maven-${MVN_VERSION}/bin/mvn"
   fi


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR modifies the `mvn` command detection logic in `build/mvn`, to check project local installed `build/apache-maven-${MVN_VERSION}/bin/mvn` ahead to avoid unnecessary network accessing.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To speed up `build/mvn` bootstrap time.

I found sometimes `build/mvn -version` is pretty slow even `build/apache-maven-${MVN_VERSION}` is already cached, and I found it may stuck at the following call when network quality is not good.

https://github.com/apache/spark/blob/879924491944be5d022df895b947bcee25837cc0/build/mvn#L129

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Tested `build/mvn -version` in the following cases:
1. when `build/apache-maven-${MVN_VERSION}/bin/mvn` is available, the command always finishes quickly.
2. when `build/apache-maven-${MVN_VERSION}/bin/mvn` is unavailable but global installed `mvn` version matches `maven.version` defined in root `pom.xml`, the command always finishes quickly too.
3. otherwise, it automatically downloads the maven binary tarball from network.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
