### PR TITLE
[SPARK-49410][SQL][TESTS] Update collation benchmarks

### DIFF
--- a/core/src/test/scala/org/apache/spark/benchmark/Benchmark.scala
+++ b/core/src/test/scala/org/apache/spark/benchmark/Benchmark.scala
@@ -94,11 +94,11 @@ private[spark] class Benchmark(
   /**
    * Runs the benchmark and outputs the results to stdout. This should be copied and added as
    * a comment with the benchmark. Although the results vary from machine to machine, it should
-   * provide some baseline. If `relative_time` is set to `true`, the `Relative` column will be
+   * provide some baseline. If `relativeTime` is set to `true`, the `Relative` column will be
    * the relative time of each case relative to the first case (less is better). Otherwise, it
    * will be the relative execution speed of each case relative to the first case (more is better).
    */
-  def run(relative_time: Boolean = false): Unit = {
+  def run(relativeTime: Boolean = false): Unit = {
     require(benchmarks.nonEmpty)
     // scalastyle:off
     println("Running benchmark: " + name)
@@ -118,7 +118,7 @@ private[spark] class Benchmark(
       name + ":", "Best Time(ms)", "Avg Time(ms)", "Stdev(ms)", "Rate(M/s)", "Per Row(ns)", "Relative")
     out.println("-" * (nameLen + 80))
     results.zip(benchmarks).foreach { case (result, benchmark) =>
-      val relative = if (relative_time) result.bestMs / firstBest else firstBest / result.bestMs
+      val relative = if (relativeTime) result.bestMs / firstBest else firstBest / result.bestMs
       out.printf(s"%-${nameLen}s %14s %14s %11s %12s %13s %10s\n",
         benchmark.name,
         "%5.0f" format result.bestMs,

--- a/core/src/test/scala/org/apache/spark/benchmark/Benchmark.scala
+++ b/core/src/test/scala/org/apache/spark/benchmark/Benchmark.scala
@@ -94,9 +94,11 @@ private[spark] class Benchmark(
   /**
    * Runs the benchmark and outputs the results to stdout. This should be copied and added as
    * a comment with the benchmark. Although the results vary from machine to machine, it should
-   * provide some baseline.
+   * provide some baseline. If `relative_time` is set to `true`, the `Relative` column will be
+   * the relative time of each case relative to the first case (less is better). Otherwise, it
+   * will be the relative execution speed of each case relative to the first case (more is better).
    */
-  def run(): Unit = {
+  def run(relative_time: Boolean = false): Unit = {
     require(benchmarks.nonEmpty)
     // scalastyle:off
     println("Running benchmark: " + name)
@@ -116,6 +118,7 @@ private[spark] class Benchmark(
       name + ":", "Best Time(ms)", "Avg Time(ms)", "Stdev(ms)", "Rate(M/s)", "Per Row(ns)", "Relative")
     out.println("-" * (nameLen + 80))
     results.zip(benchmarks).foreach { case (result, benchmark) =>
+      val relative = if (relative_time) result.bestMs / firstBest else firstBest / result.bestMs
       out.printf(s"%-${nameLen}s %14s %14s %11s %12s %13s %10s\n",
         benchmark.name,
         "%5.0f" format result.bestMs,
@@ -123,7 +126,7 @@ private[spark] class Benchmark(
         "%5.0f" format result.stdevMs,
         "%10.1f" format result.bestRate,
         "%6.1f" format (1000 / result.bestRate),
-        "%3.1fX" format (firstBest / result.bestMs))
+        "%3.1fX" format relative)
     }
     out.println()
     // scalastyle:on

--- a/core/src/test/scala/org/apache/spark/benchmark/Benchmark.scala
+++ b/core/src/test/scala/org/apache/spark/benchmark/Benchmark.scala
@@ -114,8 +114,9 @@ private[spark] class Benchmark(
     out.println(Benchmark.getJVMOSInfo())
     out.println(Benchmark.getProcessorName())
     val nameLen = Math.max(40, Math.max(name.length, benchmarks.map(_.name.length).max))
+    val relativeHeader = if (relativeTime) "Relative time" else "Relative"
     out.printf(s"%-${nameLen}s %14s %14s %11s %12s %13s %10s\n",
-      name + ":", "Best Time(ms)", "Avg Time(ms)", "Stdev(ms)", "Rate(M/s)", "Per Row(ns)", "Relative")
+      name + ":", "Best Time(ms)", "Avg Time(ms)", "Stdev(ms)", "Rate(M/s)", "Per Row(ns)", relativeHeader)
     out.println("-" * (nameLen + 80))
     results.zip(benchmarks).foreach { case (result, benchmark) =>
       val relative = if (relativeTime) result.bestMs / firstBest else firstBest / result.bestMs

--- a/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
@@ -2,53 +2,53 @@ OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                          1344           1345           1          0.1       13438.0       1.0X
-UTF8_LCASE                                           2617           2619           3          0.0       26172.7       0.5X
-UNICODE                                             16947          16976          41          0.0      169465.6       0.1X
-UNICODE_CI                                          16500          16507          10          0.0      164997.5       0.1X
+UTF8_BINARY                                          1355           1355           0          0.1       13548.6       1.0X
+UTF8_LCASE                                           2463           2463           1          0.0       24627.4       1.8X
+UNICODE                                             17692          17697           7          0.0      176919.7      13.1X
+UNICODE_CI                                          17153          17160          11          0.0      171527.7      12.7X
 
 OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                           2555           2560           7          0.0       25553.1       1.0X
-UTF8_LCASE                                            3539           3540           0          0.0       35392.8       0.7X
-UNICODE                                              17154          17161          10          0.0      171541.5       0.1X
-UNICODE_CI                                           16915          16926          17          0.0      169146.6       0.2X
+UTF8_BINARY                                           1711           1711           0          0.1       17107.6       1.0X
+UTF8_LCASE                                            2544           2545           1          0.0       25444.9       1.5X
+UNICODE                                              17617          17627          15          0.0      176170.7      10.3X
+UNICODE_CI                                           17478          17478           0          0.0      174778.2      10.2X
 
 OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        2771           2771           0          0.0       27708.6       1.0X
-UTF8_LCASE                                         5346           5347           2          0.0       53462.4       0.5X
-UNICODE                                           67678          67692          21          0.0      676775.1       0.0X
-UNICODE_CI                                        57978          57982           6          0.0      579780.7       0.0X
+UTF8_BINARY                                        2781           2782           2          0.0       27805.5       1.0X
+UTF8_LCASE                                         6440           6442           2          0.0       64401.4       2.3X
+UNICODE                                           72333          72355          31          0.0      723328.0      26.0X
+UNICODE_CI                                        53944          53953          13          0.0      539437.6      19.4X
 
 OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - contains:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        8793           8794           1          0.0       87929.3       1.0X
-UTF8_LCASE                                        19382          19394          16          0.0      193824.8       0.5X
-UNICODE                                          363790         363911         171          0.0     3637901.0       0.0X
-UNICODE_CI                                       414597         415090         697          0.0     4145972.5       0.0X
+UTF8_BINARY                                        7626           7640          20          0.0       76264.5       1.0X
+UTF8_LCASE                                        20156          20181          36          0.0      201556.2       2.6X
+UNICODE                                          394629         404032       13298          0.0     3946286.0      51.7X
+UNICODE_CI                                       450124         450209         121          0.0     4501239.3      59.0X
 
 OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - startsWith:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        7692           7695           4          0.0       76921.8       1.0X
-UTF8_LCASE                                        16451          16457           9          0.0      164507.8       0.5X
-UNICODE                                          356828         358151        1871          0.0     3568280.7       0.0X
-UNICODE_CI                                       417621         418820        1697          0.0     4176205.0       0.0X
+UTF8_BINARY                                        6867           6867           1          0.0       68665.7       1.0X
+UTF8_LCASE                                        15033          15083          72          0.0      150326.0       2.2X
+UNICODE                                          391244         391970        1026          0.0     3912440.9      57.0X
+UNICODE_CI                                       445616         448312        3813          0.0     4456155.8      64.9X
 
 OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - endsWith:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        7175           7175           0          0.0       71748.8       1.0X
-UTF8_LCASE                                        15267          15291          34          0.0      152674.6       0.5X
-UNICODE                                          371582         371601          26          0.0     3715822.1       0.0X
-UNICODE_CI                                       429637         430336         989          0.0     4296371.0       0.0X
+UTF8_BINARY                                        6849           6850           2          0.0       68492.4       1.0X
+UTF8_LCASE                                        15210          15211           1          0.0      152099.5       2.2X
+UNICODE                                          402633         408315        8035          0.0     4026328.8      58.8X
+UNICODE_CI                                       471610         472119         719          0.0     4716102.6      68.9X
 

--- a/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-jdk21-results.txt
@@ -1,54 +1,54 @@
 OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                          1355           1355           0          0.1       13548.6       1.0X
-UTF8_LCASE                                           2463           2463           1          0.0       24627.4       1.8X
-UNICODE                                             17692          17697           7          0.0      176919.7      13.1X
-UNICODE_CI                                          17153          17160          11          0.0      171527.7      12.7X
+UTF8_BINARY                                          1353           1353           1          0.1       13526.6       1.0X
+UTF8_LCASE                                           2703           2705           3          0.0       27032.4       2.0X
+UNICODE                                             16848          16894          65          0.0      168482.9      12.5X
+UNICODE_CI                                          16362          16367           8          0.0      163615.6      12.1X
 
 OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                           1711           1711           0          0.1       17107.6       1.0X
-UTF8_LCASE                                            2544           2545           1          0.0       25444.9       1.5X
-UNICODE                                              17617          17627          15          0.0      176170.7      10.3X
-UNICODE_CI                                           17478          17478           0          0.0      174778.2      10.2X
+UTF8_BINARY                                           2640           2642           3          0.0       26401.5       1.0X
+UTF8_LCASE                                            3616           3618           2          0.0       36164.8       1.4X
+UNICODE                                              17465          17470           7          0.0      174650.9       6.6X
+UNICODE_CI                                           17251          17264          18          0.0      172510.9       6.5X
 
 OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        2781           2782           2          0.0       27805.5       1.0X
-UTF8_LCASE                                         6440           6442           2          0.0       64401.4       2.3X
-UNICODE                                           72333          72355          31          0.0      723328.0      26.0X
-UNICODE_CI                                        53944          53953          13          0.0      539437.6      19.4X
+UTF8_BINARY                                        2843           2844           1          0.0       28427.2       1.0X
+UTF8_LCASE                                         5417           5437          28          0.0       54170.7       1.9X
+UNICODE                                           68601          68619          26          0.0      686010.8      24.1X
+UNICODE_CI                                        56342          56361          26          0.0      563422.2      19.8X
 
 OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - contains:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - contains:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        7626           7640          20          0.0       76264.5       1.0X
-UTF8_LCASE                                        20156          20181          36          0.0      201556.2       2.6X
-UNICODE                                          394629         404032       13298          0.0     3946286.0      51.7X
-UNICODE_CI                                       450124         450209         121          0.0     4501239.3      59.0X
+UTF8_BINARY                                        7674           7674           1          0.0       76735.3       1.0X
+UTF8_LCASE                                        20367          20376          14          0.0      203665.1       2.7X
+UNICODE                                          377133         377909        1098          0.0     3771328.8      49.1X
+UNICODE_CI                                       434710         435099         551          0.0     4347097.2      56.7X
 
 OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - startsWith:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - startsWith:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        6867           6867           1          0.0       68665.7       1.0X
-UTF8_LCASE                                        15033          15083          72          0.0      150326.0       2.2X
-UNICODE                                          391244         391970        1026          0.0     3912440.9      57.0X
-UNICODE_CI                                       445616         448312        3813          0.0     4456155.8      64.9X
+UTF8_BINARY                                        6956           6959           4          0.0       69561.7       1.0X
+UTF8_LCASE                                        14246          14262          23          0.0      142459.6       2.0X
+UNICODE                                          369940         370072         186          0.0     3699400.9      53.2X
+UNICODE_CI                                       442072         442365         414          0.0     4420718.1      63.6X
 
 OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - endsWith:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - endsWith:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        6849           6850           2          0.0       68492.4       1.0X
-UTF8_LCASE                                        15210          15211           1          0.0      152099.5       2.2X
-UNICODE                                          402633         408315        8035          0.0     4026328.8      58.8X
-UNICODE_CI                                       471610         472119         719          0.0     4716102.6      68.9X
+UTF8_BINARY                                        6927           6927           0          0.0       69265.2       1.0X
+UTF8_LCASE                                        15505          15514          12          0.0      155054.5       2.2X
+UNICODE                                          382361         382426          93          0.0     3823606.6      55.2X
+UNICODE_CI                                       449956         450063         151          0.0     4499562.9      65.0X
 

--- a/sql/core/benchmarks/CollationBenchmark-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-results.txt
@@ -1,54 +1,54 @@
 OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                          1374           1374           1          0.1       13736.0       1.0X
-UTF8_LCASE                                           3356           3356           0          0.0       33557.1       2.4X
-UNICODE                                             19584          19601          23          0.0      195842.6      14.3X
-UNICODE_CI                                          19473          19488          21          0.0      194730.8      14.2X
+UTF8_BINARY                                          1372           1372           1          0.1       13718.5       1.0X
+UTF8_LCASE                                           3115           3116           1          0.0       31154.4       2.3X
+UNICODE                                             19813          19820           9          0.0      198132.2      14.4X
+UNICODE_CI                                          19669          19686          24          0.0      196694.2      14.3X
 
 OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                           3111           3116           8          0.0       31106.0       1.0X
-UTF8_LCASE                                            5177           5179           2          0.0       51774.6       1.7X
-UNICODE                                              19604          19609           6          0.0      196041.9       6.3X
-UNICODE_CI                                           19432          19478          66          0.0      194315.9       6.2X
+UTF8_BINARY                                           1727           1728           1          0.1       17271.3       1.0X
+UTF8_LCASE                                            3034           3035           1          0.0       30337.2       1.8X
+UNICODE                                              19230          19243          18          0.0      192301.2      11.1X
+UNICODE_CI                                           19080          19082           3          0.0      190802.0      11.0X
 
 OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        7065           7076          15          0.0       70655.0       1.0X
-UTF8_LCASE                                         6265           6274          13          0.0       62650.8       0.9X
-UNICODE                                           70739          70747          12          0.0      707385.2      10.0X
-UNICODE_CI                                        54453          54463          14          0.0      544530.6       7.7X
+UTF8_BINARY                                        3080           3080           0          0.0       30796.4       1.0X
+UTF8_LCASE                                         6436           6454          25          0.0       64360.0       2.1X
+UNICODE                                           68095          68167         101          0.0      680951.3      22.1X
+UNICODE_CI                                        62122          62123           2          0.0      621215.8      20.2X
 
 OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - contains:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - contains:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        8577           8579           2          0.0       85774.3       1.0X
-UTF8_LCASE                                        23804          23813          12          0.0      238040.8       2.8X
-UNICODE                                          374896         376836        2743          0.0     3748963.7      43.7X
-UNICODE_CI                                       440466         441131         939          0.0     4404662.2      51.4X
+UTF8_BINARY                                        8260           8261           1          0.0       82604.0       1.0X
+UTF8_LCASE                                        23629          23629           0          0.0      236286.4       2.9X
+UNICODE                                          364843         366078        1747          0.0     3648427.9      44.2X
+UNICODE_CI                                       425728         426449        1020          0.0     4257275.1      51.5X
 
 OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - startsWith:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - startsWith:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        5957           5971          19          0.0       59573.1       1.0X
-UTF8_LCASE                                        21966          21994          39          0.0      219658.1       3.7X
-UNICODE                                          371824         373478        2339          0.0     3718236.0      62.4X
-UNICODE_CI                                       437328         437684         504          0.0     4373279.8      73.4X
+UTF8_BINARY                                        6844           6848           5          0.0       68440.4       1.0X
+UTF8_LCASE                                        21849          21870          30          0.0      218486.3       3.2X
+UNICODE                                          363474         363811         476          0.0     3634738.4      53.1X
+UNICODE_CI                                       427563         428029         659          0.0     4275629.8      62.5X
 
 OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - endsWith:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - endsWith:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        6064           6065           2          0.0       60641.1       1.0X
-UTF8_LCASE                                        21962          21970          11          0.0      219624.3       3.6X
-UNICODE                                          387159         388153        1405          0.0     3871591.7      63.8X
-UNICODE_CI                                       449932         450749        1156          0.0     4499317.9      74.2X
+UTF8_BINARY                                        6904           6907           4          0.0       69039.3       1.0X
+UTF8_LCASE                                        22007          22009           3          0.0      220067.8       3.2X
+UNICODE                                          376402         377858        2060          0.0     3764015.4      54.5X
+UNICODE_CI                                       444485         444809         458          0.0     4444850.8      64.4X
 

--- a/sql/core/benchmarks/CollationBenchmark-results.txt
+++ b/sql/core/benchmarks/CollationBenchmark-results.txt
@@ -2,53 +2,53 @@ OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                          1372           1373           1          0.1       13721.8       1.0X
-UTF8_LCASE                                           3161           3163           2          0.0       31614.5       0.4X
-UNICODE                                             20065          20074          13          0.0      200648.2       0.1X
-UNICODE_CI                                          19950          19952           3          0.0      199497.1       0.1X
+UTF8_BINARY                                          1374           1374           1          0.1       13736.0       1.0X
+UTF8_LCASE                                           3356           3356           0          0.0       33557.1       2.4X
+UNICODE                                             19584          19601          23          0.0      195842.6      14.3X
+UNICODE_CI                                          19473          19488          21          0.0      194730.8      14.2X
 
 OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                           1730           1730           0          0.1       17300.7       1.0X
-UTF8_LCASE                                            3181           3183           3          0.0       31807.5       0.5X
-UNICODE                                              18827          18845          26          0.0      188267.7       0.1X
-UNICODE_CI                                           18669          18671           3          0.0      186692.7       0.1X
+UTF8_BINARY                                           3111           3116           8          0.0       31106.0       1.0X
+UTF8_LCASE                                            5177           5179           2          0.0       51774.6       1.7X
+UNICODE                                              19604          19609           6          0.0      196041.9       6.3X
+UNICODE_CI                                           19432          19478          66          0.0      194315.9       6.2X
 
 OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        3080           3081           1          0.0       30796.9       1.0X
-UTF8_LCASE                                         9640           9670          42          0.0       96402.5       0.3X
-UNICODE                                           65966          66004          53          0.0      659660.4       0.0X
-UNICODE_CI                                        57631          57813         256          0.0      576314.7       0.1X
+UTF8_BINARY                                        7065           7076          15          0.0       70655.0       1.0X
+UTF8_LCASE                                         6265           6274          13          0.0       62650.8       0.9X
+UNICODE                                           70739          70747          12          0.0      707385.2      10.0X
+UNICODE_CI                                        54453          54463          14          0.0      544530.6       7.7X
 
 OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - contains:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        8792           8794           2          0.0       87923.1       1.0X
-UTF8_LCASE                                        23937          23942           8          0.0      239367.4       0.4X
-UNICODE                                          371949         372083         189          0.0     3719485.9       0.0X
-UNICODE_CI                                       431636         432296         933          0.0     4316361.9       0.0X
+UTF8_BINARY                                        8577           8579           2          0.0       85774.3       1.0X
+UTF8_LCASE                                        23804          23813          12          0.0      238040.8       2.8X
+UNICODE                                          374896         376836        2743          0.0     3748963.7      43.7X
+UNICODE_CI                                       440466         441131         939          0.0     4404662.2      51.4X
 
 OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - startsWith:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        6865           6877          16          0.0       68652.5       1.0X
-UTF8_LCASE                                        22100          22118          26          0.0      220997.8       0.3X
-UNICODE                                          365404         365627         316          0.0     3654037.8       0.0X
-UNICODE_CI                                       431409         432257        1199          0.0     4314085.3       0.0X
+UTF8_BINARY                                        5957           5971          19          0.0       59573.1       1.0X
+UTF8_LCASE                                        21966          21994          39          0.0      219658.1       3.7X
+UNICODE                                          371824         373478        2339          0.0     3718236.0      62.4X
+UNICODE_CI                                       437328         437684         504          0.0     4373279.8      73.4X
 
 OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - endsWith:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        6998           6999           2          0.0       69980.7       1.0X
-UTF8_LCASE                                        22332          22358          36          0.0      223323.5       0.3X
-UNICODE                                          382527         382805         393          0.0     3825268.8       0.0X
-UNICODE_CI                                       447621         447949         465          0.0     4476209.7       0.0X
+UTF8_BINARY                                        6064           6065           2          0.0       60641.1       1.0X
+UTF8_LCASE                                        21962          21970          11          0.0      219624.3       3.6X
+UNICODE                                          387159         388153        1405          0.0     3871591.7      63.8X
+UNICODE_CI                                       449932         450749        1156          0.0     4499317.9      74.2X
 

--- a/sql/core/benchmarks/CollationNonASCIIBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/CollationNonASCIIBenchmark-jdk21-results.txt
@@ -2,53 +2,53 @@ OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                           165            166           1          0.2        4129.8       1.0X
-UTF8_LCASE                                           6978           6980           3          0.0      174454.3       0.0X
-UNICODE                                              5542           5550          11          0.0      138543.0       0.0X
-UNICODE_CI                                           5287           5289           3          0.0      132179.7       0.0X
+UTF8_BINARY                                           167            168           3          0.2        4164.2       1.0X
+UTF8_LCASE                                           7067           7070           4          0.0      176682.4      42.4X
+UNICODE                                              5521           5525           6          0.0      138013.4      33.1X
+UNICODE_CI                                           5872           5880          12          0.0      146797.3      35.3X
 
 OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                            301            301           0          0.1        7523.1       1.0X
-UTF8_LCASE                                            6857           6871          19          0.0      171426.6       0.0X
-UNICODE                                               5163           5174          16          0.0      129074.3       0.1X
-UNICODE_CI                                            5106           5108           3          0.0      127640.2       0.1X
+UTF8_BINARY                                            308            308           0          0.1        7696.7       1.0X
+UTF8_LCASE                                            6986           6987           1          0.0      174655.7      22.7X
+UNICODE                                               5243           5243           0          0.0      131063.5      17.0X
+UNICODE_CI                                            5173           5184          15          0.0      129336.2      16.8X
 
 OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                         726            727           1          0.1       18158.8       1.0X
-UTF8_LCASE                                         3483           3486           5          0.0       87069.0       0.2X
-UNICODE                                           14715          14717           3          0.0      367874.8       0.0X
-UNICODE_CI                                        11639          11648          12          0.0      290985.0       0.1X
+UTF8_BINARY                                         383            384           1          0.1        9565.6       1.0X
+UTF8_LCASE                                         3561           3565           5          0.0       89032.3       9.3X
+UNICODE                                           14582          14588           9          0.0      364544.4      38.1X
+UNICODE_CI                                        12502          12505           5          0.0      312553.8      32.7X
 
 OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - contains:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        1335           1335           0          0.0       33374.9       1.0X
-UTF8_LCASE                                         9042           9070          40          0.0      226042.8       0.1X
-UNICODE                                           69091          69108          24          0.0     1727283.6       0.0X
-UNICODE_CI                                        77261          77295          49          0.0     1931515.1       0.0X
+UTF8_BINARY                                        1355           1358           4          0.0       33884.2       1.0X
+UTF8_LCASE                                         9367           9377          14          0.0      234173.9       6.9X
+UNICODE                                           73176          74082        1282          0.0     1829390.3      54.0X
+UNICODE_CI                                        81694          81788         134          0.0     2042343.7      60.3X
 
 OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - startsWith:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                         968            969           1          0.0       24189.2       1.0X
-UTF8_LCASE                                         5756           5770          20          0.0      143900.0       0.2X
-UNICODE                                           68123          68210         122          0.0     1703076.1       0.0X
-UNICODE_CI                                        77853          78018         233          0.0     1946331.7       0.0X
+UTF8_BINARY                                         984            984           1          0.0       24593.3       1.0X
+UTF8_LCASE                                         5821           5825           5          0.0      145532.1       5.9X
+UNICODE                                           71537          71566          41          0.0     1788431.7      72.7X
+UNICODE_CI                                        81346          81615         379          0.0     2033659.7      82.7X
 
 OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - endsWith:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                         990            991           2          0.0       24752.7       1.0X
-UTF8_LCASE                                         5932           5935           3          0.0      148305.3       0.2X
-UNICODE                                           74982          75051          98          0.0     1874541.8       0.0X
-UNICODE_CI                                        83019          83060          58          0.0     2075485.7       0.0X
+UTF8_BINARY                                        1009           1011           2          0.0       25237.3       1.0X
+UTF8_LCASE                                         5814           5826          17          0.0      145351.9       5.8X
+UNICODE                                           77725          78001         390          0.0     1943128.9      77.0X
+UNICODE_CI                                        86874          86969         134          0.0     2171851.4      86.1X
 

--- a/sql/core/benchmarks/CollationNonASCIIBenchmark-jdk21-results.txt
+++ b/sql/core/benchmarks/CollationNonASCIIBenchmark-jdk21-results.txt
@@ -1,54 +1,54 @@
 OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                           167            168           3          0.2        4164.2       1.0X
-UTF8_LCASE                                           7067           7070           4          0.0      176682.4      42.4X
-UNICODE                                              5521           5525           6          0.0      138013.4      33.1X
-UNICODE_CI                                           5872           5880          12          0.0      146797.3      35.3X
+UTF8_BINARY                                           165            165           0          0.2        4118.0       1.0X
+UTF8_LCASE                                           6996           7019          33          0.0      174899.5      42.5X
+UNICODE                                              5395           5407          18          0.0      134874.5      32.8X
+UNICODE_CI                                           5670           5672           2          0.0      141756.7      34.4X
 
 OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                            308            308           0          0.1        7696.7       1.0X
-UTF8_LCASE                                            6986           6987           1          0.0      174655.7      22.7X
-UNICODE                                               5243           5243           0          0.0      131063.5      17.0X
-UNICODE_CI                                            5173           5184          15          0.0      129336.2      16.8X
+UTF8_BINARY                                            306            306           0          0.1        7656.1       1.0X
+UTF8_LCASE                                            6950           6957          11          0.0      173739.0      22.7X
+UNICODE                                               5120           5123           3          0.0      128010.6      16.7X
+UNICODE_CI                                            5080           5099          27          0.0      127011.6      16.6X
 
 OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                         383            384           1          0.1        9565.6       1.0X
-UTF8_LCASE                                         3561           3565           5          0.0       89032.3       9.3X
-UNICODE                                           14582          14588           9          0.0      364544.4      38.1X
-UNICODE_CI                                        12502          12505           5          0.0      312553.8      32.7X
+UTF8_BINARY                                         384            384           1          0.1        9591.1       1.0X
+UTF8_LCASE                                         3549           3550           2          0.0       88721.7       9.3X
+UNICODE                                           14143          14145           3          0.0      353570.2      36.9X
+UNICODE_CI                                        11925          11929           6          0.0      298126.4      31.1X
 
 OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - contains:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - contains:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        1355           1358           4          0.0       33884.2       1.0X
-UTF8_LCASE                                         9367           9377          14          0.0      234173.9       6.9X
-UNICODE                                           73176          74082        1282          0.0     1829390.3      54.0X
-UNICODE_CI                                        81694          81788         134          0.0     2042343.7      60.3X
+UTF8_BINARY                                        1375           1376           1          0.0       34375.4       1.0X
+UTF8_LCASE                                         8740           8744           6          0.0      218504.1       6.4X
+UNICODE                                           68707          68818         158          0.0     1717667.1      50.0X
+UNICODE_CI                                        77167          77197          42          0.0     1929168.6      56.1X
 
 OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - startsWith:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - startsWith:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                         984            984           1          0.0       24593.3       1.0X
-UTF8_LCASE                                         5821           5825           5          0.0      145532.1       5.9X
-UNICODE                                           71537          71566          41          0.0     1788431.7      72.7X
-UNICODE_CI                                        81346          81615         379          0.0     2033659.7      82.7X
+UTF8_BINARY                                        1064           1065           2          0.0       26587.9       1.0X
+UTF8_LCASE                                         5820           5827          10          0.0      145506.0       5.5X
+UNICODE                                           67636          67675          54          0.0     1690904.3      63.6X
+UNICODE_CI                                        77750          77796          65          0.0     1943738.2      73.1X
 
 OpenJDK 64-Bit Server VM 21.0.4+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - endsWith:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - endsWith:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        1009           1011           2          0.0       25237.3       1.0X
-UTF8_LCASE                                         5814           5826          17          0.0      145351.9       5.8X
-UNICODE                                           77725          78001         390          0.0     1943128.9      77.0X
-UNICODE_CI                                        86874          86969         134          0.0     2171851.4      86.1X
+UTF8_BINARY                                        1090           1091           0          0.0       27260.9       1.0X
+UTF8_LCASE                                         6049           6054           7          0.0      151221.3       5.5X
+UNICODE                                           74589          74633          62          0.0     1864725.7      68.4X
+UNICODE_CI                                        83674          83708          49          0.0     2091841.0      76.7X
 

--- a/sql/core/benchmarks/CollationNonASCIIBenchmark-results.txt
+++ b/sql/core/benchmarks/CollationNonASCIIBenchmark-results.txt
@@ -1,54 +1,54 @@
 OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                           132            133           1          0.3        3310.9       1.0X
-UTF8_LCASE                                           7024           7024           0          0.0      175596.5      53.0X
-UNICODE                                              5636           5637           0          0.0      140909.5      42.6X
-UNICODE_CI                                           5569           5576          10          0.0      139226.8      42.1X
+UTF8_BINARY                                           133            133           1          0.3        3317.1       1.0X
+UTF8_LCASE                                           7092           7097           6          0.0      177310.9      53.5X
+UNICODE                                              5946           5966          29          0.0      148638.1      44.8X
+UNICODE_CI                                           5715           5717           2          0.0      142885.1      43.1X
 
 OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                            427            428           1          0.1       10669.9       1.0X
-UTF8_LCASE                                            7205           7217          17          0.0      180128.5      16.9X
-UNICODE                                               5789           5793           6          0.0      144718.8      13.6X
-UNICODE_CI                                            5756           5758           3          0.0      143894.6      13.5X
+UTF8_BINARY                                            433            435           2          0.1       10816.6       1.0X
+UTF8_LCASE                                            7365           7369           5          0.0      184135.4      17.0X
+UNICODE                                               5785           5790           7          0.0      144616.9      13.4X
+UNICODE_CI                                            5742           5744           3          0.0      143557.1      13.3X
 
 OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                         403            404           1          0.1       10077.5       1.0X
-UTF8_LCASE                                         3551           3553           3          0.0       88777.3       8.8X
-UNICODE                                           14909          14935          37          0.0      372715.8      37.0X
-UNICODE_CI                                        12200          12221          31          0.0      304990.8      30.3X
+UTF8_BINARY                                         410            411           1          0.1       10246.1       1.0X
+UTF8_LCASE                                         3588           3589           1          0.0       89698.8       8.8X
+UNICODE                                           15788          15802          20          0.0      394702.8      38.5X
+UNICODE_CI                                        12179          12192          19          0.0      304466.6      29.7X
 
 OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - contains:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - contains:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        1323           1323           0          0.0       33074.5       1.0X
-UTF8_LCASE                                        10566          10577          16          0.0      264148.3       8.0X
-UNICODE                                           67275          67328          74          0.0     1681880.6      50.9X
-UNICODE_CI                                        75764          75820          78          0.0     1894107.7      57.3X
+UTF8_BINARY                                        1367           1370           4          0.0       34182.9       1.0X
+UTF8_LCASE                                         9644           9645           1          0.0      241101.2       7.1X
+UNICODE                                           67169          67171           3          0.0     1679230.1      49.1X
+UNICODE_CI                                        79077          79209         188          0.0     1976919.1      57.8X
 
 OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - startsWith:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - startsWith:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        1098           1099           1          0.0       27456.3       1.0X
-UTF8_LCASE                                         6046           6056          14          0.0      151140.0       5.5X
-UNICODE                                           65556          65602          65          0.0     1638898.2      59.7X
-UNICODE_CI                                        75943          75990          67          0.0     1898579.5      69.1X
+UTF8_BINARY                                        1064           1067           3          0.0       26608.1       1.0X
+UTF8_LCASE                                         6487           6491           4          0.0      162186.5       6.1X
+UNICODE                                           68473          68523          71          0.0     1711818.5      64.3X
+UNICODE_CI                                        79374          79419          64          0.0     1984338.0      74.6X
 
 OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
-collation unit benchmarks - endsWith:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+collation unit benchmarks - endsWith:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns) Relative time
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        1159           1163           5          0.0       28984.0       1.0X
-UTF8_LCASE                                         6000           6010          15          0.0      149999.5       5.2X
-UNICODE                                           74091          74149          82          0.0     1852266.2      63.9X
-UNICODE_CI                                        82577          82664         123          0.0     2064428.1      71.2X
+UTF8_BINARY                                        1002           1004           2          0.0       25061.8       1.0X
+UTF8_LCASE                                         6052           6052           0          0.0      151298.7       6.0X
+UNICODE                                           74506          74551          64          0.0     1862644.2      74.3X
+UNICODE_CI                                        83607          83756         211          0.0     2090164.5      83.4X
 

--- a/sql/core/benchmarks/CollationNonASCIIBenchmark-results.txt
+++ b/sql/core/benchmarks/CollationNonASCIIBenchmark-results.txt
@@ -2,53 +2,53 @@ OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - equalsFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 --------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                           135            135           0          0.3        3377.6       1.0X
-UTF8_LCASE                                           7196           7196           0          0.0      179892.8       0.0X
-UNICODE                                              6133           6137           6          0.0      153325.1       0.0X
-UNICODE_CI                                           5828           5828           1          0.0      145690.2       0.0X
+UTF8_BINARY                                           132            133           1          0.3        3310.9       1.0X
+UTF8_LCASE                                           7024           7024           0          0.0      175596.5      53.0X
+UNICODE                                              5636           5637           0          0.0      140909.5      42.6X
+UNICODE_CI                                           5569           5576          10          0.0      139226.8      42.1X
 
 OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - compareFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ---------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                            436            436           0          0.1       10892.8       1.0X
-UTF8_LCASE                                            7193           7215          31          0.0      179823.7       0.1X
-UNICODE                                               5985           5988           4          0.0      149636.2       0.1X
-UNICODE_CI                                            5945           5946           1          0.0      148634.7       0.1X
+UTF8_BINARY                                            427            428           1          0.1       10669.9       1.0X
+UTF8_LCASE                                            7205           7217          17          0.0      180128.5      16.9X
+UNICODE                                               5789           5793           6          0.0      144718.8      13.6X
+UNICODE_CI                                            5756           5758           3          0.0      143894.6      13.5X
 
 OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - hashFunction:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                         712            713           1          0.1       17808.5       1.0X
-UTF8_LCASE                                         3594           3595           2          0.0       89843.6       0.2X
-UNICODE                                           15549          15553           6          0.0      388714.3       0.0X
-UNICODE_CI                                        13296          13311          22          0.0      332387.9       0.1X
+UTF8_BINARY                                         403            404           1          0.1       10077.5       1.0X
+UTF8_LCASE                                         3551           3553           3          0.0       88777.3       8.8X
+UNICODE                                           14909          14935          37          0.0      372715.8      37.0X
+UNICODE_CI                                        12200          12221          31          0.0      304990.8      30.3X
 
 OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - contains:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        1374           1376           3          0.0       34344.0       1.0X
-UTF8_LCASE                                        10613          10615           2          0.0      265321.4       0.1X
-UNICODE                                           65820          65876          79          0.0     1645497.8       0.0X
-UNICODE_CI                                        74936          74964          39          0.0     1873403.8       0.0X
+UTF8_BINARY                                        1323           1323           0          0.0       33074.5       1.0X
+UTF8_LCASE                                        10566          10577          16          0.0      264148.3       8.0X
+UNICODE                                           67275          67328          74          0.0     1681880.6      50.9X
+UNICODE_CI                                        75764          75820          78          0.0     1894107.7      57.3X
 
 OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - startsWith:   Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        1026           1027           1          0.0       25655.0       1.0X
-UTF8_LCASE                                         6048           6052           5          0.0      151197.9       0.2X
-UNICODE                                           64742          64763          30          0.0     1618539.6       0.0X
-UNICODE_CI                                        74924          74925           1          0.0     1873110.8       0.0X
+UTF8_BINARY                                        1098           1099           1          0.0       27456.3       1.0X
+UTF8_LCASE                                         6046           6056          14          0.0      151140.0       5.5X
+UNICODE                                           65556          65602          65          0.0     1638898.2      59.7X
+UNICODE_CI                                        75943          75990          67          0.0     1898579.5      69.1X
 
 OpenJDK 64-Bit Server VM 17.0.12+7-LTS on Linux 6.5.0-1025-azure
 AMD EPYC 7763 64-Core Processor
 collation unit benchmarks - endsWith:     Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ------------------------------------------------------------------------------------------------------------------------
-UTF8_BINARY                                        1045           1046           1          0.0       26126.0       1.0X
-UTF8_LCASE                                         6047           6049           3          0.0      151163.3       0.2X
-UNICODE                                           72297          72327          42          0.0     1807434.1       0.0X
-UNICODE_CI                                        81904          81917          18          0.0     2047587.7       0.0X
+UTF8_BINARY                                        1159           1163           5          0.0       28984.0       1.0X
+UTF8_LCASE                                         6000           6010          15          0.0      149999.5       5.2X
+UNICODE                                           74091          74149          82          0.0     1852266.2      63.9X
+UNICODE_CI                                        82577          82664         123          0.0     2064428.1      71.2X
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
@@ -49,7 +49,7 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
       }
     }
     }
-    benchmark.run(relative_time = true)
+    benchmark.run(relativeTime = true)
   }
 
   def benchmarkUTFStringCompare(collationTypes: Seq[String], utf8Strings: Seq[UTF8String]): Unit = {
@@ -73,7 +73,7 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
       }
     }
     }
-    benchmark.run(relative_time = true)
+    benchmark.run(relativeTime = true)
   }
 
   def benchmarkUTFStringHashFunction(
@@ -99,7 +99,7 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
       }
     }
     }
