### PR TITLE
[SPARK-49314][BUILD][TESTS] Upgrade `h2` to 2.3.232, `postgresql` to 42.7.4 and `mssql` to 12.8.1.jre11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,9 +325,9 @@
     </extraJavaTestArgs>
     <mariadb.java.client.version>2.7.12</mariadb.java.client.version>
     <mysql.connector.version>9.0.0</mysql.connector.version>
-    <postgresql.version>42.7.3</postgresql.version>
+    <postgresql.version>42.7.4</postgresql.version>
     <db2.jcc.version>11.5.9.0</db2.jcc.version>
-    <mssql.jdbc.version>12.8.0.jre11</mssql.jdbc.version>
+    <mssql.jdbc.version>12.8.1.jre11</mssql.jdbc.version>
     <ojdbc11.version>23.5.0.24.07</ojdbc11.version>
     <!-- Used for SBT build to retrieve the Spark version -->
     <spark.version>${project.version}</spark.version>

--- a/sql/connect/server/pom.xml
+++ b/sql/connect/server/pom.xml
@@ -254,7 +254,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>2.3.230</version>
+      <version>2.3.232</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -167,7 +167,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>2.3.230</version>
+      <version>2.3.232</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR aims to upgrade `h2` to 2.3.232, `postgresql` to 42.7.4 and `mssql` to 12.8.1.jre11.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

1. For `h2`, there are some issues fixed in version 2.3.232(full release notes: https://www.h2database.com/html/changelog.html):

    - [Issue #3945](https://github.com/h2database/h2database/issues/3945): Column not found in correlated subquery, when referencing outer column from LEFT JOIN .. ON clause
    - [Issue #4097](https://github.com/h2database/h2database/issues/4097): StackOverflowException when using multiple SELECT statements in one query (2.3.230)
    - [Issue #3982](https://github.com/h2database/h2database/issues/3982): Potential issue when using ROUND
    - [Issue #3894](https://github.com/h2database/h2database/issues/3894): Race condition causing stale data in query last result cache
    - [Issue #4075](https://github.com/h2database/h2database/issues/4075): infinite loop in compact
    - [Issue #4091](https://github.com/h2database/h2database/issues/4091): Wrong case with linked table to postgresql
    - [Issue #4088](https://github.com/h2database/h2database/issues/4088): BadGrammarException when the same alias is used within two different CTEs


2. For `postgresql`, there are some issues fixed and improvements in version 42.7.4(full release notes: https://jdbc.postgresql.org/changelogs/2024-08-22-42.7.4-release/):

    - fix: PgInterval ignores case for represented interval string [PR #3344](https://github.com/pgjdbc/pgjdbc/pull/3344)
    - perf: Avoid extra copies when receiving int4 and int2 in PGStream [PR #3295](https://github.com/pgjdbc/pgjdbc/pull/3295)
    - fix: Add support for Infinity::numeric values in ResultSet.getObject [PR #3304](https://github.com/pgjdbc/pgjdbc/pull/3304)
    - fix: Ensure order of results for getDouble [PR #3301](https://github.com/pgjdbc/pgjdbc/pull/3301)
    - perf: Replace BufferedOutputStream with unsynchronized PgBufferedOutputStream, allow configuring different Java and SO_SNDBUF buffer sizes [PR #3248](https://github.com/pgjdbc/pgjdbc/pull/3248)
    - fix: Fix SSL tests [PR #3260](https://github.com/pgjdbc/pgjdbc/pull/3260)
    - fix: Support bytea in preferQueryMode=simple [PR #3243](https://github.com/pgjdbc/pgjdbc/pull/3243)
    - fix: Fix [Issue #3234](https://github.com/pgjdbc/pgjdbc/issues/3234) - Return -1 as update count for stored procedure calls [PR #3235](https://github.com/pgjdbc/pgjdbc/pull/3235)
    - fix: Fix [Issue #3224](https://github.com/pgjdbc/pgjdbc/issues/3224) - conversion for TIME ‘24:00’ to LocalTime breaks in binary-mode [PR #3225](https://github.com/pgjdbc/pgjdbc/pull/3225)

3. For `mssql`,  there are some issues fixed in 12.8.1.jre11(full release notes: https://github.com/microsoft/mssql-jdbc/releases/tag/v12.8.1):

    - Adjusted DESTINATION_COL_METADATA_LOCK, in SQLServerBulkCopy, so that is properly released in all cases [PR #2492](https://github.com/microsoft/mssql-jdbc/pull/2492)
    - Reverted "Execute Stored Procedures Directly" feature, as well as subsequent changes related to the feature [PR #2493](https://github.com/microsoft/mssql-jdbc/pull/2493)
    - Changed driver behavior to allow prepared statement objects to be reused, preventing a "multiple queries are not allowed" error [PR #2494](https://github.com/microsoft/mssql-jdbc/pull/2494)

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.