### PR TITLE
[SPARK-49366][CONNECT] Treat Union node as leaf in dataframe column resolution

### DIFF
--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -130,6 +130,20 @@ class DataFrameTestsMixin:
         self.assertTrue(df3.columns, ["aa", "b", "a", "b"])
         self.assertTrue(df3.count() == 2)
 
+    def test_self_join_III(self):
+        df1 = self.spark.range(10).withColumn("value", lit(1))
+        df2 = df1.union(df1)
+        df3 = df1.join(df2, df1.id == df2.id, "left")
+        self.assertTrue(df3.columns, ["id", "value", "id", "value"])
+        self.assertTrue(df3.count() == 20)
+
+    def test_self_join_IV(self):
+        df1 = self.spark.range(10).withColumn("value", lit(1))
+        df2 = df1.withColumn("value", lit(2)).union(df1.withColumn("value", lit(3)))
+        df3 = df1.join(df2, df1.id == df2.id, "right")
+        self.assertTrue(df3.columns, ["id", "value", "id", "value"])
+        self.assertTrue(df3.count() == 20)
+
     def test_duplicated_column_names(self):
         df = self.spark.createDataFrame([(1, 2)], ["c", "c"])
         row = df.select("*").first()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -531,10 +531,8 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
 
     val isMetadataAccess = u.getTagValue(LogicalPlan.IS_METADATA_COL).nonEmpty
 
-    val resolved = q.map { p =>
-      resolveDataFrameColumnRecursively(u, planId, isMetadataAccess, p, 0)
-    }
-    val matched = resolved.exists(_._2)
+    val (resolved, matched) = resolveDataFrameColumnByPlanId(
+      u, planId, isMetadataAccess, q, 0)
     if (!matched) {
       // Can not find the target plan node with plan id, e.g.
       //  df1 = spark.createDataFrame([Row(a = 1, b = 2, c = 3)]])
@@ -542,7 +540,17 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
       //  df1.select(df2.a)   <-   illegal reference df2.a
       throw QueryCompilationErrors.cannotResolveDataFrameColumn(u)
     }
+    resolved.map(_._1)
+  }
 
+  private def resolveDataFrameColumnByPlanId(
+      u: UnresolvedAttribute,
+      id: Long,
+      isMetadataAccess: Boolean,
+      q: Seq[LogicalPlan],
+      currentDepth: Int): (Option[(NamedExpression, Int)], Boolean) = {
+    val resolved = q.map(resolveDataFrameColumnRecursively(
+      u, id, isMetadataAccess, _, currentDepth))
     val merged = resolved
       .flatMap(_._1)
       .sortBy(_._2) // sort by depth
@@ -551,7 +559,8 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
         case (Some((r1, 0)), (r2, d2)) if d2 != 0 => Some((r1, 0))
         case _ => throw QueryCompilationErrors.ambiguousColumnReferences(u)
       }
