### PR TITLE
[SPARK-49210][SQL] Support driver metrics for DS v2 write

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/metric/SupportCustomMetrics.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/metric/SupportCustomMetrics.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connector.metric;
+
+public interface SupportCustomMetrics {
+
+  /**
+   * Returns an array of supported custom metrics with name and description.
+   * By default, it returns empty array.
+   */
+  default CustomMetric[] supportedCustomMetrics() {
+    return new CustomMetric[]{};
+  }
+
+  /**
+   * Returns an array of custom metrics which are collected with values at the driver side only.
+   * Note that these metrics must be included in the supported custom metrics reported by
+   * `supportedCustomMetrics`.
+   *
+   * @since 3.4.0
+   */
+  default CustomTaskMetric[] reportDriverMetrics() {
+    return new CustomTaskMetric[]{};
+  }
+}

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/Scan.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/read/Scan.java
@@ -21,8 +21,7 @@ import java.util.Map;
 
 import org.apache.spark.SparkUnsupportedOperationException;
 import org.apache.spark.annotation.Evolving;
-import org.apache.spark.sql.connector.metric.CustomMetric;
-import org.apache.spark.sql.connector.metric.CustomTaskMetric;
+import org.apache.spark.sql.connector.metric.SupportCustomMetrics;
 import org.apache.spark.sql.connector.read.streaming.ContinuousStream;
 import org.apache.spark.sql.connector.read.streaming.MicroBatchStream;
 import org.apache.spark.sql.types.StructType;
@@ -43,7 +42,7 @@ import org.apache.spark.sql.connector.catalog.TableCapability;
  * @since 3.0.0
  */
 @Evolving
