### PR TITLE
[SPARK-49485][CORE]  Fix speculative task hang bug due to remaining executor lay on same host

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -668,7 +668,8 @@ class SparkContext(config: SparkConf) extends Logging {
         schedulerBackend match {
           case b: ExecutorAllocationClient =>
             Some(new ExecutorAllocationManager(
-              schedulerBackend.asInstanceOf[ExecutorAllocationClient], listenerBus, _conf,
+              schedulerBackend.asInstanceOf[ExecutorAllocationClient],
+              _taskScheduler, listenerBus, _conf,
               cleaner = cleaner, resourceProfileManager = resourceProfileManager,
               reliableShuffleStorage = _shuffleDriverComponents.supportsReliableStorage()))
           case _ =>

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -736,6 +736,10 @@ package object config {
       .version("1.2.0")
       .timeConf(TimeUnit.SECONDS).createWithDefault(1)
 
+  private[spark] val DYN_ALLOCATION_EXCLUDE_NODE_TRIGGER_TIMEOUT =
+    ConfigBuilder("spark.dynamicAllocation.excludeNodeTriggerTimeout")
+      .timeConf(TimeUnit.MINUTES).createWithDefault(10)
+
   private[spark] val DYN_ALLOCATION_SUSTAINED_SCHEDULER_BACKLOG_TIMEOUT =
     ConfigBuilder("spark.dynamicAllocation.sustainedSchedulerBacklogTimeout")
       .version("1.2.0")

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
@@ -919,8 +919,15 @@ private[spark] class TaskSchedulerImpl(
     }
   }
 
-  def handleExcludeNodes(node: String): Unit = synchronized {
-    healthTrackerOpt.foreach(_.updateBlacklistForSpeculativeTasks(node))
+  def handleExcludeNodes(node: String): Boolean = synchronized {
+    if (healthTrackerOpt.nonEmpty) {
+      return healthTrackerOpt.map(_.updateExcludedForSpeculativeTasks(node)).get
+    }
+    false
+  }
+
+  def handleReviveNodes(node: String): Unit = synchronized {
+    healthTrackerOpt.foreach(_.updateRevivedForSpeculativeTasks(node))
   }
 
   def speculativeTasksHasAttemptOnHost(

--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
@@ -337,7 +337,7 @@ private[spark] class TaskSetManager(
   }
 
   /** Check whether a task once ran an attempt on a given host */
-  private def hasAttemptOnHost(taskIndex: Int, host: String): Boolean = {
+  def hasAttemptOnHost(taskIndex: Int, host: String): Boolean = {
     taskAttempts(taskIndex).exists(_.host == host)
   }
 

--- a/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ExecutorAllocationManagerSuite.scala
@@ -952,8 +952,8 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
     assert(delta == -1)
     assert(numExecutorsTargetForDefaultProfileId(manager) == 4)
 
-    // a hardware error occur to host1 and task 18, 19 hang, speculative task submitted
-    // with index (taskId - 4)
+    // a hardware error occur to host1 and task 16-19 hang, speculative task submitted
+    // with taskId (index + 4)
     (20 to 23).foreach { taskId =>
       post(new SparkListenerSpeculativeTaskSubmitted(0, 0, taskId - 4, taskId))}
     assert(maxNumExecutorsNeededPerResourceProfile(manager, defaultProfile) == 2)
@@ -2001,6 +2001,9 @@ class ExecutorAllocationManagerSuite extends SparkFunSuite {
             0, 0, (task.partitionId / 4).toString, host, null, false) :: taskAttempts(id)
         }
       }
+    }
+    override def handleExcludeNodes(node: String): Boolean = {
+      true
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Modify ExecutorAllocationManager calculates maxNeeded logic.If remaining executors on a same host and pending speculativeTasks exists and will not execute addExecutor later, exclude current host, makes maxNeeded equal numExecutorsTarget + 1 to ensure addExecutor will execute later.Then the speculative task will launch and start.
Just run the follow job on a yarn cluster with one host and the bug will report.

```scala
object SpecHangJob {
  def main(args: Array[String]): Unit = {
    val spark = SparkSession.builder.appName("rss_test").enableHiveSupport().getOrCreate
    val sc = spark.sparkContext

    val conf = sc.getConf
    val taskNum = conf.getInt("spark.test.parallelism", 3)
    val seq = (0 until taskNum).toList
    sc.parallelize(seq, taskNum).map(
      i => {
        if (i == 0) {
          try {
            Thread.sleep(1000 * 60 * 30)
          } catch {
            case exception: Exception => println(exception.getMessage)
          }
        } else {
          try {
            Thread.sleep(1000 * 30)
          } catch {
            case e: Exception => println(e.getMessage)
          }
        }
        "haha"
      }
    ).collect()}}
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Because if the host has problem and tasks on it keep not finished, in this case speculative task will not start any more, make job run time longer than expect.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
By adding a unit test mocking remaining executors lay on same host.And feature makes speculative task start


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
