### PR TITLE
[SPARK-47259][SQL] Assign names to error conditions for interval errors

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1959,6 +1959,11 @@
       },
       "UNMATCHED_FORMAT_STRING" : {
         "message" : [
+          "Interval string does not match <intervalStr> format of <supportedFormat> when cast to <typeName>: <input>."
+        ]
+      },
+      "UNMATCHED_FORMAT_STRING_WITH_NOTICE" : {
+        "message" : [
           "Interval string does not match <intervalStr> format of <supportedFormat> when cast to <typeName>: <input><fallBackNotice>."
         ]
       },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1964,7 +1964,7 @@
       },
       "UNMATCHED_FORMAT_STRING_WITH_NOTICE" : {
         "message" : [
-          "Interval string does not match <intervalStr> format of <supportedFormat> when cast to <typeName>: <input><fallBackNotice>."
+          "Interval string does not match <intervalStr> format of <supportedFormat> when cast to <typeName>: <input>, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
         ]
       },
       "UNSUPPORTED_FROM_TO_EXPRESSION" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1834,6 +1834,44 @@
     },
     "sqlState" : "XXKUC"
   },
+  "INTERVAL_ERROR" : {
+    "message" : [
+      "Interval error."
+    ],
+    "subClass" : {
+      "ILLEGAL_DAY_OF_WEEK" : {
+        "message" : [
+          "Illegal input for day of week: <string>."
+        ]
+      },
+      "SECOND_NANO_FORMAT" : {
+        "message" : [
+          "Interval string does not match second-nano format of ss.nnnnnnnnn."
+        ]
+      },
+      "DAY_TIME_PARSING" : {
+        "message" : [
+          "Error parsing interval day-time string: <msg>."
+        ]
+      },
+      "UNSUPPORTED_FROM_TO_EXPRESSION" : {
+        "message" : [
+          "Cannot support (interval '<input>' <from> to <to>) expression."
+        ]
+      },
+      "INTERVAL_PARSING" : {
+        "message" : [
+          "Error parsing interval <interval> string: <msg>."
+        ]
+      },
+      "UNMATCHED_FORMAT_STRING" : {
+        "message" : [
+          "Interval string does not match <intervalStr> format of <supportedFormat> when cast to <typeName>: <input><fallBackNotice>."
+        ]
+      }
+    },
+    "sqlState" : "22015"
+  },
   "INTERNAL_ERROR" : {
     "message" : [
       "<message>"
@@ -8436,36 +8474,6 @@
   "_LEGACY_ERROR_TEMP_3208" : {
     "message" : [
       "The number of fields (<numFields>) in the partition identifier is not equal to the partition schema length (<schemaLen>). The identifier might not refer to one partition."
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3209" : {
-    "message" : [
-      "Illegal input for day of week: <string>"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3210" : {
-    "message" : [
-      "Interval string does not match second-nano format of ss.nnnnnnnnn"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3211" : {
-    "message" : [
-      "Error parsing interval day-time string: <msg>"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3212" : {
-    "message" : [
-      "Cannot support (interval '<input>' <from> to <to>) expression"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3213" : {
-    "message" : [
-      "Error parsing interval <interval> string: <msg>"
-    ]
-  },
-  "_LEGACY_ERROR_TEMP_3214" : {
-    "message" : [
-      "Interval string does not match <intervalStr> format of <supportedFormat> when cast to <typeName>: <input><fallBackNotice>"
     ]
   },
   "_LEGACY_ERROR_TEMP_3215" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1834,44 +1834,6 @@
     },
     "sqlState" : "XXKUC"
   },
-  "INTERVAL_ERROR" : {
-    "message" : [
-      "Interval error."
-    ],
-    "subClass" : {
-      "DAY_TIME_PARSING" : {
-        "message" : [
-          "Error parsing interval day-time string: <msg>."
-        ]
-      },
-      "INTERVAL_PARSING" : {
-        "message" : [
-          "Error parsing interval <interval> string: <msg>."
-        ]
-      },
-      "ILLEGAL_DAY_OF_WEEK" : {
-        "message" : [
-          "Illegal input for day of week: <string>."
-        ]
-      },
-      "SECOND_NANO_FORMAT" : {
-        "message" : [
-          "Interval string does not match second-nano format of ss.nnnnnnnnn."
-        ]
-      },
-      "UNMATCHED_FORMAT_STRING" : {
-        "message" : [
-          "Interval string does not match <intervalStr> format of <supportedFormat> when cast to <typeName>: <input><fallBackNotice>."
-        ]
-      },
-      "UNSUPPORTED_FROM_TO_EXPRESSION" : {
-        "message" : [
-          "Cannot support (interval '<input>' <from> to <to>) expression."
-        ]
-      }
-    },
-    "sqlState" : "22009"
-  },
   "INTERNAL_ERROR" : {
     "message" : [
       "<message>"
@@ -1969,6 +1931,44 @@
       "Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead."
     ],
     "sqlState" : "22012"
+  },
+  "INTERVAL_ERROR" : {
+    "message" : [
+      "Interval error."
+    ],
+    "subClass" : {
+      "DAY_TIME_PARSING" : {
+        "message" : [
+          "Error parsing interval day-time string: <msg>."
+        ]
+      },
+      "ILLEGAL_DAY_OF_WEEK" : {
+        "message" : [
+          "Illegal input for day of week: <string>."
+        ]
+      },
+      "INTERVAL_PARSING" : {
+        "message" : [
+          "Error parsing interval <interval> string: <msg>."
+        ]
+      },
+      "SECOND_NANO_FORMAT" : {
+        "message" : [
+          "Interval string does not match second-nano format of ss.nnnnnnnnn."
+        ]
+      },
+      "UNMATCHED_FORMAT_STRING" : {
+        "message" : [
+          "Interval string does not match <intervalStr> format of <supportedFormat> when cast to <typeName>: <input><fallBackNotice>."
+        ]
+      },
+      "UNSUPPORTED_FROM_TO_EXPRESSION" : {
+        "message" : [
+          "Cannot support (interval '<input>' <from> to <to>) expression."
+        ]
+      }
+    },
+    "sqlState" : "22009"
   },
   "INVALID_AGGREGATE_FILTER" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1839,6 +1839,16 @@
       "Interval error."
     ],
     "subClass" : {
+      "DAY_TIME_PARSING" : {
+        "message" : [
+          "Error parsing interval day-time string: <msg>."
+        ]
+      },
+      "INTERVAL_PARSING" : {
+        "message" : [
+          "Error parsing interval <interval> string: <msg>."
+        ]
+      },
       "ILLEGAL_DAY_OF_WEEK" : {
         "message" : [
           "Illegal input for day of week: <string>."
@@ -1849,28 +1859,18 @@
           "Interval string does not match second-nano format of ss.nnnnnnnnn."
         ]
       },
-      "DAY_TIME_PARSING" : {
+      "UNMATCHED_FORMAT_STRING" : {
         "message" : [
-          "Error parsing interval day-time string: <msg>."
+          "Interval string does not match <intervalStr> format of <supportedFormat> when cast to <typeName>: <input><fallBackNotice>."
         ]
       },
       "UNSUPPORTED_FROM_TO_EXPRESSION" : {
         "message" : [
           "Cannot support (interval '<input>' <from> to <to>) expression."
         ]
-      },
-      "INTERVAL_PARSING" : {
-        "message" : [
-          "Error parsing interval <interval> string: <msg>."
-        ]
-      },
-      "UNMATCHED_FORMAT_STRING" : {
-        "message" : [
-          "Interval string does not match <intervalStr> format of <supportedFormat> when cast to <typeName>: <input><fallBackNotice>."
-        ]
       }
     },
-    "sqlState" : "22015"
+    "sqlState" : "22009"
   },
   "INTERNAL_ERROR" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1583,6 +1583,12 @@
     ],
     "sqlState" : "42601"
   },
+  "ILLEGAL_DAY_OF_WEEK" : {
+    "message" : [
+      "Illegal input for day of week: <string>."
+    ],
+    "sqlState" : "22009"
+  },
   "ILLEGAL_STATE_STORE_VALUE" : {
     "message" : [
       "Illegal value provided to the State Store"
@@ -1931,29 +1937,6 @@
       "Division by zero. Use `try_divide` to tolerate divisor being 0 and return NULL instead."
     ],
     "sqlState" : "22012"
-  },
-  "INTERVAL_ERROR" : {
-    "message" : [
-      "Interval error."
-    ],
-    "subClass" : {
-      "ILLEGAL_DAY_OF_WEEK" : {
-        "message" : [
-          "Illegal input for day of week: <string>."
-        ]
-      },
-      "INTERVAL_PARSING" : {
-        "message" : [
-          "Error parsing interval <interval> string: <msg>."
-        ]
-      },
-      "SECOND_NANO_FORMAT" : {
-        "message" : [
-          "Interval string does not match second-nano format of ss.nnnnnnnnn."
-        ]
-      }
-    },
-    "sqlState" : "22009"
   },
   "INVALID_AGGREGATE_FILTER" : {
     "message" : [
@@ -2433,6 +2416,11 @@
           "Interval string cannot be null."
         ]
       },
+      "INTERVAL_PARSING" : {
+        "message" : [
+          "Error parsing interval <interval> string."
+        ]
+      },
       "INVALID_FRACTION" : {
         "message" : [
           "<unit> cannot have fractional part."
@@ -2466,6 +2454,11 @@
       "MISSING_UNIT" : {
         "message" : [
           "Expect a unit name after <word> but hit EOL."
+        ]
+      },
+      "SECOND_NANO_FORMAT" : {
+        "message" : [
+          "Interval string does not match second-nano format of ss.nnnnnnnnn."
         ]
       },
       "UNKNOWN_PARSING_ERROR" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1937,11 +1937,6 @@
       "Interval error."
     ],
     "subClass" : {
-      "DAY_TIME_PARSING" : {
-        "message" : [
-          "Error parsing interval day-time string: <msg>."
-        ]
-      },
       "ILLEGAL_DAY_OF_WEEK" : {
         "message" : [
           "Illegal input for day of week: <string>."
@@ -1955,21 +1950,6 @@
       "SECOND_NANO_FORMAT" : {
         "message" : [
           "Interval string does not match second-nano format of ss.nnnnnnnnn."
-        ]
-      },
-      "UNMATCHED_FORMAT_STRING" : {
-        "message" : [
-          "Interval string does not match <intervalStr> format of <supportedFormat> when cast to <typeName>: <input>."
-        ]
-      },
-      "UNMATCHED_FORMAT_STRING_WITH_NOTICE" : {
-        "message" : [
-          "Interval string does not match <intervalStr> format of <supportedFormat> when cast to <typeName>: <input>, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
-        ]
-      },
-      "UNSUPPORTED_FROM_TO_EXPRESSION" : {
-        "message" : [
-          "Cannot support (interval '<input>' <from> to <to>) expression."
         ]
       }
     },
@@ -2438,6 +2418,11 @@
           "Uncaught arithmetic exception while parsing '<input>'."
         ]
       },
+      "DAY_TIME_PARSING" : {
+        "message" : [
+          "Error parsing interval day-time string: <msg>."
+        ]
+      },
       "INPUT_IS_EMPTY" : {
         "message" : [
           "Interval string cannot be empty."
@@ -2488,9 +2473,24 @@
           "Unknown error when parsing <word>."
         ]
       },
+      "UNMATCHED_FORMAT_STRING" : {
+        "message" : [
+          "Interval string does not match <intervalStr> format of <supportedFormat> when cast to <typeName>: <input>."
+        ]
+      },
+      "UNMATCHED_FORMAT_STRING_WITH_NOTICE" : {
+        "message" : [
+          "Interval string does not match <intervalStr> format of <supportedFormat> when cast to <typeName>: <input>. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0."
+        ]
+      },
       "UNRECOGNIZED_NUMBER" : {
         "message" : [
           "Unrecognized number <number>."
+        ]
+      },
+      "UNSUPPORTED_FROM_TO_EXPRESSION" : {
+        "message" : [
+          "Cannot support (interval '<input>' <from> to <to>) expression."
         ]
       }
     },

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3448,8 +3448,14 @@ class AstBuilder extends DataTypeAstBuilder
             throw QueryParsingErrors.fromToIntervalUnsupportedError(from, to, ctx)
         }
       } catch {
-        // Bypass ParseExceptions
-        case pe: ParseException => throw pe
+        // Keep error class of SparkIllegalArgumentExceptions and enrich it with query context
+        case se: SparkIllegalArgumentException =>
+          val pe = new ParseException(
+            errorClass = se.getErrorClass,
+            messageParameters = se.getMessageParameters.asScala.toMap,
+            ctx)
+          pe.setStackTrace(se.getStackTrace)
+          throw pe
         // Handle Exceptions thrown by CalendarInterval
         case e: IllegalArgumentException =>
           val pe = new ParseException(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3448,6 +3448,8 @@ class AstBuilder extends DataTypeAstBuilder
             throw QueryParsingErrors.fromToIntervalUnsupportedError(from, to, ctx)
         }
       } catch {
+        // Bypass SparkThrowables
+        case st: SparkThrowable => throw st
         // Handle Exceptions thrown by CalendarInterval
         case e: IllegalArgumentException =>
           val pe = new ParseException(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -3448,8 +3448,8 @@ class AstBuilder extends DataTypeAstBuilder
             throw QueryParsingErrors.fromToIntervalUnsupportedError(from, to, ctx)
         }
       } catch {
-        // Bypass SparkThrowables
-        case st: SparkThrowable => throw st
+        // Bypass ParseExceptions
+        case pe: ParseException => throw pe
         // Handle Exceptions thrown by CalendarInterval
         case e: IllegalArgumentException =>
           val pe = new ParseException(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -389,7 +389,7 @@ object DateTimeUtils extends SparkDateTimeUtils {
       case "SA" | "SAT" | "SATURDAY" => SATURDAY
       case _ =>
         throw new SparkIllegalArgumentException(
-          errorClass = "_LEGACY_ERROR_TEMP_3209",
+          errorClass = "INTERVAL_ERROR.ILLEGAL_DAY_OF_WEEK",
           messageParameters = Map("string" -> string.toString))
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala
@@ -389,7 +389,7 @@ object DateTimeUtils extends SparkDateTimeUtils {
       case "SA" | "SAT" | "SATURDAY" => SATURDAY
       case _ =>
         throw new SparkIllegalArgumentException(
-          errorClass = "INTERVAL_ERROR.ILLEGAL_DAY_OF_WEEK",
+          errorClass = "ILLEGAL_DAY_OF_WEEK",
           messageParameters = Map("string" -> string.toString))
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -108,8 +108,8 @@ object IntervalUtils extends SparkIntervalUtils {
       fallBackNotice: Boolean = false) = {
     throw new SparkIllegalArgumentException(
       errorClass = {
-        if (fallBackNotice) "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE"
-        else "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING"
+        if (fallBackNotice) "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE"
+        else "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING"
       },
       messageParameters = Map(
         "intervalStr" -> intervalStr,
@@ -528,8 +528,10 @@ object IntervalUtils extends SparkIntervalUtils {
     } catch {
       case e: Exception =>
         throw new SparkIllegalArgumentException(
-          errorClass = "INTERVAL_ERROR.DAY_TIME_PARSING",
-          messageParameters = Map("msg" -> e.getMessage),
+          errorClass = "INVALID_INTERVAL_FORMAT.DAY_TIME_PARSING",
+          messageParameters = Map(
+            "msg" -> e.getMessage,
+            "input" -> input),
           cause = e)
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -107,14 +107,18 @@ object IntervalUtils extends SparkIntervalUtils {
       typeName: String,
       fallBackNotice: Option[String] = None) = {
     throw new SparkIllegalArgumentException(
-      errorClass = "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+      errorClass = fallBackNotice match {
+        case Some(_) => "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE"
+        case _ => "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING"
+      },
       messageParameters = Map(
         "intervalStr" -> intervalStr,
         "supportedFormat" -> supportedFormat((intervalStr, startFiled, endField))
           .map(format => s"`$format`").mkString(", "),
         "typeName" -> typeName,
-        "input" -> input.toString,
-        "fallBackNotice" -> fallBackNotice.map(s => s", $s").getOrElse("")))
+        "input" -> input.toString)
+        ++ fallBackNotice.map(s => Map("fallBackNotice" -> s", $s and $fallbackNotice")
+      ).getOrElse(Map.empty))
   }
 
   val supportedFormat = Map(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -213,7 +213,7 @@ object IntervalUtils extends SparkIntervalUtils {
       case NonFatal(e) =>
         throw new SparkIllegalArgumentException(
           errorClass = "INVALID_INTERVAL_FORMAT.INTERVAL_PARSING",
-          messageParameters = Map("input" -> input, "interval" -> interval, "msg" -> e.getMessage),
+          messageParameters = Map("input" -> input, "interval" -> interval),
           cause = e)
     }
   }
@@ -516,7 +516,7 @@ object IntervalUtils extends SparkIntervalUtils {
         case DT.SECOND =>
           // No-op
         case _ => throw new SparkIllegalArgumentException(
-          errorClass = "INTERVAL_ERROR.UNSUPPORTED_FROM_TO_EXPRESSION",
+          errorClass = "INVALID_INTERVAL_FORMAT.UNSUPPORTED_FROM_TO_EXPRESSION",
           messageParameters = Map(
             "input" -> input,
             "from" -> DT.fieldToString(from),
@@ -528,6 +528,8 @@ object IntervalUtils extends SparkIntervalUtils {
       micros = Math.addExact(micros, Math.multiplyExact(seconds, MICROS_PER_SECOND))
       new CalendarInterval(0, sign * days, sign * micros)
     } catch {
+      // Bypass SparkIllegalArgumentExceptions
+      case se: SparkIllegalArgumentException => throw se
       case e: Exception =>
         throw new SparkIllegalArgumentException(
           errorClass = "INVALID_INTERVAL_FORMAT.DAY_TIME_PARSING",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -105,20 +105,18 @@ object IntervalUtils extends SparkIntervalUtils {
       endField: Byte,
       intervalStr: String,
       typeName: String,
-      fallBackNotice: Option[String] = None) = {
+      fallBackNotice: Boolean = false) = {
     throw new SparkIllegalArgumentException(
-      errorClass = fallBackNotice match {
-        case Some(_) => "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE"
-        case _ => "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING"
+      errorClass = {
+        if (fallBackNotice) "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE"
+        else "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING"
       },
       messageParameters = Map(
         "intervalStr" -> intervalStr,
         "supportedFormat" -> supportedFormat((intervalStr, startFiled, endField))
           .map(format => s"`$format`").mkString(", "),
         "typeName" -> typeName,
-        "input" -> input.toString)
-        ++ fallBackNotice.map(s => Map("fallBackNotice" -> s", $s and $fallbackNotice")
-      ).getOrElse(Map.empty))
+        "input" -> input.toString))
   }
 
   val supportedFormat = Map(
@@ -343,7 +341,7 @@ object IntervalUtils extends SparkIntervalUtils {
                 case -1 => parseSecondNano(s"-${secondAndMicro(value, suffix)}")
               }
             case (_, _) => throwIllegalIntervalFormatException(input, startField, endField,
-              "day-time", DT(startField, endField).typeName, Some(fallbackNotice))
+              "day-time", DT(startField, endField).typeName, true)
           }
         }
       case dayTimeIndividualLiteralRegex(firstSign, secondSign, value, suffix, unit) =>
@@ -364,11 +362,11 @@ object IntervalUtils extends SparkIntervalUtils {
                 case -1 => parseSecondNano(s"-${secondAndMicro(value, suffix)}")
               }
             case _ => throwIllegalIntervalFormatException(input, startField, endField,
-              "day-time", DT(startField, endField).typeName, Some(fallbackNotice))
+              "day-time", DT(startField, endField).typeName, true)
           }
         }
       case _ => throwIllegalIntervalFormatException(input, startField, endField,
-        "day-time", DT(startField, endField).typeName, Some(fallbackNotice))
+        "day-time", DT(startField, endField).typeName, true)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -107,7 +107,7 @@ object IntervalUtils extends SparkIntervalUtils {
       typeName: String,
       fallBackNotice: Option[String] = None) = {
     throw new SparkIllegalArgumentException(
-      errorClass = "_LEGACY_ERROR_TEMP_3214",
+      errorClass = "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
       messageParameters = Map(
         "intervalStr" -> intervalStr,
         "supportedFormat" -> supportedFormat((intervalStr, startFiled, endField))
@@ -209,7 +209,7 @@ object IntervalUtils extends SparkIntervalUtils {
       case e: SparkThrowable => throw e
       case NonFatal(e) =>
         throw new SparkIllegalArgumentException(
-          errorClass = "_LEGACY_ERROR_TEMP_3213",
+          errorClass = "INTERVAL_ERROR.INTERVAL_PARSING",
           messageParameters = Map("interval" -> interval, "msg" -> e.getMessage),
           cause = e)
     }
@@ -512,7 +512,7 @@ object IntervalUtils extends SparkIntervalUtils {
         case DT.SECOND =>
           // No-op
         case _ => throw new SparkIllegalArgumentException(
-          errorClass = "_LEGACY_ERROR_TEMP_3212",
+          errorClass = "INTERVAL_ERROR.UNSUPPORTED_FROM_TO_EXPRESSION",
           messageParameters = Map(
             "input" -> input,
             "from" -> DT.fieldToString(from),
@@ -526,7 +526,7 @@ object IntervalUtils extends SparkIntervalUtils {
     } catch {
       case e: Exception =>
         throw new SparkIllegalArgumentException(
-          errorClass = "_LEGACY_ERROR_TEMP_3211",
+          errorClass = "INTERVAL_ERROR.DAY_TIME_PARSING",
           messageParameters = Map("msg" -> e.getMessage),
           cause = e)
     }
@@ -564,7 +564,7 @@ object IntervalUtils extends SparkIntervalUtils {
       case Array(secondsStr, nanosStr) =>
         val seconds = parseSeconds(secondsStr)
         Math.addExact(seconds, parseNanos(nanosStr, seconds < 0))
-      case _ => throw new SparkIllegalArgumentException("_LEGACY_ERROR_TEMP_3210")
+      case _ => throw new SparkIllegalArgumentException("INTERVAL_ERROR.SECOND_NANO_FORMAT")
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/IntervalUtils.scala
@@ -147,14 +147,15 @@ object IntervalUtils extends SparkIntervalUtils {
     def checkTargetType(targetStartField: Byte, targetEndField: Byte): Boolean =
       startField == targetStartField && endField == targetEndField
 
-    input.trimAll().toString match {
+    val trimmedInput = input.trimAll().toString
+    trimmedInput match {
       case yearMonthRegex(sign, year, month) if checkTargetType(YM.YEAR, YM.MONTH) =>
-        toYMInterval(year, month, input.trimAll().toString, finalSign(sign))
+        toYMInterval(year, month, trimmedInput, finalSign(sign))
       case yearMonthLiteralRegex(firstSign, secondSign, year, month)
         if checkTargetType(YM.YEAR, YM.MONTH) =>
-        toYMInterval(year, month, input.trimAll().toString, finalSign(firstSign, secondSign))
+        toYMInterval(year, month, trimmedInput, finalSign(firstSign, secondSign))
       case yearMonthIndividualRegex(firstSign, value) =>
-        safeToInterval("year-month", input.trimAll().toString) {
+        safeToInterval("year-month", trimmedInput) {
           val sign = finalSign(firstSign)
           if (endField == YM.YEAR) {
             sign * Math.toIntExact(value.toLong * MONTHS_PER_YEAR)
@@ -166,7 +167,7 @@ object IntervalUtils extends SparkIntervalUtils {
           }
         }
       case yearMonthIndividualLiteralRegex(firstSign, secondSign, value, unit) =>
-        safeToInterval("year-month", input.trimAll().toString) {
+        safeToInterval("year-month", trimmedInput) {
           val sign = finalSign(firstSign, secondSign)
           unit.toUpperCase(Locale.ROOT) match {
             case "YEAR" if checkTargetType(YM.YEAR, YM.YEAR) =>
@@ -287,7 +288,8 @@ object IntervalUtils extends SparkIntervalUtils {
     def checkTargetType(targetStartField: Byte, targetEndField: Byte): Boolean =
       startField == targetStartField && endField == targetEndField
 
-    input.trimAll().toString match {
+    val trimmedInput = input.trimAll().toString
+    trimmedInput match {
       case dayHourRegex(sign, day, hour) if checkTargetType(DT.DAY, DT.HOUR) =>
         toDTInterval(day, hour, "0", "0", finalSign(sign))
       case dayHourLiteralRegex(firstSign, secondSign, day, hour)
@@ -326,7 +328,7 @@ object IntervalUtils extends SparkIntervalUtils {
         toDTInterval(minute, secondAndMicro(second, micro), finalSign(firstSign, secondSign))
 
       case dayTimeIndividualRegex(firstSign, value, suffix) =>
-        safeToInterval("day-time", input.trimAll().toString) {
+        safeToInterval("day-time", trimmedInput) {
           val sign = finalSign(firstSign)
           (startField, endField) match {
             case (DT.DAY, DT.DAY) if suffix == null && value.length <= 9 =>
@@ -345,7 +347,7 @@ object IntervalUtils extends SparkIntervalUtils {
           }
         }
       case dayTimeIndividualLiteralRegex(firstSign, secondSign, value, suffix, unit) =>
-        safeToInterval("day-time", input.trimAll().toString) {
+        safeToInterval("day-time", trimmedInput) {
           val sign = finalSign(firstSign, secondSign)
           unit.toUpperCase(Locale.ROOT) match {
             case "DAY" if suffix == null && value.length <= 9 && checkTargetType(DT.DAY, DT.DAY) =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -1107,8 +1107,11 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       .foreach { interval =>
         checkErrorInExpression[SparkIllegalArgumentException](
           cast(Literal.create(interval), YearMonthIntervalType()),
-          "INTERVAL_ERROR.INTERVAL_PARSING",
-          Map("interval" -> "year-month", "msg" -> "integer overflow"))
+          "INVALID_INTERVAL_FORMAT.INTERVAL_PARSING",
+          Map(
+            "interval" -> "year-month",
+            "msg" -> "integer overflow",
+            "input" -> interval))
       }
 
     Seq(Byte.MaxValue, Short.MaxValue, Int.MaxValue, Int.MinValue + 1, Int.MinValue)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -1321,9 +1321,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
         checkErrorInExpression[SparkIllegalArgumentException](
           cast(Literal.create(interval), dataType),
           "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-          Map("fallBackNotice" -> (", set spark.sql.legacy.fromDayTimeString.enabled" +
-            " to true to restore the behavior before Spark 3.0."),
-            "intervalStr" -> "day-time",
+          Map("intervalStr" -> "day-time",
             "typeName" -> dataType.typeName,
             "input" -> interval,
             "supportedFormat" ->
@@ -1347,9 +1345,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
         checkErrorInExpression[SparkIllegalArgumentException](
           cast(Literal.create(interval), dataType),
           "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-          Map("fallBackNotice" -> (", set spark.sql.legacy.fromDayTimeString.enabled" +
-            " to true to restore the behavior before Spark 3.0."),
-            "intervalStr" -> "day-time",
+          Map("intervalStr" -> "day-time",
             "typeName" -> dataType.typeName,
             "input" -> interval,
             "supportedFormat" ->

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -1178,7 +1178,6 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
         cast(Literal.create(interval), dataType),
         "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
         Map(
-          "fallBackNotice" -> "",
           "typeName" -> "interval year to month",
           "intervalStr" -> "year-month",
           "supportedFormat" -> "`[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH`",
@@ -1200,7 +1199,6 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
           cast(Literal.create(interval), dataType),
           "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
           Map(
-            "fallBackNotice" -> "",
             "typeName" -> dataType.typeName,
             "intervalStr" -> "year-month",
             "supportedFormat" ->
@@ -1322,7 +1320,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       .foreach { case (interval, dataType) =>
         checkErrorInExpression[SparkIllegalArgumentException](
           cast(Literal.create(interval), dataType),
-          "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+          "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
           Map("fallBackNotice" -> (", set spark.sql.legacy.fromDayTimeString.enabled" +
             " to true to restore the behavior before Spark 3.0."),
             "intervalStr" -> "day-time",
@@ -1348,7 +1346,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       .foreach { case (interval, dataType) =>
         checkErrorInExpression[SparkIllegalArgumentException](
           cast(Literal.create(interval), dataType),
-          "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+          "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
           Map("fallBackNotice" -> (", set spark.sql.legacy.fromDayTimeString.enabled" +
             " to true to restore the behavior before Spark 3.0."),
             "intervalStr" -> "day-time",

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -1176,7 +1176,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       val dataType = YearMonthIntervalType()
       checkErrorInExpression[SparkIllegalArgumentException](
         cast(Literal.create(interval), dataType),
-        "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+        "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING",
         Map(
           "typeName" -> "interval year to month",
           "intervalStr" -> "year-month",
@@ -1197,7 +1197,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       .foreach { case (interval, dataType) =>
         checkErrorInExpression[SparkIllegalArgumentException](
           cast(Literal.create(interval), dataType),
-          "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+          "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING",
           Map(
             "typeName" -> dataType.typeName,
             "intervalStr" -> "year-month",
@@ -1320,7 +1320,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       .foreach { case (interval, dataType) =>
         checkErrorInExpression[SparkIllegalArgumentException](
           cast(Literal.create(interval), dataType),
-          "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+          "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
           Map("intervalStr" -> "day-time",
             "typeName" -> dataType.typeName,
             "input" -> interval,
@@ -1344,7 +1344,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       .foreach { case (interval, dataType) =>
         checkErrorInExpression[SparkIllegalArgumentException](
           cast(Literal.create(interval), dataType),
-          "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+          "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
           Map("intervalStr" -> "day-time",
             "typeName" -> dataType.typeName,
             "input" -> interval,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -1110,7 +1110,6 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
           "INVALID_INTERVAL_FORMAT.INTERVAL_PARSING",
           Map(
             "interval" -> "year-month",
-            "msg" -> "integer overflow",
             "input" -> interval))
       }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala
@@ -1107,7 +1107,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       .foreach { interval =>
         checkErrorInExpression[SparkIllegalArgumentException](
           cast(Literal.create(interval), YearMonthIntervalType()),
-          "_LEGACY_ERROR_TEMP_3213",
+          "INTERVAL_ERROR.INTERVAL_PARSING",
           Map("interval" -> "year-month", "msg" -> "integer overflow"))
       }
 
@@ -1176,7 +1176,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       val dataType = YearMonthIntervalType()
       checkErrorInExpression[SparkIllegalArgumentException](
         cast(Literal.create(interval), dataType),
-        "_LEGACY_ERROR_TEMP_3214",
+        "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
         Map(
           "fallBackNotice" -> "",
           "typeName" -> "interval year to month",
@@ -1198,7 +1198,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       .foreach { case (interval, dataType) =>
         checkErrorInExpression[SparkIllegalArgumentException](
           cast(Literal.create(interval), dataType),
-          "_LEGACY_ERROR_TEMP_3214",
+          "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
           Map(
             "fallBackNotice" -> "",
             "typeName" -> dataType.typeName,
@@ -1322,7 +1322,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       .foreach { case (interval, dataType) =>
         checkErrorInExpression[SparkIllegalArgumentException](
           cast(Literal.create(interval), dataType),
-          "_LEGACY_ERROR_TEMP_3214",
+          "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
           Map("fallBackNotice" -> (", set spark.sql.legacy.fromDayTimeString.enabled" +
             " to true to restore the behavior before Spark 3.0."),
             "intervalStr" -> "day-time",
@@ -1348,7 +1348,7 @@ abstract class CastSuiteBase extends SparkFunSuite with ExpressionEvalHelper {
       .foreach { case (interval, dataType) =>
         checkErrorInExpression[SparkIllegalArgumentException](
           cast(Literal.create(interval), dataType),
-          "_LEGACY_ERROR_TEMP_3214",
+          "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
           Map("fallBackNotice" -> (", set spark.sql.legacy.fromDayTimeString.enabled" +
             " to true to restore the behavior before Spark 3.0."),
             "intervalStr" -> "day-time",

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -896,13 +896,13 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
       exception = intercept[SparkIllegalArgumentException] {
         getDayOfWeekFromString(UTF8String.fromString("xx"))
       },
-      condition = "_LEGACY_ERROR_TEMP_3209",
+      condition = "INTERVAL_ERROR.ILLEGAL_DAY_OF_WEEK",
       parameters = Map("string" -> "xx"))
     checkError(
       exception = intercept[SparkIllegalArgumentException] {
         getDayOfWeekFromString(UTF8String.fromString("\"quote"))
       },
-      condition = "_LEGACY_ERROR_TEMP_3209",
+      condition = "INTERVAL_ERROR.ILLEGAL_DAY_OF_WEEK",
       parameters = Map("string" -> "\"quote"))
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeUtilsSuite.scala
@@ -896,13 +896,13 @@ class DateTimeUtilsSuite extends SparkFunSuite with Matchers with SQLHelper {
       exception = intercept[SparkIllegalArgumentException] {
         getDayOfWeekFromString(UTF8String.fromString("xx"))
       },
-      condition = "INTERVAL_ERROR.ILLEGAL_DAY_OF_WEEK",
+      condition = "ILLEGAL_DAY_OF_WEEK",
       parameters = Map("string" -> "xx"))
     checkError(
       exception = intercept[SparkIllegalArgumentException] {
         getDayOfWeekFromString(UTF8String.fromString("\"quote"))
       },
-      condition = "INTERVAL_ERROR.ILLEGAL_DAY_OF_WEEK",
+      condition = "ILLEGAL_DAY_OF_WEEK",
       parameters = Map("string" -> "\"quote"))
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
@@ -337,12 +337,16 @@ class IntervalUtilsSuite extends SparkFunSuite with SQLHelper {
           10,
           12 * MICROS_PER_MINUTE + millisToMicros(888)))
       assert(fromDayTimeString("-3 0:0:0") === new CalendarInterval(0, -3, 0L))
-      val dayTimeParsingException = intercept[SparkIllegalArgumentException] {
-        fromDayTimeString("5 30:12:20")
-      }
 
-      assert(dayTimeParsingException.getErrorClass === "INTERVAL_ERROR.DAY_TIME_PARSING")
-      assert(dayTimeParsingException.getSqlState === "22009")
+      checkError(
+        exception = intercept[SparkIllegalArgumentException] {
+          fromDayTimeString("5 30:12:20")
+        },
+        parameters = Map("msg" -> "requirement failed: hour 30 outside range [0, 23]"),
+        errorClass = "INTERVAL_ERROR.DAY_TIME_PARSING",
+        sqlState = Some("22009")
+      )
+
       failFuncWithInvalidInput("5 30:12:20", "hour 30 outside range", fromDayTimeString)
       failFuncWithInvalidInput("5 30-12", "must match day-time format", fromDayTimeString)
     }
@@ -385,12 +389,13 @@ class IntervalUtilsSuite extends SparkFunSuite with SQLHelper {
   }
 
   test("parsing second_nano string") {
-    val parsingException = intercept[SparkIllegalArgumentException] {
-      toDTInterval("12", "33.33.33", 1)
-    }
-
-    assert(parsingException.getErrorClass === "INTERVAL_ERROR.SECOND_NANO_FORMAT")
-    assert(parsingException.getSqlState === "22009")
+    checkError(
+      exception = intercept[SparkIllegalArgumentException] {
+        toDTInterval("12", "33.33.33", 1)
+      },
+      errorClass = "INTERVAL_ERROR.SECOND_NANO_FORMAT",
+      sqlState = Some("22009")
+    )
   }
 
   test("subtract one interval by another") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
@@ -341,8 +341,8 @@ class IntervalUtilsSuite extends SparkFunSuite with SQLHelper {
         fromDayTimeString("5 30:12:20")
       }
 
-      assert(dayTimeParsingException.getErrorClass == "INTERVAL_ERROR.DAY_TIME_PARSING")
-      assert(dayTimeParsingException.getSqlState == "22009")
+      assert(dayTimeParsingException.getErrorClass === "INTERVAL_ERROR.DAY_TIME_PARSING")
+      assert(dayTimeParsingException.getSqlState === "22009")
       failFuncWithInvalidInput("5 30:12:20", "hour 30 outside range", fromDayTimeString)
       failFuncWithInvalidInput("5 30-12", "must match day-time format", fromDayTimeString)
     }
@@ -389,8 +389,8 @@ class IntervalUtilsSuite extends SparkFunSuite with SQLHelper {
       toDTInterval("12", "33.33.33", 1)
     }
 
-    assert(parsingException.getErrorClass == "INTERVAL_ERROR.SECOND_NANO_FORMAT")
-    assert(parsingException.getSqlState == "22009")
+    assert(parsingException.getErrorClass === "INTERVAL_ERROR.SECOND_NANO_FORMAT")
+    assert(parsingException.getSqlState === "22009")
   }
 
   test("subtract one interval by another") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
@@ -337,7 +337,12 @@ class IntervalUtilsSuite extends SparkFunSuite with SQLHelper {
           10,
           12 * MICROS_PER_MINUTE + millisToMicros(888)))
       assert(fromDayTimeString("-3 0:0:0") === new CalendarInterval(0, -3, 0L))
+      val dayTimeParsingException = intercept[SparkIllegalArgumentException] {
+        fromDayTimeString("5 30:12:20")
+      }
 
+      assert(dayTimeParsingException.getErrorClass == "INTERVAL_ERROR.DAY_TIME_PARSING")
+      assert(dayTimeParsingException.getSqlState == "22009")
       failFuncWithInvalidInput("5 30:12:20", "hour 30 outside range", fromDayTimeString)
       failFuncWithInvalidInput("5 30-12", "must match day-time format", fromDayTimeString)
     }
@@ -377,6 +382,15 @@ class IntervalUtilsSuite extends SparkFunSuite with SQLHelper {
   test("negate") {
     assert(negateExact(new CalendarInterval(1, 2, 3)) === new CalendarInterval(-1, -2, -3))
     assert(negate(new CalendarInterval(1, 2, 3)) === new CalendarInterval(-1, -2, -3))
+  }
+
+  test("parsing second_nano string") {
+    val parsingException = intercept[SparkIllegalArgumentException] {
+      toDTInterval("12", "33.33.33", 1)
+    }
+
+    assert(parsingException.getErrorClass == "INTERVAL_ERROR.SECOND_NANO_FORMAT")
+    assert(parsingException.getSqlState == "22009")
   }
 
   test("subtract one interval by another") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
@@ -345,7 +345,19 @@ class IntervalUtilsSuite extends SparkFunSuite with SQLHelper {
         parameters = Map(
           "msg" -> "requirement failed: hour 30 outside range [0, 23]",
           "input" -> "5 30:12:20"),
-        errorClass = "INVALID_INTERVAL_FORMAT.DAY_TIME_PARSING",
+        condition = "INVALID_INTERVAL_FORMAT.DAY_TIME_PARSING",
+        sqlState = Some("22006")
+      )
+
+      checkError(
+        exception = intercept[SparkIllegalArgumentException] {
+          fromDayTimeString("5 12:40:30.999999999", 0, 0)
+        },
+        parameters = Map(
+          "from" -> "day",
+          "to" -> "day",
+          "input" -> "5 12:40:30.999999999"),
+        condition = "INVALID_INTERVAL_FORMAT.UNSUPPORTED_FROM_TO_EXPRESSION",
         sqlState = Some("22006")
       )
 
@@ -395,7 +407,7 @@ class IntervalUtilsSuite extends SparkFunSuite with SQLHelper {
       exception = intercept[SparkIllegalArgumentException] {
         toDTInterval("12", "33.33.33", 1)
       },
-      errorClass = "INVALID_INTERVAL_FORMAT.SECOND_NANO_FORMAT",
+      condition = "INVALID_INTERVAL_FORMAT.SECOND_NANO_FORMAT",
       parameters = Map("input" -> "33.33.33"),
       sqlState = Some("22006")
     )

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
@@ -395,8 +395,9 @@ class IntervalUtilsSuite extends SparkFunSuite with SQLHelper {
       exception = intercept[SparkIllegalArgumentException] {
         toDTInterval("12", "33.33.33", 1)
       },
-      errorClass = "INTERVAL_ERROR.SECOND_NANO_FORMAT",
-      sqlState = Some("22009")
+      errorClass = "INVALID_INTERVAL_FORMAT.SECOND_NANO_FORMAT",
+      parameters = Map("input" -> "33.33.33"),
+      sqlState = Some("22006")
     )
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
@@ -295,7 +295,7 @@ class IntervalUtilsSuite extends SparkFunSuite with SQLHelper {
     assert(fromYearMonthString("99-10") === new CalendarInterval(99 * 12 + 10, 0, 0L))
     assert(fromYearMonthString("+99-10") === new CalendarInterval(99 * 12 + 10, 0, 0L))
     assert(fromYearMonthString("-8-10") === new CalendarInterval(-8 * 12 - 10, 0, 0L))
-    failFuncWithInvalidInput("99-15", "month 15 outside range", fromYearMonthString)
+    failFuncWithInvalidInput("99-15", "year-month", fromYearMonthString)
     failFuncWithInvalidInput("9a9-15", "Interval string does not match year-month format",
       fromYearMonthString)
 
@@ -314,12 +314,12 @@ class IntervalUtilsSuite extends SparkFunSuite with SQLHelper {
     val e1 = intercept[IllegalArgumentException]{
       assert(fromYearMonthString("178956970-8") == new CalendarInterval(Int.MinValue, 0, 0))
     }.getMessage
-    assert(e1.contains("integer overflow"))
+    assert(e1.contains("year-month"))
     assert(fromYearMonthString("-178956970-8") == new CalendarInterval(Int.MinValue, 0, 0))
     val e2 = intercept[IllegalArgumentException]{
       assert(fromYearMonthString("-178956970-9") == new CalendarInterval(Int.MinValue, 0, 0))
     }.getMessage
-    assert(e2.contains("integer overflow"))
+    assert(e2.contains("year-month"))
   }
 
   test("from day-time string - legacy") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/IntervalUtilsSuite.scala
@@ -342,9 +342,11 @@ class IntervalUtilsSuite extends SparkFunSuite with SQLHelper {
         exception = intercept[SparkIllegalArgumentException] {
           fromDayTimeString("5 30:12:20")
         },
-        parameters = Map("msg" -> "requirement failed: hour 30 outside range [0, 23]"),
-        errorClass = "INTERVAL_ERROR.DAY_TIME_PARSING",
-        sqlState = Some("22009")
+        parameters = Map(
+          "msg" -> "requirement failed: hour 30 outside range [0, 23]",
+          "input" -> "5 30:12:20"),
+        errorClass = "INVALID_INTERVAL_FORMAT.DAY_TIME_PARSING",
+        sqlState = Some("22006")
       )
 
       failFuncWithInvalidInput("5 30:12:20", "hour 30 outside range", fromDayTimeString)

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/interval.sql.out
@@ -1488,8 +1488,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "sqlState" : "22006",
   "messageParameters" : {
     "input" : "178956970-8",
-    "interval" : "year-month",
-    "msg" : "integer overflow"
+    "interval" : "year-month"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/interval.sql.out
@@ -981,8 +981,8 @@ select interval '20 15:40:32.99899999' day to hour
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "20 15:40:32.99899999",
     "intervalStr" : "day-time",
@@ -997,8 +997,8 @@ select interval '20 15:40:32.99899999' day to minute
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "20 15:40:32.99899999",
     "intervalStr" : "day-time",
@@ -1013,8 +1013,8 @@ select interval '15:40:32.99899999' hour to minute
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "15:40:32.99899999",
     "intervalStr" : "day-time",
@@ -1029,8 +1029,8 @@ select interval '15:40.99899999' hour to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "15:40.99899999",
     "intervalStr" : "day-time",
@@ -1045,8 +1045,8 @@ select interval '15:40' hour to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "15:40",
     "intervalStr" : "day-time",
@@ -1061,8 +1061,8 @@ select interval '20 40:32.99899999' minute to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "20 40:32.99899999",
     "intervalStr" : "day-time",
@@ -1886,8 +1886,8 @@ select interval '-\t2-2\t' year to month
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "-\t2-2\t",
     "intervalStr" : "year-month",
@@ -1909,8 +1909,8 @@ select interval '\n-\t10\t 12:34:46.789\t' day to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "\n-\t10\t 12:34:46.789\t",
     "intervalStr" : "day-time",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/interval.sql.out
@@ -981,9 +981,13 @@ select interval '20 15:40:32.99899999' day to hour
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 20 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "20 15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
+    "typeName" : "interval day to hour"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1000,9 +1004,13 @@ select interval '20 15:40:32.99899999' day to minute
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 20 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "20 15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
+    "typeName" : "interval day to minute"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1019,9 +1027,13 @@ select interval '15:40:32.99899999' hour to minute
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
+    "typeName" : "interval hour to minute"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1038,9 +1050,13 @@ select interval '15:40.99899999' hour to second
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "15:40.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1057,9 +1073,13 @@ select interval '15:40' hour to second
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "15:40",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1076,9 +1096,13 @@ select interval '20 40:32.99899999' minute to second
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 20 40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "20 40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
+    "typeName" : "interval minute to second"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1460,9 +1484,12 @@ SELECT INTERVAL '178956970-8' YEAR TO MONTH
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.INTERVAL_PARSING",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.INTERVAL_PARSING] Error parsing '178956970-8' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Error parsing interval year-month string. SQLSTATE: 22006"
+    "input" : "178956970-8",
+    "interval" : "year-month",
+    "msg" : "integer overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1909,9 +1936,13 @@ select interval '-\t2-2\t' year to month
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING] Error parsing '-\t2-2\t' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match year-month format of `[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH` when cast to interval year to month: -\t2-2\t. SQLSTATE: 22006"
+    "input" : "-\t2-2\t",
+    "intervalStr" : "year-month",
+    "supportedFormat" : "`[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH`",
+    "typeName" : "interval year to month"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1935,9 +1966,13 @@ select interval '\n-\t10\t 12:34:46.789\t' day to second
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '\n-\t10\t 12:34:46.789\t' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: \n-\t10\t 12:34:46.789\t. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "\n-\t10\t 12:34:46.789\t",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",
+    "typeName" : "interval day to second"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/interval.sql.out
@@ -979,114 +979,102 @@ Project [INTERVAL '30' DAY AS days#x]
 -- !query
 select interval '20 15:40:32.99899999' day to hour
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 50,
-    "fragment" : "'20 15:40:32.99899999' day to hour"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "20 15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
+    "typeName" : "interval day to hour"
+  }
 }
 
 
 -- !query
 select interval '20 15:40:32.99899999' day to minute
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 52,
-    "fragment" : "'20 15:40:32.99899999' day to minute"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "20 15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
+    "typeName" : "interval day to minute"
+  }
 }
 
 
 -- !query
 select interval '15:40:32.99899999' hour to minute
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 50,
-    "fragment" : "'15:40:32.99899999' hour to minute"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
+    "typeName" : "interval hour to minute"
+  }
 }
 
 
 -- !query
 select interval '15:40.99899999' hour to second
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 47,
-    "fragment" : "'15:40.99899999' hour to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "15:40.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
+  }
 }
 
 
 -- !query
 select interval '15:40' hour to second
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 38,
-    "fragment" : "'15:40' hour to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "15:40",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
+  }
 }
 
 
 -- !query
 select interval '20 40:32.99899999' minute to second
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 20 40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 52,
-    "fragment" : "'20 40:32.99899999' minute to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "20 40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
+    "typeName" : "interval minute to second"
+  }
 }
 
 
@@ -1458,19 +1446,14 @@ Project [INTERVAL '178956970-7' YEAR TO MONTH AS INTERVAL '178956970-7' YEAR TO 
 -- !query
 SELECT INTERVAL '178956970-8' YEAR TO MONTH
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.INTERVAL_PARSING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.INTERVAL_PARSING] Interval error. Error parsing interval year-month string: integer overflow. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 43,
-    "fragment" : "'178956970-8' YEAR TO MONTH"
-  } ]
+    "interval" : "year-month",
+    "msg" : "integer overflow"
+  }
 }
 
 
@@ -1907,19 +1890,17 @@ Project [INTERVAL '2-2' YEAR TO MONTH AS INTERVAL '2-2' YEAR TO MONTH#x]
 -- !query
 select interval '-\t2-2\t' year to month
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match year-month format of `[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH` when cast to interval year to month: -\t2-2\t. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 40,
-    "fragment" : "'-\\t2-2\\t' year to month"
-  } ]
+    "fallBackNotice" : "",
+    "input" : "-\t2-2\t",
+    "intervalStr" : "year-month",
+    "supportedFormat" : "`[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH`",
+    "typeName" : "interval year to month"
+  }
 }
 
 
@@ -1933,19 +1914,17 @@ Project [INTERVAL '0 12:34:46.789' DAY TO SECOND AS INTERVAL '0 12:34:46.789' DA
 -- !query
 select interval '\n-\t10\t 12:34:46.789\t' day to second
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: \n-\t10\t 12:34:46.789\t, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 56,
-    "fragment" : "'\\n-\\t10\\t 12:34:46.789\\t' day to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "\n-\t10\t 12:34:46.789\t",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",
+    "typeName" : "interval day to second"
+  }
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/interval.sql.out
@@ -983,7 +983,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1002,7 +1002,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1021,7 +1021,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1040,7 +1040,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1059,7 +1059,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1078,7 +1078,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 20 40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 20 40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1462,7 +1462,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Error parsing interval year-month string: integer overflow"
+    "msg" : "[INTERVAL_ERROR.INTERVAL_PARSING] Interval error. Error parsing interval year-month string: integer overflow. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1911,7 +1911,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match year-month format of `[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH` when cast to interval year to month: -\t2-2\t"
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match year-month format of `[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH` when cast to interval year to month: -\t2-2\t. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1937,7 +1937,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: \n-\t10\t 12:34:46.789\t, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: \n-\t10\t 12:34:46.789\t, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/interval.sql.out
@@ -979,96 +979,114 @@ Project [INTERVAL '30' DAY AS days#x]
 -- !query
 select interval '20 15:40:32.99899999' day to hour
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "20 15:40:32.99899999",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
-    "typeName" : "interval day to hour"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 20 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 50,
+    "fragment" : "'20 15:40:32.99899999' day to hour"
+  } ]
 }
 
 
 -- !query
 select interval '20 15:40:32.99899999' day to minute
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "20 15:40:32.99899999",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
-    "typeName" : "interval day to minute"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 20 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 52,
+    "fragment" : "'20 15:40:32.99899999' day to minute"
+  } ]
 }
 
 
 -- !query
 select interval '15:40:32.99899999' hour to minute
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "15:40:32.99899999",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
-    "typeName" : "interval hour to minute"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 50,
+    "fragment" : "'15:40:32.99899999' hour to minute"
+  } ]
 }
 
 
 -- !query
 select interval '15:40.99899999' hour to second
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "15:40.99899999",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
-    "typeName" : "interval hour to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 47,
+    "fragment" : "'15:40.99899999' hour to second"
+  } ]
 }
 
 
 -- !query
 select interval '15:40' hour to second
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "15:40",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
-    "typeName" : "interval hour to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 38,
+    "fragment" : "'15:40' hour to second"
+  } ]
 }
 
 
 -- !query
 select interval '20 40:32.99899999' minute to second
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "20 40:32.99899999",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
-    "typeName" : "interval minute to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 20 40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 52,
+    "fragment" : "'20 40:32.99899999' minute to second"
+  } ]
 }
 
 
@@ -1440,14 +1458,19 @@ Project [INTERVAL '178956970-7' YEAR TO MONTH AS INTERVAL '178956970-7' YEAR TO 
 -- !query
 SELECT INTERVAL '178956970-8' YEAR TO MONTH
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INTERVAL_ERROR.INTERVAL_PARSING",
-  "sqlState" : "22009",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "interval" : "year-month",
-    "msg" : "integer overflow"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.INTERVAL_PARSING] Error parsing '178956970-8' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Error parsing interval year-month string. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 43,
+    "fragment" : "'178956970-8' YEAR TO MONTH"
+  } ]
 }
 
 
@@ -1884,16 +1907,19 @@ Project [INTERVAL '2-2' YEAR TO MONTH AS INTERVAL '2-2' YEAR TO MONTH#x]
 -- !query
 select interval '-\t2-2\t' year to month
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "-\t2-2\t",
-    "intervalStr" : "year-month",
-    "supportedFormat" : "`[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH`",
-    "typeName" : "interval year to month"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING] Error parsing '-\t2-2\t' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match year-month format of `[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH` when cast to interval year to month: -\t2-2\t. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 40,
+    "fragment" : "'-\\t2-2\\t' year to month"
+  } ]
 }
 
 
@@ -1907,16 +1933,19 @@ Project [INTERVAL '0 12:34:46.789' DAY TO SECOND AS INTERVAL '0 12:34:46.789' DA
 -- !query
 select interval '\n-\t10\t 12:34:46.789\t' day to second
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "\n-\t10\t 12:34:46.789\t",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",
-    "typeName" : "interval day to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '\n-\t10\t 12:34:46.789\t' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: \n-\t10\t 12:34:46.789\t. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 56,
+    "fragment" : "'\\n-\\t10\\t 12:34:46.789\\t' day to second"
+  } ]
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/interval.sql.out
@@ -984,7 +984,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "20 15:40:32.99899999",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
@@ -1001,7 +1000,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "20 15:40:32.99899999",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
@@ -1018,7 +1016,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "15:40:32.99899999",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
@@ -1035,7 +1032,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "15:40.99899999",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
@@ -1052,7 +1048,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "15:40",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
@@ -1069,7 +1064,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "20 40:32.99899999",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
@@ -1918,7 +1912,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "\n-\t10\t 12:34:46.789\t",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/ansi/interval.sql.out
@@ -981,7 +981,7 @@ select interval '20 15:40:32.99899999' day to hour
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -998,7 +998,7 @@ select interval '20 15:40:32.99899999' day to minute
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -1015,7 +1015,7 @@ select interval '15:40:32.99899999' hour to minute
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -1032,7 +1032,7 @@ select interval '15:40.99899999' hour to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -1049,7 +1049,7 @@ select interval '15:40' hour to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -1066,7 +1066,7 @@ select interval '20 40:32.99899999' minute to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -1895,7 +1895,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : "",
     "input" : "-\t2-2\t",
     "intervalStr" : "year-month",
     "supportedFormat" : "`[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH`",
@@ -1916,7 +1915,7 @@ select interval '\n-\t10\t 12:34:46.789\t' day to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/interval.sql.out
@@ -1488,8 +1488,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "sqlState" : "22006",
   "messageParameters" : {
     "input" : "178956970-8",
-    "interval" : "year-month",
-    "msg" : "integer overflow"
+    "interval" : "year-month"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/interval.sql.out
@@ -981,8 +981,8 @@ select interval '20 15:40:32.99899999' day to hour
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "20 15:40:32.99899999",
     "intervalStr" : "day-time",
@@ -997,8 +997,8 @@ select interval '20 15:40:32.99899999' day to minute
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "20 15:40:32.99899999",
     "intervalStr" : "day-time",
@@ -1013,8 +1013,8 @@ select interval '15:40:32.99899999' hour to minute
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "15:40:32.99899999",
     "intervalStr" : "day-time",
@@ -1029,8 +1029,8 @@ select interval '15:40.99899999' hour to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "15:40.99899999",
     "intervalStr" : "day-time",
@@ -1045,8 +1045,8 @@ select interval '15:40' hour to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "15:40",
     "intervalStr" : "day-time",
@@ -1061,8 +1061,8 @@ select interval '20 40:32.99899999' minute to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "20 40:32.99899999",
     "intervalStr" : "day-time",
@@ -1886,8 +1886,8 @@ select interval '-\t2-2\t' year to month
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "-\t2-2\t",
     "intervalStr" : "year-month",
@@ -1909,8 +1909,8 @@ select interval '\n-\t10\t 12:34:46.789\t' day to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "\n-\t10\t 12:34:46.789\t",
     "intervalStr" : "day-time",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/interval.sql.out
@@ -981,9 +981,13 @@ select interval '20 15:40:32.99899999' day to hour
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 20 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "20 15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
+    "typeName" : "interval day to hour"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1000,9 +1004,13 @@ select interval '20 15:40:32.99899999' day to minute
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 20 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "20 15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
+    "typeName" : "interval day to minute"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1019,9 +1027,13 @@ select interval '15:40:32.99899999' hour to minute
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
+    "typeName" : "interval hour to minute"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1038,9 +1050,13 @@ select interval '15:40.99899999' hour to second
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "15:40.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1057,9 +1073,13 @@ select interval '15:40' hour to second
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "15:40",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1076,9 +1096,13 @@ select interval '20 40:32.99899999' minute to second
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 20 40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "20 40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
+    "typeName" : "interval minute to second"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1460,9 +1484,12 @@ SELECT INTERVAL '178956970-8' YEAR TO MONTH
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.INTERVAL_PARSING",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.INTERVAL_PARSING] Error parsing '178956970-8' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Error parsing interval year-month string. SQLSTATE: 22006"
+    "input" : "178956970-8",
+    "interval" : "year-month",
+    "msg" : "integer overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1909,9 +1936,13 @@ select interval '-\t2-2\t' year to month
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING] Error parsing '-\t2-2\t' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match year-month format of `[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH` when cast to interval year to month: -\t2-2\t. SQLSTATE: 22006"
+    "input" : "-\t2-2\t",
+    "intervalStr" : "year-month",
+    "supportedFormat" : "`[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH`",
+    "typeName" : "interval year to month"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1935,9 +1966,13 @@ select interval '\n-\t10\t 12:34:46.789\t' day to second
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '\n-\t10\t 12:34:46.789\t' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: \n-\t10\t 12:34:46.789\t. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "\n-\t10\t 12:34:46.789\t",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",
+    "typeName" : "interval day to second"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/interval.sql.out
@@ -979,114 +979,102 @@ Project [INTERVAL '30' DAY AS days#x]
 -- !query
 select interval '20 15:40:32.99899999' day to hour
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 50,
-    "fragment" : "'20 15:40:32.99899999' day to hour"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "20 15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
+    "typeName" : "interval day to hour"
+  }
 }
 
 
 -- !query
 select interval '20 15:40:32.99899999' day to minute
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 52,
-    "fragment" : "'20 15:40:32.99899999' day to minute"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "20 15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
+    "typeName" : "interval day to minute"
+  }
 }
 
 
 -- !query
 select interval '15:40:32.99899999' hour to minute
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 50,
-    "fragment" : "'15:40:32.99899999' hour to minute"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
+    "typeName" : "interval hour to minute"
+  }
 }
 
 
 -- !query
 select interval '15:40.99899999' hour to second
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 47,
-    "fragment" : "'15:40.99899999' hour to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "15:40.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
+  }
 }
 
 
 -- !query
 select interval '15:40' hour to second
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 38,
-    "fragment" : "'15:40' hour to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "15:40",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
+  }
 }
 
 
 -- !query
 select interval '20 40:32.99899999' minute to second
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 20 40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 52,
-    "fragment" : "'20 40:32.99899999' minute to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "20 40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
+    "typeName" : "interval minute to second"
+  }
 }
 
 
