### PR TITLE
[SPARK-49370][BUILD] `maven.scaladoc.skip` should not affect test code compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3015,6 +3015,9 @@
               <goals>
                 <goal>doc-jar</goal>
               </goals>
+              <configuration>
+                <skip>${maven.scaladoc.skip}</skip>
+              </configuration>
             </execution>
           </executions>
           <configuration>
@@ -3022,7 +3025,6 @@
             <checkMultipleScalaVersions>true</checkMultipleScalaVersions>
             <failOnMultipleScalaVersions>true</failOnMultipleScalaVersions>
             <recompileMode>incremental</recompileMode>
-            <skip>${maven.scaladoc.skip}</skip>
             <args>
               <arg>-unchecked</arg>
               <arg>-deprecation</arg>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Move `maven.scaladoc.skip` from the `scala-maven-plugin`'s global configuration to its `attach-scaladocs` execution's configuration.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

`maven.scaladoc.skip` was added in SPARK-43461 to speed up the `dev/make-distribution.sh` by skipping scaladocs generation, but it was wrongly applied to a broader scope.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
It affects developers who use `build/mvn deploy -Dmaven.scaladoc.skip=true` to deploy the artifacts case, without this patch, wrong `<module>-tests.jar`s (don't contain the test classes but only resources) will be produced.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

```
build/mvn clean package -DskipTests -Dmaven.scaladoc.skip=true -pl core -am
```
before
```
$ ll core/target/spark-core_2.13-4.0.0-SNAPSHOT-tests.jar
-rw-r--r--@ 1 chengpan  staff   381K Aug 23 23:55 core/target/spark-core_2.13-4.0.0-SNAPSHOT-tests.jar

$ jar tf core/target/spark-core_2.13-4.0.0-SNAPSHOT-tests.jar | grep class | head
<nothing>
```

after
```
$ ll core/target/spark-core_2.13-4.0.0-SNAPSHOT-tests.jar
-rw-r--r--@ 1 chengpan  staff   5.7M Aug 24 00:12 core/target/spark-core_2.13-4.0.0-SNAPSHOT-tests.jar

$ jar tf core/target/spark-core_2.13-4.0.0-SNAPSHOT-tests.jar | grep class | head
test/org/apache/spark/JavaTaskContextCompileCheck.class
test/org/apache/spark/Java8RDDAPISuite.class
test/org/apache/spark/JavaAPISuite$SomeCustomClass.class
test/org/apache/spark/JavaAPISuite$BuggyMapFunction.class
test/org/apache/spark/JavaAPISuite$DoubleComparator.class
test/org/apache/spark/JavaAPISuite.class
test/org/apache/spark/JavaTaskContextCompileCheck$JavaTaskCompletionListenerImpl.class
test/org/apache/spark/JavaTaskContextCompileCheck$JavaTaskFailureListenerImpl.class
test/org/apache/spark/JavaAPISuite$Class2.class
test/org/apache/spark/JavaAPISuite$1.class
```

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.