### PR TITLE
[SPARK-49206][CORE][UI] Add `Environment Variables` table to Master `EnvironmentPage`

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/webui.js
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.js
@@ -75,6 +75,7 @@ $(function() {
   collapseTablePageLoad('collapse-aggregated-systemProperties','aggregated-systemProperties');
   collapseTablePageLoad('collapse-aggregated-metricsProperties','aggregated-metricsProperties');
   collapseTablePageLoad('collapse-aggregated-classpathEntries','aggregated-classpathEntries');
+  collapseTablePageLoad('collapse-aggregated-environmentVariables','aggregated-environmentVariables');
   collapseTablePageLoad('collapse-aggregated-activeJobs','aggregated-activeJobs');
   collapseTablePageLoad('collapse-aggregated-completedJobs','aggregated-completedJobs');
   collapseTablePageLoad('collapse-aggregated-failedJobs','aggregated-failedJobs');

--- a/core/src/main/scala/org/apache/spark/internal/config/UI.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/UI.scala
@@ -251,6 +251,13 @@ private[spark] object UI {
     .stringConf
     .createOptional
 
+  val MASTER_UI_VISIBLE_ENV_VAR_PREFIXES = ConfigBuilder("spark.master.ui.visibleEnvVarPrefixes")
+    .doc("Comma-separated list of key-prefix strings to show environment variables")
+    .version("4.0.0")
+    .stringConf
+    .toSequence
+    .createWithDefault(Seq.empty[String])
+
   val UI_SQL_GROUP_SUB_EXECUTION_ENABLED = ConfigBuilder("spark.ui.groupSQLSubExecutionEnabled")
     .doc("Whether to group sub executions together in SQL UI when they belong to the same " +
       "root execution")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Environment Variables` table to Master `EnvironmentPage` via a new configuration, `spark.master.ui.visibleEnvVarPrefixes`.

### Why are the changes needed?

To allow users to expose and show the environment variables of Spark Master.

### Does this PR introduce _any_ user-facing change?

Yes, but this is a new table on `Spark Master` UI's `EnvironmentPage`.

### How was this patch tested?

Pass the CIs with newly added test case.

**DEFAULT**
```
$ sbin/start-master.sh
```
![Screenshot 2024-08-12 at 00 53 26](https://github.com/user-attachments/assets/b7929536-a25d-4bd5-876d-908ed7403b92)

**Expose `AWS_`**
```
$ AWS_CA_BUNDLE=/tmp/root-ca.pem \
  AWS_ENDPOINT_URL=https://s3express-usw2-az1.us-west-2.amazonaws.com \
  SPARK_MASTER_OPTS="-Dspark.master.ui.visibleEnvVarPrefixes=AWS_" \
  sbin/start-master.sh
```
![Screenshot 2024-08-12 at 01 05 25](https://github.com/user-attachments/assets/50a57ba1-8ed8-4827-ad51-b303da09a663)


### Was this patch authored or co-authored using generative AI tooling?

No.