### PR TITLE
[SPARK-48482][PYTHON][FOLLOWUP] dropDuplicates and dropDuplicatesWIthinWatermark should accept named parameter

### DIFF
--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1222,10 +1222,9 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def subtract(self, other: ParentDataFrame) -> ParentDataFrame:
         return DataFrame(getattr(self._jdf, "except")(other._jdf), self.sparkSession)
 
-    def dropDuplicates(self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str) -> ParentDataFrame:
-        # Acceptable args should be str, ... or a single List[str]
-        # So if subset length is 1, it can be either single str, or a list of str
-        # if subset length is greater than 1, it must be a sequence of str
+    def dropDuplicates(
+        self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str
+    ) -> ParentDataFrame:
         if not subset:
             jdf = self._jdf.dropDuplicates()
         elif isinstance(subset, str):
@@ -1249,10 +1248,9 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
 
     drop_duplicates = dropDuplicates
 
-    def dropDuplicatesWithinWatermark(self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str) -> ParentDataFrame:
-        # Acceptable args should be str, ... or a single List[str]
-        # So if subset length is 1, it can be either single str, or a list of str
-        # if subset length is greater than 1, it must be a sequence of str
+    def dropDuplicatesWithinWatermark(
+        self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str
+    ) -> ParentDataFrame:
         if len(subset) > 1:
             assert all(isinstance(c, str) for c in subset)
 

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1223,10 +1223,10 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         return DataFrame(getattr(self._jdf, "except")(other._jdf), self.sparkSession)
 
     def dropDuplicates(
-        self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str
+        self, subset: Optional[Union[str, List[str], _NoValueType]] = _NoValue, *subset_varargs: str
     ) -> ParentDataFrame:
         # No parameter passed in (e.g. dropDuplicates())
-        if not subset:
+        if subset is _NoValue:
             jdf = self._jdf.dropDuplicates()
         # Parameters passed in as varargs
         # (e.g. dropDuplicates("col"), dropDuplicates("col1", "col2"), ...)
@@ -1259,10 +1259,10 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     drop_duplicates = dropDuplicates
 
     def dropDuplicatesWithinWatermark(
-        self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str
+        self, subset: Optional[Union[str, List[str], _NoValueType]] = _NoValue, *subset_varargs: str
     ) -> ParentDataFrame:
         # No parameter passed in (e.g. dropDuplicatesWithinWatermark())
-        if not subset:
+        if subset is _NoValue:
             jdf = self._jdf.dropDuplicatesWithinWatermark()
         # Parameters passed in as varargs
         # (e.g. dropDuplicatesWithinWatermark("col"),

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1225,8 +1225,11 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def dropDuplicates(
         self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str
     ) -> ParentDataFrame:
+        # No parameter passed in (e.g. dropDuplicates())
         if not subset:
             jdf = self._jdf.dropDuplicates()
+        # Parameters passed in as varargs
+        # (e.g. dropDuplicates("col"), dropDuplicates("col1", "col2"), ...)
         elif isinstance(subset, str):
             item = [subset] + list(subset_varargs)
             for c in item:
@@ -1236,6 +1239,8 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
                         messageParameters={"arg_name": "subset", "arg_type": type(c).__name__},
                     )
             jdf = self._jdf.dropDuplicates(self._jseq(item))
+        # Parameters passed in as list
+        # (e.g. dropDuplicates(["col"]), dropDuplicates(subset=["col1", "col2"]), ...)
         else:
             for c in subset:
                 if not isinstance(c, str):
@@ -1251,8 +1256,12 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def dropDuplicatesWithinWatermark(
         self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str
     ) -> ParentDataFrame:
+        # No parameter passed in (e.g. dropDuplicatesWithinWatermark())
         if not subset:
             jdf = self._jdf.dropDuplicatesWithinWatermark()
+        # Parameters passed in as varargs
+        # (e.g. dropDuplicatesWithinWatermark("col"),
+        #       dropDuplicatesWithinWatermark("col1", "col2"), ...)
         elif isinstance(subset, str):
             item = [subset] + list(subset_varargs)
             for c in item:
@@ -1262,6 +1271,9 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
                         messageParameters={"arg_name": "subset", "arg_type": type(c).__name__},
                     )
             jdf = self._jdf.dropDuplicatesWithinWatermark(self._jseq(item))
