### PR TITLE
[SPARK-49498][SQL][TESTS] Check differences between SR_AI and SR_Latn_AI collations

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
@@ -17,10 +17,8 @@
 
 package org.apache.spark.sql
 
-import com.ibm.icu.text.Collator
-import com.ibm.icu.util.ULocale
-
 import scala.jdk.CollectionConverters.MapHasAsJava
+
 import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.ExtendedAnalysisException
 import org.apache.spark.sql.catalyst.expressions._
@@ -192,45 +190,25 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
 
   test("check difference betweeen SR_AI and SR_Latn_AI collations") {
     // scalastyle:off nonascii
-    // SR_AI collation
-    var collationName = "SR_AI"
-    var builder = new ULocale.Builder();
-    builder.setLocale(new ULocale(collationName))
-    builder.setUnicodeLocaleKeyword("ks", "level1")
-    builder.setUnicodeLocaleKeyword("kc", "true")
-    var collator = Collator.getInstance(builder.build())
+    // SR_AI
+    checkAnswer(sql(s"SELECT 'cCćĆčČšŠžŽ' = 'čČcCćĆsSzZ' COLLATE SR_AI"), Row(true))
 
-    assert(collator.compare("cCćĆčČšŠžŽ", "čČcCćĆsSzZ") == 0)
-    checkAnswer(sql(s"SELECT 'cCćĆčČšŠžŽ' = 'čČcCćĆsSzZ' COLLATE $collationName"), Row(true))
-
-    // SR_Latn_AI collation
-    collationName = "SR_Latn_AI"
-    builder = new ULocale.Builder();
-    builder.setLocale(new ULocale(collationName))
-    builder.setUnicodeLocaleKeyword("ks", "level1")
-    builder.setUnicodeLocaleKeyword("kc", "true")
-    collator = Collator.getInstance(builder.build())
-
-    assert(collator.compare("c", "ć") != 0)
-    checkAnswer(sql(s"SELECT 'c' = 'ć' COLLATE $collationName"), Row(false))
-    assert(collator.compare("c", "č") != 0)
-    checkAnswer(sql(s"SELECT 'c' = 'č' COLLATE $collationName"), Row(false))
-    assert(collator.compare("ć", "č") != 0)
-    checkAnswer(sql(s"SELECT 'ć' = 'č' COLLATE $collationName"), Row(false))
-    assert(collator.compare("C", "Ć") != 0)
-    checkAnswer(sql(s"SELECT 'C' = 'Ć' COLLATE $collationName"), Row(false))
-    assert(collator.compare("C", "Č") != 0)
-    checkAnswer(sql(s"SELECT 'C' = 'Č' COLLATE $collationName"), Row(false))
-    assert(collator.compare("Ć", "Č") != 0)
-    checkAnswer(sql(s"SELECT 'Ć' = 'Č' COLLATE $collationName"), Row(false))
-    assert(collator.compare("s", "š") != 0)
-    checkAnswer(sql(s"SELECT 's' = 'Š' COLLATE $collationName"), Row(false))
-    assert(collator.compare("S", "Š") != 0)
-    checkAnswer(sql(s"SELECT 'S' = 'Š' COLLATE $collationName"), Row(false))
-    assert(collator.compare("z", "ž") != 0)
-    checkAnswer(sql(s"SELECT 'z' = 'ž' COLLATE $collationName"), Row(false))
-    assert(collator.compare("Z", "Ž") != 0)
-    checkAnswer(sql(s"SELECT 'Z' = 'Ž' COLLATE $collationName"), Row(false))
+    // SR_Latn_AI
+    Seq(
+      ("c", "ć"),
+      ("c", "č"),
+      ("ć", "č"),
+      ("C", "Ć"),
+      ("C", "Č"),
+      ("Ć", "Č"),
+      ("s", "š"),
+      ("S", "Š"),
+      ("z", "ž"),
+      ("Z", "Ž")
+    ).foreach {
+      case (c1, c2) =>
+        checkAnswer(sql(s"SELECT '$c1' = '$c2' COLLATE SR_Latn_AI"), Row(false))
+    }
     // scalastyle:on nonascii
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
@@ -190,10 +190,6 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
 
   test("check difference betweeen SR_AI and SR_Latn_AI collations") {
     // scalastyle:off nonascii
-    // SR_AI
-    checkAnswer(sql(s"SELECT 'cCćĆčČšŠžŽ' = 'čČcCćĆsSzZ' COLLATE SR_AI"), Row(true))
-
-    // SR_Latn_AI
     Seq(
       ("c", "ć"),
       ("c", "č"),
@@ -207,7 +203,10 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
       ("Z", "Ž")
     ).foreach {
       case (c1, c2) =>
+        // SR_Latn_AI
         checkAnswer(sql(s"SELECT '$c1' = '$c2' COLLATE SR_Latn_AI"), Row(false))
+        // SR_AI
+        checkAnswer(sql(s"SELECT '$c1' = '$c2' COLLATE SR_AI"), Row(true))
     }
     // scalastyle:on nonascii
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added test to check difference between SR_AI and SR_Latn_AI collations.


### Why are the changes needed?
Better testing.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Test added to `CollationSuite.scala`


### Was this patch authored or co-authored using generative AI tooling?
No.
