### PR TITLE
[SPARK-49402][PYTHON] Fix Binder integration in PySpark documentation

### DIFF
--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM python:3.10-slim
+# install the notebook package
+RUN  pip install --no-cache notebook jupyterlab
+
+# create user with a home directory
+ARG NB_USER
+ARG NB_UID
+ENV USER ${NB_USER}
+ENV HOME /home/${NB_USER}
+
+RUN adduser --disabled-password \
+    --gecos "Default user" \
+    --uid ${NB_UID} \
+    ${NB_USER}
+WORKDIR ${HOME}
+USER ${USER}
+
+# Make sure the contents of our repo are in ${HOME}
+COPY . ${HOME}
+USER root
+RUN chown -R ${NB_UID} ${HOME}
+RUN apt-get update && apt-get install -y openjdk-17-jre git coreutils
+USER ${NB_USER}
+
+RUN binder/postBuild
+

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,2 +1,0 @@
-openjdk-17-jre
-git

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -26,7 +26,7 @@ set -o pipefail
 set -e
 
 VERSION=$(python -c "exec(open('python/pyspark/version.py').read()); print(__version__)")
-TAG=$(git describe --tags --exact-match 2>/dev/null)
+TAG=$(git describe --tags --exact-match 2> /dev/null || true)
 
 # If a commit is tagged, exactly specified version of pyspark should be installed to avoid
 # a kind of accident that an old version of pyspark is installed in the live notebook environment.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix Binder integration by using `Dockerfile` directly.

### Why are the changes needed?

Binder integration is broken now (https://mybinder.org/v2/gh/apache/spark/bb7846dd487?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb):

![Screenshot 2024-08-27 at 2 04 35 PM](https://github.com/user-attachments/assets/29222fc2-7cc6-43fa-8e04-a65c8384c4d5)

This seems to be related to the size of the repository (https://github.com/jupyterhub/mybinder.org-deploy/issues/3074).

I tried all the ways out but could not find the way except using `Dockerfile`.

### Does this PR introduce _any_ user-facing change?

Yes. This should recover the Binder integration.

### How was this patch tested?

Manually tested within my fork:

https://mybinder.org/v2/gh/HyukjinKwon/spark/binder-test1?filepath=python%2Fdocs%2Fsource%2Fgetting_started%2Fquickstart_df.ipynb

### Was this patch authored or co-authored using generative AI tooling?

No.