### PR TITLE
[MINOR][SQL][TESTS] Changes the `test:runMain` in the code comments to `Test/runMain`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/GenTPCDSData.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/GenTPCDSData.scala
@@ -359,7 +359,7 @@ class GenTPCDSDataConfig(args: Array[String]) {
   private def printUsageAndExit(exitCode: Int): Unit = {
     // scalastyle:off
     System.err.println("""
-      |build/sbt "test:runMain <this class> [Options]"
+      |build/sbt "Test/runMain <this class> [Options]"
       |Options:
       |  --master                        the Spark master to use, default to local[*]
       |  --dsdgenDir                     location of dsdgen

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArrayBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExternalAppendOnlyUnsafeRowArrayBenchmark.scala
@@ -33,9 +33,9 @@ import org.apache.spark.util.collection.unsafe.sort.UnsafeExternalSorter
  *   1. without sbt:
  *      bin/spark-submit --class <this class> --jars <spark core test jar> <spark sql test jar>
  *   2. build/sbt build/sbt ";project sql;set javaOptions
- *        in Test += \"-Dspark.memory.debugFill=false\";test:runMain <this class>"
+ *        in Test += \"-Dspark.memory.debugFill=false\";Test/runMain <this class>"
  *   3. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt ";project sql;set javaOptions
- *        in Test += \"-Dspark.memory.debugFill=false\";test:runMain <this class>"
+ *        in Test += \"-Dspark.memory.debugFill=false\";Test/runMain <this class>"
  *      Results will be written to
  *      "benchmarks/ExternalAppendOnlyUnsafeRowArrayBenchmark-results.txt".
  * }}}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TakeOrderedAndProjectBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TakeOrderedAndProjectBenchmark.scala
@@ -28,9 +28,9 @@ import org.apache.spark.sql.internal.SQLConf
  *   1. without sbt:
  *      bin/spark-submit --class <this class>
  *        --jars <spark core test jar>,<spark catalyst test jar> <sql core test jar>
- *   2. build/sbt "sql/test:runMain <this class>"
+ *   2. build/sbt "sql/Test/runMain <this class>"
  *   3. generate result:
- *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain <this class>"
+ *      SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/Test/runMain <this class>"
  *      Results will be written to "benchmarks/TakeOrderedAndProjectBenchmark-results.txt".
  * }}}
  */

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TopKBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/TopKBenchmark.scala
@@ -26,8 +26,8 @@ import org.apache.spark.sql.internal.SQLConf.WINDOW_GROUP_LIMIT_THRESHOLD
  * {{{
  *   1. without sbt: bin/spark-submit --class <this class>
  *      --jars <spark core test jar>,<spark catalyst test jar> <spark sql test jar>
- *   2. build/sbt "sql/test:runMain <this class>"
- *   3. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/test:runMain <this class>"
+ *   2. build/sbt "sql/Test/runMain <this class>"
+ *   3. generate result: SPARK_GENERATE_BENCHMARK_FILES=1 build/sbt "sql/Test/runMain <this class>"
  *      Results will be written to "benchmarks/TopKBenchmark-results.txt".
  * }}}
  */


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR only changes the `test:runMain` description related to run command in the code comments to `Test/runMain`.

### Why are the changes needed?
When we use the execution command in the code comments, we will see the following compilation warning:


```
build/sbt "sql/test:runMain org.apache.spark.sql.execution.benchmark.TopKBenchmark"
```

```
[warn] sbt 0.13 shell syntax is deprecated; use slash syntax instead: sql / Test / runMain
```

The relevant comments should be updated to eliminate the compilation warnings when run the command.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually run the test using the updated command and check that the corresponding compilation warning is no longer present.


### Was this patch authored or co-authored using generative AI tooling?
No
