### PR TITLE
[MINOR][DOCS] Use `SparkSession.builder.getOrCreate()` over the deprecated `build()`

### DIFF
--- a/docs/spark-connect-overview.md
+++ b/docs/spark-connect-overview.md
@@ -271,7 +271,7 @@ The connection may also be programmatically created using _SparkSession#builder_
 
 {% highlight scala %}
 @ import org.apache.spark.sql.SparkSession
-@ val spark = SparkSession.builder.remote("sc://localhost:443/;token=ABCDEFG").build()
+@ val spark = SparkSession.builder.remote("sc://localhost:443/;token=ABCDEFG").getOrCreate()
 {% endhighlight %}
 
 </div>
@@ -344,7 +344,7 @@ your Spark server when you create a Spark session, as in this example:
 
 {% highlight scala %}
 import org.apache.spark.sql.SparkSession
-val spark = SparkSession.builder().remote("sc://localhost").build()
+val spark = SparkSession.builder().remote("sc://localhost").getOrCreate()
 {% endhighlight %}
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR replaces `SparkSession.builder.build()` with `SparkSession.builder.getOrCreate()`in Spark Connect overview documentation.

### Why are the changes needed?

To avoid encouraging users to use deprecated methods.

### Does this PR introduce _any_ user-facing change?

Yes, it guides users to use non-deprecated method.

### How was this patch tested?

Manually checked via Markdown editor.

### Was this patch authored or co-authored using generative AI tooling?

No.