### PR TITLE
[SPARK-49225][SQL][CONNECT] Add ColumnNode sql & normalize

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/SparkClassUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/SparkClassUtils.scala
@@ -69,6 +69,73 @@ private[spark] trait SparkClassUtils {
       targetClass == null || targetClass.isAssignableFrom(cls)
     }.getOrElse(false)
   }
+
+  /** Return the class name of the given object, removing all dollar signs */
+  def getFormattedClassName(obj: AnyRef): String = {
+    getSimpleName(obj.getClass).replace("$", "")
+  }
+
+  /**
+   * Safer than Class obj's getSimpleName which may throw Malformed class name error in scala.
+   * This method mimics scalatest's getSimpleNameOfAnObjectsClass.
+   */
+  def getSimpleName(cls: Class[_]): String = {
+    try {
+      cls.getSimpleName
+    } catch {
+      // TODO: the value returned here isn't even quite right; it returns simple names
+      // like UtilsSuite$MalformedClassObject$MalformedClass instead of MalformedClass
+      // The exact value may not matter much as it's used in log statements
+      case _: InternalError =>
+        stripDollars(stripPackages(cls.getName))
+    }
+  }
+
+  /**
+   * Remove the packages from full qualified class name
+   */
+  private def stripPackages(fullyQualifiedName: String): String = {
+    fullyQualifiedName.split("\\.").takeRight(1)(0)
+  }
+
+  /**
+   * Remove trailing dollar signs from qualified class name,
+   * and return the trailing part after the last dollar sign in the middle
+   */
+  @scala.annotation.tailrec
+  final def stripDollars(s: String): String = {
+    val lastDollarIndex = s.lastIndexOf('$')
+    if (lastDollarIndex < s.length - 1) {
+      // The last char is not a dollar sign
+      if (lastDollarIndex == -1 || !s.contains("$iw")) {
+        // The name does not have dollar sign or is not an interpreter
+        // generated class, so we should return the full string
+        s
+      } else {
+        // The class name is interpreter generated,
+        // return the part after the last dollar sign
+        // This is the same behavior as getClass.getSimpleName
+        s.substring(lastDollarIndex + 1)
+      }
+    }
+    else {
+      // The last char is a dollar sign
+      // Find last non-dollar char
+      val lastNonDollarChar = s.findLast(_ != '$')
+      lastNonDollarChar match {
+        case None => s
+        case Some(c) =>
+          val lastNonDollarIndex = s.lastIndexOf(c)
+          if (lastNonDollarIndex == -1) {
+            s
+          } else {
+            // Strip the trailing dollar signs
+            // Invoke stripDollars again to get the simple name
+            stripDollars(s.substring(0, lastNonDollarIndex + 1))
+          }
+      }
+    }
+  }
 }
 
 private[spark] object SparkClassUtils extends SparkClassUtils

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -1753,12 +1753,6 @@ private[spark] object Utils
     Files.createSymbolicLink(dst.toPath, src.toPath)
   }
 
-
-  /** Return the class name of the given object, removing all dollar signs */
-  def getFormattedClassName(obj: AnyRef): String = {
-    getSimpleName(obj.getClass).replace("$", "")
-  }
-
   /**
    * Return a Hadoop FileSystem with the scheme encoded in the given path.
    */
@@ -2812,68 +2806,6 @@ private[spark] object Utils
     val secretBytes = new Array[Byte](bits / JByte.SIZE)
     rnd.nextBytes(secretBytes)
     Hex.encodeHexString(secretBytes)
-  }
-
-  /**
-   * Safer than Class obj's getSimpleName which may throw Malformed class name error in scala.
-   * This method mimics scalatest's getSimpleNameOfAnObjectsClass.
-   */
-  def getSimpleName(cls: Class[_]): String = {
-    try {
-      cls.getSimpleName
-    } catch {
-      // TODO: the value returned here isn't even quite right; it returns simple names
-      // like UtilsSuite$MalformedClassObject$MalformedClass instead of MalformedClass
-      // The exact value may not matter much as it's used in log statements
-      case _: InternalError =>
-        stripDollars(stripPackages(cls.getName))
-    }
-  }
-
-  /**
-   * Remove the packages from full qualified class name
-   */
-  private def stripPackages(fullyQualifiedName: String): String = {
-    fullyQualifiedName.split("\\.").takeRight(1)(0)
-  }
-
-  /**
-   * Remove trailing dollar signs from qualified class name,
-   * and return the trailing part after the last dollar sign in the middle
-   */
-  @scala.annotation.tailrec
-  def stripDollars(s: String): String = {
-    val lastDollarIndex = s.lastIndexOf('$')
-    if (lastDollarIndex < s.length - 1) {
-      // The last char is not a dollar sign
-      if (lastDollarIndex == -1 || !s.contains("$iw")) {
-        // The name does not have dollar sign or is not an interpreter
-        // generated class, so we should return the full string
-        s
-      } else {
-        // The class name is interpreter generated,
-        // return the part after the last dollar sign
-        // This is the same behavior as getClass.getSimpleName
-        s.substring(lastDollarIndex + 1)
-      }
-    }
-    else {
-      // The last char is a dollar sign
-      // Find last non-dollar char
-      val lastNonDollarChar = s.findLast(_ != '$')
-      lastNonDollarChar match {
-        case None => s
-        case Some(c) =>
-          val lastNonDollarIndex = s.lastIndexOf(c)
-          if (lastNonDollarIndex == -1) {
-            s
-          } else {
-            // Strip the trailing dollar signs
-            // Invoke stripDollars again to get the simple name
-            stripDollars(s.substring(0, lastNonDollarIndex + 1))
-          }
-      }
-    }
   }
 
   /**

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/encoders/AgnosticEncoder.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/encoders/AgnosticEncoder.scala
@@ -48,12 +48,6 @@ trait AgnosticEncoder[T] extends Encoder[T] {
 }
 
 object AgnosticEncoders {
-  object UnboundEncoder extends AgnosticEncoder[Any] {
-    override def isPrimitive: Boolean = false
-    override def dataType: DataType = NullType
-    override def clsTag: ClassTag[Any] = classTag[Any]
-  }
-
   case class OptionEncoder[E](elementEncoder: AgnosticEncoder[E])
     extends AgnosticEncoder[Option[E]] {
     override def isPrimitive: Boolean = false

--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/columnNodes.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/columnNodes.scala
@@ -16,9 +16,14 @@
  */
 package org.apache.spark.sql.internal
 
-import org.apache.spark.sql.catalyst.encoders.AgnosticEncoder
+import java.util.concurrent.atomic.AtomicLong
+
+import ColumnNode._
+
 import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin}
-import org.apache.spark.sql.types.{DataType, Metadata}
+import org.apache.spark.sql.errors.DataTypeErrorsBase
+import org.apache.spark.sql.types.{DataType, IntegerType, LongType, Metadata}
+import org.apache.spark.util.SparkClassUtils
 
 /**
  * AST for constructing columns. This API is implementation agnostic and allows us to build a
@@ -30,11 +35,59 @@ import org.apache.spark.sql.types.{DataType, Metadata}
  * make constructing nodes easier (e.g. [[CaseWhenOtherwise]]). We could not use the actual connect
  * protobuf messages because of classpath clashes (e.g. Guava & gRPC) and Maven shading issues.
  */
