### PR TITLE
[SPARK-49347][R][FOLLOW-UP] Set SPARK_TESTING in Windows build

### DIFF
--- a/.github/workflows/build_sparkr_window.yml
+++ b/.github/workflows/build_sparkr_window.yml
@@ -85,6 +85,7 @@ jobs:
       shell: cmd
       env:
         NOT_CRAN: true
+        SPARK_TESTING: 1
         # See SPARK-27848. Currently installing some dependent packages causes
         # "(converted from warning) unable to identify current timezone 'C':" for an unknown reason.
         # This environment variable works around to test SparkR against a higher version.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/47842 that sets `SPARK_TESTING` in Windows build.

### Why are the changes needed?

The PR added a deprecation warning, and that fails Windows build. It should set `SPARK_TESTING` to work around the warning in the build (https://github.com/apache/spark/actions/runs/10563932730/job/29265243035).

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Will monitor the job after this PR is merged.

### Was this patch authored or co-authored using generative AI tooling?

No