-public interface Scan {
+public interface Scan extends SupportCustomMetrics {
 
   /**
    * Returns the actual schema of this data source scan, which may be different from the physical
@@ -113,25 +112,6 @@ public interface Scan {
   default ContinuousStream toContinuousStream(String checkpointLocation) {
     throw new SparkUnsupportedOperationException(
       "_LEGACY_ERROR_TEMP_3149", Map.of("description", description()));
-  }
-
-  /**
-   * Returns an array of supported custom metrics with name and description.
-   * By default it returns empty array.
-   */
-  default CustomMetric[] supportedCustomMetrics() {
-    return new CustomMetric[]{};
-  }
-
-  /**
-   * Returns an array of custom metrics which are collected with values at the driver side only.
-   * Note that these metrics must be included in the supported custom metrics reported by
-   * `supportedCustomMetrics`.
-   *
-   * @since 3.4.0
-   */
-  default CustomTaskMetric[] reportDriverMetrics() {
-    return new CustomTaskMetric[]{};
   }
 
   /**

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/Write.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/Write.java
@@ -23,7 +23,7 @@ import org.apache.spark.SparkUnsupportedOperationException;
 import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCapability;
-import org.apache.spark.sql.connector.metric.CustomMetric;
+import org.apache.spark.sql.connector.metric.SupportCustomMetrics;
 import org.apache.spark.sql.connector.write.streaming.StreamingWrite;
 
 /**
@@ -38,7 +38,7 @@ import org.apache.spark.sql.connector.write.streaming.StreamingWrite;
  * @since 3.2.0
  */
 @Evolving
-public interface Write {
+public interface Write extends SupportCustomMetrics {
 
   /**
    * Returns the description associated with this write.
@@ -67,13 +67,5 @@ public interface Write {
   default StreamingWrite toStreaming() {
     throw new SparkUnsupportedOperationException(
       "_LEGACY_ERROR_TEMP_3138", Map.of("description", description()));
-  }
-
-  /**
-   * Returns an array of supported custom metrics with name and description.
-   * By default it returns empty array.
-   */
-  default CustomMetric[] supportedCustomMetrics() {
-    return new CustomMetric[]{};
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala
@@ -24,21 +24,19 @@ import org.apache.spark.sql.catalyst.plans.physical
 import org.apache.spark.sql.catalyst.plans.physical.KeyGroupedPartitioning
 import org.apache.spark.sql.catalyst.util.{truncatedString, InternalRowComparableWrapper}
 import org.apache.spark.sql.connector.read.{HasPartitionKey, InputPartition, PartitionReaderFactory, Scan}
-import org.apache.spark.sql.execution.{ExplainUtils, LeafExecNode, SQLExecution}
-import org.apache.spark.sql.execution.metric.SQLMetrics
+import org.apache.spark.sql.execution.{ExplainUtils, LeafExecNode}
+import org.apache.spark.sql.execution.metric.{SQLMetric, SQLMetrics}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.connector.SupportsMetadata
 import org.apache.spark.sql.vectorized.ColumnarBatch
-import org.apache.spark.util.ArrayImplicits._
 import org.apache.spark.util.Utils
 
 trait DataSourceV2ScanExecBase extends LeafExecNode {
 
-  lazy val customMetrics = scan.supportedCustomMetrics().map { customMetric =>
-    customMetric.name() -> SQLMetrics.createV2CustomMetric(sparkContext, customMetric)
-  }.toMap
+  lazy val customMetrics: Map[String, SQLMetric] =
+    SQLMetrics.createV2CustomMetrics(sparkContext, scan)
 
-  override lazy val metrics = {
+  override lazy val metrics: Map[String, SQLMetric] = {
     Map("numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows")) ++
       customMetrics
   }
@@ -191,15 +189,7 @@ trait DataSourceV2ScanExecBase extends LeafExecNode {
   }
 
   protected def postDriverMetrics(): Unit = {
-    val driveSQLMetrics = scan.reportDriverMetrics().map(customTaskMetric => {
-      val metric = metrics(customTaskMetric.name())
-      metric.set(customTaskMetric.value())
-      metric
-    })
-
-    val executionId = sparkContext.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
-    SQLMetrics.postDriverMetricUpdates(sparkContext, executionId,
-      driveSQLMetrics.toImmutableArraySeq)
+    SQLMetrics.postV2DriverMetrics(sparkContext, scan, metrics)
   }
 
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DataSourceV2ScanExecBase.scala
@@ -34,7 +34,7 @@ import org.apache.spark.util.Utils
 trait DataSourceV2ScanExecBase extends LeafExecNode {
 
   lazy val customMetrics: Map[String, SQLMetric] =
-    SQLMetrics.createV2CustomMetrics(sparkContext, scan)
+    SQLMetrics.createV2CustomMetrics(sparkContext, scan.supportedCustomMetrics())
 
   override lazy val metrics: Map[String, SQLMetric] = {
     Map("numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows")) ++
@@ -189,7 +189,7 @@ trait DataSourceV2ScanExecBase extends LeafExecNode {
   }
 
   protected def postDriverMetrics(): Unit = {
-    SQLMetrics.postV2DriverMetrics(sparkContext, scan, metrics)
+    SQLMetrics.postV2DriverMetrics(sparkContext, scan.reportDriverMetrics(), metrics)
   }
 
   override def doExecuteColumnar(): RDD[ColumnarBatch] = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V1FallbackWriters.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V1FallbackWriters.scala
@@ -64,14 +64,14 @@ sealed trait V1FallbackWriters extends LeafV2CommandExec with SupportsV1Write {
   def write: V1Write
 
   protected val customMetrics: Map[String, SQLMetric] =
-    SQLMetrics.createV2CustomMetrics(sparkContext, write)
+    SQLMetrics.createV2CustomMetrics(sparkContext, write.supportedCustomMetrics())
 
   override lazy val metrics: Map[String, SQLMetric] = customMetrics
 
   override def run(): Seq[InternalRow] = {
     val writtenRows = writeWithV1(write.toInsertableRelation)
     refreshCache()
-    SQLMetrics.postV2DriverMetrics(sparkContext, write, metrics)
+    SQLMetrics.postV2DriverMetrics(sparkContext, write.reportDriverMetrics(), metrics)
     writtenRows
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/WriteToDataSourceV2Exec.scala
@@ -330,12 +330,12 @@ trait V2ExistingTableWriteExec extends V2TableWriteExec {
   def write: Write
 
   override val customMetrics: Map[String, SQLMetric] =
-    SQLMetrics.createV2CustomMetrics(sparkContext, write)
+    SQLMetrics.createV2CustomMetrics(sparkContext, write.supportedCustomMetrics())
 
   override protected def run(): Seq[InternalRow] = {
     val writtenRows = writeWithV2(write.toBatch)
     refreshCache()
-    SQLMetrics.postV2DriverMetrics(sparkContext, write, metrics)
+    SQLMetrics.postV2DriverMetrics(sparkContext, write.reportDriverMetrics(), metrics)
     writtenRows
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
@@ -26,7 +26,7 @@ import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
 
 import org.apache.spark.{SparkContext, SparkException}
 import org.apache.spark.scheduler.AccumulableInfo
-import org.apache.spark.sql.connector.metric.{CustomMetric, SupportCustomMetrics}
+import org.apache.spark.sql.connector.metric.{CustomMetric, CustomTaskMetric}
 import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.ui.SparkListenerDriverAccumUpdates
@@ -155,15 +155,15 @@ object SQLMetrics {
   }
 
   def createV2CustomMetrics(
-    sc: SparkContext, supportCustomMetrics: SupportCustomMetrics): Map[String, SQLMetric] = {
-    supportCustomMetrics.supportedCustomMetrics().map { customMetric =>
+    sc: SparkContext, customMetrics: Array[CustomMetric]): Map[String, SQLMetric] = {
+    customMetrics.map { customMetric =>
       customMetric.name() -> SQLMetrics.createV2CustomMetric(sc, customMetric)
     }.toMap
   }
 
-  def postV2DriverMetrics(sc: SparkContext, supportCustomMetrics: SupportCustomMetrics,
+  def postV2DriverMetrics(sc: SparkContext, driverMetrics: Array[CustomTaskMetric],
     metrics: Map[String, SQLMetric]): Unit = {
-    val driveSQLMetrics = supportCustomMetrics.reportDriverMetrics().map(customTaskMetric => {
+    val driveSQLMetrics = driverMetrics.map(customTaskMetric => {
       val metric = metrics(customTaskMetric.name())
       metric.set(customTaskMetric.value())
       metric

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/metric/SQLMetrics.scala
@@ -26,11 +26,13 @@ import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
 
 import org.apache.spark.{SparkContext, SparkException}
 import org.apache.spark.scheduler.AccumulableInfo
-import org.apache.spark.sql.connector.metric.CustomMetric
+import org.apache.spark.sql.connector.metric.{CustomMetric, SupportCustomMetrics}
 import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.execution.SQLExecution
 import org.apache.spark.sql.execution.ui.SparkListenerDriverAccumUpdates
 import org.apache.spark.util.{AccumulatorContext, AccumulatorV2, Utils}
 import org.apache.spark.util.AccumulatorContext.internOption
+import org.apache.spark.util.ArrayImplicits._
 
 /**
  * A metric used in a SQL query plan. This is implemented as an [[AccumulatorV2]]. Updates on
@@ -150,6 +152,25 @@ object SQLMetrics {
     val acc = new SQLMetric(CustomMetrics.buildV2CustomMetricTypeName(customMetric))
     acc.register(sc, name = metricsCache.get(customMetric.description()), countFailedValues = false)
     acc
+  }
+
+  def createV2CustomMetrics(
+    sc: SparkContext, supportCustomMetrics: SupportCustomMetrics): Map[String, SQLMetric] = {
+    supportCustomMetrics.supportedCustomMetrics().map { customMetric =>
+      customMetric.name() -> SQLMetrics.createV2CustomMetric(sc, customMetric)
+    }.toMap
+  }
+
+  def postV2DriverMetrics(sc: SparkContext, supportCustomMetrics: SupportCustomMetrics,
+    metrics: Map[String, SQLMetric]): Unit = {
+    val driveSQLMetrics = supportCustomMetrics.reportDriverMetrics().map(customTaskMetric => {
+      val metric = metrics(customTaskMetric.name())
+      metric.set(customTaskMetric.value())
+      metric
+    })
+    val executionId = sc.getLocalProperty(SQLExecution.EXECUTION_ID_KEY)
+    SQLMetrics.postDriverMetricUpdates(sc, executionId,
+      driveSQLMetrics.toImmutableArraySeq)
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Support driver metrics for DS v2 write


### Why are the changes needed?
For v2 tables like iceberg or paimon, its write metrics are very useful, by supporting driver metrics, we can report commit time, commited files, snapshot id etc.


### Does this PR introduce _any_ user-facing change?
Extract common interface `SupportCustomMetrics` for `write` and `scan`

### How was this patch tested?
Add test case for writing v2 and v1 fallback table

### Was this patch authored or co-authored using generative AI tooling?
No
