### PR TITLE
[SPARK-49232][INFRA][TESTS] Remove `3.4.2` from `SKIP_SPARK_RELEASE_VERSIONS`

### DIFF
--- a/.github/workflows/build_maven.yml
+++ b/.github/workflows/build_maven.yml
@@ -30,8 +30,3 @@ jobs:
     name: Run
     uses: ./.github/workflows/maven_test.yml
     if: github.repository == 'apache/spark'
-    with:
-      envs: >-
-        {
-          "SKIP_SPARK_RELEASE_VERSIONS": "3.4.2"
-        }

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/HiveExternalCatalogVersionsSuite.scala
@@ -248,12 +248,6 @@ class HiveExternalCatalogVersionsSuite extends SparkSubmitTestUtils {
 }
 
 object PROCESS_TABLES extends QueryTest with SQLTestUtils {
-  // TODO In SPARK-46302, the env SKIP_SPARK_RELEASE_VERSIONS has been added to
-  //  allow Maven tests to skip problematic release versions.
-  //  Related issues will be fixed in SPARK-46400, and testing will be resumed
-  //  after the fixed Spark 3.x version is released.
-  private val skipReleaseVersions =
-    sys.env.getOrElse("SKIP_SPARK_RELEASE_VERSIONS", "").split(",").toSet
   val isPythonVersionAvailable = TestUtils.isPythonVersionAvailable
   val releaseMirror = sys.env.getOrElse("SPARK_RELEASE_MIRROR",
     "https://dist.apache.org/repos/dist/release")
@@ -268,8 +262,7 @@ object PROCESS_TABLES extends QueryTest with SQLTestUtils {
         .filter(_.contains("""<a href="spark-"""))
         .filterNot(_.contains("preview"))
         .map("""<a href="spark-(\d.\d.\d)/">""".r.findFirstMatchIn(_).get.group(1))
-        .filter(_ < org.apache.spark.SPARK_VERSION)
-        .filterNot(skipReleaseVersions.contains).toImmutableArraySeq
+        .filter(_ < org.apache.spark.SPARK_VERSION).toImmutableArraySeq
     } catch {
       // Do not throw exception during object initialization.
       case NonFatal(_) => Nil


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to remove `3.4.2` from `SKIP_SPARK_RELEASE_VERSIONS(build_maven.yml)`.


### Why are the changes needed?
- Why was `SKIP_SPARK_RELEASE_VERSIONS` introduced? See here: https://issues.apache.org/jira/browse/SPARK-46400

- [SPARK-46400](https://github.com/apache/spark/pull/45017) has already merged into Spark `3.4.3`, and the corresponding issue no longer exists for Spark `3.4.3+`

- The following location only includes `the version` we have `fixed` for this issue
  https://dist.apache.org/repos/dist/release/spark/
  <img width="433" alt="image" src="https://github.com/user-attachments/assets/bfdf8bca-b972-490a-bc19-cb95eb83a352">

### Does this PR introduce _any_ user-facing change?
No, only for GA's tests.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.