### PR TITLE
[SPARK-49359][TESTS][FOLLOWUP][3.5] Fix compilation to rename `util.Map` to `jutil.Map`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/DataSourceV2SQLSuite.scala
@@ -3620,7 +3620,7 @@ class FakeStagedTableCatalog extends InMemoryCatalog with StagingTableCatalog {
       ident: Identifier,
       schema: StructType,
       partitions: Array[Transform],
-      properties: util.Map[String, String]): StagedTable = {
+      properties: jutil.Map[String, String]): StagedTable = {
     throw new RuntimeException("shouldn't be called")
   }
 
@@ -3628,7 +3628,7 @@ class FakeStagedTableCatalog extends InMemoryCatalog with StagingTableCatalog {
       ident: Identifier,
       columns: Array[ColumnV2],
       partitions: Array[Transform],
-      properties: util.Map[String, String]): StagedTable = {
+      properties: jutil.Map[String, String]): StagedTable = {
     super.createTable(ident, columns, partitions, properties)
     null
   }
@@ -3637,7 +3637,7 @@ class FakeStagedTableCatalog extends InMemoryCatalog with StagingTableCatalog {
       ident: Identifier,
       schema: StructType,
       partitions: Array[Transform],
-      properties: util.Map[String, String]): StagedTable = {
+      properties: jutil.Map[String, String]): StagedTable = {
     throw new RuntimeException("shouldn't be called")
   }
 
@@ -3645,7 +3645,7 @@ class FakeStagedTableCatalog extends InMemoryCatalog with StagingTableCatalog {
       ident: Identifier,
       columns: Array[ColumnV2],
       partitions: Array[Transform],
-      properties: util.Map[String, String]): StagedTable = {
+      properties: jutil.Map[String, String]): StagedTable = {
     super.dropTable(ident)
     super.createTable(ident, columns, partitions, properties)
     null
@@ -3655,7 +3655,7 @@ class FakeStagedTableCatalog extends InMemoryCatalog with StagingTableCatalog {
       ident: Identifier,
       schema: StructType,
       partitions: Array[Transform],
-      properties: util.Map[String, String]): StagedTable = {
+      properties: jutil.Map[String, String]): StagedTable = {
     throw new RuntimeException("shouldn't be called")
   }
 
@@ -3663,7 +3663,7 @@ class FakeStagedTableCatalog extends InMemoryCatalog with StagingTableCatalog {
       ident: Identifier,
       columns: Array[ColumnV2],
       partitions: Array[Transform],
-      properties: util.Map[String, String]): StagedTable = {
+      properties: jutil.Map[String, String]): StagedTable = {
     try {
       super.dropTable(ident)
     } catch {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a follow-up of the following and aims to fix compilation failures of `branch-3.5` by renaming `util.Map` to `jutil.Map`
- https://github.com/apache/spark/pull/47848

### Why are the changes needed?

To recover the compilation on branch-3.5.
- https://github.com/apache/spark/actions/runs/10544835250/job/29214315896

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.