-private[sql] trait ColumnNode {
+private[sql] trait ColumnNode extends ColumnNodeLike {
   /**
    * Origin where the node was created.
    */
   def origin: Origin
+
+  /**
+   * A normalized version of this node. This is stripped of dataset related (contextual) metadata.
+   * This is mostly used to power Column.equals and Column.hashcode.
+   */
+  lazy val normalized: ColumnNode = {
+    val transformed = normalize()
+    if (this != transformed) {
+      transformed
+    } else {
+      this
+    }
+  }
+
+  override private[internal] def normalize(): ColumnNode = this
+
+  /**
+   * Return a SQL-a-like representation of the node.
+   *
+   * This is best effort; there are no guarantees that the returned SQL is valid.
+   */
+  def sql: String
+}
+
+trait ColumnNodeLike {
+  private[internal] def normalize(): ColumnNodeLike = this
+  private[internal] def sql: String
+}
+
+private[internal] object ColumnNode {
+  val NO_ORIGIN: Origin = Origin()
+  def normalize[T <: ColumnNodeLike](option: Option[T]): Option[T] =
+    option.map(_.normalize().asInstanceOf[T])
+  def normalize[T <: ColumnNodeLike](nodes: Seq[T]): Seq[T] =
+    nodes.map(_.normalize().asInstanceOf[T])
+  def argumentsToSql(nodes: Seq[ColumnNodeLike]): String =
+    textArgumentsToSql(nodes.map(_.sql))
+  def textArgumentsToSql(parts: Seq[String]): String = parts.mkString("(", ", ", ")")
+  def elementsToSql(elements: Seq[ColumnNodeLike], prefix: String = ""): String = {
+    if (elements.nonEmpty) {
+      elements.map(_.sql).mkString(prefix, ", ", "")
+    } else {
+      ""
+    }
+  }
+  def optionToSql(option: Option[ColumnNodeLike]): String = {
+    option.map(_.sql).getOrElse("")
+  }
 }
 
 /**
@@ -46,7 +99,19 @@ private[sql] trait ColumnNode {
 private[sql] case class Literal(
     value: Any,
     dataType: Option[DataType] = None,
-    override val origin: Origin = CurrentOrigin.get) extends ColumnNode
+    override val origin: Origin = CurrentOrigin.get) extends ColumnNode with DataTypeErrorsBase {
+  override private[internal] def normalize(): Literal = copy(origin = NO_ORIGIN)
+
+  override def sql: String = value match {
+    case null => "NULL"
+    case v: String => toSQLValue(v)
+    case v: Long => toSQLValue(v)
+    case v: Float => toSQLValue(v)
+    case v: Double => toSQLValue(v)
+    case v: Short => toSQLValue(v)
+    case _ => value.toString
+  }
+}
 
 /**
  * Reference to an attribute produced by one of the underlying DataFrames.
@@ -60,7 +125,11 @@ private[sql] case class UnresolvedAttribute(
     planId: Option[Long] = None,
     isMetadataColumn: Boolean = false,
     override val origin: Origin = CurrentOrigin.get)
-  extends ColumnNode
+  extends ColumnNode {
+  override private[internal] def normalize(): UnresolvedAttribute =
+    copy(planId = None, origin = NO_ORIGIN)
+  override def sql: String = unparsedIdentifier
+}
 
 /**
  * Reference to all columns in a namespace (global, a Dataframe, or a nested struct).
@@ -72,7 +141,11 @@ private[sql] case class UnresolvedStar(
     unparsedTarget: Option[String],
     planId: Option[Long] = None,
     override val origin: Origin = CurrentOrigin.get)
-  extends ColumnNode
+  extends ColumnNode {
+  override private[internal] def normalize(): UnresolvedStar =
+    copy(planId = None, origin = NO_ORIGIN)
+  override def sql: String = unparsedTarget.map(_ + ".*").getOrElse("*")
+}
 
 /**
  * Call a function. This can either be a built-in function, a UDF, or a UDF registered in the
@@ -88,8 +161,14 @@ private[sql] case class UnresolvedFunction(
     arguments: Seq[ColumnNode],
     isDistinct: Boolean = false,
     isUserDefinedFunction: Boolean = false,
+    isInternal: Boolean = false,
     override val origin: Origin = CurrentOrigin.get)
-  extends ColumnNode
+  extends ColumnNode {
+  override private[internal] def normalize(): UnresolvedFunction =
+    copy(arguments = ColumnNode.normalize(arguments), origin = NO_ORIGIN)
+
+  override def sql: String = functionName + argumentsToSql(arguments)
+}
 
 /**
  * Evaluate a SQL expression.
@@ -98,7 +177,10 @@ private[sql] case class UnresolvedFunction(
  */
 private[sql] case class SqlExpression(
     expression: String,
-    override val origin: Origin = CurrentOrigin.get) extends ColumnNode
+    override val origin: Origin = CurrentOrigin.get) extends ColumnNode {
+  override private[internal] def normalize(): SqlExpression = copy(origin = NO_ORIGIN)
+  override def sql: String = expression
+}
 
 /**
  * Name a column, and (optionally) modify its metadata.
@@ -111,7 +193,18 @@ private[sql] case class Alias(
     child: ColumnNode,
     name: Seq[String],
     metadata: Option[Metadata] = None,
-    override val origin: Origin = CurrentOrigin.get) extends ColumnNode
+    override val origin: Origin = CurrentOrigin.get) extends ColumnNode {
+  override private[internal] def normalize(): Alias =
+    copy(child = child.normalize(), origin = NO_ORIGIN)
+
+  override def sql: String = {
+    val alias = name match {
+      case Seq(single) => single
+      case multiple => textArgumentsToSql(multiple)
+    }
+    s"${child.sql} AS $alias"
+  }
+}
 
 /**
  * Cast the value of a Column to a different [[DataType]]. The behavior of the cast can be
@@ -124,14 +217,21 @@ private[sql] case class Alias(
 private[sql] case class Cast(
     child: ColumnNode,
     dataType: DataType,
-    evalMode: Option[Cast.EvalMode.Value] = None,
-    override val origin: Origin = CurrentOrigin.get) extends ColumnNode
+    evalMode: Option[Cast.EvalMode] = None,
+    override val origin: Origin = CurrentOrigin.get) extends ColumnNode {
+  override private[internal] def normalize(): Cast =
+    copy(child = child.normalize(), origin = NO_ORIGIN)
+
+  override def sql: String = {
+    s"${optionToSql(evalMode)}CAST(${child.sql} AS ${dataType.sql})"
+  }
+}
 
 private[sql] object Cast {
-  object EvalMode extends Enumeration {
-    type EvalMode = Value
-    val Legacy, Ansi, Try = Value
-  }
+  sealed abstract class EvalMode(override val sql: String = "") extends ColumnNodeLike
+  object Legacy extends EvalMode
+  object Ansi extends EvalMode
+  object Try extends EvalMode("TRY_")
 }
 
 /**
@@ -143,7 +243,11 @@ private[sql] object Cast {
 private[sql] case class UnresolvedRegex(
     regex: String,
     planId: Option[Long] = None,
-    override val origin: Origin = CurrentOrigin.get) extends ColumnNode
+    override val origin: Origin = CurrentOrigin.get) extends ColumnNode {
+  override private[internal] def normalize(): UnresolvedRegex =
+    copy(planId = None, origin = NO_ORIGIN)
+  override def sql: String = regex
+}
 
 /**
  * Sort the input column.
@@ -154,20 +258,23 @@ private[sql] case class UnresolvedRegex(
  */
 private[sql] case class SortOrder(
     child: ColumnNode,
-    sortDirection: SortOrder.SortDirection.Value,
-    nullOrdering: SortOrder.NullOrdering.Value,
+    sortDirection: SortOrder.SortDirection,
+    nullOrdering: SortOrder.NullOrdering,
     override val origin: Origin = CurrentOrigin.get)
