### PR TITLE
[MINOR][INFRA] Do not upload docker build record

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -402,6 +402,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+    env:
+      DOCKER_BUILD_RECORD_UPLOAD: false
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `docker/build-push-action` action not upload the docker build record.

### Why are the changes needed?
The way `docker/build-push-action` uploads the file breaks action `dawidd6/action-download-artifact`, which breaks the `test_report.yaml` workflow that publishes test results.

```
==> Downloading: G-Research~spark~R7TXVG.dockerbuild.zip (23.76 kB)
Error: Invalid or unsupported zip format. No END header found
```
https://github.com/G-Research/spark/actions/runs/10733657395/job/29767392437#step:2:27-27

See https://github.com/docker/build-push-action/issues/1167.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tested in GitHub CI.

### Was this patch authored or co-authored using generative AI tooling?
No.