### PR TITLE
[MINOR][SQL] Fix the incorrect method `@link` tag in `StagingTableCatalog` 

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/StagingTableCatalog.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/StagingTableCatalog.java
@@ -102,7 +102,7 @@ public interface StagingTableCatalog extends TableCatalog {
    * returned table's {@link StagedTable#commitStagedChanges()} is called.
    * <p>
    * This is deprecated, please override
-   * {@link #stageReplace(Identifier, StructType, Transform[], Map)} instead.
+   * {@link #stageReplace(Identifier, Column[], Transform[], Map)} instead.
    */
   @Deprecated(since = "3.4.0")
   default StagedTable stageReplace(


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr fixes an incorrect method `@link` in `StagingTableCatalog`, link it to the method that should be `override` instead of the current method. 

### Why are the changes needed?
Fix the incorrect method `@link` tag 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No