### PR TITLE
[SPARK-49249][SPARK-49122][CONNECT][SQL] Add missing doc for the `addArtifact` API

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/api/SparkSession.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/api/SparkSession.scala
@@ -333,6 +333,24 @@ abstract class SparkSession[DS[U] <: Dataset[U, DS]] extends Serializable with C
   @Experimental
   def addArtifact(uri: URI): Unit
 
+  /**
+   * Add a single in-memory artifact to the session while preserving the directory structure
+   * specified by `target` under the session's working directory of that particular file
+   * extension.
+   *
+   * Supported target file extensions are .jar and .class.
+   *
+   * ==Example==
+   * {{{
+   *  addArtifact(bytesBar, "foo/bar.class")
+   *  addArtifact(bytesFlat, "flat.class")
+   *  // Directory structure of the session's working directory for class files would look like:
+   *  // ${WORKING_DIR_FOR_CLASS_FILES}/flat.class
+   *  // ${WORKING_DIR_FOR_CLASS_FILES}/foo/bar.class
+   * }}}
+   *
+   * @since 4.0.0
+   */
   @Experimental
   def addArtifact(bytes: Array[Byte], target: String): Unit
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a follow-up of https://github.com/apache/spark/pull/47631 which adds a docstring to the `addArtifact` API. The doc was missing from the previous PR.


### Why are the changes needed?

The previous PR missed a docstring.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Not needed.

### Was this patch authored or co-authored using generative AI tooling?

No.
