### PR TITLE
[SPARK-49323][CONNECT] Move MockObserver from Spark Connect Server's test folder to the Server's main folder

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/MockObserver.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/MockObserver.scala
@@ -21,6 +21,17 @@ import io.grpc.stub.StreamObserver
 
 import org.apache.spark.connect.proto
 
+/*
+ * The [[MockObserver]] class is a mock of the [[StreamObserver]] class from the gRPC library,
+ * used for testing the process function of [[SparkConnectPlanner]].
+ * Currently, the [[MockObserver]] class is located in the test folder,
+ * which is not shaded by sbt-assembly, unlike the main folder.
+ * This results in a compilation error when external libraries call the transform function,
+ * which in turn calls [[SparkConnectPlanner(executeHolder).process(command, new MockObserver())]].
+ *
+ * To resolve this, the [[MockObserver]] class should be moved to the main folder
+ * to be shaded as well.
+ */
 private[connect] class MockObserver extends StreamObserver[proto.ExecutePlanResponse] {
   override def onNext(value: proto.ExecutePlanResponse): Unit = {}
   override def onError(t: Throwable): Unit = {}

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/MockObserver.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/MockObserver.scala
@@ -22,15 +22,16 @@ import io.grpc.stub.StreamObserver
 import org.apache.spark.connect.proto
 
 /*
- * The [[MockObserver]] class is a mock of the [[StreamObserver]] class from the gRPC library,
- * used for testing the process function of [[SparkConnectPlanner]].
+ * The [[MockObserver]] class is a mock of the [[StreamObserver]] class from
+ * the gRPC library, used for testing the process function of [[SparkConnectPlanner]].
  *
  * Currently, the [[MockObserver]] class is located in the test folder,
  * which is not shaded by sbt-assembly, unlike the main folder.
  *
  * This results in a compilation error when open-source libraries call the
- * [[transform(spark: SparkSession, command: proto.Command)]] function in [[SparkConnectPlannerTestUtils]],
- * which in turn calls [[SparkConnectPlanner(executeHolder).process(command, new MockObserver())]].
+ * [[transform(spark: SparkSession, command: proto.Command)]] function in
+ * [[SparkConnectPlannerTestUtils]], which in turn calls
+ * [[SparkConnectPlanner(executeHolder).process(command, new MockObserver())]].
  *
  * To resolve this, the [[MockObserver]] class should be moved to the main folder
  * to be shaded as well.

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/MockObserver.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/MockObserver.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.planner
+
+import io.grpc.stub.StreamObserver
+
+import org.apache.spark.connect.proto
+
+private[connect] class MockObserver extends StreamObserver[proto.ExecutePlanResponse] {
+  override def onNext(value: proto.ExecutePlanResponse): Unit = {}
+  override def onError(t: Throwable): Unit = {}
+  override def onCompleted(): Unit = {}
+}

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/MockObserver.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/MockObserver.scala
@@ -24,9 +24,12 @@ import org.apache.spark.connect.proto
 /*
  * The [[MockObserver]] class is a mock of the [[StreamObserver]] class from the gRPC library,
  * used for testing the process function of [[SparkConnectPlanner]].
+ *
  * Currently, the [[MockObserver]] class is located in the test folder,
  * which is not shaded by sbt-assembly, unlike the main folder.
- * This results in a compilation error when external libraries call the transform function,
+ *
+ * This results in a compilation error when open-source libraries call the
+ * [[transform(spark: SparkSession, command: proto.Command)]] function in [[SparkConnectPlannerTestUtils]],
  * which in turn calls [[SparkConnectPlanner(executeHolder).process(command, new MockObserver())]].
  *
  * To resolve this, the [[MockObserver]] class should be moved to the main folder

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerTestUtils.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectPlannerTestUtils.scala
@@ -17,10 +17,7 @@
 
 package org.apache.spark.sql.connect.planner
 
-import io.grpc.stub.StreamObserver
-
 import org.apache.spark.connect.proto
-import org.apache.spark.connect.proto.ExecutePlanResponse
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.connect.SparkConnectTestUtils
@@ -61,11 +58,5 @@ object SparkConnectPlannerTestUtils {
     val executeHolder = SparkConnectService.executionManager.createExecuteHolder(request)
     executeHolder.eventsManager.status_(ExecuteStatus.Started)
     executeHolder
-  }
-
-  private class MockObserver extends StreamObserver[proto.ExecutePlanResponse] {
-    override def onNext(value: ExecutePlanResponse): Unit = {}
-    override def onError(t: Throwable): Unit = {}
-    override def onCompleted(): Unit = {}
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


Move class `MockObserver` from the Spark Connect Server's test folder to the Server's main folder, so that this class can be shaded as well, from `io.grpc` to `org.sparkproject.connect.grpc`.

https://github.com/apache/spark/blob/ba208b9ca99990fa329c36b28d0aa2a5f4d0a77e/project/SparkBuild.scala#L775

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The `MockObserver` class is a mock of the `StreamObserver` class from the gRPC library, used for testing the process function of [SparkConnectPlanner](url).


Currently, the [[`MockObserver`]] class is located in the test folder, which is not shaded by sbt-assembly, unlike the main folder.

This results in a compilation error when open-source libraries call the `transform(spark: SparkSession, command: proto.Command)` function in `SparkConnectPlannerTestUtils`, which in turn calls `SparkConnectPlanner(executeHolder).process(command, new MockObserver())`.

To resolve this, the `MockObserver` class should be moved to the main folder to be shaded as well.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing UTs.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.