### PR TITLE
[SPARK-49532][DOCS][PS] Improve documentation of "plotting.sample_ratio" option

### DIFF
--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -288,7 +288,7 @@ _options: List[Option] = [
             "'plotting.sample_ratio' sets the proportion of data that will be plotted for sample-"
             "based plots such as `plot.line` and `plot.area`. "
             "If not set, it is derived from 'plotting.max_rows', by calculating the ratio of "
-            "'plotting.max_rows' to the total dataset size."
+            "'plotting.max_rows' to the total data size."
         ),
         default=None,
         types=(float, type(None)),

--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -287,7 +287,7 @@ _options: List[Option] = [
         doc=(
             "'plotting.sample_ratio' sets the proportion of data that will be plotted for sample-"
             "based plots such as `plot.line` and `plot.area`. "
-            "If not set, it is derived from ‘plotting.max_rows’, by calculating the ratio of "
+            "If not set, it is derived from 'plotting.max_rows', by calculating the ratio of "
             "'plotting.max_rows' to the total dataset size."
         ),
         default=None,

--- a/python/pyspark/pandas/config.py
+++ b/python/pyspark/pandas/config.py
@@ -287,7 +287,8 @@ _options: List[Option] = [
         doc=(
             "'plotting.sample_ratio' sets the proportion of data that will be plotted for sample-"
             "based plots such as `plot.line` and `plot.area`. "
-            "This option defaults to 'plotting.max_rows' option."
+            "If not set, it is derived from ‘plotting.max_rows’, by calculating the ratio of "
+            "'plotting.max_rows' to the total dataset size."
         ),
         default=None,
         types=(float, type(None)),


### PR DESCRIPTION
### What changes were proposed in this pull request?
The current documentation incorrectly suggests that "plotting.sample_ratio" **defaults** to "plotting.max_rows". In reality, if "plotting.sample_ratio" is not explicitly set, it is **derived** based on the ratio of "plotting.max_rows" to the dataset size.

### Why are the changes needed?
To avoid misunderstandings about how these options interact. 

### Does this PR introduce _any_ user-facing change?
Doc change only.

### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No.
