### PR TITLE
[SPARK-49268][CORE] Log IO exceptions in SHS history provider

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -1286,12 +1286,12 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         rebuildAppStore(store, reader, attempt.info.lastUpdated.getTime())
         hybridStore = store
       } catch {
-        case _: IOException if !retried =>
+        case ioe: IOException if !retried =>
           // compaction may touch the file(s) which app rebuild wants to read
           // compaction wouldn't run in short interval, so try again...
           logWarning(log"Exception occurred while rebuilding log path " +
             log"${MDC(PATH, attempt.logPath)} - " +
-            log"trying again...")
+            log"trying again...", ioe)
           store.close()
           memoryManager.release(appId, attempt.info.attemptId)
           retried = true
@@ -1359,11 +1359,11 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         }
         newStorePath = lease.commit(appId, attempt.info.attemptId)
       } catch {
-        case _: IOException if !retried =>
+        case ioe: IOException if !retried =>
           // compaction may touch the file(s) which app rebuild wants to read
           // compaction wouldn't run in short interval, so try again...
           logWarning(log"Exception occurred while rebuilding app ${MDC(APP_ID, appId)} - " +
-            log"trying again...")
+            log"trying again...", ioe)
           lease.rollback()
           retried = true
 
@@ -1387,11 +1387,11 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         rebuildAppStore(s, reader, attempt.info.lastUpdated.getTime())
         store = s
       } catch {
-        case _: IOException if !retried =>
+        case ioe: IOException if !retried =>
           // compaction may touch the file(s) which app rebuild wants to read
           // compaction wouldn't run in short interval, so try again...
           logWarning(log"Exception occurred while rebuilding log path " +
-            log"${MDC(LogKeys.PATH, attempt.logPath)} - trying again...")
+            log"${MDC(LogKeys.PATH, attempt.logPath)} - trying again...", ioe)
           retried = true
 
         case e: Exception =>

--- a/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/FsHistoryProvider.scala
@@ -1289,7 +1289,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         case ioe: IOException if !retried =>
           // compaction may touch the file(s) which app rebuild wants to read
           // compaction wouldn't run in short interval, so try again...
-          logWarning(log"Exception occurred while rebuilding log path " +
+          logInfo(log"Exception occurred while rebuilding log path " +
             log"${MDC(PATH, attempt.logPath)} - " +
             log"trying again...", ioe)
           store.close()
@@ -1362,7 +1362,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         case ioe: IOException if !retried =>
           // compaction may touch the file(s) which app rebuild wants to read
           // compaction wouldn't run in short interval, so try again...
-          logWarning(log"Exception occurred while rebuilding app ${MDC(APP_ID, appId)} - " +
+          logInfo(log"Exception occurred while rebuilding app ${MDC(APP_ID, appId)} - " +
             log"trying again...", ioe)
           lease.rollback()
           retried = true
@@ -1390,7 +1390,7 @@ private[history] class FsHistoryProvider(conf: SparkConf, clock: Clock)
         case ioe: IOException if !retried =>
           // compaction may touch the file(s) which app rebuild wants to read
           // compaction wouldn't run in short interval, so try again...
-          logWarning(log"Exception occurred while rebuilding log path " +
+          logInfo(log"Exception occurred while rebuilding log path " +
             log"${MDC(LogKeys.PATH, attempt.logPath)} - trying again...", ioe)
           retried = true
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR logs the IOException details in FileHistoryProvider, used by SHS.

### Why are the changes needed?
Before this change, when an IOException is caught generic messages are logged without the exception details. This makes it hard to troubleshoot because the root cause is lost. This enhancement will make it easier to troubleshoot IO issues.

### Does this PR introduce _any_ user-facing change?
Yes, the logging is changed to include the exception information.

### How was this patch tested?
Manual testing

### Was this patch authored or co-authored using generative AI tooling?
No
