### PR TITLE
[SPARK-48760][SQL][FOLLOWUP] Override `hashCode` method for `TableChange.ClusterBy`

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableChange.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/TableChange.java
@@ -781,5 +781,10 @@ public interface TableChange {
       ClusterBy that = (ClusterBy) o;
       return Arrays.equals(clusteringColumns, that.clusteringColumns());
     }
+
+    @Override
+    public int hashCode() {
+      return Arrays.hashCode(clusteringColumns);
+    }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr just overrides the `hashCode` method for the `TableChange.ClusterBy`

### Why are the changes needed?
Conventionally, `hashCode` and `equals` should be overridden in pairs.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions

### Was this patch authored or co-authored using generative AI tooling?
No