### PR TITLE
[SPARK-49344][PS] Support `json_normalize` for Pandas API on Spark

### DIFF
--- a/python/docs/source/reference/pyspark.pandas/io.rst
+++ b/python/docs/source/reference/pyspark.pandas/io.rst
@@ -105,6 +105,7 @@ JSON
 .. autosummary::
    :toctree: api/
 
+   json_normalize
    read_json
    DataFrame.to_json
 

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -3695,6 +3695,7 @@ def json_normalize(
 ) -> DataFrame:
     """
     Normalize semi-structured JSON data into a flat table.
+
     .. versionadded:: 4.0.0
 
     Parameters

--- a/python/pyspark/pandas/namespace.py
+++ b/python/pyspark/pandas/namespace.py
@@ -3695,6 +3695,7 @@ def json_normalize(
 ) -> DataFrame:
     """
     Normalize semi-structured JSON data into a flat table.
+    .. versionadded:: 4.0.0
 
     Parameters
     ----------

--- a/python/pyspark/pandas/tests/test_namespace.py
+++ b/python/pyspark/pandas/tests/test_namespace.py
@@ -639,7 +639,7 @@ class NamespaceTestsMixin:
         ]
         assert_frame_equal(pd.json_normalize(data), ps.json_normalize(data))
 
-        # Test case with various data types (integers, booleans, etc.)
+        # Test case with various data types
         data = [
             {
                 "id": 1,
@@ -678,9 +678,6 @@ class NamespaceTestsMixin:
 
 
 class NamespaceTests(NamespaceTestsMixin, PandasOnSparkTestCase, SQLTestUtils):
-    def test_json_normalize(self):
-        super().test_json_normalize()
-
     pass
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to support `json_normalize` for Pandas API on Spark.

### Why are the changes needed?

For Pandas feature parity: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.json_normalize.html

### Does this PR introduce _any_ user-facing change?

Introduce new API `ps.json_normalize`

```python
>>> data = [
...     {"id": 1, "name": "Alice", "address": {"city": "NYC", "zipcode": "10001"}},
...     {"id": 2, "name": "Bob", "address": {"city": "SF", "zipcode": "94105"}},
... ]
>>> ps.json_normalize(data)
   id   name address.city address.zipcode
0   1  Alice          NYC           10001
1   2    Bob           SF           94105
```

### How was this patch tested?

Added UTs

### Was this patch authored or co-authored using generative AI tooling?

No