### PR TITLE
[SPARK-49396][SQL] remain nullability while simplifyConditional

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -598,7 +598,7 @@ object SimplifyConditionals extends Rule[LogicalPlan] {
         // a branch with a true condition eliminates all following branches,
         // these branches can be pruned away
         val (h, t) = branches.span(_._1 != TrueLiteral)
-        CaseWhen( h :+ t.head, None)
+        CaseWhen( h :+ t.head, t.head._2)
 
       case e @ CaseWhen(branches, elseOpt)
           if branches.forall(_._2.semanticEquals(elseOpt.getOrElse(Literal(null, e.dataType)))) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -598,7 +598,9 @@ object SimplifyConditionals extends Rule[LogicalPlan] {
         // a branch with a true condition eliminates all following branches,
         // these branches can be pruned away
         val (h, t) = branches.span(_._1 != TrueLiteral)
-        CaseWhen( h :+ t.head, t.head._2)
+        // Use the value of TrueLiteral expression as elseValue to maintain
+        // nullability of CaseWhen expressions
+        CaseWhen(h :+ t.head, t.head._2)
 
       case e @ CaseWhen(branches, elseOpt)
           if branches.forall(_._2.semanticEquals(elseOpt.getOrElse(Literal(null, e.dataType)))) =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceNullWithFalseInPredicateSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceNullWithFalseInPredicateSuite.scala
@@ -145,7 +145,8 @@ class ReplaceNullWithFalseInPredicateSuite extends PlanTest {
       (UnresolvedAttribute("i") < Literal(10)) -> TrueLiteral,
       (UnresolvedAttribute("i") > Literal(10)) -> FalseLiteral,
       TrueLiteral -> TrueLiteral)
-    val expectedCond = CaseWhen(expectedBranches, FalseLiteral)
+    // elseValue is simplified to the value of first True branch
+    val expectedCond = CaseWhen(expectedBranches, TrueLiteral)
 
     testFilter(originalCond, expectedCond)
     testJoin(originalCond, expectedCond)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SimplifyConditionalSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/SimplifyConditionalSuite.scala
@@ -110,7 +110,7 @@ class SimplifyConditionalSuite extends PlanTest with ExpressionEvalHelper {
     // Make sure this doesn't trigger if there is a non-foldable branch before the true branch
     assertEquivalent(
       CaseWhen(normalBranch :: trueBranch :: normalBranch :: Nil, None),
-      CaseWhen(normalBranch :: trueBranch :: Nil, None))
+      CaseWhen(normalBranch :: trueBranch :: Nil, Literal(5)))
   }
 
   test("simplify CaseWhen, prune branches following a definite true") {
@@ -120,7 +120,7 @@ class SimplifyConditionalSuite extends PlanTest with ExpressionEvalHelper {
         trueBranch :: normalBranch ::
         Nil,
         None),
-      CaseWhen(normalBranch :: trueBranch :: Nil, None))
+      CaseWhen(normalBranch :: trueBranch :: Nil, Literal(5)))
   }
 
   test("simplify CaseWhen if all the outputs are semantic equivalence") {

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/complexTypesSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/complexTypesSuite.scala
@@ -235,7 +235,9 @@ class ComplexTypesSuite extends PlanTest with ExpressionEvalHelper {
           (EqualTo(13L, $"id"), ($"id" + 1L)),
           (EqualTo(13L, ($"id" + 1L)), ($"id" + 2L)),
           (EqualTo(13L, ($"id" + 2L)), ($"id" + 3L)),
-          (Literal(true), $"id"))) as "a")
+          (Literal(true), $"id")),
+          $"id"
+        ) as "a")
     checkRule(query, expected)
   }
 
@@ -256,7 +258,9 @@ class ComplexTypesSuite extends PlanTest with ExpressionEvalHelper {
           (EqualTo($"id" + 3L, $"id"), ($"id" + 1L)),
           (EqualTo($"id" + 3L, ($"id" + 1L)), ($"id" + 2L)),
           (EqualTo($"id" + 3L, ($"id" + 2L)), ($"id" + 3L)),
-          (Literal(true), ($"id" + 4L)))) as "a")
+          (Literal(true), ($"id" + 4L))),
+          ($"id" + 4L)
+        ) as "a")
     checkRule(query, expected)
   }
 
@@ -329,7 +333,7 @@ class ComplexTypesSuite extends PlanTest with ExpressionEvalHelper {
           // this is a definite match (two constants),
           // but it cannot override a potential match with ('id + 2L),
           // which is exactly what [[Coalesce]] would do in this case.
-          (Literal.TrueLiteral, $"id"))) as "a")
+          (Literal.TrueLiteral, $"id")), $"id") as "a")
     checkRule(rel, expected)
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
`SimplifyConditionals` has a simplification code where if any of the (not first) branches in `CaseWhen` is `TrueLiteral` we remove all the remaining branches including the elseValue.

```
case CaseWhen(branches, ) if branches.exists(._1 == TrueLiteral) => // a branch with a true condition eliminates all following branches,
// these branches can be pruned away
val (h, t) = branches.span(_._1 != TrueLiteral)
CaseWhen( h :+ t.head, None)
```
Now, the nullability check of CaseWhen checks that
(1) either of the branches including elseValue is nullable or
(2) elseValue is None.

The above simplification makes the elseValue as None. Combined with this nullability check makes the CaseWhen switch from non-nullable to nullable.

This ticket aims to fix this issue and remain the nullability of the expression by replacing the elsevalue to the value of the TrueLiteral expression.

### Why are the changes needed?
See the section above 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
no

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
unit tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no
