### PR TITLE
[SPARK-49216][CORE]Fix to not log message context with explicitly LogEntry constructed when Structured Logging conf is off

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
@@ -151,7 +151,9 @@ trait Logging {
       args.foreach { mdc =>
         val value = if (mdc.value != null) mdc.value.toString else null
         sb.append(value)
-        context.put(mdc.key.name, value)
+        if (Logging.isStructuredLoggingEnabled) {
+          context.put(mdc.key.name, value)
+        }
 
         if (processedParts.hasNext) {
           sb.append(StringContext.processEscapes(processedParts.next()))
@@ -163,7 +165,7 @@ trait Logging {
   }
 
   protected def withLogContext(context: java.util.HashMap[String, String])(body: => Unit): Unit = {
-    // put into context only when structured logging is enabled
+    // put into thread context only when structured logging is enabled
     val updatedContext = if (Logging.isStructuredLoggingEnabled) {
       context
     } else {

--- a/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/Logging.scala
@@ -166,16 +166,16 @@ trait Logging {
 
   protected def withLogContext(context: java.util.HashMap[String, String])(body: => Unit): Unit = {
     // put into thread context only when structured logging is enabled
-    val updatedContext = if (Logging.isStructuredLoggingEnabled) {
-      context
+    val closeableThreadContextOpt = if (Logging.isStructuredLoggingEnabled) {
+      Some(CloseableThreadContext.putAll(context))
     } else {
-      new java.util.HashMap[String, String]()
+      None
     }
-    val threadContext = CloseableThreadContext.putAll(updatedContext)
+
     try {
       body
     } finally {
-      threadContext.close()
+      closeableThreadContextOpt.foreach(_.close())
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
To use structured logging developers usually do
```scala
logInfo(log"Lost executor ${MDC(LogKeys.EXECUTOR_ID, "1")}."),
```
When the structured logging conf is off, the context is not logged.
However if explicitly constructing the LogEntry and calling the public API,
```scala
logInfo(
  MessageWithContext(
    "Lost executor 1.",
    new java.util.HashMap[String, String] { put(LogKeys.EXECUTOR_ID.name, "1") }
  )
)
```
the conf does not take effect and even when it is off, the context is still logged.


This PR creates a fix for both cases to observe the conf, by toggling in the `withLogContext` function.

This PR also adds a extra small test on explicitly setting MDC.

### Why are the changes needed?
To keep consistency between APIs.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Added new unit tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
