### PR TITLE
[SPARK-49250][SQL] Improve error message for nested UnresolvedWindowExpression in CheckAnalysis

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -305,6 +305,11 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
               throw QueryCompilationErrors.invalidStarUsageError(operator.nodeName, Seq(s))
             }
 
+          // Should be before `e.checkInputDataTypes()` to produce the correct error for unknown
+          // window expressions nested inside other expressions
+          case UnresolvedWindowExpression(_, WindowSpecReference(windowName)) =>
+            throw QueryCompilationErrors.windowSpecificationNotDefinedError(windowName)
+
           case e: Expression if e.checkInputDataTypes().isFailure =>
             e.checkInputDataTypes() match {
               case checkRes: TypeCheckResult.DataTypeMismatch =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

When `CheckAnalysis` encounters `UnresolvedWindowExpression` in `Project` or `Aggregate`, it throws `QueryCompilationErrors.windowSpecificationNotDefinedError`:
- https://github.com/apache/spark/commit/4718d59c6c4
- https://github.com/apache/spark/commit/0b48d3f61b7

However, consider the following query:

`SELECT (SUM(col1) OVER(unspecified_window) / 1) FROM VALUES (1)`

Here `UnreolvedWindowExpression` is wrapped into the division expression. And `CheckAnalysis` throws a different unrelated `org.apache.spark.sql.catalyst.analysis.UnresolvedException: [INTERNAL_ERROR] Invalid call to dataType on unresolved object SQLSTATE: XX000` exception earlier from this [case](https://github.com/apache/spark/blob/0b48d3f61b726209e96b0b967530534b5ad9101d/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala#L308).

The solution to improve this would be to match `UnreolvedWindowExpression` early.

### Why are the changes needed?

To improve error message for incorrect window usage.


### Does this PR introduce _any_ user-facing change?

Yes, the error message is better now


### How was this patch tested?

Added a unit test


### Was this patch authored or co-authored using generative AI tooling?

No