### PR TITLE
[SPARK-48796][SS] Load Column Family Id from RocksDBCheckpointMetadata for VCF when restarting

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -285,7 +285,6 @@ class RocksDB(
     }
   }
 
-
   /**
    * Load from the start snapshot version and apply all the changelog records to reach the
    * end version. Note that this will copy all the necessary files from DFS to local disk as needed,
@@ -540,6 +539,7 @@ class RocksDB(
   def commit(): Long = {
     val newVersion = loadedVersion + 1
     try {
+
       logInfo(log"Flushing updates for ${MDC(LogKeys.VERSION_NUM, newVersion)}")
 
       var compactTimeMs = 0L
@@ -686,6 +686,7 @@ class RocksDB(
           for (snapshot <- oldSnapshotsImmutable) {
             snapshot.close()
           }
+
         }
       case _ =>
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -25,7 +25,6 @@ import javax.annotation.concurrent.GuardedBy
 
 import scala.collection.{mutable, Map}
 import scala.collection.mutable.ListBuffer
-import scala.jdk.CollectionConverters.{MapHasAsJava, MapHasAsScala}
 import scala.ref.WeakReference
 import scala.util.Try
 
@@ -501,9 +500,9 @@ class RocksDB(
    * - Sync the checkpoint dir files to DFS
    */
   def commit(
-      columnFamilyMapping: Map[String, Short],
-      maxColumnFamilyId: Short,
-      colFamilyIdsChanged: Boolean): Long = {
+      columnFamilyMapping: Map[String, Short] = Map.empty,
+      maxColumnFamilyId: Short = 0,
+      colFamilyIdsChanged: Boolean = false): Long = {
     val newVersion = loadedVersion + 1
     try {
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -497,8 +497,8 @@ class RocksDB(
    * @param columnFamilyMapping A map of column family names to their corresponding VCF IDs.
    * @param maxColumnFamilyId The maximum VCF ID used for column families.
    * @param colFamilyIdsChanged A flag indicating whether column family IDs have changed.
-   *                            If they have, we need to commit regardless of changelog
-   *                            checkpointing being enabled or not
+   *                            If they have, we need to create a snapshot regardless of whether
+   *                            changelog checkpointing is enabled or not
    * Commit all the updates made as a version to DFS. The steps it needs to do to commits are:
    * - Flush all changes to disk
    * - Create a RocksDB checkpoint in a new local dir

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -73,9 +73,6 @@ class RocksDB(
     loggingId: String = "",
     useColumnFamilies: Boolean = false) extends Logging {
 
-  private val colFamilyNameToIdMap = new ConcurrentHashMap[String, Short]()
-  private val maxColumnFamilyId = new AtomicInteger(0)
-
   case class RocksDBSnapshot(
       checkpointDir: File,
       version: Long,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -164,6 +164,7 @@ class RocksDB(
   @volatile private var numKeysOnLoadedVersion = 0L
   @volatile private var numKeysOnWritingVersion = 0L
   @volatile private var fileManagerMetrics = RocksDBFileManagerMetrics.EMPTY_METRICS
+  // if column family ids have changed since last load, we want to take a full snapshot
   @volatile private var colFamilyIdsChanged = false
 
   // SPARK-46249 - Keep track of recorded metrics per version which can be used for querying later

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -19,8 +19,7 @@ package org.apache.spark.sql.execution.streaming.state
 
 import java.io.File
 import java.util.Locale
-import java.util.concurrent.{ConcurrentHashMap, TimeUnit}
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.TimeUnit
 import javax.annotation.concurrent.GuardedBy
 
 import scala.collection.{mutable, Map}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -494,6 +494,11 @@ class RocksDB(
   }
 
   /**
+   * @param columnFamilyMapping A map of column family names to their corresponding VCF IDs.
+   * @param maxColumnFamilyId The maximum VCF ID used for column families.
+   * @param colFamilyIdsChanged A flag indicating whether column family IDs have changed.
+   *                            If they have, we need to commit regardless of changelog
+   *                            checkpointing being enabled or not
    * Commit all the updates made as a version to DFS. The steps it needs to do to commits are:
    * - Flush all changes to disk
    * - Create a RocksDB checkpoint in a new local dir

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
@@ -922,6 +922,7 @@ case class RocksDBCheckpointMetadata(
   def immutableFiles: Seq[RocksDBImmutableFile] = sstFiles ++ logFiles
 }
 
+/** Helper class for [[RocksDBCheckpointMetadata]] */
 object RocksDBCheckpointMetadata {
   val VERSION = 1
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
@@ -935,8 +935,8 @@ object RocksDBCheckpointMetadata {
     val reader = Files.newBufferedReader(metadataFile.toPath, UTF_8)
     try {
       val versionLine = reader.readLine()
-      if (versionLine != "v1") {
-        throw QueryExecutionErrors.cannotReadCheckpoint(versionLine, s"v$VERSION or v1")
+      if (versionLine != s"v$VERSION") {
+        throw QueryExecutionErrors.cannotReadCheckpoint(versionLine, s"v$VERSION")
       }
       Serialization.read[RocksDBCheckpointMetadata](reader)
     } finally {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -65,6 +65,7 @@ private[sql] class RocksDBStateStoreProvider
       val colFamilyId = ColumnFamilyUtils.createColFamilyIfAbsent(colFamilyName, isInternal)
 
       colFamilyId.foreach { id =>
+        logError(s"### createColFamilyIfAbsent, $colFamilyName, $id")
         keyValueEncoderMap.putIfAbsent(colFamilyName,
           (RocksDBStateEncoder.getKeyEncoder(keyStateEncoderSpec, useColumnFamilies, Some(id)),
             RocksDBStateEncoder.getValueEncoder(valueSchema, useMultipleValuesPerKey)))
@@ -375,6 +376,7 @@ private[sql] class RocksDBStateStoreProvider
       val store = new RocksDBStateStore(version)
       (colFamilyMapping, maxColFamilyId) match {
         case (Some(mapping), Some(id)) =>
+          logError(s"### setting columnFamilyIds: ${mapping}")
           colFamilyNameToIdMap.putAll(mapping.asJava)
           maxColumnFamilyId = id
         case _ =>
@@ -455,7 +457,8 @@ private[sql] class RocksDBStateStoreProvider
   private val keyValueEncoderMap = new java.util.concurrent.ConcurrentHashMap[String,
     (RocksDBKeyStateEncoder, RocksDBValueStateEncoder)]
 
-  private val colFamilyNameToIdMap = new ConcurrentHashMap[String, Short]()
+  // make visible for testing
+  private[sql] val colFamilyNameToIdMap = new ConcurrentHashMap[String, Short]()
 
   private val defaultColFamilyId: Option[Short] = Some(0)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -65,7 +65,6 @@ private[sql] class RocksDBStateStoreProvider
       val colFamilyId = ColumnFamilyUtils.createColFamilyIfAbsent(colFamilyName, isInternal)
 
       colFamilyId.foreach { id =>
-        logError(s"### createColFamilyIfAbsent, $colFamilyName, $id")
         keyValueEncoderMap.putIfAbsent(colFamilyName,
           (RocksDBStateEncoder.getKeyEncoder(keyStateEncoderSpec, useColumnFamilies, Some(id)),
             RocksDBStateEncoder.getValueEncoder(valueSchema, useMultipleValuesPerKey)))
@@ -376,7 +375,6 @@ private[sql] class RocksDBStateStoreProvider
       val store = new RocksDBStateStore(version)
       (colFamilyMapping, maxColFamilyId) match {
         case (Some(mapping), Some(id)) =>
-          logError(s"### setting columnFamilyIds: ${mapping}")
           colFamilyNameToIdMap.putAll(mapping.asJava)
           maxColumnFamilyId = id
         case _ =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -463,7 +463,7 @@ private[sql] class RocksDBStateStoreProvider
 
   private val defaultColFamilyId: Option[Short] = Some(0)
 
-  private val maxColumnFamilyId: AtomicInteger = new AtomicInteger(1)
+  private val maxColumnFamilyId: AtomicInteger = new AtomicInteger(0)
 
   private val columnFamilyIdsChanged: AtomicBoolean = new AtomicBoolean(false)
 
@@ -597,7 +597,7 @@ private[sql] class RocksDBStateStoreProvider
       Option[Short] = {
       verifyColFamilyCreationOrDeletion("create_col_family", colFamilyName, isInternal)
       if (!checkColFamilyExists(colFamilyName)) {
-        val newColumnFamilyId = maxColumnFamilyId.getAndIncrement().toShort
+        val newColumnFamilyId = maxColumnFamilyId.incrementAndGet().toShort
         colFamilyNameToIdMap.putIfAbsent(colFamilyName, newColumnFamilyId)
         columnFamilyIdsChanged.set(true)
         Option(newColumnFamilyId)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -155,7 +155,6 @@ private[sql] class RocksDBStateStoreProvider
       val kvEncoder = keyValueEncoderMap.get(colFamilyName)
       val rowPair = new UnsafeRowPair()
 
-      logError(s"### colFamilyName: $colFamilyName")
       // As Virtual Column Family attaches a column family prefix to the key row,
       // we'll need to do prefixScan on the default column family with the same column
       // family id prefix to get all rows stored in a given virtual column family

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -463,7 +463,7 @@ private[sql] class RocksDBStateStoreProvider
 
   private val defaultColFamilyId: Option[Short] = Some(0)
 
-  private val maxColumnFamilyId: AtomicInteger = new AtomicInteger(0)
+  private val maxColumnFamilyId: AtomicInteger = new AtomicInteger(1)
 
   private val columnFamilyIdsChanged: AtomicBoolean = new AtomicBoolean(false)
 
@@ -597,7 +597,7 @@ private[sql] class RocksDBStateStoreProvider
       Option[Short] = {
       verifyColFamilyCreationOrDeletion("create_col_family", colFamilyName, isInternal)
       if (!checkColFamilyExists(colFamilyName)) {
-        val newColumnFamilyId = (maxColumnFamilyId.getAndIncrement()).toShort
+        val newColumnFamilyId = maxColumnFamilyId.getAndIncrement().toShort
         colFamilyNameToIdMap.putIfAbsent(colFamilyName, newColumnFamilyId)
         columnFamilyIdsChanged.set(true)
         Option(newColumnFamilyId)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -1026,7 +1026,6 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
     }
   }
 
-  // TODO SPARK-48796 after restart state id will not be the same
   test(s"get, put, iterator, commit, load with multiple column families") {
     tryWithProviderResource(newStoreProvider(useColumnFamilies = true)) { provider =>
       def get(store: StateStore, col1: String, col2: Int, colFamilyName: String): UnsafeRow = {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -1032,8 +1032,8 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
         store.get(dataToKeyRow(col1, col2), colFamilyName)
       }
 
-      def iterator(store: StateStore, colFamilyName: String): Seq[((String, Int), Int)] = {
-        store.iterator(colFamilyName).toSeq.map {
+      def iterator(store: StateStore, colFamilyName: String): Iterator[((String, Int), Int)] = {
+        store.iterator(colFamilyName).map {
           case unsafePair =>
             (keyRowToData(unsafePair.key), valueRowToData(unsafePair.value))
         }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -1094,6 +1094,9 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
       var store = provider.getStore(0)
       val colFamily1: String = "abc"
       val colFamily2: String = "def"
+      val colFamily3: String = "ghi"
+      val colFamily4: String = "jkl"
+      val colFamily5: String = "mno"
       store.createColFamilyIfAbsent(colFamily1, keySchema, valueSchema,
         NoPrefixKeyStateEncoderSpec(keySchema))
       store.createColFamilyIfAbsent(colFamily2, keySchema, valueSchema,
@@ -1101,7 +1104,6 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
       store.commit()
 
       store = provider.getStore(1)
-      val colFamily3: String = "ghi"
       store.removeColFamilyIfExists(colFamily2)
       store.commit()
 
@@ -1111,6 +1113,15 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
       assert(!provider.colFamilyNameToIdMap.containsKey(colFamily2))
       // maxColFamilyId should be 2, we should increment the id and then assign it.
       assert(provider.colFamilyNameToIdMap.get(colFamily3) === 3)
+      store.removeColFamilyIfExists(colFamily1)
+      store.removeColFamilyIfExists(colFamily3)
+      store.createColFamilyIfAbsent(colFamily4, keySchema, valueSchema,
+        NoPrefixKeyStateEncoderSpec(keySchema))
+      assert(provider.colFamilyNameToIdMap.get(colFamily4) == 4)
+      store.commit()
+      store.createColFamilyIfAbsent(colFamily5, keySchema, valueSchema,
+        NoPrefixKeyStateEncoderSpec(keySchema))
+      assert(provider.colFamilyNameToIdMap.get(colFamily5) == 5)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreSuite.scala
@@ -1027,7 +1027,7 @@ class RocksDBStateStoreSuite extends StateStoreSuiteBase[RocksDBStateStoreProvid
   }
 
   // TODO SPARK-48796 after restart state id will not be the same
-  ignore(s"get, put, iterator, commit, load with multiple column families") {
+  test(s"get, put, iterator, commit, load with multiple column families") {
     tryWithProviderResource(newStoreProvider(useColumnFamilies = true)) { provider =>
       def get(store: StateStore, col1: String, col2: Int, colFamilyName: String): UnsafeRow = {
         store.get(dataToKeyRow(col1, col2), colFamilyName)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -627,14 +627,14 @@ class RocksDBSuite extends AlsoTestWithChangelogCheckpointingEnabled with Shared
           db.commit()
         }
       }
-      assert(db.load(10, readOnly = true)._1.iterator().map(toStr).toSet === version10Data)
+      assert(db.load(10, readOnly = true).db.iterator().map(toStr).toSet === version10Data)
       CreateAtomicTestManager.shouldFailInCreateAtomic = false
 
       // Abort commit for next version and verify that reloading resets the files
       db.load(10)
       db.put("11", "11")
       db.rollback()
-      assert(db.load(10, readOnly = true)._1.iterator().map(toStr).toSet === version10Data)
+      assert(db.load(10, readOnly = true).db.iterator().map(toStr).toSet === version10Data)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -627,14 +627,14 @@ class RocksDBSuite extends AlsoTestWithChangelogCheckpointingEnabled with Shared
           db.commit()
         }
       }
-      assert(db.load(10, readOnly = true).iterator().map(toStr).toSet === version10Data)
+      assert(db.load(10, readOnly = true)._1.iterator().map(toStr).toSet === version10Data)
       CreateAtomicTestManager.shouldFailInCreateAtomic = false
 
       // Abort commit for next version and verify that reloading resets the files
       db.load(10)
       db.put("11", "11")
       db.rollback()
-      assert(db.load(10, readOnly = true).iterator().map(toStr).toSet === version10Data)
+      assert(db.load(10, readOnly = true)._1.iterator().map(toStr).toSet === version10Data)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Persisting the mapping between columnFamilyName to columnFamilyId in RocksDBCheckpointMetadata and RocksDBSnapshot. On `load` RocksDB will propagate the mapping and the maximum column family ID so far to the provider, and the RocksDBStateStoreProvider will populate its mapping of columnFamilyName and columnFamilyId, and use this for any columnFamily operations. 
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To enable the use of virtual column families, and the performance benefits it comes along with, with the TransformWithState operator

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Amended unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No