### PR TITLE
[SPARK-48486][SQL] To solve the issue of generating excessively large execution plans when encountering multiple levels of subqueries while enabling DynamicPartitionPruning.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -351,6 +351,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val DYNAMIC_PARTITION_PRUNING_MAX_LENGTH =
+    buildConf("spark.sql.optimizer.dynamicPartitionPruning.max.length")
+      .doc("The maximum character length of the plan for the nested subquery.When the set length " +
+        "is too large, it may cause the final plan to exceed the limit or memory overflow.")
+      .version("3.3.0")
+      .intConf
+      .createWithDefault(10 * 1024 * 1024)
+
   val DYNAMIC_PARTITION_PRUNING_USE_STATS =
     buildConf("spark.sql.optimizer.dynamicPartitionPruning.useStats")
       .internal()
@@ -5295,6 +5303,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def planChangeBatches: Option[String] = getConf(PLAN_CHANGE_LOG_BATCHES)
 
   def dynamicPartitionPruningEnabled: Boolean = getConf(DYNAMIC_PARTITION_PRUNING_ENABLED)
+
+  def dynamicPartitionPruningMaxLength: Int = getConf(DYNAMIC_PARTITION_PRUNING_MAX_LENGTH)
 
   def dynamicPartitionPruningUseStats: Boolean = getConf(DYNAMIC_PARTITION_PRUNING_USE_STATS)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -355,7 +355,7 @@ object SQLConf {
     buildConf("spark.sql.optimizer.dynamicPartitionPruning.max.length")
       .doc("The maximum character length of the plan for the nested subquery.When the set length " +
         "is too large, it may cause the final plan to exceed the limit or memory overflow.")
-      .version("3.3.0")
+      .version("4.0.0")
       .intConf
       .createWithDefault(10 * 1024 * 1024)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PartitionPruning.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/dynamicpruning/PartitionPruning.scala
@@ -225,9 +225,9 @@ object PartitionPruning extends Rule[LogicalPlan] with PredicateHelper with Join
 
     plan transformUp {
       // skip this rule if there's already a DPP subquery on the LHS of a join
-      case j@Join(Filter(_: DynamicPruningSubquery, _), _, _, _, _) => j
-      case j@Join(_, Filter(_: DynamicPruningSubquery, _), _, _, _) => j
-      case j@Join(left, right, joinType, Some(condition), hint) =>
+      case j @ Join(Filter(_: DynamicPruningSubquery, _), _, _, _, _) => j
+      case j @ Join(_, Filter(_: DynamicPruningSubquery, _), _, _, _) => j
+      case j @ Join(left, right, joinType, Some(condition), hint) =>
         var newLeft = left
         var newRight = right
 
@@ -242,13 +242,12 @@ object PartitionPruning extends Rule[LogicalPlan] with PredicateHelper with Join
           def fromLeftRight(x: Expression, y: Expression) =
             !x.references.isEmpty && x.references.subsetOf(left.outputSet) &&
               !y.references.isEmpty && y.references.subsetOf(right.outputSet)
-
           fromLeftRight(x, y) || fromLeftRight(y, x)
         }
 
         splitConjunctivePredicates(condition).foreach {
           case EqualTo(a: Expression, b: Expression)
-            if fromDifferentSides(a, b) =>
+              if fromDifferentSides(a, b) =>
             val (l, r) = if (a.references.subsetOf(left.outputSet) &&
               b.references.subsetOf(right.outputSet)) {
               a -> b


### PR DESCRIPTION
[SPARK-48486][CORE] Instead of PartitionPruning#prune is expected
### What changes were proposed in this pull request?

The code of method: prune in class: org.apache.spark.sql.execution.dynamicpruning.PartitionPruning is modified. And class: org.apache.spark.sql.internal.SQLConf has added a property value: DYNAMIC_PARTITION_PRUNING_MAX_LENGTH and a dynamicPartitionPruningMaxLength method.

### Why are the changes needed?

In order to address the issue of Spark's DynamicPartitionPruning generating plans with excessive character length and causing excessive memory usage leading to OOM errors when encountering too many levels of subqueries.

### Does this PR introduce _any_ user-facing change?
yes
When DYNAMIC_PARTITION_PRUNING_ENABLED is set to true and DPP optimization is enabled, the generated execution plan may trigger a potential issue.

### How was this patch tested?
I have provided test cases as much as possible.


### Was this patch authored or co-authored using generative AI tooling?
no