### PR TITLE
[SPARK-49523][CONNECT] Increase maximum wait time for connect server to come up for testing

### DIFF
--- a/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/test/RemoteSparkSession.scala
+++ b/connector/connect/client/jvm/src/test/scala/org/apache/spark/sql/test/RemoteSparkSession.scala
@@ -19,9 +19,11 @@ package org.apache.spark.sql.test
 import java.io.{File, IOException, OutputStream}
 import java.lang.ProcessBuilder.Redirect
 import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
 
 import scala.concurrent.duration.FiniteDuration
 
+import org.scalatest.{BeforeAndAfterAll, Suite}
 import org.scalatest.concurrent.Eventually.eventually
 import org.scalatest.concurrent.Futures.timeout
 import org.scalatest.time.SpanSugar._


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR increases the max time we wait for a connect server to come up for testing. The current threshold is too low, and is causing flakyness.

### Why are the changes needed?
It makes connect tests less flaky.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
It is test infra code.

### Was this patch authored or co-authored using generative AI tooling?
No.