-  extends ColumnNode
+  extends ColumnNode {
+  override private[internal] def normalize(): SortOrder =
+    copy(child = child.normalize(), origin = NO_ORIGIN)
+
+  override def sql: String = s"${child.sql} ${sortDirection.sql} ${nullOrdering.sql}"
+}
 
 private[sql] object SortOrder {
-  object SortDirection extends Enumeration {
-    type SortDirection = Value
-    val Ascending, Descending = Value
-  }
-  object NullOrdering extends  Enumeration {
-    type NullOrdering = Value
-    val NullsFirst, NullsLast = Value
-  }
+  sealed abstract class SortDirection(override val sql: String) extends ColumnNodeLike
+  object Ascending extends SortDirection("ASC")
+  object Descending extends SortDirection("DESC")
+  sealed abstract class NullOrdering(override val sql: String) extends ColumnNodeLike
+  object NullsFirst extends NullOrdering("NULLS FIRST")
+  object NullsLast extends NullOrdering("NULLS LAST")
 }
 
 /**
@@ -180,28 +287,66 @@ private[sql] case class Window(
     windowFunction: ColumnNode,
     windowSpec: WindowSpec,
     override val origin: Origin = CurrentOrigin.get)
-  extends ColumnNode
+  extends ColumnNode {
+  override private[internal] def normalize(): Window = copy(
+    windowFunction = windowFunction.normalize(),
+    windowSpec = windowSpec.normalize(),
+    origin = NO_ORIGIN)
+
+  override def sql: String = s"${windowFunction.sql} OVER (${windowSpec.sql})"
+}
 
 private[sql] case class WindowSpec(
     partitionColumns: Seq[ColumnNode],
     sortColumns: Seq[SortOrder],
-    frame: Option[WindowFrame] = None)
+    frame: Option[WindowFrame] = None) extends ColumnNodeLike {
+  override private[internal] def normalize(): WindowSpec = copy(
+    partitionColumns = ColumnNode.normalize(partitionColumns),
+    sortColumns = ColumnNode.normalize(sortColumns),
+    frame = ColumnNode.normalize(frame))
+  override private[internal] def sql: String = {
+    val parts = Seq(
+      elementsToSql(partitionColumns, "PARTITION BY "),
+      elementsToSql(sortColumns, "ORDER BY "),
+      optionToSql(frame))
+    parts.filter(_.nonEmpty).mkString(" ")
+  }
+}
 
 private[sql] case class WindowFrame(
-    frameType: WindowFrame.FrameType.Value,
+    frameType: WindowFrame.FrameType,
     lower: WindowFrame.FrameBoundary,
     upper: WindowFrame.FrameBoundary)
+  extends ColumnNodeLike {
+  override private[internal] def normalize(): WindowFrame =
+    copy(lower = lower.normalize(), upper = upper.normalize())
+  override private[internal] def sql: String =
+    s"${frameType.sql} BETWEEN ${lower.sql} AND ${upper.sql}"
+}
 
 private[sql] object WindowFrame {
-  object FrameType extends Enumeration {
-    type FrameType = this.Value
-    val Row, Range = this.Value
-  }
+  sealed abstract class FrameType(override val sql: String) extends ColumnNodeLike
+  object Row extends FrameType("ROWS")
+  object Range extends FrameType("RANGE")
 
-  sealed trait FrameBoundary
-  object CurrentRow extends FrameBoundary
-  object Unbounded extends FrameBoundary
-  case class Value(value: ColumnNode) extends FrameBoundary
+  sealed abstract class FrameBoundary extends ColumnNodeLike {
+    override private[internal] def normalize(): FrameBoundary = this
+  }
+  object CurrentRow extends FrameBoundary {
+    override private[internal] def sql = "CURRENT ROW"
+  }
+  object UnboundedPreceding extends FrameBoundary {
+    override private[internal] def sql = "UNBOUNDED PRECEDING"
+  }
+  object UnboundedFollowing extends FrameBoundary {
+    override private[internal] def sql = "UNBOUNDED FOLLOWING"
+  }
+  case class Value(value: ColumnNode) extends FrameBoundary {
+    override private[internal] def normalize(): Value = copy(value.normalize())
+    override private[internal] def sql: String = value.sql
+  }
+  def value(i: Int): Value = Value(Literal(i, Some(IntegerType)))
+  def value(l: Long): Value = Value(Literal(l, Some(LongType)))
 }
 
 /**
@@ -213,7 +358,26 @@ private[sql] object WindowFrame {
 private[sql] case class LambdaFunction(
     function: ColumnNode,
     arguments: Seq[UnresolvedNamedLambdaVariable],
-    override val origin: Origin = CurrentOrigin.get) extends ColumnNode
+    override val origin: Origin) extends ColumnNode {
+
+  override private[internal] def normalize(): LambdaFunction = copy(
+    function = function.normalize(),
+    arguments = ColumnNode.normalize(arguments),
+    origin = NO_ORIGIN)
+
+  override def sql: String = {
+    val argumentsSql = arguments match {
+      case Seq(arg) => arg.sql
+      case _ => argumentsToSql(arguments)
+    }
+    argumentsSql + " -> " + function.sql
+  }
+}
+
+object LambdaFunction {
+  def apply(function: ColumnNode, arguments: Seq[UnresolvedNamedLambdaVariable]): LambdaFunction =
+    new LambdaFunction(function, arguments, CurrentOrigin.get)
+}
 
 /**
  * Variable used in a [[LambdaFunction]].
@@ -222,7 +386,20 @@ private[sql] case class LambdaFunction(
  */
 private[sql] case class UnresolvedNamedLambdaVariable(
     name: String,
-    override val origin: Origin = CurrentOrigin.get) extends ColumnNode
+    override val origin: Origin = CurrentOrigin.get) extends ColumnNode {
+  override private[internal] def normalize(): UnresolvedNamedLambdaVariable =
+    copy(origin = NO_ORIGIN)
+
+  override def sql: String = name
+}
+
+object UnresolvedNamedLambdaVariable {
+  private val nextId = new AtomicLong()
+  def apply(name: String): UnresolvedNamedLambdaVariable = {
+    // Generate a unique name because we reuse lambda variable names (e.g. x, y, or z).
+    new UnresolvedNamedLambdaVariable(s"${name}_${nextId.incrementAndGet()}")
+  }
+}
 
 /**
  * Extract a value from a complex type. This can be a field from a struct, a value from a map,
@@ -235,7 +412,14 @@ private[sql] case class UnresolvedNamedLambdaVariable(
 private[sql] case class UnresolvedExtractValue(
     child: ColumnNode,
     extraction: ColumnNode,
-    override val origin: Origin = CurrentOrigin.get) extends ColumnNode
+    override val origin: Origin = CurrentOrigin.get) extends ColumnNode {
+  override private[internal] def normalize(): UnresolvedExtractValue = copy(
+    child = child.normalize(),
+    extraction = extraction.normalize(),
+    origin = NO_ORIGIN)
+
+  override def sql: String = s"${child.sql}[${extraction.sql}]"
+}
 
 /**
  * Update or drop the field of a struct.
@@ -248,7 +432,16 @@ private[sql] case class UpdateFields(
     structExpression: ColumnNode,
     fieldName: String,
     valueExpression: Option[ColumnNode] = None,
-    override val origin: Origin = CurrentOrigin.get) extends ColumnNode
+    override val origin: Origin = CurrentOrigin.get) extends ColumnNode {
+  override private[internal] def normalize(): UpdateFields = copy(
+    structExpression = structExpression.normalize(),
+    valueExpression = ColumnNode.normalize(valueExpression),
+    origin = NO_ORIGIN)
+  override def sql: String = valueExpression match {
+    case Some(value) => s"update_field(${structExpression.sql}, $fieldName, ${value.sql})"
+    case None => s"drop_field(${structExpression.sql}, $fieldName)"
+  }
+}
 
 /**
  * Evaluate one or more conditional branches. The value of the first branch for which the predicate
@@ -262,7 +455,19 @@ private[sql] case class CaseWhenOtherwise(
     branches: Seq[(ColumnNode, ColumnNode)],
     otherwise: Option[ColumnNode] = None,
     override val origin: Origin = CurrentOrigin.get)
-  extends ColumnNode
+  extends ColumnNode {
+  assert(branches.nonEmpty)
+  override private[internal] def normalize(): CaseWhenOtherwise = copy(
+    branches = branches.map(kv => (kv._1.normalize(), kv._2.normalize())),
+    otherwise = ColumnNode.normalize(otherwise),
+    origin = NO_ORIGIN)
+
+  override def sql: String =
+    "CASE" +
+      branches.map(cv => s" WHEN ${cv._1.sql} THEN ${cv._2.sql}").mkString +
+      otherwise.map(o => s" ELSE ${o.sql}").getOrElse("") +
+      " END"
+}
 
 /**
  * Invoke an inline user defined function.
@@ -271,25 +476,18 @@ private[sql] case class CaseWhenOtherwise(
  * @param arguments to pass into the user defined function.
  */
 private[sql] case class InvokeInlineUserDefinedFunction(
-    function: UserDefinedFunction,
+    function: UserDefinedFunctionLike,
     arguments: Seq[ColumnNode],
+    isDistinct: Boolean = false,
     override val origin: Origin = CurrentOrigin.get)
