### PR TITLE
[SPARK-49507][SQL] Fix the case issue after enabling metastorePartitionPruningFastFallback

### DIFF
--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -417,11 +417,11 @@ private[client] class Shim_v2_0 extends Shim with Logging {
       try {
         val partitionSchema = CharVarcharUtils.replaceCharVarcharWithStringInSchema(
           catalogTable.partitionSchema)
-        val transformedPredicates = predicates.map(_.transform {
+        val lowerCasePredicates = predicates.map(_.transform {
           case a: AttributeReference => a.withName(a.name.toLowerCase(Locale.ROOT))
         })
         val boundPredicate = ExternalCatalogUtils.generatePartitionPredicateByFilter(
-          catalogTable, partitionSchema, transformedPredicates)
+          catalogTable, partitionSchema, lowerCasePredicates)
 
         def toRow(spec: TablePartitionSpec): InternalRow = {
           InternalRow.fromSeq(partitionSchema.map { field =>

--- a/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
+++ b/sql/hive/src/main/scala/org/apache/spark/sql/hive/client/HiveShim.scala
@@ -417,8 +417,11 @@ private[client] class Shim_v2_0 extends Shim with Logging {
       try {
         val partitionSchema = CharVarcharUtils.replaceCharVarcharWithStringInSchema(
           catalogTable.partitionSchema)
+        val transformedPredicates = predicates.map(_.transform {
+          case a: AttributeReference => a.withName(a.name.toLowerCase(Locale.ROOT))
+        })
         val boundPredicate = ExternalCatalogUtils.generatePartitionPredicateByFilter(
-          catalogTable, partitionSchema, predicates)
+          catalogTable, partitionSchema, transformedPredicates)
 
         def toRow(spec: TablePartitionSpec): InternalRow = {
           InternalRow.fromSeq(partitionSchema.map { field =>

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitionsSuite.scala
@@ -178,10 +178,12 @@ class PruneHiveTablePartitionsSuite extends PrunePartitionSuiteBase with TestHiv
   }
 
   test("SPARK-49507: Fix the case issue after enabling metastorePartitionPruningFastFallback") {
-    withSQLConf(SQLConf.HIVE_METASTORE_PARTITION_PRUNING_FAST_FALLBACK.key -> "true") {
-      sql("CREATE TABLE t(ID BIGINT, DT STRING) USING PARQUET PARTITIONED BY (DT)")
-      sql("INSERT INTO TABLE t SELECT 1, '20240820'")
-      checkAnswer(sql("SELECT * FROM t WHERE dt=20240820"), Row(1, "20240820") :: Nil)
+    withTable("t") {
+      withSQLConf(SQLConf.HIVE_METASTORE_PARTITION_PRUNING_FAST_FALLBACK.key -> "true") {
+        sql("CREATE TABLE t(ID BIGINT, DT STRING) USING PARQUET PARTITIONED BY (DT)")
+        sql("INSERT INTO TABLE t SELECT 1, '20240820'")
+        checkAnswer(sql("SELECT * FROM t WHERE dt=20240820"), Row(1, "20240820") :: Nil)
+      }
     }
   }
 

--- a/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitionsSuite.scala
+++ b/sql/hive/src/test/scala/org/apache/spark/sql/hive/execution/PruneHiveTablePartitionsSuite.scala
@@ -177,6 +177,14 @@ class PruneHiveTablePartitionsSuite extends PrunePartitionSuiteBase with TestHiv
     }
   }
 
+  test("SPARK-49507: Fix the case issue after enabling metastorePartitionPruningFastFallback") {
+    withSQLConf(SQLConf.HIVE_METASTORE_PARTITION_PRUNING_FAST_FALLBACK.key -> "true") {
+      sql("CREATE TABLE t(ID BIGINT, DT STRING) USING PARQUET PARTITIONED BY (DT)")
+      sql("INSERT INTO TABLE t SELECT 1, '20240820'")
+      checkAnswer(sql("SELECT * FROM t WHERE dt=20240820"), Row(1, "20240820") :: Nil)
+    }
+  }
+
   protected def collectPartitionFiltersFn(): PartialFunction[SparkPlan, Seq[Expression]] = {
     case scan: HiveTableScanExec => scan.partitionPruningPred
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR enhances the partition predicate handling in the `HiveShim` by ensuring that partition schema and predicates are properly transformed to lowercase. This change improves compatibility when generating partition predicates for filtering.

How to reproduce:
```
CREATE TABLE t (ID BIGINT, DT STRING) USING parquet PARTITIONED BY (DT);
set spark.sql.hive.metastorePartitionPruningFastFallback=true;
select * from t where dt=20240820;
```
Error message:
```
org.apache.spark.sql.AnalysisException: Expected only partition pruning predicates: List(isnotnull(DT#21), (cast(DT#21 as bigint) = 20240820)).
  at org.apache.spark.sql.errors.QueryCompilationErrors$.nonPartitionPruningPredicatesNotExpectedError(QueryCompilationErrors.scala:2414)
  at org.apache.spark.sql.catalyst.catalog.ExternalCatalogUtils$.generatePartitionPredicateByFilter(ExternalCatalo
```

### Why are the changes needed?

Bug fix.


### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Unit test.

### Was this patch authored or co-authored using generative AI tooling?

No