@@ -1458,19 +1446,14 @@ Project [INTERVAL '178956970-7' YEAR TO MONTH AS INTERVAL '178956970-7' YEAR TO 
 -- !query
 SELECT INTERVAL '178956970-8' YEAR TO MONTH
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.INTERVAL_PARSING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.INTERVAL_PARSING] Interval error. Error parsing interval year-month string: integer overflow. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 43,
-    "fragment" : "'178956970-8' YEAR TO MONTH"
-  } ]
+    "interval" : "year-month",
+    "msg" : "integer overflow"
+  }
 }
 
 
@@ -1907,19 +1890,17 @@ Project [INTERVAL '2-2' YEAR TO MONTH AS INTERVAL '2-2' YEAR TO MONTH#x]
 -- !query
 select interval '-\t2-2\t' year to month
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match year-month format of `[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH` when cast to interval year to month: -\t2-2\t. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 40,
-    "fragment" : "'-\\t2-2\\t' year to month"
-  } ]
+    "fallBackNotice" : "",
+    "input" : "-\t2-2\t",
+    "intervalStr" : "year-month",
+    "supportedFormat" : "`[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH`",
+    "typeName" : "interval year to month"
+  }
 }
 
 
@@ -1933,19 +1914,17 @@ Project [INTERVAL '0 12:34:46.789' DAY TO SECOND AS INTERVAL '0 12:34:46.789' DA
 -- !query
 select interval '\n-\t10\t 12:34:46.789\t' day to second
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: \n-\t10\t 12:34:46.789\t, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 56,
-    "fragment" : "'\\n-\\t10\\t 12:34:46.789\\t' day to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "\n-\t10\t 12:34:46.789\t",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",
+    "typeName" : "interval day to second"
+  }
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/interval.sql.out
@@ -983,7 +983,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1002,7 +1002,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1021,7 +1021,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1040,7 +1040,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1059,7 +1059,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1078,7 +1078,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 20 40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 20 40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1462,7 +1462,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Error parsing interval year-month string: integer overflow"
+    "msg" : "[INTERVAL_ERROR.INTERVAL_PARSING] Interval error. Error parsing interval year-month string: integer overflow. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1911,7 +1911,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match year-month format of `[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH` when cast to interval year to month: -\t2-2\t"
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match year-month format of `[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH` when cast to interval year to month: -\t2-2\t. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1937,7 +1937,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: \n-\t10\t 12:34:46.789\t, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: \n-\t10\t 12:34:46.789\t, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/interval.sql.out
@@ -979,96 +979,114 @@ Project [INTERVAL '30' DAY AS days#x]
 -- !query
 select interval '20 15:40:32.99899999' day to hour
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "20 15:40:32.99899999",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
-    "typeName" : "interval day to hour"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 20 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 50,
+    "fragment" : "'20 15:40:32.99899999' day to hour"
+  } ]
 }
 
 
 -- !query
 select interval '20 15:40:32.99899999' day to minute
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "20 15:40:32.99899999",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
-    "typeName" : "interval day to minute"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 20 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 52,
+    "fragment" : "'20 15:40:32.99899999' day to minute"
+  } ]
 }
 
 
 -- !query
 select interval '15:40:32.99899999' hour to minute
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "15:40:32.99899999",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
-    "typeName" : "interval hour to minute"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 50,
+    "fragment" : "'15:40:32.99899999' hour to minute"
+  } ]
 }
 
 
 -- !query
 select interval '15:40.99899999' hour to second
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "15:40.99899999",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
-    "typeName" : "interval hour to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 47,
+    "fragment" : "'15:40.99899999' hour to second"
+  } ]
 }
 
 
 -- !query
 select interval '15:40' hour to second
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "15:40",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
-    "typeName" : "interval hour to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 38,
+    "fragment" : "'15:40' hour to second"
+  } ]
 }
 
 
 -- !query
 select interval '20 40:32.99899999' minute to second
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "20 40:32.99899999",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
-    "typeName" : "interval minute to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 20 40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 52,
+    "fragment" : "'20 40:32.99899999' minute to second"
+  } ]
 }
 
 
