### PR TITLE
[SPARK-49375][BUILD] Upgrade `postgresql` to 42.7.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@
     </extraJavaTestArgs>
     <mariadb.java.client.version>2.7.12</mariadb.java.client.version>
     <mysql.connector.version>9.0.0</mysql.connector.version>
-    <postgresql.version>42.7.3</postgresql.version>
+    <postgresql.version>42.7.4</postgresql.version>
     <db2.jcc.version>11.5.9.0</db2.jcc.version>
     <mssql.jdbc.version>12.8.0.jre11</mssql.jdbc.version>
     <ojdbc11.version>23.5.0.24.07</ojdbc11.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `postgresql` from `42.7.3` to `42.7.4`.

### Why are the changes needed?
The version `42.7.3` full release notes:
https://jdbc.postgresql.org/changelogs/2024-08-22-42.7.4-release/
- fix: Ensure order of results for getDouble [PR #3301](https://github.com/pgjdbc/pgjdbc/pull/3301)
- fix: Fix #3224 - conversion for TIME ‘24:00’ to LocalTime breaks in binary-mode [PR #3225](https://github.com/pgjdbc/pgjdbc/pull/3225)

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.

### Was this patch authored or co-authored using generative AI tooling?
No.