### PR TITLE
[SPARK-49142][FOLLOWUP][CONNECT][PYTHON] Use PySparkLogger for Spark Connect client log

### DIFF
--- a/python/pyspark/sql/connect/client/logging.py
+++ b/python/pyspark/sql/connect/client/logging.py
@@ -17,6 +17,7 @@
 
 
 import logging
+from pyspark.logger import PySparkLogger
 import os
 from typing import Optional
 
@@ -27,7 +28,7 @@ __all__ = [
 
 def _configure_logging() -> logging.Logger:
     """Configure logging for the Spark Connect clients."""
-    logger = logging.getLogger(__name__)
+    logger = PySparkLogger.getLogger(__name__)
     handler = logging.StreamHandler()
     handler.setFormatter(
         logging.Formatter(fmt="%(asctime)s %(process)d %(levelname)s %(funcName)s %(message)s")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This followups for https://github.com/apache/spark/pull/47647 to switch the standard logger into PySparkLogger for Spark Connect client log

### Why are the changes needed?

Use PySpark specific logger


### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?

No