### PR TITLE
[SPARK-49495][DOCS] Document and Feature Preview on the master branch via Live GitHub Pages Updates

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,9 +23,6 @@ on:
   push:
     branches:
       - master
-  pull_request_target:
-    branches:
-      - master
 
 
 concurrency:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,7 +24,6 @@ on:
     branches:
       - master
 
-
 concurrency:
   group: 'docs preview'
   cancel-in-progress: true

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: GitHub pages deployment
+name: GitHub Pages deployment
 
 on:
   push:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install Pandoc
         uses: pandoc/actions/setup@d6abb76f6c8a1a9a5e15a5190c96a02aabffd1ee
         with:
-          version: 3.0
+          version: 3.3
       - name: Install dependencies for documentation generation
         run: |
           cd docs

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,7 +42,6 @@ jobs:
       - name: Checkout Spark repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           repository: apache/spark
           ref: 'master'
       - name: Install Java 17

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,90 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: GitHub pages deployment
+
+on:
+  push:
+    branches:
+      - master
+  pull_request_target:
+    branches:
+      - master
+
+
+concurrency:
+  group: 'docs preview'
+  cancel-in-progress: true
+
+jobs:
+  docs:
+    name: Build and deploy documentation
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      pages: write
+    env:
+      SPARK_TESTING: 1 # Reduce some noise in the logs
+    steps:
+      - name: Checkout Spark repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          repository: apache/spark
+          ref: 'master'
+      - name: Install Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+      - name: Install Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+          architecture: x64
+          cache: 'pip'
+      - name: Install Python dependencies
+        run: pip install --upgrade -r dev/requirements.txt
+      - name: Install Ruby for documentation generation
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+      - name: Install Pandoc
+        uses: pandoc/actions/setup@d6abb76f6c8a1a9a5e15a5190c96a02aabffd1ee
+        with:
+          version: 3.0
+      - name: Install dependencies for documentation generation
+        run: |
+          cd docs
+          gem install bundler -v 2.4.22 -n /usr/local/bin
+          bundle install --retry=100
+      - name: Run documentation build
+        run: |
+          cd docs
+          SKIP_RDOC=1 bundle exec jekyll build
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'docs/_site'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,6 +38,7 @@ jobs:
       pages: write
     env:
       SPARK_TESTING: 1 # Reduce some noise in the logs
+      RELEASE_VERSION: 'In-Progress'
     steps:
       - name: Checkout Spark repository
         uses: actions/checkout@v4
@@ -74,6 +75,10 @@ jobs:
           bundle install --retry=100
       - name: Run documentation build
         run: |
+          sed -i".tmp1" 's/SPARK_VERSION:.*$/SPARK_VERSION: '"$RELEASE_VERSION"'/g' docs/_config.yml
+          sed -i".tmp2" 's/SPARK_VERSION_SHORT:.*$/SPARK_VERSION_SHORT: '"$RELEASE_VERSION"'/g' docs/_config.yml
+          sed -i".tmp3" "s/'facetFilters':.*$/'facetFilters': [\"version:$RELEASE_VERSION\"]/g" docs/_config.yml
+          sed -i".tmp4" 's/__version__: str = .*$/__version__: str = "'"$RELEASE_VERSION"'"/' python/pyspark/version.py
           cd docs
           SKIP_RDOC=1 bundle exec jekyll build
       - name: Setup Pages


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pull request introduces functionalities that enable 'Document and Feature Preview on the master branch via Live GitHub Pages Updates'.



### Why are the changes needed?

- Instead of limited 72-hour voting phases, it provides the developer community with more opportunities to preview and verify the documentation contents.
- Instead of waiting for the final announcement of an official spark feature release, users can now preview some of the ongoing documented features, increasing the willingness to upgrade, sensing breaking changes in advance, and reducing the burden during the final upgrades.


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

An [example](https://yaooqinn.github.io/spark-gh-pages/) has been established by this repo - https://github.com/yaooqinn/spark-gh-pages

- Broken logo links are fixed at https://github.com/apache/spark/pull/47966

### Was this patch authored or co-authored using generative AI tooling?
no
