### PR TITLE
[SPARK-29474] [CORE] [WIP] CLI support for Spark-on-Docker-on-Yarn

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -689,6 +689,24 @@ private[spark] class SparkSubmit extends Logging {
         mergeFn = Some(mergeFileLists(_, _))),
       OptionAssigner(args.archives, YARN, ALL_DEPLOY_MODES, confKey = "spark.yarn.dist.archives",
         mergeFn = Some(mergeFileLists(_, _))),
+      OptionAssigner(
+        if (args.yarnDockerImage != null) "docker" else "",
+        YARN, ALL_DEPLOY_MODES, confKey = "spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_TYPE"),
+      OptionAssigner(
+        args.yarnDockerImage, YARN, ALL_DEPLOY_MODES,
+        confKey = "spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE"),
+      OptionAssigner(
+        args.yarnDockerMounts, YARN, ALL_DEPLOY_MODES,
+        confKey = "spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_MOUNTS"),
+      OptionAssigner(
+        if (args.executorDockerImage != null) "docker" else "",
+        YARN, ALL_DEPLOY_MODES, confKey = "spark.executorEnv.YARN_CONTAINER_RUNTIME_TYPE"),
+      OptionAssigner(
+        args.executorDockerImage, YARN, ALL_DEPLOY_MODES,
+        confKey = "spark.executorEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE"),
+      OptionAssigner(
+        args.executorDockerMounts, YARN, ALL_DEPLOY_MODES,
+        confKey = "spark.executorEnv.YARN_CONTAINER_RUNTIME_DOCKER_MOUNTS"),
 
       // Other options
       OptionAssigner(args.numExecutors, YARN | KUBERNETES, ALL_DEPLOY_MODES,

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -51,6 +51,10 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
   var totalExecutorCores: String = null
   var propertiesFile: String = null
   private var loadSparkDefaults: Boolean = false
+  var yarnDockerImage: String = null;
+  var yarnDockerMounts: String = null;
+  var executorDockerImage: String = null;
+  var executorDockerMounts: String = null;
   var driverMemory: String = null
   var driverExtraClassPath: String = null
   var driverExtraLibraryPath: String = null
@@ -228,6 +232,11 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
       name = Option(name).orElse(env.get("SPARK_YARN_APP_NAME")).orNull
     }
 
+    yarnDockerImage = Option(yarnDockerImage).orNull
+    yarnDockerMounts = Option(yarnDockerMounts).orNull
+    executorDockerImage = Option(executorDockerImage).orNull
+    executorDockerMounts = Option(executorDockerMounts).orNull
+
     // Set name from main class if not given
     name = Option(name).orElse(Option(mainClass)).orNull
     if (name == null && primaryResource != null) {
@@ -324,6 +333,10 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
     |  driverExtraClassPath    $driverExtraClassPath
     |  driverExtraLibraryPath  $driverExtraLibraryPath
     |  driverExtraJavaOptions  $driverExtraJavaOptions
+    |  yarnDockerImage         $yarnDockerImage
+    |  yarnDockerMounts        $yarnDockerMounts
+    |  executorDockerImage     $executorDockerImage
+    |  executorDockerMounts    $executorDockerMounts
     |  supervise               $supervise
     |  queue                   $queue
     |  numExecutors            $numExecutors
@@ -393,6 +406,18 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
 
       case DRIVER_LIBRARY_PATH =>
         driverExtraLibraryPath = value
+
+      case YARN_DOCKER_IMAGE =>
+        yarnDockerImage = value
+
+      case YARN_DOCKER_MOUNTS =>
+        yarnDockerMounts = value
+
+      case EXECUTOR_DOCKER_IMAGE =>
+        executorDockerImage = value
+
+      case EXECUTOR_DOCKER_MOUNTS =>
+        executorDockerMounts = value
 
       case PROPERTIES_FILE =>
         propertiesFile = value
@@ -556,6 +581,16 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
         |                              classpath.
         |
         |  --executor-memory MEM       Memory per executor (e.g. 1000M, 2G) (Default: 1G).
+        |
+        |  --yarn-docker-image         The docker image to use for YARN app master - also sets
+        |                              the YARN app master runtime to docker.
+        |
+        |  --yarn-docker-mounts        The volumes to mount on the YARN docker container.
+        |
+        |  --executor-docker-image     The docker image to use for the executors - also sets the
+        |                              executor runtime to docker.
+        |
+        |  --executor-docker-mounts    The volumes to mount on the executor docker containers.
         |
         |  --proxy-user NAME           User to impersonate when submitting the application.
         |                              This argument does not work with --principal / --keytab.

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitOptionParser.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitOptionParser.java
@@ -46,6 +46,10 @@ class SparkSubmitOptionParser {
   protected final String DRIVER_LIBRARY_PATH = "--driver-library-path";
   protected final String DRIVER_MEMORY = "--driver-memory";
   protected final String EXECUTOR_MEMORY = "--executor-memory";
+  protected final String YARN_DOCKER_IMAGE = "--yarn-docker-image";
+  protected final String YARN_DOCKER_MOUNTS = "--yarn-docker-mounts";
+  protected final String EXECUTOR_DOCKER_IMAGE = "--executor-docker-image";
+  protected final String EXECUTOR_DOCKER_MOUNTS = "--executor-docker-mounts";
   protected final String FILES = "--files";
   protected final String JARS = "--jars";
   protected final String KILL_SUBMISSION = "--kill";
@@ -120,6 +124,10 @@ class SparkSubmitOptionParser {
     { REPOSITORIES },
     { STATUS },
     { TOTAL_EXECUTOR_CORES },
+    { YARN_DOCKER_IMAGE },
+    { YARN_DOCKER_MOUNTS },
+    { EXECUTOR_DOCKER_IMAGE },
+    { EXECUTOR_DOCKER_MOUNTS },
   };
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Introduce four new command line arguments to spark-submit:

```
--yarn-docker-image
--yarn-docker-mounts
--executor-docker-image
--executor-docker-mounts
```

These arguments can be used to simplify the boilerplate code for using docker with YARN, such as: 

```sh
--conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
--conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=repo/image:tag
--conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_MOUNTS="/etc/passwd:/etc/passwd:ro,/etc/hadoop:/etc/hadoop:ro"
--conf spark.executorEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
--conf spark.executorEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=repo/image:tag
--conf spark.executorEnv.YARN_CONTAINER_RUNTIME_DOCKER_MOUNTS="/etc/passwd:/etc/passwd:ro,/etc/hadoop:/etc/hadoop:ro"
```


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The reasoning behind this change is [this issue](https://issues.apache.org/jira/browse/SPARK-29474). It's important to have a more user friendly interface for using docker, instead of the boilerplate aforementioned, where spark/YARN configs for docker stay hidden behind a façade. 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

It adds the aforementioned command line arguments, that will be available on `spark-submit` and subsequently `spark-shell` once this PR is applied.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Tests were added, where it is tested if the configs from the boilerplace are properly applied. It was also tested using Github actions.

To do: test these changes on a real YARN cluster. 


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No. 
