### PR TITLE
[SPARK-49402][PYTHON][FOLLOW-UP] Manually load ~/.profile in Spark Connect notebook

### DIFF
--- a/python/docs/source/getting_started/quickstart_connect.ipynb
+++ b/python/docs/source/getting_started/quickstart_connect.ipynb
@@ -28,7 +28,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!$HOME/sbin/start-connect-server.sh"
+    "%%bash\n",
+    "source ~/.profile # Make sure environment variables are loaded.\n",
+    "$HOME/sbin/start-connect-server.sh"
    ]
   },
   {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a followup of https://github.com/apache/spark/pull/47883 that adds manual `source ~/.profile`.

### Why are the changes needed?

Ever since we switched to `Dockerfile`, none of `./profile`, `/.bashrc`, `./bash_profile`, etc seems working. There are a couple of related issues in Jupyter but I cannot figure it out.

This is the only cell it needs the environment variable so decided to simply work around.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.