### PR TITLE
[MINOR][SQL] Remove unnecessary asserts from loop iterators

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -225,7 +225,6 @@ class IfElseStatementExec(
 
       override def next(): CompoundStatementExec = state match {
         case IfElseState.Condition =>
-          assert(curr.get.isInstanceOf[SingleStatementExec])
           val condition = curr.get.asInstanceOf[SingleStatementExec]
           if (evaluateBooleanCondition(session, condition)) {
             state = IfElseState.Body
@@ -293,7 +292,6 @@ class WhileStatementExec(
 
       override def next(): CompoundStatementExec = state match {
           case WhileState.Condition =>
-            assert(curr.get.isInstanceOf[SingleStatementExec])
             val condition = curr.get.asInstanceOf[SingleStatementExec]
             if (evaluateBooleanCondition(session, condition)) {
               state = WhileState.Body


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove unnecessary checks in the code to make it cleaner.

### Why are the changes needed?
We are sure that `condition` is `SingleStatementExec` and if `assert(curr.get.isInstanceOf[SingleStatementExec])` passes we are still not sure if everything is working correctly. If it fails, we are sure something is wrong, but then it represents the bug in our `iterator` code and should be caught by different unit tests .  

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No.
