### PR TITLE
[SPARK-49312][PYTHON] Improve error message for `assertSchemaEqual`

### DIFF
--- a/python/pyspark/sql/tests/test_utils.py
+++ b/python/pyspark/sql/tests/test_utils.py
@@ -27,6 +27,7 @@ from pyspark.errors import (
     PySparkValueError,
     IllegalArgumentException,
     SparkUpgradeException,
+    PySparkTypeError,
 )
 from pyspark.testing.utils import assertDataFrameEqual, assertSchemaEqual, _context_diff, have_numpy
 from pyspark.testing.sqlutils import ReusedSQLTestCase
@@ -1358,13 +1359,13 @@ class UtilsTestsMixin:
         s1 = "names: int"
         s2 = "names: int"
 
-        with self.assertRaises(PySparkAssertionError) as pe:
+        with self.assertRaises(PySparkTypeError) as pe:
             assertSchemaEqual(s1, s2)
 
         self.check_error(
             exception=pe.exception,
-            errorClass="UNSUPPORTED_DATA_TYPE",
-            messageParameters={"data_type": type(s1)},
+            errorClass="NOT_STRUCT",
+            messageParameters={"arg_name": "actual", "arg_type": "str"},
         )
 
     def test_spark_sql(self):

--- a/python/pyspark/testing/utils.py
+++ b/python/pyspark/testing/utils.py
@@ -53,7 +53,7 @@ except ImportError:
     pass
 
 from pyspark import SparkConf
-from pyspark.errors import PySparkAssertionError, PySparkException
+from pyspark.errors import PySparkAssertionError, PySparkException, PySparkTypeError
 from pyspark.errors.exceptions.captured import CapturedException
 from pyspark.errors.exceptions.base import QueryContextType
 from pyspark.find_spark_home import _find_spark_home
@@ -442,14 +442,14 @@ def assertSchemaEqual(
     >>> assertSchemaEqual(s1, s2, ignoreColumnName=True)
     """
     if not isinstance(actual, StructType):
-        raise PySparkAssertionError(
-            errorClass="UNSUPPORTED_DATA_TYPE",
-            messageParameters={"data_type": type(actual)},
+        raise PySparkTypeError(
+            errorClass="NOT_STRUCT",
+            messageParameters={"arg_name": "actual", "arg_type": type(actual).__name__},
         )
     if not isinstance(expected, StructType):
-        raise PySparkAssertionError(
-            errorClass="UNSUPPORTED_DATA_TYPE",
-            messageParameters={"data_type": type(expected)},
+        raise PySparkTypeError(
+            errorClass="NOT_STRUCT",
+            messageParameters={"arg_name": "expected", "arg_type": type(expected).__name__},
         )
 
     def compare_schemas_ignore_nullable(s1: StructType, s2: StructType):


### PR DESCRIPTION


### What changes were proposed in this pull request?

This PR proposes to improve error message for `assertSchemaEqual`

### Why are the changes needed?

Current error message is not very actionable and lack of detail when the given parameter has invalid data type:

```python
>>> assertSchemaEqual(df, df)  # Should be `df.schama` instead of `df`
[UNSUPPORTED_DATA_TYPE] Unsupported DataType `<class 'pyspark.sql.classic.dataframe.DataFrame'>`.
```


### Does this PR introduce _any_ user-facing change?

No API change, but there is some user-facing error message change:

**Before**
```python
[UNSUPPORTED_DATA_TYPE] Unsupported DataType `<class 'pyspark.sql.classic.dataframe.DataFrame'>`.
```

**After**
```python
[NOT_STRUCT] Argument `actual` should be a struct type, got DataFrame.
```


### How was this patch tested?

The existing CI should pass

### Was this patch authored or co-authored using generative AI tooling?
No