### PR TITLE
[SPARK-45278][YARN] Support executor bind address in Yarn executors for Spark 3.5

### DIFF
--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -512,6 +512,25 @@ To use a custom metrics.properties for the application master and executors, upd
   <td>1.6.0</td>
 </tr>
 <tr>
+  <td><code>spark.yarn.executor.bindAddress</code></td>
+  <td><code>(executor hostname)</code></td>
+  <td>
+  Hostname or IP address where to bind listening sockets in YARN cluster and client mode.
+  <br />It also allows a different address from the local one to be advertised to other
+  executors or external systems.
+  </td>
+  <td>4.0.0</td>
+</tr>
+<tr>
+  <td><code>spark.yarn.executor.failuresValidityInterval</code></td>
+  <td>(none)</td>
+  <td>
+  Defines the validity interval for executor failure tracking.
+  Executor failures which are older than the validity interval will be ignored.
+  </td>
+  <td>2.0.0</td>
+</tr>
+<tr>
   <td><code>spark.yarn.executor.nodeLabelExpression</code></td>
   <td>(none)</td>
   <td>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -519,7 +519,7 @@ To use a custom metrics.properties for the application master and executors, upd
   <br />It also allows a different address from the local one to be advertised to other
   executors or external systems.
   </td>
-  <td>4.0.0</td>
+  <td>3.5.3</td>
 </tr>
 <tr>
   <td><code>spark.yarn.executor.nodeLabelExpression</code></td>

--- a/docs/running-on-yarn.md
+++ b/docs/running-on-yarn.md
@@ -522,15 +522,6 @@ To use a custom metrics.properties for the application master and executors, upd
   <td>4.0.0</td>
 </tr>
 <tr>
-  <td><code>spark.yarn.executor.failuresValidityInterval</code></td>
-  <td>(none)</td>
-  <td>
-  Defines the validity interval for executor failure tracking.
-  Executor failures which are older than the validity interval will be ignored.
-  </td>
-  <td>2.0.0</td>
-</tr>
-<tr>
   <td><code>spark.yarn.executor.nodeLabelExpression</code></td>
   <td>(none)</td>
   <td>

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ApplicationMaster.scala
@@ -460,8 +460,9 @@ private[spark] class ApplicationMaster(
     logInfo {
       val executorMemory = _sparkConf.get(EXECUTOR_MEMORY).toInt
       val executorCores = _sparkConf.get(EXECUTOR_CORES)
-      val dummyRunner = new ExecutorRunnable(None, yarnConf, _sparkConf, driverUrl, "<executorId>",
-        "<hostname>", executorMemory, executorCores, appId, securityMgr, localResources,
+      val dummyRunner = new ExecutorRunnable(None, yarnConf, _sparkConf, driverUrl,
+        "<executorId>", "<bindAddress>", "<hostname>",
+        executorMemory, executorCores, appId, securityMgr, localResources,
         ResourceProfile.DEFAULT_RESOURCE_PROFILE_ID)
       dummyRunner.launchContextDebugInfo()
     }

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ExecutorRunnable.scala
@@ -49,6 +49,7 @@ private[yarn] class ExecutorRunnable(
     sparkConf: SparkConf,
     masterAddress: String,
     executorId: String,
+    bindAddress: String,
     hostname: String,
     executorMemory: Int,
     executorCores: Int,
@@ -117,7 +118,7 @@ private[yarn] class ExecutorRunnable(
     } catch {
       case ex: Exception =>
         throw new SparkException(s"Exception while starting container ${container.get.getId}" +
-          s" on host $hostname", ex)
+          s" on host $hostname ($bindAddress)", ex)
     }
   }
 
@@ -189,6 +190,7 @@ private[yarn] class ExecutorRunnable(
       Seq("org.apache.spark.executor.YarnCoarseGrainedExecutorBackend",
         "--driver-url", masterAddress,
         "--executor-id", executorId,
+        "--bind-address", bindAddress,
         "--hostname", hostname,
         "--cores", executorCores.toString,
         "--app-id", appId,

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -339,6 +339,13 @@ package object config extends Logging {
       .stringConf
       .createOptional
 
+  private[spark] val EXECUTOR_BIND_ADDRESS =
+    ConfigBuilder("spark.yarn.executor.bindAddress")
+      .doc("Address where to bind network listen sockets on the executor.")
+      .version("4.0.0")
+      .stringConf
+      .createOptional
+
   /* Unmanaged AM configuration. */
 
   private[spark] val YARN_UNMANAGED_AM = ConfigBuilder("spark.yarn.unmanagedAM.enabled")

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/config.scala
@@ -342,7 +342,7 @@ package object config extends Logging {
   private[spark] val EXECUTOR_BIND_ADDRESS =
     ConfigBuilder("spark.yarn.executor.bindAddress")
       .doc("Address where to bind network listen sockets on the executor.")
-      .version("4.0.0")
+      .version("3.5.3")
       .stringConf
       .createOptional
 

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ExecutorRunnableSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ExecutorRunnableSuite.scala
@@ -42,6 +42,7 @@ class ExecutorRunnableSuite extends SparkFunSuite {
       "yarn",
       "exec-1",
       "localhost",
+      "localhost",
       1,
       1,
       "application_123_1",


### PR DESCRIPTION
### What changes were proposed in this pull request?

Uptake `--bind-address` parameter in `YarnCoarseGrainedExecutorBackend` when launching new container in Yarn cluster. This PR also ensure `YarnAllocator` uses default hostname when its not configured.

### Why are the changes needed?

We've came across issue with Spark running on Yarn in Istio enabled Kubernetes cluster. Previous PR https://github.com/apache/spark/pull/32633 is not merged because Spark 2.4 was EOL and 3.x branch didnt get enough traction.

### Does this PR introduce any user-facing change?

Yes, new config specifically for Yarn cluster mode is added and relevant doc is updated.

### How was this patch tested?

Tested in Kubenetes with Istio and added tests to `YarnAllocatorSuite`

Thanks!