@@ -1440,14 +1458,19 @@ Project [INTERVAL '178956970-7' YEAR TO MONTH AS INTERVAL '178956970-7' YEAR TO 
 -- !query
 SELECT INTERVAL '178956970-8' YEAR TO MONTH
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INTERVAL_ERROR.INTERVAL_PARSING",
-  "sqlState" : "22009",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "interval" : "year-month",
-    "msg" : "integer overflow"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.INTERVAL_PARSING] Error parsing '178956970-8' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Error parsing interval year-month string. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 43,
+    "fragment" : "'178956970-8' YEAR TO MONTH"
+  } ]
 }
 
 
@@ -1884,16 +1907,19 @@ Project [INTERVAL '2-2' YEAR TO MONTH AS INTERVAL '2-2' YEAR TO MONTH#x]
 -- !query
 select interval '-\t2-2\t' year to month
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "-\t2-2\t",
-    "intervalStr" : "year-month",
-    "supportedFormat" : "`[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH`",
-    "typeName" : "interval year to month"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING] Error parsing '-\t2-2\t' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match year-month format of `[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH` when cast to interval year to month: -\t2-2\t. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 40,
+    "fragment" : "'-\\t2-2\\t' year to month"
+  } ]
 }
 
 
@@ -1907,16 +1933,19 @@ Project [INTERVAL '0 12:34:46.789' DAY TO SECOND AS INTERVAL '0 12:34:46.789' DA
 -- !query
 select interval '\n-\t10\t 12:34:46.789\t' day to second
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "\n-\t10\t 12:34:46.789\t",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",
-    "typeName" : "interval day to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '\n-\t10\t 12:34:46.789\t' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: \n-\t10\t 12:34:46.789\t. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 56,
+    "fragment" : "'\\n-\\t10\\t 12:34:46.789\\t' day to second"
+  } ]
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/interval.sql.out
@@ -984,7 +984,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "20 15:40:32.99899999",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
@@ -1001,7 +1000,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "20 15:40:32.99899999",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
@@ -1018,7 +1016,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "15:40:32.99899999",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
@@ -1035,7 +1032,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "15:40.99899999",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
@@ -1052,7 +1048,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "15:40",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
@@ -1069,7 +1064,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "20 40:32.99899999",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
@@ -1918,7 +1912,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "\n-\t10\t 12:34:46.789\t",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/interval.sql.out
@@ -981,7 +981,7 @@ select interval '20 15:40:32.99899999' day to hour
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -998,7 +998,7 @@ select interval '20 15:40:32.99899999' day to minute
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -1015,7 +1015,7 @@ select interval '15:40:32.99899999' hour to minute
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -1032,7 +1032,7 @@ select interval '15:40.99899999' hour to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -1049,7 +1049,7 @@ select interval '15:40' hour to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -1066,7 +1066,7 @@ select interval '20 40:32.99899999' minute to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -1895,7 +1895,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : "",
     "input" : "-\t2-2\t",
     "intervalStr" : "year-month",
     "supportedFormat" : "`[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH`",
