### PR TITLE
[SPARK-49382][PS] Make frame box plot properly render the fliers/outliers

### DIFF
--- a/python/pyspark/pandas/plot/core.py
+++ b/python/pyspark/pandas/plot/core.py
@@ -428,7 +428,6 @@ class BoxPlotBase:
         # Here we normalize the values by subtracting the minimum value from
         # each, and use absolute values.
         order_col = F.abs(F.col("`{}`".format(colname)) - min_val.item())
-
         fliers = (
             fliers_df.select(F.col("`{}`".format(colname)))
             .orderBy(order_col)

--- a/python/pyspark/pandas/plot/core.py
+++ b/python/pyspark/pandas/plot/core.py
@@ -429,14 +429,6 @@ class BoxPlotBase:
         # each, and use absolute values.
         order_col = F.abs(F.col("`{}`".format(colname)) - min_val.item())
 
-        print()
-        print()
-        print()
-        print(f"min_val = {min_val.item()}")
-        print()
-        print()
-        print()
-
         fliers = (
             fliers_df.select(F.col("`{}`".format(colname)))
             .orderBy(order_col)
@@ -445,31 +437,16 @@ class BoxPlotBase:
             .values
         )
 
-        print()
-        print()
-        print()
-        print(fliers)
-        print()
-        print()
-        print()
-
         return fliers
 
     @staticmethod
     def get_multicol_fliers(colnames, multicol_outliers, multicol_whiskers):
-        print()
-        print()
-        print(f"multicol_whiskers = {multicol_whiskers}")
-        print()
-        print()
-
         scols = []
         extract_colnames = []
         for i, colname in enumerate(colnames):
             formated_colname = "`{}`".format(colname)
             outlier_colname = "__{}_outlier".format(colname)
             min_val = multicol_whiskers[colname]["min"]
-            print(f"min_val = {min_val}")
             pair_col = F.struct(
                 F.abs(F.col(formated_colname) - min_val).alias("ord"),
                 F.col(formated_colname).alias("val"),
@@ -487,25 +464,9 @@ class BoxPlotBase:
 
         results = multicol_outliers.select(scols).select(extract_colnames).first()
 
-        print()
-        print()
-        print()
-        print(results)
-        print()
-        print()
-        print()
-
         fliers = {}
         for i, colname in enumerate(colnames):
             fliers[colname] = results[i]
-
-        print()
-        print()
-        print()
-        print(fliers)
-        print()
-        print()
-        print()
 
         return fliers
 

--- a/python/pyspark/pandas/plot/core.py
+++ b/python/pyspark/pandas/plot/core.py
@@ -448,7 +448,7 @@ class BoxPlotBase:
             outlier_colname = "__{}_outlier".format(colname)
             min_val = multicol_whiskers[colname]["min"]
             pair_col = F.struct(
-                F.abs(F.col(formated_colname) - min_val).alias("ord"),
+                F.abs(F.col(formated_colname) - F.lit(min_val)).alias("ord"),
                 F.col(formated_colname).alias("val"),
             )
             scols.append(

--- a/python/pyspark/pandas/plot/plotly.py
+++ b/python/pyspark/pandas/plot/plotly.py
@@ -209,7 +209,7 @@ def plot_box(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
             col_whiskers = whiskers[colname]
 
             col_fliers = None
-            if fliers is not None and len(fliers[colname]) > 0:
+            if fliers is not None and colname in fliers and len(fliers[colname]) > 0:
                 col_fliers = [fliers[colname]]
 
             fig.add_trace(

--- a/python/pyspark/pandas/plot/plotly.py
+++ b/python/pyspark/pandas/plot/plotly.py
@@ -210,7 +210,7 @@ def plot_box(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
 
             col_fliers = None
             if fliers is not None and len(fliers[colname]) > 0:
-                col_fliers = fliers[colname]
+                col_fliers = [fliers[colname]]
 
             fig.add_trace(
                 go.Box(
@@ -222,7 +222,7 @@ def plot_box(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
                     mean=[col_stats["mean"]],
                     lowerfence=[col_whiskers["min"]],
                     upperfence=[col_whiskers["max"]],
-                    y=None,
+                    y=col_fliers,
                     boxpoints=boxpoints,
                     notched=notched,
                     **kwargs,

--- a/python/pyspark/pandas/plot/plotly.py
+++ b/python/pyspark/pandas/plot/plotly.py
@@ -199,10 +199,18 @@ def plot_box(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
         # Computes min and max values of non-outliers - the whiskers
         whiskers = BoxPlotBase.calc_multicol_whiskers(numeric_column_names, outliers)
 
+        fliers = None
+        if boxpoints:
+            fliers = BoxPlotBase.get_multicol_fliers(numeric_column_names, outliers, whiskers)
+
         i = 0
         for colname in numeric_column_names:
             col_stats = multicol_stats[colname]
             col_whiskers = whiskers[colname]
+
+            col_fliers = None
+            if fliers is not None and len(fliers[colname]) > 0:
+                col_fliers = fliers[colname]
 
             fig.add_trace(
                 go.Box(
@@ -214,7 +222,7 @@ def plot_box(data: Union["ps.DataFrame", "ps.Series"], **kwargs):
                     mean=[col_stats["mean"]],
                     lowerfence=[col_whiskers["min"]],
                     upperfence=[col_whiskers["max"]],
-                    y=None,  # todo: support y=fliers
+                    y=None,
                     boxpoints=boxpoints,
                     notched=notched,
                     **kwargs,

--- a/python/pyspark/pandas/spark/functions.py
+++ b/python/pyspark/pandas/spark/functions.py
@@ -174,6 +174,19 @@ def null_index(col: Column) -> Column:
         return Column(sc._jvm.PythonSQLUtils.nullIndex(col._jc))
 
 
+def collect_top_k(col: Column, num: int, reverse: bool) -> Column:
+    if is_remote():
+        from pyspark.sql.connect.functions.builtin import _invoke_function_over_columns
+
+        return _invoke_function_over_columns("collect_top_k", col, F.lit(num), F.lit(reverse))
+
+    else:
+        from pyspark import SparkContext
+
+        sc = SparkContext._active_spark_context
+        return Column(sc._jvm.PythonSQLUtils.collect_top_k(col._jc, num, reverse))
+
+
 def make_interval(unit: str, e: Union[Column, int, float]) -> Column:
     unit_mapping = {
         "YEAR": "years",

--- a/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/api/python/PythonSQLUtils.scala
@@ -149,6 +149,9 @@ private[sql] object PythonSQLUtils extends Logging {
 
   def nullIndex(e: Column): Column = Column.internalFn("null_index", e)
 
+  def collect_top_k(e: Column, num: Int, reverse: Boolean): Column =
+    Column.internalFn("collect_top_k", e, lit(num), lit(reverse))
+
   def pandasProduct(e: Column, ignoreNA: Boolean): Column =
     Column.internalFn("pandas_product", e, lit(ignoreNA))
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
fliers/outliers was ignored in the initial implementation https://github.com/apache/spark/pull/36317


### Why are the changes needed?
feature parity for Pandas and Series box plot


### Does this PR introduce _any_ user-facing change?

```
import pyspark.pandas as ps
df = ps.DataFrame([[5.1, 3.5, 0], [4.9, 3.0, 0], [7.0, 3.2, 1], [6.4, 3.2, 1], [5.9, 3.0, 2], [100, 200, 300]], columns=['length', 'width', 'species'])
df.boxplot()
```

`df.length.plot.box()`
![image](https://github.com/user-attachments/assets/43da563c-5f68-4305-ad27-a4f04815dfd1)

before:
`df.boxplot()`
![image](https://github.com/user-attachments/assets/e25c2760-c12a-4801-a730-3987a020f889)

after:
`df.boxplot()`
![image](https://github.com/user-attachments/assets/c19f13b1-b9e4-423e-bcec-0c47c1c8df32)


### How was this patch tested?
CI and manually check


### Was this patch authored or co-authored using generative AI tooling?
No
