### PR TITLE
[SPARK-49306][SQL] Create new SQL functions 'zeroifnull' and 'nullifzero' 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -376,6 +376,7 @@ object FunctionRegistry {
     expression[Least]("least"),
     expression[NaNvl]("nanvl"),
     expression[NullIf]("nullif"),
+    expression[NullIfZero]("nullifzero"),
     expression[Nvl]("nvl"),
     expression[Nvl2]("nvl2"),
     expression[PosExplode]("posexplode"),
@@ -384,6 +385,7 @@ object FunctionRegistry {
     expression[Rand]("random", true, Some("3.0.0")),
     expression[Randn]("randn"),
     expression[Stack]("stack"),
+    expression[ZeroIfNull]("zeroifnull"),
     CaseWhen.registryEntry,
 
     // math functions

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/nullExpressions.scala
@@ -177,6 +177,47 @@ case class NullIf(left: Expression, right: Expression, replacement: Expression)
   }
 }
 
+@ExpressionDescription(
+  usage = "_FUNC_(expr) - Returns null if `expr` is equal to zero, or `expr` otherwise.",
+  examples = """
+    Examples:
+      > SELECT _FUNC_(0);
+       NULL
+      > SELECT _FUNC_(2);
+       2
+  """,
+  since = "4.0.0",
+  group = "conditional_funcs")
+case class NullIfZero(input: Expression, replacement: Expression)
+  extends RuntimeReplaceable with InheritAnalysisRules {
+  def this(input: Expression) = this(input, If(EqualTo(input, Literal(0)), Literal(null), input))
+
+  override def parameters: Seq[Expression] = Seq(input)
+
+  override protected def withNewChildInternal(newInput: Expression): Expression =
+    copy(replacement = newInput)
+}
+
+@ExpressionDescription(
+  usage = "_FUNC_(expr) - Returns zero if `expr` is equal to null, or `expr` otherwise.",
+  examples = """
+    Examples:
+      > SELECT _FUNC_(NULL);
+       0
+      > SELECT _FUNC_(2);
+       2
+  """,
+  since = "4.0.0",
+  group = "conditional_funcs")
+case class ZeroIfNull(input: Expression, replacement: Expression)
+  extends RuntimeReplaceable with InheritAnalysisRules {
+  def this(input: Expression) = this(input, new Nvl(input, Literal(0)))
+
+  override def parameters: Seq[Expression] = Seq(input)
+
+  override protected def withNewChildInternal(newInput: Expression): Expression =
+    copy(replacement = newInput)
+}
 
 @ExpressionDescription(
   usage = "_FUNC_(expr1, expr2) - Returns `expr2` if `expr1` is null, or `expr1` otherwise.",

--- a/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
+++ b/sql/core/src/test/resources/sql-functions/sql-expression-schema.md
@@ -238,6 +238,7 @@
 | org.apache.spark.sql.catalyst.expressions.Now | now | SELECT now() | struct<now():timestamp> |
 | org.apache.spark.sql.catalyst.expressions.NthValue | nth_value | SELECT a, b, nth_value(b, 2) OVER (PARTITION BY a ORDER BY b) FROM VALUES ('A1', 2), ('A1', 1), ('A2', 3), ('A1', 1) tab(a, b) | struct<a:string,b:int,nth_value(b, 2) OVER (PARTITION BY a ORDER BY b ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW):int> |
 | org.apache.spark.sql.catalyst.expressions.NullIf | nullif | SELECT nullif(2, 2) | struct<nullif(2, 2):int> |
+| org.apache.spark.sql.catalyst.expressions.NullIfZero | nullifzero | SELECT nullifzero(0) | struct<nullifzero(0):int> |
 | org.apache.spark.sql.catalyst.expressions.Nvl | ifnull | SELECT ifnull(NULL, array('2')) | struct<ifnull(NULL, array(2)):array<string>> |
 | org.apache.spark.sql.catalyst.expressions.Nvl | nvl | SELECT nvl(NULL, array('2')) | struct<nvl(NULL, array(2)):array<string>> |
 | org.apache.spark.sql.catalyst.expressions.Nvl2 | nvl2 | SELECT nvl2(NULL, 2, 1) | struct<nvl2(NULL, 2, 1):int> |
@@ -384,6 +385,7 @@
 | org.apache.spark.sql.catalyst.expressions.XmlToStructs | from_xml | SELECT from_xml('<p><a>1</a><b>0.8</b></p>', 'a INT, b DOUBLE') | struct<from_xml(<p><a>1</a><b>0.8</b></p>):struct<a:int,b:double>> |
 | org.apache.spark.sql.catalyst.expressions.XxHash64 | xxhash64 | SELECT xxhash64('Spark', array(123), 2) | struct<xxhash64(Spark, array(123), 2):bigint> |
 | org.apache.spark.sql.catalyst.expressions.Year | year | SELECT year('2016-07-30') | struct<year(2016-07-30):int> |
+| org.apache.spark.sql.catalyst.expressions.ZeroIfNull | zeroifnull | SELECT zeroifnull(NULL) | struct<zeroifnull(NULL):int> |
 | org.apache.spark.sql.catalyst.expressions.ZipWith | zip_with | SELECT zip_with(array(1, 2, 3), array('a', 'b', 'c'), (x, y) -> (y, x)) | struct<zip_with(array(1, 2, 3), array(a, b, c), lambdafunction(named_struct(y, namedlambdavariable(), x, namedlambdavariable()), namedlambdavariable(), namedlambdavariable())):array<struct<y:string,x:int>>> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.AnyValue | any_value | SELECT any_value(col) FROM VALUES (10), (5), (20) AS tab(col) | struct<any_value(col):int> |
 | org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile | approx_percentile | SELECT approx_percentile(col, array(0.5, 0.4, 0.1), 100) FROM VALUES (0), (1), (2), (10) AS tab(col) | struct<approx_percentile(col, array(0.5, 0.4, 0.1), 100):array<int>> |

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/conditional-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/conditional-functions.sql.out
@@ -99,6 +99,43 @@ Project [CASE WHEN (1 > 2) THEN (cast(1 as double) / cast(0 as double)) ELSE cas
 
 
 -- !query
+SELECT nullifzero(0),
+  nullifzero(cast(0 as tinyint)),
+  nullifzero(cast(0 as bigint)),
+  nullifzero('0'),
+  nullifzero(0.0),
+  nullifzero(1),
+  nullifzero(null)
+-- !query analysis
+Project [nullifzero(0) AS nullifzero(0)#x, nullifzero(cast(0 as tinyint)) AS nullifzero(CAST(0 AS TINYINT))#x, nullifzero(cast(0 as bigint)) AS nullifzero(CAST(0 AS BIGINT))#xL, nullifzero(0) AS nullifzero(0)#x, nullifzero(0.0) AS nullifzero(0.0)#x, nullifzero(1) AS nullifzero(1)#x, nullifzero(null) AS nullifzero(NULL)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT nullifzero('abc')
+-- !query analysis
+Project [nullifzero(abc) AS nullifzero(abc)#x]
++- OneRowRelation
+
+
+-- !query
+SELECT zeroifnull(null),
+  zeroifnull(1),
+  zeroifnull(cast(1 as tinyint)),
+  zeroifnull(cast(1 as bigint))
+-- !query analysis
+Project [zeroifnull(null) AS zeroifnull(NULL)#x, zeroifnull(1) AS zeroifnull(1)#x, zeroifnull(cast(1 as tinyint)) AS zeroifnull(CAST(1 AS TINYINT))#x, zeroifnull(cast(1 as bigint)) AS zeroifnull(CAST(1 AS BIGINT))#xL]
++- OneRowRelation
+
+
+-- !query
+SELECT zeroifnull('abc')
+-- !query analysis
+Project [zeroifnull(abc) AS zeroifnull(abc)#xL]
++- OneRowRelation
+
+
+-- !query
 DROP TABLE conditional_t
 -- !query analysis
 DropTable false, false

--- a/sql/core/src/test/resources/sql-tests/inputs/ansi/conditional-functions.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/ansi/conditional-functions.sql
@@ -18,4 +18,21 @@ SELECT case when c2 >= 0 then 1 else 1/0 end from conditional_t;
 SELECT case when 1 < 2 then 1 else 1/0 end;
 SELECT case when 1 > 2 then 1/0 else 1 end;
 
+SELECT nullifzero(0),
+  nullifzero(cast(0 as tinyint)),
+  nullifzero(cast(0 as bigint)),
+  nullifzero('0'),
+  nullifzero(0.0),
+  nullifzero(1),
+  nullifzero(null);
+
+SELECT nullifzero('abc');
+
+SELECT zeroifnull(null),
+  zeroifnull(1),
+  zeroifnull(cast(1 as tinyint)),
+  zeroifnull(cast(1 as bigint));
+
+SELECT zeroifnull('abc');
+
 DROP TABLE conditional_t;

--- a/sql/core/src/test/resources/sql-tests/results/ansi/conditional-functions.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/conditional-functions.sql.out
@@ -122,6 +122,81 @@ struct<CASE WHEN (1 > 2) THEN (1 / 0) ELSE 1 END:double>
 
 
 -- !query
+SELECT nullifzero(0),
+  nullifzero(cast(0 as tinyint)),
+  nullifzero(cast(0 as bigint)),
+  nullifzero('0'),
+  nullifzero(0.0),
+  nullifzero(1),
+  nullifzero(null)
+-- !query schema
+struct<nullifzero(0):int,nullifzero(CAST(0 AS TINYINT)):tinyint,nullifzero(CAST(0 AS BIGINT)):bigint,nullifzero(0):string,nullifzero(0.0):decimal(1,1),nullifzero(1):int,nullifzero(NULL):void>
+-- !query output
+NULL	NULL	NULL	NULL	NULL	1	NULL
+
+
+-- !query
+SELECT nullifzero('abc')
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkNumberFormatException
+{
+  "errorClass" : "CAST_INVALID_INPUT",
+  "sqlState" : "22018",
+  "messageParameters" : {
+    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
+    "expression" : "'abc'",
+    "sourceType" : "\"STRING\"",
+    "targetType" : "\"BIGINT\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 24,
+    "fragment" : "nullifzero('abc')"
+  } ]
+}
+
+
+-- !query
+SELECT zeroifnull(null),
+  zeroifnull(1),
+  zeroifnull(cast(1 as tinyint)),
+  zeroifnull(cast(1 as bigint))
+-- !query schema
+struct<zeroifnull(NULL):int,zeroifnull(1):int,zeroifnull(CAST(1 AS TINYINT)):int,zeroifnull(CAST(1 AS BIGINT)):bigint>
+-- !query output
+0	1	1	1
+
+
+-- !query
+SELECT zeroifnull('abc')
+-- !query schema
+struct<>
+-- !query output
+org.apache.spark.SparkNumberFormatException
+{
+  "errorClass" : "CAST_INVALID_INPUT",
+  "sqlState" : "22018",
+  "messageParameters" : {
+    "ansiConfig" : "\"spark.sql.ansi.enabled\"",
+    "expression" : "'abc'",
+    "sourceType" : "\"STRING\"",
+    "targetType" : "\"BIGINT\""
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 8,
+    "stopIndex" : 24,
+    "fragment" : "zeroifnull('abc')"
+  } ]
+}
+
+
+-- !query
 DROP TABLE conditional_t
 -- !query schema
 struct<>

--- a/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/MiscFunctionsSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql
 
-import org.apache.spark.{SPARK_REVISION, SPARK_VERSION_SHORT, SparkNumberFormatException}
+import org.apache.spark.{SPARK_REVISION, SPARK_VERSION_SHORT}
 import org.apache.spark.sql.catalyst.expressions.Hex
 import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.functions._
@@ -284,48 +284,6 @@ class MiscFunctionsSuite extends QueryTest with SharedSparkSession {
 
     assert(df.selectExpr("random(1)").collect() != null)
     assert(df.select(random(lit(1))).collect() != null)
-  }
-
-  test("SPARK-49306 nullifzero and zeroifnull functions") {
-    val df = Seq((1, 2, 3)).toDF("a", "b", "c")
-    checkAnswer(df.selectExpr("nullifzero(0)"), Row(null))
-    checkAnswer(df.selectExpr("nullifzero(cast(0 as tinyint))"), Row(null))
-    checkAnswer(df.selectExpr("nullifzero(cast(0 as bigint))"), Row(null))
-    checkAnswer(df.selectExpr("nullifzero('0')"), Row(null))
-    checkAnswer(df.selectExpr("nullifzero(0.0)"), Row(null))
-    checkAnswer(df.selectExpr("nullifzero(1)"), Row(1))
-    checkAnswer(df.selectExpr("nullifzero(null)"), Row(null))
-    var expr = "nullifzero('abc')"
-    checkError(
-      exception = intercept[SparkNumberFormatException] {
-        checkAnswer(df.selectExpr(expr), Row(null))
-      },
-      errorClass = "CAST_INVALID_INPUT",
-      parameters = Map(
-        "expression" -> "'abc'",
-        "sourceType" -> "\"STRING\"",
-        "targetType" -> "\"BIGINT\"",
-        "ansiConfig" -> "\"spark.sql.ansi.enabled\""
-      ),
-      context = ExpectedContext("", "", 0, expr.length - 1, expr))
-
-    checkAnswer(df.selectExpr("zeroifnull(null)"), Row(0))
-    checkAnswer(df.selectExpr("zeroifnull(1)"), Row(1))
-    checkAnswer(df.selectExpr("zeroifnull(cast(1 as tinyint))"), Row(1))
-    checkAnswer(df.selectExpr("zeroifnull(cast(1 as bigint))"), Row(1))
-    expr = "zeroifnull('abc')"
-    checkError(
-      exception = intercept[SparkNumberFormatException] {
-        checkAnswer(df.selectExpr(expr), Row(null))
-      },
-      errorClass = "CAST_INVALID_INPUT",
-      parameters = Map(
-        "expression" -> "'abc'",
-        "sourceType" -> "\"STRING\"",
-        "targetType" -> "\"BIGINT\"",
-        "ansiConfig" -> "\"spark.sql.ansi.enabled\""
-      ),
-      context = ExpectedContext("", "", 0, expr.length - 1, expr))
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR creates new SQL functions `zeroifnull` and `nullifzero`.

These are equivalent to `nvl(input, 0)` and `if(input = 0, null, input)`, respectively. The analyzer performs these replacements inline in this PR to take advantage of existing query optimizations for `nvl` and `if` expressions.

For example:

```
> select zeroifnull(null);
 0
> select zeroifnull(2);
 2

> select nullifzero(0);
 null
> select nullifzero(2);
 2
```

### Why are the changes needed?

We are adding these functions for compatibility with other systems which also have these SQL functions.

### Does this PR introduce _any_ user-facing change?

Yes, see above.

### How was this patch tested?

This PR adds unit test coverage.

### Was this patch authored or co-authored using generative AI tooling?

No.