### PR TITLE
[SPARK-45854][SQL] listTables should not fail with a temp view and DelegatingCatalogExtension

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/CatalogExtension.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/CatalogExtension.java
@@ -37,4 +37,6 @@ public interface CatalogExtension extends TableCatalog, FunctionCatalog, Support
    * {@link #initialize(String, CaseInsensitiveStringMap)} is called.
    */
   void setDelegateCatalog(CatalogPlugin delegate);
+
+  CatalogPlugin getDelegateCatalog();
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DelegatingCatalogExtension.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/DelegatingCatalogExtension.java
@@ -46,6 +46,11 @@ public abstract class DelegatingCatalogExtension implements CatalogExtension {
   }
 
   @Override
+  public final CatalogPlugin getDelegateCatalog() {
+    return delegate;
+  }
+
+  @Override
   public String name() {
     return delegate.name();
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowTablesExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowTablesExec.scala
@@ -22,7 +22,7 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.util.StringUtils
-import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
+import org.apache.spark.sql.connector.catalog.{DelegatingCatalogExtension, Identifier, TableCatalog}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.NamespaceHelper
 import org.apache.spark.sql.execution.LeafExecNode
 
@@ -50,6 +50,8 @@ case class ShowTablesExec(
   private def isTempView(ident: Identifier): Boolean = {
     catalog match {
       case s: V2SessionCatalog => s.isTempView(ident)
+      case d: DelegatingCatalogExtension if d.getDelegateCatalog().isInstanceOf[V2SessionCatalog] =>
+        d.getDelegateCatalog().asInstanceOf[V2SessionCatalog].isTempView(ident)
       case _ => false
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix `spark.catalog.listTables()` failing when there is a temp view when the catalog is a V2 session catalog extending DelegatingCatalogExtension.

### Why are the changes needed?
Some third-party libraries such as Delta Lake provide its own V2 session catalog implementation with DelegatingCatalogExtension. When using those libraries, `spark.catalog.listTable()` failed with an incomprehensible error like this:

```
org.apache.spark.sql.catalyst.parser.ParseException: [PARSE_EMPTY_STATEMENT] Syntax error, unexpected empty statement. SQLSTATE: 42617 (line 1, pos 0)
```

### Does this PR introduce _any_ user-facing change?
Fixes the issue

### How was this patch tested?
Unit tests added

### Was this patch authored or co-authored using generative AI tooling?
No
