### PR TITLE
[SPARK-49504][BUILD] Add `jjwt` profile

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -339,6 +339,14 @@
       </properties>
     </profile>
 
+    <!-- Pull in jjwt-impl and jjwt-jackson jars -->
+    <profile>
+      <id>jjwt</id>
+      <properties>
+        <jjwt.deps.scope>compile</jjwt.deps.scope>
+      </properties>
+    </profile>
+
     <!--
      Pull in spark-hadoop-cloud and its associated JARs,
     -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -122,19 +122,14 @@
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt-api</artifactId>
-      <version>0.12.6</version>
     </dependency>
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt-impl</artifactId>
-      <version>0.12.6</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt-jackson</artifactId>
-      <version>0.12.6</version>
-      <scope>test</scope>
     </dependency>
 
     <!-- Jetty dependencies promoted to compile here so they are shaded
@@ -624,6 +619,12 @@
       </activation>
       <properties>
         <script.extension>.sh</script.extension>
+      </properties>
+    </profile>
+    <profile>
+      <id>jjwt</id>
+      <properties>
+        <jjwt.deps.scope>compile</jjwt.deps.scope>
       </properties>
     </profile>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,7 @@
     -->
     <arrow.version>17.0.0</arrow.version>
     <ammonite.version>3.0.0-M2</ammonite.version>
+    <jjwt.version>0.12.6</jjwt.version>
 
     <!-- org.fusesource.leveldbjni will be used except on arm64 platform. -->
     <leveldbjni.group>org.fusesource.leveldbjni</leveldbjni.group>
@@ -276,6 +277,7 @@
     <orc.deps.scope>compile</orc.deps.scope>
     <parquet.deps.scope>compile</parquet.deps.scope>
     <parquet.test.deps.scope>test</parquet.test.deps.scope>
+    <jjwt.deps.scope>test</jjwt.deps.scope>
 
     <spark.yarn.isHadoopProvided>false</spark.yarn.isHadoopProvided>
 
@@ -676,6 +678,23 @@
         <groupId>org.apache.ivy</groupId>
         <artifactId>ivy</artifactId>
         <version>${ivy.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jsonwebtoken</groupId>
+        <artifactId>jjwt-api</artifactId>
+        <version>${jjwt.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.jsonwebtoken</groupId>
+        <artifactId>jjwt-impl</artifactId>
+        <version>${jjwt.version}</version>
+        <scope>${jjwt.deps.scope}</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.jsonwebtoken</groupId>
+        <artifactId>jjwt-jackson</artifactId>
+        <version>${jjwt.version}</version>
+        <scope>${jjwt.deps.scope}</scope>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
@@ -3808,6 +3827,9 @@
     </profile>
     <profile>
       <id>sparkr</id>
+    </profile>
+    <profile>
+      <id>jjwt</id>
     </profile>
     <!-- use org.openlabtesting.leveldbjni on aarch64 platform except MacOS -->
     <profile>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a new profile `jjwt` to provide `jjwt-impl` and `jjwt-jackson` jars files in a Spark distribution.

### Why are the changes needed?

To provide an easy way to build a Spark distribution.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manually.

**BEFORE**
```
$ mvn dependency:tree --pl assembly --am | grep jjwt-impl
[INFO] +- io.jsonwebtoken:jjwt-impl:jar:0.12.6:test
```

**AFTER**
```
$ mvn dependency:tree --pl assembly --am -Pjjwt | grep jjwt-impl
[INFO] +- io.jsonwebtoken:jjwt-impl:jar:0.12.6:compile
[INFO] |  +- io.jsonwebtoken:jjwt-impl:jar:0.12.6:test
[INFO] |  +- io.jsonwebtoken:jjwt-impl:jar:0.12.6:test
[INFO] |  +- io.jsonwebtoken:jjwt-impl:jar:0.12.6:test
[INFO] |  +- io.jsonwebtoken:jjwt-impl:jar:0.12.6:test
[INFO] |  +- io.jsonwebtoken:jjwt-impl:jar:0.12.6:test
[INFO] |  +- io.jsonwebtoken:jjwt-impl:jar:0.12.6:test
[INFO] |  +- io.jsonwebtoken:jjwt-impl:jar:0.12.6:test
[INFO] |  +- io.jsonwebtoken:jjwt-impl:jar:0.12.6:test
[INFO] |  +- io.jsonwebtoken:jjwt-impl:jar:0.12.6:test
[INFO] |  +- io.jsonwebtoken:jjwt-impl:jar:0.12.6:test
[INFO] |  +- io.jsonwebtoken:jjwt-impl:jar:0.12.6:compile
```

Or, build the distribution. 

```
$ dev/make-distribution.sh -Pjjwt
$ ls dist/jars/jj*
dist/jars/jjwt-api-0.12.6.jar
dist/jars/jjwt-impl-0.12.6.jar
dist/jars/jjwt-jackson-0.12.6.jar
```
### Was this patch authored or co-authored using generative AI tooling?

No.