+        # Parameters passed in as list
+        # (e.g. dropDuplicatesWithinWatermark(["col"]),
+        #       dropDuplicatesWithinWatermark(subset=["col1", "col2"]), ...)
         else:
             for c in subset:
                 if not isinstance(c, str):

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1237,7 +1237,7 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
                     )
             jdf = self._jdf.dropDuplicates(self._jseq(item))
         else:
-            for c in subset:  # type: ignore[assignment]
+            for c in subset:
                 if not isinstance(c, str):
                     raise PySparkTypeError(
                         errorClass="NOT_STR",
@@ -1251,9 +1251,6 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
     def dropDuplicatesWithinWatermark(
         self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str
     ) -> ParentDataFrame:
-        if len(subset) > 1:
-            assert all(isinstance(c, str) for c in subset)
-
         if not subset:
             jdf = self._jdf.dropDuplicatesWithinWatermark()
         elif isinstance(subset, str):
@@ -1266,7 +1263,7 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
                     )
             jdf = self._jdf.dropDuplicatesWithinWatermark(self._jseq(item))
         else:
-            for c in subset:  # type: ignore[assignment]
+            for c in subset:
                 if not isinstance(c, str):
                     raise PySparkTypeError(
                         errorClass="NOT_STR",

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1241,7 +1241,7 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
             jdf = self._jdf.dropDuplicates(self._jseq(item))
         # Parameters passed in as list
         # (e.g. dropDuplicates(["col"]), dropDuplicates(subset=["col1", "col2"]), ...)
-        else:
+        elif isinstance(subset, list):
             for c in subset:
                 if not isinstance(c, str):
                     raise PySparkTypeError(
@@ -1249,6 +1249,11 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
                         messageParameters={"arg_name": "subset", "arg_type": type(c).__name__},
                     )
             jdf = self._jdf.dropDuplicates(self._jseq(subset))
+        else:
+            raise PySparkTypeError(
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
+            )
         return DataFrame(jdf, self.sparkSession)
 
     drop_duplicates = dropDuplicates
@@ -1274,7 +1279,7 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         # Parameters passed in as list
         # (e.g. dropDuplicatesWithinWatermark(["col"]),
         #       dropDuplicatesWithinWatermark(subset=["col1", "col2"]), ...)
-        else:
+        elif isinstance(subset, list):
             for c in subset:
                 if not isinstance(c, str):
                     raise PySparkTypeError(
@@ -1282,6 +1287,11 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
                         messageParameters={"arg_name": "subset", "arg_type": type(c).__name__},
                     )
             jdf = self._jdf.dropDuplicatesWithinWatermark(self._jseq(subset))
+        else:
+            raise PySparkTypeError(
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
+            )
         return DataFrame(jdf, self.sparkSession)
 
     def dropna(

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -474,9 +474,6 @@ class DataFrame(ParentDataFrame):
     def dropDuplicatesWithinWatermark(
         self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str
     ) -> ParentDataFrame:
-        if len(subset) > 1:
-            assert all(isinstance(c, str) for c in subset)
-
         # No parameter passed in (e.g. dropDuplicatesWithinWatermark())
         if not subset:
             return DataFrame(

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -430,23 +430,18 @@ class DataFrame(ParentDataFrame):
         res._cached_schema = self._cached_schema
         return res
 
-    def dropDuplicates(self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str) -> ParentDataFrame:
-        # Acceptable args should be str, ... or a single List[str]
-        # So if subset length is 1, it can be either single str, or a list of str
-        # if subset length is greater than 1, it must be a sequence of str
-
+    def dropDuplicates(
+        self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str
+    ) -> ParentDataFrame:
         # No parameter passed in (e.g. dropDuplicates())
         if not subset:
-            print("wei== subset is: " + str(subset))
             res = DataFrame(
                 plan.Deduplicate(child=self._plan, all_columns_as_keys=True), session=self._session
             )
         # Parameters passed in as varargs
         # (e.g. dropDuplicates("col"), dropDuplicates("col1", "col2"), ...)
         elif isinstance(subset, str):
-            print("wei== subset is: " + subset + " varargs is: " + str(subset_varargs))
             item = [subset] + list(subset_varargs)
-            print("wei== item is: " + str(item))
             for c in item:
                 if not isinstance(c, str):
                     raise PySparkTypeError(
@@ -460,7 +455,6 @@ class DataFrame(ParentDataFrame):
         # Parameters passed in as list
         # (e.g. dropDuplicates(["col"]), dropDuplicates(subset=["col1", "col2"]), ...)
         else:
-            print("wei== 3rd subset is: " + str(subset))
             for c in subset:
                 if not isinstance(c, str):
                     raise PySparkTypeError(
@@ -477,10 +471,9 @@ class DataFrame(ParentDataFrame):
 
     drop_duplicates = dropDuplicates
 
-    def dropDuplicatesWithinWatermark(self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str) -> ParentDataFrame:
-        # Acceptable args should be str, ... or a single List[str]
-        # So if subset length is 1, it can be either single str, or a list of str
-        # if subset length is greater than 1, it must be a sequence of str
+    def dropDuplicatesWithinWatermark(
+        self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str
+    ) -> ParentDataFrame:
         if len(subset) > 1:
             assert all(isinstance(c, str) for c in subset)
 

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -431,10 +431,10 @@ class DataFrame(ParentDataFrame):
         return res
 
     def dropDuplicates(
-        self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str
+        self, subset: Optional[Union[str, List[str], _NoValueType]] = _NoValue, *subset_varargs: str
     ) -> ParentDataFrame:
         # No parameter passed in (e.g. dropDuplicates())
-        if not subset:
+        if subset is _NoValue:
             res = DataFrame(
                 plan.Deduplicate(child=self._plan, all_columns_as_keys=True), session=self._session
             )
@@ -477,10 +477,10 @@ class DataFrame(ParentDataFrame):
     drop_duplicates = dropDuplicates
 
     def dropDuplicatesWithinWatermark(
-        self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str
+        self, subset: Optional[Union[str, List[str], _NoValueType]] = _NoValue, *subset_varargs: str
     ) -> ParentDataFrame:
         # No parameter passed in (e.g. dropDuplicatesWithinWatermark())
-        if not subset:
+        if subset is _NoValue:
             return DataFrame(
                 plan.Deduplicate(child=self._plan, all_columns_as_keys=True, within_watermark=True),
                 session=self._session,

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -454,7 +454,7 @@ class DataFrame(ParentDataFrame):
             )
         # Parameters passed in as list
         # (e.g. dropDuplicates(["col"]), dropDuplicates(subset=["col1", "col2"]), ...)
-        else:
+        elif isinstance(subset, list):
             for c in subset:
                 if not isinstance(c, str):
                     raise PySparkTypeError(
@@ -464,6 +464,11 @@ class DataFrame(ParentDataFrame):
             res = DataFrame(
                 plan.Deduplicate(child=self._plan, column_names=subset),
                 session=self._session,
+            )
+        else:
+            raise PySparkTypeError(
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
             )
 
         res._cached_schema = self._cached_schema
@@ -498,7 +503,7 @@ class DataFrame(ParentDataFrame):
         # Parameters passed in as list
         # (e.g. dropDuplicatesWithinWatermark(["col"]),
         #       dropDuplicatesWithinWatermark(subset=["col1", "col2"]), ...)
-        else:
+        elif isinstance(subset, list):
             for c in subset:
                 if not isinstance(c, str):
                     raise PySparkTypeError(
@@ -512,6 +517,11 @@ class DataFrame(ParentDataFrame):
                     within_watermark=True,
                 ),
                 session=self._session,
+            )
+        else:
+            raise PySparkTypeError(
+                errorClass="NOT_STR",
+                messageParameters={"arg_name": "subset", "arg_type": type(subset).__name__},
             )
 
     def distinct(self) -> ParentDataFrame:

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -4597,6 +4597,8 @@ class DataFrame:
         subset : list of column names, optional
             List of columns to use for duplicate comparison (default All columns).
 
+        subset_varargs : optional arguments used for supporting variable-length argument.
+
         Returns
         -------
         :class:`DataFrame`
@@ -4624,6 +4626,15 @@ class DataFrame:
         Deduplicate values on 'name' and 'height' columns.
 
         >>> df.dropDuplicates('name', 'height').show()
+        +-----+---+------+
+        | name|age|height|
+        +-----+---+------+
+        |Alice|  5|    80|
+        +-----+---+------+
+
+        Deduplicate values on 'name' and 'height' columns.
+
+        >>> df.dropDuplicates(subset=['name', 'height']).show()
         +-----+---+------+
         | name|age|height|
         +-----+---+------+
@@ -4660,6 +4671,8 @@ class DataFrame:
          subset : List of column names, optional
              List of columns to use for duplicate comparison (default All columns).
 
+         subset_varargs : optional arguments used for supporting variable-length argument.
+
          Returns
          -------
          :class:`DataFrame`
@@ -4685,6 +4698,10 @@ class DataFrame:
          Deduplicate values on 'value' columns.
 
          >>> df.dropDuplicatesWithinWatermark('value')  # doctest: +SKIP
+
+         Deduplicate values on 'value' columns.
+
+         >>> df.dropDuplicatesWithinWatermark(subset=['value'])  # doctest: +SKIP
         """
         ...
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -4570,7 +4570,9 @@ class DataFrame:
         ...
 
     @dispatch_df_method
-    def dropDuplicates(self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str) -> "DataFrame":
+    def dropDuplicates(
+        self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str
+    ) -> "DataFrame":
         """Return a new :class:`DataFrame` with duplicate rows removed,
         optionally only considering certain columns.
 
@@ -4631,7 +4633,9 @@ class DataFrame:
         ...
 
     @dispatch_df_method
-    def dropDuplicatesWithinWatermark(self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str) -> "DataFrame":
+    def dropDuplicatesWithinWatermark(
+        self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str
+    ) -> "DataFrame":
         """Return a new :class:`DataFrame` with duplicate rows removed,
          optionally only considering certain columns, within watermark.
 
@@ -5937,7 +5941,9 @@ class DataFrame:
         ...
 
     @dispatch_df_method
-    def drop_duplicates(self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str) -> "DataFrame":
+    def drop_duplicates(
+        self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str
+    ) -> "DataFrame":
         """
         :func:`drop_duplicates` is an alias for :func:`dropDuplicates`.
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -4570,7 +4570,7 @@ class DataFrame:
         ...
 
     @dispatch_df_method
-    def dropDuplicates(self, *subset: Union[str, List[str]]) -> "DataFrame":
+    def dropDuplicates(self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str) -> "DataFrame":
         """Return a new :class:`DataFrame` with duplicate rows removed,
         optionally only considering certain columns.
 
@@ -4631,7 +4631,7 @@ class DataFrame:
         ...
 
     @dispatch_df_method
-    def dropDuplicatesWithinWatermark(self, *subset: Union[str, List[str]]) -> "DataFrame":
+    def dropDuplicatesWithinWatermark(self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str) -> "DataFrame":
         """Return a new :class:`DataFrame` with duplicate rows removed,
          optionally only considering certain columns, within watermark.
 
@@ -5937,7 +5937,7 @@ class DataFrame:
         ...
 
     @dispatch_df_method
-    def drop_duplicates(self, *subset: Union[str, List[str]]) -> "DataFrame":
+    def drop_duplicates(self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str) -> "DataFrame":
         """
         :func:`drop_duplicates` is an alias for :func:`dropDuplicates`.
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -4571,7 +4571,7 @@ class DataFrame:
 
     @dispatch_df_method
     def dropDuplicates(
-        self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str
+        self, subset: Optional[Union[str, List[str], _NoValueType]] = _NoValue, *subset_varargs: str
     ) -> "DataFrame":
         """Return a new :class:`DataFrame` with duplicate rows removed,
         optionally only considering certain columns.
@@ -4634,7 +4634,7 @@ class DataFrame:
 
     @dispatch_df_method
     def dropDuplicatesWithinWatermark(
-        self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str
+        self, subset: Optional[Union[str, List[str], _NoValueType]] = _NoValue, *subset_varargs: str
     ) -> "DataFrame":
         """Return a new :class:`DataFrame` with duplicate rows removed,
          optionally only considering certain columns, within watermark.
@@ -5942,7 +5942,7 @@ class DataFrame:
 
     @dispatch_df_method
     def drop_duplicates(
-        self, subset: Optional[Union[str, List[str]]] = None, *subset_varargs: str
+        self, subset: Optional[Union[str, List[str], _NoValueType]] = _NoValue, *subset_varargs: str
     ) -> "DataFrame":
         """
         :func:`drop_duplicates` is an alias for :func:`dropDuplicates`.

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -678,13 +678,9 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
             df2.dropDuplicates(["col1", "col2"]).toPandas(),
         )
 
+        self.assert_eq(df.dropDuplicates("col1").toPandas(), df2.dropDuplicates("col1").toPandas())
         self.assert_eq(
-            df.dropDuplicates("col1").toPandas(),
-            df2.dropDuplicates("col1").toPandas()
-        )
-        self.assert_eq(
-            df.drop_duplicates("col1").toPandas(),
-            df2.drop_duplicates("col1").toPandas()
+            df.drop_duplicates("col1").toPandas(), df2.drop_duplicates("col1").toPandas()
         )
 
         self.assert_eq(
@@ -707,11 +703,11 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
         # Verify existing use case with named parameter
         self.assert_eq(
             df.dropDuplicates(subset=["col1"]).toPandas(),
-            df2.dropDuplicates(subset=["col1"]).toPandas()
+            df2.dropDuplicates(subset=["col1"]).toPandas(),
         )
         self.assert_eq(
             df.drop_duplicates(subset=["col1"]).toPandas(),
-            df2.drop_duplicates(subset=["col1"]).toPandas()
+            df2.drop_duplicates(subset=["col1"]).toPandas(),
         )
         self.assert_eq(
             df.dropDuplicates(subset=["col1", "col2"]).toPandas(),

--- a/python/pyspark/sql/tests/connect/test_connect_basic.py
+++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
@@ -663,25 +663,72 @@ class SparkConnectBasicTests(SparkConnectSQLTestCase):
 
     def test_deduplicate(self):
         # SPARK-41326: test distinct and dropDuplicates.
-        df = self.connect.read.table(self.tbl_name)
-        df2 = self.spark.read.table(self.tbl_name)
+        df = self.connect.read.table(self.tbl_name2)
+        df2 = self.spark.read.table(self.tbl_name2)
         self.assert_eq(df.distinct().toPandas(), df2.distinct().toPandas())
         self.assert_eq(df.dropDuplicates().toPandas(), df2.dropDuplicates().toPandas())
         self.assert_eq(
-            df.dropDuplicates(["name"]).toPandas(), df2.dropDuplicates(["name"]).toPandas()
+            df.dropDuplicates(["col1"]).toPandas(), df2.dropDuplicates(["col1"]).toPandas()
         )
         self.assert_eq(
-            df.drop_duplicates(["name"]).toPandas(), df2.drop_duplicates(["name"]).toPandas()
+            df.drop_duplicates(["col1"]).toPandas(), df2.drop_duplicates(["col1"]).toPandas()
         )
         self.assert_eq(
-            df.dropDuplicates(["name", "id"]).toPandas(),
-            df2.dropDuplicates(["name", "id"]).toPandas(),
+            df.dropDuplicates(["col1", "col2"]).toPandas(),
+            df2.dropDuplicates(["col1", "col2"]).toPandas(),
+        )
+
+        self.assert_eq(
+            df.dropDuplicates("col1").toPandas(),
+            df2.dropDuplicates("col1").toPandas()
         )
         self.assert_eq(
-            df.drop_duplicates(["name", "id"]).toPandas(),
-            df2.drop_duplicates(["name", "id"]).toPandas(),
+            df.drop_duplicates("col1").toPandas(),
+            df2.drop_duplicates("col1").toPandas()
         )
-        self.assert_eq(df.dropDuplicates("name").toPandas(), df2.dropDuplicates("name").toPandas())
+
+        self.assert_eq(
+            df.dropDuplicates("col1", "col2").toPandas(),
+            df2.dropDuplicates("col1", "col2").toPandas(),
+        )
+        self.assert_eq(
+            df.drop_duplicates(["col1", "col2"]).toPandas(),
+            df2.drop_duplicates(["col1", "col2"]).toPandas(),
+        )
+        self.assert_eq(
+            df.dropDuplicates("col1", "col2", "col3").toPandas(),
+            df2.dropDuplicates("col1", "col2", "col3").toPandas(),
+        )
+        self.assert_eq(
+            df.drop_duplicates(["col1", "col2"]).toPandas(),
+            df2.drop_duplicates(["col1", "col2"]).toPandas(),
+        )
+
+        # Verify existing use case with named parameter
+        self.assert_eq(
+            df.dropDuplicates(subset=["col1"]).toPandas(),
+            df2.dropDuplicates(subset=["col1"]).toPandas()
+        )
+        self.assert_eq(
+            df.drop_duplicates(subset=["col1"]).toPandas(),
+            df2.drop_duplicates(subset=["col1"]).toPandas()
+        )
+        self.assert_eq(
+            df.dropDuplicates(subset=["col1", "col2"]).toPandas(),
+            df2.dropDuplicates(subset=["col1", "col2"]).toPandas(),
+        )
+        self.assert_eq(
+            df.drop_duplicates(subset=["col1", "col2"]).toPandas(),
+            df2.drop_duplicates(subset=["col1", "col2"]).toPandas(),
+        )
+        self.assert_eq(
+            df.drop_duplicates(subset=["col1", "col2"]).toPandas(),
+            df2.drop_duplicates(subset=["col1", "col2"]).toPandas(),
+        )
+        self.assert_eq(
+            df.dropDuplicates(subset=["col1", "col2", "col3"]).toPandas(),
+            df2.dropDuplicates(subset=["col1", "col2", "col3"]).toPandas(),
+        )
 
     def test_drop(self):
         # SPARK-41169: test drop

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -260,6 +260,9 @@ class DataFrameTestsMixin:
         self.assertEqual(df.dropDuplicates(["name"]).count(), 1)
         self.assertEqual(df.dropDuplicates(["name", "age"]).count(), 2)
 
+        self.assertEqual(df.dropDuplicates(subset=["name"]).count(), 1)
+        self.assertEqual(df.dropDuplicates(subset=["name", "age"]).count(), 2)
+
         self.assertEqual(df.drop_duplicates(["name"]).count(), 1)
         self.assertEqual(df.drop_duplicates(["name", "age"]).count(), 2)
 
@@ -272,15 +275,6 @@ class DataFrameTestsMixin:
         # Should raise proper error when taking non-string values
         with self.assertRaises(PySparkTypeError) as pe:
             df.dropDuplicates([None]).show()
-
-        self.check_error(
-            exception=pe.exception,
-            errorClass="NOT_STR",
-            messageParameters={"arg_name": "subset", "arg_type": "NoneType"},
-        )
-
-        with self.assertRaises(PySparkTypeError) as pe:
-            df.dropDuplicates(None).show()
 
         self.check_error(
             exception=pe.exception,

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -283,6 +283,15 @@ class DataFrameTestsMixin:
         )
 
         with self.assertRaises(PySparkTypeError) as pe:
+            df.dropDuplicates(None).show()
+
+        self.check_error(
+            exception=pe.exception,
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "subset", "arg_type": "NoneType"},
+        )
+
+        with self.assertRaises(PySparkTypeError) as pe:
             df.dropDuplicates([1]).show()
 
         self.check_error(

--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -309,6 +309,78 @@ class DataFrameTestsMixin:
             messageParameters={"arg_name": "subset", "arg_type": "int"},
         )
 
+        with self.assertRaises(PySparkTypeError) as pe:
+            df.dropDuplicates(subset=["1", 1]).show()
+
+        self.check_error(
+            exception=pe.exception,
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "subset", "arg_type": "int"},
+        )
+
+        with self.assertRaises(PySparkTypeError) as pe:
+            df.dropDuplicates("1", 1).show()
+
+        self.check_error(
+            exception=pe.exception,
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "subset", "arg_type": "int"},
+        )
+
+        with self.assertRaises(PySparkTypeError) as pe:
+            df.dropDuplicates(1, "1").show()
+
+        self.check_error(
+            exception=pe.exception,
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "subset", "arg_type": "int"},
+        )
+
+        with self.assertRaises(PySparkTypeError) as pe:
+            df.dropDuplicates("1", None).show()
+
+        self.check_error(
+            exception=pe.exception,
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "subset", "arg_type": "NoneType"},
+        )
+
+        with self.assertRaises(PySparkTypeError) as pe:
+            df.dropDuplicates(None, "1").show()
+
+        self.check_error(
+            exception=pe.exception,
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "subset", "arg_type": "NoneType"},
+        )
+
+        with self.assertRaises(PySparkTypeError) as pe:
+            df.dropDuplicates(subset=[None, "1"]).show()
+
+        self.check_error(
+            exception=pe.exception,
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "subset", "arg_type": "NoneType"},
+        )
+
+        with self.assertRaises(PySparkTypeError) as pe:
+            df.dropDuplicates(subset=[None, 1]).show()
+
+        self.check_error(
+            exception=pe.exception,
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "subset", "arg_type": "NoneType"},
+        )
+
+        with self.assertRaises(PySparkTypeError) as pe:
+            df.dropDuplicates(1, None).show()
+
+        self.check_error(
+            exception=pe.exception,
+            errorClass="NOT_STR",
+            messageParameters={"arg_name": "subset", "arg_type": "int"},
+        )
+
     def test_drop_duplicates_with_ambiguous_reference(self):
         df1 = self.spark.createDataFrame([(14, "Tom"), (23, "Alice"), (16, "Bob")], ["age", "name"])
         df2 = self.spark.createDataFrame([Row(height=80, name="Tom"), Row(height=85, name="Bob")])


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
https://github.com/apache/spark/commit/560c08332b35941260169124b4f522bdc82b84d8 unintentionally made `dropDuplicates(subset=["col"])` doesn't work, this patches this scenario.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Bug fix

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit test 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No