### PR TITLE
[SPARK-47741][SQL][TESTS][FOLLOWUP] Make `EXEC IMMEDIATE STACK OVERFLOW` in `ExecuteImmediateEndToEndSuite` check the intercepted exception

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
@@ -50,7 +50,7 @@ class ExecuteImmediateEndToEndSuite extends QueryTest with SharedSparkSession {
         }
 
         checkError(
-          exception = intercept[ParseException](sql(query).collect()),
+          exception = e,
           errorClass = "FAILED_TO_PARSE_TOO_COMPLEX",
           parameters = Map(),
           context = ExpectedContext(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr change the test case `EXEC IMMEDIATE STACK OVERFLOW` in `ExecuteImmediateEndToEndSuite` to check existing exception. 


### Why are the changes needed?
Before this pr:

https://github.com/apache/spark/blob/e3ba74b65b9d534655fbcf40bb2c00b7f5c69418/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala#L44-L60

The test case intercepts an exception on lines 48 to 50, but the `exception` used in `checkError` is not related to the previously intercepted exception. Moreover, although the test is looped twice, the two `checkError` calls are actually checking the same SQL scenario, which appears to be a coding error.



### Does this PR introduce _any_ user-facing change?
No, just for test


### How was this patch tested?
- Pass GitHub Action
- locally test

```
build/mvn clean install -pl sql/core -am -Dtest=none -DwildcardSuites=org.apache.spark.sql.execution.ExecuteImmediateEndToEndSuite
```

```
ExecuteImmediateEndToEndSuite:
19:21:45.191 WARN org.apache.spark.util.Utils: Your hostname, MacBook-Pro.local, resolves to a loopback address: 127.0.0.1; using 172.22.200.238 instead (on interface en0)

19:21:45.193 WARN org.apache.spark.util.Utils: Set SPARK_LOCAL_IP if you need to bind to another address

19:21:45.330 WARN org.apache.hadoop.util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable

- SPARK-47033: EXECUTE IMMEDIATE USING does not recognize session variable names
- EXEC IMMEDIATE STACK OVERFLOW
19:21:47.722 WARN org.apache.spark.sql.execution.ExecuteImmediateEndToEndSuite: 

===== POSSIBLE THREAD LEAK IN SUITE o.a.s.sql.execution.ExecuteImmediateEndToEndSuite, threads: rpc-boss-3-1 (daemon=true), shuffle-boss-6-1 (daemon=true) =====


Run completed in 4 seconds, 765 milliseconds.
Total number of tests run: 2
Suites: completed 2, aborted 0
Tests: succeeded 2, failed 0, canceled 0, ignored 0, pending 0
All tests passed.

```

### Was this patch authored or co-authored using generative AI tooling?
No