-  extends ColumnNode
+  extends ColumnNode {
+  override private[internal] def normalize(): InvokeInlineUserDefinedFunction =
+    copy(arguments = ColumnNode.normalize(arguments), origin = NO_ORIGIN)
 
-// This is a temporary class until we move the actual interfaces
-private[sql] case class UserDefinedFunction(
-    function: AnyRef,
-    resultEncoder: AgnosticEncoder[Any],
-    inputEncoders: Seq[AgnosticEncoder[Any]],
-    name: Option[String],
-    nonNullable: Boolean,
-    deterministic: Boolean)
+  override def sql: String =
+    function.name + argumentsToSql(arguments)
+}
 
-/**
- * Extension point that allows an implementation to use its column representation to be used in a
- * generic column expression. This should only be used when the Column constructed is used within
- * the implementation.
- */
-private[sql] case class Extension(
-    value: Any,
-    override val origin: Origin = CurrentOrigin.get) extends ColumnNode
+private[sql] trait UserDefinedFunctionLike {
+  def name: String = SparkClassUtils.getFormattedClassName(this)
+}

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -1744,7 +1744,7 @@ class SparkConnectPlanner(
       UserDefinedAggregator(
         aggregator = udfPacket.function.asInstanceOf[Aggregator[Any, Any, Any]],
         inputEncoder = ExpressionEncoder(udfPacket.inputEncoders.head),
-        name = Option(fun.getFunctionName),
+        givenName = Option(fun.getFunctionName),
         nullable = udf.getNullable,
         deterministic = fun.getDeterministic)
     } else {
@@ -1753,7 +1753,7 @@ class SparkConnectPlanner(
         dataType = transformDataType(udf.getOutputType),
         inputEncoders = udfPacket.inputEncoders.map(e => Try(ExpressionEncoder(e)).toOption),
         outputEncoder = Option(ExpressionEncoder(udfPacket.outputEncoder)),
-        name = Option(fun.getFunctionName),
+        givenName = Option(fun.getFunctionName),
         nullable = udf.getNullable,
         deterministic = fun.getDeterministic)
     }
@@ -1899,15 +1899,7 @@ class SparkConnectPlanner(
       fun: org.apache.spark.sql.expressions.UserDefinedFunction,
       exprs: Seq[Expression]): ScalaUDF = {
     val f = fun.asInstanceOf[org.apache.spark.sql.expressions.SparkUserDefinedFunction]
-    ScalaUDF(
-      function = f.f,
-      dataType = f.dataType,
-      children = exprs,
-      inputEncoders = f.inputEncoders,
-      outputEncoder = f.outputEncoder,
-      udfName = f.name,
-      nullable = f.nullable,
-      udfDeterministic = f.deterministic)
+    f.createScalaUDF(exprs)
   }
 
   private def extractProtobufArgs(children: Seq[Expression]) = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/expressions/Aggregator.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/expressions/Aggregator.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.expressions
 import org.apache.spark.sql.{Encoder, TypedColumn}
 import org.apache.spark.sql.catalyst.encoders.encoderFor
 import org.apache.spark.sql.execution.aggregate.TypedAggregateExpression
+import org.apache.spark.sql.internal.UserDefinedFunctionLike
 
 /**
  * A base class for user-defined aggregations, which can be used in `Dataset` operations to take
@@ -50,7 +51,7 @@ import org.apache.spark.sql.execution.aggregate.TypedAggregateExpression
  * @since 1.6.0
  */
 @SerialVersionUID(2093413866369130093L)
