### PR TITLE
[SPARK-49338][CORE][SQL][K8S] Make Spark Deamons support `spark.log.structuredLogging.enabled` system property

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/ExternalShuffleService.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/ExternalShuffleService.scala
@@ -165,6 +165,7 @@ object ExternalShuffleService extends Logging {
   private[spark] def main(
       args: Array[String],
       newShuffleService: (SparkConf, SecurityManager) => ExternalShuffleService): Unit = {
+    Utils.resetStructuredLogging()
     Utils.initDaemon(log)
     val sparkConf = new SparkConf
     Utils.loadDefaultSparkProperties(sparkConf)

--- a/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/history/HistoryServer.scala
@@ -292,11 +292,12 @@ class HistoryServer(
  * This launches the HistoryServer as a Spark daemon.
  */
 object HistoryServer extends Logging {
-  private val conf = new SparkConf
+  private lazy val conf = new SparkConf
 
   val UI_PATH_PREFIX = "/history"
 
   def main(argStrings: Array[String]): Unit = {
+    Utils.resetStructuredLogging()
     Utils.initDaemon(log)
     new HistoryServerArguments(conf, argStrings)
     initSecurity()

--- a/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/master/Master.scala
@@ -1382,6 +1382,7 @@ private[deploy] object Master extends Logging {
   def main(argStrings: Array[String]): Unit = {
     Thread.setDefaultUncaughtExceptionHandler(new SparkUncaughtExceptionHandler(
       exitOnUncaughtException = false))
+    Utils.resetStructuredLogging()
     Utils.initDaemon(log)
     val conf = new SparkConf
     val args = new MasterArguments(argStrings, conf)

--- a/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/worker/Worker.scala
@@ -980,6 +980,7 @@ private[deploy] object Worker extends Logging {
   def main(argStrings: Array[String]): Unit = {
     Thread.setDefaultUncaughtExceptionHandler(new SparkUncaughtExceptionHandler(
       exitOnUncaughtException = false))
+    Utils.resetStructuredLogging()
     Utils.initDaemon(log)
     val conf = new SparkConf
     val args = new WorkerArguments(argStrings, conf)

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -422,6 +422,7 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
       backendCreateFn: (RpcEnv, Arguments, SparkEnv, ResourceProfile) =>
         CoarseGrainedExecutorBackend): Unit = {
 
+    Utils.resetStructuredLogging()
     Utils.initDaemon(log)
 
     SparkHadoopUtil.get.runAsSparkUser { () =>

--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2581,6 +2581,19 @@ private[spark] object Utils
   }
 
   /**
+   * Utility function to enable or disable structured logging based on system properties.
+   * This is designed for a code path which we cannot use SparkConf yet, and should be used before
+   * the first invocation of `Logging.log()`. For example, this should be used before `initDaemon`.
+   */
+  def resetStructuredLogging(): Unit = {
+    if (System.getProperty(STRUCTURED_LOGGING_ENABLED.key, "false").equals("false")) {
+      Logging.disableStructuredLogging()
+    } else {
+      Logging.enableStructuredLogging()
+    }
+  }
+
+  /**
    * Return the jar files pointed by the "spark.jars" property. Spark internally will distribute
    * these jars through file server. In the YARN mode, it will return an empty list, since YARN
    * has its own mechanism to distribute jars.

--- a/docs/core-migration-guide.md
+++ b/docs/core-migration-guide.md
@@ -45,7 +45,7 @@ license: |
 - Since Spark 4.0, Spark uses the external shuffle service for deleting shuffle blocks for deallocated executors when the shuffle is no longer needed. To restore the legacy behavior, you can set `spark.shuffle.service.removeShuffle` to `false`.
 
 - Starting with Spark 4.0, the default logging format for `spark-submit` has changed from plain text to JSON lines to improve log analysis. If you prefer plain text logs, you have two options:
-  - Set the Spark configuration `spark.log.structuredLogging.enabled` to `false`. 
+  - Set the Spark configuration `spark.log.structuredLogging.enabled` to `false`. For example, you can use `JDK_JAVA_OPTIONS=-Dspark.log.structuredLogging.enabled=false`.
   - Use a custom log4j configuration file, such as renaming the template file `conf/log4j2.properties.pattern-layout-template` to `conf/log4j2.properties`.
 
 - Since Spark 4.0, the MDC (Mapped Diagnostic Context) key for Spark task names in Spark logs has been changed from `mdc.taskName` to `task_name`. To use the key `mdc.taskName`, you can set `spark.log.legacyTaskNameMdc.enabled` to `true`.

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBackend.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/scheduler/cluster/k8s/KubernetesExecutorBackend.scala
@@ -62,6 +62,7 @@ private[spark] object KubernetesExecutorBackend extends Logging {
       backendCreateFn: (RpcEnv, Arguments, SparkEnv, ResourceProfile, String) =>
         CoarseGrainedExecutorBackend): Unit = {
 
+    Utils.resetStructuredLogging()
     Utils.initDaemon(log)
 
     SparkHadoopUtil.get.runAsSparkUser { () =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `Spark Deamon`s support `spark.log.structuredLogging.enabled` via system property via globally `JDK_JAVA_OPTIONS`.

```
$ JDK_JAVA_OPTIONS=-Dspark.log.structuredLogging.enabled=false sbin/start-master.sh
```

In addition, their own environment variables are supported too.
- Spark Master: `SPARK_MASTER_OPTS`
- Spark Worker: `SPARK_WORKER_OPTS`
- Spark History Server: `SPARK_HISTORY_OPTS `

### Why are the changes needed?

Currently, `spark.log.structuredLogging.enabled` is ignored in deamons like Spark Master, Spark Worker, Spark History Server while the interactive shells and SparkThriftServer respect it.

**BEFORE**
- Spark Master
```
$ SPARK_NO_DAEMONIZE=1 SPARK_MASTER_OPTS=-Dspark.log.structuredLogging.enabled=false sbin/start-master.sh
starting org.apache.spark.deploy.master.Master, logging to /Users/dongjoon/APACHE/spark-releases/spark-4.0.0-preview1-bin-hadoop3/logs/spark-dongjoon-org.apache.spark.deploy.master.Master-1-M3-Max.local.out
Spark Command: /Users/dongjoon/.jenv/versions/17/bin/java -cp /Users/dongjoon/APACHE/spark-releases/spark-4.0.0-preview1-bin-hadoop3/conf/:/Users/dongjoon/APACHE/spark-releases/spark-4.0.0-preview1-bin-hadoop3/jars/slf4j-api-2.0.13.jar:/Users/dongjoon/APACHE/spark-releases/spark-4.0.0-preview1-bin-hadoop3/jars/* -Dspark.log.structuredLogging.enabled=false -Xmx1g org.apache.spark.deploy.master.Master --host M3-Max.local --port 7077 --webui-port 8080
========================================
Using Spark's default log4j profile: org/apache/spark/log4j2-defaults.properties
{"ts":"2024-08-21T16:16:25.954Z","level":"INFO","msg":"Started daemon with process name: 23363@M3-Max.local","logger":"Master"}
```

- Spark Worker
```
$ SPARK_NO_DAEMONIZE=1 SPARK_WORKER_OPTS=-Dspark.log.structuredLogging.enabled=false sbin/start-worker.sh spark://master:port
starting org.apache.spark.deploy.worker.Worker, logging to /Users/dongjoon/APACHE/spark-releases/spark-4.0.0-preview1-bin-hadoop3/logs/spark-dongjoon-org.apache.spark.deploy.worker.Worker-1-M3-Max.local.out
Spark Command: /Users/dongjoon/.jenv/versions/17/bin/java -cp /Users/dongjoon/APACHE/spark-releases/spark-4.0.0-preview1-bin-hadoop3/conf/:/Users/dongjoon/APACHE/spark-releases/spark-4.0.0-preview1-bin-hadoop3/jars/slf4j-api-2.0.13.jar:/Users/dongjoon/APACHE/spark-releases/spark-4.0.0-preview1-bin-hadoop3/jars/* -Dspark.log.structuredLogging.enabled=false -Xmx1g org.apache.spark.deploy.worker.Worker --webui-port 8081 spark://master:port
========================================
Using Spark's default log4j profile: org/apache/spark/log4j2-defaults.properties
{"ts":"2024-08-21T17:04:04.955Z","level":"INFO","msg":"Started daemon with process name: 32154@M3-Max.local","logger":"Worker"}
```

- Spark History Server
```
$ SPARK_NO_DAEMONIZE=1 SPARK_HISTORY_OPTS=-Dspark.log.structuredLogging.enabled=false sbin/start-history-server.sh
starting org.apache.spark.deploy.history.HistoryServer, logging to /Users/dongjoon/APACHE/spark-releases/spark-4.0.0-preview1-bin-hadoop3/logs/spark-dongjoon-org.apache.spark.deploy.history.HistoryServer-1-M3-Max.local.out
Spark Command: /Users/dongjoon/.jenv/versions/17/bin/java -cp /Users/dongjoon/APACHE/spark-releases/spark-4.0.0-preview1-bin-hadoop3/conf/:/Users/dongjoon/APACHE/spark-releases/spark-4.0.0-preview1-bin-hadoop3/jars/slf4j-api-2.0.13.jar:/Users/dongjoon/APACHE/spark-releases/spark-4.0.0-preview1-bin-hadoop3/jars/* -Dspark.log.structuredLogging.enabled=false -Xmx1g org.apache.spark.deploy.history.HistoryServer
========================================
Using Spark's default log4j profile: org/apache/spark/log4j2-defaults.properties
{"ts":"2024-08-21T17:02:57.504Z","level":"INFO","msg":"Started daemon with process name: 31954@M3-Max.local","logger":"HistoryServer"}
```

**AFTER**
- Spark Master
```
$ SPARK_NO_DAEMONIZE=1 SPARK_MASTER_OPTS=-Dspark.log.structuredLogging.enabled=false sbin/start-master.sh
starting org.apache.spark.deploy.master.Master, logging to /Users/dongjoon/APACHE/spark-merge/logs/spark-dongjoon-org.apache.spark.deploy.master.Master-1-M3-Max.local.out
Spark Command: /Users/dongjoon/.jenv/versions/17/bin/java -cp /Users/dongjoon/APACHE/spark-merge/conf/:/Users/dongjoon/APACHE/spark-merge/assembly/target/scala-2.13/jars/slf4j-api-2.0.16.jar:/Users/dongjoon/APACHE/spark-merge/assembly/target/scala-2.13/jars/* -Dspark.log.structuredLogging.enabled=false -Xmx1g org.apache.spark.deploy.master.Master --host M3-Max.local --port 7077 --webui-port 8080
========================================
Using Spark's default log4j profile: org/apache/spark/log4j2-pattern-layout-defaults.properties
24/08/21 09:56:07 INFO Master: Started daemon with process name: 30324@M3-Max.local
```

- Spark Worker
```
$ SPARK_NO_DAEMONIZE=1 SPARK_WORKER_OPTS=-Dspark.log.structuredLogging.enabled=false sbin/start-worker.sh spark://master:port
starting org.apache.spark.deploy.worker.Worker, logging to /Users/dongjoon/APACHE/spark-merge/logs/spark-dongjoon-org.apache.spark.deploy.worker.Worker-1-M3-Max.local.out
Spark Command: /Users/dongjoon/.jenv/versions/17/bin/java -cp /Users/dongjoon/APACHE/spark-merge/conf/:/Users/dongjoon/APACHE/spark-merge/assembly/target/scala-2.13/jars/slf4j-api-2.0.16.jar:/Users/dongjoon/APACHE/spark-merge/assembly/target/scala-2.13/jars/* -Dspark.log.structuredLogging.enabled=false -Xmx1g org.apache.spark.deploy.worker.Worker --webui-port 8081 spark://master:port
========================================
Using Spark's default log4j profile: org/apache/spark/log4j2-pattern-layout-defaults.properties
24/08/21 10:04:35 INFO Worker: Started daemon with process name: 32273@M3-Max.local
```

- Spark History Server
```
$ SPARK_NO_DAEMONIZE=1 SPARK_HISTORY_OPTS=-Dspark.log.structuredLogging.enabled=false sbin/start-history-server.sh
starting org.apache.spark.deploy.history.HistoryServer, logging to /Users/dongjoon/APACHE/spark-merge/logs/spark-dongjoon-org.apache.spark.deploy.history.HistoryServer-1-M3-Max.local.out
Spark Command: /Users/dongjoon/.jenv/versions/17/bin/java -cp /Users/dongjoon/APACHE/spark-merge/conf/:/Users/dongjoon/APACHE/spark-merge/assembly/target/scala-2.13/jars/slf4j-api-2.0.16.jar:/Users/dongjoon/APACHE/spark-merge/assembly/target/scala-2.13/jars/* -Dspark.log.structuredLogging.enabled=false -Xmx1g org.apache.spark.deploy.history.HistoryServer
========================================
Using Spark's default log4j profile: org/apache/spark/log4j2-pattern-layout-defaults.properties
24/08/21 10:01:18 INFO HistoryServer: Started daemon with process name: 31363@M3-Max.local
```

### Does this PR introduce _any_ user-facing change?

Yes, this is a regression fix at `Apache Spark 4.0` because we voted to provide a way to control (disable) this.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.