### PR TITLE
[SPARK-49263][CONNECT] Spark Connect python client: Consistently handle boolean Dataframe reader options

### DIFF
--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -281,9 +281,13 @@ class DataSource(LogicalPlan):
         assert schema is None or isinstance(schema, str)
 
         if options is not None:
+            new_options = {}
             for k, v in options.items():
-                assert isinstance(k, str)
-                assert v is None or isinstance(v, str)
+                if v is not None:
+                    assert isinstance(k, str)
+                    assert isinstance(v, str)
+                    new_options[k] = v
+            options = new_options
 
         if paths is not None:
             assert isinstance(paths, list)

--- a/python/pyspark/sql/connect/plan.py
+++ b/python/pyspark/sql/connect/plan.py
@@ -283,7 +283,7 @@ class DataSource(LogicalPlan):
         if options is not None:
             for k, v in options.items():
                 assert isinstance(k, str)
-                assert isinstance(v, str)
+                assert v is None or isinstance(v, str)
 
         if paths is not None:
             assert isinstance(paths, list)

--- a/python/pyspark/sql/connect/readwriter.py
+++ b/python/pyspark/sql/connect/readwriter.py
@@ -94,7 +94,7 @@ class DataFrameReader(OptionUtils):
     schema.__doc__ = PySparkDataFrameReader.schema.__doc__
 
     def option(self, key: str, value: "OptionalPrimitiveType") -> "DataFrameReader":
-        self._options[key] = str(value)
+        self._options[key] = to_str(value)
         return self
 
     option.__doc__ = PySparkDataFrameReader.option.__doc__

--- a/python/pyspark/sql/connect/readwriter.py
+++ b/python/pyspark/sql/connect/readwriter.py
@@ -94,7 +94,7 @@ class DataFrameReader(OptionUtils):
     schema.__doc__ = PySparkDataFrameReader.schema.__doc__
 
     def option(self, key: str, value: "OptionalPrimitiveType") -> "DataFrameReader":
-        self._options[key] = to_str(value)
+        self._options[key] = cast(str, to_str(value))
         return self
 
     option.__doc__ = PySparkDataFrameReader.option.__doc__

--- a/python/pyspark/sql/tests/test_datasources.py
+++ b/python/pyspark/sql/tests/test_datasources.py
@@ -211,7 +211,8 @@ class DataSourcesTestsMixin:
                 ]
             )
             df = (
-                self.spark.read.option("header", "true").option("quote", None)
+                self.spark.read.option("header", "true")
+                .option("quote", None)
                 .schema(schema)
                 .csv(path, enforceSchema=False)
             )

--- a/python/pyspark/sql/tests/test_datasources.py
+++ b/python/pyspark/sql/tests/test_datasources.py
@@ -211,7 +211,7 @@ class DataSourcesTestsMixin:
                 ]
             )
             df = (
-                self.spark.read.option("header", "true")
+                self.spark.read.option("header", True)
                 .schema(schema)
                 .csv(path, enforceSchema=False)
             )

--- a/python/pyspark/sql/tests/test_datasources.py
+++ b/python/pyspark/sql/tests/test_datasources.py
@@ -211,7 +211,7 @@ class DataSourcesTestsMixin:
                 ]
             )
             df = (
-                self.spark.read.option("header", True)
+                self.spark.read.option("header", "true").option("quote", None)
                 .schema(schema)
                 .csv(path, enforceSchema=False)
             )


### PR DESCRIPTION
### What changes were proposed in this pull request?

Using `spark.read.option("Foo", True)` resulted in an uppercase `'True'` string in Python Spark Connect client, while in all other cases (scala with both Spark Connect and no Spark Connect, pyspark with no Spark Connect) it would be normalized to `'true'`. This is because `to_str` helper should be used instead of `str`.

### Why are the changes needed?

This is now inconsistent with other cases. Passing `"True"` as boolean options seems to be breaking Delta CDF reader (to be fixed separately, that it should be able to handle the literal case-insensitively)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unittest added

### Was this patch authored or co-authored using generative AI tooling?

No.
