### PR TITLE
[SPARK-49335][BUILD] Upgrade Maven to 3.9.9

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -306,12 +306,6 @@ jobs:
         name: unit-tests-log-${{ matrix.modules }}-${{ matrix.comment }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ matrix.hive }}
         path: "**/target/unit-tests.log"
 
-  maven-test:
-    name: "Run Maven Test"
-    permissions:
-      packages: write
-    uses: ./.github/workflows/maven_test.yml
-
   infra-image:
     name: "Base image build"
     needs: precondition

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -306,6 +306,12 @@ jobs:
         name: unit-tests-log-${{ matrix.modules }}-${{ matrix.comment }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ matrix.hive }}
         path: "**/target/unit-tests.log"
 
+  maven-test:
+    name: "Run Maven Test"
+    permissions:
+      packages: write
+    uses: ./.github/workflows/maven_test.yml
+
   infra-image:
     name: "Base image build"
     needs: precondition

--- a/docs/building-spark.md
+++ b/docs/building-spark.md
@@ -27,7 +27,7 @@ license: |
 ## Apache Maven
 
 The Maven-based build is the build of reference for Apache Spark.
-Building Spark using Maven requires Maven 3.9.8 and Java 17/21.
+Building Spark using Maven requires Maven 3.9.9 and Java 17/21.
 Spark requires Scala 2.13; support for Scala 2.12 was removed in Spark 4.0.0.
 
 ### Setting up Maven's Memory Usage

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>17</java.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
-    <maven.version>3.9.8</maven.version>
+    <maven.version>3.9.9</maven.version>
     <exec-maven-plugin.version>3.2.0</exec-maven-plugin.version>
     <sbt.project.name>spark</sbt.project.name>
     <asm.version>9.7</asm.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Maven to 3.9.9.

### Why are the changes needed?

Release Note:
- https://maven.apache.org/docs/3.9.9/release-notes.html

    > Notable improvements in area of memory usage arrives with [Resolver 1.2.22](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12320628&version=12354902).


Bug Fixes:

- [MNG-8159](https://issues.apache.org/jira/browse/MNG-8159) - Fix search for topDirectory when using -f / --file for Maven 3.9.x
- [MNG-8165](https://issues.apache.org/jira/browse/MNG-8165) - Maven does not find extensions for -f when current dir is root
- [MNG-8177](https://issues.apache.org/jira/browse/MNG-8177) - Warning "'dependencyManagement.dependencies.dependency.systemPath' for com.sun:tools:jar refers to a non-existing file C:\Temp\jdk-11.0.23\..\lib\tools.jar"
- [MNG-8178](https://issues.apache.org/jira/browse/MNG-8178) - Profile activation based on OS properties is broken for "mvn site"
- [MNG-8180](https://issues.apache.org/jira/browse/MNG-8180) - Resolver will blindly assume it is deploying a plugin by presence of META-INF/maven/plugins.xml in JAR
- [MNG-8182](https://issues.apache.org/jira/browse/MNG-8182) - Missing or mismatching Trusted Checksum for some artifacts is not properly reported
- [MNG-8188](https://issues.apache.org/jira/browse/MNG-8188) - [REGRESSION] Property not resolved in profile pluginManagement

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.