### PR TITLE
[SPARK-49190][K8S][FOLLOW-UP] Add how to populate executor log url vars with env vars

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -436,10 +436,10 @@ When there exists a log collection system, you can expose it at Spark Driver `Ex
 spark.ui.custom.executor.log.url='https://log-server/log?appId={{APP_ID}}&execId={{EXECUTOR_ID}}'
 ```
 
-You can add custom variables to this url template, populated with the values of existing executor environment variables like
+You can add additional custom variables to this url template, populated with the values of existing executor environment variables like
 
 ```
-spark.executorEnv.SPARK_EXECUTOR_ATTRIBUTE_YOUR_VAR='$(EXECUTOR_ENV_VAR)'
+spark.executorEnv.SPARK_EXECUTOR_ATTRIBUTE_YOUR_VAR='$(EXISTING_EXECUTOR_ENV_VAR)'
 spark.ui.custom.executor.log.url='https://log-server/log?appId={{APP_ID}}&execId={{EXECUTOR_ID}}&your_var={{YOUR_VAR}}'
 ```
 

--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -436,6 +436,13 @@ When there exists a log collection system, you can expose it at Spark Driver `Ex
 spark.ui.custom.executor.log.url='https://log-server/log?appId={{APP_ID}}&execId={{EXECUTOR_ID}}'
 ```
 
+You can add custom variables to this url template, populated with the values of existing executor environment variables like
+
+```
+spark.executorEnv.SPARK_EXECUTOR_ATTRIBUTE_YOUR_VAR='$(EXECUTOR_ENV_VAR)'
+spark.ui.custom.executor.log.url='https://log-server/log?appId={{APP_ID}}&execId={{EXECUTOR_ID}}&your_var={{YOUR_VAR}}'
+```
+
 ### Accessing Driver UI
 
 The UI associated with any application can be accessed locally using


### PR DESCRIPTION
### What changes were proposed in this pull request?
Mentions in the docs how to populate custom executor log url vars with environment variable's values.

### Why are the changes needed?
This feature exists since 3.0.0 but is not documented elsewhere.

### Does this PR introduce _any_ user-facing change?
Improves documentation.

### How was this patch tested?
Not tested.

### Was this patch authored or co-authored using generative AI tooling?
No.