### PR TITLE
[SPARK-49512][K8S][DOCS] Drop K8s v1.27 Support

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -44,7 +44,7 @@ Cluster administrators should use [Pod Security Policies](https://kubernetes.io/
 
 # Prerequisites
 
-* A running Kubernetes cluster at version >= 1.27 with access configured to it using
+* A running Kubernetes cluster at version >= 1.28 with access configured to it using
 [kubectl](https://kubernetes.io/docs/reference/kubectl/).  If you do not already have a working Kubernetes cluster,
 you may set up a test cluster on your local machine using
 [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/).


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update K8s docs to recommend K8s v1.28+ for Apache Spark 4.0.0.
- As of now (2024-09-04), v1.28, v1.29, v1.30, and v1.31 are available.

This is a kind of follow-up of the following previous PR because Apache Spark 4.0.0 schedule is delayed slightly.
- #46168

### Why are the changes needed?

**1. K8s community archived v1.27.19 on 2024-07-16 and starts to release v1.31.0 from 2024-08-13**
- https://kubernetes.io/releases/#release-v1-31
- https://kubernetes.io/releases/patch-releases/#non-active-branch-history

**2. Default K8s Versions in Public Cloud environments**

The default K8s versions of public cloud providers are already moving to K8s 1.30 like the following.

- EKS: v1.30 (Default)
- GKE: v1.30 (Rapid),  v1.29 (Regular), v1.29 (Stable)
- AKS: v1.29 (Default), v1.30 (Support)

**3. End Of Support**

In addition, K8s 1.27 reached or will reach a standard support EOL in two weeks before Apache Spark 4.0.0 release. 

| K8s  |   EKS   |  AKS  |   GKE   |
| ---- | ------- | ------- | ------- |
| 1.27 | 2024-07 | 2024-07 | 2024-09-16 |

- [EKS EOL Schedule](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar)
- [AKS EOL Schedule](https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar)
- [GKE EOL Schedule](https://cloud.google.com/kubernetes-engine/docs/release-schedule)

### Does this PR introduce _any_ user-facing change?

- No, this is a documentation-only change about K8s versions.
- Apache Spark K8s Integration Test is currently using K8s **v1.30.0** on Minikube already.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.