### PR TITLE
[SPARK-45590][BUILD][3.4] Upgrade okio to 1.17.6 from 1.15.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-2-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-2-hive-2.3
@@ -220,7 +220,7 @@ netty-transport-native-unix-common/4.1.87.Final//netty-transport-native-unix-com
 netty-transport/4.1.87.Final//netty-transport-4.1.87.Final.jar
 objenesis/3.2//objenesis-3.2.jar
 okhttp/3.12.12//okhttp-3.12.12.jar
-okio/1.15.0//okio-1.15.0.jar
+okio/1.17.6//okio-1.17.6.jar
 opencsv/2.3//opencsv-2.3.jar
 orc-core/1.8.7/shaded-protobuf/orc-core-1.8.7-shaded-protobuf.jar
 orc-mapreduce/1.8.7/shaded-protobuf/orc-mapreduce-1.8.7-shaded-protobuf.jar

--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -204,7 +204,7 @@ netty-transport-native-unix-common/4.1.87.Final//netty-transport-native-unix-com
 netty-transport/4.1.87.Final//netty-transport-4.1.87.Final.jar
 objenesis/3.2//objenesis-3.2.jar
 okhttp/3.12.12//okhttp-3.12.12.jar
-okio/1.15.0//okio-1.15.0.jar
+okio/1.17.6//okio-1.17.6.jar
 opencsv/2.3//opencsv-2.3.jar
 opentracing-api/0.33.0//opentracing-api-0.33.0.jar
 opentracing-noop/0.33.0//opentracing-noop-0.33.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,7 @@
     <!-- org.fusesource.leveldbjni will be used except on arm64 platform. -->
     <leveldbjni.group>org.fusesource.leveldbjni</leveldbjni.group>
     <kubernetes-client.version>6.4.1</kubernetes-client.version>
+    <okio.version>1.17.6</okio.version>
 
     <test.java.home>${java.home}</test.java.home>
 
@@ -2789,6 +2790,11 @@
         <groupId>dev.ludovic.netlib</groupId>
         <artifactId>arpack</artifactId>
         <version>${netlib.ludovic.dev.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okio</groupId>
+        <artifactId>okio</artifactId>
+        <version>${okio.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Backport #47758 to 3.4

### What changes were proposed in this pull request?

This PR aims to upgrade `okio` from 1.15.0 to 1.17.6.

### Why are the changes needed?

Okio 1.15.0 is vulnerable due to CVE-2023-3635,  details: https://nvd.nist.gov/vuln/detail/CVE-2023-3635

Previous attempts to fix this security issue:

Update okio to version 1.17.6 #5587: https://github.com/fabric8io/kubernetes-client/pull/5587
Followup to Update okio to version 1.17.6 #5935: https://github.com/fabric8io/kubernetes-client/pull/5935

Unfortunately it is still using 1.15.0:

https://github.com/apache/spark/blob/v4.0.0-preview1/dev/deps/spark-deps-hadoop-3-hive-2.3#L227 https://github.com/apache/spark/blob/v3.5.2/dev/deps/spark-deps-hadoop-3-hive-2.3#L210

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.