### PR TITLE
[SPARK-49483][BUILD] Upgrade `commons-lang3` to 3.17.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -45,7 +45,7 @@ commons-crypto/1.1.0//commons-crypto-1.1.0.jar
 commons-dbcp/1.4//commons-dbcp-1.4.jar
 commons-io/2.16.1//commons-io-2.16.1.jar
 commons-lang/2.6//commons-lang-2.6.jar
-commons-lang3/3.16.0//commons-lang3-3.16.0.jar
+commons-lang3/3.17.0//commons-lang3-3.17.0.jar
 commons-math3/3.6.1//commons-math3-3.6.1.jar
 commons-pool/1.5.4//commons-pool-1.5.4.jar
 commons-text/1.12.0//commons-text-1.12.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
     <!-- To support Hive UDF jars built by Hive 2.0.0 ~ 2.3.9 and 3.0.0 ~ 3.1.3. -->
     <commons-lang2.version>2.6</commons-lang2.version>
     <!-- org.apache.commons/commons-lang3/-->
-    <commons-lang3.version>3.16.0</commons-lang3.version>
+    <commons-lang3.version>3.17.0</commons-lang3.version>
     <!-- org.apache.commons/commons-pool2/-->
     <commons-pool2.version>2.12.0</commons-pool2.version>
     <datanucleus-core.version>4.1.17</datanucleus-core.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `commons-lang3` from `3.16.0` to `3.17.0`.


### Why are the changes needed?
- v3.16.0 VS v3.17.0
  https://github.com/apache/commons-lang/compare/rel/commons-lang-3.16.0...rel/commons-lang-3.17.0

- The new version has brought some bug fixes, eg:
  [Using RandomStringUtils.insecure() still leads to using the secure() random](https://github.com/apache/commons-lang/commit/f92016c288410dd085ac4fdfab68375e7b18651b)
  [Let existing catch clause handle the NPE edge case](https://github.com/apache/commons-lang/commit/ee2041464e60082a601d72be329bac57bc67328f)

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