-    merged.map(_._1)
+    val matched = resolved.exists(_._2)
+    (merged, matched)
   }
 
   private def resolveDataFrameColumnRecursively(
@@ -559,9 +568,9 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
       id: Long,
       isMetadataAccess: Boolean,
       p: LogicalPlan,
-      currentDepth: Int): (Seq[(NamedExpression, Int)], Boolean) = {
+      currentDepth: Int): (Option[(NamedExpression, Int)], Boolean) = {
     val (resolved, matched) = if (p.getTagValue(LogicalPlan.PLAN_ID_TAG).contains(id)) {
-      val r = try {
+      val resolved = try {
         if (!isMetadataAccess) {
           p.resolve(u.nameParts, conf.resolver)
         } else if (u.nameParts.size == 1) {
@@ -574,14 +583,14 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
           logDebug(s"Fail to resolve $u with $p due to $e")
           None
       }
-      (r.toSeq.map(r0 => (r0, currentDepth)), true)
+      (resolved.map(r => (r, currentDepth)), true)
     } else {
-      p.children.foldLeft((Seq.empty[(NamedExpression, Int)], false)) {
-        case ((r1, m1), c) =>
-          val (r2, m2) = resolveDataFrameColumnRecursively(u, id,
-            isMetadataAccess, c, currentDepth + 1)
-          (r1 ++ r2, m1 || m2)
+      val children = p match {
+        // treat Union node as the leaf node
+        case _: Union => Seq.empty[LogicalPlan]
+        case _ => p.children
       }
+      resolveDataFrameColumnByPlanId(u, id, isMetadataAccess, children, currentDepth + 1)
     }
 
     // In self join case like:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -33,7 +33,6 @@ import org.apache.spark.sql.connector.catalog.{CatalogManager, Identifier}
 import org.apache.spark.sql.errors.{DataTypeErrorsBase, QueryCompilationErrors}
 import org.apache.spark.sql.internal.SQLConf
 
-// scalastyle:off println
 trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
 
   def conf: SQLConf
@@ -450,11 +449,6 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
       plan: LogicalPlan,
       throws: Boolean = false,
       includeLastResort: Boolean = false): Expression = {
-    println(s"resolveExpressionByPlanOutput: e = $expr")
-    println(s"resolveExpressionByPlanOutput: q = \n$plan")
-    println()
-    println()
-    println()
     resolveExpression(
       tryResolveDataFrameColumns(expr, Seq(plan)),
       resolveColumnByName = nameParts => {
@@ -477,11 +471,6 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
       e: Expression,
       q: LogicalPlan,
       includeLastResort: Boolean = false): Expression = {
-    println(s"resolveExpressionByPlanChildren: e = $e")
-    println(s"resolveExpressionByPlanChildren: q = \n$q")
-    println()
-    println()
-    println()
     resolveExpression(
       tryResolveDataFrameColumns(e, q.children),
       resolveColumnByName = nameParts => {
@@ -539,15 +528,12 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
     if (planIdOpt.isEmpty) return None
     val planId = planIdOpt.get
     logDebug(s"Extract plan_id $planId from $u")
-    println()
-    println()
-    println(s"Extract plan_id $planId from $u")
-    println()
-    println()
 
     val isMetadataAccess = u.getTagValue(LogicalPlan.IS_METADATA_COL).nonEmpty
 
-    val resolved = q.map(resolveDataFrameColumnRecursively(u, planId, isMetadataAccess, _, 0))
+    val resolved = q.map { p =>
+      resolveDataFrameColumnRecursively(u, planId, isMetadataAccess, p, 0)
+    }
     val matched = resolved.exists(_._2)
     if (!matched) {
       // Can not find the target plan node with plan id, e.g.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -574,12 +574,12 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
           logDebug(s"Fail to resolve $u with $p due to $e")
           None
       }
-      (r.map((_, currentDepth)).toSeq, true)
+      (r.toSeq.map(r1 => (r1, currentDepth)), true)
     } else {
-      p.children.map { child =>
-        resolveDataFrameColumnRecursively(u, id, isMetadataAccess, child, currentDepth + 1)
-      }.foldLeft((Seq.empty[(NamedExpression, Int)], false)) {
-        case ((r1, m1), (r2, m2)) => (r1 ++ r2, m1 || m2)
+      p.children.foldLeft((Seq.empty[(NamedExpression, Int)], false)) {
+        case ((r1, m1), c) =>
+          val (r2, m2) = resolveDataFrameColumnRecursively(u, id, isMetadataAccess, c, currentDepth)
+          (r1 ++ r2, m1 || m2)
       }
     }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -574,11 +574,12 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
           logDebug(s"Fail to resolve $u with $p due to $e")
           None
       }
-      (r.toSeq.map(r1 => (r1, currentDepth)), true)
+      (r.toSeq.map(r0 => (r0, currentDepth)), true)
     } else {
       p.children.foldLeft((Seq.empty[(NamedExpression, Int)], false)) {
         case ((r1, m1), c) =>
-          val (r2, m2) = resolveDataFrameColumnRecursively(u, id, isMetadataAccess, c, currentDepth)
+          val (r2, m2) = resolveDataFrameColumnRecursively(u, id,
+            isMetadataAccess, c, currentDepth + 1)
           (r1 ++ r2, m1 || m2)
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.connector.catalog.{CatalogManager, Identifier}
 import org.apache.spark.sql.errors.{DataTypeErrorsBase, QueryCompilationErrors}
 import org.apache.spark.sql.internal.SQLConf
 
+// scalastyle:off println
 trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
 
   def conf: SQLConf
@@ -449,6 +450,11 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
       plan: LogicalPlan,
       throws: Boolean = false,
       includeLastResort: Boolean = false): Expression = {
+    println(s"resolveExpressionByPlanOutput: e = $expr")
+    println(s"resolveExpressionByPlanOutput: q = \n$plan")
+    println()
+    println()
+    println()
     resolveExpression(
       tryResolveDataFrameColumns(expr, Seq(plan)),
       resolveColumnByName = nameParts => {
@@ -471,6 +477,11 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
       e: Expression,
       q: LogicalPlan,
       includeLastResort: Boolean = false): Expression = {
+    println(s"resolveExpressionByPlanChildren: e = $e")
+    println(s"resolveExpressionByPlanChildren: q = \n$q")
+    println()
+    println()
+    println()
     resolveExpression(
       tryResolveDataFrameColumns(e, q.children),
       resolveColumnByName = nameParts => {
@@ -528,6 +539,11 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
     if (planIdOpt.isEmpty) return None
     val planId = planIdOpt.get
     logDebug(s"Extract plan_id $planId from $u")
+    println()
+    println()
+    println(s"Extract plan_id $planId from $u")
+    println()
+    println()
 
     val isMetadataAccess = u.getTagValue(LogicalPlan.IS_METADATA_COL).nonEmpty
 
@@ -557,7 +573,14 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
       .foldLeft(Option.empty[(NamedExpression, Int)]) {
         case (None, (r2, d2)) => Some((r2, d2))
         case (Some((r1, 0)), (r2, d2)) if d2 != 0 => Some((r1, 0))
-        case _ => throw QueryCompilationErrors.ambiguousColumnReferences(u)
+        case other =>
+          println("ambiguousColumnReferences")
+          println(s"${u} with id = $id")
+          println()
+          q.foreach(p => println(p))
+          println()
+          println(s"resolved: ${resolved}")
+          throw QueryCompilationErrors.ambiguousColumnReferences(u)
       }
     val matched = resolved.exists(_._2)
     (merged, matched)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -107,7 +107,7 @@ abstract class LogicalPlan
   lazy val resolved: Boolean = expressions.forall(_.resolved) && childrenResolved
 
   override protected def statePrefix = {
-    val prefix = if (!resolved) {
+    if (!resolved) {
       "'"
     } else {
       val prefixFromSuper = super.statePrefix
@@ -119,9 +119,6 @@ abstract class LogicalPlan
         prefixFromSuper
       }
     }
-
-    this.getTagValue(LogicalPlan.PLAN_ID_TAG)
-      .map(id => s"$prefix[id=$id]").getOrElse(prefix)
   }
 
   /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LogicalPlan.scala
@@ -107,7 +107,7 @@ abstract class LogicalPlan
   lazy val resolved: Boolean = expressions.forall(_.resolved) && childrenResolved
 
   override protected def statePrefix = {
-    if (!resolved) {
+    val prefix = if (!resolved) {
       "'"
     } else {
       val prefixFromSuper = super.statePrefix
@@ -119,6 +119,9 @@ abstract class LogicalPlan
         prefixFromSuper
       }
     }
+
+    this.getTagValue(LogicalPlan.PLAN_ID_TAG)
+      .map(id => s"$prefix[id=$id]").getOrElse(prefix)
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

Treat Union node as leaf in column resolution



### Why are the changes needed?
bug fix:
```
from pyspark.sql.functions import concat, lit, col
df1 = spark.range(10).withColumn("value", lit(1))
df2 = df1.union(df1)
df1.join(df2, df1.id == df2.id, "left").show()
```
fails with `AMBIGUOUS_COLUMN_REFERENCE`

```
resolveExpressionByPlanChildren: e = '`==`('id, 'id)
resolveExpressionByPlanChildren: q =
'[id=63]Join LeftOuter, '`==`('id, 'id)
:- [id=61]Project [id#550L, 1 AS value#553]
:  +- Range (0, 10, step=1, splits=Some(12))
+- [id=62]Union false, false
   :- [id=61]Project [id#564L, 1 AS value#565]
   :  +- Range (0, 10, step=1, splits=Some(12))
   +- [id=61]Project [id#566L, 1 AS value#567]
      +- Range (0, 10, step=1, splits=Some(12))

'id with id = 61

[id=61]Project [id#564L, 1 AS value#565]
+- Range (0, 10, step=1, splits=Some(12))

[id=61]Project [id#566L, 1 AS value#567]
+- Range (0, 10, step=1, splits=Some(12))


resolved: Vector((Some((id#564L,1)),true), (Some((id#566L,1)),true))
```

When resolving `'id with id = 61`, existing detection fails in the second child.



### Does this PR introduce _any_ user-facing change?
yes, bug fix


### How was this patch tested?
added tests

### Was this patch authored or co-authored using generative AI tooling?
No
