### PR TITLE
[MINOR][DOCS] Explicitly mention RDD/SparkContext are unsupported in Spark Connect

### DIFF
--- a/docs/spark-connect-overview.md
+++ b/docs/spark-connect-overview.md
@@ -409,6 +409,6 @@ Majority of the Streaming API is supported, including
 [StreamingQueryListener](api/scala/org/apache/spark/sql/streaming/StreamingQueryListener.html).
 
 APIs such as [SparkContext](api/scala/org/apache/spark/SparkContext.html)
-and [RDD](api/scala/org/apache/spark/rdd/RDD.html) are deprecated in all Spark Connect versions.
+and [RDD](api/scala/org/apache/spark/rdd/RDD.html) are unsupported in Spark Connect.
 
 Support for more APIs is planned for upcoming Spark releases.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to explicitly mention RDD/SparkContext are unsupported in Spark Connect instead of saying they are deprecated.

### Why are the changes needed?

To guide users properly about supported API.

### Does this PR introduce _any_ user-facing change?

Yes, it fixes the user-facing documentation.

### How was this patch tested?

Documentation build

### Was this patch authored or co-authored using generative AI tooling?

No.