-    benchmark.run(relative_time = true)
+    benchmark.run(relativeTime = true)
   }
 
   def benchmarkContains(
@@ -127,7 +127,7 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
       }
     }
     }
-    benchmark.run(relative_time = true)
+    benchmark.run(relativeTime = true)
   }
 
   def benchmarkStartsWith(
@@ -155,7 +155,7 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
       }
     }
     }
-    benchmark.run(relative_time = true)
+    benchmark.run(relativeTime = true)
   }
 
   def benchmarkEndsWith(
@@ -183,7 +183,7 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
       }
     }
     }
-    benchmark.run(relative_time = true)
+    benchmark.run(relativeTime = true)
   }
 }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/benchmark/CollationBenchmark.scala
@@ -49,7 +49,7 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
       }
     }
     }
-    benchmark.run()
+    benchmark.run(relative_time = true)
   }
 
   def benchmarkUTFStringCompare(collationTypes: Seq[String], utf8Strings: Seq[UTF8String]): Unit = {
@@ -73,7 +73,7 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
       }
     }
     }
-    benchmark.run()
+    benchmark.run(relative_time = true)
   }
 
   def benchmarkUTFStringHashFunction(
@@ -99,7 +99,7 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
       }
     }
     }
-    benchmark.run()
+    benchmark.run(relative_time = true)
   }
 
   def benchmarkContains(
@@ -127,7 +127,7 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
       }
     }
     }
-    benchmark.run()
+    benchmark.run(relative_time = true)
   }
 
   def benchmarkStartsWith(
@@ -155,7 +155,7 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
       }
     }
     }
-    benchmark.run()
+    benchmark.run(relative_time = true)
   }
 
   def benchmarkEndsWith(
@@ -183,7 +183,7 @@ abstract class CollationBenchmarkBase extends BenchmarkBase {
       }
     }
     }
-    benchmark.run()
+    benchmark.run(relative_time = true)
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Updating collation benchmarks to compute relative time, instead of relative speed. Also, re-run all collation benchmarks (after introducing various perf improvements as part of the recent collation effort).


### Why are the changes needed?
Relative speed is displayed in format: "x0.0" for collations that are slower than the referent collation (UTF8_BINARY).


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
