### PR TITLE
[SPARK-41262][SQL] Fix `spark.sql.optimizer.canChangeCachedPlanOutputPartitioning` Configuration Default to Match Documentation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1681,7 +1681,7 @@ object SQLConf {
         s"is ${ADAPTIVE_EXECUTION_APPLY_FINAL_STAGE_SHUFFLE_OPTIMIZATIONS.key}.")
       .version("3.2.0")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val DEFAULT_CACHE_STORAGE_LEVEL = buildConf("spark.sql.defaultCacheStorageLevel")
     .doc("The default storage level of `dataset.cache()`, `catalog.cacheTable()` and " +


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://spark.apache.org/docs/latest/sql-migration-guide.html#upgrading-from-spark-sql-34-to-35 states that `spark.sql.optimizer.canChangeCachedPlanOutputPartitioning` is set by default, but that's currently not true, and causes confusion along with lost debugging time.

Notably, when working with cached dataframes in Spark 3.5.0, I saw AQE not working until I manually set the flag myself. 




### Why are the changes needed?
This aligns the code with the documentation which prevents confusion. 


### Does this PR introduce _any_ user-facing change?
Yes, but nothing the documentation doesn't already state.


### How was this patch tested?
Simple config change. 


### Was this patch authored or co-authored using generative AI tooling?
NO
