### PR TITLE
[SPARK-44239][SQL][FOLLOWUP] Do not disable vector memory optimization when hugeVectorThreshold=0 to align its document

### DIFF
--- a/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/vectorized/WritableColumnVector.java
@@ -72,7 +72,7 @@ public abstract class WritableColumnVector extends ColumnVector {
       numNulls = 0;
     }
 
-    if (hugeVectorThreshold > 0 && capacity > hugeVectorThreshold) {
+    if (hugeVectorThreshold > -1 && capacity > hugeVectorThreshold) {
       capacity = defaultCapacity;
       releaseMemory();
       reserveInternal(capacity);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Minor fix: Update default hugeVectorThreshold from 0 to -1 in code to match the documentation.
Keep consistent with the documentation

### Why are the changes needed?

Keep code and documentation consistent

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Exists UT


### Was this patch authored or co-authored using generative AI tooling?

No
