### PR TITLE
[SPARK-49338][CORE][SQL][K8S] Make Spark Deamons support `spark.log.structuredLogging.enabled`

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/ExternalShuffleService.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ExternalShuffleService.scala
@@ -167,6 +167,7 @@ object ExternalShuffleService extends Logging {
       newShuffleService: (SparkConf, SecurityManager) => ExternalShuffleService): Unit = {
     Utils.initDaemon(log)
     val sparkConf = new SparkConf
+    Utils.resetStructuredLogging(sparkConf)
     Utils.loadDefaultSparkProperties(sparkConf)
     val securityManager = new SecurityManager(sparkConf)
 

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -79,11 +79,7 @@ private[spark] class SparkSubmit extends Logging {
     } else {
       // For non-shell applications, enable structured logging if it's not explicitly disabled
       // via the configuration `spark.log.structuredLogging.enabled`.
-      if (sparkConf.getBoolean(STRUCTURED_LOGGING_ENABLED.key, defaultValue = true)) {
-        Logging.enableStructuredLogging()
-      } else {
-        Logging.disableStructuredLogging()
-      }
+      Utils.resetStructuredLogging(sparkConf)
     }
     // Initialize logging if it hasn't been done yet. Keep track of whether logging needs to
     // be reset before the application starts.

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -297,6 +297,7 @@ object HistoryServer extends Logging {
   val UI_PATH_PREFIX = "/history"
 
   def main(argStrings: Array[String]): Unit = {
+    Utils.resetStructuredLogging(conf)
     Utils.initDaemon(log)
     new HistoryServerArguments(conf, argStrings)
     initSecurity()

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -1384,6 +1384,7 @@ private[deploy] object Master extends Logging {
       exitOnUncaughtException = false))
     Utils.initDaemon(log)
     val conf = new SparkConf
+    Utils.resetStructuredLogging(conf)
     val args = new MasterArguments(argStrings, conf)
     val (rpcEnv, _, _) = startRpcEnvAndEndpoint(args.host, args.port, args.webUiPort, conf)
     rpcEnv.awaitTermination()

--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -982,6 +982,7 @@ private[deploy] object Worker extends Logging {
       exitOnUncaughtException = false))
     Utils.initDaemon(log)
     val conf = new SparkConf
+    Utils.resetStructuredLogging(conf)
     val args = new WorkerArguments(argStrings, conf)
     val rpcEnv = startRpcEnvAndEndpoint(args.host, args.port, args.webUiPort, args.cores,
       args.memory, args.masters, args.workDir, conf = conf,

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -430,6 +430,7 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
 
       // Bootstrap to fetch the driver's Spark properties.
       val executorConf = new SparkConf
+      Utils.resetStructuredLogging(executorConf)
       val fetcher = RpcEnv.create(
         "driverPropsFetcher",
         arguments.bindAddress,

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2581,6 +2581,19 @@ private[spark] object Utils
   }
 
   /**
+   * Utility function to enable or disable structured logging.
+   * Note that this requires `SparkConf` which may cause a validation failure.
+   * To avoid any logic change, this should be used where SparkConf object exists already.
+   */
+  def resetStructuredLogging(conf: SparkConf): Unit = {
+    if (conf.getBoolean(STRUCTURED_LOGGING_ENABLED.key, defaultValue = true)) {
+      Logging.enableStructuredLogging()
+    } else {
+      Logging.disableStructuredLogging()
+    }
+  }
+
+  /**
    * Return the jar files pointed by the "spark.jars" property. Spark internally will distribute
    * these jars through file server. In the YARN mode, it will return an empty list, since YARN
    * has its own mechanism to distribute jars.

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBackend.scala
@@ -71,6 +71,7 @@ private[spark] object KubernetesExecutorBackend extends Logging {
 
       // Bootstrap to fetch the driver's Spark properties.
       val executorConf = new SparkConf
+      Utils.resetStructuredLogging(executorConf)
       val fetcher = RpcEnv.create(
         "driverPropsFetcher",
         arguments.bindAddress,

--- a/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
+++ b/sql/hive-thriftserver/src/main/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2.scala
@@ -118,6 +118,7 @@ object HiveThriftServer2 extends Logging {
 
     logInfo("Starting SparkContext")
     SparkSQLEnv.init()
+    Utils.resetStructuredLogging(SparkSQLEnv.sparkContext.getConf)
 
     ShutdownHookManager.addShutdownHook { () =>
       SparkSQLEnv.stop()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `Spark Deamon`s support `spark.log.structuredLogging.enabled`.

### Why are the changes needed?

Currently, `spark.log.structuredLogging.enabled` is ignored in deamons like Spark Master, Spark Worker, Spark History Server, Spark Thrift Server.

**Apache Spark 4.0.0-preview1**
```
$ SPARK_NO_DAEMONIZE=1 SPARK_MASTER_OPTS=-Dspark.log.structuredLogging.enabled=false sbin/start-master.sh
starting org.apache.spark.deploy.master.Master, logging to /Users/dongjoon/APACHE/spark-releases/spark-4.0.0-preview1-bin-hadoop3/logs/spark-dongjoon-org.apache.spark.deploy.master.Master-1-M3-Max.local.out
Spark Command: /Users/dongjoon/.jenv/versions/17/bin/java -cp /Users/dongjoon/APACHE/spark-releases/spark-4.0.0-preview1-bin-hadoop3/conf/:/Users/dongjoon/APACHE/spark-releases/spark-4.0.0-preview1-bin-hadoop3/jars/slf4j-api-2.0.13.jar:/Users/dongjoon/APACHE/spark-releases/spark-4.0.0-preview1-bin-hadoop3/jars/* -Dspark.log.structuredLogging.enabled=false -Xmx1g org.apache.spark.deploy.master.Master --host M3-Max.local --port 7077 --webui-port 8080
========================================
Using Spark's default log4j profile: org/apache/spark/log4j2-defaults.properties
{"ts":"2024-08-21T16:16:25.954Z","level":"INFO","msg":"Started daemon with process name: 23363@M3-Max.local","logger":"Master"}
{"ts":"2024-08-21T16:16:25.969Z","level":"INFO","msg":"Registering signal handler for TERM","context":{"signal":"TERM"},"logger":"SignalUtils"}
{"ts":"2024-08-21T16:16:25.969Z","level":"INFO","msg":"Registering signal handler for HUP","context":{"signal":"HUP"},"logger":"SignalUtils"}
{"ts":"2024-08-21T16:16:25.969Z","level":"INFO","msg":"Registering signal handler for INT","context":{"signal":"INT"},"logger":"SignalUtils"}
{"ts":"2024-08-21T16:16:26.133Z","level":"WARN","msg":"Unable to load native-hadoop library for your platform... using builtin-java classes where applicable","logger":"NativeCodeLoader"}
{"ts":"2024-08-21T16:16:26.148Z","level":"INFO","msg":"Changing view acls to: dongjoon","logger":"SecurityManager"}
{"ts":"2024-08-21T16:16:26.148Z","level":"INFO","msg":"Changing modify acls to: dongjoon","logger":"SecurityManager"}
{"ts":"2024-08-21T16:16:26.148Z","level":"INFO","msg":"Changing view acls groups to: ","logger":"SecurityManager"}
{"ts":"2024-08-21T16:16:26.148Z","level":"INFO","msg":"Changing modify acls groups to: ","logger":"SecurityManager"}
```

### Does this PR introduce _any_ user-facing change?

Yes, this is a regression fix at `Apache Spark 4.0` because we voted to provide a way to control (disable) this.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.