-abstract class Aggregator[-IN, BUF, OUT] extends Serializable {
+abstract class Aggregator[-IN, BUF, OUT] extends Serializable with UserDefinedFunctionLike {
 
   /**
    * A zero value for this aggregation. Should satisfy the property that any b + zero = b.

--- a/sql/core/src/main/scala/org/apache/spark/sql/internal/columnNodeSupport.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/internal/columnNodeSupport.scala
@@ -17,19 +17,18 @@
 package org.apache.spark.sql.internal
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.analysis
-import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders.UnboundEncoder
-import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
-import org.apache.spark.sql.catalyst.expressions
-import org.apache.spark.sql.catalyst.expressions.{Expression, ScalaUDF}
+import org.apache.spark.sql.{Dataset, SparkSession}
+import org.apache.spark.sql.catalyst.{analysis, expressions, CatalystTypeConverters}
+import org.apache.spark.sql.catalyst.encoders.encoderFor
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression, ScalaUDF}
 import org.apache.spark.sql.catalyst.parser.{ParserInterface, ParserUtils}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.catalyst.trees.CurrentOrigin
+import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin}
 import org.apache.spark.sql.catalyst.util.CharVarcharUtils
 import org.apache.spark.sql.execution.SparkSqlParser
-import org.apache.spark.sql.execution.aggregate.{ScalaAggregator, TypedAggregateExpression}
-import org.apache.spark.sql.expressions.Aggregator
+import org.apache.spark.sql.execution.aggregate.{ScalaAggregator, ScalaUDAF, TypedAggregateExpression}
+import org.apache.spark.sql.execution.analysis.DetectAmbiguousSelfJoin
+import org.apache.spark.sql.expressions.{Aggregator, SparkUserDefinedFunction, UserDefinedAggregateFunction, UserDefinedAggregator}
 
 /**
  * Convert a [[ColumnNode]] into an [[Expression]].
@@ -42,7 +41,8 @@ private[sql] trait ColumnNodeToExpressionConverter extends (ColumnNode => Expres
   override def apply(node: ColumnNode): Expression = CurrentOrigin.withOrigin(node.origin) {
     node match {
       case Literal(value, Some(dataType), _) =>
-        expressions.Literal.create(value, dataType)
+        val converter = CatalystTypeConverters.createToCatalystConverter(dataType)
+        expressions.Literal(converter(value), dataType)
 
       case Literal(value, None, _) =>
         expressions.Literal(value)
@@ -66,13 +66,21 @@ private[sql] trait ColumnNodeToExpressionConverter extends (ColumnNode => Expres
       case UnresolvedRegex(unparsedIdentifier, planId, _) =>
         convertUnresolvedAttribute(unparsedIdentifier, planId, isMetadataColumn = false)
 
-      case UnresolvedFunction(functionName, arguments, isDistinct, isUDF, _) =>
+      case UnresolvedFunction(functionName, arguments, isDistinct, isUDF, isInternal, _) =>
         val nameParts = if (isUDF) {
           parser.parseMultipartIdentifier(functionName)
         } else {
           Seq(functionName)
         }
-        analysis.UnresolvedFunction(nameParts, arguments.map(apply), isDistinct)
+        analysis.UnresolvedFunction(
+          nameParts = nameParts,
+          arguments = arguments.map(apply),
+          isDistinct = isDistinct,
+          isInternal = isInternal)
+
+      case Alias(child, Seq(name), None, _) =>
+        expressions.Alias(apply(child), name)(
+          nonInheritableMetadataKeys = Seq(Dataset.DATASET_ID_KEY, Dataset.COL_POS_KEY))
 
       case Alias(child, Seq(name), metadata, _) =>
         expressions.Alias(apply(child), name)(explicitMetadata = metadata)
@@ -82,9 +90,9 @@ private[sql] trait ColumnNodeToExpressionConverter extends (ColumnNode => Expres
 
       case Cast(child, dataType, evalMode, _) =>
         val convertedEvalMode = evalMode match {
-          case Some(Cast.EvalMode.Ansi) => expressions.EvalMode.ANSI
-          case Some(Cast.EvalMode.Legacy) => expressions.EvalMode.LEGACY
-          case Some(Cast.EvalMode.Try) => expressions.EvalMode.TRY
+          case Some(Cast.Ansi) => expressions.EvalMode.ANSI
+          case Some(Cast.Legacy) => expressions.EvalMode.LEGACY
+          case Some(Cast.Try) => expressions.EvalMode.TRY
           case _ => expressions.EvalMode.fromSQLConf(conf)
         }
         val cast = expressions.Cast(
@@ -105,20 +113,13 @@ private[sql] trait ColumnNodeToExpressionConverter extends (ColumnNode => Expres
         val frame = spec.frame match {
           case Some(WindowFrame(frameType, lower, upper)) =>
             val convertedFrameType = frameType match {
-              case WindowFrame.FrameType.Range => expressions.RangeFrame
-              case WindowFrame.FrameType.Row => expressions.RowFrame
+              case WindowFrame.Range => expressions.RangeFrame
+              case WindowFrame.Row => expressions.RowFrame
             }
-            val convertedLower = lower match {
-              case WindowFrame.CurrentRow => expressions.CurrentRow
-              case WindowFrame.Unbounded => expressions.UnboundedPreceding
-              case WindowFrame.Value(node) => apply(node)
-            }
-            val convertedUpper = upper match {
-              case WindowFrame.CurrentRow => expressions.CurrentRow
-              case WindowFrame.Unbounded => expressions.UnboundedFollowing
-              case WindowFrame.Value(node) => apply(node)
-            }
-            expressions.SpecifiedWindowFrame(convertedFrameType, convertedLower, convertedUpper)
+            expressions.SpecifiedWindowFrame(
+              convertedFrameType,
+              convertWindowFrameBoundary(lower),
+              convertWindowFrameBoundary(upper))
           case None =>
             expressions.UnspecifiedFrame
         }
@@ -153,40 +154,39 @@ private[sql] trait ColumnNodeToExpressionConverter extends (ColumnNode => Expres
           },
           elseValue = otherwise.map(apply))
 
-      case InvokeInlineUserDefinedFunction(f, arguments, _) =>
-        // This code is a bit clunky, it will stay this way until we have moved everything to
-        // sql/api and we can actually use the SparkUserDefinedFunction and
-        // UserDefinedAggregator classes.
-        (f.function, arguments.map(apply)) match {
-          case (a: Aggregator[Any @unchecked, Any @unchecked, Any @unchecked], Nil) =>
-            TypedAggregateExpression(a)(a.bufferEncoder, a.outputEncoder).toAggregateExpression()
+      case InvokeInlineUserDefinedFunction(
+          a: Aggregator[Any @unchecked, Any @unchecked, Any @unchecked], Nil, isDistinct, _) =>
+        TypedAggregateExpression(a)(a.bufferEncoder, a.outputEncoder)
+          .toAggregateExpression(isDistinct)
 
-          case (a: Aggregator[Any @unchecked, Any  @unchecked, Any  @unchecked], children) =>
-            ScalaAggregator(
-              agg = a,
-              children = children,
-              inputEncoder = ExpressionEncoder(f.inputEncoders.head),
-              bufferEncoder = ExpressionEncoder(f.resultEncoder),
-              aggregatorName = f.name,
-              nullable = !f.nonNullable && f.resultEncoder.nullable,
-              isDeterministic = f.deterministic).toAggregateExpression()
+      case InvokeInlineUserDefinedFunction(
+          a: UserDefinedAggregator[Any @unchecked, Any @unchecked, Any @unchecked],
+          arguments, isDistinct, _) =>
+        ScalaAggregator(
+          agg = a.aggregator,
+          children = arguments.map(apply),
+          inputEncoder = encoderFor(a.inputEncoder),
+          bufferEncoder = encoderFor(a.aggregator.bufferEncoder),
+          aggregatorName = a.givenName,
+          nullable = a.nullable,
+          isDeterministic = a.deterministic).toAggregateExpression(isDistinct)
 
-          case (function, children) =>
-            ScalaUDF(
-              function = function,
-              dataType = f.resultEncoder.dataType,
-              children = children,
-              inputEncoders = f.inputEncoders.map {
-                case UnboundEncoder => None
-                case encoder => Option(ExpressionEncoder(encoder))
-              },
-              outputEncoder = Option(ExpressionEncoder(f.resultEncoder)),
-              udfName = f.name,
-              nullable = !f.nonNullable && f.resultEncoder.nullable,
-              udfDeterministic = f.deterministic)
-        }
+      case InvokeInlineUserDefinedFunction(
+          a: UserDefinedAggregateFunction, arguments, isDistinct, _) =>
+        ScalaUDAF(udaf = a, children = arguments.map(apply)).toAggregateExpression(isDistinct)
 
-      case Extension(expression: Expression, _) =>
+      case InvokeInlineUserDefinedFunction(udf: SparkUserDefinedFunction, arguments, _, _) =>
+        ScalaUDF(
+          function = udf.f,
+          dataType = udf.dataType,
+          children = arguments.map(apply),
+          inputEncoders = udf.inputEncoders,
+          outputEncoder = udf.outputEncoder,
+          udfName = udf.givenName,
+          nullable = udf.deterministic,
+          udfDeterministic = udf.deterministic)
+
+      case Wrapper(expression, _) =>
         expression
 
       case node =>
@@ -201,14 +201,23 @@ private[sql] trait ColumnNodeToExpressionConverter extends (ColumnNode => Expres
 
   private def convertSortOrder(sortOrder: SortOrder): expressions.SortOrder = {
     val sortDirection = sortOrder.sortDirection match {
-      case SortOrder.SortDirection.Ascending => expressions.Ascending
-      case SortOrder.SortDirection.Descending => expressions.Descending
+      case SortOrder.Ascending => expressions.Ascending
+      case SortOrder.Descending => expressions.Descending
     }
     val nullOrdering = sortOrder.nullOrdering match {
-      case SortOrder.NullOrdering.NullsFirst => expressions.NullsFirst
-      case SortOrder.NullOrdering.NullsLast => expressions.NullsLast
+      case SortOrder.NullsFirst => expressions.NullsFirst
+      case SortOrder.NullsLast => expressions.NullsLast
     }
     expressions.SortOrder(apply(sortOrder.child), sortDirection, nullOrdering, Nil)
+  }
+
+  private def convertWindowFrameBoundary(boundary: WindowFrame.FrameBoundary): Expression = {
+    boundary match {
+      case WindowFrame.CurrentRow => expressions.CurrentRow
+      case WindowFrame.UnboundedPreceding => expressions.UnboundedPreceding
+      case WindowFrame.UnboundedFollowing => expressions.UnboundedFollowing
+      case WindowFrame.Value(node) => apply(node)
+    }
   }
 
   private def convertUnresolvedAttribute(
@@ -226,7 +235,7 @@ private[sql] trait ColumnNodeToExpressionConverter extends (ColumnNode => Expres
   }
 }
 
-object ColumnNodeToExpressionConverter extends ColumnNodeToExpressionConverter {
+private[sql] object ColumnNodeToExpressionConverter extends ColumnNodeToExpressionConverter {
   override protected def parser: ParserInterface = {
     SparkSession.getActiveSession.map(_.sessionState.sqlParser).getOrElse {
       new SparkSqlParser()
@@ -234,4 +243,21 @@ object ColumnNodeToExpressionConverter extends ColumnNodeToExpressionConverter {
   }
 
   override protected def conf: SQLConf = SQLConf.get
+}
+
+/**
+ * [[ColumnNode]] wrapper for an [[Expression]].
+ */
+private[sql] case class Wrapper(
+    expression: Expression,
+    override val origin: Origin = CurrentOrigin.get) extends ColumnNode {
+  override def normalize(): Wrapper = {
+    val updated = expression.transform {
+      case a: AttributeReference =>
+        DetectAmbiguousSelfJoin.stripColumnReferenceMetadata(a)
+    }
+    copy(updated, ColumnNode.NO_ORIGIN)
+  }
+
+  override def sql: String = expression.sql
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/IntegratedUDFTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/IntegratedUDFTestUtils.scala
@@ -1576,7 +1576,7 @@ object IntegratedUDFTestUtils extends SQLHelper {
     },
     StringType,
     inputEncoders = Seq.fill(1)(None),
-    name = Some(name)) {
+    givenName = Some(name)) {
 
     override def apply(exprs: Column*): Column = {
       assert(exprs.length == 1, "Defined UDF only has one column")

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/ColumnNodeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/ColumnNodeSuite.scala
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.internal
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.{functions, Dataset}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, ExprId}
+import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin}
+import org.apache.spark.sql.types.{IntegerType, LongType, Metadata, MetadataBuilder, StringType}
+
+class ColumnNodeSuite extends SparkFunSuite {
+  private val simpleUdf = functions.udf((i: Int) => i + 1)
+
+  test("sql") {
+    testSql(Literal(null), "NULL")
+    testSql(Literal(10), "10")
+    testSql(Literal(33L), "33L")
+    testSql(Literal(55.toShort), "55S")
+    testSql(Literal(3.14), "3.14")
+    testSql(Literal(Double.NaN), "NaN")
+    testSql(Literal(Double.NegativeInfinity), "-Infinity")
+    testSql(Literal(Double.PositiveInfinity), "Infinity")
+    testSql(Literal(3.9f), "3.9")
+    testSql(Literal(Float.NaN), "NaN")
+    testSql(Literal(Float.NegativeInfinity), "-Infinity")
+    testSql(Literal(Float.PositiveInfinity), "Infinity")
+    testSql(Literal("hello"), "'hello'")
+    testSql(Literal("\\_'"), "'\\\\_\\''")
+    testSql(Literal((1, 2)), "(1,2)")
+    testSql(UnresolvedStar(None), "*")
+    testSql(UnresolvedStar(Option("prefix")), "prefix.*")
+    testSql(UnresolvedAttribute("a"), "a")
+    testSql(SqlExpression("1 + 1"), "1 + 1")
+    testSql(Alias(UnresolvedAttribute("b"), Seq("new_b")), "b AS new_b")
+    testSql(Alias(UnresolvedAttribute("c"), Seq("x", "y", "z")), "c AS (x, y, z)")
+    testSql(Cast(UnresolvedAttribute("c"), IntegerType), "CAST(c AS INT)")
+    testSql(Cast(UnresolvedAttribute("d"), StringType, Option(Cast.Try)), "TRY_CAST(d AS STRING)")
+    testSql(
+      SortOrder(attribute("e"), SortOrder.Ascending, SortOrder.NullsLast),
+      "e ASC NULLS LAST")
+    testSql(
+      SortOrder(attribute("f"), SortOrder.Ascending, SortOrder.NullsFirst),
+      "f ASC NULLS FIRST")
+    testSql(
+      SortOrder(attribute("g"), SortOrder.Descending, SortOrder.NullsLast),
+      "g DESC NULLS LAST")
+    testSql(
+      SortOrder(attribute("h"), SortOrder.Descending, SortOrder.NullsFirst),
+      "h DESC NULLS FIRST")
+    testSql(
+      UnresolvedFunction("coalesce", Seq(Literal(null), UnresolvedAttribute("i"))),
+      "coalesce(NULL, i)")
+    val lambdaVariableX = new UnresolvedNamedLambdaVariable("x")
+    val lambdaVariableY = new UnresolvedNamedLambdaVariable("y")
+    testSql(
+      UnresolvedFunction(
+        "transform", Seq(
+          UnresolvedAttribute("input"),
+          LambdaFunction(
+            UnresolvedFunction("adjust", Seq(lambdaVariableX, UnresolvedAttribute("b"))),
+            Seq(lambdaVariableX)))),
+      "transform(input, x -> adjust(x, b))")
+    testSql(
+      UnresolvedFunction(
+        "transform", Seq(
+          UnresolvedAttribute("input"),
+          LambdaFunction(
+            UnresolvedFunction(
+              "combine",
+              Seq(lambdaVariableX, lambdaVariableY, UnresolvedAttribute("b"))),
+            Seq(lambdaVariableX, lambdaVariableY)))),
+      "transform(input, (x, y) -> combine(x, y, b))")
+    testSql(UnresolvedExtractValue(attribute("a", 2), attribute("b", 3)), "a[b]")
+    testSql(UpdateFields(UnresolvedAttribute("struct"), "a"), "drop_field(struct, a)")
+    testSql(
+      UpdateFields(UnresolvedAttribute("struct"), "b", Option(Literal(10.toLong))),
+      "update_field(struct, b, 10L)")
+    testSql(CaseWhenOtherwise(
+      Seq(UnresolvedAttribute("c1") -> UnresolvedAttribute("v1"))),
+      "CASE WHEN c1 THEN v1 END")
+    testSql(CaseWhenOtherwise(
+      Seq(
+        UnresolvedAttribute("c1") -> UnresolvedAttribute("v1"),
+        UnresolvedAttribute("c2") -> UnresolvedAttribute("v2")),
+      Option(Literal(25))),
+      "CASE WHEN c1 THEN v1 WHEN c2 THEN v2 ELSE 25 END")
+    val windowSpec = WindowSpec(
+      Seq(UnresolvedAttribute("a"), UnresolvedAttribute("b")),
+      Seq(
+        SortOrder(attribute("x"), SortOrder.Descending, SortOrder.NullsFirst),
+        SortOrder(attribute("y"), SortOrder.Ascending, SortOrder.NullsFirst)))
+    val reducedWindowSpec = windowSpec.copy(
+      partitionColumns = windowSpec.partitionColumns.take(1),
+      sortColumns = windowSpec.sortColumns.take(1))
+    val window = Window(
+      UnresolvedFunction("sum", Seq(UnresolvedAttribute("i"))),
+      WindowSpec(Nil, Nil))
+    testSql(window, "sum(i) OVER ()")
+    testSql(
+      window.copy(windowSpec = windowSpec.copy(sortColumns = Nil)),
+      "sum(i) OVER (PARTITION BY a, b)")
+    testSql(
+      window.copy(windowSpec = windowSpec.copy(partitionColumns = Nil)),
+      "sum(i) OVER (ORDER BY x DESC NULLS FIRST, y ASC NULLS FIRST)")
+    testSql(
+      window.copy(windowSpec = windowSpec),
+      "sum(i) OVER (PARTITION BY a, b ORDER BY x DESC NULLS FIRST, y ASC NULLS FIRST)")
+    testSql(
+      window.copy(windowSpec = reducedWindowSpec),
+      "sum(i) OVER (PARTITION BY a ORDER BY x DESC NULLS FIRST)")
+    testSql(
+      window.copy(windowSpec = reducedWindowSpec.copy(frame = Option(WindowFrame(
+        WindowFrame.Row,
+        WindowFrame.UnboundedPreceding,
+        WindowFrame.CurrentRow)))),
+      "sum(i) OVER (PARTITION BY a ORDER BY x DESC NULLS FIRST " +
+        "ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)")
+    testSql(
+      window.copy(windowSpec = reducedWindowSpec.copy(frame = Option(WindowFrame(
+        WindowFrame.Range,
+        WindowFrame.Value(Literal(-10)),
+        WindowFrame.UnboundedFollowing)))),
+      "sum(i) OVER (PARTITION BY a ORDER BY x DESC NULLS FIRST " +
+        "RANGE BETWEEN -10 AND UNBOUNDED FOLLOWING)")
+    testSql(InvokeInlineUserDefinedFunction(simpleUdf, Seq(UnresolvedAttribute("x"))), "UDF(x)")
+    testSql(
+      InvokeInlineUserDefinedFunction(simpleUdf.withName("smple"), Seq(UnresolvedAttribute("x"))),
+      "smple(x)")
+  }
+
+  private def testSql(node: ColumnNode, expectedSql: String): Unit = {
+    assert(node.sql == expectedSql)
+  }
+
+  test("normalization") {
+    testNormalization(Literal(1))
+    testNormalization(UnresolvedStar(Option("a.b"), planId = planId()))
+    testNormalization(UnresolvedAttribute("x", planId = planId()))
+    testNormalization(UnresolvedRegex(".*", planId = planId()))
+    testNormalization(SqlExpression("1 + 1"))
+    testNormalization(attribute("a"))
+    testNormalization(Alias(attribute("a"), Seq("aa"), None))
+    testNormalization(Cast(attribute("b"), IntegerType, Some(Cast.Try)))
+    testNormalization(SortOrder(attribute("c"), SortOrder.Ascending, SortOrder.NullsLast))
+    val lambdaVariable = UnresolvedNamedLambdaVariable("x")
+    testNormalization(
+      UnresolvedFunction(
+        "transform", Seq(
+          attribute("input", 331),
+          LambdaFunction(
+            UnresolvedFunction("adjust", Seq(lambdaVariable, attribute("b", 2))),
+            Seq(lambdaVariable)))))
+    testNormalization(UnresolvedExtractValue(attribute("b", 2), attribute("a", 8)))
+    testNormalization(UpdateFields(attribute("struct", 4), "a", Option(attribute("a", 11))))
+    testNormalization(CaseWhenOtherwise(
+      Seq(
+        attribute("c1", 5) -> attribute("v1", 2),
+        attribute("c2", 3) -> attribute("v2", 4)),
+      Option(attribute("v2", 5))))
+    testNormalization(Window(
+      UnresolvedFunction("sum", Seq(attribute("a")), isInternal = true, isDistinct = true),
+      WindowSpec(
+        Seq(attribute("b", 2)),
+        Seq(SortOrder(attribute("c", 3), SortOrder.Descending, SortOrder.NullsFirst)),
+        // Not a supported frame, just here for testing.
+        Option(WindowFrame(
+          WindowFrame.Range,
+          WindowFrame.Value(attribute("d", 3)),
+          WindowFrame.Value(attribute("e", 4)))))))
+    testNormalization(InvokeInlineUserDefinedFunction(
+      simpleUdf,
+      Seq(attribute("a", 2))))
+  }
+
+  private def testNormalization(generate: => ColumnNode): Unit = {
+    val a = CurrentOrigin.withOrigin(origin())(generate)
+    val b = CurrentOrigin.withOrigin(origin())(generate)
+    val c = try {
+      createNormalized.set(true)
+      CurrentOrigin.withOrigin(ColumnNode.NO_ORIGIN)(generate)
+    } finally {
+      createNormalized.set(false)
+    }
+    assert(a != a.normalized)
+    assert(a.normalized eq a.normalized.normalized)
+    assert(a != b)
+    assert(a.normalized == b.normalized)
+    assert(a.normalized == c)
+  }
+
+  private val createNormalized: ThreadLocal[Boolean] = new ThreadLocal[Boolean] {
+    override def initialValue(): Boolean = false
+  }
+
+  private val idGenerator = new AtomicInteger()
+  private def nextId: Int = idGenerator.incrementAndGet()
+
+  private def origin(): Origin = Origin(line = Option(nextId))
+
+  private def planId(): Option[Long] = {
+    if (!createNormalized.get()) {
+      Some(nextId.toLong)
+    } else {
+      None
+    }
+  }
+
+  private def attribute(name: String, id: Long = 1): ColumnNode = {
+    val metadata = if (!createNormalized.get()) {
+      new MetadataBuilder()
+        .putLong(Dataset.DATASET_ID_KEY, nextId)
+        .build()
+    } else {
+      Metadata.empty
+    }
+    Wrapper(AttributeReference(name, LongType, metadata = metadata)(exprId = ExprId(id)))
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/internal/ColumnNodeToExpressionConverterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/internal/ColumnNodeToExpressionConverterSuite.scala
@@ -17,18 +17,19 @@
 package org.apache.spark.sql.internal
 
 import org.apache.spark.{SparkException, SparkFunSuite}
-import org.apache.spark.sql.Encoders
-import org.apache.spark.sql.catalyst.analysis
+import org.apache.spark.sql.{Dataset, Encoders}
+import org.apache.spark.sql.catalyst.{analysis, expressions, InternalRow}
 import org.apache.spark.sql.catalyst.encoders.{encoderFor, AgnosticEncoder, AgnosticEncoders}
-import org.apache.spark.sql.catalyst.expressions
+import org.apache.spark.sql.catalyst.encoders.AgnosticEncoders._
 import org.apache.spark.sql.catalyst.expressions.{Expression, ExprId}
 import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, Origin}
 import org.apache.spark.sql.execution.SparkSqlParser
 import org.apache.spark.sql.execution.aggregate
-import org.apache.spark.sql.expressions.Aggregator
+import org.apache.spark.sql.expressions.{Aggregator, SparkUserDefinedFunction, UserDefinedAggregator}
 import org.apache.spark.sql.types._
+import org.apache.spark.unsafe.types.UTF8String
 
 /**
  * Test suite for [[ColumnNode]] to [[Expression]] conversions.
@@ -58,6 +59,8 @@ class ColumnNodeToExpressionConverterSuite extends SparkFunSuite {
       d.copy(inputAttributes = d.inputAttributes.map(_.withExprId(ExprId(0))))
     case a: expressions.aggregate.AggregateExpression =>
       a.copy(resultId = ExprId(0))
+    case expressions.UnresolvedNamedLambdaVariable(Seq(name)) =>
+      expressions.UnresolvedNamedLambdaVariable(name.takeWhile(_ != '_') :: Nil)
   }
 
   test("literal") {
@@ -65,6 +68,16 @@ class ColumnNodeToExpressionConverterSuite extends SparkFunSuite {
     testConversion(
       Literal("foo", Option(StringType)),
       expressions.Literal.create("foo", StringType))
+    val dataType = new StructType()
+      .add("_1", DoubleType)
+      .add("_2", StringType)
+      .add("_3", DoubleType)
+      .add("_4", StringType)
+    testConversion(
+      Literal((12.0, "north", 60.0, "west"), Option(dataType)),
+      expressions.Literal(
+        InternalRow(12.0, UTF8String.fromString("north"), 60.0, UTF8String.fromString("west")),
+        dataType))
   }
 
   test("attribute") {
@@ -123,7 +136,13 @@ class ColumnNodeToExpressionConverterSuite extends SparkFunSuite {
   test("alias") {
     testConversion(
       Alias(Literal("qwe"), "newA" :: Nil),
-      expressions.Alias(expressions.Literal("qwe"), "newA")())
+      expressions.Alias(expressions.Literal("qwe"), "newA")(
+        nonInheritableMetadataKeys = Seq(Dataset.DATASET_ID_KEY, Dataset.COL_POS_KEY)))
+    val metadata = new MetadataBuilder().putLong("q", 10).build()
+    testConversion(
+      Alias(UnresolvedAttribute("a"), "b" :: Nil, Option(metadata)),
+      expressions.Alias(analysis.UnresolvedAttribute("a"), "b")(
+        explicitMetadata = Option(metadata)))
     testConversion(
       Alias(UnresolvedAttribute("complex"), "newA" :: "newB" :: Nil),
       analysis.MultiAlias(analysis.UnresolvedAttribute("complex"), Seq("newA", "newB")))
@@ -131,7 +150,7 @@ class ColumnNodeToExpressionConverterSuite extends SparkFunSuite {
 
   private def testCast(
       dataType: DataType,
-      colEvalMode: Cast.EvalMode.Value,
+      colEvalMode: Cast.EvalMode,
       catEvalMode: expressions.EvalMode.Value): Unit = {
     testConversion(
       Cast(UnresolvedAttribute("attr"), dataType, Option(colEvalMode)),
@@ -143,14 +162,14 @@ class ColumnNodeToExpressionConverterSuite extends SparkFunSuite {
       Cast(UnresolvedAttribute("str"), DoubleType),
       expressions.Cast(analysis.UnresolvedAttribute("str"), DoubleType))
 
-    testCast(LongType, Cast.EvalMode.Legacy, expressions.EvalMode.LEGACY)
-    testCast(BinaryType, Cast.EvalMode.Try, expressions.EvalMode.TRY)
-    testCast(ShortType, Cast.EvalMode.Ansi, expressions.EvalMode.ANSI)
+    testCast(LongType, Cast.Legacy, expressions.EvalMode.LEGACY)
+    testCast(BinaryType, Cast.Try, expressions.EvalMode.TRY)
+    testCast(ShortType, Cast.Ansi, expressions.EvalMode.ANSI)
   }
 
   private def testSortOrder(
-      colDirection: SortOrder.SortDirection.SortDirection,
-      colNullOrdering: SortOrder.NullOrdering.NullOrdering,
+      colDirection: SortOrder.SortDirection,
+      colNullOrdering: SortOrder.NullOrdering,
       catDirection: expressions.SortDirection,
       catNullOrdering: expressions.NullOrdering): Unit = {
     testConversion(
@@ -164,29 +183,29 @@ class ColumnNodeToExpressionConverterSuite extends SparkFunSuite {
 
   test("sortOrder") {
     testSortOrder(
-      SortOrder.SortDirection.Ascending,
-      SortOrder.NullOrdering.NullsFirst,
+      SortOrder.Ascending,
+      SortOrder.NullsFirst,
       expressions.Ascending,
       expressions.NullsFirst)
     testSortOrder(
-      SortOrder.SortDirection.Ascending,
-      SortOrder.NullOrdering.NullsLast,
+      SortOrder.Ascending,
+      SortOrder.NullsLast,
       expressions.Ascending,
       expressions.NullsLast)
     testSortOrder(
-      SortOrder.SortDirection.Descending,
-      SortOrder.NullOrdering.NullsFirst,
+      SortOrder.Descending,
+      SortOrder.NullsFirst,
       expressions.Descending,
       expressions.NullsFirst)
     testSortOrder(
-      SortOrder.SortDirection.Descending,
-      SortOrder.NullOrdering.NullsLast,
+      SortOrder.Descending,
+      SortOrder.NullsLast,
       expressions.Descending,
       expressions.NullsLast)
   }
 
   private def testWindowFrame(
-      colFrameType: WindowFrame.FrameType.FrameType,
+      colFrameType: WindowFrame.FrameType,
       colLower: WindowFrame.FrameBoundary,
       colUpper: WindowFrame.FrameBoundary,
       catFrameType: expressions.FrameType,
@@ -199,8 +218,8 @@ class ColumnNodeToExpressionConverterSuite extends SparkFunSuite {
           Seq(UnresolvedAttribute("b"), UnresolvedAttribute("c")),
           Seq(SortOrder(
             UnresolvedAttribute("d"),
-            SortOrder.SortDirection.Descending,
-            SortOrder.NullOrdering.NullsLast)),
+            SortOrder.Descending,
+            SortOrder.NullsLast)),
           Option(WindowFrame(colFrameType, colLower, colUpper)))),
       expressions.WindowExpression(
         analysis.UnresolvedFunction(
@@ -235,15 +254,15 @@ class ColumnNodeToExpressionConverterSuite extends SparkFunSuite {
           Nil,
           expressions.UnspecifiedFrame)))
     testWindowFrame(
-      WindowFrame.FrameType.Row,
+      WindowFrame.Row,
       WindowFrame.Value(Literal(-10)),
-      WindowFrame.Unbounded,
+      WindowFrame.UnboundedFollowing,
       expressions.RowFrame,
       expressions.Literal(-10),
       expressions.UnboundedFollowing)
     testWindowFrame(
-      WindowFrame.FrameType.Range,
-      WindowFrame.Unbounded,
+      WindowFrame.Range,
+      WindowFrame.UnboundedPreceding,
       WindowFrame.CurrentRow,
       expressions.RangeFrame,
       expressions.UnboundedPreceding,
@@ -301,14 +320,6 @@ class ColumnNodeToExpressionConverterSuite extends SparkFunSuite {
 
   test("udf") {
     val int2LongSum = new aggregate.TypedSumLong[Int]((i: Int) => i.toLong)
-    val aggregator = UserDefinedFunction(
-      int2LongSum,
-      toAny(AgnosticEncoders.PrimitiveLongEncoder),
-      toAny(AgnosticEncoders.PrimitiveIntEncoder) :: Nil,
-      name = Option("int2LongSum"),
-      nonNullable = false,
-      deterministic = true)
-
     val bufferEncoder = encoderFor(int2LongSum.bufferEncoder)
     val outputEncoder = encoderFor(int2LongSum.outputEncoder)
     val bufferAttrs = bufferEncoder.namedExpressions.map {
@@ -317,7 +328,7 @@ class ColumnNodeToExpressionConverterSuite extends SparkFunSuite {
 
     // Aggregator applied on the entire Dataset.
     testConversion(
-      InvokeInlineUserDefinedFunction(aggregator, Nil),
+      InvokeInlineUserDefinedFunction(int2LongSum, Nil),
       aggregate.SimpleTypedAggregateExpression(
         aggregator = int2LongSum.asInstanceOf[Aggregator[Any, Any, Any]],
         inputDeserializer = None,
@@ -336,12 +347,18 @@ class ColumnNodeToExpressionConverterSuite extends SparkFunSuite {
 
     // Aggregator applied on an input.
     testConversion(
-      InvokeInlineUserDefinedFunction(aggregator, UnresolvedAttribute("i_col") :: Nil),
+      InvokeInlineUserDefinedFunction(
+        UserDefinedAggregator(
+          aggregator = int2LongSum,
+          inputEncoder = AgnosticEncoders.PrimitiveIntEncoder,
+          nullable = false,
+          givenName = Option("int2LongSum")),
+        UnresolvedAttribute("i_col") :: Nil),
       aggregate.ScalaAggregator(
         children = analysis.UnresolvedAttribute("i_col") :: Nil,
         agg = int2LongSum,
-        inputEncoder = encoderFor(AgnosticEncoders.PrimitiveIntEncoder),
-        bufferEncoder = encoderFor(AgnosticEncoders.PrimitiveLongEncoder),
+        inputEncoder = encoderFor(PrimitiveIntEncoder),
+        bufferEncoder = encoderFor(PrimitiveLongEncoder),
         nullable = false,
         aggregatorName = Option("int2LongSum")).toAggregateExpression())
 
@@ -349,12 +366,12 @@ class ColumnNodeToExpressionConverterSuite extends SparkFunSuite {
     val concat = (a: String, b: String) => a + b
     testConversion(
       InvokeInlineUserDefinedFunction(
-        UserDefinedFunction(
-          function = concat,
-          resultEncoder = toAny(AgnosticEncoders.StringEncoder),
-          AgnosticEncoders.UnboundEncoder :: toAny(AgnosticEncoders.StringEncoder) :: Nil,
-          name = None,
-          nonNullable = true,
+        SparkUserDefinedFunction(
+          f = concat,
+          inputEncoders = None :: Option(encoderFor(StringEncoder)) :: Nil,
+          outputEncoder = Option(encoderFor(StringEncoder)),
+          dataType = StringType,
+          nullable = false,
           deterministic = false),
         Seq(UnresolvedAttribute("a"), UnresolvedAttribute("b"))),
       expressions.ScalaUDF(
@@ -370,11 +387,17 @@ class ColumnNodeToExpressionConverterSuite extends SparkFunSuite {
 
   test("extension") {
     testConversion(
-      Extension(analysis.UnresolvedAttribute("bar")),
+      Wrapper(analysis.UnresolvedAttribute("bar")),
       analysis.UnresolvedAttribute("bar"))
   }
 
   test("unsupported") {
-    intercept[SparkException](Converter(Extension("kaboom")))
+    intercept[SparkException](Converter(Nope()))
   }
+}
+
+private[internal] case class Nope(override val origin: Origin = CurrentOrigin.get)
+  extends ColumnNode {
+  override private[internal] def normalize(): Nope = this
+  override def sql: String = "nope"
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds the ColumnNode.sql and ColumnNode.normalize functions. Both are needed when we integrate ColumnNode in the Column. This PR also improves some of the UDF handling.

### Why are the changes needed?
ColumnNode needs to support all the functionality needed by Column.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
(Improved) existing tests, and added a test suite for sql and normalize.

### Was this patch authored or co-authored using generative AI tooling?
No.