### PR TITLE
[SPARK-49207][SQL] Fix one-to-many case mapping in SplitPart and StringSplitSQL

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
@@ -1278,7 +1278,7 @@ public class CollationAwareUTF8String {
     if (delimiter.numBytes() == 0) return new UTF8String[] { string };
     if (string.numBytes() == 0) return new UTF8String[] { UTF8String.EMPTY_UTF8 };
     List<UTF8String> strings = new ArrayList<>();
-    String target = string.toString(), pattern = delimiter.toString();
+    String target = string.toValidString(), pattern = delimiter.toValidString();
     StringSearch stringSearch = CollationFactory.getStringSearch(target, pattern, collationId);
     int start = 0, end;
     while ((end = stringSearch.next()) != StringSearch.DONE) {

--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationAwareUTF8String.java
@@ -38,7 +38,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 /**
  * Utility class for collation-aware UTF8String operations.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Fix the following string expressions to handle one-to-many case mapping properly:

- SplitPart
- StringSplitSQL

Examples of incorrect results (under `UTF8_LCASE` collation):

```
SplitPart("Ai\u0307B", "İ", 2) // returns: "\u0307B" (incorrect), instead of: "B" (correct)
SplitPart("AİB", "i\u0307", 1) // returns: "AİB", instead of: "A", "B" (correct)

StringSplitSQL("Ai\u0307B", "İ") // returns: ["A", "\u0307B"] (incorrect), instead of: ["A", "B"] (correct)
StringSplitSQL("AİB", "i\u0307") // returns: ["AİB"] (incorrect), instead of: ["A", "B"] (correct)
```

### Why are the changes needed?
Currently, some string expressions are giving wrong results when working with one-to-many case mapping.


### Does this PR introduce _any_ user-facing change?
Yes, this expression will now work properly with surrogate pairs: `split_part`.


### How was this patch tested?
New tests in `CollationSupportSuite`.


### Was this patch authored or co-authored using generative AI tooling?
Yes.
