### PR TITLE
[SPARK-49373][PROTOBUF][TESTS] Fix `ProtobufFunctionsSuite` to be environment-independent

### DIFF
--- a/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
+++ b/connector/protobuf/src/test/scala/org/apache/spark/sql/protobuf/ProtobufFunctionsSuite.scala
@@ -2085,6 +2085,7 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
       )
 
       // Negative tests for to_protobuf.
+      var fragment = s"to_protobuf(complex_struct, 42, '$testFileDescFile', map())"
       checkError(
         exception = intercept[AnalysisException](sql(
           s"""
@@ -2099,9 +2100,9 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
             "string representing the Protobuf message name"),
           "hint" -> ""),
         queryContext = Array(ExpectedContext(
-          fragment = s"to_protobuf(complex_struct, 42, '$testFileDescFile', map())",
+          fragment = fragment,
           start = 10,
-          stop = 153))
+          stop = fragment.length + 9))
       )
       checkError(
         exception = intercept[AnalysisException](sql(
@@ -2121,6 +2122,7 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
           start = 10,
           stop = 73))
       )
+      fragment = s"to_protobuf(complex_struct, 'SimpleMessageJavaTypes', '$testFileDescFile', 42)"
       checkError(
         exception = intercept[AnalysisException](sql(
           s"""
@@ -2137,13 +2139,13 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
             "to Protobuf format"),
           "hint" -> ""),
         queryContext = Array(ExpectedContext(
-          fragment =
-            s"to_protobuf(complex_struct, 'SimpleMessageJavaTypes', '$testFileDescFile', 42)",
+          fragment = fragment,
           start = 10,
-          stop = 172))
+          stop = fragment.length + 9))
       )
 
       // Negative tests for from_protobuf.
+      fragment = s"from_protobuf(protobuf_data, 42, '$testFileDescFile', map())"
       checkError(
         exception = intercept[AnalysisException](sql(
           s"""
@@ -2157,9 +2159,9 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
             "string representing the Protobuf message name"),
           "hint" -> ""),
         queryContext = Array(ExpectedContext(
-          fragment = s"from_protobuf(protobuf_data, 42, '$testFileDescFile', map())",
+          fragment = fragment,
           start = 8,
-          stop = 152))
+          stop = fragment.length + 7))
       )
       checkError(
         exception = intercept[AnalysisException](sql(
@@ -2178,6 +2180,7 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
           start = 8,
           stop = 72))
       )
+      fragment = s"from_protobuf(protobuf_data, 'SimpleMessageJavaTypes', '$testFileDescFile', 42)"
       checkError(
         exception = intercept[AnalysisException](sql(
           s"""
@@ -2194,10 +2197,9 @@ class ProtobufFunctionsSuite extends QueryTest with SharedSparkSession with Prot
             "from Protobuf format"),
           "hint" -> ""),
         queryContext = Array(ExpectedContext(
-          fragment =
-            s"from_protobuf(protobuf_data, 'SimpleMessageJavaTypes', '$testFileDescFile', 42)",
+          fragment = fragment,
           start = 10,
-          stop = 173))
+          stop = fragment.length + 9))
       )
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch modifies `ProtobufFunctionsSuite`'s test case `SPARK-49121: from_protobuf and to_protobuf SQL functions` to check the stop index depending on the file path length.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

During debugging CI failure in https://github.com/apache/spark/pull/47843, we found that `ProtobufFunctionsSuite`'s test case `SPARK-49121: from_protobuf and to_protobuf SQL functions` is environment-dependent.
In the test, it checks the start and stop indices of SQL text fragment but the fragment length depends on the repo name of the author of a PR.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

No, test only.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Unit test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No