### PR TITLE
[SPARK-49456][DOCS] Fix hash fragment scrolling behavior on versioned Spark documentation 

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -1,3 +1,7 @@
+:root {
+  --navbar-height: 80px;
+}
+
 body {
   color: #666666;
   font-family: "DM Sans", sans-serif;
@@ -5,8 +9,8 @@ body {
   font-weight: 400;
   overflow-wrap: anywhere;
   overflow-x: auto;
-  padding-top: 80px;
   padding-bottom: 20px;
+  padding-top: var(--navbar-height);
 }
 
 a {
@@ -25,6 +29,17 @@ a:focus {
   border-radius: 0;
   z-index: 9999;
   transition: none !important;
+  height: var(--navbar-height);
+}
+
+/*
+Any element with an id attribute can be scrolled to via the URL hash fragment.
+But since the navbar is fixed at the top, elements will, by default, get hidden
+by the navbar. To prevent this, we make sure that there's a margin above these
+links.
+*/
+*[id] {
+  scroll-margin-top: var(--navbar-height);
 }
 
 .navbar .nav-item:hover .dropdown-menu,

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -87,15 +87,6 @@ function codeTabs() {
 }
 
 
-// A script to fix internal hash links because we have an overlapping top bar.
-// Based on https://github.com/twitter/bootstrap/issues/193#issuecomment-2281510
-function maybeScrollToHash() {
-  if (window.location.hash && $(window.location.hash).length) {
-    var newTop = $(window.location.hash).offset().top - 57;
-    $(window).scrollTop(newTop);
-  }
-}
-
 $(function() {
   codeTabs();
   // Display anchor links when hovering over headers. For documentation of the
@@ -104,14 +95,6 @@ $(function() {
     placement: 'right'
   };
   anchors.add();
-
-  $(window).bind('hashchange', function() {
-    maybeScrollToHash();
-  });
-
-  // Scroll now too in case we had opened the page on a hash, but wait a bit because some browsers
-  // will try to do *their* initial scroll after running the onReady handler.
-  $(window).on('load', function() { setTimeout(function() { maybeScrollToHash(); }, 25); });
 
   // Make dropdown menus in nav bars show on hover instead of click
   // using solution at https://webdesign.tutsplus.com/tutorials/how-


### PR DESCRIPTION
### Why are the changes needed?

Spark docs have always incorrectly scrolled to the right place when a hash fragment is specified in the URL: 

<img width="868" alt="image" src="https://github.com/user-attachments/assets/956646a7-b2c6-4072-b818-061f4de5a247">

We have a 12-year-old hack to fix this with Javascript, but this isn't the right solution for 2024. [Most browsers now support](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top#browser_compatibility) `scroll-margin-top`, which allows you to specify a margin that the browser will keep between the top of the element and the top-border of the viewport.

If a user's browser doesn't support this, their hyperlinks will be off by about ~80 pixels, which is no worse than the UX today.

You can play with the live changes [here](https://second-spark-site.vercel.app/). 

### Does this PR introduce _any_ user-facing change?

Yes. When they click/visit Spark links, the page will actually scroll where they want to go.

### How was this patch tested?

I tested this on Chromium 128.0.6613.85, and Safari 17.4.1. 

### Was this patch authored or co-authored using generative AI tooling?

No.