@@ -1916,7 +1915,7 @@ select interval '\n-\t10\t 12:34:46.789\t' day to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/interval.sql.out
@@ -88,8 +88,8 @@ SELECT interval '1 2:03' day to hour
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "1 2:03",
     "intervalStr" : "day-time",
@@ -104,8 +104,8 @@ SELECT interval '1 2:03:04' day to hour
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "1 2:03:04",
     "intervalStr" : "day-time",
@@ -127,8 +127,8 @@ SELECT interval '1 2:03:04' day to minute
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "1 2:03:04",
     "intervalStr" : "day-time",
@@ -143,8 +143,8 @@ SELECT interval '1 2:03' day to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "1 2:03",
     "intervalStr" : "day-time",
@@ -166,8 +166,8 @@ SELECT interval '1 2:03' hour to minute
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "1 2:03",
     "intervalStr" : "day-time",
@@ -182,8 +182,8 @@ SELECT interval '1 2:03:04' hour to minute
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "1 2:03:04",
     "intervalStr" : "day-time",
@@ -198,8 +198,8 @@ SELECT interval '1 2:03' hour to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "1 2:03",
     "intervalStr" : "day-time",
@@ -214,8 +214,8 @@ SELECT interval '1 2:03:04' hour to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "1 2:03:04",
     "intervalStr" : "day-time",
