### PR TITLE
[SPARK-49243][INFRA][K8S] Add `OpenContainers` Annotations in docker images

### DIFF
--- a/dev/create-release/spark-rm/Dockerfile
+++ b/dev/create-release/spark-rm/Dockerfile
@@ -20,6 +20,7 @@ FROM ubuntu:jammy-20240227
 LABEL org.opencontainers.image.authors="Apache Spark project <dev@spark.apache.org>"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.ref.name="Apache Spark Release Manager Image"
+# Overwrite this label to avoid exposing the underlying Ubuntu OS version label
 LABEL org.opencontainers.image.version=""
 
 ENV FULL_REFRESH_DATE 20240318

--- a/dev/create-release/spark-rm/Dockerfile
+++ b/dev/create-release/spark-rm/Dockerfile
@@ -17,6 +17,10 @@
 
 # Image for building Spark releases. Based on Ubuntu 22.04.
 FROM ubuntu:jammy-20240227
+LABEL org.opencontainers.image.authors="Apache Spark project <dev@spark.apache.org>"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.ref.name="Apache Spark Release Manager Image"
+LABEL org.opencontainers.image.version=""
 
 ENV FULL_REFRESH_DATE 20240318
 

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -21,6 +21,7 @@ FROM ubuntu:jammy-20240227
 LABEL org.opencontainers.image.authors="Apache Spark project <dev@spark.apache.org>"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.ref.name="Apache Spark Infra Image"
+# Overwrite this label to avoid exposing the underlying Ubuntu OS version label
 LABEL org.opencontainers.image.version=""
 
 ENV FULL_REFRESH_DATE 20240318

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -18,6 +18,10 @@
 # Image for building and testing Spark branches. Based on Ubuntu 22.04.
 # See also in https://hub.docker.com/_/ubuntu
 FROM ubuntu:jammy-20240227
+LABEL org.opencontainers.image.authors="Apache Spark project <dev@spark.apache.org>"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.ref.name="Apache Spark Infra Image"
+LABEL org.opencontainers.image.version=""
 
 ENV FULL_REFRESH_DATE 20240318
 

--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -20,6 +20,7 @@ FROM azul/zulu-openjdk:${java_image_tag}
 LABEL org.opencontainers.image.authors="Apache Spark project <dev@spark.apache.org>"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.ref.name="Apache Spark Scala/Java Image"
+# Overwrite this label to avoid exposing the underlying Ubuntu OS version label
 LABEL org.opencontainers.image.version=""
 
 ARG spark_uid=185

--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile
@@ -17,6 +17,10 @@
 ARG java_image_tag=21
 
 FROM azul/zulu-openjdk:${java_image_tag}
+LABEL org.opencontainers.image.authors="Apache Spark project <dev@spark.apache.org>"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.ref.name="Apache Spark Scala/Java Image"
+LABEL org.opencontainers.image.version=""
 
 ARG spark_uid=185
 

--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/R/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/R/Dockerfile
@@ -21,6 +21,7 @@ FROM ${base_img:-spark}
 LABEL org.opencontainers.image.authors="Apache Spark project <dev@spark.apache.org>"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.ref.name="Apache Spark R Image"
+# Overwrite this label to avoid exposing the underlying Ubuntu OS version label
 LABEL org.opencontainers.image.version=""
 WORKDIR /
 

--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/R/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/R/Dockerfile
@@ -18,6 +18,10 @@
 ARG base_img
 
 FROM ${base_img:-spark}
+LABEL org.opencontainers.image.authors="Apache Spark project <dev@spark.apache.org>"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.ref.name="Apache Spark R Image"
+LABEL org.opencontainers.image.version=""
 WORKDIR /
 
 # Reset to root to run installation tasks

--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile
@@ -18,6 +18,10 @@
 ARG base_img
 
 FROM ${base_img:-spark}
+LABEL org.opencontainers.image.authors="Apache Spark project <dev@spark.apache.org>"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.ref.name="Apache Spark Python Image"
+LABEL org.opencontainers.image.version=""
 WORKDIR /
 
 # Reset to root to run installation tasks

--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile
@@ -21,6 +21,7 @@ FROM ${base_img:-spark}
 LABEL org.opencontainers.image.authors="Apache Spark project <dev@spark.apache.org>"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.ref.name="Apache Spark Python Image"
+# Overwrite this label to avoid exposing the underlying Ubuntu OS version label
 LABEL org.opencontainers.image.version=""
 WORKDIR /
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `OpenContainers` Annotations to docker image to add metadata like `Apache License`.

- https://specs.opencontainers.org/image-spec/annotations/

### Why are the changes needed?

**BEFORE**
```
$ docker inspect apache/spark:3.5.2 | jq '.[0].Config.Labels'
{
  "org.opencontainers.image.ref.name": "ubuntu",
  "org.opencontainers.image.version": "20.04"
}
```

**AFTER**

```
$ NO_MANUAL=1 ./dev/make-distribution.sh -Pkubernetes
$ bin/docker-image-tool.sh -t SPARK-49243 -n build
$ docker inspect spark:SPARK-49243 | jq '.[0].Config.Labels'
{
  "org.opencontainers.image.authors": "Apache Spark project <dev@spark.apache.org>",
  "org.opencontainers.image.licenses": "Apache-2.0",
  "org.opencontainers.image.ref.name": "Apache Spark Scala/Java Image",
  "org.opencontainers.image.version": ""
}
```

### Does this PR introduce _any_ user-facing change?

No, it's only a metadata change.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.