### PR TITLE
[SPARK-49372][SS] Ensure that latestSnapshot is set to none on close to avoid subsequent use

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -784,6 +784,7 @@ class RocksDB(
       dbLogger.close()
       synchronized {
         latestSnapshot.foreach(_.close())
+        latestSnapshot = None
       }
       silentDeleteRecursively(localRootDir, "closing RocksDB")
     } catch {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Ensure that latestSnapshot is set to none on close to avoid subsequent use


### Why are the changes needed?
Changes are needed to ensure that latestSnapshot is not used after db close since it might throw an exception in the context of the maint thread with this trace

```
[info]   java.lang.IllegalArgumentException: requirement failed
[info]   at scala.Predef$.require(Predef.scala:324)
[info]   at org.apache.spark.util.SparkFileUtils.recursiveList(SparkFileUtils.scala:56)
[info]   at org.apache.spark.util.SparkFileUtils.recursiveList$(SparkFileUtils.scala:55)
[info]   at org.apache.spark.util.Utils$.recursiveList(Utils.scala:99)
[info]   at org.apache.spark.sql.execution.streaming.state.RocksDBFileManager.files$lzycompute$1(RocksDBFileManager.scala:801)
[info]   at org.apache.spark.sql.execution.streaming.state.RocksDBFileManager.files$2(RocksDBFileManager.scala:801)
[info]   at org.apache.spark.sql.execution.streaming.state.RocksDBFileManager.$anonfun$logFilesInDir$3(RocksDBFileManager.scala:804)
[info]   at org.apache.spark.internal.LogEntry.cachedMessageWithContext$lzycompute(Logging.scala:102)
[info]   at org.apache.spark.internal.LogEntry.cachedMessageWithContext(Logging.scala:102)
[info]   at org.apache.spark.internal.LogEntry.context(Logging.scala:106)
[info]   at org.apache.spark.internal.Logging.logInfo(Logging.scala:189)
[info]   at org.apache.spark.internal.Logging.logInfo$(Logging.scala:187)
[info]   at org.apache.spark.sql.execution.streaming.state.RocksDBFileManager.logInfo(RocksDBFileManager.scala:126)
[info]   at org.apache.spark.sql.execution.streaming.state.RocksDBFileManager.logFilesInDir(RocksDBFileManager.scala:804)
[info]   at org.apache.spark.sql.execution.streaming.state.RocksDBFileManager.saveCheckpointToDfs(RocksDBFileManager.scala:256)
[info]   at org.apache.spark.sql.execution.streaming.state.RocksDB.$anonfun$uploadSnapshot$1(RocksDB.scala:730)
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added unit tests

Before the fix:
```
[info] Run completed in 5 seconds, 666 milliseconds.
[info] Total number of tests run: 8
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 6, failed 2, canceled 0, ignored 0, pending 0
[info] *** 2 TESTS FAILED ***
```

After the fix:
```
[info] Run completed in 5 seconds, 661 milliseconds.
[info] Total number of tests run: 8
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 8, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```


### Was this patch authored or co-authored using generative AI tooling?
No