@@ -230,8 +230,8 @@ SELECT interval '1 2:03' minute to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "1 2:03",
     "intervalStr" : "day-time",
@@ -246,8 +246,8 @@ SELECT interval '1 2:03:04' minute to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "1 2:03:04",
     "intervalStr" : "day-time",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/interval.sql.out
@@ -88,9 +88,13 @@ SELECT interval '1 2:03' day to hour
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 1 2:03. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "1 2:03",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
+    "typeName" : "interval day to hour"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -107,9 +111,13 @@ SELECT interval '1 2:03:04' day to hour
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03:04' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 1 2:03:04. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "1 2:03:04",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
+    "typeName" : "interval day to hour"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -133,9 +141,13 @@ SELECT interval '1 2:03:04' day to minute
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03:04' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 1 2:03:04. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "1 2:03:04",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
+    "typeName" : "interval day to minute"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -152,9 +164,13 @@ SELECT interval '1 2:03' day to second
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: 1 2:03. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "1 2:03",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",
+    "typeName" : "interval day to second"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -178,9 +194,13 @@ SELECT interval '1 2:03' hour to minute
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 1 2:03. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "1 2:03",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
+    "typeName" : "interval hour to minute"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -197,9 +217,13 @@ SELECT interval '1 2:03:04' hour to minute
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03:04' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 1 2:03:04. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "1 2:03:04",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
+    "typeName" : "interval hour to minute"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -216,9 +240,13 @@ SELECT interval '1 2:03' hour to second
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 1 2:03. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "1 2:03",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -235,9 +263,13 @@ SELECT interval '1 2:03:04' hour to second
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03:04' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 1 2:03:04. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "1 2:03:04",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -254,9 +286,13 @@ SELECT interval '1 2:03' minute to second
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 1 2:03. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "1 2:03",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
+    "typeName" : "interval minute to second"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -273,9 +309,13 @@ SELECT interval '1 2:03:04' minute to second
 -- !query analysis
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03:04' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 1 2:03:04. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "1 2:03:04",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
+    "typeName" : "interval minute to second"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/interval.sql.out
@@ -86,32 +86,38 @@ Project [1 years 2 months AS INTERVAL '1 years 2 months'#x]
 -- !query
 SELECT interval '1 2:03' day to hour
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "1 2:03",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
-    "typeName" : "interval day to hour"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 1 2:03. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 36,
+    "fragment" : "'1 2:03' day to hour"
+  } ]
 }
 
 
 -- !query
 SELECT interval '1 2:03:04' day to hour
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "1 2:03:04",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
-    "typeName" : "interval day to hour"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03:04' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 1 2:03:04. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 39,
+    "fragment" : "'1 2:03:04' day to hour"
+  } ]
 }
 
 
@@ -125,32 +131,38 @@ Project [1 days 2 hours 3 minutes AS INTERVAL '1 days 2 hours 3 minutes'#x]
 -- !query
 SELECT interval '1 2:03:04' day to minute
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "1 2:03:04",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
-    "typeName" : "interval day to minute"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03:04' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 1 2:03:04. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 41,
+    "fragment" : "'1 2:03:04' day to minute"
+  } ]
 }
 
 
 -- !query
 SELECT interval '1 2:03' day to second
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "1 2:03",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",
-    "typeName" : "interval day to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: 1 2:03. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 38,
+    "fragment" : "'1 2:03' day to second"
+  } ]
 }
 
 
