### PR TITLE
[SPARK-49441][ML] `StringIndexer` sort arrays in executors

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -210,9 +210,7 @@ class StringIndexer @Since("1.4.0") (
       .groupBy("index", "value")
       .agg(countCol.as("count"))
       .groupBy("index")
-      .agg(collect_list(struct("count", "value")).alias("array"))
-      .repartition(8, col("index"))
-      .select(col("index"), sort_array(col("array")).getField("value"))
+      .agg(sort_array(collect_list(struct("count", "value"))).getField("value"))
       .collect()
       .foreach(r => result(r.getInt(0)) = r.getSeq[String](1).toArray)
     result
@@ -227,9 +225,7 @@ class StringIndexer @Since("1.4.0") (
     dataset.select(posexplode(array(selectedCols: _*)).as(Seq("index", "value")))
       .where(col("value").isNotNull)
       .groupBy("index")
-      .agg(collect_set("value").alias("array"))
-      .repartition(8, col("index"))
-      .select(col("index"), sort_array(col("array"), ascending))
+      .agg(sort_array(collect_set("value"), ascending))
       .collect()
       .foreach(r => result(r.getInt(0)) = r.getSeq[String](1).toArray)
     result

--- a/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/feature/StringIndexer.scala
@@ -27,11 +27,10 @@ import org.apache.spark.ml.attribute.{Attribute, NominalAttribute}
 import org.apache.spark.ml.param._
 import org.apache.spark.ml.param.shared._
 import org.apache.spark.ml.util._
-import org.apache.spark.sql.{AnalysisException, Column, DataFrame, Dataset, Row}
+import org.apache.spark.sql.{AnalysisException, Column, DataFrame, Dataset}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.apache.spark.util.ArrayImplicits._
-import org.apache.spark.util.ThreadUtils
 import org.apache.spark.util.VersionUtils.majorMinorVersion
 import org.apache.spark.util.collection.OpenHashMap
 
@@ -197,53 +196,43 @@ class StringIndexer @Since("1.4.0") (
     }
   }
 
-  private def countByValue(
-      dataset: Dataset[_],
-      inputCols: Array[String]): Array[OpenHashMap[String, Long]] = {
+  private def sortByFreq(dataset: Dataset[_], ascending: Boolean): Array[Array[String]] = {
+    val (inputCols, _) = getInOutCols()
     val selectedCols = getSelectedCols(dataset, inputCols.toImmutableArraySeq)
-    val results = Array.fill(selectedCols.size)(new OpenHashMap[String, Long]())
+    val numCols = inputCols.length
+
+    // In the case of equal frequency, always sorts strings by alphabet (ascending).
+    val countCol = if (ascending) count(lit(1)) else negate(count(lit(1)))
+
+    val result = Array.fill(numCols)(Array.empty[String])
     dataset.select(posexplode(array(selectedCols: _*)).as(Seq("index", "value")))
       .where(col("value").isNotNull)
       .groupBy("index", "value")
-      .agg(count(lit(1)).as("count"))
+      .agg(countCol.as("count"))
       .groupBy("index")
-      .agg(collect_list(struct("value", "count")))
+      .agg(collect_list(struct("count", "value")).alias("array"))
+      .repartition(8, col("index"))
+      .select(col("index"), sort_array(col("array")).getField("value"))
       .collect()
-      .foreach { row =>
-        val index = row.getInt(0)
-        val result = results(index)
-        row.getSeq[Row](1).foreach { case Row(label: String, count: Long) =>
-          result.update(label, count)
-        }
-      }
-    results
-  }
-
-  private def sortByFreq(dataset: Dataset[_], ascending: Boolean): Array[Array[String]] = {
-    val (inputCols, _) = getInOutCols()
-
-    val sortFunc = StringIndexer.getSortFunc(ascending = ascending)
-    val orgStrings = countByValue(dataset, inputCols).toImmutableArraySeq
-    ThreadUtils.parmap(orgStrings, "sortingStringLabels", 8) { counts =>
-      counts.toSeq.sortWith(sortFunc).map(_._1).toArray
-    }.toArray
+      .foreach(r => result(r.getInt(0)) = r.getSeq[String](1).toArray)
+    result
   }
 
   private def sortByAlphabet(dataset: Dataset[_], ascending: Boolean): Array[Array[String]] = {
     val (inputCols, _) = getInOutCols()
+    val selectedCols = getSelectedCols(dataset, inputCols.toImmutableArraySeq)
+    val numCols = inputCols.length
 
-    val selectedCols = getSelectedCols(dataset, inputCols.toImmutableArraySeq).map(collect_set)
-    val allLabels = dataset.select(selectedCols: _*)
-      .collect().toImmutableArraySeq.flatMap(_.toSeq)
-      .asInstanceOf[scala.collection.Seq[scala.collection.Seq[String]]].toSeq
-    ThreadUtils.parmap(allLabels, "sortingStringLabels", 8) { labels =>
-      val sorted = labels.filter(_ != null).sorted
-      if (ascending) {
-        sorted.toArray
-      } else {
-        sorted.reverse.toArray
-      }
-    }.toArray
+    val result = Array.fill(numCols)(Array.empty[String])
+    dataset.select(posexplode(array(selectedCols: _*)).as(Seq("index", "value")))
+      .where(col("value").isNotNull)
+      .groupBy("index")
+      .agg(collect_set("value").alias("array"))
+      .repartition(8, col("index"))
+      .select(col("index"), sort_array(col("array"), ascending))
+      .collect()
+      .foreach(r => result(r.getInt(0)) = r.getSeq[String](1).toArray)
+    result
   }
 
   @Since("2.0.0")
@@ -286,27 +275,6 @@ object StringIndexer extends DefaultParamsReadable[StringIndexer] {
 
   @Since("1.6.0")
   override def load(path: String): StringIndexer = super.load(path)
-
-  // Returns a function used to sort strings by frequency (ascending or descending).
-  // In case of equal frequency, it sorts strings by alphabet (ascending).
-  private[feature] def getSortFunc(
-      ascending: Boolean): ((String, Long), (String, Long)) => Boolean = {
-    if (ascending) {
-      case ((strA: String, freqA: Long), (strB: String, freqB: Long)) =>
-        if (freqA == freqB) {
-          strA < strB
-        } else {
-          freqA < freqB
-        }
-    } else {
-      case ((strA: String, freqA: Long), (strB: String, freqB: Long)) =>
-        if (freqA == freqB) {
-          strA < strB
-        } else {
-          freqA > freqB
-        }
-    }
-  }
 }
 
 /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
`StringIndexer` sort arrays in executors


### Why are the changes needed?
Existing implementation collect all arrays at driver, and then sort them with a `ForkJoinPool` via `ThreadUtils.parmap`.

This PR aims to move sorting from driver to executors.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI and manually test:
```
import org.apache.spark.ml.feature.StringIndexer

val numCol = 300

val data = (0 to 10000).map { i =>
  (i, 100 * i)
}
var df = data.toDF("id", "label0")
(1 to numCol).foreach { idx =>
  df = df.withColumn(s"label$idx", col("label0") + 1)
}
val inputCols = (0 to numCol).map(i => s"label$i").toArray
val outputCols = (0 to numCol).map(i => s"labelIndex$i").toArray
df.cache()
df.count()

Seq.range(0, 10).foreach(i => new StringIndexer().setInputCols(inputCols).setOutputCols(outputCols).setStringOrderType("alphabetDesc").fit(df)) // warm up


val t0 = System.nanoTime()
Seq.range(0, 10).foreach(i => new StringIndexer().setInputCols(inputCols).setOutputCols(outputCols).setStringOrderType("alphabetDesc").fit(df))
val t1 = System.nanoTime()
println("Elapsed time: " + (t1 - t0) / 1000000000.0 + "s")
```

master:
```
Elapsed time: 12.181134084s
```

this PR:
```
Elapsed time: 11.432259833s
```

The performance is similar, the main change is that the sort happens in executors.

### Was this patch authored or co-authored using generative AI tooling?
No