### PR TITLE
[SPARK-49294][UI] Add width attribute for shuffle-write-time checkbox.

### DIFF
--- a/core/src/main/resources/org/apache/spark/ui/static/webui.css
+++ b/core/src/main/resources/org/apache/spark/ui/static/webui.css
@@ -361,6 +361,10 @@ a.downloadbutton {
   width: 170px;
 }
 
+.shuffle-write-time-checkbox-div {
+  width: 155px; 
+} 
+
 .result-serialization-time-checkbox-div {
   width: 185px;
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to add the style for `shuffle-write-time-checkbox-div` and set the width to be `155` pixels.

### Why are the changes needed?
Fix bug for UI.

The tip of `shuffle-write-time` appears in an strange position before this change.
As shown below
![MEITU_20240819_105642523](https://github.com/user-attachments/assets/1e4e9639-a949-4fc3-86f4-7cb65d6d9c73)


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually check.

### Was this patch authored or co-authored using generative AI tooling?
No.