### PR TITLE
[SPARK-49511][SQL][FOLLOW-UP] Fix `@see` links to recover Scaladoc build

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/api/KeyValueGroupedDataset.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/api/KeyValueGroupedDataset.scala
@@ -145,7 +145,7 @@ abstract class KeyValueGroupedDataset[K, V, DS[U] <: Dataset[U, DS]] extends Ser
    * complexity.
    *
    * @see
-   *   [[org.apache.spark.sql.api.KeyValueGroupedDataset#flatMapGroups]]
+   *   `org.apache.spark.sql.api.KeyValueGroupedDataset#flatMapGroups`
    * @since 3.4.0
    */
   def flatMapSortedGroups[U: Encoder](sortExprs: Column*)(
@@ -172,7 +172,7 @@ abstract class KeyValueGroupedDataset[K, V, DS[U] <: Dataset[U, DS]] extends Ser
    * complexity.
    *
    * @see
-   *   [[org.apache.spark.sql.api.KeyValueGroupedDataset#flatMapGroups]]
+   *   `org.apache.spark.sql.api.KeyValueGroupedDataset#flatMapGroups`
    * @since 3.4.0
    */
   def flatMapSortedGroups[U](
@@ -987,7 +987,7 @@ abstract class KeyValueGroupedDataset[K, V, DS[U] <: Dataset[U, DS]] extends Ser
    * complexity.
    *
    * @see
-   *   [[org.apache.spark.sql.api.KeyValueGroupedDataset#cogroup]]
+   *   `org.apache.spark.sql.api.KeyValueGroupedDataset#cogroup`
    * @since 3.4.0
    */
   def cogroupSorted[U, R: Encoder](other: KVDS[K, U])(thisSortExprs: Column*)(
@@ -1005,7 +1005,7 @@ abstract class KeyValueGroupedDataset[K, V, DS[U] <: Dataset[U, DS]] extends Ser
    * complexity.
    *
    * @see
-   *   [[org.apache.spark.sql.api.KeyValueGroupedDataset#cogroup]]
+   *   `org.apache.spark.sql.api.KeyValueGroupedDataset#cogroup`
    * @since 3.4.0
    */
   def cogroupSorted[U, R](


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/47989 that fixes Scaladoc failure


### Why are the changes needed?

To recover the build.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually via:

```bash
build/sbt -Pkinesis-asl unidoc
```

### Was this patch authored or co-authored using generative AI tooling?

No.