### PR TITLE
[SPARK-49300][CORE] Fix Hadoop delegation token leak when tokenRenewalInterval is not set.

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala
@@ -150,6 +150,7 @@ private[deploy] class HadoopFSDelegationTokenProvider
         val interval = newExpiration - getIssueDate(tokenKind, identifier)
         logInfo(log"Renewal interval is ${MDC(TOTAL_TIME, interval)} for" +
           log" token ${MDC(TOKEN_KIND, tokenKind)}")
+        token.cancel(hadoopConf)
         interval
       }.toOption
     }

--- a/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala
@@ -150,6 +150,8 @@ private[deploy] class HadoopFSDelegationTokenProvider
         val interval = newExpiration - getIssueDate(tokenKind, identifier)
         logInfo(log"Renewal interval is ${MDC(TOTAL_TIME, interval)} for" +
           log" token ${MDC(TOKEN_KIND, tokenKind)}")
+        // The token here is only used to obtain renewal intervals. We should cancel it in
+        // a timely manner to avoid causing additional pressure on the server.
         token.cancel(hadoopConf)
         interval
       }.toOption


### PR DESCRIPTION
When `tokenRenewalInterval` is not set, HadoopFSDelegationTokenProvider#getTokenRenewalInterval will fetch some tokens and renew them to get a interval value. 
https://github.com/apache/spark/blob/dd259b0b27841e6dd7c07f8ca3cc05d275863dd5/core/src/main/scala/org/apache/spark/deploy/security/HadoopFSDelegationTokenProvider.scala#L60-L64
These tokens do not call cancel(), resulting in a large number of existing tokens on HDFS not being cleared in a timely manner, causing additional pressure on the HDFS server.