### PR TITLE
[SPARK-46995][DOCS][FOLLOWUP] Update `sql-migration-guide.md` documentation

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -40,6 +40,7 @@ license: |
   - `spark.sql.avro.datetimeRebaseModeInWrite` instead of `spark.sql.legacy.avro.datetimeRebaseModeInWrite`
   - `spark.sql.avro.datetimeRebaseModeInRead` instead of `spark.sql.legacy.avro.datetimeRebaseModeInRead`
 - Since Spark 4.0, the default value of `spark.sql.orc.compression.codec` is changed from `snappy` to `zstd`. To restore the previous behavior, set `spark.sql.orc.compression.codec` to `snappy`.
+- Since Spark 4.0, `spark.sql.optimizer.canChangeCachedPlanOutputPartitioning` has been disabled by default once again. To restore the previous behavior, set `spark.sql.optimizer.canChangeCachedPlanOutputPartitioning` to `true`.
 - Since Spark 4.0, the SQL config `spark.sql.legacy.allowZeroIndexInFormatString` is deprecated. Consider to change `strfmt` of the `format_string` function to use 1-based indexes. The first argument must be referenced by `1$`, the second by `2$`, etc.
 - Since Spark 4.0, Postgres JDBC datasource will read JDBC read TIMESTAMP WITH TIME ZONE as TimestampType regardless of the JDBC read option `preferTimestampNTZ`, while in 3.5 and previous, TimestampNTZType when `preferTimestampNTZ=true`. To restore the previous behavior, set `spark.sql.legacy.postgres.datetimeMapping.enabled` to `true`.
 - Since Spark 4.0, Postgres JDBC datasource will write TimestampType as TIMESTAMP WITH TIME ZONE, while in 3.5 and previous, it wrote as TIMESTAMP a.k.a. TIMESTAMP WITHOUT TIME ZONE. To restore the previous behavior, set `spark.sql.legacy.postgres.datetimeMapping.enabled` to `true`.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixing the documentation.


### Why are the changes needed?
Migration guide for 3.5.0 said a default was enabled, but upcoming changes for 4.0.0 will disable it but there are no documentation updates indicating this. 


### Does this PR introduce _any_ user-facing change?
Yes, this fixes the documentation to align with actual Spark behavior introduced in https://github.com/apache/spark/commit/becc04a9b6e27ffdaf56b35530db1e923254861a. 

### How was this patch tested?
Documentation only change. 


### Was this patch authored or co-authored using generative AI tooling?
NO