### PR TITLE
[SPARK-49121][PROTOBUF][TESTS][FOLLOWUP] Change to dynamically calculate `ExpectedContext#stop` in test case "SPARK-49121: from_protobuf and to_protobuf SQL functions"

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -306,12 +306,6 @@ jobs:
         name: unit-tests-log-${{ matrix.modules }}-${{ matrix.comment }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ matrix.hive }}
         path: "**/target/unit-tests.log"
 
-  maven-test:
-    name: "Run Maven Test"
-    permissions:
-      packages: write
-    uses: ./.github/workflows/maven_test.yml
-
   infra-image:
     name: "Base image build"
     needs: precondition

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -306,6 +306,12 @@ jobs:
         name: unit-tests-log-${{ matrix.modules }}-${{ matrix.comment }}-${{ matrix.java }}-${{ matrix.hadoop }}-${{ matrix.hive }}
         path: "**/target/unit-tests.log"
 
+  maven-test:
+    name: "Run Maven Test"
+    permissions:
+      packages: write
+    uses: ./.github/workflows/maven_test.yml
+
   infra-image:
     name: "Base image build"
     needs: precondition

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
@@ -2102,6 +2102,7 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
         queryContext = Array(ExpectedContext(
           fragment = s"to_protobuf(complex_struct, 42, '$testFileDescFile', map())",
           start = 10,
+          // The subsequent test scenarios also follow the following rules to define `stop`:
           // stop = (start - 1) + prefixLength + fileNameLength + suffixLength
           stop = 9 + 33 + fileNameLength + 9))
       )

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
@@ -2102,6 +2102,7 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
         queryContext = Array(ExpectedContext(
           fragment = s"to_protobuf(complex_struct, 42, '$testFileDescFile', map())",
           start = 10,
+          // stop = (start - 1) + prefixLength + fileNameLength + suffixLength
           stop = 9 + 33 + fileNameLength + 9))
       )
       checkError(

--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
@@ -2084,6 +2084,7 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
         Seq(Row(Row(1L, "test_string", 32, 64L, 123.456, 789.01F, true, "sample_bytes".getBytes)))
       )
 
+      val fileNameLength = testFileDescFile.length
       // Negative tests for to_protobuf.
       checkError(
         exception = intercept[AnalysisException](sql(
@@ -2101,7 +2102,7 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
         queryContext = Array(ExpectedContext(
           fragment = s"to_protobuf(complex_struct, 42, '$testFileDescFile', map())",
           start = 10,
-          stop = 153))
+          stop = 9 + 33 + fileNameLength + 9))
       )
       checkError(
         exception = intercept[AnalysisException](sql(
@@ -2140,7 +2141,7 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
           fragment =
             s"to_protobuf(complex_struct, 'SimpleMessageJavaTypes', '$testFileDescFile', 42)",
           start = 10,
-          stop = 172))
+          stop = 9 + 55 + fileNameLength + 6))
       )
 
       // Negative tests for from_protobuf.
@@ -2159,7 +2160,7 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
         queryContext = Array(ExpectedContext(
           fragment = s"from_protobuf(protobuf_data, 42, '$testFileDescFile', map())",
           start = 8,
-          stop = 152))
+          stop = 7 + 34 + fileNameLength + 9))
       )
       checkError(
         exception = intercept[AnalysisException](sql(
@@ -2197,7 +2198,7 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
           fragment =
             s"from_protobuf(protobuf_data, 'SimpleMessageJavaTypes', '$testFileDescFile', 42)",
           start = 10,
-          stop = 173))
+          stop = 9 + 56 + fileNameLength + 6))
       )
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, in the test case "SPARK-49121: from_protobuf and to_protobuf SQL functions", for the test case where the `fragment` contains the `testFileDescFile` variable, we also use an absolute position to define `ExpectedContext#stop`. 

However, since the content of `testFileDescFile` is related to both the build tool and the execution directory of the test case, its length is not fixed. 

For example, the maven daily test failed

- Java 21: https://github.com/apache/spark/actions/runs/10509632076/job/29116303271
- Java 17: https://github.com/apache/spark/actions/runs/10508648823/job/29113000899


```
- SPARK-49121: from_protobuf and to_protobuf SQL functions *** FAILED ***
  150 did not equal 153 Invalid stopIndex of a query context. Actual:SQLQueryContext(Some(3),Some(2),Some(10),Some(150),Some(
  SELECT
    to_protobuf(complex_struct, 42, '/home/runner/work/spark/spark/connector/protobuf/target/generated-test-sources/functions_suite.desc', map())
  FROM protobuf_test_table
  ),None,None) (SparkFunSuite.scala:376)
```

and when I run the test locally using `sbt`, it also failed:

```
build/sbt "protobuf/testOnly org.apache.spark.sql.protobuf.ProtobufFunctionsSuite"
[info] - SPARK-49121: from_protobuf and to_protobuf SQL functions *** FAILED *** (248 milliseconds)
[info]   165 did not equal 153 Invalid stopIndex of a query context. Actual:SQLQueryContext(Some(3),Some(2),Some(10),Some(165),Some(
[info]   SELECT
[info]     to_protobuf(complex_struct, 42, '/Users/yangjie01/SourceCode/git/spark-sbt/connector/protobuf/target/generated-test-sources/descriptor-set-sbt.desc', map())
[info]   FROM protobuf_test_table
[info]   ),None,None) (SparkFunSuite.scala:376)
```

So this PR changes ExpectedContext#stop to a relative definition: stop = (start - 1) + prefixLength + fileNameLength + suffixLength

For example: 

```scala
...
queryContext = Array(ExpectedContext(
          fragment = s"to_protobuf(complex_struct, 42, '$testFileDescFile', map())",
          start = 10,
          stop = 153))
...
```

```
(start - 1) = 10 -1 = 9
prefixLength = "to_protobuf(complex_struct, 42, '".length = 33
suffixLength = "', map())".length = 9
```

So the `stop` definition  will change from `stop = 153`  to `stop = 9 + 33 + fileNameLength + 9`, similar change have been made to other cases as well.


### Why are the changes needed?
Make the test more robust and fix the maven daily test.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
- Pass GitHub Actions
- locally test:

maven:

```
build/mvn clean install -pl connector/protobuf -am -DskipTests
build/mvn test -pl connector/protobuf -Dtest=none -DwildcardSuites=org.apache.spark.sql.protobuf.ProtobufFunctionsSuite
```

```
Run completed in 10 seconds, 719 milliseconds.
Total number of tests run: 40
Suites: completed 2, aborted 0
Tests: succeeded 40, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
```

sbt:

```
build/sbt clean "protobuf/testOnly org.apache.spark.sql.protobuf.ProtobufFunctionsSuite"
```

```
[info] Run completed in 11 seconds, 786 milliseconds.
[info] Total number of tests run: 40
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 40, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```

- maven test using Git Hub Actions: https://github.com/LuciferYang/spark/runs/29157086061

![image](https://github.com/user-attachments/assets/b5cbef70-895c-4de2-8ea2-bb1aed1bf0c6)

maven tests passed

### Was this patch authored or co-authored using generative AI tooling?
No
