### PR TITLE
[SPARK-49327][BUILD] Upgrade `commons-compress` to 1.27.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -40,7 +40,7 @@ commons-codec/1.17.1//commons-codec-1.17.1.jar
 commons-collections/3.2.2//commons-collections-3.2.2.jar
 commons-collections4/4.4//commons-collections4-4.4.jar
 commons-compiler/3.1.9//commons-compiler-3.1.9.jar
-commons-compress/1.27.0//commons-compress-1.27.0.jar
+commons-compress/1.27.1//commons-compress-1.27.1.jar
 commons-crypto/1.1.0//commons-crypto-1.1.0.jar
 commons-dbcp/1.4//commons-dbcp-1.4.jar
 commons-io/2.16.1//commons-io-2.16.1.jar

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
     <snappy.version>1.1.10.6</snappy.version>
     <netlib.ludovic.dev.version>3.0.3</netlib.ludovic.dev.version>
     <commons-codec.version>1.17.1</commons-codec.version>
-    <commons-compress.version>1.27.0</commons-compress.version>
+    <commons-compress.version>1.27.1</commons-compress.version>
     <commons-io.version>2.16.1</commons-io.version>
     <!-- To support Hive UDF jars built by Hive 2.0.0 ~ 2.3.9 and 3.0.0 ~ 3.1.3. -->
     <commons-lang2.version>2.6</commons-lang2.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `commons-compress` from `1.27.0` to `1.27.1`


### Why are the changes needed?
Although the last upgrade occurred 10 days ago, this version fixed a serious bug as follows:
https://commons.apache.org/proper/commons-compress/changes-report.html#a1.27.1
- Compression into BZip2 format has unexpected end of file when using a BufferedOutputStream. Fixes [COMPRESS-686](https://issues.apache.org/jira/browse/COMPRESS-686).


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