@@ -164,94 +176,112 @@ Project [1 days 2 hours 3 minutes 4 seconds AS INTERVAL '1 days 2 hours 3 minute
 -- !query
 SELECT interval '1 2:03' hour to minute
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "1 2:03",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
-    "typeName" : "interval hour to minute"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 1 2:03. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 39,
+    "fragment" : "'1 2:03' hour to minute"
+  } ]
 }
 
 
 -- !query
 SELECT interval '1 2:03:04' hour to minute
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "1 2:03:04",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
-    "typeName" : "interval hour to minute"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03:04' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 1 2:03:04. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 42,
+    "fragment" : "'1 2:03:04' hour to minute"
+  } ]
 }
 
 
 -- !query
 SELECT interval '1 2:03' hour to second
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "1 2:03",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
-    "typeName" : "interval hour to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 1 2:03. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 39,
+    "fragment" : "'1 2:03' hour to second"
+  } ]
 }
 
 
 -- !query
 SELECT interval '1 2:03:04' hour to second
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "1 2:03:04",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
-    "typeName" : "interval hour to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03:04' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 1 2:03:04. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 42,
+    "fragment" : "'1 2:03:04' hour to second"
+  } ]
 }
 
 
 -- !query
 SELECT interval '1 2:03' minute to second
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "1 2:03",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
-    "typeName" : "interval minute to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 1 2:03. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 41,
+    "fragment" : "'1 2:03' minute to second"
+  } ]
 }
 
 
 -- !query
 SELECT interval '1 2:03:04' minute to second
 -- !query analysis
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "1 2:03:04",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
-    "typeName" : "interval minute to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03:04' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 1 2:03:04. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 44,
+    "fragment" : "'1 2:03:04' minute to second"
+  } ]
 }

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/interval.sql.out
@@ -90,7 +90,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -109,7 +109,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -135,7 +135,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -154,7 +154,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -180,7 +180,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -199,7 +199,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -218,7 +218,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -237,7 +237,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -256,7 +256,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -275,7 +275,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/interval.sql.out
@@ -88,7 +88,7 @@ SELECT interval '1 2:03' day to hour
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -105,7 +105,7 @@ SELECT interval '1 2:03:04' day to hour
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -129,7 +129,7 @@ SELECT interval '1 2:03:04' day to minute
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -146,7 +146,7 @@ SELECT interval '1 2:03' day to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -170,7 +170,7 @@ SELECT interval '1 2:03' hour to minute
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -187,7 +187,7 @@ SELECT interval '1 2:03:04' hour to minute
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -204,7 +204,7 @@ SELECT interval '1 2:03' hour to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -221,7 +221,7 @@ SELECT interval '1 2:03:04' hour to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -238,7 +238,7 @@ SELECT interval '1 2:03' minute to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -255,7 +255,7 @@ SELECT interval '1 2:03:04' minute to second
 -- !query analysis
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/interval.sql.out
@@ -91,7 +91,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "1 2:03",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
@@ -108,7 +107,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "1 2:03:04",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
@@ -132,7 +130,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "1 2:03:04",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
@@ -149,7 +146,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "1 2:03",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",
@@ -173,7 +169,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "1 2:03",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
@@ -190,7 +185,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "1 2:03:04",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
@@ -207,7 +201,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "1 2:03",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
@@ -224,7 +217,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "1 2:03:04",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
@@ -241,7 +233,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "1 2:03",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
@@ -258,7 +249,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "1 2:03:04",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/interval.sql.out
@@ -86,38 +86,34 @@ Project [1 years 2 months AS INTERVAL '1 years 2 months'#x]
 -- !query
 SELECT interval '1 2:03' day to hour
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 36,
-    "fragment" : "'1 2:03' day to hour"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "1 2:03",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
+    "typeName" : "interval day to hour"
+  }
 }
 
 
 -- !query
 SELECT interval '1 2:03:04' day to hour
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 39,
-    "fragment" : "'1 2:03:04' day to hour"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "1 2:03:04",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
+    "typeName" : "interval day to hour"
+  }
 }
 
 
@@ -131,38 +127,34 @@ Project [1 days 2 hours 3 minutes AS INTERVAL '1 days 2 hours 3 minutes'#x]
 -- !query
 SELECT interval '1 2:03:04' day to minute
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 41,
-    "fragment" : "'1 2:03:04' day to minute"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "1 2:03:04",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
+    "typeName" : "interval day to minute"
+  }
 }
 
 
 -- !query
 SELECT interval '1 2:03' day to second
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 38,
-    "fragment" : "'1 2:03' day to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "1 2:03",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",
+    "typeName" : "interval day to second"
+  }
 }
 
 
@@ -176,112 +168,100 @@ Project [1 days 2 hours 3 minutes 4 seconds AS INTERVAL '1 days 2 hours 3 minute
 -- !query
 SELECT interval '1 2:03' hour to minute
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 39,
-    "fragment" : "'1 2:03' hour to minute"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "1 2:03",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
+    "typeName" : "interval hour to minute"
+  }
 }
 
 
 -- !query
 SELECT interval '1 2:03:04' hour to minute
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 42,
-    "fragment" : "'1 2:03:04' hour to minute"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "1 2:03:04",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
+    "typeName" : "interval hour to minute"
+  }
 }
 
 
 -- !query
 SELECT interval '1 2:03' hour to second
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 39,
-    "fragment" : "'1 2:03' hour to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "1 2:03",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
+  }
 }
 
 
 -- !query
 SELECT interval '1 2:03:04' hour to second
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 42,
-    "fragment" : "'1 2:03:04' hour to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "1 2:03:04",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
+  }
 }
 
 
 -- !query
 SELECT interval '1 2:03' minute to second
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 41,
-    "fragment" : "'1 2:03' minute to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "1 2:03",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
+    "typeName" : "interval minute to second"
+  }
 }
 
 
 -- !query
 SELECT interval '1 2:03:04' minute to second
 -- !query analysis
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 44,
-    "fragment" : "'1 2:03:04' minute to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "1 2:03:04",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
+    "typeName" : "interval minute to second"
+  }
 }

--- a/sql/core/src/test/resources/sql-tests/results/ansi/date.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/date.sql.out
@@ -269,6 +269,7 @@ struct<>
 org.apache.spark.SparkIllegalArgumentException
 {
   "errorClass" : "INTERVAL_ERROR.ILLEGAL_DAY_OF_WEEK",
+  "sqlState" : "22009",
   "messageParameters" : {
     "string" : "xx"
   }

--- a/sql/core/src/test/resources/sql-tests/results/ansi/date.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/date.sql.out
@@ -268,7 +268,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_3209",
+  "errorClass" : "INTERVAL_ERROR.ILLEGAL_DAY_OF_WEEK",
   "messageParameters" : {
     "string" : "xx"
   }

--- a/sql/core/src/test/resources/sql-tests/results/ansi/date.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/date.sql.out
@@ -268,7 +268,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.ILLEGAL_DAY_OF_WEEK",
+  "errorClass" : "ILLEGAL_DAY_OF_WEEK",
   "sqlState" : "22009",
   "messageParameters" : {
     "string" : "xx"

--- a/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
@@ -1825,8 +1825,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "sqlState" : "22006",
   "messageParameters" : {
     "input" : "178956970-8",
-    "interval" : "year-month",
-    "msg" : "integer overflow"
+    "interval" : "year-month"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
@@ -1259,16 +1259,19 @@ select interval '20 15:40:32.99899999' day to hour
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "20 15:40:32.99899999",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
-    "typeName" : "interval day to hour"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 20 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 50,
+    "fragment" : "'20 15:40:32.99899999' day to hour"
+  } ]
 }
 
 
@@ -1277,16 +1280,19 @@ select interval '20 15:40:32.99899999' day to minute
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "20 15:40:32.99899999",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
-    "typeName" : "interval day to minute"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 20 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 52,
+    "fragment" : "'20 15:40:32.99899999' day to minute"
+  } ]
 }
 
 
@@ -1295,16 +1301,19 @@ select interval '15:40:32.99899999' hour to minute
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "15:40:32.99899999",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
-    "typeName" : "interval hour to minute"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 50,
+    "fragment" : "'15:40:32.99899999' hour to minute"
+  } ]
 }
 
 
@@ -1313,16 +1322,19 @@ select interval '15:40.99899999' hour to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "15:40.99899999",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
-    "typeName" : "interval hour to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 47,
+    "fragment" : "'15:40.99899999' hour to second"
+  } ]
 }
 
 
@@ -1331,16 +1343,19 @@ select interval '15:40' hour to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "15:40",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
-    "typeName" : "interval hour to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 38,
+    "fragment" : "'15:40' hour to second"
+  } ]
 }
 
 
@@ -1349,16 +1364,19 @@ select interval '20 40:32.99899999' minute to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "20 40:32.99899999",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
-    "typeName" : "interval minute to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 20 40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 52,
+    "fragment" : "'20 40:32.99899999' minute to second"
+  } ]
 }
 
 
@@ -1777,14 +1795,19 @@ SELECT INTERVAL '178956970-8' YEAR TO MONTH
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INTERVAL_ERROR.INTERVAL_PARSING",
-  "sqlState" : "22009",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "interval" : "year-month",
-    "msg" : "integer overflow"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.INTERVAL_PARSING] Error parsing '178956970-8' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Error parsing interval year-month string. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 43,
+    "fragment" : "'178956970-8' YEAR TO MONTH"
+  } ]
 }
 
 
@@ -2323,16 +2346,19 @@ select interval '-\t2-2\t' year to month
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "-\t2-2\t",
-    "intervalStr" : "year-month",
-    "supportedFormat" : "`[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH`",
-    "typeName" : "interval year to month"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING] Error parsing '-\t2-2\t' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match year-month format of `[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH` when cast to interval year to month: -\t2-2\t. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 40,
+    "fragment" : "'-\\t2-2\\t' year to month"
+  } ]
 }
 
 
@@ -2349,16 +2375,19 @@ select interval '\n-\t10\t 12:34:46.789\t' day to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "\n-\t10\t 12:34:46.789\t",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",
-    "typeName" : "interval day to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '\n-\t10\t 12:34:46.789\t' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: \n-\t10\t 12:34:46.789\t. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 56,
+    "fragment" : "'\\n-\\t10\\t 12:34:46.789\\t' day to second"
+  } ]
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
@@ -1261,9 +1261,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 20 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "20 15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
+    "typeName" : "interval day to hour"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1282,9 +1286,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 20 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "20 15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
+    "typeName" : "interval day to minute"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1303,9 +1311,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
+    "typeName" : "interval hour to minute"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1324,9 +1336,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "15:40.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1345,9 +1361,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "15:40",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1366,9 +1386,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 20 40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "20 40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
+    "typeName" : "interval minute to second"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1797,9 +1821,12 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.INTERVAL_PARSING",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.INTERVAL_PARSING] Error parsing '178956970-8' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Error parsing interval year-month string. SQLSTATE: 22006"
+    "input" : "178956970-8",
+    "interval" : "year-month",
+    "msg" : "integer overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -2348,9 +2375,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING] Error parsing '-\t2-2\t' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match year-month format of `[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH` when cast to interval year to month: -\t2-2\t. SQLSTATE: 22006"
+    "input" : "-\t2-2\t",
+    "intervalStr" : "year-month",
+    "supportedFormat" : "`[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH`",
+    "typeName" : "interval year to month"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -2377,9 +2408,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '\n-\t10\t 12:34:46.789\t' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: \n-\t10\t 12:34:46.789\t. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "\n-\t10\t 12:34:46.789\t",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",
+    "typeName" : "interval day to second"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
@@ -1261,7 +1261,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -1280,7 +1280,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -1299,7 +1299,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -1318,7 +1318,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -1337,7 +1337,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -1356,7 +1356,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -2334,7 +2334,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : "",
     "input" : "-\t2-2\t",
     "intervalStr" : "year-month",
     "supportedFormat" : "`[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH`",
@@ -2358,7 +2357,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",

--- a/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
@@ -1264,7 +1264,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "20 15:40:32.99899999",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
@@ -1283,7 +1282,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "20 15:40:32.99899999",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
@@ -1302,7 +1300,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "15:40:32.99899999",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
@@ -1321,7 +1318,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "15:40.99899999",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
@@ -1340,7 +1336,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "15:40",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
@@ -1359,7 +1354,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "20 40:32.99899999",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
@@ -2360,7 +2354,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "\n-\t10\t 12:34:46.789\t",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",

--- a/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
@@ -1259,19 +1259,17 @@ select interval '20 15:40:32.99899999' day to hour
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 50,
-    "fragment" : "'20 15:40:32.99899999' day to hour"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "20 15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
+    "typeName" : "interval day to hour"
+  }
 }
 
 
@@ -1280,19 +1278,17 @@ select interval '20 15:40:32.99899999' day to minute
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 52,
-    "fragment" : "'20 15:40:32.99899999' day to minute"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "20 15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
+    "typeName" : "interval day to minute"
+  }
 }
 
 
@@ -1301,19 +1297,17 @@ select interval '15:40:32.99899999' hour to minute
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 50,
-    "fragment" : "'15:40:32.99899999' hour to minute"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
+    "typeName" : "interval hour to minute"
+  }
 }
 
 
@@ -1322,19 +1316,17 @@ select interval '15:40.99899999' hour to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 47,
-    "fragment" : "'15:40.99899999' hour to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "15:40.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
+  }
 }
 
 
@@ -1343,19 +1335,17 @@ select interval '15:40' hour to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 38,
-    "fragment" : "'15:40' hour to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "15:40",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
+  }
 }
 
 
@@ -1364,19 +1354,17 @@ select interval '20 40:32.99899999' minute to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 20 40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 52,
-    "fragment" : "'20 40:32.99899999' minute to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "20 40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
+    "typeName" : "interval minute to second"
+  }
 }
 
 
@@ -1795,19 +1783,14 @@ SELECT INTERVAL '178956970-8' YEAR TO MONTH
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.INTERVAL_PARSING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.INTERVAL_PARSING] Interval error. Error parsing interval year-month string: integer overflow. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 43,
-    "fragment" : "'178956970-8' YEAR TO MONTH"
-  } ]
+    "interval" : "year-month",
+    "msg" : "integer overflow"
+  }
 }
 
 
@@ -2346,19 +2329,17 @@ select interval '-\t2-2\t' year to month
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match year-month format of `[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH` when cast to interval year to month: -\t2-2\t. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 40,
-    "fragment" : "'-\\t2-2\\t' year to month"
-  } ]
+    "fallBackNotice" : "",
+    "input" : "-\t2-2\t",
+    "intervalStr" : "year-month",
+    "supportedFormat" : "`[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH`",
+    "typeName" : "interval year to month"
+  }
 }
 
 
