### PR TITLE
[SPARK-49264][SQL][TESTS] Add collation support unit tests for Contains, StartsWith, and EndsWith

### DIFF
--- a/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
+++ b/common/unsafe/src/test/java/org/apache/spark/unsafe/types/CollationSupportSuite.java
@@ -213,6 +213,17 @@ public class CollationSupportSuite {
       assertContains("a", "", collationName, true);
       assertContains("", "x", collationName, false);
       // Basic tests.
+      assertContains("a", "a", collationName, true);
+      assertContains("_a_", "_a_", collationName, true);
+      assertContains("_a_", "a", collationName, true);
+      assertContains("%a%", "%a%", collationName, true);
+      assertContains("%a%", "a", collationName, true);
+      assertContains("*a*", "*a*", collationName, true);
+      assertContains("*a*", "a", collationName, true);
+      assertContains("?a?", "?a?", collationName, true);
+      assertContains("?a?", "a", collationName, true);
+      assertContains("/a/", "/a/", collationName, true);
+      assertContains("/a/", "a", collationName, true);
       assertContains("abcde", "xyz", collationName, false);
       assertContains("abcde", "bcd", collationName, true);
       assertContains("abcde", "abc", collationName, true);
@@ -447,6 +458,17 @@ public class CollationSupportSuite {
       assertStartsWith("a", "", collationName, true);
       assertStartsWith("", "x", collationName, false);
       // Basic tests.
+      assertStartsWith("a", "a", collationName, true);
+      assertStartsWith("_a_", "_a", collationName, true);
+      assertStartsWith("_a_", "a", collationName, false);
+      assertStartsWith("%a%", "%a", collationName, true);
+      assertStartsWith("%a%", "a", collationName, false);
+      assertStartsWith("*a*", "*a", collationName, true);
+      assertStartsWith("*a*", "a", collationName, false);
+      assertStartsWith("?a?", "?a", collationName, true);
+      assertStartsWith("?a?", "a", collationName, false);
+      assertStartsWith("/a/", "/a", collationName, true);
+      assertStartsWith("/a/", "a", collationName, false);
       assertStartsWith("abcde", "xyz", collationName, false);
       assertStartsWith("abcde", "bcd", collationName, false);
       assertStartsWith("abcde", "abc", collationName, true);
@@ -686,6 +708,17 @@ public class CollationSupportSuite {
       assertEndsWith("a", "", collationName, true);
       assertEndsWith("", "x", collationName, false);
       // Basic tests.
+      assertEndsWith("a", "a", collationName, true);
+      assertEndsWith("_a_", "a_", collationName, true);
+      assertEndsWith("_a_", "a", collationName, false);
+      assertEndsWith("%a%", "a%", collationName, true);
+      assertEndsWith("%a%", "a", collationName, false);
+      assertEndsWith("*a*", "a*", collationName, true);
+      assertEndsWith("*a*", "a", collationName, false);
+      assertEndsWith("?a?", "a?", collationName, true);
+      assertEndsWith("?a?", "a", collationName, false);
+      assertEndsWith("/a/", "a/", collationName, true);
+      assertEndsWith("/a/", "a", collationName, false);
       assertEndsWith("abcde", "xyz", collationName, false);
       assertEndsWith("abcde", "bcd", collationName, false);
       assertEndsWith("abcde", "abc", collationName, false);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Add collation support unit tests for:

- Contains
- StartsWith
- EndsWith

This PR contains test-only changes, providing additional test coverage for cases such as:
- case and accent variation 
- one-to-many case mapping
- conditional case mapping
- surrogate pairs
- etc.


### Why are the changes needed?
Improve collation support testing.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
New unit tests in `CollationSupportSuite`.


### Was this patch authored or co-authored using generative AI tooling?
Yes.
