### PR TITLE
[SPARK-49137][SQL][FOLLOWUP] Assign a reasonable error condition, when the Boolean condition in the if statement returns an empty row

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -125,6 +125,12 @@
     ],
     "sqlState" : "22003"
   },
+  "BOOLEAN_STATEMENT_EMPTY_ROWS" : {
+    "message" : [
+      "Boolean statement <invalidStatement> is invalid. It returns an empty row."
+    ],
+    "sqlState" : "21000"
+  },
   "CALL_ON_STREAMING_DATASET_UNSUPPORTED" : {
     "message" : [
       "The method <methodName> can not be called on streaming Dataset/DataFrame."

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -125,9 +125,9 @@
     ],
     "sqlState" : "22003"
   },
-  "BOOLEAN_STATEMENT_EMPTY_ROWS" : {
+  "BOOLEAN_STATEMENT_WITH_EMPTY_ROW" : {
     "message" : [
-      "Boolean statement <invalidStatement> is invalid. It returns an empty row."
+      "Boolean statement <invalidStatement> is invalid. Expected single row with a value of the BOOLEAN type, but got an empty row."
     ],
     "sqlState" : "21000"
   },

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
@@ -74,4 +74,14 @@ private[sql] object SqlScriptingErrors {
       cause = null,
       messageParameters = Map("invalidStatement" -> toSQLStmt(stmt)))
   }
+
+  def booleanStatementEmptyRows(
+      origin: Origin,
+      stmt: String): Throwable = {
+    new SqlScriptingException(
+      origin = origin,
+      errorClass = "BOOLEAN_STATEMENT_EMPTY_ROWS",
+      cause = null,
+      messageParameters = Map("invalidStatement" -> toSQLStmt(stmt)))
+  }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
@@ -75,7 +75,7 @@ private[sql] object SqlScriptingErrors {
       messageParameters = Map("invalidStatement" -> toSQLStmt(stmt)))
   }
 