@@ -2375,19 +2356,17 @@ select interval '\n-\t10\t 12:34:46.789\t' day to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: \n-\t10\t 12:34:46.789\t, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 56,
-    "fragment" : "'\\n-\\t10\\t 12:34:46.789\\t' day to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "\n-\t10\t 12:34:46.789\t",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",
+    "typeName" : "interval day to second"
+  }
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
@@ -1261,8 +1261,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "20 15:40:32.99899999",
     "intervalStr" : "day-time",
@@ -1279,8 +1279,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "20 15:40:32.99899999",
     "intervalStr" : "day-time",
@@ -1297,8 +1297,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "15:40:32.99899999",
     "intervalStr" : "day-time",
@@ -1315,8 +1315,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "15:40.99899999",
     "intervalStr" : "day-time",
@@ -1333,8 +1333,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "15:40",
     "intervalStr" : "day-time",
@@ -1351,8 +1351,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "20 40:32.99899999",
     "intervalStr" : "day-time",
@@ -2325,8 +2325,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "-\t2-2\t",
     "intervalStr" : "year-month",
@@ -2351,8 +2351,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "\n-\t10\t 12:34:46.789\t",
     "intervalStr" : "day-time",

--- a/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/ansi/interval.sql.out
@@ -1263,7 +1263,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1284,7 +1284,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1305,7 +1305,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1326,7 +1326,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1347,7 +1347,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1368,7 +1368,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 20 40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 20 40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1799,7 +1799,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Error parsing interval year-month string: integer overflow"
+    "msg" : "[INTERVAL_ERROR.INTERVAL_PARSING] Interval error. Error parsing interval year-month string: integer overflow. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -2350,7 +2350,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match year-month format of `[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH` when cast to interval year to month: -\t2-2\t"
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match year-month format of `[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH` when cast to interval year to month: -\t2-2\t. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -2379,7 +2379,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: \n-\t10\t 12:34:46.789\t, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: \n-\t10\t 12:34:46.789\t, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/interval.sql.out
@@ -1140,16 +1140,19 @@ select interval '20 15:40:32.99899999' day to hour
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "20 15:40:32.99899999",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
-    "typeName" : "interval day to hour"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 20 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 50,
+    "fragment" : "'20 15:40:32.99899999' day to hour"
+  } ]
 }
 
 
@@ -1158,16 +1161,19 @@ select interval '20 15:40:32.99899999' day to minute
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "20 15:40:32.99899999",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
-    "typeName" : "interval day to minute"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 20 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 52,
+    "fragment" : "'20 15:40:32.99899999' day to minute"
+  } ]
 }
 
 
@@ -1176,16 +1182,19 @@ select interval '15:40:32.99899999' hour to minute
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "15:40:32.99899999",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
-    "typeName" : "interval hour to minute"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 50,
+    "fragment" : "'15:40:32.99899999' hour to minute"
+  } ]
 }
 
 
@@ -1194,16 +1203,19 @@ select interval '15:40.99899999' hour to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "15:40.99899999",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
-    "typeName" : "interval hour to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 47,
+    "fragment" : "'15:40.99899999' hour to second"
+  } ]
 }
 
 
@@ -1212,16 +1224,19 @@ select interval '15:40' hour to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "15:40",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
-    "typeName" : "interval hour to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 38,
+    "fragment" : "'15:40' hour to second"
+  } ]
 }
 
 
@@ -1230,16 +1245,19 @@ select interval '20 40:32.99899999' minute to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "20 40:32.99899999",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
-    "typeName" : "interval minute to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 20 40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 52,
+    "fragment" : "'20 40:32.99899999' minute to second"
+  } ]
 }
 
 
@@ -1658,14 +1676,19 @@ SELECT INTERVAL '178956970-8' YEAR TO MONTH
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INTERVAL_ERROR.INTERVAL_PARSING",
-  "sqlState" : "22009",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "interval" : "year-month",
-    "msg" : "integer overflow"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.INTERVAL_PARSING] Error parsing '178956970-8' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Error parsing interval year-month string. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 43,
+    "fragment" : "'178956970-8' YEAR TO MONTH"
+  } ]
 }
 
 
@@ -2136,16 +2159,19 @@ select interval '-\t2-2\t' year to month
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "-\t2-2\t",
-    "intervalStr" : "year-month",
-    "supportedFormat" : "`[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH`",
-    "typeName" : "interval year to month"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING] Error parsing '-\t2-2\t' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match year-month format of `[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH` when cast to interval year to month: -\t2-2\t. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 40,
+    "fragment" : "'-\\t2-2\\t' year to month"
+  } ]
 }
 
 
@@ -2162,16 +2188,19 @@ select interval '\n-\t10\t 12:34:46.789\t' day to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "\n-\t10\t 12:34:46.789\t",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",
-    "typeName" : "interval day to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '\n-\t10\t 12:34:46.789\t' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: \n-\t10\t 12:34:46.789\t. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 56,
+    "fragment" : "'\\n-\\t10\\t 12:34:46.789\\t' day to second"
+  } ]
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/interval.sql.out
@@ -1145,7 +1145,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "20 15:40:32.99899999",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
@@ -1164,7 +1163,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "20 15:40:32.99899999",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
@@ -1183,7 +1181,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "15:40:32.99899999",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
@@ -1202,7 +1199,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "15:40.99899999",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
@@ -1221,7 +1217,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "15:40",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
@@ -1240,7 +1235,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "20 40:32.99899999",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
@@ -2173,7 +2167,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "\n-\t10\t 12:34:46.789\t",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",

--- a/sql/core/src/test/resources/sql-tests/results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/interval.sql.out
@@ -1140,19 +1140,17 @@ select interval '20 15:40:32.99899999' day to hour
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 50,
-    "fragment" : "'20 15:40:32.99899999' day to hour"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "20 15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
+    "typeName" : "interval day to hour"
+  }
 }
 
 
@@ -1161,19 +1159,17 @@ select interval '20 15:40:32.99899999' day to minute
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 52,
-    "fragment" : "'20 15:40:32.99899999' day to minute"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "20 15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
+    "typeName" : "interval day to minute"
+  }
 }
 
 
@@ -1182,19 +1178,17 @@ select interval '15:40:32.99899999' hour to minute
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 50,
-    "fragment" : "'15:40:32.99899999' hour to minute"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
+    "typeName" : "interval hour to minute"
+  }
 }
 
 
@@ -1203,19 +1197,17 @@ select interval '15:40.99899999' hour to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 47,
-    "fragment" : "'15:40.99899999' hour to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "15:40.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
+  }
 }
 
 
@@ -1224,19 +1216,17 @@ select interval '15:40' hour to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 38,
-    "fragment" : "'15:40' hour to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "15:40",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
+  }
 }
 
 
@@ -1245,19 +1235,17 @@ select interval '20 40:32.99899999' minute to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 20 40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 52,
-    "fragment" : "'20 40:32.99899999' minute to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "20 40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
+    "typeName" : "interval minute to second"
+  }
 }
 
 
@@ -1676,19 +1664,14 @@ SELECT INTERVAL '178956970-8' YEAR TO MONTH
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.INTERVAL_PARSING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.INTERVAL_PARSING] Interval error. Error parsing interval year-month string: integer overflow. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 43,
-    "fragment" : "'178956970-8' YEAR TO MONTH"
-  } ]
+    "interval" : "year-month",
+    "msg" : "integer overflow"
+  }
 }
 
 
@@ -2159,19 +2142,17 @@ select interval '-\t2-2\t' year to month
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match year-month format of `[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH` when cast to interval year to month: -\t2-2\t. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 40,
-    "fragment" : "'-\\t2-2\\t' year to month"
-  } ]
+    "fallBackNotice" : "",
+    "input" : "-\t2-2\t",
+    "intervalStr" : "year-month",
+    "supportedFormat" : "`[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH`",
+    "typeName" : "interval year to month"
+  }
 }
 
 
@@ -2188,19 +2169,17 @@ select interval '\n-\t10\t 12:34:46.789\t' day to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: \n-\t10\t 12:34:46.789\t, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 56,
-    "fragment" : "'\\n-\\t10\\t 12:34:46.789\\t' day to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "\n-\t10\t 12:34:46.789\t",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",
+    "typeName" : "interval day to second"
+  }
 }
 
 

--- a/sql/core/src/test/resources/sql-tests/results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/interval.sql.out
@@ -1144,7 +1144,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1165,7 +1165,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 20 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1186,7 +1186,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 15:40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1207,7 +1207,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1228,7 +1228,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1249,7 +1249,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 20 40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 20 40:32.99899999, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1680,7 +1680,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Error parsing interval year-month string: integer overflow"
+    "msg" : "[INTERVAL_ERROR.INTERVAL_PARSING] Interval error. Error parsing interval year-month string: integer overflow. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -2163,7 +2163,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match year-month format of `[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH` when cast to interval year to month: -\t2-2\t"
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match year-month format of `[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH` when cast to interval year to month: -\t2-2\t. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -2192,7 +2192,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: \n-\t10\t 12:34:46.789\t, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: \n-\t10\t 12:34:46.789\t, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/interval.sql.out
@@ -1706,8 +1706,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "sqlState" : "22006",
   "messageParameters" : {
     "input" : "178956970-8",
-    "interval" : "year-month",
-    "msg" : "integer overflow"
+    "interval" : "year-month"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/interval.sql.out
@@ -1142,7 +1142,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -1161,7 +1161,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -1180,7 +1180,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -1199,7 +1199,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -1218,7 +1218,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -1237,7 +1237,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -2147,7 +2147,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : "",
     "input" : "-\t2-2\t",
     "intervalStr" : "year-month",
     "supportedFormat" : "`[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH`",
@@ -2171,7 +2170,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",

--- a/sql/core/src/test/resources/sql-tests/results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/interval.sql.out
@@ -1142,9 +1142,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 20 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "20 15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
+    "typeName" : "interval day to hour"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1163,9 +1167,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 20 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "20 15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
+    "typeName" : "interval day to minute"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1184,9 +1192,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 15:40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "15:40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
+    "typeName" : "interval hour to minute"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1205,9 +1217,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "15:40.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1226,9 +1242,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '15:40' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 15:40. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "15:40",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1247,9 +1267,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '20 40:32.99899999' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 20 40:32.99899999. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "20 40:32.99899999",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
+    "typeName" : "interval minute to second"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -1678,9 +1702,12 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.INTERVAL_PARSING",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.INTERVAL_PARSING] Error parsing '178956970-8' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Error parsing interval year-month string. SQLSTATE: 22006"
+    "input" : "178956970-8",
+    "interval" : "year-month",
+    "msg" : "integer overflow"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -2161,9 +2188,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING] Error parsing '-\t2-2\t' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match year-month format of `[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH` when cast to interval year to month: -\t2-2\t. SQLSTATE: 22006"
+    "input" : "-\t2-2\t",
+    "intervalStr" : "year-month",
+    "supportedFormat" : "`[+|-]y-m`, `INTERVAL [+|-]'[+|-]y-m' YEAR TO MONTH`",
+    "typeName" : "interval year to month"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -2190,9 +2221,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '\n-\t10\t 12:34:46.789\t' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: \n-\t10\t 12:34:46.789\t. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "\n-\t10\t 12:34:46.789\t",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",
+    "typeName" : "interval day to second"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/interval.sql.out
@@ -1142,8 +1142,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "20 15:40:32.99899999",
     "intervalStr" : "day-time",
@@ -1160,8 +1160,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "20 15:40:32.99899999",
     "intervalStr" : "day-time",
@@ -1178,8 +1178,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "15:40:32.99899999",
     "intervalStr" : "day-time",
@@ -1196,8 +1196,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "15:40.99899999",
     "intervalStr" : "day-time",
@@ -1214,8 +1214,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "15:40",
     "intervalStr" : "day-time",
@@ -1232,8 +1232,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "20 40:32.99899999",
     "intervalStr" : "day-time",
@@ -2138,8 +2138,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "-\t2-2\t",
     "intervalStr" : "year-month",
@@ -2164,8 +2164,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "\n-\t10\t 12:34:46.789\t",
     "intervalStr" : "day-time",

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/interval.sql.out
@@ -102,9 +102,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 1 2:03. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "1 2:03",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
+    "typeName" : "interval day to hour"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -123,9 +127,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03:04' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 1 2:03:04. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "1 2:03:04",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
+    "typeName" : "interval day to hour"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -152,9 +160,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03:04' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 1 2:03:04. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "1 2:03:04",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
+    "typeName" : "interval day to minute"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -173,9 +185,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: 1 2:03. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "1 2:03",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",
+    "typeName" : "interval day to second"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -202,9 +218,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 1 2:03. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "1 2:03",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
+    "typeName" : "interval hour to minute"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -223,9 +243,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03:04' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 1 2:03:04. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "1 2:03:04",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
+    "typeName" : "interval hour to minute"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -244,9 +268,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 1 2:03. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "1 2:03",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -265,9 +293,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03:04' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 1 2:03:04. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "1 2:03:04",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -286,9 +318,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 1 2:03. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "1 2:03",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
+    "typeName" : "interval minute to second"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -307,9 +343,13 @@ struct<>
 -- !query output
 org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
