### PR TITLE
[SPARK-49187][BUILD] Upgrade slf4j to 2.0.16

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -126,7 +126,7 @@ javax.servlet-api/4.0.1//javax.servlet-api-4.0.1.jar
 javolution/5.5.1//javolution-5.5.1.jar
 jaxb-api/2.2.11//jaxb-api-2.2.11.jar
 jaxb-runtime/2.3.2//jaxb-runtime-2.3.2.jar
-jcl-over-slf4j/2.0.14//jcl-over-slf4j-2.0.14.jar
+jcl-over-slf4j/2.0.16//jcl-over-slf4j-2.0.16.jar
 jdo-api/3.0.1//jdo-api-3.0.1.jar
 jdom2/2.0.6//jdom2-2.0.6.jar
 jersey-client/3.0.12//jersey-client-3.0.12.jar
@@ -153,7 +153,7 @@ json4s-jackson_2.13/4.0.7//json4s-jackson_2.13-4.0.7.jar
 json4s-scalap_2.13/4.0.7//json4s-scalap_2.13-4.0.7.jar
 jsr305/3.0.0//jsr305-3.0.0.jar
 jta/1.1//jta-1.1.jar
-jul-to-slf4j/2.0.14//jul-to-slf4j-2.0.14.jar
+jul-to-slf4j/2.0.16//jul-to-slf4j-2.0.16.jar
 kryo-shaded/4.0.2//kryo-shaded-4.0.2.jar
 kubernetes-client-api/6.13.1//kubernetes-client-api-6.13.1.jar
 kubernetes-client/6.13.1//kubernetes-client-6.13.1.jar
@@ -253,7 +253,7 @@ scala-parallel-collections_2.13/1.0.4//scala-parallel-collections_2.13-1.0.4.jar
 scala-parser-combinators_2.13/2.4.0//scala-parser-combinators_2.13-2.4.0.jar
 scala-reflect/2.13.14//scala-reflect-2.13.14.jar
 scala-xml_2.13/2.3.0//scala-xml_2.13-2.3.0.jar
-slf4j-api/2.0.14//slf4j-api-2.0.14.jar
+slf4j-api/2.0.16//slf4j-api-2.0.16.jar
 snakeyaml-engine/2.7//snakeyaml-engine-2.7.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
 snappy-java/1.1.10.6//snappy-java-1.1.10.6.jar

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <exec-maven-plugin.version>3.2.0</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
     <asm.version>9.7</asm.version>
-    <slf4j.version>2.0.14</slf4j.version>
+    <slf4j.version>2.0.16</slf4j.version>
     <log4j.version>2.22.1</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.4.0</hadoop.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade slf4j from 2.0.14 to 2.0.16.


### Why are the changes needed?
The new version bring 2 fix:

- Fixed issue with stale MANIFEST.MF files. This issue was raisied in https://github.com/qos-ch/slf4j/issues/421
- The information about the provider LoggerFactory connected with will now be reported using the level DEBUG and will not be printed by default.(https://github.com/qos-ch/slf4j/commit/3ff00870b32c2067d72fb83d6a9e9554dddd8130)


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Action
- manual check

run `build/sbt core/test`

**before**

we can see the following message before test

```
SLF4J(I): Connected with provider of type [org.apache.logging.slf4j.SLF4JServiceProvider]
```

**after**

No more logs similar to `SLF4J(I): Connected with provider of type [org.apache.logging.slf4j.SLF4JServiceProvider]`


### Was this patch authored or co-authored using generative AI tooling?
No
