### PR TITLE
[SPARK-48803][FOLLOWUP] Remove unused error-condition `_LEGACY_ERROR_TEMP_2088`

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -6794,11 +6794,6 @@
       "Invalid value `<n>` for parameter `<jdbcNumPartitions>` in table writing via JDBC. The minimum value is 1."
     ]
   },
-  "_LEGACY_ERROR_TEMP_2088" : {
-    "message" : [
-      "<dataType> is not supported yet."
-    ]
-  },
   "_LEGACY_ERROR_TEMP_2089" : {
     "message" : [
       "DataType: <catalogString>."


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr is following up  https://github.com/apache/spark/pull/47208.


### Why are the changes needed?
In this PR https://github.com/apache/spark/pull/47208, the method `dataTypeUnsupportedYetError` of using `_LEGACY_ERROR_TEMP_2088` has been removed, but the corresponding error condition `_LEGACY_ERROR_TEMP_2088` has not been synchronously deleted, and currently the Spark code repo no longer uses this error condition.
<img width="1022" alt="image" src="https://github.com/user-attachments/assets/19723637-3535-4162-9259-5ddcea0ee579">

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
