### PR TITLE
[MINOR][INFRA] Upgrade actions in test_report.yml workflow

### DIFF
--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download test results to report
-      uses: dawidd6/action-download-artifact@09385b76de790122f4da9c82b17bccf858b9557c # pin@v2
+      uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # pin@v6
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         workflow: ${{ github.event.workflow_run.workflow_id }}

--- a/.github/workflows/test_report.yml
+++ b/.github/workflows/test_report.yml
@@ -30,14 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download test results to report
-      uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # pin@v6
+      uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # pin @v6
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         workflow: ${{ github.event.workflow_run.workflow_id }}
         commit: ${{ github.event.workflow_run.head_commit.id }}
         workflow_conclusion: completed
     - name: Publish test report
-      uses: scacap/action-surefire-report@482f012643ed0560e23ef605a79e8e87ca081648 # pin@v1
+      uses: scacap/action-surefire-report@a2911bd1a4412ec18dde2d93b1758b3e56d2a880 # pin @v1.8.0
       with:
         check_name: Report test results
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade `dawidd6/action-download-artifact` from v1 to v6
Upgrade `scacap/action-surefire-report` from v1.0.13 to v1.8.0

### Why are the changes needed?
Current versions have the following problems:

`dawidd6/action-download-artifact` failing:
```
 ==> Downloading: apache~spark~ADIBKZ.dockerbuild.zip (44.7 kB)
Error: ﻿<?xml version="1.0" encoding="utf-8"?>
<Error><Code>AuthenticationFailed</Code><Message>Server failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature.
RequestId:2c8b19f5-601e-007f-54e7-ffac7a000000
Time:2024-09-05T23:01:54.1979479Z</Message></Error>
```
https://github.com/apache/spark/actions/runs/10729437729/job/29756039009#step:2:15-17

`scacap/action-surefire-report` warning:
```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```
https://github.com/apache/spark/actions/runs/10723482700/job/29736875911#step:3:14

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
In GitHub CI:
The download succeeds (authentication issue above resolved), not hit by another bug: https://github.com/docker/build-push-action/issues/1167
```
==> Downloading: G-Research~spark~R7TXVG.dockerbuild.zip (23.76 kB)
Error: Invalid or unsupported zip format. No END header found
```
https://github.com/G-Research/spark/actions/runs/10733657395/job/29767392437#step:2:27

To be fixed in #48012.

### Was this patch authored or co-authored using generative AI tooling?
No.