### PR TITLE
[SPARK-49367][PS] Parallelize the KDE computation for multiple columns (plotly backend)

### DIFF
--- a/python/pyspark/pandas/plot/core.py
+++ b/python/pyspark/pandas/plot/core.py
@@ -521,7 +521,7 @@ class KdePlotBase(NumericPlotBase):
     @staticmethod
     def compute_kde(sdf, bw_method=None, ind=None):
         input_col = F.col(sdf.columns[0])
-        kde_col = KdePlotBase.compute_kde_col(input_col, bw_method, ind)
+        kde_col = KdePlotBase.compute_kde_col(input_col, bw_method, ind).alias("kde")
         row = sdf.select(kde_col).first()
         return row[0]
 

--- a/python/pyspark/pandas/plot/plotly.py
+++ b/python/pyspark/pandas/plot/plotly.py
@@ -244,8 +244,8 @@ def plot_kde(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
             input_col=psdf._internal.spark_column_for(label),
             ind=ind,
             bw_method=bw_method,
-        )
-        for label in psdf._internal.column_labels
+        ).alias(f"kde_{i}")
+        for i, label in enumerate(psdf._internal.column_labels)
     ]
     kde_results = sdf.select(*kde_cols).first()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Parallelize the KDE computation for `plotly` backend.

Note that `matplotlib` backend is not optimized in this PR, due to the computation logic is slightly different between `plotly` and `matplotlib`:
1, `plotly`: compute a global `ind` across all input columns, and then compute all curves based on it;
2, `matplotlib`: for each input column, compute its `ind` and then the curve;

I think `matplotlib`'s approach seems more reasonable, but it make this optimization cannot be directly applied on `matplotlib`, so it needs more investigation.


### Why are the changes needed?
existing implementation compute each curve once, this PR aims to compute multiple columns together


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI and manually test


### Was this patch authored or co-authored using generative AI tooling?
No