-    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03:04' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 1 2:03:04. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+    "input" : "1 2:03:04",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
+    "typeName" : "interval minute to second"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/interval.sql.out
@@ -104,7 +104,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -125,7 +125,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -154,7 +154,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -175,7 +175,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -204,7 +204,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -225,7 +225,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -246,7 +246,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -267,7 +267,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -288,7 +288,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",
@@ -309,7 +309,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
 {
   "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "msg" : "Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0."
+    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
   },
   "queryContext" : [ {
     "objectType" : "",

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/interval.sql.out
@@ -102,8 +102,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "1 2:03",
     "intervalStr" : "day-time",
@@ -120,8 +120,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "1 2:03:04",
     "intervalStr" : "day-time",
@@ -146,8 +146,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "1 2:03:04",
     "intervalStr" : "day-time",
@@ -164,8 +164,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "1 2:03",
     "intervalStr" : "day-time",
@@ -190,8 +190,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "1 2:03",
     "intervalStr" : "day-time",
@@ -208,8 +208,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "1 2:03:04",
     "intervalStr" : "day-time",
@@ -226,8 +226,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "1 2:03",
     "intervalStr" : "day-time",
@@ -244,8 +244,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "1 2:03:04",
     "intervalStr" : "day-time",
@@ -262,8 +262,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "1 2:03",
     "intervalStr" : "day-time",
@@ -280,8 +280,8 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22009",
+  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
+  "sqlState" : "22006",
   "messageParameters" : {
     "input" : "1 2:03:04",
     "intervalStr" : "day-time",

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/interval.sql.out
@@ -100,19 +100,17 @@ SELECT interval '1 2:03' day to hour
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 36,
-    "fragment" : "'1 2:03' day to hour"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "1 2:03",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
+    "typeName" : "interval day to hour"
+  }
 }
 
 
@@ -121,19 +119,17 @@ SELECT interval '1 2:03:04' day to hour
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 39,
-    "fragment" : "'1 2:03:04' day to hour"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "1 2:03:04",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
+    "typeName" : "interval day to hour"
+  }
 }
 
 
@@ -150,19 +146,17 @@ SELECT interval '1 2:03:04' day to minute
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 41,
-    "fragment" : "'1 2:03:04' day to minute"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "1 2:03:04",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
+    "typeName" : "interval day to minute"
+  }
 }
 
 
@@ -171,19 +165,17 @@ SELECT interval '1 2:03' day to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 38,
-    "fragment" : "'1 2:03' day to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "1 2:03",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",
+    "typeName" : "interval day to second"
+  }
 }
 
 
@@ -200,19 +192,17 @@ SELECT interval '1 2:03' hour to minute
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 39,
-    "fragment" : "'1 2:03' hour to minute"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "1 2:03",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
+    "typeName" : "interval hour to minute"
+  }
 }
 
 
@@ -221,19 +211,17 @@ SELECT interval '1 2:03:04' hour to minute
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 42,
-    "fragment" : "'1 2:03:04' hour to minute"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "1 2:03:04",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
+    "typeName" : "interval hour to minute"
+  }
 }
 
 
@@ -242,19 +230,17 @@ SELECT interval '1 2:03' hour to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 39,
-    "fragment" : "'1 2:03' hour to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "1 2:03",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
+  }
 }
 
 
@@ -263,19 +249,17 @@ SELECT interval '1 2:03:04' hour to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 42,
-    "fragment" : "'1 2:03:04' hour to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "1 2:03:04",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
+    "typeName" : "interval hour to second"
+  }
 }
 
 
@@ -284,19 +268,17 @@ SELECT interval '1 2:03' minute to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 1 2:03, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 41,
-    "fragment" : "'1 2:03' minute to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "1 2:03",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
+    "typeName" : "interval minute to second"
+  }
 }
 
 
@@ -305,17 +287,15 @@ SELECT interval '1 2:03:04' minute to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.sql.catalyst.parser.ParseException
+org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "sqlState" : "22009",
   "messageParameters" : {
-    "msg" : "[INTERVAL_ERROR.UNMATCHED_FORMAT_STRING] Interval error. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 1 2:03:04, set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.. SQLSTATE: 22009"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 17,
-    "stopIndex" : 44,
-    "fragment" : "'1 2:03:04' minute to second"
-  } ]
+    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
+    "input" : "1 2:03:04",
+    "intervalStr" : "day-time",
+    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
+    "typeName" : "interval minute to second"
+  }
 }

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/interval.sql.out
@@ -105,7 +105,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "1 2:03",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
@@ -124,7 +123,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "1 2:03:04",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
@@ -151,7 +149,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "1 2:03:04",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
@@ -170,7 +167,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "1 2:03",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",
@@ -197,7 +193,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "1 2:03",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
@@ -216,7 +211,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "1 2:03:04",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
@@ -235,7 +229,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "1 2:03",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
@@ -254,7 +247,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "1 2:03:04",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
@@ -273,7 +265,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "1 2:03",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
@@ -292,7 +283,6 @@ org.apache.spark.SparkIllegalArgumentException
   "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
-    "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
     "input" : "1 2:03:04",
     "intervalStr" : "day-time",
     "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/interval.sql.out
@@ -100,16 +100,19 @@ SELECT interval '1 2:03' day to hour
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "1 2:03",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
-    "typeName" : "interval day to hour"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 1 2:03. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 36,
+    "fragment" : "'1 2:03' day to hour"
+  } ]
 }
 
 
@@ -118,16 +121,19 @@ SELECT interval '1 2:03:04' day to hour
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "1 2:03:04",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR`",
-    "typeName" : "interval day to hour"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03:04' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h`, `INTERVAL [+|-]'[+|-]d h' DAY TO HOUR` when cast to interval day to hour: 1 2:03:04. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 39,
+    "fragment" : "'1 2:03:04' day to hour"
+  } ]
 }
 
 
@@ -144,16 +150,19 @@ SELECT interval '1 2:03:04' day to minute
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "1 2:03:04",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE`",
-    "typeName" : "interval day to minute"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03:04' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m`, `INTERVAL [+|-]'[+|-]d h:m' DAY TO MINUTE` when cast to interval day to minute: 1 2:03:04. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 41,
+    "fragment" : "'1 2:03:04' day to minute"
+  } ]
 }
 
 
@@ -162,16 +171,19 @@ SELECT interval '1 2:03' day to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "1 2:03",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND`",
-    "typeName" : "interval day to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]d h:m:s.n`, `INTERVAL [+|-]'[+|-]d h:m:s.n' DAY TO SECOND` when cast to interval day to second: 1 2:03. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 38,
+    "fragment" : "'1 2:03' day to second"
+  } ]
 }
 
 
@@ -188,16 +200,19 @@ SELECT interval '1 2:03' hour to minute
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "1 2:03",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
-    "typeName" : "interval hour to minute"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 1 2:03. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 39,
+    "fragment" : "'1 2:03' hour to minute"
+  } ]
 }
 
 
@@ -206,16 +221,19 @@ SELECT interval '1 2:03:04' hour to minute
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "1 2:03:04",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE`",
-    "typeName" : "interval hour to minute"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03:04' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m`, `INTERVAL [+|-]'[+|-]h:m' HOUR TO MINUTE` when cast to interval hour to minute: 1 2:03:04. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 42,
+    "fragment" : "'1 2:03:04' hour to minute"
+  } ]
 }
 
 
@@ -224,16 +242,19 @@ SELECT interval '1 2:03' hour to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "1 2:03",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
-    "typeName" : "interval hour to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 1 2:03. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 39,
+    "fragment" : "'1 2:03' hour to second"
+  } ]
 }
 
 
@@ -242,16 +263,19 @@ SELECT interval '1 2:03:04' hour to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "1 2:03:04",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND`",
-    "typeName" : "interval hour to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03:04' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]h:m:s.n`, `INTERVAL [+|-]'[+|-]h:m:s.n' HOUR TO SECOND` when cast to interval hour to second: 1 2:03:04. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 42,
+    "fragment" : "'1 2:03:04' hour to second"
+  } ]
 }
 
 
@@ -260,16 +284,19 @@ SELECT interval '1 2:03' minute to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "1 2:03",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
-    "typeName" : "interval minute to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 1 2:03. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 41,
+    "fragment" : "'1 2:03' minute to second"
+  } ]
 }
 
 
@@ -278,14 +305,17 @@ SELECT interval '1 2:03:04' minute to second
 -- !query schema
 struct<>
 -- !query output
-org.apache.spark.SparkIllegalArgumentException
+org.apache.spark.sql.catalyst.parser.ParseException
 {
-  "errorClass" : "INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
-  "sqlState" : "22006",
+  "errorClass" : "_LEGACY_ERROR_TEMP_0063",
   "messageParameters" : {
-    "input" : "1 2:03:04",
-    "intervalStr" : "day-time",
-    "supportedFormat" : "`[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND`",
-    "typeName" : "interval minute to second"
-  }
+    "msg" : "[INVALID_INTERVAL_FORMAT.UNMATCHED_FORMAT_STRING_WITH_NOTICE] Error parsing '1 2:03:04' to interval. Please ensure that the value provided is in a valid format for defining an interval. You can reference the documentation for the correct format. Interval string does not match day-time format of `[+|-]m:s.n`, `INTERVAL [+|-]'[+|-]m:s.n' MINUTE TO SECOND` when cast to interval minute to second: 1 2:03:04. Set \"spark.sql.legacy.fromDayTimeString.enabled\" to \"true\" to restore the behavior before Spark 3.0. SQLSTATE: 22006"
+  },
+  "queryContext" : [ {
+    "objectType" : "",
+    "objectName" : "",
+    "startIndex" : 17,
+    "stopIndex" : 44,
+    "fragment" : "'1 2:03:04' minute to second"
+  } ]
 }

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/interval.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/interval.sql.out
@@ -102,7 +102,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -121,7 +121,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -148,7 +148,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -167,7 +167,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -194,7 +194,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -213,7 +213,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -232,7 +232,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -251,7 +251,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -270,7 +270,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",
@@ -289,7 +289,7 @@ struct<>
 -- !query output
 org.apache.spark.SparkIllegalArgumentException
 {
-  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING",
+  "errorClass" : "INTERVAL_ERROR.UNMATCHED_FORMAT_STRING_WITH_NOTICE",
   "sqlState" : "22009",
   "messageParameters" : {
     "fallBackNotice" : ", set spark.sql.legacy.fromDayTimeString.enabled to true to restore the behavior before Spark 3.0.",

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
@@ -408,8 +408,7 @@ class DDLParserSuite extends AnalysisTest with SharedSparkSession {
       condition = "INVALID_INTERVAL_FORMAT.INTERVAL_PARSING",
       parameters = Map(
         "input" -> "42-32",
-        "interval" -> "year-month",
-        "msg" -> "requirement failed: month 32 outside range [0, 11]"),
+        "interval" -> "year-month"),
       context = ExpectedContext(
         fragment = fragment1,
         start = 16,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
@@ -402,8 +402,10 @@ class DDLParserSuite extends AnalysisTest with SharedSparkSession {
 
   test("Invalid interval term should throw AnalysisException") {
     val sql1 = "select interval '42-32' year to month"
-    val value1 = "Error parsing interval year-month string: " +
-      "requirement failed: month 32 outside range [0, 11]"
+    val value1 = "[INTERVAL_ERROR.INTERVAL_PARSING] Interval error. " +
+      "Error parsing interval year-month string: " +
+      "requirement failed: month 32 outside range [0, 11]. " +
+      "SQLSTATE: 22009"
     val fragment1 = "'42-32' year to month"
     checkError(
       exception = parseException(sql1),

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.execution.command
 
-import org.apache.spark.{SparkIllegalArgumentException, SparkThrowable}
+import org.apache.spark.SparkThrowable
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.{AnalysisTest, GlobalTempView, LocalTempView, SchemaCompensation, UnresolvedAttribute, UnresolvedFunctionName, UnresolvedIdentifier}
 import org.apache.spark.sql.catalyst.catalog.{ArchiveResource, FileResource, FunctionResource, JarResource}
@@ -402,15 +402,18 @@ class DDLParserSuite extends AnalysisTest with SharedSparkSession {
 
   test("Invalid interval term should throw AnalysisException") {
     val sql1 = "select interval '42-32' year to month"
+    val fragment1 = "'42-32' year to month"
     checkError(
-      exception = intercept[SparkIllegalArgumentException] {
-        parser.parsePlan(sql1)
-      },
+      exception = parseException(sql1),
       condition = "INVALID_INTERVAL_FORMAT.INTERVAL_PARSING",
       parameters = Map(
         "input" -> "42-32",
         "interval" -> "year-month",
-        "msg" -> "requirement failed: month 32 outside range [0, 11]"))
+        "msg" -> "requirement failed: month 32 outside range [0, 11]"),
+      context = ExpectedContext(
+        fragment = fragment1,
+        start = 16,
+        stop = 36))
 
     val sql2 = "select interval '5 49:12:15' day to second"
     val fragment2 = "'5 49:12:15' day to second"

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/command/DDLParserSuite.scala
@@ -406,10 +406,11 @@ class DDLParserSuite extends AnalysisTest with SharedSparkSession {
       exception = intercept[SparkIllegalArgumentException] {
         parser.parsePlan(sql1)
       },
-      condition = "INTERVAL_ERROR.INTERVAL_PARSING",
-      parameters = Map("interval" -> "year-month",
-        "msg" -> "requirement failed: month 32 outside range [0, 11]")
-    )
+      condition = "INVALID_INTERVAL_FORMAT.INTERVAL_PARSING",
+      parameters = Map(
+        "input" -> "42-32",
+        "interval" -> "year-month",
+        "msg" -> "requirement failed: month 32 outside range [0, 11]"))
 
     val sql2 = "select interval '5 49:12:15' day to second"
     val fragment2 = "'5 49:12:15' day to second"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In the PR, I propose to rename the legacy error classes `_LEGACY_ERROR_TEMP_32[09-14]` to `ILLEGAL_DAY_OF_WEEK`, `INVALID_INTERVAL_FORMAT.[SECOND_NANO_FORMAT, DAY_TIME_PARSING, UNSUPPORTED_FROM_TO_EXPRESSION, INTERVAL_PARSING, UNMATCHED_FORMAT_STRING]` and modifying their error messages properly. Also, I propose modifying the test that checks `INVALID_INTERVAL_FORMAT.DAY_TIME_PARSING` in a way that it also checks error class and sql state. Furthermore, I propose to add tests which check whether the exceptions `INVALID_INTERVAL_FORMAT.SECOND_NANO_FORMAT` and `INVALID_INTERVAL_FORMAT. UNSUPPORTED_FROM_TO_EXPRESSION ` are thrown properly. Additionally, I propose to keep the query context of these exceptions in golden files.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Proper name improves user experience w/ Spark SQL.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
It was tested by modifying existing tests in `IntervalUtilsSuite`, `DateTimeUtilsSuite`, `DDLParserSuite` and `CastSuiteBase` classes. Tests were modified to check modified names and sql states. Additionally, test for checking `INVALID_INTERVAL_FORMAT.SECOND_NANO_FORMAT` and `INVALID_INTERVAL_FORMAT.UNSUPPORTED_FROM_TO_EXPRESSION` exceptions were added in `IntervalUtilsSuite`.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No