-  def booleanStatementEmptyRows(
+  def booleanStatementWithEmptyRow(
       origin: Origin,
       stmt: String): Throwable = {
     new SqlScriptingException(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
@@ -80,7 +80,7 @@ private[sql] object SqlScriptingErrors {
       stmt: String): Throwable = {
     new SqlScriptingException(
       origin = origin,
-      errorClass = "BOOLEAN_STATEMENT_EMPTY_ROWS",
+      errorClass = "BOOLEAN_STATEMENT_WITH_EMPTY_ROW",
       cause = null,
       messageParameters = Map("invalidStatement" -> toSQLStmt(stmt)))
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -81,7 +81,12 @@ trait NonLeafStatementExec extends CompoundStatementExec {
       df.schema.fields match {
         case Array(field) if field.dataType == BooleanType =>
           df.limit(2).collect() match {
-            case Array(row) => row.getBoolean(0)
+            case Array(row) =>
+              if (row.isNullAt(0)) {
+                throw SqlScriptingErrors.booleanStatementEmptyRows(
+                  statement.origin, statement.getText)
+              }
+              row.getBoolean(0)
             case _ =>
               throw SparkException.internalError(
                 s"Boolean statement ${statement.getText} is invalid. It returns more than one row.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -83,7 +83,7 @@ trait NonLeafStatementExec extends CompoundStatementExec {
           df.limit(2).collect() match {
             case Array(row) =>
               if (row.isNullAt(0)) {
-                throw SqlScriptingErrors.booleanStatementEmptyRows(
+                throw SqlScriptingErrors.booleanStatementWithEmptyRow(
                   statement.origin, statement.getText)
               }
               row.getBoolean(0)

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -395,7 +395,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         """
           |BEGIN
           |  CREATE TABLE t1 (a BOOLEAN) USING parquet;
-          |  IF (select * from t1) THEN
+          |  IF (SELECT * FROM t1) THEN
           |    SELECT 46;
           |  END IF;
           |END
@@ -415,7 +415,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
           |  CREATE TABLE t2 (a BOOLEAN) USING parquet;
           |  INSERT INTO t2 VALUES (true);
           |  INSERT INTO t2 VALUES (true);
-          |  IF (select * from t2) THEN
+          |  IF (SELECT * FROM t2) THEN
           |    SELECT 46;
           |  END IF;
           |END

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -404,7 +404,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         exception = intercept[SqlScriptingException] (
           runSqlScript(commands1)
         ),
-        errorClass = "BOOLEAN_STATEMENT_EMPTY_ROWS",
+        errorClass = "BOOLEAN_STATEMENT_WITH_EMPTY_ROW",
         parameters = Map("invalidStatement" -> "(SELECT * FROM T1)")
       )
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -389,25 +389,44 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
   }
 
   test("if's condition must return a single row data") {
-    withTable("t") {
-      val commands =
+    withTable("t1", "t2") {
+      // empty row
+      val commands1 =
         """
           |BEGIN
-          |  CREATE TABLE t (a BOOLEAN) USING parquet;
-          |  INSERT INTO t VALUES (true);
-          |  INSERT INTO t VALUES (true);
-          |  IF (select * from t) THEN
+          |  CREATE TABLE t1 (a BOOLEAN) USING parquet;
+          |  IF (select * from t1) THEN
+          |    SELECT 46;
+          |  END IF;
+          |END
+          |""".stripMargin
+      checkError(
+        exception = intercept[SqlScriptingException] (
+          runSqlScript(commands1)
+        ),
+        errorClass = "BOOLEAN_STATEMENT_EMPTY_ROWS",
+        parameters = Map("invalidStatement" -> "(SELECT * FROM T1)")
+      )
+
+      // too many rows ( > 1 )
+      val commands2 =
+        """
+          |BEGIN
+          |  CREATE TABLE t2 (a BOOLEAN) USING parquet;
+          |  INSERT INTO t2 VALUES (true);
+          |  INSERT INTO t2 VALUES (true);
+          |  IF (select * from t2) THEN
           |    SELECT 46;
           |  END IF;
           |END
           |""".stripMargin
       checkError(
         exception = intercept[SparkException] (
-          runSqlScript(commands)
+          runSqlScript(commands2)
         ),
         errorClass = "SCALAR_SUBQUERY_TOO_MANY_ROWS",
         parameters = Map.empty,
-        context = ExpectedContext(fragment = "(select * from t)", start = 118, stop = 134)
+        context = ExpectedContext(fragment = "(select * from t2)", start = 121, stop = 138)
       )
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -426,7 +426,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         ),
         errorClass = "SCALAR_SUBQUERY_TOO_MANY_ROWS",
         parameters = Map.empty,
-        context = ExpectedContext(fragment = "(select * from t2)", start = 121, stop = 138)
+        context = ExpectedContext(fragment = "(SELECT * FROM t2)", start = 121, stop = 138)
       )
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr is following up https://github.com/apache/spark/pull/47648.
The pr aims to assign a reasonable `error condition`, when `the Boolean condition in the if statement` returns `an empty row`.

### Why are the changes needed?
In the previous PR, we overlooked a scenario where `the Boolean condition in the if statement` returns `an empty row`.

```
BEGIN
  CREATE TABLE t1 (a BOOLEAN) USING parquet;
  IF (select * from t1) THEN
    SELECT 46;
  END IF;
END
```

- Before:
```
[ROW_VALUE_IS_NULL] Found NULL in a row at the index 0, expected a non-NULL value. SQLSTATE: 22023
org.apache.spark.SparkRuntimeException: [ROW_VALUE_IS_NULL] Found NULL in a row at the index 0, expected a non-NULL value. SQLSTATE: 22023
	at org.apache.spark.sql.errors.DataTypeErrors$.valueIsNullError(DataTypeErrors.scala:275)
	at org.apache.spark.sql.Row.getAnyValAs(Row.scala:536)
	at org.apache.spark.sql.Row.getBoolean(Row.scala:224)
	at org.apache.spark.sql.Row.getBoolean$(Row.scala:224)
	at org.apache.spark.sql.catalyst.expressions.GenericRow.getBoolean(rows.scala:28)
	at org.apache.spark.sql.scripting.NonLeafStatementExec.evaluateBooleanCondition(SqlScriptingExecutionNode.scala:84)
	at org.apache.spark.sql.scripting.NonLeafStatementExec.evaluateBooleanCondition$(SqlScriptingExecutionNode.scala:71)
	at org.apache.spark.sql.scripting.IfElseStatementExec.evaluateBooleanCondition(SqlScriptingExecutionNode.scala:206)
	at org.apache.spark.sql.scripting.IfElseStatementExec$$anon$2.next(SqlScriptingExecutionNode.scala:230)
	at org.apache.spark.sql.scripting.IfElseStatementExec$$anon$2.next(SqlScriptingExecutionNode.scala:223)
	at org.apache.spark.sql.scripting.CompoundNestedStatementIteratorExec$$anon$1.next(SqlScriptingExecutionNode.scala:168)
	at org.apache.spark.sql.scripting.CompoundNestedStatementIteratorExec$$anon$1.next(SqlScriptingExecutionNode.scala:146)
```


- After:
```
{LINE:4} [BOOLEAN_STATEMENT_EMPTY_ROWS] Boolean statement (SELECT * FROM T1) is invalid. It returns an empty row. SQLSTATE: 21000
org.apache.spark.sql.exceptions.SqlScriptingException: {LINE:4} [BOOLEAN_STATEMENT_EMPTY_ROWS] Boolean statement (SELECT * FROM T1) is invalid. It returns an empty row. SQLSTATE: 21000
	at org.apache.spark.sql.errors.SqlScriptingErrors$.booleanStatementEmptyRows(SqlScriptingErrors.scala:85)
	at org.apache.spark.sql.scripting.NonLeafStatementExec.evaluateBooleanCondition(SqlScriptingExecutionNode.scala:87)
	at org.apache.spark.sql.scripting.NonLeafStatementExec.evaluateBooleanCondition$(SqlScriptingExecutionNode.scala:71)
	at org.apache.spark.sql.scripting.IfElseStatementExec.evaluateBooleanCondition(SqlScriptingExecutionNode.scala:211)
	at org.apache.spark.sql.scripting.IfElseStatementExec$$anon$2.next(SqlScriptingExecutionNode.scala:235)
	at org.apache.spark.sql.scripting.IfElseStatementExec$$anon$2.next(SqlScriptingExecutionNode.scala:228)
	at org.apache.spark.sql.scripting.CompoundNestedStatementIteratorExec$$anon$1.next(SqlScriptingExecutionNode.scala:173)
	at org.apache.spark.sql.scripting.CompoundNestedStatementIteratorExec$$anon$1.next(SqlScriptingExecutionNode.scala:151)
```


### Does this PR introduce _any_ user-facing change?
Yes, provide end-users with a more user-friendly error message.


### How was this patch tested?
Add new UT.


### Was this patch authored or co-authored using generative AI tooling?
No.
