### PR TITLE
[SPARK-49537][SQL] Improve Join stats estimate 

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/JoinEstimation.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/statsEstimation/JoinEstimation.scala
@@ -233,7 +233,8 @@ case class JoinEstimation(join: Join) extends Logging {
     val rightKeyStat = rightStats.attributeStats(rightKey)
     val maxNdv = leftKeyStat.distinctCount.get.max(rightKeyStat.distinctCount.get)
     // Compute cardinality by the basic formula.
-    val card = BigDecimal(leftStats.rowCount.get * rightStats.rowCount.get) / BigDecimal(maxNdv)
+    val card = BigDecimal(leftStats.rowCount.get * rightStats.rowCount.get) /
+      BigDecimal(leftKeyStat.distinctCount.get.min(rightKeyStat.distinctCount.get))
 
     // Get the intersected column stat.
     val newNdv = Some(leftKeyStat.distinctCount.get.min(rightKeyStat.distinctCount.get))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/joinReorder/StarJoinCostBasedReorderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/joinReorder/StarJoinCostBasedReorderSuite.scala
@@ -253,11 +253,11 @@ class StarJoinCostBasedReorderSuite extends JoinReorderPlanTestBase with StatsEs
           (nameToAttr("t2_c2") === nameToAttr("t3_c1")))
 
     val expected =
-      f1.join(d2, Inner, Some(nameToAttr("f1_fk2") === nameToAttr("d2_pk")))
-        .join(d1, Inner, Some(nameToAttr("f1_fk1") === nameToAttr("d1_pk")))
-        .join(t3.join(t2, Inner, Some(nameToAttr("t2_c2") === nameToAttr("t3_c1"))), Inner,
-          Some(nameToAttr("d1_c2") === nameToAttr("t2_c1")))
+      f1.join(d2, Inner, Some(nameToAttr("d2_pk") === nameToAttr("f1_fk2")))
+        .join(d1, Inner, Some(nameToAttr("d1_pk") === nameToAttr("f1_fk1")))
         .join(t1, Inner, Some(nameToAttr("t1_c1") === nameToAttr("f1_c1")))
+        .join(t2.join(t3, Inner, Some(nameToAttr("t3_c1") === nameToAttr("t2_c2"))), Inner,
+          Some(nameToAttr("d1_c2") === nameToAttr("t2_c1")))
         .select(outputsOf(d1, t1, t2, f1, d2, t3): _*)
 
     assertEqualJoinPlans(Optimize, query, expected)
@@ -294,14 +294,15 @@ class StarJoinCostBasedReorderSuite extends JoinReorderPlanTestBase with StatsEs
           (nameToAttr("f1_fk2") === nameToAttr("d2_pk")))
 
     val expected =
-      f1
-        .join(d2, Inner, Some(nameToAttr("f1_fk2") === nameToAttr("d2_pk")))
-        .join(d1, Inner, Some(nameToAttr("f1_fk1") === nameToAttr("d1_pk")))
-        .join(t3.join(t4, Inner, Some(nameToAttr("t3_c1") === nameToAttr("t4_c1"))), Inner,
-          Some(nameToAttr("d1_c2") === nameToAttr("t4_c1")))
-        .join(t1.join(t2, Inner, Some(nameToAttr("t1_c1") === nameToAttr("t2_c1"))), Inner,
-          Some(nameToAttr("t1_c2") === nameToAttr("t4_c2")))
-        .select(outputsOf(d1, t1, t2, t3, t4, f1, d2): _*)
+      t4
+        .join(t3, Inner, Some(nameToAttr("t4_c1") === nameToAttr("t3_c1")))
+        .join(
+          t1.join(t2, Inner, Some(nameToAttr("t2_c1") === nameToAttr("t1_c1"))),
+          Inner, Some(nameToAttr("t4_c2") === nameToAttr("t1_c2")))
+        .join(
+          f1.join(d2, Inner, Some(nameToAttr("d2_pk") === nameToAttr("f1_fk2")))
+            .join(d1, Inner, Some(nameToAttr("d1_pk") === nameToAttr("f1_fk1"))), Inner,
+          Some(nameToAttr("d1_c2") === nameToAttr("t4_c3")))
 
     assertEqualJoinPlans(Optimize, query, expected)
   }
@@ -345,15 +346,15 @@ class StarJoinCostBasedReorderSuite extends JoinReorderPlanTestBase with StatsEs
           (nameToAttr("t1_c2") === nameToAttr("t2_c2")))
 
     val expected =
-      f1.join(d3, Inner, Some(nameToAttr("f1_fk3") === nameToAttr("d3_pk")))
-        .join(d2, Inner, Some(nameToAttr("f1_fk2") === nameToAttr("d2_pk")))
-        .join(d1, Inner, Some(nameToAttr("f1_fk1") === nameToAttr("d1_pk")))
-        .join(t4.join(t3, Inner, Some(nameToAttr("t3_c2") === nameToAttr("t4_c2"))), Inner,
-          Some(nameToAttr("d1_c2") === nameToAttr("t3_c1")))
-        .join(t2.join(t1, Inner, Some(nameToAttr("t1_c2") === nameToAttr("t2_c2"))), Inner,
-          Some(nameToAttr("d3_c2") === nameToAttr("t1_c1")))
-        .join(t5.join(t6, Inner, Some(nameToAttr("t5_c2") === nameToAttr("t6_c2"))), Inner,
-          Some(nameToAttr("d2_c2") === nameToAttr("t5_c1")))
+      f1.join(d2, Inner, Some(nameToAttr("d2_pk") === nameToAttr("f1_fk2")))
+        .join(d3, Inner, Some(nameToAttr("f1_fk3") === nameToAttr("d3_pk")))
+        .join(d1, Inner, Some(nameToAttr("d1_pk") === nameToAttr("f1_fk1")))
+        .join(t5.join(t6, Inner, Some(nameToAttr("t6_c2") === nameToAttr("t5_c2"))), Inner,
+          Some(nameToAttr("t5_c1") === nameToAttr("d2_c2")))
+        .join(t3.join(t4, Inner, Some(nameToAttr("t4_c2") === nameToAttr("t3_c2"))), Inner,
+          Some(nameToAttr("t3_c1") === nameToAttr("d1_c2")))
+        .join(t1.join(t2, Inner, Some(nameToAttr("t2_c2") === nameToAttr("t1_c2"))), Inner,
+          Some(nameToAttr("t1_c1") === nameToAttr("d3_c2")))
         .select(outputsOf(d1, t3, t4, f1, d3, d2, t5, t6, t1, t2): _*)
 
     assertEqualJoinPlans(Optimize, query, expected)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/joinReorder/StarJoinCostBasedReorderSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/joinReorder/StarJoinCostBasedReorderSuite.scala
@@ -303,6 +303,7 @@ class StarJoinCostBasedReorderSuite extends JoinReorderPlanTestBase with StatsEs
           f1.join(d2, Inner, Some(nameToAttr("d2_pk") === nameToAttr("f1_fk2")))
             .join(d1, Inner, Some(nameToAttr("d1_pk") === nameToAttr("f1_fk1"))), Inner,
           Some(nameToAttr("d1_c2") === nameToAttr("t4_c3")))
+        .select(outputsOf(d1, t1, t2, t3, t4, f1, d2): _*)
 
     assertEqualJoinPlans(Optimize, query, expected)
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/JoinEstimationSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/statsEstimation/JoinEstimationSuite.scala
@@ -373,11 +373,11 @@ class JoinEstimationSuite extends StatsEstimationTestBase {
       nullCount = Some(0), avgLen = Some(4), maxLen = Some(4))
     // Update column stat for other column if #outputRow / #sideRow < 1 (key-5-9), or keep it
     // unchanged (key-2-4).
-    val colStatForkey59 = nameToColInfo("key-5-9")._2.copy(distinctCount = Some(5 * 3 / 5))
+    val colStatForkey59 = nameToColInfo("key-5-9")._2.copy(distinctCount = Some(5 * 3 / 3))
 
     val expectedStats = Statistics(
-      sizeInBytes = 3 * (8 + 4 * 4),
-      rowCount = Some(3),
+      sizeInBytes = 8 * (8 + 4 * 4),
+      rowCount = Some(8),
       attributeStats = AttributeMap(
         Seq(nameToAttr("key-1-5") -> joinedColStat, nameToAttr("key-1-2") -> joinedColStat,
           nameToAttr("key-5-9") -> colStatForkey59, nameToColInfo("key-2-4"))))
@@ -398,8 +398,8 @@ class JoinEstimationSuite extends StatsEstimationTestBase {
       nullCount = Some(0), avgLen = Some(4), maxLen = Some(4))
 
     val expectedStats = Statistics(
-      sizeInBytes = 2 * (8 + 4 * 4),
-      rowCount = Some(2),
+      sizeInBytes = 3 * (8 + 4 * 4),
+      rowCount = Some(3),
       attributeStats = AttributeMap(
         Seq(nameToAttr("key-1-2") -> joinedColStat1, nameToAttr("key-1-2") -> joinedColStat1,
           nameToAttr("key-2-4") -> joinedColStat2, nameToAttr("key-2-3") -> joinedColStat2)))
@@ -415,8 +415,8 @@ class JoinEstimationSuite extends StatsEstimationTestBase {
       nullCount = Some(0), avgLen = Some(4), maxLen = Some(4))
 
     val expectedStats = Statistics(
-      sizeInBytes = 2 * (8 + 4 * 4),
-      rowCount = Some(2),
+      sizeInBytes = 3 * (8 + 4 * 4),
+      rowCount = Some(3),
       // Keep the column stat from left side unchanged.
       attributeStats = AttributeMap(
         Seq(nameToColInfo("key-1-2"), nameToColInfo("key-2-3"),
@@ -433,8 +433,8 @@ class JoinEstimationSuite extends StatsEstimationTestBase {
       nullCount = Some(0), avgLen = Some(4), maxLen = Some(4))
 
     val expectedStats = Statistics(
-      sizeInBytes = 2 * (8 + 4 * 4),
-      rowCount = Some(2),
+      sizeInBytes = 3 * (8 + 4 * 4),
+      rowCount = Some(3),
       // Keep the column stat from right side unchanged.
       attributeStats = AttributeMap(
         Seq(nameToColInfo("key-1-2"), nameToAttr("key-2-4") -> joinedColStat,

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10.sf100/explain.txt
@@ -1,52 +1,55 @@
 == Physical Plan ==
-TakeOrderedAndProject (48)
-+- * HashAggregate (47)
-   +- Exchange (46)
-      +- * HashAggregate (45)
-         +- * Project (44)
-            +- * BroadcastHashJoin Inner BuildLeft (43)
-               :- BroadcastExchange (39)
-               :  +- * Project (38)
-               :     +- * BroadcastHashJoin Inner BuildRight (37)
-               :        :- * Project (31)
-               :        :  +- * SortMergeJoin LeftSemi (30)
-               :        :     :- * SortMergeJoin LeftSemi (21)
-               :        :     :  :- * Sort (5)
-               :        :     :  :  +- Exchange (4)
-               :        :     :  :     +- * Filter (3)
-               :        :     :  :        +- * ColumnarToRow (2)
-               :        :     :  :           +- Scan parquet spark_catalog.default.customer (1)
-               :        :     :  +- * Sort (20)
-               :        :     :     +- Exchange (19)
-               :        :     :        +- Union (18)
-               :        :     :           :- * Project (11)
-               :        :     :           :  +- * BroadcastHashJoin Inner BuildRight (10)
-               :        :     :           :     :- * Filter (8)
-               :        :     :           :     :  +- * ColumnarToRow (7)
-               :        :     :           :     :     +- Scan parquet spark_catalog.default.web_sales (6)
-               :        :     :           :     +- ReusedExchange (9)
-               :        :     :           +- * Project (17)
-               :        :     :              +- * BroadcastHashJoin Inner BuildRight (16)
-               :        :     :                 :- * Filter (14)
-               :        :     :                 :  +- * ColumnarToRow (13)
-               :        :     :                 :     +- Scan parquet spark_catalog.default.catalog_sales (12)
-               :        :     :                 +- ReusedExchange (15)
-               :        :     +- * Sort (29)
-               :        :        +- Exchange (28)
-               :        :           +- * Project (27)
-               :        :              +- * BroadcastHashJoin Inner BuildRight (26)
-               :        :                 :- * Filter (24)
-               :        :                 :  +- * ColumnarToRow (23)
-               :        :                 :     +- Scan parquet spark_catalog.default.store_sales (22)
-               :        :                 +- ReusedExchange (25)
-               :        +- BroadcastExchange (36)
-               :           +- * Project (35)
-               :              +- * Filter (34)
-               :                 +- * ColumnarToRow (33)
-               :                    +- Scan parquet spark_catalog.default.customer_address (32)
-               +- * Filter (42)
-                  +- * ColumnarToRow (41)
-                     +- Scan parquet spark_catalog.default.customer_demographics (40)
+TakeOrderedAndProject (51)
++- * HashAggregate (50)
+   +- Exchange (49)
+      +- * HashAggregate (48)
+         +- * Project (47)
+            +- * SortMergeJoin Inner (46)
+               :- * Sort (40)
+               :  +- Exchange (39)
+               :     +- * Project (38)
+               :        +- * BroadcastHashJoin Inner BuildRight (37)
+               :           :- * Project (31)
+               :           :  +- * SortMergeJoin LeftSemi (30)
+               :           :     :- * SortMergeJoin LeftSemi (21)
+               :           :     :  :- * Sort (5)
+               :           :     :  :  +- Exchange (4)
+               :           :     :  :     +- * Filter (3)
+               :           :     :  :        +- * ColumnarToRow (2)
+               :           :     :  :           +- Scan parquet spark_catalog.default.customer (1)
+               :           :     :  +- * Sort (20)
+               :           :     :     +- Exchange (19)
+               :           :     :        +- Union (18)
+               :           :     :           :- * Project (11)
+               :           :     :           :  +- * BroadcastHashJoin Inner BuildRight (10)
+               :           :     :           :     :- * Filter (8)
+               :           :     :           :     :  +- * ColumnarToRow (7)
+               :           :     :           :     :     +- Scan parquet spark_catalog.default.web_sales (6)
+               :           :     :           :     +- ReusedExchange (9)
+               :           :     :           +- * Project (17)
+               :           :     :              +- * BroadcastHashJoin Inner BuildRight (16)
+               :           :     :                 :- * Filter (14)
+               :           :     :                 :  +- * ColumnarToRow (13)
+               :           :     :                 :     +- Scan parquet spark_catalog.default.catalog_sales (12)
+               :           :     :                 +- ReusedExchange (15)
+               :           :     +- * Sort (29)
+               :           :        +- Exchange (28)
+               :           :           +- * Project (27)
+               :           :              +- * BroadcastHashJoin Inner BuildRight (26)
+               :           :                 :- * Filter (24)
+               :           :                 :  +- * ColumnarToRow (23)
+               :           :                 :     +- Scan parquet spark_catalog.default.store_sales (22)
+               :           :                 +- ReusedExchange (25)
+               :           +- BroadcastExchange (36)
+               :              +- * Project (35)
+               :                 +- * Filter (34)
+               :                    +- * ColumnarToRow (33)
+               :                       +- Scan parquet spark_catalog.default.customer_address (32)
+               +- * Sort (45)
+                  +- Exchange (44)
+                     +- * Filter (43)
+                        +- * ColumnarToRow (42)
+                           +- Scan parquet spark_catalog.default.customer_demographics (41)
 
 
 (1) Scan parquet spark_catalog.default.customer
@@ -86,7 +89,7 @@ Input [2]: [ws_bill_customer_sk#6, ws_sold_date_sk#7]
 Input [2]: [ws_bill_customer_sk#6, ws_sold_date_sk#7]
 Condition : isnotnull(ws_bill_customer_sk#6)
 
-(9) ReusedExchange [Reuses operator id: 60]
+(9) ReusedExchange [Reuses operator id: 63]
 Output [1]: [d_date_sk#9]
 
 (10) BroadcastHashJoin [codegen id : 4]
@@ -114,7 +117,7 @@ Input [2]: [cs_ship_customer_sk#11, cs_sold_date_sk#12]
 Input [2]: [cs_ship_customer_sk#11, cs_sold_date_sk#12]
 Condition : isnotnull(cs_ship_customer_sk#11)
 
-(15) ReusedExchange [Reuses operator id: 60]
+(15) ReusedExchange [Reuses operator id: 63]
 Output [1]: [d_date_sk#13]
 
 (16) BroadcastHashJoin [codegen id : 6]
@@ -158,7 +161,7 @@ Input [2]: [ss_customer_sk#15, ss_sold_date_sk#16]
 Input [2]: [ss_customer_sk#15, ss_sold_date_sk#16]
 Condition : isnotnull(ss_customer_sk#15)
 
-(25) ReusedExchange [Reuses operator id: 60]
+(25) ReusedExchange [Reuses operator id: 63]
 Output [1]: [d_date_sk#17]
 
 (26) BroadcastHashJoin [codegen id : 10]
@@ -221,98 +224,110 @@ Join condition: None
 Output [1]: [c_current_cdemo_sk#2]
 Input [3]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#19]
 
-(39) BroadcastExchange
+(39) Exchange
 Input [1]: [c_current_cdemo_sk#2]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+Arguments: hashpartitioning(c_current_cdemo_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(40) Scan parquet spark_catalog.default.customer_demographics
+(40) Sort [codegen id : 14]
+Input [1]: [c_current_cdemo_sk#2]
+Arguments: [c_current_cdemo_sk#2 ASC NULLS FIRST], false, 0
+
+(41) Scan parquet spark_catalog.default.customer_demographics
 Output [9]: [cd_demo_sk#21, cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_education_status:string,cd_purchase_estimate:int,cd_credit_rating:string,cd_dep_count:int,cd_dep_employed_count:int,cd_dep_college_count:int>
 
-(41) ColumnarToRow
+(42) ColumnarToRow [codegen id : 15]
 Input [9]: [cd_demo_sk#21, cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
 
-(42) Filter
+(43) Filter [codegen id : 15]
 Input [9]: [cd_demo_sk#21, cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
 Condition : isnotnull(cd_demo_sk#21)
 
-(43) BroadcastHashJoin [codegen id : 14]
+(44) Exchange
+Input [9]: [cd_demo_sk#21, cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
+Arguments: hashpartitioning(cd_demo_sk#21, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(45) Sort [codegen id : 16]
+Input [9]: [cd_demo_sk#21, cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
+Arguments: [cd_demo_sk#21 ASC NULLS FIRST], false, 0
+
+(46) SortMergeJoin [codegen id : 17]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#21]
 Join type: Inner
 Join condition: None
 
-(44) Project [codegen id : 14]
+(47) Project [codegen id : 17]
 Output [8]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
 Input [10]: [c_current_cdemo_sk#2, cd_demo_sk#21, cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
 
-(45) HashAggregate [codegen id : 14]
+(48) HashAggregate [codegen id : 17]
 Input [8]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
 Keys [8]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
 Functions [1]: [partial_count(1)]
 Aggregate Attributes [1]: [count#30]
 Results [9]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29, count#31]
 
-(46) Exchange
+(49) Exchange
 Input [9]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29, count#31]
-Arguments: hashpartitioning(cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Arguments: hashpartitioning(cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(47) HashAggregate [codegen id : 15]
+(50) HashAggregate [codegen id : 18]
 Input [9]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29, count#31]
 Keys [8]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cd_purchase_estimate#25, cd_credit_rating#26, cd_dep_count#27, cd_dep_employed_count#28, cd_dep_college_count#29]
 Functions [1]: [count(1)]
 Aggregate Attributes [1]: [count(1)#32]
 Results [14]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, count(1)#32 AS cnt1#33, cd_purchase_estimate#25, count(1)#32 AS cnt2#34, cd_credit_rating#26, count(1)#32 AS cnt3#35, cd_dep_count#27, count(1)#32 AS cnt4#36, cd_dep_employed_count#28, count(1)#32 AS cnt5#37, cd_dep_college_count#29, count(1)#32 AS cnt6#38]
 
-(48) TakeOrderedAndProject
+(51) TakeOrderedAndProject
 Input [14]: [cd_gender#22, cd_marital_status#23, cd_education_status#24, cnt1#33, cd_purchase_estimate#25, cnt2#34, cd_credit_rating#26, cnt3#35, cd_dep_count#27, cnt4#36, cd_dep_employed_count#28, cnt5#37, cd_dep_college_count#29, cnt6#38]
 Arguments: 100, [cd_gender#22 ASC NULLS FIRST, cd_marital_status#23 ASC NULLS FIRST, cd_education_status#24 ASC NULLS FIRST, cd_purchase_estimate#25 ASC NULLS FIRST, cd_credit_rating#26 ASC NULLS FIRST, cd_dep_count#27 ASC NULLS FIRST, cd_dep_employed_count#28 ASC NULLS FIRST, cd_dep_college_count#29 ASC NULLS FIRST], [cd_gender#22, cd_marital_status#23, cd_education_status#24, cnt1#33, cd_purchase_estimate#25, cnt2#34, cd_credit_rating#26, cnt3#35, cd_dep_count#27, cnt4#36, cd_dep_employed_count#28, cnt5#37, cd_dep_college_count#29, cnt6#38]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#4, [id=#5]
-ObjectHashAggregate (55)
-+- Exchange (54)
-   +- ObjectHashAggregate (53)
-      +- * Project (52)
-         +- * Filter (51)
-            +- * ColumnarToRow (50)
-               +- Scan parquet spark_catalog.default.customer_address (49)
+ObjectHashAggregate (58)
++- Exchange (57)
+   +- ObjectHashAggregate (56)
+      +- * Project (55)
+         +- * Filter (54)
+            +- * ColumnarToRow (53)
+               +- Scan parquet spark_catalog.default.customer_address (52)
 
 
-(49) Scan parquet spark_catalog.default.customer_address
+(52) Scan parquet spark_catalog.default.customer_address
 Output [2]: [ca_address_sk#19, ca_county#20]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_county, [Dona Ana County,Douglas County,Gaines County,Richland County,Walker County]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
-(50) ColumnarToRow [codegen id : 1]
+(53) ColumnarToRow [codegen id : 1]
 Input [2]: [ca_address_sk#19, ca_county#20]
 
-(51) Filter [codegen id : 1]
+(54) Filter [codegen id : 1]
 Input [2]: [ca_address_sk#19, ca_county#20]
 Condition : (ca_county#20 IN (Walker County,Richland County,Gaines County,Douglas County,Dona Ana County) AND isnotnull(ca_address_sk#19))
 
-(52) Project [codegen id : 1]
+(55) Project [codegen id : 1]
 Output [1]: [ca_address_sk#19]
 Input [2]: [ca_address_sk#19, ca_county#20]
 
-(53) ObjectHashAggregate
+(56) ObjectHashAggregate
 Input [1]: [ca_address_sk#19]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#19, 42), 2555, 57765, 0, 0)]
 Aggregate Attributes [1]: [buf#39]
 Results [1]: [buf#40]
 
-(54) Exchange
+(57) Exchange
 Input [1]: [buf#40]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
-(55) ObjectHashAggregate
+(58) ObjectHashAggregate
 Input [1]: [buf#40]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#19, 42), 2555, 57765, 0, 0)]
@@ -320,34 +335,34 @@ Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#19, 42), 2555
 Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#19, 42), 2555, 57765, 0, 0)#41 AS bloomFilter#42]
 
 Subquery:2 Hosting operator id = 6 Hosting Expression = ws_sold_date_sk#7 IN dynamicpruning#8
-BroadcastExchange (60)
-+- * Project (59)
-   +- * Filter (58)
-      +- * ColumnarToRow (57)
-         +- Scan parquet spark_catalog.default.date_dim (56)
+BroadcastExchange (63)
++- * Project (62)
+   +- * Filter (61)
+      +- * ColumnarToRow (60)
+         +- Scan parquet spark_catalog.default.date_dim (59)
 
 
-(56) Scan parquet spark_catalog.default.date_dim
+(59) Scan parquet spark_catalog.default.date_dim
 Output [3]: [d_date_sk#9, d_year#43, d_moy#44]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2002), GreaterThanOrEqual(d_moy,4), LessThanOrEqual(d_moy,7), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(57) ColumnarToRow [codegen id : 1]
+(60) ColumnarToRow [codegen id : 1]
 Input [3]: [d_date_sk#9, d_year#43, d_moy#44]
 
-(58) Filter [codegen id : 1]
+(61) Filter [codegen id : 1]
 Input [3]: [d_date_sk#9, d_year#43, d_moy#44]
 Condition : (((((isnotnull(d_year#43) AND isnotnull(d_moy#44)) AND (d_year#43 = 2002)) AND (d_moy#44 >= 4)) AND (d_moy#44 <= 7)) AND isnotnull(d_date_sk#9))
 
-(59) Project [codegen id : 1]
+(62) Project [codegen id : 1]
 Output [1]: [d_date_sk#9]
 Input [3]: [d_date_sk#9, d_year#43, d_moy#44]
 
-(60) BroadcastExchange
+(63) BroadcastExchange
 Input [1]: [d_date_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
 Subquery:3 Hosting operator id = 12 Hosting Expression = cs_sold_date_sk#12 IN dynamicpruning#8
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q10.sf100/simplified.txt
@@ -1,99 +1,108 @@
 TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count,cnt1,cnt2,cnt3,cnt4,cnt5,cnt6]
-  WholeStageCodegen (15)
+  WholeStageCodegen (18)
     HashAggregate [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count,count] [count(1),cnt1,cnt2,cnt3,cnt4,cnt5,cnt6,count]
       InputAdapter
         Exchange [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count] #1
-          WholeStageCodegen (14)
+          WholeStageCodegen (17)
             HashAggregate [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count] [count,count]
               Project [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count]
-                BroadcastHashJoin [c_current_cdemo_sk,cd_demo_sk]
+                SortMergeJoin [c_current_cdemo_sk,cd_demo_sk]
                   InputAdapter
-                    BroadcastExchange #2
-                      WholeStageCodegen (13)
-                        Project [c_current_cdemo_sk]
-                          BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
-                            Project [c_current_cdemo_sk,c_current_addr_sk]
-                              SortMergeJoin [c_customer_sk,customer_sk]
-                                InputAdapter
-                                  WholeStageCodegen (8)
+                    WholeStageCodegen (14)
+                      Sort [c_current_cdemo_sk]
+                        InputAdapter
+                          Exchange [c_current_cdemo_sk] #2
+                            WholeStageCodegen (13)
+                              Project [c_current_cdemo_sk]
+                                BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
+                                  Project [c_current_cdemo_sk,c_current_addr_sk]
                                     SortMergeJoin [c_customer_sk,customer_sk]
                                       InputAdapter
-                                        WholeStageCodegen (2)
-                                          Sort [c_customer_sk]
+                                        WholeStageCodegen (8)
+                                          SortMergeJoin [c_customer_sk,customer_sk]
                                             InputAdapter
-                                              Exchange [c_customer_sk] #3
-                                                WholeStageCodegen (1)
-                                                  Filter [c_customer_sk,c_current_addr_sk,c_current_cdemo_sk]
-                                                    Subquery #1
-                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 2555, 57765, 0, 0),bloomFilter,buf]
-                                                        Exchange #4
-                                                          ObjectHashAggregate [ca_address_sk] [buf,buf]
-                                                            WholeStageCodegen (1)
-                                                              Project [ca_address_sk]
-                                                                Filter [ca_county,ca_address_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
-                                                    ColumnarToRow
-                                                      InputAdapter
-                                                        Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
+                                              WholeStageCodegen (2)
+                                                Sort [c_customer_sk]
+                                                  InputAdapter
+                                                    Exchange [c_customer_sk] #3
+                                                      WholeStageCodegen (1)
+                                                        Filter [c_customer_sk,c_current_addr_sk,c_current_cdemo_sk]
+                                                          Subquery #1
+                                                            ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 2555, 57765, 0, 0),bloomFilter,buf]
+                                                              Exchange #4
+                                                                ObjectHashAggregate [ca_address_sk] [buf,buf]
+                                                                  WholeStageCodegen (1)
+                                                                    Project [ca_address_sk]
+                                                                      Filter [ca_county,ca_address_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
+                                            InputAdapter
+                                              WholeStageCodegen (7)
+                                                Sort [customer_sk]
+                                                  InputAdapter
+                                                    Exchange [customer_sk] #5
+                                                      Union
+                                                        WholeStageCodegen (4)
+                                                          Project [ws_bill_customer_sk]
+                                                            BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                              Filter [ws_bill_customer_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
+                                                                      SubqueryBroadcast [d_date_sk] #2
+                                                                        BroadcastExchange #6
+                                                                          WholeStageCodegen (1)
+                                                                            Project [d_date_sk]
+                                                                              Filter [d_year,d_moy,d_date_sk]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                                                              InputAdapter
+                                                                ReusedExchange [d_date_sk] #6
+                                                        WholeStageCodegen (6)
+                                                          Project [cs_ship_customer_sk]
+                                                            BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                              Filter [cs_ship_customer_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet spark_catalog.default.catalog_sales [cs_ship_customer_sk,cs_sold_date_sk]
+                                                                      ReusedSubquery [d_date_sk] #2
+                                                              InputAdapter
+                                                                ReusedExchange [d_date_sk] #6
                                       InputAdapter
-                                        WholeStageCodegen (7)
+                                        WholeStageCodegen (11)
                                           Sort [customer_sk]
                                             InputAdapter
-                                              Exchange [customer_sk] #5
-                                                Union
-                                                  WholeStageCodegen (4)
-                                                    Project [ws_bill_customer_sk]
-                                                      BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                        Filter [ws_bill_customer_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
-                                                                SubqueryBroadcast [d_date_sk] #2
-                                                                  BroadcastExchange #6
-                                                                    WholeStageCodegen (1)
-                                                                      Project [d_date_sk]
-                                                                        Filter [d_year,d_moy,d_date_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
-                                                        InputAdapter
-                                                          ReusedExchange [d_date_sk] #6
-                                                  WholeStageCodegen (6)
-                                                    Project [cs_ship_customer_sk]
-                                                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                        Filter [cs_ship_customer_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.catalog_sales [cs_ship_customer_sk,cs_sold_date_sk]
-                                                                ReusedSubquery [d_date_sk] #2
-                                                        InputAdapter
-                                                          ReusedExchange [d_date_sk] #6
-                                InputAdapter
-                                  WholeStageCodegen (11)
-                                    Sort [customer_sk]
-                                      InputAdapter
-                                        Exchange [customer_sk] #7
-                                          WholeStageCodegen (10)
-                                            Project [ss_customer_sk]
-                                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                Filter [ss_customer_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
-                                                        ReusedSubquery [d_date_sk] #2
-                                                InputAdapter
-                                                  ReusedExchange [d_date_sk] #6
-                            InputAdapter
-                              BroadcastExchange #8
-                                WholeStageCodegen (12)
-                                  Project [ca_address_sk]
-                                    Filter [ca_county,ca_address_sk]
-                                      ColumnarToRow
-                                        InputAdapter
-                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
-                  Filter [cd_demo_sk]
-                    ColumnarToRow
-                      InputAdapter
-                        Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count]
+                                              Exchange [customer_sk] #7
+                                                WholeStageCodegen (10)
+                                                  Project [ss_customer_sk]
+                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                      Filter [ss_customer_sk]
+                                                        ColumnarToRow
+                                                          InputAdapter
+                                                            Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
+                                                              ReusedSubquery [d_date_sk] #2
+                                                      InputAdapter
+                                                        ReusedExchange [d_date_sk] #6
+                                  InputAdapter
+                                    BroadcastExchange #8
+                                      WholeStageCodegen (12)
+                                        Project [ca_address_sk]
+                                          Filter [ca_county,ca_address_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
+                  InputAdapter
+                    WholeStageCodegen (16)
+                      Sort [cd_demo_sk]
+                        InputAdapter
+                          Exchange [cd_demo_sk] #9
+                            WholeStageCodegen (15)
+                              Filter [cd_demo_sk]
+                                ColumnarToRow
+                                  InputAdapter
+                                    Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19.sf100/explain.txt
@@ -1,43 +1,49 @@
 == Physical Plan ==
-TakeOrderedAndProject (39)
-+- * HashAggregate (38)
-   +- Exchange (37)
-      +- * HashAggregate (36)
-         +- * Project (35)
-            +- * BroadcastHashJoin Inner BuildRight (34)
-               :- * Project (28)
-               :  +- * BroadcastHashJoin Inner BuildLeft (27)
-               :     :- BroadcastExchange (23)
-               :     :  +- * Project (22)
-               :     :     +- * BroadcastHashJoin Inner BuildRight (21)
-               :     :        :- * Project (16)
-               :     :        :  +- * BroadcastHashJoin Inner BuildLeft (15)
-               :     :        :     :- BroadcastExchange (11)
-               :     :        :     :  +- * Project (10)
-               :     :        :     :     +- * BroadcastHashJoin Inner BuildLeft (9)
-               :     :        :     :        :- BroadcastExchange (5)
-               :     :        :     :        :  +- * Project (4)
-               :     :        :     :        :     +- * Filter (3)
-               :     :        :     :        :        +- * ColumnarToRow (2)
-               :     :        :     :        :           +- Scan parquet spark_catalog.default.date_dim (1)
-               :     :        :     :        +- * Filter (8)
-               :     :        :     :           +- * ColumnarToRow (7)
-               :     :        :     :              +- Scan parquet spark_catalog.default.store_sales (6)
-               :     :        :     +- * Filter (14)
-               :     :        :        +- * ColumnarToRow (13)
-               :     :        :           +- Scan parquet spark_catalog.default.customer (12)
-               :     :        +- BroadcastExchange (20)
-               :     :           +- * Filter (19)
-               :     :              +- * ColumnarToRow (18)
-               :     :                 +- Scan parquet spark_catalog.default.store (17)
-               :     +- * Filter (26)
-               :        +- * ColumnarToRow (25)
-               :           +- Scan parquet spark_catalog.default.customer_address (24)
-               +- BroadcastExchange (33)
-                  +- * Project (32)
-                     +- * Filter (31)
-                        +- * ColumnarToRow (30)
-                           +- Scan parquet spark_catalog.default.item (29)
+TakeOrderedAndProject (45)
++- * HashAggregate (44)
+   +- Exchange (43)
+      +- * HashAggregate (42)
+         +- * Project (41)
+            +- * BroadcastHashJoin Inner BuildRight (40)
+               :- * Project (35)
+               :  +- * SortMergeJoin Inner (34)
+               :     :- * Sort (19)
+               :     :  +- Exchange (18)
+               :     :     +- * Project (17)
+               :     :        +- * BroadcastHashJoin Inner BuildRight (16)
+               :     :           :- * Project (10)
+               :     :           :  +- * BroadcastHashJoin Inner BuildLeft (9)
+               :     :           :     :- BroadcastExchange (5)
+               :     :           :     :  +- * Project (4)
+               :     :           :     :     +- * Filter (3)
+               :     :           :     :        +- * ColumnarToRow (2)
+               :     :           :     :           +- Scan parquet spark_catalog.default.date_dim (1)
+               :     :           :     +- * Filter (8)
+               :     :           :        +- * ColumnarToRow (7)
+               :     :           :           +- Scan parquet spark_catalog.default.store_sales (6)
+               :     :           +- BroadcastExchange (15)
+               :     :              +- * Project (14)
+               :     :                 +- * Filter (13)
+               :     :                    +- * ColumnarToRow (12)
+               :     :                       +- Scan parquet spark_catalog.default.item (11)
+               :     +- * Sort (33)
+               :        +- Exchange (32)
+               :           +- * Project (31)
+               :              +- * SortMergeJoin Inner (30)
+               :                 :- * Sort (24)
+               :                 :  +- Exchange (23)
+               :                 :     +- * Filter (22)
+               :                 :        +- * ColumnarToRow (21)
+               :                 :           +- Scan parquet spark_catalog.default.customer (20)
+               :                 +- * Sort (29)
+               :                    +- Exchange (28)
+               :                       +- * Filter (27)
+               :                          +- * ColumnarToRow (26)
+               :                             +- Scan parquet spark_catalog.default.customer_address (25)
+               +- BroadcastExchange (39)
+                  +- * Filter (38)
+                     +- * ColumnarToRow (37)
+                        +- Scan parquet spark_catalog.default.store (36)
 
 
 (1) Scan parquet spark_catalog.default.date_dim
@@ -77,161 +83,185 @@ Input [5]: [ss_item_sk#4, ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7,
 Input [5]: [ss_item_sk#4, ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7, ss_sold_date_sk#8]
 Condition : ((isnotnull(ss_item_sk#4) AND isnotnull(ss_customer_sk#5)) AND isnotnull(ss_store_sk#6))
 
-(9) BroadcastHashJoin [codegen id : 2]
+(9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [d_date_sk#1]
 Right keys [1]: [ss_sold_date_sk#8]
 Join type: Inner
 Join condition: None
 
-(10) Project [codegen id : 2]
+(10) Project [codegen id : 3]
 Output [4]: [ss_item_sk#4, ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7]
 Input [6]: [d_date_sk#1, ss_item_sk#4, ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7, ss_sold_date_sk#8]
 
-(11) BroadcastExchange
-Input [4]: [ss_item_sk#4, ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [plan_id=2]
-
-(12) Scan parquet spark_catalog.default.customer
-Output [2]: [c_customer_sk#10, c_current_addr_sk#11]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer]
-PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
-ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
-
-(13) ColumnarToRow
-Input [2]: [c_customer_sk#10, c_current_addr_sk#11]
-
-(14) Filter
-Input [2]: [c_customer_sk#10, c_current_addr_sk#11]
-Condition : (isnotnull(c_customer_sk#10) AND isnotnull(c_current_addr_sk#11))
-
-(15) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_customer_sk#5]
-Right keys [1]: [c_customer_sk#10]
-Join type: Inner
-Join condition: None
-
-(16) Project [codegen id : 4]
-Output [4]: [ss_item_sk#4, ss_store_sk#6, ss_ext_sales_price#7, c_current_addr_sk#11]
-Input [6]: [ss_item_sk#4, ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7, c_customer_sk#10, c_current_addr_sk#11]
-
-(17) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#12, s_zip#13]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_zip), IsNotNull(s_store_sk)]
-ReadSchema: struct<s_store_sk:int,s_zip:string>
-
-(18) ColumnarToRow [codegen id : 3]
-Input [2]: [s_store_sk#12, s_zip#13]
-
-(19) Filter [codegen id : 3]
-Input [2]: [s_store_sk#12, s_zip#13]
-Condition : (isnotnull(s_zip#13) AND isnotnull(s_store_sk#12))
-
-(20) BroadcastExchange
-Input [2]: [s_store_sk#12, s_zip#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
-
-(21) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_store_sk#6]
-Right keys [1]: [s_store_sk#12]
-Join type: Inner
-Join condition: None
-
-(22) Project [codegen id : 4]
-Output [4]: [ss_item_sk#4, ss_ext_sales_price#7, c_current_addr_sk#11, s_zip#13]
-Input [6]: [ss_item_sk#4, ss_store_sk#6, ss_ext_sales_price#7, c_current_addr_sk#11, s_store_sk#12, s_zip#13]
-
-(23) BroadcastExchange
-Input [4]: [ss_item_sk#4, ss_ext_sales_price#7, c_current_addr_sk#11, s_zip#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [plan_id=4]
-
-(24) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#14, ca_zip#15]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_zip)]
-ReadSchema: struct<ca_address_sk:int,ca_zip:string>
-
-(25) ColumnarToRow
-Input [2]: [ca_address_sk#14, ca_zip#15]
-
-(26) Filter
-Input [2]: [ca_address_sk#14, ca_zip#15]
-Condition : (isnotnull(ca_address_sk#14) AND isnotnull(ca_zip#15))
-
-(27) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [c_current_addr_sk#11]
-Right keys [1]: [ca_address_sk#14]
-Join type: Inner
-Join condition: NOT (substr(ca_zip#15, 1, 5) = substr(s_zip#13, 1, 5))
-
-(28) Project [codegen id : 6]
-Output [2]: [ss_item_sk#4, ss_ext_sales_price#7]
-Input [6]: [ss_item_sk#4, ss_ext_sales_price#7, c_current_addr_sk#11, s_zip#13, ca_address_sk#14, ca_zip#15]
-
-(29) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#16, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20, i_manager_id#21]
+(11) Scan parquet spark_catalog.default.item
+Output [6]: [i_item_sk#10, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14, i_manager_id#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_manager_id), EqualTo(i_manager_id,7), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_brand:string,i_manufact_id:int,i_manufact:string,i_manager_id:int>
 
-(30) ColumnarToRow [codegen id : 5]
-Input [6]: [i_item_sk#16, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20, i_manager_id#21]
+(12) ColumnarToRow [codegen id : 2]
+Input [6]: [i_item_sk#10, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14, i_manager_id#15]
 
-(31) Filter [codegen id : 5]
-Input [6]: [i_item_sk#16, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20, i_manager_id#21]
-Condition : ((isnotnull(i_manager_id#21) AND (i_manager_id#21 = 7)) AND isnotnull(i_item_sk#16))
+(13) Filter [codegen id : 2]
+Input [6]: [i_item_sk#10, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14, i_manager_id#15]
+Condition : ((isnotnull(i_manager_id#15) AND (i_manager_id#15 = 7)) AND isnotnull(i_item_sk#10))
 
-(32) Project [codegen id : 5]
-Output [5]: [i_item_sk#16, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20]
-Input [6]: [i_item_sk#16, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20, i_manager_id#21]
+(14) Project [codegen id : 2]
+Output [5]: [i_item_sk#10, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14]
+Input [6]: [i_item_sk#10, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14, i_manager_id#15]
 
-(33) BroadcastExchange
-Input [5]: [i_item_sk#16, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+(15) BroadcastExchange
+Input [5]: [i_item_sk#10, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
-(34) BroadcastHashJoin [codegen id : 6]
+(16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_item_sk#4]
-Right keys [1]: [i_item_sk#16]
+Right keys [1]: [i_item_sk#10]
 Join type: Inner
 Join condition: None
 
-(35) Project [codegen id : 6]
-Output [5]: [ss_ext_sales_price#7, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20]
-Input [7]: [ss_item_sk#4, ss_ext_sales_price#7, i_item_sk#16, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20]
+(17) Project [codegen id : 3]
+Output [7]: [ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14]
+Input [9]: [ss_item_sk#4, ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7, i_item_sk#10, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14]
 
-(36) HashAggregate [codegen id : 6]
-Input [5]: [ss_ext_sales_price#7, i_brand_id#17, i_brand#18, i_manufact_id#19, i_manufact#20]
-Keys [4]: [i_brand#18, i_brand_id#17, i_manufact_id#19, i_manufact#20]
+(18) Exchange
+Input [7]: [ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14]
+Arguments: hashpartitioning(ss_customer_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(19) Sort [codegen id : 4]
+Input [7]: [ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14]
+Arguments: [ss_customer_sk#5 ASC NULLS FIRST], false, 0
+
+(20) Scan parquet spark_catalog.default.customer
+Output [2]: [c_customer_sk#16, c_current_addr_sk#17]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
+ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
+
+(21) ColumnarToRow [codegen id : 5]
+Input [2]: [c_customer_sk#16, c_current_addr_sk#17]
+
+(22) Filter [codegen id : 5]
+Input [2]: [c_customer_sk#16, c_current_addr_sk#17]
+Condition : (isnotnull(c_customer_sk#16) AND isnotnull(c_current_addr_sk#17))
+
+(23) Exchange
+Input [2]: [c_customer_sk#16, c_current_addr_sk#17]
+Arguments: hashpartitioning(c_current_addr_sk#17, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(24) Sort [codegen id : 6]
+Input [2]: [c_customer_sk#16, c_current_addr_sk#17]
+Arguments: [c_current_addr_sk#17 ASC NULLS FIRST], false, 0
+
+(25) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#18, ca_zip#19]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_zip)]
+ReadSchema: struct<ca_address_sk:int,ca_zip:string>
+
+(26) ColumnarToRow [codegen id : 7]
+Input [2]: [ca_address_sk#18, ca_zip#19]
+
+(27) Filter [codegen id : 7]
+Input [2]: [ca_address_sk#18, ca_zip#19]
+Condition : (isnotnull(ca_address_sk#18) AND isnotnull(ca_zip#19))
+
+(28) Exchange
+Input [2]: [ca_address_sk#18, ca_zip#19]
+Arguments: hashpartitioning(ca_address_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(29) Sort [codegen id : 8]
+Input [2]: [ca_address_sk#18, ca_zip#19]
+Arguments: [ca_address_sk#18 ASC NULLS FIRST], false, 0
+
+(30) SortMergeJoin [codegen id : 9]
+Left keys [1]: [c_current_addr_sk#17]
+Right keys [1]: [ca_address_sk#18]
+Join type: Inner
+Join condition: None
+
+(31) Project [codegen id : 9]
+Output [2]: [c_customer_sk#16, ca_zip#19]
+Input [4]: [c_customer_sk#16, c_current_addr_sk#17, ca_address_sk#18, ca_zip#19]
+
+(32) Exchange
+Input [2]: [c_customer_sk#16, ca_zip#19]
+Arguments: hashpartitioning(c_customer_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(33) Sort [codegen id : 10]
+Input [2]: [c_customer_sk#16, ca_zip#19]
+Arguments: [c_customer_sk#16 ASC NULLS FIRST], false, 0
+
+(34) SortMergeJoin [codegen id : 12]
+Left keys [1]: [ss_customer_sk#5]
+Right keys [1]: [c_customer_sk#16]
+Join type: Inner
+Join condition: None
+
+(35) Project [codegen id : 12]
+Output [7]: [ss_store_sk#6, ss_ext_sales_price#7, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14, ca_zip#19]
+Input [9]: [ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14, c_customer_sk#16, ca_zip#19]
+
+(36) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#20, s_zip#21]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [IsNotNull(s_zip), IsNotNull(s_store_sk)]
+ReadSchema: struct<s_store_sk:int,s_zip:string>
+
+(37) ColumnarToRow [codegen id : 11]
+Input [2]: [s_store_sk#20, s_zip#21]
+
+(38) Filter [codegen id : 11]
+Input [2]: [s_store_sk#20, s_zip#21]
+Condition : (isnotnull(s_zip#21) AND isnotnull(s_store_sk#20))
+
+(39) BroadcastExchange
+Input [2]: [s_store_sk#20, s_zip#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
+
+(40) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [ss_store_sk#6]
+Right keys [1]: [s_store_sk#20]
+Join type: Inner
+Join condition: NOT (substr(ca_zip#19, 1, 5) = substr(s_zip#21, 1, 5))
+
+(41) Project [codegen id : 12]
+Output [5]: [ss_ext_sales_price#7, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14]
+Input [9]: [ss_store_sk#6, ss_ext_sales_price#7, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14, ca_zip#19, s_store_sk#20, s_zip#21]
+
+(42) HashAggregate [codegen id : 12]
+Input [5]: [ss_ext_sales_price#7, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14]
+Keys [4]: [i_brand#12, i_brand_id#11, i_manufact_id#13, i_manufact#14]
 Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#7))]
 Aggregate Attributes [1]: [sum#22]
-Results [5]: [i_brand#18, i_brand_id#17, i_manufact_id#19, i_manufact#20, sum#23]
+Results [5]: [i_brand#12, i_brand_id#11, i_manufact_id#13, i_manufact#14, sum#23]
 
-(37) Exchange
-Input [5]: [i_brand#18, i_brand_id#17, i_manufact_id#19, i_manufact#20, sum#23]
-Arguments: hashpartitioning(i_brand#18, i_brand_id#17, i_manufact_id#19, i_manufact#20, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+(43) Exchange
+Input [5]: [i_brand#12, i_brand_id#11, i_manufact_id#13, i_manufact#14, sum#23]
+Arguments: hashpartitioning(i_brand#12, i_brand_id#11, i_manufact_id#13, i_manufact#14, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(38) HashAggregate [codegen id : 7]
-Input [5]: [i_brand#18, i_brand_id#17, i_manufact_id#19, i_manufact#20, sum#23]
-Keys [4]: [i_brand#18, i_brand_id#17, i_manufact_id#19, i_manufact#20]
+(44) HashAggregate [codegen id : 13]
+Input [5]: [i_brand#12, i_brand_id#11, i_manufact_id#13, i_manufact#14, sum#23]
+Keys [4]: [i_brand#12, i_brand_id#11, i_manufact_id#13, i_manufact#14]
 Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#7))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#7))#24]
-Results [5]: [i_brand_id#17 AS brand_id#25, i_brand#18 AS brand#26, i_manufact_id#19, i_manufact#20, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#7))#24,17,2) AS ext_price#27]
+Results [5]: [i_brand_id#11 AS brand_id#25, i_brand#12 AS brand#26, i_manufact_id#13, i_manufact#14, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#7))#24,17,2) AS ext_price#27]
 
-(39) TakeOrderedAndProject
-Input [5]: [brand_id#25, brand#26, i_manufact_id#19, i_manufact#20, ext_price#27]
-Arguments: 100, [ext_price#27 DESC NULLS LAST, brand#26 ASC NULLS FIRST, brand_id#25 ASC NULLS FIRST, i_manufact_id#19 ASC NULLS FIRST, i_manufact#20 ASC NULLS FIRST], [brand_id#25, brand#26, i_manufact_id#19, i_manufact#20, ext_price#27]
+(45) TakeOrderedAndProject
+Input [5]: [brand_id#25, brand#26, i_manufact_id#13, i_manufact#14, ext_price#27]
+Arguments: 100, [ext_price#27 DESC NULLS LAST, brand#26 ASC NULLS FIRST, brand_id#25 ASC NULLS FIRST, i_manufact_id#13 ASC NULLS FIRST, i_manufact#14 ASC NULLS FIRST], [brand_id#25, brand#26, i_manufact_id#13, i_manufact#14, ext_price#27]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
-ReusedExchange (40)
+ReusedExchange (46)
 
 
-(40) ReusedExchange [Reuses operator id: 5]
+(46) ReusedExchange [Reuses operator id: 5]
 Output [1]: [d_date_sk#1]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q19.sf100/simplified.txt
@@ -1,60 +1,78 @@
 TakeOrderedAndProject [ext_price,brand,brand_id,i_manufact_id,i_manufact]
-  WholeStageCodegen (7)
+  WholeStageCodegen (13)
     HashAggregate [i_brand,i_brand_id,i_manufact_id,i_manufact,sum] [sum(UnscaledValue(ss_ext_sales_price)),brand_id,brand,ext_price,sum]
       InputAdapter
         Exchange [i_brand,i_brand_id,i_manufact_id,i_manufact] #1
-          WholeStageCodegen (6)
+          WholeStageCodegen (12)
             HashAggregate [i_brand,i_brand_id,i_manufact_id,i_manufact,ss_ext_sales_price] [sum,sum]
               Project [ss_ext_sales_price,i_brand_id,i_brand,i_manufact_id,i_manufact]
-                BroadcastHashJoin [ss_item_sk,i_item_sk]
-                  Project [ss_item_sk,ss_ext_sales_price]
-                    BroadcastHashJoin [c_current_addr_sk,ca_address_sk,ca_zip,s_zip]
+                BroadcastHashJoin [ss_store_sk,s_store_sk,ca_zip,s_zip]
+                  Project [ss_store_sk,ss_ext_sales_price,i_brand_id,i_brand,i_manufact_id,i_manufact,ca_zip]
+                    SortMergeJoin [ss_customer_sk,c_customer_sk]
                       InputAdapter
-                        BroadcastExchange #2
-                          WholeStageCodegen (4)
-                            Project [ss_item_sk,ss_ext_sales_price,c_current_addr_sk,s_zip]
-                              BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                Project [ss_item_sk,ss_store_sk,ss_ext_sales_price,c_current_addr_sk]
-                                  BroadcastHashJoin [ss_customer_sk,c_customer_sk]
-                                    InputAdapter
-                                      BroadcastExchange #3
-                                        WholeStageCodegen (2)
-                                          Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ext_sales_price]
-                                            BroadcastHashJoin [d_date_sk,ss_sold_date_sk]
+                        WholeStageCodegen (4)
+                          Sort [ss_customer_sk]
+                            InputAdapter
+                              Exchange [ss_customer_sk] #2
+                                WholeStageCodegen (3)
+                                  Project [ss_customer_sk,ss_store_sk,ss_ext_sales_price,i_brand_id,i_brand,i_manufact_id,i_manufact]
+                                    BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                      Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ext_sales_price]
+                                        BroadcastHashJoin [d_date_sk,ss_sold_date_sk]
+                                          InputAdapter
+                                            BroadcastExchange #3
+                                              WholeStageCodegen (1)
+                                                Project [d_date_sk]
+                                                  Filter [d_moy,d_year,d_date_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                                          Filter [ss_item_sk,ss_customer_sk,ss_store_sk]
+                                            ColumnarToRow
                                               InputAdapter
-                                                BroadcastExchange #4
-                                                  WholeStageCodegen (1)
-                                                    Project [d_date_sk]
-                                                      Filter [d_moy,d_year,d_date_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
-                                              Filter [ss_item_sk,ss_customer_sk,ss_store_sk]
+                                                Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ext_sales_price,ss_sold_date_sk]
+                                                  SubqueryBroadcast [d_date_sk] #1
+                                                    ReusedExchange [d_date_sk] #3
+                                      InputAdapter
+                                        BroadcastExchange #4
+                                          WholeStageCodegen (2)
+                                            Project [i_item_sk,i_brand_id,i_brand,i_manufact_id,i_manufact]
+                                              Filter [i_manager_id,i_item_sk]
                                                 ColumnarToRow
                                                   InputAdapter
-                                                    Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ext_sales_price,ss_sold_date_sk]
-                                                      SubqueryBroadcast [d_date_sk] #1
-                                                        ReusedExchange [d_date_sk] #4
-                                    Filter [c_customer_sk,c_current_addr_sk]
-                                      ColumnarToRow
-                                        InputAdapter
-                                          Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
-                                InputAdapter
-                                  BroadcastExchange #5
-                                    WholeStageCodegen (3)
-                                      Filter [s_zip,s_store_sk]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.store [s_store_sk,s_zip]
-                      Filter [ca_address_sk,ca_zip]
-                        ColumnarToRow
-                          InputAdapter
-                            Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_zip]
+                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_brand,i_manufact_id,i_manufact,i_manager_id]
+                      InputAdapter
+                        WholeStageCodegen (10)
+                          Sort [c_customer_sk]
+                            InputAdapter
+                              Exchange [c_customer_sk] #5
+                                WholeStageCodegen (9)
+                                  Project [c_customer_sk,ca_zip]
+                                    SortMergeJoin [c_current_addr_sk,ca_address_sk]
+                                      InputAdapter
+                                        WholeStageCodegen (6)
+                                          Sort [c_current_addr_sk]
+                                            InputAdapter
+                                              Exchange [c_current_addr_sk] #6
+                                                WholeStageCodegen (5)
+                                                  Filter [c_customer_sk,c_current_addr_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
+                                      InputAdapter
+                                        WholeStageCodegen (8)
+                                          Sort [ca_address_sk]
+                                            InputAdapter
+                                              Exchange [ca_address_sk] #7
+                                                WholeStageCodegen (7)
+                                                  Filter [ca_address_sk,ca_zip]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_zip]
                   InputAdapter
-                    BroadcastExchange #6
-                      WholeStageCodegen (5)
-                        Project [i_item_sk,i_brand_id,i_brand,i_manufact_id,i_manufact]
-                          Filter [i_manager_id,i_item_sk]
-                            ColumnarToRow
-                              InputAdapter
-                                Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_brand,i_manufact_id,i_manufact,i_manager_id]
+                    BroadcastExchange #8
+                      WholeStageCodegen (11)
+                        Filter [s_zip,s_store_sk]
+                          ColumnarToRow
+                            InputAdapter
+                              Scan parquet spark_catalog.default.store [s_store_sk,s_zip]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q27.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q27.sf100/explain.txt
@@ -36,20 +36,20 @@ TakeOrderedAndProject (73)
    :           +- * BroadcastHashJoin Inner BuildRight (46)
    :              :- * Project (44)
    :              :  +- * BroadcastHashJoin Inner BuildRight (43)
-   :              :     :- * Project (41)
-   :              :     :  +- * BroadcastHashJoin Inner BuildRight (40)
+   :              :     :- * Project (37)
+   :              :     :  +- * BroadcastHashJoin Inner BuildRight (36)
    :              :     :     :- * Project (34)
    :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (33)
    :              :     :     :     :- * Filter (31)
    :              :     :     :     :  +- * ColumnarToRow (30)
    :              :     :     :     :     +- Scan parquet spark_catalog.default.store_sales (29)
    :              :     :     :     +- ReusedExchange (32)
-   :              :     :     +- BroadcastExchange (39)
-   :              :     :        +- * Project (38)
-   :              :     :           +- * Filter (37)
-   :              :     :              +- * ColumnarToRow (36)
-   :              :     :                 +- Scan parquet spark_catalog.default.store (35)
-   :              :     +- ReusedExchange (42)
+   :              :     :     +- ReusedExchange (35)
+   :              :     +- BroadcastExchange (42)
+   :              :        +- * Project (41)
+   :              :           +- * Filter (40)
+   :              :              +- * ColumnarToRow (39)
+   :              :                 +- Scan parquet spark_catalog.default.store (38)
    :              +- ReusedExchange (45)
    +- * HashAggregate (71)
       +- Exchange (70)
@@ -236,50 +236,50 @@ Join condition: None
 Output [7]: [ss_item_sk#48, ss_cdemo_sk#49, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54]
 Input [9]: [ss_item_sk#48, ss_cdemo_sk#49, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55, d_date_sk#56]
 
-(35) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#57, s_state#58]
+(35) ReusedExchange [Reuses operator id: 11]
+Output [1]: [cd_demo_sk#57]
+
+(36) BroadcastHashJoin [codegen id : 11]
+Left keys [1]: [ss_cdemo_sk#49]
+Right keys [1]: [cd_demo_sk#57]
+Join type: Inner
+Join condition: None
+
+(37) Project [codegen id : 11]
+Output [6]: [ss_item_sk#48, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54]
+Input [8]: [ss_item_sk#48, ss_cdemo_sk#49, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, cd_demo_sk#57]
+
+(38) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#58, s_state#59]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [In(s_state, [AL,SD,TN]), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_state:string>
 
-(36) ColumnarToRow [codegen id : 8]
-Input [2]: [s_store_sk#57, s_state#58]
+(39) ColumnarToRow [codegen id : 9]
+Input [2]: [s_store_sk#58, s_state#59]
 
-(37) Filter [codegen id : 8]
-Input [2]: [s_store_sk#57, s_state#58]
-Condition : (s_state#58 IN (TN,AL,SD) AND isnotnull(s_store_sk#57))
+(40) Filter [codegen id : 9]
+Input [2]: [s_store_sk#58, s_state#59]
+Condition : (s_state#59 IN (TN,AL,SD) AND isnotnull(s_store_sk#58))
 
-(38) Project [codegen id : 8]
-Output [1]: [s_store_sk#57]
-Input [2]: [s_store_sk#57, s_state#58]
+(41) Project [codegen id : 9]
+Output [1]: [s_store_sk#58]
+Input [2]: [s_store_sk#58, s_state#59]
 
-(39) BroadcastExchange
-Input [1]: [s_store_sk#57]
+(42) BroadcastExchange
+Input [1]: [s_store_sk#58]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
-(40) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ss_store_sk#50]
-Right keys [1]: [s_store_sk#57]
-Join type: Inner
-Join condition: None
-
-(41) Project [codegen id : 11]
-Output [6]: [ss_item_sk#48, ss_cdemo_sk#49, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54]
-Input [8]: [ss_item_sk#48, ss_cdemo_sk#49, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, s_store_sk#57]
-
-(42) ReusedExchange [Reuses operator id: 11]
-Output [1]: [cd_demo_sk#59]
-
 (43) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ss_cdemo_sk#49]
-Right keys [1]: [cd_demo_sk#59]
+Left keys [1]: [ss_store_sk#50]
+Right keys [1]: [s_store_sk#58]
 Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 11]
 Output [5]: [ss_item_sk#48, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54]
-Input [7]: [ss_item_sk#48, ss_cdemo_sk#49, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, cd_demo_sk#59]
+Input [7]: [ss_item_sk#48, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, s_store_sk#58]
 
 (45) ReusedExchange [Reuses operator id: 23]
 Output [2]: [i_item_sk#60, i_item_id#61]
@@ -340,31 +340,31 @@ Join condition: None
 Output [7]: [ss_item_sk#92, ss_cdemo_sk#93, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98]
 Input [9]: [ss_item_sk#92, ss_cdemo_sk#93, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99, d_date_sk#100]
 
-(57) ReusedExchange [Reuses operator id: 39]
-Output [1]: [s_store_sk#101]
+(57) ReusedExchange [Reuses operator id: 11]
+Output [1]: [cd_demo_sk#101]
 
 (58) BroadcastHashJoin [codegen id : 17]
-Left keys [1]: [ss_store_sk#94]
-Right keys [1]: [s_store_sk#101]
+Left keys [1]: [ss_cdemo_sk#93]
+Right keys [1]: [cd_demo_sk#101]
 Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 17]
-Output [6]: [ss_item_sk#92, ss_cdemo_sk#93, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98]
-Input [8]: [ss_item_sk#92, ss_cdemo_sk#93, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, s_store_sk#101]
+Output [6]: [ss_item_sk#92, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98]
+Input [8]: [ss_item_sk#92, ss_cdemo_sk#93, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, cd_demo_sk#101]
 
-(60) ReusedExchange [Reuses operator id: 11]
-Output [1]: [cd_demo_sk#102]
+(60) ReusedExchange [Reuses operator id: 42]
+Output [1]: [s_store_sk#102]
 
 (61) BroadcastHashJoin [codegen id : 17]
-Left keys [1]: [ss_cdemo_sk#93]
-Right keys [1]: [cd_demo_sk#102]
+Left keys [1]: [ss_store_sk#94]
+Right keys [1]: [s_store_sk#102]
 Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 17]
 Output [5]: [ss_item_sk#92, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98]
-Input [7]: [ss_item_sk#92, ss_cdemo_sk#93, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, cd_demo_sk#102]
+Input [7]: [ss_item_sk#92, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, s_store_sk#102]
 
 (63) Scan parquet spark_catalog.default.item
 Output [1]: [i_item_sk#103]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q27.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q27.sf100/simplified.txt
@@ -59,9 +59,9 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                 Project [i_item_id,ss_quantity,ss_list_price,ss_coupon_amt,ss_sales_price]
                   BroadcastHashJoin [ss_item_sk,i_item_sk]
                     Project [ss_item_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
-                      BroadcastHashJoin [ss_cdemo_sk,cd_demo_sk]
-                        Project [ss_item_sk,ss_cdemo_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
-                          BroadcastHashJoin [ss_store_sk,s_store_sk]
+                      BroadcastHashJoin [ss_store_sk,s_store_sk]
+                        Project [ss_item_sk,ss_store_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
+                          BroadcastHashJoin [ss_cdemo_sk,cd_demo_sk]
                             Project [ss_item_sk,ss_cdemo_sk,ss_store_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
                               BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                 Filter [ss_cdemo_sk,ss_store_sk,ss_item_sk]
@@ -72,15 +72,15 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                                 InputAdapter
                                   ReusedExchange [d_date_sk] #2
                             InputAdapter
-                              BroadcastExchange #7
-                                WholeStageCodegen (8)
-                                  Project [s_store_sk]
-                                    Filter [s_state,s_store_sk]
-                                      ColumnarToRow
-                                        InputAdapter
-                                          Scan parquet spark_catalog.default.store [s_store_sk,s_state]
+                              ReusedExchange [cd_demo_sk] #3
                         InputAdapter
-                          ReusedExchange [cd_demo_sk] #3
+                          BroadcastExchange #7
+                            WholeStageCodegen (9)
+                              Project [s_store_sk]
+                                Filter [s_state,s_store_sk]
+                                  ColumnarToRow
+                                    InputAdapter
+                                      Scan parquet spark_catalog.default.store [s_store_sk,s_state]
                     InputAdapter
                       ReusedExchange [i_item_sk,i_item_id] #5
     WholeStageCodegen (18)
@@ -92,9 +92,9 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                 Project [ss_quantity,ss_list_price,ss_coupon_amt,ss_sales_price]
                   BroadcastHashJoin [ss_item_sk,i_item_sk]
                     Project [ss_item_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
-                      BroadcastHashJoin [ss_cdemo_sk,cd_demo_sk]
-                        Project [ss_item_sk,ss_cdemo_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
-                          BroadcastHashJoin [ss_store_sk,s_store_sk]
+                      BroadcastHashJoin [ss_store_sk,s_store_sk]
+                        Project [ss_item_sk,ss_store_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
+                          BroadcastHashJoin [ss_cdemo_sk,cd_demo_sk]
                             Project [ss_item_sk,ss_cdemo_sk,ss_store_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
                               BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                 Filter [ss_cdemo_sk,ss_store_sk,ss_item_sk]
@@ -105,9 +105,9 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                                 InputAdapter
                                   ReusedExchange [d_date_sk] #2
                             InputAdapter
-                              ReusedExchange [s_store_sk] #7
+                              ReusedExchange [cd_demo_sk] #3
                         InputAdapter
-                          ReusedExchange [cd_demo_sk] #3
+                          ReusedExchange [s_store_sk] #7
                     InputAdapter
                       BroadcastExchange #9
                         WholeStageCodegen (16)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q34.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q34.sf100/explain.txt
@@ -23,12 +23,12 @@
          :                       :        +- * Project (10)
          :                       :           +- * Filter (9)
          :                       :              +- * ColumnarToRow (8)
-         :                       :                 +- Scan parquet spark_catalog.default.store (7)
+         :                       :                 +- Scan parquet spark_catalog.default.household_demographics (7)
          :                       +- BroadcastExchange (18)
          :                          +- * Project (17)
          :                             +- * Filter (16)
          :                                +- * ColumnarToRow (15)
-         :                                   +- Scan parquet spark_catalog.default.household_demographics (14)
+         :                                   +- Scan parquet spark_catalog.default.store (14)
          +- * Sort (31)
             +- Exchange (30)
                +- * Filter (29)
@@ -64,69 +64,69 @@ Join condition: None
 Output [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4]
 Input [6]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5, d_date_sk#7]
 
-(7) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#8, s_county#9]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [In(s_county, [Appanoose County,Daviess County,Fairfield County,Raleigh County,Saginaw County,Sumner County,Williamson County,Ziebach County]), IsNotNull(s_store_sk)]
-ReadSchema: struct<s_store_sk:int,s_county:string>
-
-(8) ColumnarToRow [codegen id : 2]
-Input [2]: [s_store_sk#8, s_county#9]
-
-(9) Filter [codegen id : 2]
-Input [2]: [s_store_sk#8, s_county#9]
-Condition : (s_county#9 IN (Saginaw County,Sumner County,Appanoose County,Daviess County,Fairfield County,Raleigh County,Ziebach County,Williamson County) AND isnotnull(s_store_sk#8))
-
-(10) Project [codegen id : 2]
-Output [1]: [s_store_sk#8]
-Input [2]: [s_store_sk#8, s_county#9]
-
-(11) BroadcastExchange
-Input [1]: [s_store_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
-
-(12) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#8]
-Join type: Inner
-Join condition: None
-
-(13) Project [codegen id : 4]
-Output [3]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4]
-Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, s_store_sk#8]
-
-(14) Scan parquet spark_catalog.default.household_demographics
-Output [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
+(7) Scan parquet spark_catalog.default.household_demographics
+Output [4]: [hd_demo_sk#8, hd_buy_potential#9, hd_dep_count#10, hd_vehicle_count#11]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [IsNotNull(hd_vehicle_count), Or(EqualTo(hd_buy_potential,>10000         ),EqualTo(hd_buy_potential,Unknown        )), GreaterThan(hd_vehicle_count,0), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string,hd_dep_count:int,hd_vehicle_count:int>
 
+(8) ColumnarToRow [codegen id : 2]
+Input [4]: [hd_demo_sk#8, hd_buy_potential#9, hd_dep_count#10, hd_vehicle_count#11]
+
+(9) Filter [codegen id : 2]
+Input [4]: [hd_demo_sk#8, hd_buy_potential#9, hd_dep_count#10, hd_vehicle_count#11]
+Condition : ((((isnotnull(hd_vehicle_count#11) AND ((hd_buy_potential#9 = >10000         ) OR (hd_buy_potential#9 = Unknown        ))) AND (hd_vehicle_count#11 > 0)) AND CASE WHEN (hd_vehicle_count#11 > 0) THEN ((cast(hd_dep_count#10 as double) / cast(hd_vehicle_count#11 as double)) > 1.2) END) AND isnotnull(hd_demo_sk#8))
+
+(10) Project [codegen id : 2]
+Output [1]: [hd_demo_sk#8]
+Input [4]: [hd_demo_sk#8, hd_buy_potential#9, hd_dep_count#10, hd_vehicle_count#11]
+
+(11) BroadcastExchange
+Input [1]: [hd_demo_sk#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
+
+(12) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_hdemo_sk#2]
+Right keys [1]: [hd_demo_sk#8]
+Join type: Inner
+Join condition: None
+
+(13) Project [codegen id : 4]
+Output [3]: [ss_customer_sk#1, ss_store_sk#3, ss_ticket_number#4]
+Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, hd_demo_sk#8]
+
+(14) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#12, s_county#13]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [In(s_county, [Appanoose County,Daviess County,Fairfield County,Raleigh County,Saginaw County,Sumner County,Williamson County,Ziebach County]), IsNotNull(s_store_sk)]
+ReadSchema: struct<s_store_sk:int,s_county:string>
+
 (15) ColumnarToRow [codegen id : 3]
-Input [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
+Input [2]: [s_store_sk#12, s_county#13]
 
 (16) Filter [codegen id : 3]
-Input [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
-Condition : ((((isnotnull(hd_vehicle_count#13) AND ((hd_buy_potential#11 = >10000         ) OR (hd_buy_potential#11 = Unknown        ))) AND (hd_vehicle_count#13 > 0)) AND CASE WHEN (hd_vehicle_count#13 > 0) THEN ((cast(hd_dep_count#12 as double) / cast(hd_vehicle_count#13 as double)) > 1.2) END) AND isnotnull(hd_demo_sk#10))
+Input [2]: [s_store_sk#12, s_county#13]
+Condition : (s_county#13 IN (Saginaw County,Sumner County,Appanoose County,Daviess County,Fairfield County,Raleigh County,Ziebach County,Williamson County) AND isnotnull(s_store_sk#12))
 
 (17) Project [codegen id : 3]
-Output [1]: [hd_demo_sk#10]
-Input [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
+Output [1]: [s_store_sk#12]
+Input [2]: [s_store_sk#12, s_county#13]
 
 (18) BroadcastExchange
-Input [1]: [hd_demo_sk#10]
+Input [1]: [s_store_sk#12]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
 (19) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_hdemo_sk#2]
-Right keys [1]: [hd_demo_sk#10]
+Left keys [1]: [ss_store_sk#3]
+Right keys [1]: [s_store_sk#12]
 Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
 Output [2]: [ss_customer_sk#1, ss_ticket_number#4]
-Input [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4, hd_demo_sk#10]
+Input [4]: [ss_customer_sk#1, ss_store_sk#3, ss_ticket_number#4, s_store_sk#12]
 
 (21) HashAggregate [codegen id : 4]
 Input [2]: [ss_customer_sk#1, ss_ticket_number#4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q34.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q34.sf100/simplified.txt
@@ -18,9 +18,9 @@ WholeStageCodegen (10)
                                   WholeStageCodegen (4)
                                     HashAggregate [ss_ticket_number,ss_customer_sk] [count,count]
                                       Project [ss_customer_sk,ss_ticket_number]
-                                        BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
-                                          Project [ss_customer_sk,ss_hdemo_sk,ss_ticket_number]
-                                            BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                        BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                          Project [ss_customer_sk,ss_store_sk,ss_ticket_number]
+                                            BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
                                               Project [ss_customer_sk,ss_hdemo_sk,ss_store_sk,ss_ticket_number]
                                                 BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                   Filter [ss_store_sk,ss_hdemo_sk,ss_customer_sk]
@@ -40,19 +40,19 @@ WholeStageCodegen (10)
                                               InputAdapter
                                                 BroadcastExchange #5
                                                   WholeStageCodegen (2)
-                                                    Project [s_store_sk]
-                                                      Filter [s_county,s_store_sk]
+                                                    Project [hd_demo_sk]
+                                                      Filter [hd_vehicle_count,hd_buy_potential,hd_dep_count,hd_demo_sk]
                                                         ColumnarToRow
                                                           InputAdapter
-                                                            Scan parquet spark_catalog.default.store [s_store_sk,s_county]
+                                                            Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_buy_potential,hd_dep_count,hd_vehicle_count]
                                           InputAdapter
                                             BroadcastExchange #6
                                               WholeStageCodegen (3)
-                                                Project [hd_demo_sk]
-                                                  Filter [hd_vehicle_count,hd_buy_potential,hd_dep_count,hd_demo_sk]
+                                                Project [s_store_sk]
+                                                  Filter [s_county,s_store_sk]
                                                     ColumnarToRow
                                                       InputAdapter
-                                                        Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_buy_potential,hd_dep_count,hd_vehicle_count]
+                                                        Scan parquet spark_catalog.default.store [s_store_sk,s_county]
               InputAdapter
                 WholeStageCodegen (8)
                   Sort [c_customer_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q46.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q46.sf100/explain.txt
@@ -2,270 +2,270 @@
 TakeOrderedAndProject (47)
 +- * Project (46)
    +- * SortMergeJoin Inner (45)
-      :- * Sort (42)
-      :  +- Exchange (41)
-      :     +- * Project (40)
-      :        +- * SortMergeJoin Inner (39)
-      :           :- * Sort (33)
-      :           :  +- Exchange (32)
-      :           :     +- * HashAggregate (31)
-      :           :        +- * HashAggregate (30)
-      :           :           +- * Project (29)
-      :           :              +- * SortMergeJoin Inner (28)
-      :           :                 :- * Sort (22)
-      :           :                 :  +- Exchange (21)
-      :           :                 :     +- * Project (20)
-      :           :                 :        +- * BroadcastHashJoin Inner BuildRight (19)
-      :           :                 :           :- * Project (13)
-      :           :                 :           :  +- * BroadcastHashJoin Inner BuildRight (12)
-      :           :                 :           :     :- * Project (6)
-      :           :                 :           :     :  +- * BroadcastHashJoin Inner BuildRight (5)
-      :           :                 :           :     :     :- * Filter (3)
-      :           :                 :           :     :     :  +- * ColumnarToRow (2)
-      :           :                 :           :     :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-      :           :                 :           :     :     +- ReusedExchange (4)
-      :           :                 :           :     +- BroadcastExchange (11)
-      :           :                 :           :        +- * Project (10)
-      :           :                 :           :           +- * Filter (9)
-      :           :                 :           :              +- * ColumnarToRow (8)
-      :           :                 :           :                 +- Scan parquet spark_catalog.default.store (7)
-      :           :                 :           +- BroadcastExchange (18)
-      :           :                 :              +- * Project (17)
-      :           :                 :                 +- * Filter (16)
-      :           :                 :                    +- * ColumnarToRow (15)
-      :           :                 :                       +- Scan parquet spark_catalog.default.household_demographics (14)
-      :           :                 +- * Sort (27)
-      :           :                    +- Exchange (26)
-      :           :                       +- * Filter (25)
-      :           :                          +- * ColumnarToRow (24)
-      :           :                             +- Scan parquet spark_catalog.default.customer_address (23)
-      :           +- * Sort (38)
-      :              +- Exchange (37)
-      :                 +- * Filter (36)
-      :                    +- * ColumnarToRow (35)
-      :                       +- Scan parquet spark_catalog.default.customer (34)
+      :- * Sort (14)
+      :  +- Exchange (13)
+      :     +- * Project (12)
+      :        +- * SortMergeJoin Inner (11)
+      :           :- * Sort (5)
+      :           :  +- Exchange (4)
+      :           :     +- * Filter (3)
+      :           :        +- * ColumnarToRow (2)
+      :           :           +- Scan parquet spark_catalog.default.customer (1)
+      :           +- * Sort (10)
+      :              +- Exchange (9)
+      :                 +- * Filter (8)
+      :                    +- * ColumnarToRow (7)
+      :                       +- Scan parquet spark_catalog.default.customer_address (6)
       +- * Sort (44)
-         +- ReusedExchange (43)
+         +- Exchange (43)
+            +- * HashAggregate (42)
+               +- * HashAggregate (41)
+                  +- * Project (40)
+                     +- * SortMergeJoin Inner (39)
+                        :- * Sort (36)
+                        :  +- Exchange (35)
+                        :     +- * Project (34)
+                        :        +- * BroadcastHashJoin Inner BuildRight (33)
+                        :           :- * Project (27)
+                        :           :  +- * BroadcastHashJoin Inner BuildRight (26)
+                        :           :     :- * Project (20)
+                        :           :     :  +- * BroadcastHashJoin Inner BuildRight (19)
+                        :           :     :     :- * Filter (17)
+                        :           :     :     :  +- * ColumnarToRow (16)
+                        :           :     :     :     +- Scan parquet spark_catalog.default.store_sales (15)
+                        :           :     :     +- ReusedExchange (18)
+                        :           :     +- BroadcastExchange (25)
+                        :           :        +- * Project (24)
+                        :           :           +- * Filter (23)
+                        :           :              +- * ColumnarToRow (22)
+                        :           :                 +- Scan parquet spark_catalog.default.household_demographics (21)
+                        :           +- BroadcastExchange (32)
+                        :              +- * Project (31)
+                        :                 +- * Filter (30)
+                        :                    +- * ColumnarToRow (29)
+                        :                       +- Scan parquet spark_catalog.default.store (28)
+                        +- * Sort (38)
+                           +- ReusedExchange (37)
 
 
-(1) Scan parquet spark_catalog.default.store_sales
-Output [8]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, ss_sold_date_sk#8]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [ss_sold_date_sk#8 INSET 2451181, 2451182, 2451188, 2451189, 2451195, 2451196, 2451202, 2451203, 2451209, 2451210, 2451216, 2451217, 2451223, 2451224, 2451230, 2451231, 2451237, 2451238, 2451244, 2451245, 2451251, 2451252, 2451258, 2451259, 2451265, 2451266, 2451272, 2451273, 2451279, 2451280, 2451286, 2451287, 2451293, 2451294, 2451300, 2451301, 2451307, 2451308, 2451314, 2451315, 2451321, 2451322, 2451328, 2451329, 2451335, 2451336, 2451342, 2451343, 2451349, 2451350, 2451356, 2451357, 2451363, 2451364, 2451370, 2451371, 2451377, 2451378, 2451384, 2451385, 2451391, 2451392, 2451398, 2451399, 2451405, 2451406, 2451412, 2451413, 2451419, 2451420, 2451426, 2451427, 2451433, 2451434, 2451440, 2451441, 2451447, 2451448, 2451454, 2451455, 2451461, 2451462, 2451468, 2451469, 2451475, 2451476, 2451482, 2451483, 2451489, 2451490, 2451496, 2451497, 2451503, 2451504, 2451510, 2451511, 2451517, 2451518, 2451524, 2451525, 2451531, 2451532, 2451538, 2451539, 2451545, 2451546, 2451552, 2451553, 2451559, 2451560, 2451566, 2451567, 2451573, 2451574, 2451580, 2451581, 2451587, 2451588, 2451594, 2451595, 2451601, 2451602, 2451608, 2451609, 2451615, 2451616, 2451622, 2451623, 2451629, 2451630, 2451636, 2451637, 2451643, 2451644, 2451650, 2451651, 2451657, 2451658, 2451664, 2451665, 2451671, 2451672, 2451678, 2451679, 2451685, 2451686, 2451692, 2451693, 2451699, 2451700, 2451706, 2451707, 2451713, 2451714, 2451720, 2451721, 2451727, 2451728, 2451734, 2451735, 2451741, 2451742, 2451748, 2451749, 2451755, 2451756, 2451762, 2451763, 2451769, 2451770, 2451776, 2451777, 2451783, 2451784, 2451790, 2451791, 2451797, 2451798, 2451804, 2451805, 2451811, 2451812, 2451818, 2451819, 2451825, 2451826, 2451832, 2451833, 2451839, 2451840, 2451846, 2451847, 2451853, 2451854, 2451860, 2451861, 2451867, 2451868, 2451874, 2451875, 2451881, 2451882, 2451888, 2451889, 2451895, 2451896, 2451902, 2451903, 2451909, 2451910, 2451916, 2451917, 2451923, 2451924, 2451930, 2451931, 2451937, 2451938, 2451944, 2451945, 2451951, 2451952, 2451958, 2451959, 2451965, 2451966, 2451972, 2451973, 2451979, 2451980, 2451986, 2451987, 2451993, 2451994, 2452000, 2452001, 2452007, 2452008, 2452014, 2452015, 2452021, 2452022, 2452028, 2452029, 2452035, 2452036, 2452042, 2452043, 2452049, 2452050, 2452056, 2452057, 2452063, 2452064, 2452070, 2452071, 2452077, 2452078, 2452084, 2452085, 2452091, 2452092, 2452098, 2452099, 2452105, 2452106, 2452112, 2452113, 2452119, 2452120, 2452126, 2452127, 2452133, 2452134, 2452140, 2452141, 2452147, 2452148, 2452154, 2452155, 2452161, 2452162, 2452168, 2452169, 2452175, 2452176, 2452182, 2452183, 2452189, 2452190, 2452196, 2452197, 2452203, 2452204, 2452210, 2452211, 2452217, 2452218, 2452224, 2452225, 2452231, 2452232, 2452238, 2452239, 2452245, 2452246, 2452252, 2452253, 2452259, 2452260, 2452266, 2452267, 2452273, 2452274, isnotnull(ss_sold_date_sk#8), dynamicpruningexpression(ss_sold_date_sk#8 IN dynamicpruning#9)]
-PushedFilters: [IsNotNull(ss_store_sk), IsNotNull(ss_hdemo_sk), IsNotNull(ss_addr_sk), IsNotNull(ss_customer_sk)]
-ReadSchema: struct<ss_customer_sk:int,ss_hdemo_sk:int,ss_addr_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_coupon_amt:decimal(7,2),ss_net_profit:decimal(7,2)>
-
-(2) ColumnarToRow [codegen id : 4]
-Input [8]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, ss_sold_date_sk#8]
-
-(3) Filter [codegen id : 4]
-Input [8]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, ss_sold_date_sk#8]
-Condition : (((isnotnull(ss_store_sk#4) AND isnotnull(ss_hdemo_sk#2)) AND isnotnull(ss_addr_sk#3)) AND isnotnull(ss_customer_sk#1))
-
-(4) ReusedExchange [Reuses operator id: 52]
-Output [1]: [d_date_sk#10]
-
-(5) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#8]
-Right keys [1]: [d_date_sk#10]
-Join type: Inner
-Join condition: None
-
-(6) Project [codegen id : 4]
-Output [7]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7]
-Input [9]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, ss_sold_date_sk#8, d_date_sk#10]
-
-(7) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#11, s_city#12]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [In(s_city, [Brownsville,Concord,Greenville,Midway,Spring Hill]), IsNotNull(s_store_sk)]
-ReadSchema: struct<s_store_sk:int,s_city:string>
-
-(8) ColumnarToRow [codegen id : 2]
-Input [2]: [s_store_sk#11, s_city#12]
-
-(9) Filter [codegen id : 2]
-Input [2]: [s_store_sk#11, s_city#12]
-Condition : (s_city#12 IN (Midway,Concord,Spring Hill,Brownsville,Greenville) AND isnotnull(s_store_sk#11))
-
-(10) Project [codegen id : 2]
-Output [1]: [s_store_sk#11]
-Input [2]: [s_store_sk#11, s_city#12]
-
-(11) BroadcastExchange
-Input [1]: [s_store_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
-
-(12) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_store_sk#4]
-Right keys [1]: [s_store_sk#11]
-Join type: Inner
-Join condition: None
-
-(13) Project [codegen id : 4]
-Output [6]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7]
-Input [8]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, s_store_sk#11]
-
-(14) Scan parquet spark_catalog.default.household_demographics
-Output [3]: [hd_demo_sk#13, hd_dep_count#14, hd_vehicle_count#15]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/household_demographics]
-PushedFilters: [Or(EqualTo(hd_dep_count,5),EqualTo(hd_vehicle_count,3)), IsNotNull(hd_demo_sk)]
-ReadSchema: struct<hd_demo_sk:int,hd_dep_count:int,hd_vehicle_count:int>
-
-(15) ColumnarToRow [codegen id : 3]
-Input [3]: [hd_demo_sk#13, hd_dep_count#14, hd_vehicle_count#15]
-
-(16) Filter [codegen id : 3]
-Input [3]: [hd_demo_sk#13, hd_dep_count#14, hd_vehicle_count#15]
-Condition : (((hd_dep_count#14 = 5) OR (hd_vehicle_count#15 = 3)) AND isnotnull(hd_demo_sk#13))
-
-(17) Project [codegen id : 3]
-Output [1]: [hd_demo_sk#13]
-Input [3]: [hd_demo_sk#13, hd_dep_count#14, hd_vehicle_count#15]
-
-(18) BroadcastExchange
-Input [1]: [hd_demo_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
-
-(19) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_hdemo_sk#2]
-Right keys [1]: [hd_demo_sk#13]
-Join type: Inner
-Join condition: None
-
-(20) Project [codegen id : 4]
-Output [5]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7]
-Input [7]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, hd_demo_sk#13]
-
-(21) Exchange
-Input [5]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7]
-Arguments: hashpartitioning(ss_addr_sk#3, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(22) Sort [codegen id : 5]
-Input [5]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7]
-Arguments: [ss_addr_sk#3 ASC NULLS FIRST], false, 0
-
-(23) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#16, ca_city#17]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_city)]
-ReadSchema: struct<ca_address_sk:int,ca_city:string>
-
-(24) ColumnarToRow [codegen id : 6]
-Input [2]: [ca_address_sk#16, ca_city#17]
-
-(25) Filter [codegen id : 6]
-Input [2]: [ca_address_sk#16, ca_city#17]
-Condition : (isnotnull(ca_address_sk#16) AND isnotnull(ca_city#17))
-
-(26) Exchange
-Input [2]: [ca_address_sk#16, ca_city#17]
-Arguments: hashpartitioning(ca_address_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(27) Sort [codegen id : 7]
-Input [2]: [ca_address_sk#16, ca_city#17]
-Arguments: [ca_address_sk#16 ASC NULLS FIRST], false, 0
-
-(28) SortMergeJoin [codegen id : 8]
-Left keys [1]: [ss_addr_sk#3]
-Right keys [1]: [ca_address_sk#16]
-Join type: Inner
-Join condition: None
-
-(29) Project [codegen id : 8]
-Output [6]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, ca_city#17]
-Input [7]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, ca_address_sk#16, ca_city#17]
-
-(30) HashAggregate [codegen id : 8]
-Input [6]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_coupon_amt#6, ss_net_profit#7, ca_city#17]
-Keys [4]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#17]
-Functions [2]: [partial_sum(UnscaledValue(ss_coupon_amt#6)), partial_sum(UnscaledValue(ss_net_profit#7))]
-Aggregate Attributes [2]: [sum#18, sum#19]
-Results [6]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#17, sum#20, sum#21]
-
-(31) HashAggregate [codegen id : 8]
-Input [6]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#17, sum#20, sum#21]
-Keys [4]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#17]
-Functions [2]: [sum(UnscaledValue(ss_coupon_amt#6)), sum(UnscaledValue(ss_net_profit#7))]
-Aggregate Attributes [2]: [sum(UnscaledValue(ss_coupon_amt#6))#22, sum(UnscaledValue(ss_net_profit#7))#23]
-Results [5]: [ss_ticket_number#5, ss_customer_sk#1, ca_city#17 AS bought_city#24, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#6))#22,17,2) AS amt#25, MakeDecimal(sum(UnscaledValue(ss_net_profit#7))#23,17,2) AS profit#26]
-
-(32) Exchange
-Input [5]: [ss_ticket_number#5, ss_customer_sk#1, bought_city#24, amt#25, profit#26]
-Arguments: hashpartitioning(ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(33) Sort [codegen id : 9]
-Input [5]: [ss_ticket_number#5, ss_customer_sk#1, bought_city#24, amt#25, profit#26]
-Arguments: [ss_customer_sk#1 ASC NULLS FIRST], false, 0
-
-(34) Scan parquet spark_catalog.default.customer
-Output [4]: [c_customer_sk#27, c_current_addr_sk#28, c_first_name#29, c_last_name#30]
+(1) Scan parquet spark_catalog.default.customer
+Output [4]: [c_customer_sk#1, c_current_addr_sk#2, c_first_name#3, c_last_name#4]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int,c_first_name:string,c_last_name:string>
 
-(35) ColumnarToRow [codegen id : 10]
-Input [4]: [c_customer_sk#27, c_current_addr_sk#28, c_first_name#29, c_last_name#30]
+(2) ColumnarToRow [codegen id : 1]
+Input [4]: [c_customer_sk#1, c_current_addr_sk#2, c_first_name#3, c_last_name#4]
 
-(36) Filter [codegen id : 10]
-Input [4]: [c_customer_sk#27, c_current_addr_sk#28, c_first_name#29, c_last_name#30]
-Condition : (isnotnull(c_customer_sk#27) AND isnotnull(c_current_addr_sk#28))
+(3) Filter [codegen id : 1]
+Input [4]: [c_customer_sk#1, c_current_addr_sk#2, c_first_name#3, c_last_name#4]
+Condition : (isnotnull(c_customer_sk#1) AND isnotnull(c_current_addr_sk#2))
 
-(37) Exchange
-Input [4]: [c_customer_sk#27, c_current_addr_sk#28, c_first_name#29, c_last_name#30]
-Arguments: hashpartitioning(c_customer_sk#27, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+(4) Exchange
+Input [4]: [c_customer_sk#1, c_current_addr_sk#2, c_first_name#3, c_last_name#4]
+Arguments: hashpartitioning(c_current_addr_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 
-(38) Sort [codegen id : 11]
-Input [4]: [c_customer_sk#27, c_current_addr_sk#28, c_first_name#29, c_last_name#30]
-Arguments: [c_customer_sk#27 ASC NULLS FIRST], false, 0
+(5) Sort [codegen id : 2]
+Input [4]: [c_customer_sk#1, c_current_addr_sk#2, c_first_name#3, c_last_name#4]
+Arguments: [c_current_addr_sk#2 ASC NULLS FIRST], false, 0
 
-(39) SortMergeJoin [codegen id : 12]
-Left keys [1]: [ss_customer_sk#1]
-Right keys [1]: [c_customer_sk#27]
+(6) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#5, ca_city#6]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_city)]
+ReadSchema: struct<ca_address_sk:int,ca_city:string>
+
+(7) ColumnarToRow [codegen id : 3]
+Input [2]: [ca_address_sk#5, ca_city#6]
+
+(8) Filter [codegen id : 3]
+Input [2]: [ca_address_sk#5, ca_city#6]
+Condition : (isnotnull(ca_address_sk#5) AND isnotnull(ca_city#6))
+
+(9) Exchange
+Input [2]: [ca_address_sk#5, ca_city#6]
+Arguments: hashpartitioning(ca_address_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+
+(10) Sort [codegen id : 4]
+Input [2]: [ca_address_sk#5, ca_city#6]
+Arguments: [ca_address_sk#5 ASC NULLS FIRST], false, 0
+
+(11) SortMergeJoin [codegen id : 5]
+Left keys [1]: [c_current_addr_sk#2]
+Right keys [1]: [ca_address_sk#5]
 Join type: Inner
 Join condition: None
 
-(40) Project [codegen id : 12]
-Output [7]: [ss_ticket_number#5, bought_city#24, amt#25, profit#26, c_current_addr_sk#28, c_first_name#29, c_last_name#30]
-Input [9]: [ss_ticket_number#5, ss_customer_sk#1, bought_city#24, amt#25, profit#26, c_customer_sk#27, c_current_addr_sk#28, c_first_name#29, c_last_name#30]
+(12) Project [codegen id : 5]
+Output [4]: [c_customer_sk#1, c_first_name#3, c_last_name#4, ca_city#6]
+Input [6]: [c_customer_sk#1, c_current_addr_sk#2, c_first_name#3, c_last_name#4, ca_address_sk#5, ca_city#6]
 
-(41) Exchange
-Input [7]: [ss_ticket_number#5, bought_city#24, amt#25, profit#26, c_current_addr_sk#28, c_first_name#29, c_last_name#30]
-Arguments: hashpartitioning(c_current_addr_sk#28, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(13) Exchange
+Input [4]: [c_customer_sk#1, c_first_name#3, c_last_name#4, ca_city#6]
+Arguments: hashpartitioning(c_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(42) Sort [codegen id : 13]
-Input [7]: [ss_ticket_number#5, bought_city#24, amt#25, profit#26, c_current_addr_sk#28, c_first_name#29, c_last_name#30]
-Arguments: [c_current_addr_sk#28 ASC NULLS FIRST], false, 0
+(14) Sort [codegen id : 6]
+Input [4]: [c_customer_sk#1, c_first_name#3, c_last_name#4, ca_city#6]
+Arguments: [c_customer_sk#1 ASC NULLS FIRST], false, 0
 
-(43) ReusedExchange [Reuses operator id: 26]
-Output [2]: [ca_address_sk#31, ca_city#32]
+(15) Scan parquet spark_catalog.default.store_sales
+Output [8]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, ss_sold_date_sk#14]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [ss_sold_date_sk#14 INSET 2451181, 2451182, 2451188, 2451189, 2451195, 2451196, 2451202, 2451203, 2451209, 2451210, 2451216, 2451217, 2451223, 2451224, 2451230, 2451231, 2451237, 2451238, 2451244, 2451245, 2451251, 2451252, 2451258, 2451259, 2451265, 2451266, 2451272, 2451273, 2451279, 2451280, 2451286, 2451287, 2451293, 2451294, 2451300, 2451301, 2451307, 2451308, 2451314, 2451315, 2451321, 2451322, 2451328, 2451329, 2451335, 2451336, 2451342, 2451343, 2451349, 2451350, 2451356, 2451357, 2451363, 2451364, 2451370, 2451371, 2451377, 2451378, 2451384, 2451385, 2451391, 2451392, 2451398, 2451399, 2451405, 2451406, 2451412, 2451413, 2451419, 2451420, 2451426, 2451427, 2451433, 2451434, 2451440, 2451441, 2451447, 2451448, 2451454, 2451455, 2451461, 2451462, 2451468, 2451469, 2451475, 2451476, 2451482, 2451483, 2451489, 2451490, 2451496, 2451497, 2451503, 2451504, 2451510, 2451511, 2451517, 2451518, 2451524, 2451525, 2451531, 2451532, 2451538, 2451539, 2451545, 2451546, 2451552, 2451553, 2451559, 2451560, 2451566, 2451567, 2451573, 2451574, 2451580, 2451581, 2451587, 2451588, 2451594, 2451595, 2451601, 2451602, 2451608, 2451609, 2451615, 2451616, 2451622, 2451623, 2451629, 2451630, 2451636, 2451637, 2451643, 2451644, 2451650, 2451651, 2451657, 2451658, 2451664, 2451665, 2451671, 2451672, 2451678, 2451679, 2451685, 2451686, 2451692, 2451693, 2451699, 2451700, 2451706, 2451707, 2451713, 2451714, 2451720, 2451721, 2451727, 2451728, 2451734, 2451735, 2451741, 2451742, 2451748, 2451749, 2451755, 2451756, 2451762, 2451763, 2451769, 2451770, 2451776, 2451777, 2451783, 2451784, 2451790, 2451791, 2451797, 2451798, 2451804, 2451805, 2451811, 2451812, 2451818, 2451819, 2451825, 2451826, 2451832, 2451833, 2451839, 2451840, 2451846, 2451847, 2451853, 2451854, 2451860, 2451861, 2451867, 2451868, 2451874, 2451875, 2451881, 2451882, 2451888, 2451889, 2451895, 2451896, 2451902, 2451903, 2451909, 2451910, 2451916, 2451917, 2451923, 2451924, 2451930, 2451931, 2451937, 2451938, 2451944, 2451945, 2451951, 2451952, 2451958, 2451959, 2451965, 2451966, 2451972, 2451973, 2451979, 2451980, 2451986, 2451987, 2451993, 2451994, 2452000, 2452001, 2452007, 2452008, 2452014, 2452015, 2452021, 2452022, 2452028, 2452029, 2452035, 2452036, 2452042, 2452043, 2452049, 2452050, 2452056, 2452057, 2452063, 2452064, 2452070, 2452071, 2452077, 2452078, 2452084, 2452085, 2452091, 2452092, 2452098, 2452099, 2452105, 2452106, 2452112, 2452113, 2452119, 2452120, 2452126, 2452127, 2452133, 2452134, 2452140, 2452141, 2452147, 2452148, 2452154, 2452155, 2452161, 2452162, 2452168, 2452169, 2452175, 2452176, 2452182, 2452183, 2452189, 2452190, 2452196, 2452197, 2452203, 2452204, 2452210, 2452211, 2452217, 2452218, 2452224, 2452225, 2452231, 2452232, 2452238, 2452239, 2452245, 2452246, 2452252, 2452253, 2452259, 2452260, 2452266, 2452267, 2452273, 2452274, isnotnull(ss_sold_date_sk#14), dynamicpruningexpression(ss_sold_date_sk#14 IN dynamicpruning#15)]
+PushedFilters: [IsNotNull(ss_store_sk), IsNotNull(ss_hdemo_sk), IsNotNull(ss_addr_sk), IsNotNull(ss_customer_sk)]
+ReadSchema: struct<ss_customer_sk:int,ss_hdemo_sk:int,ss_addr_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_coupon_amt:decimal(7,2),ss_net_profit:decimal(7,2)>
+
+(16) ColumnarToRow [codegen id : 10]
+Input [8]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, ss_sold_date_sk#14]
+
+(17) Filter [codegen id : 10]
+Input [8]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, ss_sold_date_sk#14]
+Condition : (((isnotnull(ss_store_sk#10) AND isnotnull(ss_hdemo_sk#8)) AND isnotnull(ss_addr_sk#9)) AND isnotnull(ss_customer_sk#7))
+
+(18) ReusedExchange [Reuses operator id: 52]
+Output [1]: [d_date_sk#16]
+
+(19) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ss_sold_date_sk#14]
+Right keys [1]: [d_date_sk#16]
+Join type: Inner
+Join condition: None
+
+(20) Project [codegen id : 10]
+Output [7]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13]
+Input [9]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, ss_sold_date_sk#14, d_date_sk#16]
+
+(21) Scan parquet spark_catalog.default.household_demographics
+Output [3]: [hd_demo_sk#17, hd_dep_count#18, hd_vehicle_count#19]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/household_demographics]
+PushedFilters: [Or(EqualTo(hd_dep_count,5),EqualTo(hd_vehicle_count,3)), IsNotNull(hd_demo_sk)]
+ReadSchema: struct<hd_demo_sk:int,hd_dep_count:int,hd_vehicle_count:int>
+
+(22) ColumnarToRow [codegen id : 8]
+Input [3]: [hd_demo_sk#17, hd_dep_count#18, hd_vehicle_count#19]
+
+(23) Filter [codegen id : 8]
+Input [3]: [hd_demo_sk#17, hd_dep_count#18, hd_vehicle_count#19]
+Condition : (((hd_dep_count#18 = 5) OR (hd_vehicle_count#19 = 3)) AND isnotnull(hd_demo_sk#17))
+
+(24) Project [codegen id : 8]
+Output [1]: [hd_demo_sk#17]
+Input [3]: [hd_demo_sk#17, hd_dep_count#18, hd_vehicle_count#19]
+
+(25) BroadcastExchange
+Input [1]: [hd_demo_sk#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
+
+(26) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ss_hdemo_sk#8]
+Right keys [1]: [hd_demo_sk#17]
+Join type: Inner
+Join condition: None
+
+(27) Project [codegen id : 10]
+Output [6]: [ss_customer_sk#7, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13]
+Input [8]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, hd_demo_sk#17]
+
+(28) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#20, s_city#21]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [In(s_city, [Brownsville,Concord,Greenville,Midway,Spring Hill]), IsNotNull(s_store_sk)]
+ReadSchema: struct<s_store_sk:int,s_city:string>
+
+(29) ColumnarToRow [codegen id : 9]
+Input [2]: [s_store_sk#20, s_city#21]
+
+(30) Filter [codegen id : 9]
+Input [2]: [s_store_sk#20, s_city#21]
+Condition : (s_city#21 IN (Midway,Concord,Spring Hill,Brownsville,Greenville) AND isnotnull(s_store_sk#20))
+
+(31) Project [codegen id : 9]
+Output [1]: [s_store_sk#20]
+Input [2]: [s_store_sk#20, s_city#21]
+
+(32) BroadcastExchange
+Input [1]: [s_store_sk#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+
+(33) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ss_store_sk#10]
+Right keys [1]: [s_store_sk#20]
+Join type: Inner
+Join condition: None
+
+(34) Project [codegen id : 10]
+Output [5]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13]
+Input [7]: [ss_customer_sk#7, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, s_store_sk#20]
+
+(35) Exchange
+Input [5]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13]
+Arguments: hashpartitioning(ss_addr_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(36) Sort [codegen id : 11]
+Input [5]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13]
+Arguments: [ss_addr_sk#9 ASC NULLS FIRST], false, 0
+
+(37) ReusedExchange [Reuses operator id: 9]
+Output [2]: [ca_address_sk#22, ca_city#23]
+
+(38) Sort [codegen id : 13]
+Input [2]: [ca_address_sk#22, ca_city#23]
+Arguments: [ca_address_sk#22 ASC NULLS FIRST], false, 0
+
+(39) SortMergeJoin [codegen id : 14]
+Left keys [1]: [ss_addr_sk#9]
+Right keys [1]: [ca_address_sk#22]
+Join type: Inner
+Join condition: None
+
+(40) Project [codegen id : 14]
+Output [6]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, ca_city#23]
+Input [7]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, ca_address_sk#22, ca_city#23]
+
+(41) HashAggregate [codegen id : 14]
+Input [6]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, ca_city#23]
+Keys [4]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#23]
+Functions [2]: [partial_sum(UnscaledValue(ss_coupon_amt#12)), partial_sum(UnscaledValue(ss_net_profit#13))]
+Aggregate Attributes [2]: [sum#24, sum#25]
+Results [6]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#23, sum#26, sum#27]
+
+(42) HashAggregate [codegen id : 14]
+Input [6]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#23, sum#26, sum#27]
+Keys [4]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#23]
+Functions [2]: [sum(UnscaledValue(ss_coupon_amt#12)), sum(UnscaledValue(ss_net_profit#13))]
+Aggregate Attributes [2]: [sum(UnscaledValue(ss_coupon_amt#12))#28, sum(UnscaledValue(ss_net_profit#13))#29]
+Results [5]: [ss_ticket_number#11, ss_customer_sk#7, ca_city#23 AS bought_city#30, MakeDecimal(sum(UnscaledValue(ss_coupon_amt#12))#28,17,2) AS amt#31, MakeDecimal(sum(UnscaledValue(ss_net_profit#13))#29,17,2) AS profit#32]
+
+(43) Exchange
+Input [5]: [ss_ticket_number#11, ss_customer_sk#7, bought_city#30, amt#31, profit#32]
+Arguments: hashpartitioning(ss_customer_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
 (44) Sort [codegen id : 15]
-Input [2]: [ca_address_sk#31, ca_city#32]
-Arguments: [ca_address_sk#31 ASC NULLS FIRST], false, 0
+Input [5]: [ss_ticket_number#11, ss_customer_sk#7, bought_city#30, amt#31, profit#32]
+Arguments: [ss_customer_sk#7 ASC NULLS FIRST], false, 0
 
 (45) SortMergeJoin [codegen id : 16]
-Left keys [1]: [c_current_addr_sk#28]
-Right keys [1]: [ca_address_sk#31]
+Left keys [1]: [c_customer_sk#1]
+Right keys [1]: [ss_customer_sk#7]
 Join type: Inner
-Join condition: NOT (ca_city#32 = bought_city#24)
+Join condition: NOT (ca_city#6 = bought_city#30)
 
 (46) Project [codegen id : 16]
-Output [7]: [c_last_name#30, c_first_name#29, ca_city#32, bought_city#24, ss_ticket_number#5, amt#25, profit#26]
-Input [9]: [ss_ticket_number#5, bought_city#24, amt#25, profit#26, c_current_addr_sk#28, c_first_name#29, c_last_name#30, ca_address_sk#31, ca_city#32]
+Output [7]: [c_last_name#4, c_first_name#3, ca_city#6, bought_city#30, ss_ticket_number#11, amt#31, profit#32]
+Input [9]: [c_customer_sk#1, c_first_name#3, c_last_name#4, ca_city#6, ss_ticket_number#11, ss_customer_sk#7, bought_city#30, amt#31, profit#32]
 
 (47) TakeOrderedAndProject
-Input [7]: [c_last_name#30, c_first_name#29, ca_city#32, bought_city#24, ss_ticket_number#5, amt#25, profit#26]
-Arguments: 100, [c_last_name#30 ASC NULLS FIRST, c_first_name#29 ASC NULLS FIRST, ca_city#32 ASC NULLS FIRST, bought_city#24 ASC NULLS FIRST, ss_ticket_number#5 ASC NULLS FIRST], [c_last_name#30, c_first_name#29, ca_city#32, bought_city#24, ss_ticket_number#5, amt#25, profit#26]
+Input [7]: [c_last_name#4, c_first_name#3, ca_city#6, bought_city#30, ss_ticket_number#11, amt#31, profit#32]
+Arguments: 100, [c_last_name#4 ASC NULLS FIRST, c_first_name#3 ASC NULLS FIRST, ca_city#6 ASC NULLS FIRST, bought_city#30 ASC NULLS FIRST, ss_ticket_number#11 ASC NULLS FIRST], [c_last_name#4, c_first_name#3, ca_city#6, bought_city#30, ss_ticket_number#11, amt#31, profit#32]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
+Subquery:1 Hosting operator id = 15 Hosting Expression = ss_sold_date_sk#14 IN dynamicpruning#15
 BroadcastExchange (52)
 +- * Project (51)
    +- * Filter (50)
@@ -274,25 +274,25 @@ BroadcastExchange (52)
 
 
 (48) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#10, d_year#33, d_dow#34]
+Output [3]: [d_date_sk#16, d_year#33, d_dow#34]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_dow, [0,6]), In(d_year, [1999,2000,2001]), In(d_date_sk, [2451181,2451182,2451188,2451189,2451195,2451196,2451202,2451203,2451209,2451210,2451216,2451217,2451223,2451224,2451230,2451231,2451237,2451238,2451244,2451245,2451251,2451252,2451258,2451259,2451265,2451266,2451272,2451273,2451279,2451280,2451286,2451287,2451293,2451294,2451300,2451301,2451307,2451308,2451314,2451315,2451321,2451322,2451328,2451329,2451335,2451336,2451342,2451343,2451349,2451350,2451356,2451357,2451363,2451364,2451370,2451371,2451377,2451378,2451384,2451385,2451391,2451392,2451398,2451399,2451405,2451406,2451412,2451413,2451419,2451420,2451426,2451427,2451433,2451434,2451440,2451441,2451447,2451448,2451454,2451455,2451461,2451462,2451468,2451469,2451475,2451476,2451482,2451483,2451489,2451490,2451496,2451497,2451503,2451504,2451510,2451511,2451517,2451518,2451524,2451525,2451531,2451532,2451538,2451539,2451545,2451546,2451552,2451553,2451559,2451560,2451566,2451567,2451573,2451574,2451580,2451581,2451587,2451588,2451594,2451595,2451601,2451602,2451608,2451609,2451615,2451616,2451622,2451623,2451629,2451630,2451636,2451637,2451643,2451644,2451650,2451651,2451657,2451658,2451664,2451665,2451671,2451672,2451678,2451679,2451685,2451686,2451692,2451693,2451699,2451700,2451706,2451707,2451713,2451714,2451720,2451721,2451727,2451728,2451734,2451735,2451741,2451742,2451748,2451749,2451755,2451756,2451762,2451763,2451769,2451770,2451776,2451777,2451783,2451784,2451790,2451791,2451797,2451798,2451804,2451805,2451811,2451812,2451818,2451819,2451825,2451826,2451832,2451833,2451839,2451840,2451846,2451847,2451853,2451854,2451860,2451861,2451867,2451868,2451874,2451875,2451881,2451882,2451888,2451889,2451895,2451896,2451902,2451903,2451909,2451910,2451916,2451917,2451923,2451924,2451930,2451931,2451937,2451938,2451944,2451945,2451951,2451952,2451958,2451959,2451965,2451966,2451972,2451973,2451979,2451980,2451986,2451987,2451993,2451994,2452000,2452001,2452007,2452008,2452014,2452015,2452021,2452022,2452028,2452029,2452035,2452036,2452042,2452043,2452049,2452050,2452056,2452057,2452063,2452064,2452070,2452071,2452077,2452078,2452084,2452085,2452091,2452092,2452098,2452099,2452105,2452106,2452112,2452113,2452119,2452120,2452126,2452127,2452133,2452134,2452140,2452141,2452147,2452148,2452154,2452155,2452161,2452162,2452168,2452169,2452175,2452176,2452182,2452183,2452189,2452190,2452196,2452197,2452203,2452204,2452210,2452211,2452217,2452218,2452224,2452225,2452231,2452232,2452238,2452239,2452245,2452246,2452252,2452253,2452259,2452260,2452266,2452267,2452273,2452274]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_dow:int>
 
 (49) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#10, d_year#33, d_dow#34]
+Input [3]: [d_date_sk#16, d_year#33, d_dow#34]
 
 (50) Filter [codegen id : 1]
-Input [3]: [d_date_sk#10, d_year#33, d_dow#34]
-Condition : (((d_dow#34 IN (6,0) AND d_year#33 IN (1999,2000,2001)) AND d_date_sk#10 INSET 2451181, 2451182, 2451188, 2451189, 2451195, 2451196, 2451202, 2451203, 2451209, 2451210, 2451216, 2451217, 2451223, 2451224, 2451230, 2451231, 2451237, 2451238, 2451244, 2451245, 2451251, 2451252, 2451258, 2451259, 2451265, 2451266, 2451272, 2451273, 2451279, 2451280, 2451286, 2451287, 2451293, 2451294, 2451300, 2451301, 2451307, 2451308, 2451314, 2451315, 2451321, 2451322, 2451328, 2451329, 2451335, 2451336, 2451342, 2451343, 2451349, 2451350, 2451356, 2451357, 2451363, 2451364, 2451370, 2451371, 2451377, 2451378, 2451384, 2451385, 2451391, 2451392, 2451398, 2451399, 2451405, 2451406, 2451412, 2451413, 2451419, 2451420, 2451426, 2451427, 2451433, 2451434, 2451440, 2451441, 2451447, 2451448, 2451454, 2451455, 2451461, 2451462, 2451468, 2451469, 2451475, 2451476, 2451482, 2451483, 2451489, 2451490, 2451496, 2451497, 2451503, 2451504, 2451510, 2451511, 2451517, 2451518, 2451524, 2451525, 2451531, 2451532, 2451538, 2451539, 2451545, 2451546, 2451552, 2451553, 2451559, 2451560, 2451566, 2451567, 2451573, 2451574, 2451580, 2451581, 2451587, 2451588, 2451594, 2451595, 2451601, 2451602, 2451608, 2451609, 2451615, 2451616, 2451622, 2451623, 2451629, 2451630, 2451636, 2451637, 2451643, 2451644, 2451650, 2451651, 2451657, 2451658, 2451664, 2451665, 2451671, 2451672, 2451678, 2451679, 2451685, 2451686, 2451692, 2451693, 2451699, 2451700, 2451706, 2451707, 2451713, 2451714, 2451720, 2451721, 2451727, 2451728, 2451734, 2451735, 2451741, 2451742, 2451748, 2451749, 2451755, 2451756, 2451762, 2451763, 2451769, 2451770, 2451776, 2451777, 2451783, 2451784, 2451790, 2451791, 2451797, 2451798, 2451804, 2451805, 2451811, 2451812, 2451818, 2451819, 2451825, 2451826, 2451832, 2451833, 2451839, 2451840, 2451846, 2451847, 2451853, 2451854, 2451860, 2451861, 2451867, 2451868, 2451874, 2451875, 2451881, 2451882, 2451888, 2451889, 2451895, 2451896, 2451902, 2451903, 2451909, 2451910, 2451916, 2451917, 2451923, 2451924, 2451930, 2451931, 2451937, 2451938, 2451944, 2451945, 2451951, 2451952, 2451958, 2451959, 2451965, 2451966, 2451972, 2451973, 2451979, 2451980, 2451986, 2451987, 2451993, 2451994, 2452000, 2452001, 2452007, 2452008, 2452014, 2452015, 2452021, 2452022, 2452028, 2452029, 2452035, 2452036, 2452042, 2452043, 2452049, 2452050, 2452056, 2452057, 2452063, 2452064, 2452070, 2452071, 2452077, 2452078, 2452084, 2452085, 2452091, 2452092, 2452098, 2452099, 2452105, 2452106, 2452112, 2452113, 2452119, 2452120, 2452126, 2452127, 2452133, 2452134, 2452140, 2452141, 2452147, 2452148, 2452154, 2452155, 2452161, 2452162, 2452168, 2452169, 2452175, 2452176, 2452182, 2452183, 2452189, 2452190, 2452196, 2452197, 2452203, 2452204, 2452210, 2452211, 2452217, 2452218, 2452224, 2452225, 2452231, 2452232, 2452238, 2452239, 2452245, 2452246, 2452252, 2452253, 2452259, 2452260, 2452266, 2452267, 2452273, 2452274) AND isnotnull(d_date_sk#10))
+Input [3]: [d_date_sk#16, d_year#33, d_dow#34]
+Condition : (((d_dow#34 IN (6,0) AND d_year#33 IN (1999,2000,2001)) AND d_date_sk#16 INSET 2451181, 2451182, 2451188, 2451189, 2451195, 2451196, 2451202, 2451203, 2451209, 2451210, 2451216, 2451217, 2451223, 2451224, 2451230, 2451231, 2451237, 2451238, 2451244, 2451245, 2451251, 2451252, 2451258, 2451259, 2451265, 2451266, 2451272, 2451273, 2451279, 2451280, 2451286, 2451287, 2451293, 2451294, 2451300, 2451301, 2451307, 2451308, 2451314, 2451315, 2451321, 2451322, 2451328, 2451329, 2451335, 2451336, 2451342, 2451343, 2451349, 2451350, 2451356, 2451357, 2451363, 2451364, 2451370, 2451371, 2451377, 2451378, 2451384, 2451385, 2451391, 2451392, 2451398, 2451399, 2451405, 2451406, 2451412, 2451413, 2451419, 2451420, 2451426, 2451427, 2451433, 2451434, 2451440, 2451441, 2451447, 2451448, 2451454, 2451455, 2451461, 2451462, 2451468, 2451469, 2451475, 2451476, 2451482, 2451483, 2451489, 2451490, 2451496, 2451497, 2451503, 2451504, 2451510, 2451511, 2451517, 2451518, 2451524, 2451525, 2451531, 2451532, 2451538, 2451539, 2451545, 2451546, 2451552, 2451553, 2451559, 2451560, 2451566, 2451567, 2451573, 2451574, 2451580, 2451581, 2451587, 2451588, 2451594, 2451595, 2451601, 2451602, 2451608, 2451609, 2451615, 2451616, 2451622, 2451623, 2451629, 2451630, 2451636, 2451637, 2451643, 2451644, 2451650, 2451651, 2451657, 2451658, 2451664, 2451665, 2451671, 2451672, 2451678, 2451679, 2451685, 2451686, 2451692, 2451693, 2451699, 2451700, 2451706, 2451707, 2451713, 2451714, 2451720, 2451721, 2451727, 2451728, 2451734, 2451735, 2451741, 2451742, 2451748, 2451749, 2451755, 2451756, 2451762, 2451763, 2451769, 2451770, 2451776, 2451777, 2451783, 2451784, 2451790, 2451791, 2451797, 2451798, 2451804, 2451805, 2451811, 2451812, 2451818, 2451819, 2451825, 2451826, 2451832, 2451833, 2451839, 2451840, 2451846, 2451847, 2451853, 2451854, 2451860, 2451861, 2451867, 2451868, 2451874, 2451875, 2451881, 2451882, 2451888, 2451889, 2451895, 2451896, 2451902, 2451903, 2451909, 2451910, 2451916, 2451917, 2451923, 2451924, 2451930, 2451931, 2451937, 2451938, 2451944, 2451945, 2451951, 2451952, 2451958, 2451959, 2451965, 2451966, 2451972, 2451973, 2451979, 2451980, 2451986, 2451987, 2451993, 2451994, 2452000, 2452001, 2452007, 2452008, 2452014, 2452015, 2452021, 2452022, 2452028, 2452029, 2452035, 2452036, 2452042, 2452043, 2452049, 2452050, 2452056, 2452057, 2452063, 2452064, 2452070, 2452071, 2452077, 2452078, 2452084, 2452085, 2452091, 2452092, 2452098, 2452099, 2452105, 2452106, 2452112, 2452113, 2452119, 2452120, 2452126, 2452127, 2452133, 2452134, 2452140, 2452141, 2452147, 2452148, 2452154, 2452155, 2452161, 2452162, 2452168, 2452169, 2452175, 2452176, 2452182, 2452183, 2452189, 2452190, 2452196, 2452197, 2452203, 2452204, 2452210, 2452211, 2452217, 2452218, 2452224, 2452225, 2452231, 2452232, 2452238, 2452239, 2452245, 2452246, 2452252, 2452253, 2452259, 2452260, 2452266, 2452267, 2452273, 2452274) AND isnotnull(d_date_sk#16))
 
 (51) Project [codegen id : 1]
-Output [1]: [d_date_sk#10]
-Input [3]: [d_date_sk#10, d_year#33, d_dow#34]
+Output [1]: [d_date_sk#16]
+Input [3]: [d_date_sk#16, d_year#33, d_dow#34]
 
 (52) BroadcastExchange
-Input [1]: [d_date_sk#10]
+Input [1]: [d_date_sk#16]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q46.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q46.sf100/simplified.txt
@@ -1,89 +1,89 @@
 TakeOrderedAndProject [c_last_name,c_first_name,ca_city,bought_city,ss_ticket_number,amt,profit]
   WholeStageCodegen (16)
     Project [c_last_name,c_first_name,ca_city,bought_city,ss_ticket_number,amt,profit]
-      SortMergeJoin [c_current_addr_sk,ca_address_sk,ca_city,bought_city]
+      SortMergeJoin [c_customer_sk,ss_customer_sk,ca_city,bought_city]
         InputAdapter
-          WholeStageCodegen (13)
-            Sort [c_current_addr_sk]
+          WholeStageCodegen (6)
+            Sort [c_customer_sk]
               InputAdapter
-                Exchange [c_current_addr_sk] #1
-                  WholeStageCodegen (12)
-                    Project [ss_ticket_number,bought_city,amt,profit,c_current_addr_sk,c_first_name,c_last_name]
-                      SortMergeJoin [ss_customer_sk,c_customer_sk]
+                Exchange [c_customer_sk] #1
+                  WholeStageCodegen (5)
+                    Project [c_customer_sk,c_first_name,c_last_name,ca_city]
+                      SortMergeJoin [c_current_addr_sk,ca_address_sk]
                         InputAdapter
-                          WholeStageCodegen (9)
-                            Sort [ss_customer_sk]
+                          WholeStageCodegen (2)
+                            Sort [c_current_addr_sk]
                               InputAdapter
-                                Exchange [ss_customer_sk] #2
-                                  WholeStageCodegen (8)
-                                    HashAggregate [ss_ticket_number,ss_customer_sk,ss_addr_sk,ca_city,sum,sum] [sum(UnscaledValue(ss_coupon_amt)),sum(UnscaledValue(ss_net_profit)),bought_city,amt,profit,sum,sum]
-                                      HashAggregate [ss_ticket_number,ss_customer_sk,ss_addr_sk,ca_city,ss_coupon_amt,ss_net_profit] [sum,sum,sum,sum]
-                                        Project [ss_customer_sk,ss_addr_sk,ss_ticket_number,ss_coupon_amt,ss_net_profit,ca_city]
-                                          SortMergeJoin [ss_addr_sk,ca_address_sk]
-                                            InputAdapter
-                                              WholeStageCodegen (5)
-                                                Sort [ss_addr_sk]
-                                                  InputAdapter
-                                                    Exchange [ss_addr_sk] #3
-                                                      WholeStageCodegen (4)
-                                                        Project [ss_customer_sk,ss_addr_sk,ss_ticket_number,ss_coupon_amt,ss_net_profit]
-                                                          BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
-                                                            Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_ticket_number,ss_coupon_amt,ss_net_profit]
-                                                              BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                                Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_coupon_amt,ss_net_profit]
-                                                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                    Filter [ss_store_sk,ss_hdemo_sk,ss_addr_sk,ss_customer_sk]
-                                                                      ColumnarToRow
-                                                                        InputAdapter
-                                                                          Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_coupon_amt,ss_net_profit,ss_sold_date_sk]
-                                                                            SubqueryBroadcast [d_date_sk] #1
-                                                                              BroadcastExchange #4
-                                                                                WholeStageCodegen (1)
-                                                                                  Project [d_date_sk]
-                                                                                    Filter [d_dow,d_year,d_date_sk]
-                                                                                      ColumnarToRow
-                                                                                        InputAdapter
-                                                                                          Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_dow]
-                                                                    InputAdapter
-                                                                      ReusedExchange [d_date_sk] #4
-                                                                InputAdapter
-                                                                  BroadcastExchange #5
-                                                                    WholeStageCodegen (2)
-                                                                      Project [s_store_sk]
-                                                                        Filter [s_city,s_store_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet spark_catalog.default.store [s_store_sk,s_city]
-                                                            InputAdapter
-                                                              BroadcastExchange #6
-                                                                WholeStageCodegen (3)
-                                                                  Project [hd_demo_sk]
-                                                                    Filter [hd_dep_count,hd_vehicle_count,hd_demo_sk]
-                                                                      ColumnarToRow
-                                                                        InputAdapter
-                                                                          Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_dep_count,hd_vehicle_count]
-                                            InputAdapter
-                                              WholeStageCodegen (7)
-                                                Sort [ca_address_sk]
-                                                  InputAdapter
-                                                    Exchange [ca_address_sk] #7
-                                                      WholeStageCodegen (6)
-                                                        Filter [ca_address_sk,ca_city]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_city]
-                        InputAdapter
-                          WholeStageCodegen (11)
-                            Sort [c_customer_sk]
-                              InputAdapter
-                                Exchange [c_customer_sk] #8
-                                  WholeStageCodegen (10)
+                                Exchange [c_current_addr_sk] #2
+                                  WholeStageCodegen (1)
                                     Filter [c_customer_sk,c_current_addr_sk]
                                       ColumnarToRow
                                         InputAdapter
                                           Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk,c_first_name,c_last_name]
+                        InputAdapter
+                          WholeStageCodegen (4)
+                            Sort [ca_address_sk]
+                              InputAdapter
+                                Exchange [ca_address_sk] #3
+                                  WholeStageCodegen (3)
+                                    Filter [ca_address_sk,ca_city]
+                                      ColumnarToRow
+                                        InputAdapter
+                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_city]
         InputAdapter
           WholeStageCodegen (15)
-            Sort [ca_address_sk]
+            Sort [ss_customer_sk]
               InputAdapter
-                ReusedExchange [ca_address_sk,ca_city] #7
+                Exchange [ss_customer_sk] #4
+                  WholeStageCodegen (14)
+                    HashAggregate [ss_ticket_number,ss_customer_sk,ss_addr_sk,ca_city,sum,sum] [sum(UnscaledValue(ss_coupon_amt)),sum(UnscaledValue(ss_net_profit)),bought_city,amt,profit,sum,sum]
+                      HashAggregate [ss_ticket_number,ss_customer_sk,ss_addr_sk,ca_city,ss_coupon_amt,ss_net_profit] [sum,sum,sum,sum]
+                        Project [ss_customer_sk,ss_addr_sk,ss_ticket_number,ss_coupon_amt,ss_net_profit,ca_city]
+                          SortMergeJoin [ss_addr_sk,ca_address_sk]
+                            InputAdapter
+                              WholeStageCodegen (11)
+                                Sort [ss_addr_sk]
+                                  InputAdapter
+                                    Exchange [ss_addr_sk] #5
+                                      WholeStageCodegen (10)
+                                        Project [ss_customer_sk,ss_addr_sk,ss_ticket_number,ss_coupon_amt,ss_net_profit]
+                                          BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                            Project [ss_customer_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_coupon_amt,ss_net_profit]
+                                              BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
+                                                Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_coupon_amt,ss_net_profit]
+                                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                    Filter [ss_store_sk,ss_hdemo_sk,ss_addr_sk,ss_customer_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_coupon_amt,ss_net_profit,ss_sold_date_sk]
+                                                            SubqueryBroadcast [d_date_sk] #1
+                                                              BroadcastExchange #6
+                                                                WholeStageCodegen (1)
+                                                                  Project [d_date_sk]
+                                                                    Filter [d_dow,d_year,d_date_sk]
+                                                                      ColumnarToRow
+                                                                        InputAdapter
+                                                                          Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_dow]
+                                                    InputAdapter
+                                                      ReusedExchange [d_date_sk] #6
+                                                InputAdapter
+                                                  BroadcastExchange #7
+                                                    WholeStageCodegen (8)
+                                                      Project [hd_demo_sk]
+                                                        Filter [hd_dep_count,hd_vehicle_count,hd_demo_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_dep_count,hd_vehicle_count]
+                                            InputAdapter
+                                              BroadcastExchange #8
+                                                WholeStageCodegen (9)
+                                                  Project [s_store_sk]
+                                                    Filter [s_city,s_store_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet spark_catalog.default.store [s_store_sk,s_city]
+                            InputAdapter
+                              WholeStageCodegen (13)
+                                Sort [ca_address_sk]
+                                  InputAdapter
+                                    ReusedExchange [ca_address_sk,ca_city] #3

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q53.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q53.sf100/explain.txt
@@ -10,158 +10,158 @@ TakeOrderedAndProject (28)
                      +- * HashAggregate (20)
                         +- * Project (19)
                            +- * BroadcastHashJoin Inner BuildRight (18)
-                              :- * Project (16)
-                              :  +- * BroadcastHashJoin Inner BuildRight (15)
-                              :     :- * Project (10)
-                              :     :  +- * BroadcastHashJoin Inner BuildLeft (9)
-                              :     :     :- BroadcastExchange (5)
-                              :     :     :  +- * Project (4)
-                              :     :     :     +- * Filter (3)
-                              :     :     :        +- * ColumnarToRow (2)
-                              :     :     :           +- Scan parquet spark_catalog.default.item (1)
-                              :     :     +- * Filter (8)
-                              :     :        +- * ColumnarToRow (7)
-                              :     :           +- Scan parquet spark_catalog.default.store_sales (6)
-                              :     +- BroadcastExchange (14)
-                              :        +- * Filter (13)
-                              :           +- * ColumnarToRow (12)
-                              :              +- Scan parquet spark_catalog.default.store (11)
-                              +- ReusedExchange (17)
+                              :- * Project (13)
+                              :  +- * BroadcastHashJoin Inner BuildRight (12)
+                              :     :- * Project (6)
+                              :     :  +- * BroadcastHashJoin Inner BuildRight (5)
+                              :     :     :- * Filter (3)
+                              :     :     :  +- * ColumnarToRow (2)
+                              :     :     :     +- Scan parquet spark_catalog.default.store_sales (1)
+                              :     :     +- ReusedExchange (4)
+                              :     +- BroadcastExchange (11)
+                              :        +- * Project (10)
+                              :           +- * Filter (9)
+                              :              +- * ColumnarToRow (8)
+                              :                 +- Scan parquet spark_catalog.default.item (7)
+                              +- BroadcastExchange (17)
+                                 +- * Filter (16)
+                                    +- * ColumnarToRow (15)
+                                       +- Scan parquet spark_catalog.default.store (14)
 
 
-(1) Scan parquet spark_catalog.default.item
-Output [5]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4, i_manufact_id#5]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [Or(And(And(In(i_category, [Books                                             ,Children                                          ,Electronics                                       ]),In(i_class, [personal                                          ,portable                                          ,reference                                         ,self-help                                         ])),In(i_brand, [exportiunivamalg #6                               ,scholaramalgamalg #7                             ,scholaramalgamalg #8                              ,scholaramalgamalg #6                              ])),And(And(In(i_category, [Men                                               ,Music                                             ,Women                                             ]),In(i_class, [accessories                                       ,classical                                         ,fragrances                                        ,pants                                             ])),In(i_brand, [amalgimporto #9                                   ,edu packscholar #9                                ,exportiimporto #9                                 ,importoamalg #9                                   ]))), IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_brand:string,i_class:string,i_category:string,i_manufact_id:int>
-
-(2) ColumnarToRow [codegen id : 1]
-Input [5]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4, i_manufact_id#5]
-
-(3) Filter [codegen id : 1]
-Input [5]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4, i_manufact_id#5]
-Condition : ((((i_category#4 IN (Books                                             ,Children                                          ,Electronics                                       ) AND i_class#3 IN (personal                                          ,portable                                          ,reference                                         ,self-help                                         )) AND i_brand#2 IN (scholaramalgamalg #7                             ,scholaramalgamalg #8                              ,exportiunivamalg #6                               ,scholaramalgamalg #6                              )) OR ((i_category#4 IN (Women                                             ,Music                                             ,Men                                               ) AND i_class#3 IN (accessories                                       ,classical                                         ,fragrances                                        ,pants                                             )) AND i_brand#2 IN (amalgimporto #9                                   ,edu packscholar #9                                ,exportiimporto #9                                 ,importoamalg #9                                   ))) AND isnotnull(i_item_sk#1))
-
-(4) Project [codegen id : 1]
-Output [2]: [i_item_sk#1, i_manufact_id#5]
-Input [5]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4, i_manufact_id#5]
-
-(5) BroadcastExchange
-Input [2]: [i_item_sk#1, i_manufact_id#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
-
-(6) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_item_sk#10, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
+(1) Scan parquet spark_catalog.default.store_sales
+Output [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#13), (ss_sold_date_sk#13 >= 2451911), (ss_sold_date_sk#13 <= 2452275), dynamicpruningexpression(ss_sold_date_sk#13 IN dynamicpruning#14)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#4), (ss_sold_date_sk#4 >= 2451911), (ss_sold_date_sk#4 <= 2452275), dynamicpruningexpression(ss_sold_date_sk#4 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_store_sk:int,ss_sales_price:decimal(7,2)>
 
-(7) ColumnarToRow
-Input [4]: [ss_item_sk#10, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
+(2) ColumnarToRow [codegen id : 4]
+Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
 
-(8) Filter
-Input [4]: [ss_item_sk#10, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
-Condition : (isnotnull(ss_item_sk#10) AND isnotnull(ss_store_sk#11))
+(3) Filter [codegen id : 4]
+Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
+Condition : (isnotnull(ss_item_sk#1) AND isnotnull(ss_store_sk#2))
 
-(9) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [i_item_sk#1]
-Right keys [1]: [ss_item_sk#10]
+(4) ReusedExchange [Reuses operator id: 33]
+Output [2]: [d_date_sk#6, d_qoy#7]
+
+(5) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_sold_date_sk#4]
+Right keys [1]: [d_date_sk#6]
 Join type: Inner
 Join condition: None
 
-(10) Project [codegen id : 4]
-Output [4]: [i_manufact_id#5, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
-Input [6]: [i_item_sk#1, i_manufact_id#5, ss_item_sk#10, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
+(6) Project [codegen id : 4]
+Output [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_qoy#7]
+Input [6]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4, d_date_sk#6, d_qoy#7]
 
-(11) Scan parquet spark_catalog.default.store
-Output [1]: [s_store_sk#15]
+(7) Scan parquet spark_catalog.default.item
+Output [5]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11, i_manufact_id#12]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [Or(And(And(In(i_category, [Books                                             ,Children                                          ,Electronics                                       ]),In(i_class, [personal                                          ,portable                                          ,reference                                         ,self-help                                         ])),In(i_brand, [exportiunivamalg #13                               ,scholaramalgamalg #14                             ,scholaramalgamalg #15                              ,scholaramalgamalg #13                              ])),And(And(In(i_category, [Men                                               ,Music                                             ,Women                                             ]),In(i_class, [accessories                                       ,classical                                         ,fragrances                                        ,pants                                             ])),In(i_brand, [amalgimporto #16                                   ,edu packscholar #16                                ,exportiimporto #16                                 ,importoamalg #16                                   ]))), IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_brand:string,i_class:string,i_category:string,i_manufact_id:int>
+
+(8) ColumnarToRow [codegen id : 2]
+Input [5]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11, i_manufact_id#12]
+
+(9) Filter [codegen id : 2]
+Input [5]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11, i_manufact_id#12]
+Condition : ((((i_category#11 IN (Books                                             ,Children                                          ,Electronics                                       ) AND i_class#10 IN (personal                                          ,portable                                          ,reference                                         ,self-help                                         )) AND i_brand#9 IN (scholaramalgamalg #14                             ,scholaramalgamalg #15                              ,exportiunivamalg #13                               ,scholaramalgamalg #13                              )) OR ((i_category#11 IN (Women                                             ,Music                                             ,Men                                               ) AND i_class#10 IN (accessories                                       ,classical                                         ,fragrances                                        ,pants                                             )) AND i_brand#9 IN (amalgimporto #16                                   ,edu packscholar #16                                ,exportiimporto #16                                 ,importoamalg #16                                   ))) AND isnotnull(i_item_sk#8))
+
+(10) Project [codegen id : 2]
+Output [2]: [i_item_sk#8, i_manufact_id#12]
+Input [5]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11, i_manufact_id#12]
+
+(11) BroadcastExchange
+Input [2]: [i_item_sk#8, i_manufact_id#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
+
+(12) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_item_sk#1]
+Right keys [1]: [i_item_sk#8]
+Join type: Inner
+Join condition: None
+
+(13) Project [codegen id : 4]
+Output [4]: [ss_store_sk#2, ss_sales_price#3, d_qoy#7, i_manufact_id#12]
+Input [6]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_qoy#7, i_item_sk#8, i_manufact_id#12]
+
+(14) Scan parquet spark_catalog.default.store
+Output [1]: [s_store_sk#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int>
 
-(12) ColumnarToRow [codegen id : 2]
-Input [1]: [s_store_sk#15]
+(15) ColumnarToRow [codegen id : 3]
+Input [1]: [s_store_sk#17]
 
-(13) Filter [codegen id : 2]
-Input [1]: [s_store_sk#15]
-Condition : isnotnull(s_store_sk#15)
+(16) Filter [codegen id : 3]
+Input [1]: [s_store_sk#17]
+Condition : isnotnull(s_store_sk#17)
 
-(14) BroadcastExchange
-Input [1]: [s_store_sk#15]
+(17) BroadcastExchange
+Input [1]: [s_store_sk#17]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
 
-(15) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_store_sk#11]
-Right keys [1]: [s_store_sk#15]
-Join type: Inner
-Join condition: None
-
-(16) Project [codegen id : 4]
-Output [3]: [i_manufact_id#5, ss_sales_price#12, ss_sold_date_sk#13]
-Input [5]: [i_manufact_id#5, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13, s_store_sk#15]
-
-(17) ReusedExchange [Reuses operator id: 33]
-Output [2]: [d_date_sk#16, d_qoy#17]
-
 (18) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#13]
-Right keys [1]: [d_date_sk#16]
+Left keys [1]: [ss_store_sk#2]
+Right keys [1]: [s_store_sk#17]
 Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]
-Output [3]: [i_manufact_id#5, ss_sales_price#12, d_qoy#17]
-Input [5]: [i_manufact_id#5, ss_sales_price#12, ss_sold_date_sk#13, d_date_sk#16, d_qoy#17]
+Output [3]: [i_manufact_id#12, ss_sales_price#3, d_qoy#7]
+Input [5]: [ss_store_sk#2, ss_sales_price#3, d_qoy#7, i_manufact_id#12, s_store_sk#17]
 
 (20) HashAggregate [codegen id : 4]
-Input [3]: [i_manufact_id#5, ss_sales_price#12, d_qoy#17]
-Keys [2]: [i_manufact_id#5, d_qoy#17]
-Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#12))]
+Input [3]: [i_manufact_id#12, ss_sales_price#3, d_qoy#7]
+Keys [2]: [i_manufact_id#12, d_qoy#7]
+Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#3))]
 Aggregate Attributes [1]: [sum#18]
-Results [3]: [i_manufact_id#5, d_qoy#17, sum#19]
+Results [3]: [i_manufact_id#12, d_qoy#7, sum#19]
 
 (21) Exchange
-Input [3]: [i_manufact_id#5, d_qoy#17, sum#19]
-Arguments: hashpartitioning(i_manufact_id#5, d_qoy#17, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [3]: [i_manufact_id#12, d_qoy#7, sum#19]
+Arguments: hashpartitioning(i_manufact_id#12, d_qoy#7, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (22) HashAggregate [codegen id : 5]
-Input [3]: [i_manufact_id#5, d_qoy#17, sum#19]
-Keys [2]: [i_manufact_id#5, d_qoy#17]
-Functions [1]: [sum(UnscaledValue(ss_sales_price#12))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#12))#20]
-Results [3]: [i_manufact_id#5, MakeDecimal(sum(UnscaledValue(ss_sales_price#12))#20,17,2) AS sum_sales#21, MakeDecimal(sum(UnscaledValue(ss_sales_price#12))#20,17,2) AS _w0#22]
+Input [3]: [i_manufact_id#12, d_qoy#7, sum#19]
+Keys [2]: [i_manufact_id#12, d_qoy#7]
+Functions [1]: [sum(UnscaledValue(ss_sales_price#3))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#3))#20]
+Results [3]: [i_manufact_id#12, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#20,17,2) AS sum_sales#21, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#20,17,2) AS _w0#22]
 
 (23) Exchange
-Input [3]: [i_manufact_id#5, sum_sales#21, _w0#22]
-Arguments: hashpartitioning(i_manufact_id#5, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [3]: [i_manufact_id#12, sum_sales#21, _w0#22]
+Arguments: hashpartitioning(i_manufact_id#12, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (24) Sort [codegen id : 6]
-Input [3]: [i_manufact_id#5, sum_sales#21, _w0#22]
-Arguments: [i_manufact_id#5 ASC NULLS FIRST], false, 0
+Input [3]: [i_manufact_id#12, sum_sales#21, _w0#22]
+Arguments: [i_manufact_id#12 ASC NULLS FIRST], false, 0
 
 (25) Window
-Input [3]: [i_manufact_id#5, sum_sales#21, _w0#22]
-Arguments: [avg(_w0#22) windowspecdefinition(i_manufact_id#5, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_quarterly_sales#23], [i_manufact_id#5]
+Input [3]: [i_manufact_id#12, sum_sales#21, _w0#22]
+Arguments: [avg(_w0#22) windowspecdefinition(i_manufact_id#12, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_quarterly_sales#23], [i_manufact_id#12]
 
 (26) Filter [codegen id : 7]
-Input [4]: [i_manufact_id#5, sum_sales#21, _w0#22, avg_quarterly_sales#23]
+Input [4]: [i_manufact_id#12, sum_sales#21, _w0#22, avg_quarterly_sales#23]
 Condition : CASE WHEN (avg_quarterly_sales#23 > 0.000000) THEN ((abs((sum_sales#21 - avg_quarterly_sales#23)) / avg_quarterly_sales#23) > 0.1000000000000000) ELSE false END
 
 (27) Project [codegen id : 7]
-Output [3]: [i_manufact_id#5, sum_sales#21, avg_quarterly_sales#23]
-Input [4]: [i_manufact_id#5, sum_sales#21, _w0#22, avg_quarterly_sales#23]
+Output [3]: [i_manufact_id#12, sum_sales#21, avg_quarterly_sales#23]
+Input [4]: [i_manufact_id#12, sum_sales#21, _w0#22, avg_quarterly_sales#23]
 
 (28) TakeOrderedAndProject
-Input [3]: [i_manufact_id#5, sum_sales#21, avg_quarterly_sales#23]
-Arguments: 100, [avg_quarterly_sales#23 ASC NULLS FIRST, sum_sales#21 ASC NULLS FIRST, i_manufact_id#5 ASC NULLS FIRST], [i_manufact_id#5, sum_sales#21, avg_quarterly_sales#23]
+Input [3]: [i_manufact_id#12, sum_sales#21, avg_quarterly_sales#23]
+Arguments: 100, [avg_quarterly_sales#23 ASC NULLS FIRST, sum_sales#21 ASC NULLS FIRST, i_manufact_id#12 ASC NULLS FIRST], [i_manufact_id#12, sum_sales#21, avg_quarterly_sales#23]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#13 IN dynamicpruning#14
+Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
 BroadcastExchange (33)
 +- * Project (32)
    +- * Filter (31)
@@ -170,25 +170,25 @@ BroadcastExchange (33)
 
 
 (29) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#16, d_month_seq#24, d_qoy#17]
+Output [3]: [d_date_sk#6, d_month_seq#24, d_qoy#7]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_month_seq, [1212,1213,1214,1215,1216,1217,1218,1219,1220,1221,1222,1223]), GreaterThanOrEqual(d_date_sk,2451911), LessThanOrEqual(d_date_sk,2452275), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int,d_qoy:int>
 
 (30) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#16, d_month_seq#24, d_qoy#17]
+Input [3]: [d_date_sk#6, d_month_seq#24, d_qoy#7]
 
 (31) Filter [codegen id : 1]
-Input [3]: [d_date_sk#16, d_month_seq#24, d_qoy#17]
-Condition : (((d_month_seq#24 INSET 1212, 1213, 1214, 1215, 1216, 1217, 1218, 1219, 1220, 1221, 1222, 1223 AND (d_date_sk#16 >= 2451911)) AND (d_date_sk#16 <= 2452275)) AND isnotnull(d_date_sk#16))
+Input [3]: [d_date_sk#6, d_month_seq#24, d_qoy#7]
+Condition : (((d_month_seq#24 INSET 1212, 1213, 1214, 1215, 1216, 1217, 1218, 1219, 1220, 1221, 1222, 1223 AND (d_date_sk#6 >= 2451911)) AND (d_date_sk#6 <= 2452275)) AND isnotnull(d_date_sk#6))
 
 (32) Project [codegen id : 1]
-Output [2]: [d_date_sk#16, d_qoy#17]
-Input [3]: [d_date_sk#16, d_month_seq#24, d_qoy#17]
+Output [2]: [d_date_sk#6, d_qoy#7]
+Input [3]: [d_date_sk#6, d_month_seq#24, d_qoy#7]
 
 (33) BroadcastExchange
-Input [2]: [d_date_sk#16, d_qoy#17]
+Input [2]: [d_date_sk#6, d_qoy#7]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q53.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q53.sf100/simplified.txt
@@ -15,37 +15,37 @@ TakeOrderedAndProject [avg_quarterly_sales,sum_sales,i_manufact_id]
                             WholeStageCodegen (4)
                               HashAggregate [i_manufact_id,d_qoy,ss_sales_price] [sum,sum]
                                 Project [i_manufact_id,ss_sales_price,d_qoy]
-                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                    Project [i_manufact_id,ss_sales_price,ss_sold_date_sk]
-                                      BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                        Project [i_manufact_id,ss_store_sk,ss_sales_price,ss_sold_date_sk]
-                                          BroadcastHashJoin [i_item_sk,ss_item_sk]
-                                            InputAdapter
-                                              BroadcastExchange #3
-                                                WholeStageCodegen (1)
-                                                  Project [i_item_sk,i_manufact_id]
-                                                    Filter [i_category,i_class,i_brand,i_item_sk]
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_class,i_category,i_manufact_id]
+                                  BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                    Project [ss_store_sk,ss_sales_price,d_qoy,i_manufact_id]
+                                      BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                        Project [ss_item_sk,ss_store_sk,ss_sales_price,d_qoy]
+                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                             Filter [ss_item_sk,ss_store_sk]
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_sales_price,ss_sold_date_sk]
                                                     SubqueryBroadcast [d_date_sk] #1
-                                                      BroadcastExchange #4
+                                                      BroadcastExchange #3
                                                         WholeStageCodegen (1)
                                                           Project [d_date_sk,d_qoy]
                                                             Filter [d_month_seq,d_date_sk]
                                                               ColumnarToRow
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.date_dim [d_date_sk,d_month_seq,d_qoy]
+                                            InputAdapter
+                                              ReusedExchange [d_date_sk,d_qoy] #3
                                         InputAdapter
-                                          BroadcastExchange #5
+                                          BroadcastExchange #4
                                             WholeStageCodegen (2)
-                                              Filter [s_store_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.store [s_store_sk]
+                                              Project [i_item_sk,i_manufact_id]
+                                                Filter [i_category,i_class,i_brand,i_item_sk]
+                                                  ColumnarToRow
+                                                    InputAdapter
+                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_class,i_category,i_manufact_id]
                                     InputAdapter
-                                      ReusedExchange [d_date_sk,d_qoy] #4
+                                      BroadcastExchange #5
+                                        WholeStageCodegen (3)
+                                          Filter [s_store_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet spark_catalog.default.store [s_store_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q59.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q59.sf100/explain.txt
@@ -1,58 +1,61 @@
 == Physical Plan ==
-TakeOrderedAndProject (54)
-+- * Project (53)
-   +- * BroadcastHashJoin Inner BuildRight (52)
-      :- * Project (25)
-      :  +- * BroadcastHashJoin Inner BuildRight (24)
-      :     :- * Project (18)
-      :     :  +- * BroadcastHashJoin Inner BuildRight (17)
-      :     :     :- * HashAggregate (12)
-      :     :     :  +- Exchange (11)
-      :     :     :     +- * HashAggregate (10)
-      :     :     :        +- * Project (9)
-      :     :     :           +- * BroadcastHashJoin Inner BuildRight (8)
-      :     :     :              :- * Filter (3)
-      :     :     :              :  +- * ColumnarToRow (2)
-      :     :     :              :     +- Scan parquet spark_catalog.default.store_sales (1)
-      :     :     :              +- BroadcastExchange (7)
-      :     :     :                 +- * Filter (6)
-      :     :     :                    +- * ColumnarToRow (5)
-      :     :     :                       +- Scan parquet spark_catalog.default.date_dim (4)
-      :     :     +- BroadcastExchange (16)
-      :     :        +- * Filter (15)
-      :     :           +- * ColumnarToRow (14)
-      :     :              +- Scan parquet spark_catalog.default.store (13)
-      :     +- BroadcastExchange (23)
-      :        +- * Project (22)
-      :           +- * Filter (21)
-      :              +- * ColumnarToRow (20)
-      :                 +- Scan parquet spark_catalog.default.date_dim (19)
-      +- BroadcastExchange (51)
-         +- * Project (50)
-            +- * BroadcastHashJoin Inner BuildRight (49)
-               :- * Project (43)
-               :  +- * BroadcastHashJoin Inner BuildRight (42)
-               :     :- * HashAggregate (37)
-               :     :  +- Exchange (36)
-               :     :     +- * HashAggregate (35)
-               :     :        +- * Project (34)
-               :     :           +- * BroadcastHashJoin Inner BuildRight (33)
-               :     :              :- * Filter (28)
-               :     :              :  +- * ColumnarToRow (27)
-               :     :              :     +- Scan parquet spark_catalog.default.store_sales (26)
-               :     :              +- BroadcastExchange (32)
-               :     :                 +- * Filter (31)
-               :     :                    +- * ColumnarToRow (30)
-               :     :                       +- Scan parquet spark_catalog.default.date_dim (29)
-               :     +- BroadcastExchange (41)
-               :        +- * Filter (40)
-               :           +- * ColumnarToRow (39)
-               :              +- Scan parquet spark_catalog.default.store (38)
-               +- BroadcastExchange (48)
-                  +- * Project (47)
-                     +- * Filter (46)
-                        +- * ColumnarToRow (45)
-                           +- Scan parquet spark_catalog.default.date_dim (44)
+TakeOrderedAndProject (57)
++- * Project (56)
+   +- * SortMergeJoin Inner (55)
+      :- * Sort (27)
+      :  +- Exchange (26)
+      :     +- * Project (25)
+      :        +- * BroadcastHashJoin Inner BuildRight (24)
+      :           :- * Project (18)
+      :           :  +- * BroadcastHashJoin Inner BuildRight (17)
+      :           :     :- * HashAggregate (12)
+      :           :     :  +- Exchange (11)
+      :           :     :     +- * HashAggregate (10)
+      :           :     :        +- * Project (9)
+      :           :     :           +- * BroadcastHashJoin Inner BuildRight (8)
+      :           :     :              :- * Filter (3)
+      :           :     :              :  +- * ColumnarToRow (2)
+      :           :     :              :     +- Scan parquet spark_catalog.default.store_sales (1)
+      :           :     :              +- BroadcastExchange (7)
+      :           :     :                 +- * Filter (6)
+      :           :     :                    +- * ColumnarToRow (5)
+      :           :     :                       +- Scan parquet spark_catalog.default.date_dim (4)
+      :           :     +- BroadcastExchange (16)
+      :           :        +- * Filter (15)
+      :           :           +- * ColumnarToRow (14)
+      :           :              +- Scan parquet spark_catalog.default.store (13)
+      :           +- BroadcastExchange (23)
+      :              +- * Project (22)
+      :                 +- * Filter (21)
+      :                    +- * ColumnarToRow (20)
+      :                       +- Scan parquet spark_catalog.default.date_dim (19)
+      +- * Sort (54)
+         +- Exchange (53)
+            +- * Project (52)
+               +- * BroadcastHashJoin Inner BuildRight (51)
+                  :- * Project (45)
+                  :  +- * BroadcastHashJoin Inner BuildRight (44)
+                  :     :- * HashAggregate (39)
+                  :     :  +- Exchange (38)
+                  :     :     +- * HashAggregate (37)
+                  :     :        +- * Project (36)
+                  :     :           +- * BroadcastHashJoin Inner BuildRight (35)
+                  :     :              :- * Filter (30)
+                  :     :              :  +- * ColumnarToRow (29)
+                  :     :              :     +- Scan parquet spark_catalog.default.store_sales (28)
+                  :     :              +- BroadcastExchange (34)
+                  :     :                 +- * Filter (33)
+                  :     :                    +- * ColumnarToRow (32)
+                  :     :                       +- Scan parquet spark_catalog.default.date_dim (31)
+                  :     +- BroadcastExchange (43)
+                  :        +- * Filter (42)
+                  :           +- * ColumnarToRow (41)
+                  :              +- Scan parquet spark_catalog.default.store (40)
+                  +- BroadcastExchange (50)
+                     +- * Project (49)
+                        +- * Filter (48)
+                           +- * ColumnarToRow (47)
+                              +- Scan parquet spark_catalog.default.date_dim (46)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -109,7 +112,7 @@ Results [9]: [d_week_seq#5, ss_store_sk#1, sum#16, sum#17, sum#18, sum#19, sum#2
 Input [9]: [d_week_seq#5, ss_store_sk#1, sum#16, sum#17, sum#18, sum#19, sum#20, sum#21, sum#22]
 Arguments: hashpartitioning(d_week_seq#5, ss_store_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(12) HashAggregate [codegen id : 10]
+(12) HashAggregate [codegen id : 5]
 Input [9]: [d_week_seq#5, ss_store_sk#1, sum#16, sum#17, sum#18, sum#19, sum#20, sum#21, sum#22]
 Keys [2]: [d_week_seq#5, ss_store_sk#1]
 Functions [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#6 = Sunday   ) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Monday   ) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Tuesday  ) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Wednesday) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Thursday ) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Friday   ) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Saturday ) THEN ss_sales_price#2 END))]
@@ -134,13 +137,13 @@ Condition : (isnotnull(s_store_sk#37) AND isnotnull(s_store_id#38))
 Input [3]: [s_store_sk#37, s_store_id#38, s_store_name#39]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
 
-(17) BroadcastHashJoin [codegen id : 10]
+(17) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#1]
 Right keys [1]: [s_store_sk#37]
 Join type: Inner
 Join condition: None
 
-(18) Project [codegen id : 10]
+(18) Project [codegen id : 5]
 Output [10]: [d_week_seq#5, sun_sales#30, mon_sales#31, tue_sales#32, wed_sales#33, thu_sales#34, fri_sales#35, sat_sales#36, s_store_id#38, s_store_name#39]
 Input [12]: [d_week_seq#5, ss_store_sk#1, sun_sales#30, mon_sales#31, tue_sales#32, wed_sales#33, thu_sales#34, fri_sales#35, sat_sales#36, s_store_sk#37, s_store_id#38, s_store_name#39]
 
@@ -166,17 +169,25 @@ Input [2]: [d_month_seq#40, d_week_seq#41]
 Input [1]: [d_week_seq#41]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
-(24) BroadcastHashJoin [codegen id : 10]
+(24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [d_week_seq#5]
 Right keys [1]: [d_week_seq#41]
 Join type: Inner
 Join condition: None
 
-(25) Project [codegen id : 10]
+(25) Project [codegen id : 5]
 Output [10]: [s_store_name#39 AS s_store_name1#42, d_week_seq#5 AS d_week_seq1#43, s_store_id#38 AS s_store_id1#44, sun_sales#30 AS sun_sales1#45, mon_sales#31 AS mon_sales1#46, tue_sales#32 AS tue_sales1#47, wed_sales#33 AS wed_sales1#48, thu_sales#34 AS thu_sales1#49, fri_sales#35 AS fri_sales1#50, sat_sales#36 AS sat_sales1#51]
 Input [11]: [d_week_seq#5, sun_sales#30, mon_sales#31, tue_sales#32, wed_sales#33, thu_sales#34, fri_sales#35, sat_sales#36, s_store_id#38, s_store_name#39, d_week_seq#41]
 
-(26) Scan parquet spark_catalog.default.store_sales
+(26) Exchange
+Input [10]: [s_store_name1#42, d_week_seq1#43, s_store_id1#44, sun_sales1#45, mon_sales1#46, tue_sales1#47, wed_sales1#48, thu_sales1#49, fri_sales1#50, sat_sales1#51]
+Arguments: hashpartitioning(s_store_id1#44, d_week_seq1#43, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(27) Sort [codegen id : 6]
+Input [10]: [s_store_name1#42, d_week_seq1#43, s_store_id1#44, sun_sales1#45, mon_sales1#46, tue_sales1#47, wed_sales1#48, thu_sales1#49, fri_sales1#50, sat_sales1#51]
+Arguments: [s_store_id1#44 ASC NULLS FIRST, d_week_seq1#43 ASC NULLS FIRST], false, 0
+
+(28) Scan parquet spark_catalog.default.store_sales
 Output [3]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54]
 Batched: true
 Location: InMemoryFileIndex []
@@ -184,225 +195,229 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#54)]
 PushedFilters: [IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_store_sk:int,ss_sales_price:decimal(7,2)>
 
-(27) ColumnarToRow [codegen id : 6]
+(29) ColumnarToRow [codegen id : 8]
 Input [3]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54]
 
-(28) Filter [codegen id : 6]
+(30) Filter [codegen id : 8]
 Input [3]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54]
 Condition : isnotnull(ss_store_sk#52)
 
-(29) Scan parquet spark_catalog.default.date_dim
+(31) Scan parquet spark_catalog.default.date_dim
 Output [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date_sk), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int,d_day_name:string>
 
-(30) ColumnarToRow [codegen id : 5]
+(32) ColumnarToRow [codegen id : 7]
 Input [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
 
-(31) Filter [codegen id : 5]
+(33) Filter [codegen id : 7]
 Input [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
 Condition : ((isnotnull(d_date_sk#55) AND isnotnull(d_week_seq#56)) AND might_contain(Subquery scalar-subquery#58, [id=#59], xxhash64(d_week_seq#56, 42)))
 
-(32) BroadcastExchange
+(34) BroadcastExchange
 Input [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=6]
 
-(33) BroadcastHashJoin [codegen id : 6]
+(35) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_sold_date_sk#54]
 Right keys [1]: [d_date_sk#55]
 Join type: Inner
 Join condition: None
 
-(34) Project [codegen id : 6]
+(36) Project [codegen id : 8]
 Output [4]: [ss_store_sk#52, ss_sales_price#53, d_week_seq#56, d_day_name#57]
 Input [6]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54, d_date_sk#55, d_week_seq#56, d_day_name#57]
 
-(35) HashAggregate [codegen id : 6]
+(37) HashAggregate [codegen id : 8]
 Input [4]: [ss_store_sk#52, ss_sales_price#53, d_week_seq#56, d_day_name#57]
 Keys [2]: [d_week_seq#56, ss_store_sk#52]
 Functions [6]: [partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))]
 Aggregate Attributes [6]: [sum#60, sum#61, sum#62, sum#63, sum#64, sum#65]
 Results [8]: [d_week_seq#56, ss_store_sk#52, sum#66, sum#67, sum#68, sum#69, sum#70, sum#71]
 
-(36) Exchange
+(38) Exchange
 Input [8]: [d_week_seq#56, ss_store_sk#52, sum#66, sum#67, sum#68, sum#69, sum#70, sum#71]
-Arguments: hashpartitioning(d_week_seq#56, ss_store_sk#52, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Arguments: hashpartitioning(d_week_seq#56, ss_store_sk#52, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(37) HashAggregate [codegen id : 9]
+(39) HashAggregate [codegen id : 11]
 Input [8]: [d_week_seq#56, ss_store_sk#52, sum#66, sum#67, sum#68, sum#69, sum#70, sum#71]
 Keys [2]: [d_week_seq#56, ss_store_sk#52]
 Functions [6]: [sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))]
 Aggregate Attributes [6]: [sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END))#23, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END))#24, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END))#26, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END))#27, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END))#28, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))#29]
 Results [8]: [d_week_seq#56, ss_store_sk#52, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END))#23,17,2) AS sun_sales#72, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END))#24,17,2) AS mon_sales#73, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END))#26,17,2) AS wed_sales#74, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END))#27,17,2) AS thu_sales#75, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END))#28,17,2) AS fri_sales#76, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))#29,17,2) AS sat_sales#77]
 
-(38) Scan parquet spark_catalog.default.store
+(40) Scan parquet spark_catalog.default.store
 Output [2]: [s_store_sk#78, s_store_id#79]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_store_id)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string>
 
-(39) ColumnarToRow [codegen id : 7]
+(41) ColumnarToRow [codegen id : 9]
 Input [2]: [s_store_sk#78, s_store_id#79]
 
-(40) Filter [codegen id : 7]
+(42) Filter [codegen id : 9]
 Input [2]: [s_store_sk#78, s_store_id#79]
 Condition : (isnotnull(s_store_sk#78) AND isnotnull(s_store_id#79))
 
-(41) BroadcastExchange
+(43) BroadcastExchange
 Input [2]: [s_store_sk#78, s_store_id#79]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=8]
 
-(42) BroadcastHashJoin [codegen id : 9]
+(44) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_store_sk#52]
 Right keys [1]: [s_store_sk#78]
 Join type: Inner
 Join condition: None
 
-(43) Project [codegen id : 9]
+(45) Project [codegen id : 11]
 Output [8]: [d_week_seq#56, sun_sales#72, mon_sales#73, wed_sales#74, thu_sales#75, fri_sales#76, sat_sales#77, s_store_id#79]
 Input [10]: [d_week_seq#56, ss_store_sk#52, sun_sales#72, mon_sales#73, wed_sales#74, thu_sales#75, fri_sales#76, sat_sales#77, s_store_sk#78, s_store_id#79]
 
-(44) Scan parquet spark_catalog.default.date_dim
+(46) Scan parquet spark_catalog.default.date_dim
 Output [2]: [d_month_seq#80, d_week_seq#81]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1197), LessThanOrEqual(d_month_seq,1208), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_month_seq:int,d_week_seq:int>
 
-(45) ColumnarToRow [codegen id : 8]
+(47) ColumnarToRow [codegen id : 10]
 Input [2]: [d_month_seq#80, d_week_seq#81]
 
-(46) Filter [codegen id : 8]
+(48) Filter [codegen id : 10]
 Input [2]: [d_month_seq#80, d_week_seq#81]
 Condition : (((isnotnull(d_month_seq#80) AND (d_month_seq#80 >= 1197)) AND (d_month_seq#80 <= 1208)) AND isnotnull(d_week_seq#81))
 
-(47) Project [codegen id : 8]
+(49) Project [codegen id : 10]
 Output [1]: [d_week_seq#81]
 Input [2]: [d_month_seq#80, d_week_seq#81]
 
-(48) BroadcastExchange
+(50) BroadcastExchange
 Input [1]: [d_week_seq#81]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
-(49) BroadcastHashJoin [codegen id : 9]
+(51) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [d_week_seq#56]
 Right keys [1]: [d_week_seq#81]
 Join type: Inner
 Join condition: None
 
-(50) Project [codegen id : 9]
+(52) Project [codegen id : 11]
 Output [8]: [d_week_seq#56 AS d_week_seq2#82, s_store_id#79 AS s_store_id2#83, sun_sales#72 AS sun_sales2#84, mon_sales#73 AS mon_sales2#85, wed_sales#74 AS wed_sales2#86, thu_sales#75 AS thu_sales2#87, fri_sales#76 AS fri_sales2#88, sat_sales#77 AS sat_sales2#89]
 Input [9]: [d_week_seq#56, sun_sales#72, mon_sales#73, wed_sales#74, thu_sales#75, fri_sales#76, sat_sales#77, s_store_id#79, d_week_seq#81]
 
-(51) BroadcastExchange
+(53) Exchange
 Input [8]: [d_week_seq2#82, s_store_id2#83, sun_sales2#84, mon_sales2#85, wed_sales2#86, thu_sales2#87, fri_sales2#88, sat_sales2#89]
-Arguments: HashedRelationBroadcastMode(List(input[1, string, true], (input[0, int, true] - 52)),false), [plan_id=9]
+Arguments: hashpartitioning(s_store_id2#83, (d_week_seq2#82 - 52), 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(52) BroadcastHashJoin [codegen id : 10]
+(54) Sort [codegen id : 12]
+Input [8]: [d_week_seq2#82, s_store_id2#83, sun_sales2#84, mon_sales2#85, wed_sales2#86, thu_sales2#87, fri_sales2#88, sat_sales2#89]
+Arguments: [s_store_id2#83 ASC NULLS FIRST, (d_week_seq2#82 - 52) ASC NULLS FIRST], false, 0
+
+(55) SortMergeJoin [codegen id : 13]
 Left keys [2]: [s_store_id1#44, d_week_seq1#43]
 Right keys [2]: [s_store_id2#83, (d_week_seq2#82 - 52)]
 Join type: Inner
 Join condition: None
 
-(53) Project [codegen id : 10]
+(56) Project [codegen id : 13]
 Output [10]: [s_store_name1#42, s_store_id1#44, d_week_seq1#43, (sun_sales1#45 / sun_sales2#84) AS (sun_sales1 / sun_sales2)#90, (mon_sales1#46 / mon_sales2#85) AS (mon_sales1 / mon_sales2)#91, (tue_sales1#47 / tue_sales1#47) AS (tue_sales1 / tue_sales1)#92, (wed_sales1#48 / wed_sales2#86) AS (wed_sales1 / wed_sales2)#93, (thu_sales1#49 / thu_sales2#87) AS (thu_sales1 / thu_sales2)#94, (fri_sales1#50 / fri_sales2#88) AS (fri_sales1 / fri_sales2)#95, (sat_sales1#51 / sat_sales2#89) AS (sat_sales1 / sat_sales2)#96]
 Input [18]: [s_store_name1#42, d_week_seq1#43, s_store_id1#44, sun_sales1#45, mon_sales1#46, tue_sales1#47, wed_sales1#48, thu_sales1#49, fri_sales1#50, sat_sales1#51, d_week_seq2#82, s_store_id2#83, sun_sales2#84, mon_sales2#85, wed_sales2#86, thu_sales2#87, fri_sales2#88, sat_sales2#89]
 
-(54) TakeOrderedAndProject
+(57) TakeOrderedAndProject
 Input [10]: [s_store_name1#42, s_store_id1#44, d_week_seq1#43, (sun_sales1 / sun_sales2)#90, (mon_sales1 / mon_sales2)#91, (tue_sales1 / tue_sales1)#92, (wed_sales1 / wed_sales2)#93, (thu_sales1 / thu_sales2)#94, (fri_sales1 / fri_sales2)#95, (sat_sales1 / sat_sales2)#96]
 Arguments: 100, [s_store_name1#42 ASC NULLS FIRST, s_store_id1#44 ASC NULLS FIRST, d_week_seq1#43 ASC NULLS FIRST], [s_store_name1#42, s_store_id1#44, d_week_seq1#43, (sun_sales1 / sun_sales2)#90, (mon_sales1 / mon_sales2)#91, (tue_sales1 / tue_sales1)#92, (wed_sales1 / wed_sales2)#93, (thu_sales1 / thu_sales2)#94, (fri_sales1 / fri_sales2)#95, (sat_sales1 / sat_sales2)#96]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 6 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
-ObjectHashAggregate (61)
-+- Exchange (60)
-   +- ObjectHashAggregate (59)
-      +- * Project (58)
-         +- * Filter (57)
-            +- * ColumnarToRow (56)
-               +- Scan parquet spark_catalog.default.date_dim (55)
+ObjectHashAggregate (64)
++- Exchange (63)
+   +- ObjectHashAggregate (62)
+      +- * Project (61)
+         +- * Filter (60)
+            +- * ColumnarToRow (59)
+               +- Scan parquet spark_catalog.default.date_dim (58)
 
 
-(55) Scan parquet spark_catalog.default.date_dim
+(58) Scan parquet spark_catalog.default.date_dim
 Output [2]: [d_month_seq#40, d_week_seq#41]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1185), LessThanOrEqual(d_month_seq,1196), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_month_seq:int,d_week_seq:int>
 
-(56) ColumnarToRow [codegen id : 1]
+(59) ColumnarToRow [codegen id : 1]
 Input [2]: [d_month_seq#40, d_week_seq#41]
 
-(57) Filter [codegen id : 1]
+(60) Filter [codegen id : 1]
 Input [2]: [d_month_seq#40, d_week_seq#41]
 Condition : (((isnotnull(d_month_seq#40) AND (d_month_seq#40 >= 1185)) AND (d_month_seq#40 <= 1196)) AND isnotnull(d_week_seq#41))
 
-(58) Project [codegen id : 1]
+(61) Project [codegen id : 1]
 Output [1]: [d_week_seq#41]
 Input [2]: [d_month_seq#40, d_week_seq#41]
 
-(59) ObjectHashAggregate
+(62) ObjectHashAggregate
 Input [1]: [d_week_seq#41]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)]
 Aggregate Attributes [1]: [buf#97]
 Results [1]: [buf#98]
 
-(60) Exchange
+(63) Exchange
 Input [1]: [buf#98]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
 
-(61) ObjectHashAggregate
+(64) ObjectHashAggregate
 Input [1]: [buf#98]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)]
 Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)#99]
 Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)#99 AS bloomFilter#100]
 
-Subquery:2 Hosting operator id = 31 Hosting Expression = Subquery scalar-subquery#58, [id=#59]
-ObjectHashAggregate (68)
-+- Exchange (67)
-   +- ObjectHashAggregate (66)
-      +- * Project (65)
-         +- * Filter (64)
-            +- * ColumnarToRow (63)
-               +- Scan parquet spark_catalog.default.date_dim (62)
+Subquery:2 Hosting operator id = 33 Hosting Expression = Subquery scalar-subquery#58, [id=#59]
+ObjectHashAggregate (71)
++- Exchange (70)
+   +- ObjectHashAggregate (69)
+      +- * Project (68)
+         +- * Filter (67)
+            +- * ColumnarToRow (66)
+               +- Scan parquet spark_catalog.default.date_dim (65)
 
 
-(62) Scan parquet spark_catalog.default.date_dim
+(65) Scan parquet spark_catalog.default.date_dim
 Output [2]: [d_month_seq#80, d_week_seq#81]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1197), LessThanOrEqual(d_month_seq,1208), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_month_seq:int,d_week_seq:int>
 
-(63) ColumnarToRow [codegen id : 1]
+(66) ColumnarToRow [codegen id : 1]
 Input [2]: [d_month_seq#80, d_week_seq#81]
 
-(64) Filter [codegen id : 1]
+(67) Filter [codegen id : 1]
 Input [2]: [d_month_seq#80, d_week_seq#81]
 Condition : (((isnotnull(d_month_seq#80) AND (d_month_seq#80 >= 1197)) AND (d_month_seq#80 <= 1208)) AND isnotnull(d_week_seq#81))
 
-(65) Project [codegen id : 1]
+(68) Project [codegen id : 1]
 Output [1]: [d_week_seq#81]
 Input [2]: [d_month_seq#80, d_week_seq#81]
 
-(66) ObjectHashAggregate
+(69) ObjectHashAggregate
 Input [1]: [d_week_seq#81]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#81, 42), 335, 8990, 0, 0)]
 Aggregate Attributes [1]: [buf#101]
 Results [1]: [buf#102]
 
-(67) Exchange
+(70) Exchange
 Input [1]: [buf#102]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
 
-(68) ObjectHashAggregate
+(71) ObjectHashAggregate
 Input [1]: [buf#102]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#81, 42), 335, 8990, 0, 0)]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q59.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q59.sf100/simplified.txt
@@ -1,101 +1,110 @@
 TakeOrderedAndProject [s_store_name1,s_store_id1,d_week_seq1,(sun_sales1 / sun_sales2),(mon_sales1 / mon_sales2),(tue_sales1 / tue_sales1),(wed_sales1 / wed_sales2),(thu_sales1 / thu_sales2),(fri_sales1 / fri_sales2),(sat_sales1 / sat_sales2)]
-  WholeStageCodegen (10)
+  WholeStageCodegen (13)
     Project [s_store_name1,s_store_id1,d_week_seq1,sun_sales1,sun_sales2,mon_sales1,mon_sales2,tue_sales1,wed_sales1,wed_sales2,thu_sales1,thu_sales2,fri_sales1,fri_sales2,sat_sales1,sat_sales2]
-      BroadcastHashJoin [s_store_id1,d_week_seq1,s_store_id2,d_week_seq2]
-        Project [s_store_name,d_week_seq,s_store_id,sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales]
-          BroadcastHashJoin [d_week_seq,d_week_seq]
-            Project [d_week_seq,sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales,s_store_id,s_store_name]
-              BroadcastHashJoin [ss_store_sk,s_store_sk]
-                HashAggregate [d_week_seq,ss_store_sk,sum,sum,sum,sum,sum,sum,sum] [sum(UnscaledValue(CASE WHEN (d_day_name = Sunday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Monday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Tuesday  ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Wednesday) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Thursday ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Friday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Saturday ) THEN ss_sales_price END)),sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales,sum,sum,sum,sum,sum,sum,sum]
-                  InputAdapter
-                    Exchange [d_week_seq,ss_store_sk] #1
-                      WholeStageCodegen (2)
-                        HashAggregate [d_week_seq,ss_store_sk,d_day_name,ss_sales_price] [sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum]
-                          Project [ss_store_sk,ss_sales_price,d_week_seq,d_day_name]
-                            BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                              Filter [ss_store_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_sales_price,ss_sold_date_sk]
-                              InputAdapter
-                                BroadcastExchange #2
-                                  WholeStageCodegen (1)
-                                    Filter [d_date_sk,d_week_seq]
-                                      Subquery #1
-                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_week_seq, 42), 335, 8990, 0, 0),bloomFilter,buf]
-                                          Exchange #3
-                                            ObjectHashAggregate [d_week_seq] [buf,buf]
-                                              WholeStageCodegen (1)
-                                                Project [d_week_seq]
-                                                  Filter [d_month_seq,d_week_seq]
-                                                    ColumnarToRow
-                                                      InputAdapter
-                                                        Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
-                                      ColumnarToRow
-                                        InputAdapter
-                                          Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq,d_day_name]
-                InputAdapter
-                  BroadcastExchange #4
-                    WholeStageCodegen (3)
-                      Filter [s_store_sk,s_store_id]
-                        ColumnarToRow
-                          InputAdapter
-                            Scan parquet spark_catalog.default.store [s_store_sk,s_store_id,s_store_name]
-            InputAdapter
-              BroadcastExchange #5
-                WholeStageCodegen (4)
-                  Project [d_week_seq]
-                    Filter [d_month_seq,d_week_seq]
-                      ColumnarToRow
-                        InputAdapter
-                          Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
+      SortMergeJoin [s_store_id1,d_week_seq1,s_store_id2,d_week_seq2]
         InputAdapter
-          BroadcastExchange #6
-            WholeStageCodegen (9)
-              Project [d_week_seq,s_store_id,sun_sales,mon_sales,wed_sales,thu_sales,fri_sales,sat_sales]
-                BroadcastHashJoin [d_week_seq,d_week_seq]
-                  Project [d_week_seq,sun_sales,mon_sales,wed_sales,thu_sales,fri_sales,sat_sales,s_store_id]
-                    BroadcastHashJoin [ss_store_sk,s_store_sk]
-                      HashAggregate [d_week_seq,ss_store_sk,sum,sum,sum,sum,sum,sum] [sum(UnscaledValue(CASE WHEN (d_day_name = Sunday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Monday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Wednesday) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Thursday ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Friday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Saturday ) THEN ss_sales_price END)),sun_sales,mon_sales,wed_sales,thu_sales,fri_sales,sat_sales,sum,sum,sum,sum,sum,sum]
-                        InputAdapter
-                          Exchange [d_week_seq,ss_store_sk] #7
-                            WholeStageCodegen (6)
-                              HashAggregate [d_week_seq,ss_store_sk,d_day_name,ss_sales_price] [sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum]
-                                Project [ss_store_sk,ss_sales_price,d_week_seq,d_day_name]
-                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                    Filter [ss_store_sk]
-                                      ColumnarToRow
-                                        InputAdapter
-                                          Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_sales_price,ss_sold_date_sk]
-                                    InputAdapter
-                                      BroadcastExchange #8
-                                        WholeStageCodegen (5)
-                                          Filter [d_date_sk,d_week_seq]
-                                            Subquery #2
-                                              ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_week_seq, 42), 335, 8990, 0, 0),bloomFilter,buf]
-                                                Exchange #9
-                                                  ObjectHashAggregate [d_week_seq] [buf,buf]
-                                                    WholeStageCodegen (1)
-                                                      Project [d_week_seq]
-                                                        Filter [d_month_seq,d_week_seq]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
+          WholeStageCodegen (6)
+            Sort [s_store_id1,d_week_seq1]
+              InputAdapter
+                Exchange [s_store_id1,d_week_seq1] #1
+                  WholeStageCodegen (5)
+                    Project [s_store_name,d_week_seq,s_store_id,sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales]
+                      BroadcastHashJoin [d_week_seq,d_week_seq]
+                        Project [d_week_seq,sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales,s_store_id,s_store_name]
+                          BroadcastHashJoin [ss_store_sk,s_store_sk]
+                            HashAggregate [d_week_seq,ss_store_sk,sum,sum,sum,sum,sum,sum,sum] [sum(UnscaledValue(CASE WHEN (d_day_name = Sunday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Monday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Tuesday  ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Wednesday) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Thursday ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Friday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Saturday ) THEN ss_sales_price END)),sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales,sum,sum,sum,sum,sum,sum,sum]
+                              InputAdapter
+                                Exchange [d_week_seq,ss_store_sk] #2
+                                  WholeStageCodegen (2)
+                                    HashAggregate [d_week_seq,ss_store_sk,d_day_name,ss_sales_price] [sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum]
+                                      Project [ss_store_sk,ss_sales_price,d_week_seq,d_day_name]
+                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                          Filter [ss_store_sk]
                                             ColumnarToRow
                                               InputAdapter
-                                                Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq,d_day_name]
-                      InputAdapter
-                        BroadcastExchange #10
-                          WholeStageCodegen (7)
-                            Filter [s_store_sk,s_store_id]
-                              ColumnarToRow
-                                InputAdapter
-                                  Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
-                  InputAdapter
-                    BroadcastExchange #11
-                      WholeStageCodegen (8)
-                        Project [d_week_seq]
-                          Filter [d_month_seq,d_week_seq]
-                            ColumnarToRow
+                                                Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_sales_price,ss_sold_date_sk]
+                                          InputAdapter
+                                            BroadcastExchange #3
+                                              WholeStageCodegen (1)
+                                                Filter [d_date_sk,d_week_seq]
+                                                  Subquery #1
+                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_week_seq, 42), 335, 8990, 0, 0),bloomFilter,buf]
+                                                      Exchange #4
+                                                        ObjectHashAggregate [d_week_seq] [buf,buf]
+                                                          WholeStageCodegen (1)
+                                                            Project [d_week_seq]
+                                                              Filter [d_month_seq,d_week_seq]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
+                                                  ColumnarToRow
+                                                    InputAdapter
+                                                      Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq,d_day_name]
+                            InputAdapter
+                              BroadcastExchange #5
+                                WholeStageCodegen (3)
+                                  Filter [s_store_sk,s_store_id]
+                                    ColumnarToRow
+                                      InputAdapter
+                                        Scan parquet spark_catalog.default.store [s_store_sk,s_store_id,s_store_name]
+                        InputAdapter
+                          BroadcastExchange #6
+                            WholeStageCodegen (4)
+                              Project [d_week_seq]
+                                Filter [d_month_seq,d_week_seq]
+                                  ColumnarToRow
+                                    InputAdapter
+                                      Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
+        InputAdapter
+          WholeStageCodegen (12)
+            Sort [s_store_id2,d_week_seq2]
+              InputAdapter
+                Exchange [s_store_id2,d_week_seq2] #7
+                  WholeStageCodegen (11)
+                    Project [d_week_seq,s_store_id,sun_sales,mon_sales,wed_sales,thu_sales,fri_sales,sat_sales]
+                      BroadcastHashJoin [d_week_seq,d_week_seq]
+                        Project [d_week_seq,sun_sales,mon_sales,wed_sales,thu_sales,fri_sales,sat_sales,s_store_id]
+                          BroadcastHashJoin [ss_store_sk,s_store_sk]
+                            HashAggregate [d_week_seq,ss_store_sk,sum,sum,sum,sum,sum,sum] [sum(UnscaledValue(CASE WHEN (d_day_name = Sunday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Monday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Wednesday) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Thursday ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Friday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Saturday ) THEN ss_sales_price END)),sun_sales,mon_sales,wed_sales,thu_sales,fri_sales,sat_sales,sum,sum,sum,sum,sum,sum]
                               InputAdapter
-                                Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
+                                Exchange [d_week_seq,ss_store_sk] #8
+                                  WholeStageCodegen (8)
+                                    HashAggregate [d_week_seq,ss_store_sk,d_day_name,ss_sales_price] [sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum]
+                                      Project [ss_store_sk,ss_sales_price,d_week_seq,d_day_name]
+                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                          Filter [ss_store_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_sales_price,ss_sold_date_sk]
+                                          InputAdapter
+                                            BroadcastExchange #9
+                                              WholeStageCodegen (7)
+                                                Filter [d_date_sk,d_week_seq]
+                                                  Subquery #2
+                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_week_seq, 42), 335, 8990, 0, 0),bloomFilter,buf]
+                                                      Exchange #10
+                                                        ObjectHashAggregate [d_week_seq] [buf,buf]
+                                                          WholeStageCodegen (1)
+                                                            Project [d_week_seq]
+                                                              Filter [d_month_seq,d_week_seq]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
+                                                  ColumnarToRow
+                                                    InputAdapter
+                                                      Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq,d_day_name]
+                            InputAdapter
+                              BroadcastExchange #11
+                                WholeStageCodegen (9)
+                                  Filter [s_store_sk,s_store_id]
+                                    ColumnarToRow
+                                      InputAdapter
+                                        Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
+                        InputAdapter
+                          BroadcastExchange #12
+                            WholeStageCodegen (10)
+                              Project [d_week_seq]
+                                Filter [d_month_seq,d_week_seq]
+                                  ColumnarToRow
+                                    InputAdapter
+                                      Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q63.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q63.sf100/explain.txt
@@ -10,158 +10,158 @@ TakeOrderedAndProject (28)
                      +- * HashAggregate (20)
                         +- * Project (19)
                            +- * BroadcastHashJoin Inner BuildRight (18)
-                              :- * Project (16)
-                              :  +- * BroadcastHashJoin Inner BuildRight (15)
-                              :     :- * Project (10)
-                              :     :  +- * BroadcastHashJoin Inner BuildLeft (9)
-                              :     :     :- BroadcastExchange (5)
-                              :     :     :  +- * Project (4)
-                              :     :     :     +- * Filter (3)
-                              :     :     :        +- * ColumnarToRow (2)
-                              :     :     :           +- Scan parquet spark_catalog.default.item (1)
-                              :     :     +- * Filter (8)
-                              :     :        +- * ColumnarToRow (7)
-                              :     :           +- Scan parquet spark_catalog.default.store_sales (6)
-                              :     +- BroadcastExchange (14)
-                              :        +- * Filter (13)
-                              :           +- * ColumnarToRow (12)
-                              :              +- Scan parquet spark_catalog.default.store (11)
-                              +- ReusedExchange (17)
+                              :- * Project (13)
+                              :  +- * BroadcastHashJoin Inner BuildRight (12)
+                              :     :- * Project (6)
+                              :     :  +- * BroadcastHashJoin Inner BuildRight (5)
+                              :     :     :- * Filter (3)
+                              :     :     :  +- * ColumnarToRow (2)
+                              :     :     :     +- Scan parquet spark_catalog.default.store_sales (1)
+                              :     :     +- ReusedExchange (4)
+                              :     +- BroadcastExchange (11)
+                              :        +- * Project (10)
+                              :           +- * Filter (9)
+                              :              +- * ColumnarToRow (8)
+                              :                 +- Scan parquet spark_catalog.default.item (7)
+                              +- BroadcastExchange (17)
+                                 +- * Filter (16)
+                                    +- * ColumnarToRow (15)
+                                       +- Scan parquet spark_catalog.default.store (14)
 
 
-(1) Scan parquet spark_catalog.default.item
-Output [5]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4, i_manager_id#5]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [Or(And(And(In(i_category, [Books                                             ,Children                                          ,Electronics                                       ]),In(i_class, [personal                                          ,portable                                          ,reference                                         ,self-help                                         ])),In(i_brand, [exportiunivamalg #6                               ,scholaramalgamalg #7                             ,scholaramalgamalg #8                              ,scholaramalgamalg #6                              ])),And(And(In(i_category, [Men                                               ,Music                                             ,Women                                             ]),In(i_class, [accessories                                       ,classical                                         ,fragrances                                        ,pants                                             ])),In(i_brand, [amalgimporto #9                                   ,edu packscholar #9                                ,exportiimporto #9                                 ,importoamalg #9                                   ]))), IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_brand:string,i_class:string,i_category:string,i_manager_id:int>
-
-(2) ColumnarToRow [codegen id : 1]
-Input [5]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4, i_manager_id#5]
-
-(3) Filter [codegen id : 1]
-Input [5]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4, i_manager_id#5]
-Condition : ((((i_category#4 IN (Books                                             ,Children                                          ,Electronics                                       ) AND i_class#3 IN (personal                                          ,portable                                          ,reference                                         ,self-help                                         )) AND i_brand#2 IN (scholaramalgamalg #7                             ,scholaramalgamalg #8                              ,exportiunivamalg #6                               ,scholaramalgamalg #6                              )) OR ((i_category#4 IN (Women                                             ,Music                                             ,Men                                               ) AND i_class#3 IN (accessories                                       ,classical                                         ,fragrances                                        ,pants                                             )) AND i_brand#2 IN (amalgimporto #9                                   ,edu packscholar #9                                ,exportiimporto #9                                 ,importoamalg #9                                   ))) AND isnotnull(i_item_sk#1))
-
-(4) Project [codegen id : 1]
-Output [2]: [i_item_sk#1, i_manager_id#5]
-Input [5]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4, i_manager_id#5]
-
-(5) BroadcastExchange
-Input [2]: [i_item_sk#1, i_manager_id#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
-
-(6) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_item_sk#10, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
+(1) Scan parquet spark_catalog.default.store_sales
+Output [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#13), (ss_sold_date_sk#13 >= 2452123), (ss_sold_date_sk#13 <= 2452487), dynamicpruningexpression(ss_sold_date_sk#13 IN dynamicpruning#14)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#4), (ss_sold_date_sk#4 >= 2452123), (ss_sold_date_sk#4 <= 2452487), dynamicpruningexpression(ss_sold_date_sk#4 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_store_sk:int,ss_sales_price:decimal(7,2)>
 
-(7) ColumnarToRow
-Input [4]: [ss_item_sk#10, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
+(2) ColumnarToRow [codegen id : 4]
+Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
 
-(8) Filter
-Input [4]: [ss_item_sk#10, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
-Condition : (isnotnull(ss_item_sk#10) AND isnotnull(ss_store_sk#11))
+(3) Filter [codegen id : 4]
+Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
+Condition : (isnotnull(ss_item_sk#1) AND isnotnull(ss_store_sk#2))
 
-(9) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [i_item_sk#1]
-Right keys [1]: [ss_item_sk#10]
+(4) ReusedExchange [Reuses operator id: 33]
+Output [2]: [d_date_sk#6, d_moy#7]
+
+(5) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_sold_date_sk#4]
+Right keys [1]: [d_date_sk#6]
 Join type: Inner
 Join condition: None
 
-(10) Project [codegen id : 4]
-Output [4]: [i_manager_id#5, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
-Input [6]: [i_item_sk#1, i_manager_id#5, ss_item_sk#10, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
+(6) Project [codegen id : 4]
+Output [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_moy#7]
+Input [6]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4, d_date_sk#6, d_moy#7]
 
-(11) Scan parquet spark_catalog.default.store
-Output [1]: [s_store_sk#15]
+(7) Scan parquet spark_catalog.default.item
+Output [5]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11, i_manager_id#12]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [Or(And(And(In(i_category, [Books                                             ,Children                                          ,Electronics                                       ]),In(i_class, [personal                                          ,portable                                          ,reference                                         ,self-help                                         ])),In(i_brand, [exportiunivamalg #13                               ,scholaramalgamalg #14                             ,scholaramalgamalg #15                              ,scholaramalgamalg #13                              ])),And(And(In(i_category, [Men                                               ,Music                                             ,Women                                             ]),In(i_class, [accessories                                       ,classical                                         ,fragrances                                        ,pants                                             ])),In(i_brand, [amalgimporto #16                                   ,edu packscholar #16                                ,exportiimporto #16                                 ,importoamalg #16                                   ]))), IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_brand:string,i_class:string,i_category:string,i_manager_id:int>
+
+(8) ColumnarToRow [codegen id : 2]
+Input [5]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11, i_manager_id#12]
+
+(9) Filter [codegen id : 2]
+Input [5]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11, i_manager_id#12]
+Condition : ((((i_category#11 IN (Books                                             ,Children                                          ,Electronics                                       ) AND i_class#10 IN (personal                                          ,portable                                          ,reference                                         ,self-help                                         )) AND i_brand#9 IN (scholaramalgamalg #14                             ,scholaramalgamalg #15                              ,exportiunivamalg #13                               ,scholaramalgamalg #13                              )) OR ((i_category#11 IN (Women                                             ,Music                                             ,Men                                               ) AND i_class#10 IN (accessories                                       ,classical                                         ,fragrances                                        ,pants                                             )) AND i_brand#9 IN (amalgimporto #16                                   ,edu packscholar #16                                ,exportiimporto #16                                 ,importoamalg #16                                   ))) AND isnotnull(i_item_sk#8))
+
+(10) Project [codegen id : 2]
+Output [2]: [i_item_sk#8, i_manager_id#12]
+Input [5]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11, i_manager_id#12]
+
+(11) BroadcastExchange
+Input [2]: [i_item_sk#8, i_manager_id#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
+
+(12) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_item_sk#1]
+Right keys [1]: [i_item_sk#8]
+Join type: Inner
+Join condition: None
+
+(13) Project [codegen id : 4]
+Output [4]: [ss_store_sk#2, ss_sales_price#3, d_moy#7, i_manager_id#12]
+Input [6]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_moy#7, i_item_sk#8, i_manager_id#12]
+
+(14) Scan parquet spark_catalog.default.store
+Output [1]: [s_store_sk#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int>
 
-(12) ColumnarToRow [codegen id : 2]
-Input [1]: [s_store_sk#15]
+(15) ColumnarToRow [codegen id : 3]
+Input [1]: [s_store_sk#17]
 
-(13) Filter [codegen id : 2]
-Input [1]: [s_store_sk#15]
-Condition : isnotnull(s_store_sk#15)
+(16) Filter [codegen id : 3]
+Input [1]: [s_store_sk#17]
+Condition : isnotnull(s_store_sk#17)
 
-(14) BroadcastExchange
-Input [1]: [s_store_sk#15]
+(17) BroadcastExchange
+Input [1]: [s_store_sk#17]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
 
-(15) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_store_sk#11]
-Right keys [1]: [s_store_sk#15]
-Join type: Inner
-Join condition: None
-
-(16) Project [codegen id : 4]
-Output [3]: [i_manager_id#5, ss_sales_price#12, ss_sold_date_sk#13]
-Input [5]: [i_manager_id#5, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13, s_store_sk#15]
-
-(17) ReusedExchange [Reuses operator id: 33]
-Output [2]: [d_date_sk#16, d_moy#17]
-
 (18) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#13]
-Right keys [1]: [d_date_sk#16]
+Left keys [1]: [ss_store_sk#2]
+Right keys [1]: [s_store_sk#17]
 Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]
-Output [3]: [i_manager_id#5, ss_sales_price#12, d_moy#17]
-Input [5]: [i_manager_id#5, ss_sales_price#12, ss_sold_date_sk#13, d_date_sk#16, d_moy#17]
+Output [3]: [i_manager_id#12, ss_sales_price#3, d_moy#7]
+Input [5]: [ss_store_sk#2, ss_sales_price#3, d_moy#7, i_manager_id#12, s_store_sk#17]
 
 (20) HashAggregate [codegen id : 4]
-Input [3]: [i_manager_id#5, ss_sales_price#12, d_moy#17]
-Keys [2]: [i_manager_id#5, d_moy#17]
-Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#12))]
+Input [3]: [i_manager_id#12, ss_sales_price#3, d_moy#7]
+Keys [2]: [i_manager_id#12, d_moy#7]
+Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#3))]
 Aggregate Attributes [1]: [sum#18]
-Results [3]: [i_manager_id#5, d_moy#17, sum#19]
+Results [3]: [i_manager_id#12, d_moy#7, sum#19]
 
 (21) Exchange
-Input [3]: [i_manager_id#5, d_moy#17, sum#19]
-Arguments: hashpartitioning(i_manager_id#5, d_moy#17, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [3]: [i_manager_id#12, d_moy#7, sum#19]
+Arguments: hashpartitioning(i_manager_id#12, d_moy#7, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (22) HashAggregate [codegen id : 5]
-Input [3]: [i_manager_id#5, d_moy#17, sum#19]
-Keys [2]: [i_manager_id#5, d_moy#17]
-Functions [1]: [sum(UnscaledValue(ss_sales_price#12))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#12))#20]
-Results [3]: [i_manager_id#5, MakeDecimal(sum(UnscaledValue(ss_sales_price#12))#20,17,2) AS sum_sales#21, MakeDecimal(sum(UnscaledValue(ss_sales_price#12))#20,17,2) AS _w0#22]
+Input [3]: [i_manager_id#12, d_moy#7, sum#19]
+Keys [2]: [i_manager_id#12, d_moy#7]
+Functions [1]: [sum(UnscaledValue(ss_sales_price#3))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#3))#20]
+Results [3]: [i_manager_id#12, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#20,17,2) AS sum_sales#21, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#20,17,2) AS _w0#22]
 
 (23) Exchange
-Input [3]: [i_manager_id#5, sum_sales#21, _w0#22]
-Arguments: hashpartitioning(i_manager_id#5, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [3]: [i_manager_id#12, sum_sales#21, _w0#22]
+Arguments: hashpartitioning(i_manager_id#12, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (24) Sort [codegen id : 6]
-Input [3]: [i_manager_id#5, sum_sales#21, _w0#22]
-Arguments: [i_manager_id#5 ASC NULLS FIRST], false, 0
+Input [3]: [i_manager_id#12, sum_sales#21, _w0#22]
+Arguments: [i_manager_id#12 ASC NULLS FIRST], false, 0
 
 (25) Window
-Input [3]: [i_manager_id#5, sum_sales#21, _w0#22]
-Arguments: [avg(_w0#22) windowspecdefinition(i_manager_id#5, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_monthly_sales#23], [i_manager_id#5]
+Input [3]: [i_manager_id#12, sum_sales#21, _w0#22]
+Arguments: [avg(_w0#22) windowspecdefinition(i_manager_id#12, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_monthly_sales#23], [i_manager_id#12]
 
 (26) Filter [codegen id : 7]
-Input [4]: [i_manager_id#5, sum_sales#21, _w0#22, avg_monthly_sales#23]
+Input [4]: [i_manager_id#12, sum_sales#21, _w0#22, avg_monthly_sales#23]
 Condition : CASE WHEN (avg_monthly_sales#23 > 0.000000) THEN ((abs((sum_sales#21 - avg_monthly_sales#23)) / avg_monthly_sales#23) > 0.1000000000000000) ELSE false END
 
 (27) Project [codegen id : 7]
-Output [3]: [i_manager_id#5, sum_sales#21, avg_monthly_sales#23]
-Input [4]: [i_manager_id#5, sum_sales#21, _w0#22, avg_monthly_sales#23]
+Output [3]: [i_manager_id#12, sum_sales#21, avg_monthly_sales#23]
+Input [4]: [i_manager_id#12, sum_sales#21, _w0#22, avg_monthly_sales#23]
 
 (28) TakeOrderedAndProject
-Input [3]: [i_manager_id#5, sum_sales#21, avg_monthly_sales#23]
-Arguments: 100, [i_manager_id#5 ASC NULLS FIRST, avg_monthly_sales#23 ASC NULLS FIRST, sum_sales#21 ASC NULLS FIRST], [i_manager_id#5, sum_sales#21, avg_monthly_sales#23]
+Input [3]: [i_manager_id#12, sum_sales#21, avg_monthly_sales#23]
+Arguments: 100, [i_manager_id#12 ASC NULLS FIRST, avg_monthly_sales#23 ASC NULLS FIRST, sum_sales#21 ASC NULLS FIRST], [i_manager_id#12, sum_sales#21, avg_monthly_sales#23]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#13 IN dynamicpruning#14
+Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
 BroadcastExchange (33)
 +- * Project (32)
    +- * Filter (31)
@@ -170,25 +170,25 @@ BroadcastExchange (33)
 
 
 (29) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#16, d_month_seq#24, d_moy#17]
+Output [3]: [d_date_sk#6, d_month_seq#24, d_moy#7]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_month_seq, [1219,1220,1221,1222,1223,1224,1225,1226,1227,1228,1229,1230]), GreaterThanOrEqual(d_date_sk,2452123), LessThanOrEqual(d_date_sk,2452487), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int,d_moy:int>
 
 (30) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#16, d_month_seq#24, d_moy#17]
+Input [3]: [d_date_sk#6, d_month_seq#24, d_moy#7]
 
 (31) Filter [codegen id : 1]
-Input [3]: [d_date_sk#16, d_month_seq#24, d_moy#17]
-Condition : (((d_month_seq#24 INSET 1219, 1220, 1221, 1222, 1223, 1224, 1225, 1226, 1227, 1228, 1229, 1230 AND (d_date_sk#16 >= 2452123)) AND (d_date_sk#16 <= 2452487)) AND isnotnull(d_date_sk#16))
+Input [3]: [d_date_sk#6, d_month_seq#24, d_moy#7]
+Condition : (((d_month_seq#24 INSET 1219, 1220, 1221, 1222, 1223, 1224, 1225, 1226, 1227, 1228, 1229, 1230 AND (d_date_sk#6 >= 2452123)) AND (d_date_sk#6 <= 2452487)) AND isnotnull(d_date_sk#6))
 
 (32) Project [codegen id : 1]
-Output [2]: [d_date_sk#16, d_moy#17]
-Input [3]: [d_date_sk#16, d_month_seq#24, d_moy#17]
+Output [2]: [d_date_sk#6, d_moy#7]
+Input [3]: [d_date_sk#6, d_month_seq#24, d_moy#7]
 
 (33) BroadcastExchange
-Input [2]: [d_date_sk#16, d_moy#17]
+Input [2]: [d_date_sk#6, d_moy#7]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q63.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q63.sf100/simplified.txt
@@ -15,37 +15,37 @@ TakeOrderedAndProject [i_manager_id,avg_monthly_sales,sum_sales]
                             WholeStageCodegen (4)
                               HashAggregate [i_manager_id,d_moy,ss_sales_price] [sum,sum]
                                 Project [i_manager_id,ss_sales_price,d_moy]
-                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                    Project [i_manager_id,ss_sales_price,ss_sold_date_sk]
-                                      BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                        Project [i_manager_id,ss_store_sk,ss_sales_price,ss_sold_date_sk]
-                                          BroadcastHashJoin [i_item_sk,ss_item_sk]
-                                            InputAdapter
-                                              BroadcastExchange #3
-                                                WholeStageCodegen (1)
-                                                  Project [i_item_sk,i_manager_id]
-                                                    Filter [i_category,i_class,i_brand,i_item_sk]
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_class,i_category,i_manager_id]
+                                  BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                    Project [ss_store_sk,ss_sales_price,d_moy,i_manager_id]
+                                      BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                        Project [ss_item_sk,ss_store_sk,ss_sales_price,d_moy]
+                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                             Filter [ss_item_sk,ss_store_sk]
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_sales_price,ss_sold_date_sk]
                                                     SubqueryBroadcast [d_date_sk] #1
-                                                      BroadcastExchange #4
+                                                      BroadcastExchange #3
                                                         WholeStageCodegen (1)
                                                           Project [d_date_sk,d_moy]
                                                             Filter [d_month_seq,d_date_sk]
                                                               ColumnarToRow
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.date_dim [d_date_sk,d_month_seq,d_moy]
+                                            InputAdapter
+                                              ReusedExchange [d_date_sk,d_moy] #3
                                         InputAdapter
-                                          BroadcastExchange #5
+                                          BroadcastExchange #4
                                             WholeStageCodegen (2)
-                                              Filter [s_store_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.store [s_store_sk]
+                                              Project [i_item_sk,i_manager_id]
+                                                Filter [i_category,i_class,i_brand,i_item_sk]
+                                                  ColumnarToRow
+                                                    InputAdapter
+                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_class,i_category,i_manager_id]
                                     InputAdapter
-                                      ReusedExchange [d_date_sk,d_moy] #4
+                                      BroadcastExchange #5
+                                        WholeStageCodegen (3)
+                                          Filter [s_store_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet spark_catalog.default.store [s_store_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q65.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q65.sf100/explain.txt
@@ -1,43 +1,46 @@
 == Physical Plan ==
-TakeOrderedAndProject (39)
-+- * Project (38)
-   +- * BroadcastHashJoin Inner BuildLeft (37)
-      :- BroadcastExchange (33)
-      :  +- * Project (32)
-      :     +- * BroadcastHashJoin Inner BuildLeft (31)
-      :        :- BroadcastExchange (27)
-      :        :  +- * Project (26)
-      :        :     +- * BroadcastHashJoin Inner BuildRight (25)
-      :        :        :- * Filter (10)
-      :        :        :  +- * HashAggregate (9)
-      :        :        :     +- Exchange (8)
-      :        :        :        +- * HashAggregate (7)
-      :        :        :           +- * Project (6)
-      :        :        :              +- * BroadcastHashJoin Inner BuildRight (5)
-      :        :        :                 :- * Filter (3)
-      :        :        :                 :  +- * ColumnarToRow (2)
-      :        :        :                 :     +- Scan parquet spark_catalog.default.store_sales (1)
-      :        :        :                 +- ReusedExchange (4)
-      :        :        +- BroadcastExchange (24)
-      :        :           +- * Filter (23)
-      :        :              +- * HashAggregate (22)
-      :        :                 +- Exchange (21)
-      :        :                    +- * HashAggregate (20)
-      :        :                       +- * HashAggregate (19)
-      :        :                          +- Exchange (18)
-      :        :                             +- * HashAggregate (17)
-      :        :                                +- * Project (16)
-      :        :                                   +- * BroadcastHashJoin Inner BuildRight (15)
-      :        :                                      :- * Filter (13)
-      :        :                                      :  +- * ColumnarToRow (12)
-      :        :                                      :     +- Scan parquet spark_catalog.default.store_sales (11)
-      :        :                                      +- ReusedExchange (14)
-      :        +- * Filter (30)
-      :           +- * ColumnarToRow (29)
-      :              +- Scan parquet spark_catalog.default.store (28)
-      +- * Filter (36)
-         +- * ColumnarToRow (35)
-            +- Scan parquet spark_catalog.default.item (34)
+TakeOrderedAndProject (42)
++- * Project (41)
+   +- * BroadcastHashJoin Inner BuildRight (40)
+      :- * Project (35)
+      :  +- * SortMergeJoin Inner (34)
+      :     :- * Sort (28)
+      :     :  +- Exchange (27)
+      :     :     +- * Project (26)
+      :     :        +- * BroadcastHashJoin Inner BuildRight (25)
+      :     :           :- * Filter (10)
+      :     :           :  +- * HashAggregate (9)
+      :     :           :     +- Exchange (8)
+      :     :           :        +- * HashAggregate (7)
+      :     :           :           +- * Project (6)
+      :     :           :              +- * BroadcastHashJoin Inner BuildRight (5)
+      :     :           :                 :- * Filter (3)
+      :     :           :                 :  +- * ColumnarToRow (2)
+      :     :           :                 :     +- Scan parquet spark_catalog.default.store_sales (1)
+      :     :           :                 +- ReusedExchange (4)
+      :     :           +- BroadcastExchange (24)
+      :     :              +- * Filter (23)
+      :     :                 +- * HashAggregate (22)
+      :     :                    +- Exchange (21)
+      :     :                       +- * HashAggregate (20)
+      :     :                          +- * HashAggregate (19)
+      :     :                             +- Exchange (18)
+      :     :                                +- * HashAggregate (17)
+      :     :                                   +- * Project (16)
+      :     :                                      +- * BroadcastHashJoin Inner BuildRight (15)
+      :     :                                         :- * Filter (13)
+      :     :                                         :  +- * ColumnarToRow (12)
+      :     :                                         :     +- Scan parquet spark_catalog.default.store_sales (11)
+      :     :                                         +- ReusedExchange (14)
+      :     +- * Sort (33)
+      :        +- Exchange (32)
+      :           +- * Filter (31)
+      :              +- * ColumnarToRow (30)
+      :                 +- Scan parquet spark_catalog.default.item (29)
+      +- BroadcastExchange (39)
+         +- * Filter (38)
+            +- * ColumnarToRow (37)
+               +- Scan parquet spark_catalog.default.store (36)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -55,7 +58,7 @@ Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
 Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
 Condition : (isnotnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1))
 
-(4) ReusedExchange [Reuses operator id: 44]
+(4) ReusedExchange [Reuses operator id: 47]
 Output [1]: [d_date_sk#6]
 
 (5) BroadcastHashJoin [codegen id : 2]
@@ -105,7 +108,7 @@ Input [4]: [ss_item_sk#11, ss_store_sk#12, ss_sales_price#13, ss_sold_date_sk#14
 Input [4]: [ss_item_sk#11, ss_store_sk#12, ss_sales_price#13, ss_sold_date_sk#14]
 Condition : isnotnull(ss_store_sk#12)
 
-(14) ReusedExchange [Reuses operator id: 44]
+(14) ReusedExchange [Reuses operator id: 47]
 Output [1]: [d_date_sk#15]
 
 (15) BroadcastHashJoin [codegen id : 4]
@@ -172,97 +175,109 @@ Join condition: (cast(revenue#10 as decimal(23,7)) <= (0.1 * ave#25))
 Output [3]: [ss_store_sk#2, ss_item_sk#1, revenue#10]
 Input [5]: [ss_store_sk#2, ss_item_sk#1, revenue#10, ss_store_sk#12, ave#25]
 
-(27) BroadcastExchange
+(27) Exchange
 Input [3]: [ss_store_sk#2, ss_item_sk#1, revenue#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(28) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#26, s_store_name#27]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_store_sk)]
-ReadSchema: struct<s_store_sk:int,s_store_name:string>
+(28) Sort [codegen id : 8]
+Input [3]: [ss_store_sk#2, ss_item_sk#1, revenue#10]
+Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(29) ColumnarToRow
-Input [2]: [s_store_sk#26, s_store_name#27]
-
-(30) Filter
-Input [2]: [s_store_sk#26, s_store_name#27]
-Condition : isnotnull(s_store_sk#26)
-
-(31) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ss_store_sk#2]
-Right keys [1]: [s_store_sk#26]
-Join type: Inner
-Join condition: None
-
-(32) Project [codegen id : 8]
-Output [3]: [ss_item_sk#1, revenue#10, s_store_name#27]
-Input [5]: [ss_store_sk#2, ss_item_sk#1, revenue#10, s_store_sk#26, s_store_name#27]
-
-(33) BroadcastExchange
-Input [3]: [ss_item_sk#1, revenue#10, s_store_name#27]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
-
-(34) Scan parquet spark_catalog.default.item
-Output [5]: [i_item_sk#28, i_item_desc#29, i_current_price#30, i_wholesale_cost#31, i_brand#32]
+(29) Scan parquet spark_catalog.default.item
+Output [5]: [i_item_sk#26, i_item_desc#27, i_current_price#28, i_wholesale_cost#29, i_brand#30]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_desc:string,i_current_price:decimal(7,2),i_wholesale_cost:decimal(7,2),i_brand:string>
 
-(35) ColumnarToRow
-Input [5]: [i_item_sk#28, i_item_desc#29, i_current_price#30, i_wholesale_cost#31, i_brand#32]
+(30) ColumnarToRow [codegen id : 9]
+Input [5]: [i_item_sk#26, i_item_desc#27, i_current_price#28, i_wholesale_cost#29, i_brand#30]
 
-(36) Filter
-Input [5]: [i_item_sk#28, i_item_desc#29, i_current_price#30, i_wholesale_cost#31, i_brand#32]
-Condition : isnotnull(i_item_sk#28)
+(31) Filter [codegen id : 9]
+Input [5]: [i_item_sk#26, i_item_desc#27, i_current_price#28, i_wholesale_cost#29, i_brand#30]
+Condition : isnotnull(i_item_sk#26)
 
-(37) BroadcastHashJoin [codegen id : 9]
+(32) Exchange
+Input [5]: [i_item_sk#26, i_item_desc#27, i_current_price#28, i_wholesale_cost#29, i_brand#30]
+Arguments: hashpartitioning(i_item_sk#26, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(33) Sort [codegen id : 10]
+Input [5]: [i_item_sk#26, i_item_desc#27, i_current_price#28, i_wholesale_cost#29, i_brand#30]
+Arguments: [i_item_sk#26 ASC NULLS FIRST], false, 0
+
+(34) SortMergeJoin [codegen id : 12]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#28]
+Right keys [1]: [i_item_sk#26]
 Join type: Inner
 Join condition: None
 
-(38) Project [codegen id : 9]
-Output [6]: [s_store_name#27, i_item_desc#29, revenue#10, i_current_price#30, i_wholesale_cost#31, i_brand#32]
-Input [8]: [ss_item_sk#1, revenue#10, s_store_name#27, i_item_sk#28, i_item_desc#29, i_current_price#30, i_wholesale_cost#31, i_brand#32]
+(35) Project [codegen id : 12]
+Output [6]: [ss_store_sk#2, revenue#10, i_item_desc#27, i_current_price#28, i_wholesale_cost#29, i_brand#30]
+Input [8]: [ss_store_sk#2, ss_item_sk#1, revenue#10, i_item_sk#26, i_item_desc#27, i_current_price#28, i_wholesale_cost#29, i_brand#30]
 
-(39) TakeOrderedAndProject
-Input [6]: [s_store_name#27, i_item_desc#29, revenue#10, i_current_price#30, i_wholesale_cost#31, i_brand#32]
-Arguments: 100, [s_store_name#27 ASC NULLS FIRST, i_item_desc#29 ASC NULLS FIRST], [s_store_name#27, i_item_desc#29, revenue#10, i_current_price#30, i_wholesale_cost#31, i_brand#32]
+(36) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#31, s_store_name#32]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [IsNotNull(s_store_sk)]
+ReadSchema: struct<s_store_sk:int,s_store_name:string>
+
+(37) ColumnarToRow [codegen id : 11]
+Input [2]: [s_store_sk#31, s_store_name#32]
+
+(38) Filter [codegen id : 11]
+Input [2]: [s_store_sk#31, s_store_name#32]
+Condition : isnotnull(s_store_sk#31)
+
+(39) BroadcastExchange
+Input [2]: [s_store_sk#31, s_store_name#32]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
+
+(40) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [ss_store_sk#2]
+Right keys [1]: [s_store_sk#31]
+Join type: Inner
+Join condition: None
+
+(41) Project [codegen id : 12]
+Output [6]: [s_store_name#32, i_item_desc#27, revenue#10, i_current_price#28, i_wholesale_cost#29, i_brand#30]
+Input [8]: [ss_store_sk#2, revenue#10, i_item_desc#27, i_current_price#28, i_wholesale_cost#29, i_brand#30, s_store_sk#31, s_store_name#32]
+
+(42) TakeOrderedAndProject
+Input [6]: [s_store_name#32, i_item_desc#27, revenue#10, i_current_price#28, i_wholesale_cost#29, i_brand#30]
+Arguments: 100, [s_store_name#32 ASC NULLS FIRST, i_item_desc#27 ASC NULLS FIRST], [s_store_name#32, i_item_desc#27, revenue#10, i_current_price#28, i_wholesale_cost#29, i_brand#30]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
-BroadcastExchange (44)
-+- * Project (43)
-   +- * Filter (42)
-      +- * ColumnarToRow (41)
-         +- Scan parquet spark_catalog.default.date_dim (40)
+BroadcastExchange (47)
++- * Project (46)
+   +- * Filter (45)
+      +- * ColumnarToRow (44)
+         +- Scan parquet spark_catalog.default.date_dim (43)
 
 
-(40) Scan parquet spark_catalog.default.date_dim
+(43) Scan parquet spark_catalog.default.date_dim
 Output [2]: [d_date_sk#6, d_month_seq#33]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1212), LessThanOrEqual(d_month_seq,1223), GreaterThanOrEqual(d_date_sk,2451911), LessThanOrEqual(d_date_sk,2452275), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int>
 
-(41) ColumnarToRow [codegen id : 1]
+(44) ColumnarToRow [codegen id : 1]
 Input [2]: [d_date_sk#6, d_month_seq#33]
 
-(42) Filter [codegen id : 1]
+(45) Filter [codegen id : 1]
 Input [2]: [d_date_sk#6, d_month_seq#33]
 Condition : (((((isnotnull(d_month_seq#33) AND (d_month_seq#33 >= 1212)) AND (d_month_seq#33 <= 1223)) AND (d_date_sk#6 >= 2451911)) AND (d_date_sk#6 <= 2452275)) AND isnotnull(d_date_sk#6))
 
-(43) Project [codegen id : 1]
+(46) Project [codegen id : 1]
 Output [1]: [d_date_sk#6]
 Input [2]: [d_date_sk#6, d_month_seq#33]
 
-(44) BroadcastExchange
+(47) BroadcastExchange
 Input [1]: [d_date_sk#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 
 Subquery:2 Hosting operator id = 11 Hosting Expression = ss_sold_date_sk#14 IN dynamicpruning#5
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q65.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q65.sf100/simplified.txt
@@ -1,21 +1,21 @@
 TakeOrderedAndProject [s_store_name,i_item_desc,revenue,i_current_price,i_wholesale_cost,i_brand]
-  WholeStageCodegen (9)
+  WholeStageCodegen (12)
     Project [s_store_name,i_item_desc,revenue,i_current_price,i_wholesale_cost,i_brand]
-      BroadcastHashJoin [ss_item_sk,i_item_sk]
-        InputAdapter
-          BroadcastExchange #1
-            WholeStageCodegen (8)
-              Project [ss_item_sk,revenue,s_store_name]
-                BroadcastHashJoin [ss_store_sk,s_store_sk]
+      BroadcastHashJoin [ss_store_sk,s_store_sk]
+        Project [ss_store_sk,revenue,i_item_desc,i_current_price,i_wholesale_cost,i_brand]
+          SortMergeJoin [ss_item_sk,i_item_sk]
+            InputAdapter
+              WholeStageCodegen (8)
+                Sort [ss_item_sk]
                   InputAdapter
-                    BroadcastExchange #2
+                    Exchange [ss_item_sk] #1
                       WholeStageCodegen (7)
                         Project [ss_store_sk,ss_item_sk,revenue]
                           BroadcastHashJoin [ss_store_sk,ss_store_sk,revenue,ave]
                             Filter [revenue]
                               HashAggregate [ss_store_sk,ss_item_sk,sum] [sum(UnscaledValue(ss_sales_price)),revenue,sum]
                                 InputAdapter
-                                  Exchange [ss_store_sk,ss_item_sk] #3
+                                  Exchange [ss_store_sk,ss_item_sk] #2
                                     WholeStageCodegen (2)
                                       HashAggregate [ss_store_sk,ss_item_sk,ss_sales_price] [sum,sum]
                                         Project [ss_item_sk,ss_store_sk,ss_sales_price]
@@ -25,7 +25,7 @@ TakeOrderedAndProject [s_store_name,i_item_desc,revenue,i_current_price,i_wholes
                                                 InputAdapter
                                                   Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_sales_price,ss_sold_date_sk]
                                                     SubqueryBroadcast [d_date_sk] #1
-                                                      BroadcastExchange #4
+                                                      BroadcastExchange #3
                                                         WholeStageCodegen (1)
                                                           Project [d_date_sk]
                                                             Filter [d_month_seq,d_date_sk]
@@ -33,19 +33,19 @@ TakeOrderedAndProject [s_store_name,i_item_desc,revenue,i_current_price,i_wholes
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.date_dim [d_date_sk,d_month_seq]
                                             InputAdapter
-                                              ReusedExchange [d_date_sk] #4
+                                              ReusedExchange [d_date_sk] #3
                             InputAdapter
-                              BroadcastExchange #5
+                              BroadcastExchange #4
                                 WholeStageCodegen (6)
                                   Filter [ave]
                                     HashAggregate [ss_store_sk,sum,count] [avg(revenue),ave,sum,count]
                                       InputAdapter
-                                        Exchange [ss_store_sk] #6
+                                        Exchange [ss_store_sk] #5
                                           WholeStageCodegen (5)
                                             HashAggregate [ss_store_sk,revenue] [sum,count,sum,count]
                                               HashAggregate [ss_store_sk,ss_item_sk,sum] [sum(UnscaledValue(ss_sales_price)),revenue,sum]
                                                 InputAdapter
-                                                  Exchange [ss_store_sk,ss_item_sk] #7
+                                                  Exchange [ss_store_sk,ss_item_sk] #6
                                                     WholeStageCodegen (4)
                                                       HashAggregate [ss_store_sk,ss_item_sk,ss_sales_price] [sum,sum]
                                                         Project [ss_item_sk,ss_store_sk,ss_sales_price]
@@ -56,12 +56,21 @@ TakeOrderedAndProject [s_store_name,i_item_desc,revenue,i_current_price,i_wholes
                                                                   Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_sales_price,ss_sold_date_sk]
                                                                     ReusedSubquery [d_date_sk] #1
                                                             InputAdapter
-                                                              ReusedExchange [d_date_sk] #4
-                  Filter [s_store_sk]
-                    ColumnarToRow
-                      InputAdapter
-                        Scan parquet spark_catalog.default.store [s_store_sk,s_store_name]
-        Filter [i_item_sk]
-          ColumnarToRow
+                                                              ReusedExchange [d_date_sk] #3
             InputAdapter
-              Scan parquet spark_catalog.default.item [i_item_sk,i_item_desc,i_current_price,i_wholesale_cost,i_brand]
+              WholeStageCodegen (10)
+                Sort [i_item_sk]
+                  InputAdapter
+                    Exchange [i_item_sk] #7
+                      WholeStageCodegen (9)
+                        Filter [i_item_sk]
+                          ColumnarToRow
+                            InputAdapter
+                              Scan parquet spark_catalog.default.item [i_item_sk,i_item_desc,i_current_price,i_wholesale_cost,i_brand]
+        InputAdapter
+          BroadcastExchange #8
+            WholeStageCodegen (11)
+              Filter [s_store_sk]
+                ColumnarToRow
+                  InputAdapter
+                    Scan parquet spark_catalog.default.store [s_store_sk,s_store_name]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q68.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q68.sf100/explain.txt
@@ -1,291 +1,298 @@
 == Physical Plan ==
-TakeOrderedAndProject (45)
-+- * Project (44)
-   +- * SortMergeJoin Inner (43)
-      :- * Sort (37)
-      :  +- Exchange (36)
-      :     +- * Project (35)
-      :        +- * BroadcastHashJoin Inner BuildLeft (34)
-      :           :- BroadcastExchange (30)
-      :           :  +- * HashAggregate (29)
-      :           :     +- Exchange (28)
-      :           :        +- * HashAggregate (27)
-      :           :           +- * Project (26)
-      :           :              +- * BroadcastHashJoin Inner BuildLeft (25)
-      :           :                 :- BroadcastExchange (21)
-      :           :                 :  +- * Project (20)
-      :           :                 :     +- * BroadcastHashJoin Inner BuildRight (19)
-      :           :                 :        :- * Project (13)
-      :           :                 :        :  +- * BroadcastHashJoin Inner BuildRight (12)
-      :           :                 :        :     :- * Project (6)
-      :           :                 :        :     :  +- * BroadcastHashJoin Inner BuildRight (5)
-      :           :                 :        :     :     :- * Filter (3)
-      :           :                 :        :     :     :  +- * ColumnarToRow (2)
-      :           :                 :        :     :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-      :           :                 :        :     :     +- ReusedExchange (4)
-      :           :                 :        :     +- BroadcastExchange (11)
-      :           :                 :        :        +- * Project (10)
-      :           :                 :        :           +- * Filter (9)
-      :           :                 :        :              +- * ColumnarToRow (8)
-      :           :                 :        :                 +- Scan parquet spark_catalog.default.store (7)
-      :           :                 :        +- BroadcastExchange (18)
-      :           :                 :           +- * Project (17)
-      :           :                 :              +- * Filter (16)
-      :           :                 :                 +- * ColumnarToRow (15)
-      :           :                 :                    +- Scan parquet spark_catalog.default.household_demographics (14)
-      :           :                 +- * Filter (24)
-      :           :                    +- * ColumnarToRow (23)
-      :           :                       +- Scan parquet spark_catalog.default.customer_address (22)
-      :           +- * Filter (33)
-      :              +- * ColumnarToRow (32)
-      :                 +- Scan parquet spark_catalog.default.customer (31)
-      +- * Sort (42)
-         +- Exchange (41)
-            +- * Filter (40)
-               +- * ColumnarToRow (39)
-                  +- Scan parquet spark_catalog.default.customer_address (38)
+TakeOrderedAndProject (47)
++- * Project (46)
+   +- * SortMergeJoin Inner (45)
+      :- * Sort (14)
+      :  +- Exchange (13)
+      :     +- * Project (12)
+      :        +- * SortMergeJoin Inner (11)
+      :           :- * Sort (5)
+      :           :  +- Exchange (4)
+      :           :     +- * Filter (3)
+      :           :        +- * ColumnarToRow (2)
+      :           :           +- Scan parquet spark_catalog.default.customer (1)
+      :           +- * Sort (10)
+      :              +- Exchange (9)
+      :                 +- * Filter (8)
+      :                    +- * ColumnarToRow (7)
+      :                       +- Scan parquet spark_catalog.default.customer_address (6)
+      +- * Sort (44)
+         +- Exchange (43)
+            +- * HashAggregate (42)
+               +- * HashAggregate (41)
+                  +- * Project (40)
+                     +- * SortMergeJoin Inner (39)
+                        :- * Sort (36)
+                        :  +- Exchange (35)
+                        :     +- * Project (34)
+                        :        +- * BroadcastHashJoin Inner BuildRight (33)
+                        :           :- * Project (27)
+                        :           :  +- * BroadcastHashJoin Inner BuildRight (26)
+                        :           :     :- * Project (20)
+                        :           :     :  +- * BroadcastHashJoin Inner BuildRight (19)
+                        :           :     :     :- * Filter (17)
+                        :           :     :     :  +- * ColumnarToRow (16)
+                        :           :     :     :     +- Scan parquet spark_catalog.default.store_sales (15)
+                        :           :     :     +- ReusedExchange (18)
+                        :           :     +- BroadcastExchange (25)
+                        :           :        +- * Project (24)
+                        :           :           +- * Filter (23)
+                        :           :              +- * ColumnarToRow (22)
+                        :           :                 +- Scan parquet spark_catalog.default.store (21)
+                        :           +- BroadcastExchange (32)
+                        :              +- * Project (31)
+                        :                 +- * Filter (30)
+                        :                    +- * ColumnarToRow (29)
+                        :                       +- Scan parquet spark_catalog.default.household_demographics (28)
+                        +- * Sort (38)
+                           +- ReusedExchange (37)
 
 
-(1) Scan parquet spark_catalog.default.store_sales
-Output [9]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [ss_sold_date_sk#9 INSET 2451180, 2451181, 2451211, 2451212, 2451239, 2451240, 2451270, 2451271, 2451300, 2451301, 2451331, 2451332, 2451361, 2451362, 2451392, 2451393, 2451423, 2451424, 2451453, 2451454, 2451484, 2451485, 2451514, 2451515, 2451545, 2451546, 2451576, 2451577, 2451605, 2451606, 2451636, 2451637, 2451666, 2451667, 2451697, 2451698, 2451727, 2451728, 2451758, 2451759, 2451789, 2451790, 2451819, 2451820, 2451850, 2451851, 2451880, 2451881, 2451911, 2451912, 2451942, 2451943, 2451970, 2451971, 2452001, 2452002, 2452031, 2452032, 2452062, 2452063, 2452092, 2452093, 2452123, 2452124, 2452154, 2452155, 2452184, 2452185, 2452215, 2452216, 2452245, 2452246, isnotnull(ss_sold_date_sk#9), dynamicpruningexpression(ss_sold_date_sk#9 IN dynamicpruning#10)]
-PushedFilters: [IsNotNull(ss_store_sk), IsNotNull(ss_hdemo_sk), IsNotNull(ss_addr_sk), IsNotNull(ss_customer_sk)]
-ReadSchema: struct<ss_customer_sk:int,ss_hdemo_sk:int,ss_addr_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_ext_sales_price:decimal(7,2),ss_ext_list_price:decimal(7,2),ss_ext_tax:decimal(7,2)>
-
-(2) ColumnarToRow [codegen id : 4]
-Input [9]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9]
-
-(3) Filter [codegen id : 4]
-Input [9]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9]
-Condition : (((isnotnull(ss_store_sk#4) AND isnotnull(ss_hdemo_sk#2)) AND isnotnull(ss_addr_sk#3)) AND isnotnull(ss_customer_sk#1))
-
-(4) ReusedExchange [Reuses operator id: 50]
-Output [1]: [d_date_sk#11]
-
-(5) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#9]
-Right keys [1]: [d_date_sk#11]
-Join type: Inner
-Join condition: None
-
-(6) Project [codegen id : 4]
-Output [8]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8]
-Input [10]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ss_sold_date_sk#9, d_date_sk#11]
-
-(7) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#12, s_city#13]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [In(s_city, [Fairview,Midway]), IsNotNull(s_store_sk)]
-ReadSchema: struct<s_store_sk:int,s_city:string>
-
-(8) ColumnarToRow [codegen id : 2]
-Input [2]: [s_store_sk#12, s_city#13]
-
-(9) Filter [codegen id : 2]
-Input [2]: [s_store_sk#12, s_city#13]
-Condition : (s_city#13 IN (Midway,Fairview) AND isnotnull(s_store_sk#12))
-
-(10) Project [codegen id : 2]
-Output [1]: [s_store_sk#12]
-Input [2]: [s_store_sk#12, s_city#13]
-
-(11) BroadcastExchange
-Input [1]: [s_store_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
-
-(12) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_store_sk#4]
-Right keys [1]: [s_store_sk#12]
-Join type: Inner
-Join condition: None
-
-(13) Project [codegen id : 4]
-Output [7]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8]
-Input [9]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, s_store_sk#12]
-
-(14) Scan parquet spark_catalog.default.household_demographics
-Output [3]: [hd_demo_sk#14, hd_dep_count#15, hd_vehicle_count#16]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/household_demographics]
-PushedFilters: [Or(EqualTo(hd_dep_count,5),EqualTo(hd_vehicle_count,3)), IsNotNull(hd_demo_sk)]
-ReadSchema: struct<hd_demo_sk:int,hd_dep_count:int,hd_vehicle_count:int>
-
-(15) ColumnarToRow [codegen id : 3]
-Input [3]: [hd_demo_sk#14, hd_dep_count#15, hd_vehicle_count#16]
-
-(16) Filter [codegen id : 3]
-Input [3]: [hd_demo_sk#14, hd_dep_count#15, hd_vehicle_count#16]
-Condition : (((hd_dep_count#15 = 5) OR (hd_vehicle_count#16 = 3)) AND isnotnull(hd_demo_sk#14))
-
-(17) Project [codegen id : 3]
-Output [1]: [hd_demo_sk#14]
-Input [3]: [hd_demo_sk#14, hd_dep_count#15, hd_vehicle_count#16]
-
-(18) BroadcastExchange
-Input [1]: [hd_demo_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
-
-(19) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_hdemo_sk#2]
-Right keys [1]: [hd_demo_sk#14]
-Join type: Inner
-Join condition: None
-
-(20) Project [codegen id : 4]
-Output [6]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8]
-Input [8]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, hd_demo_sk#14]
-
-(21) BroadcastExchange
-Input [6]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [plan_id=3]
-
-(22) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#17, ca_city#18]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_city)]
-ReadSchema: struct<ca_address_sk:int,ca_city:string>
-
-(23) ColumnarToRow
-Input [2]: [ca_address_sk#17, ca_city#18]
-
-(24) Filter
-Input [2]: [ca_address_sk#17, ca_city#18]
-Condition : (isnotnull(ca_address_sk#17) AND isnotnull(ca_city#18))
-
-(25) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [ss_addr_sk#3]
-Right keys [1]: [ca_address_sk#17]
-Join type: Inner
-Join condition: None
-
-(26) Project [codegen id : 5]
-Output [7]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ca_city#18]
-Input [8]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ca_address_sk#17, ca_city#18]
-
-(27) HashAggregate [codegen id : 5]
-Input [7]: [ss_customer_sk#1, ss_addr_sk#3, ss_ticket_number#5, ss_ext_sales_price#6, ss_ext_list_price#7, ss_ext_tax#8, ca_city#18]
-Keys [4]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#18]
-Functions [3]: [partial_sum(UnscaledValue(ss_ext_sales_price#6)), partial_sum(UnscaledValue(ss_ext_list_price#7)), partial_sum(UnscaledValue(ss_ext_tax#8))]
-Aggregate Attributes [3]: [sum#19, sum#20, sum#21]
-Results [7]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#18, sum#22, sum#23, sum#24]
-
-(28) Exchange
-Input [7]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#18, sum#22, sum#23, sum#24]
-Arguments: hashpartitioning(ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#18, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(29) HashAggregate [codegen id : 6]
-Input [7]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#18, sum#22, sum#23, sum#24]
-Keys [4]: [ss_ticket_number#5, ss_customer_sk#1, ss_addr_sk#3, ca_city#18]
-Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#6)), sum(UnscaledValue(ss_ext_list_price#7)), sum(UnscaledValue(ss_ext_tax#8))]
-Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#6))#25, sum(UnscaledValue(ss_ext_list_price#7))#26, sum(UnscaledValue(ss_ext_tax#8))#27]
-Results [6]: [ss_ticket_number#5, ss_customer_sk#1, ca_city#18 AS bought_city#28, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#6))#25,17,2) AS extended_price#29, MakeDecimal(sum(UnscaledValue(ss_ext_list_price#7))#26,17,2) AS list_price#30, MakeDecimal(sum(UnscaledValue(ss_ext_tax#8))#27,17,2) AS extended_tax#31]
-
-(30) BroadcastExchange
-Input [6]: [ss_ticket_number#5, ss_customer_sk#1, bought_city#28, extended_price#29, list_price#30, extended_tax#31]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [plan_id=5]
-
-(31) Scan parquet spark_catalog.default.customer
-Output [4]: [c_customer_sk#32, c_current_addr_sk#33, c_first_name#34, c_last_name#35]
+(1) Scan parquet spark_catalog.default.customer
+Output [4]: [c_customer_sk#1, c_current_addr_sk#2, c_first_name#3, c_last_name#4]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int,c_first_name:string,c_last_name:string>
 
-(32) ColumnarToRow
-Input [4]: [c_customer_sk#32, c_current_addr_sk#33, c_first_name#34, c_last_name#35]
+(2) ColumnarToRow [codegen id : 1]
+Input [4]: [c_customer_sk#1, c_current_addr_sk#2, c_first_name#3, c_last_name#4]
 
-(33) Filter
-Input [4]: [c_customer_sk#32, c_current_addr_sk#33, c_first_name#34, c_last_name#35]
-Condition : (isnotnull(c_customer_sk#32) AND isnotnull(c_current_addr_sk#33))
+(3) Filter [codegen id : 1]
+Input [4]: [c_customer_sk#1, c_current_addr_sk#2, c_first_name#3, c_last_name#4]
+Condition : (isnotnull(c_customer_sk#1) AND isnotnull(c_current_addr_sk#2))
 
-(34) BroadcastHashJoin [codegen id : 7]
-Left keys [1]: [ss_customer_sk#1]
-Right keys [1]: [c_customer_sk#32]
-Join type: Inner
-Join condition: None
+(4) Exchange
+Input [4]: [c_customer_sk#1, c_current_addr_sk#2, c_first_name#3, c_last_name#4]
+Arguments: hashpartitioning(c_current_addr_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 
-(35) Project [codegen id : 7]
-Output [8]: [ss_ticket_number#5, bought_city#28, extended_price#29, list_price#30, extended_tax#31, c_current_addr_sk#33, c_first_name#34, c_last_name#35]
-Input [10]: [ss_ticket_number#5, ss_customer_sk#1, bought_city#28, extended_price#29, list_price#30, extended_tax#31, c_customer_sk#32, c_current_addr_sk#33, c_first_name#34, c_last_name#35]
+(5) Sort [codegen id : 2]
+Input [4]: [c_customer_sk#1, c_current_addr_sk#2, c_first_name#3, c_last_name#4]
+Arguments: [c_current_addr_sk#2 ASC NULLS FIRST], false, 0
 
-(36) Exchange
-Input [8]: [ss_ticket_number#5, bought_city#28, extended_price#29, list_price#30, extended_tax#31, c_current_addr_sk#33, c_first_name#34, c_last_name#35]
-Arguments: hashpartitioning(c_current_addr_sk#33, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(37) Sort [codegen id : 8]
-Input [8]: [ss_ticket_number#5, bought_city#28, extended_price#29, list_price#30, extended_tax#31, c_current_addr_sk#33, c_first_name#34, c_last_name#35]
-Arguments: [c_current_addr_sk#33 ASC NULLS FIRST], false, 0
-
-(38) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#36, ca_city#37]
+(6) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#5, ca_city#6]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_city)]
 ReadSchema: struct<ca_address_sk:int,ca_city:string>
 
-(39) ColumnarToRow [codegen id : 9]
-Input [2]: [ca_address_sk#36, ca_city#37]
+(7) ColumnarToRow [codegen id : 3]
+Input [2]: [ca_address_sk#5, ca_city#6]
 
-(40) Filter [codegen id : 9]
-Input [2]: [ca_address_sk#36, ca_city#37]
-Condition : (isnotnull(ca_address_sk#36) AND isnotnull(ca_city#37))
+(8) Filter [codegen id : 3]
+Input [2]: [ca_address_sk#5, ca_city#6]
+Condition : (isnotnull(ca_address_sk#5) AND isnotnull(ca_city#6))
 
-(41) Exchange
-Input [2]: [ca_address_sk#36, ca_city#37]
-Arguments: hashpartitioning(ca_address_sk#36, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(9) Exchange
+Input [2]: [ca_address_sk#5, ca_city#6]
+Arguments: hashpartitioning(ca_address_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(42) Sort [codegen id : 10]
-Input [2]: [ca_address_sk#36, ca_city#37]
-Arguments: [ca_address_sk#36 ASC NULLS FIRST], false, 0
+(10) Sort [codegen id : 4]
+Input [2]: [ca_address_sk#5, ca_city#6]
+Arguments: [ca_address_sk#5 ASC NULLS FIRST], false, 0
 
-(43) SortMergeJoin [codegen id : 11]
-Left keys [1]: [c_current_addr_sk#33]
-Right keys [1]: [ca_address_sk#36]
+(11) SortMergeJoin [codegen id : 5]
+Left keys [1]: [c_current_addr_sk#2]
+Right keys [1]: [ca_address_sk#5]
 Join type: Inner
-Join condition: NOT (ca_city#37 = bought_city#28)
+Join condition: None
 
-(44) Project [codegen id : 11]
-Output [8]: [c_last_name#35, c_first_name#34, ca_city#37, bought_city#28, ss_ticket_number#5, extended_price#29, extended_tax#31, list_price#30]
-Input [10]: [ss_ticket_number#5, bought_city#28, extended_price#29, list_price#30, extended_tax#31, c_current_addr_sk#33, c_first_name#34, c_last_name#35, ca_address_sk#36, ca_city#37]
+(12) Project [codegen id : 5]
+Output [4]: [c_customer_sk#1, c_first_name#3, c_last_name#4, ca_city#6]
+Input [6]: [c_customer_sk#1, c_current_addr_sk#2, c_first_name#3, c_last_name#4, ca_address_sk#5, ca_city#6]
 
-(45) TakeOrderedAndProject
-Input [8]: [c_last_name#35, c_first_name#34, ca_city#37, bought_city#28, ss_ticket_number#5, extended_price#29, extended_tax#31, list_price#30]
-Arguments: 100, [c_last_name#35 ASC NULLS FIRST, ss_ticket_number#5 ASC NULLS FIRST], [c_last_name#35, c_first_name#34, ca_city#37, bought_city#28, ss_ticket_number#5, extended_price#29, extended_tax#31, list_price#30]
+(13) Exchange
+Input [4]: [c_customer_sk#1, c_first_name#3, c_last_name#4, ca_city#6]
+Arguments: hashpartitioning(c_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(14) Sort [codegen id : 6]
+Input [4]: [c_customer_sk#1, c_first_name#3, c_last_name#4, ca_city#6]
+Arguments: [c_customer_sk#1 ASC NULLS FIRST], false, 0
+
+(15) Scan parquet spark_catalog.default.store_sales
+Output [9]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, ss_sold_date_sk#15]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [ss_sold_date_sk#15 INSET 2451180, 2451181, 2451211, 2451212, 2451239, 2451240, 2451270, 2451271, 2451300, 2451301, 2451331, 2451332, 2451361, 2451362, 2451392, 2451393, 2451423, 2451424, 2451453, 2451454, 2451484, 2451485, 2451514, 2451515, 2451545, 2451546, 2451576, 2451577, 2451605, 2451606, 2451636, 2451637, 2451666, 2451667, 2451697, 2451698, 2451727, 2451728, 2451758, 2451759, 2451789, 2451790, 2451819, 2451820, 2451850, 2451851, 2451880, 2451881, 2451911, 2451912, 2451942, 2451943, 2451970, 2451971, 2452001, 2452002, 2452031, 2452032, 2452062, 2452063, 2452092, 2452093, 2452123, 2452124, 2452154, 2452155, 2452184, 2452185, 2452215, 2452216, 2452245, 2452246, isnotnull(ss_sold_date_sk#15), dynamicpruningexpression(ss_sold_date_sk#15 IN dynamicpruning#16)]
+PushedFilters: [IsNotNull(ss_store_sk), IsNotNull(ss_hdemo_sk), IsNotNull(ss_addr_sk), IsNotNull(ss_customer_sk)]
+ReadSchema: struct<ss_customer_sk:int,ss_hdemo_sk:int,ss_addr_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_ext_sales_price:decimal(7,2),ss_ext_list_price:decimal(7,2),ss_ext_tax:decimal(7,2)>
+
+(16) ColumnarToRow [codegen id : 10]
+Input [9]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, ss_sold_date_sk#15]
+
+(17) Filter [codegen id : 10]
+Input [9]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, ss_sold_date_sk#15]
+Condition : (((isnotnull(ss_store_sk#10) AND isnotnull(ss_hdemo_sk#8)) AND isnotnull(ss_addr_sk#9)) AND isnotnull(ss_customer_sk#7))
+
+(18) ReusedExchange [Reuses operator id: 52]
+Output [1]: [d_date_sk#17]
+
+(19) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ss_sold_date_sk#15]
+Right keys [1]: [d_date_sk#17]
+Join type: Inner
+Join condition: None
+
+(20) Project [codegen id : 10]
+Output [8]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14]
+Input [10]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, ss_sold_date_sk#15, d_date_sk#17]
+
+(21) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#18, s_city#19]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [In(s_city, [Fairview,Midway]), IsNotNull(s_store_sk)]
+ReadSchema: struct<s_store_sk:int,s_city:string>
+
+(22) ColumnarToRow [codegen id : 8]
+Input [2]: [s_store_sk#18, s_city#19]
+
+(23) Filter [codegen id : 8]
+Input [2]: [s_store_sk#18, s_city#19]
+Condition : (s_city#19 IN (Midway,Fairview) AND isnotnull(s_store_sk#18))
+
+(24) Project [codegen id : 8]
+Output [1]: [s_store_sk#18]
+Input [2]: [s_store_sk#18, s_city#19]
+
+(25) BroadcastExchange
+Input [1]: [s_store_sk#18]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
+
+(26) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ss_store_sk#10]
+Right keys [1]: [s_store_sk#18]
+Join type: Inner
+Join condition: None
+
+(27) Project [codegen id : 10]
+Output [7]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14]
+Input [9]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, s_store_sk#18]
+
+(28) Scan parquet spark_catalog.default.household_demographics
+Output [3]: [hd_demo_sk#20, hd_dep_count#21, hd_vehicle_count#22]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/household_demographics]
+PushedFilters: [Or(EqualTo(hd_dep_count,5),EqualTo(hd_vehicle_count,3)), IsNotNull(hd_demo_sk)]
+ReadSchema: struct<hd_demo_sk:int,hd_dep_count:int,hd_vehicle_count:int>
+
+(29) ColumnarToRow [codegen id : 9]
+Input [3]: [hd_demo_sk#20, hd_dep_count#21, hd_vehicle_count#22]
+
+(30) Filter [codegen id : 9]
+Input [3]: [hd_demo_sk#20, hd_dep_count#21, hd_vehicle_count#22]
+Condition : (((hd_dep_count#21 = 5) OR (hd_vehicle_count#22 = 3)) AND isnotnull(hd_demo_sk#20))
+
+(31) Project [codegen id : 9]
+Output [1]: [hd_demo_sk#20]
+Input [3]: [hd_demo_sk#20, hd_dep_count#21, hd_vehicle_count#22]
+
+(32) BroadcastExchange
+Input [1]: [hd_demo_sk#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+
+(33) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ss_hdemo_sk#8]
+Right keys [1]: [hd_demo_sk#20]
+Join type: Inner
+Join condition: None
+
+(34) Project [codegen id : 10]
+Output [6]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14]
+Input [8]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, hd_demo_sk#20]
+
+(35) Exchange
+Input [6]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14]
+Arguments: hashpartitioning(ss_addr_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(36) Sort [codegen id : 11]
+Input [6]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14]
+Arguments: [ss_addr_sk#9 ASC NULLS FIRST], false, 0
+
+(37) ReusedExchange [Reuses operator id: 9]
+Output [2]: [ca_address_sk#23, ca_city#24]
+
+(38) Sort [codegen id : 13]
+Input [2]: [ca_address_sk#23, ca_city#24]
+Arguments: [ca_address_sk#23 ASC NULLS FIRST], false, 0
+
+(39) SortMergeJoin [codegen id : 14]
+Left keys [1]: [ss_addr_sk#9]
+Right keys [1]: [ca_address_sk#23]
+Join type: Inner
+Join condition: None
+
+(40) Project [codegen id : 14]
+Output [7]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, ca_city#24]
+Input [8]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, ca_address_sk#23, ca_city#24]
+
+(41) HashAggregate [codegen id : 14]
+Input [7]: [ss_customer_sk#7, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, ca_city#24]
+Keys [4]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#24]
+Functions [3]: [partial_sum(UnscaledValue(ss_ext_sales_price#12)), partial_sum(UnscaledValue(ss_ext_list_price#13)), partial_sum(UnscaledValue(ss_ext_tax#14))]
+Aggregate Attributes [3]: [sum#25, sum#26, sum#27]
+Results [7]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#24, sum#28, sum#29, sum#30]
+
+(42) HashAggregate [codegen id : 14]
+Input [7]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#24, sum#28, sum#29, sum#30]
+Keys [4]: [ss_ticket_number#11, ss_customer_sk#7, ss_addr_sk#9, ca_city#24]
+Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#12)), sum(UnscaledValue(ss_ext_list_price#13)), sum(UnscaledValue(ss_ext_tax#14))]
+Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#12))#31, sum(UnscaledValue(ss_ext_list_price#13))#32, sum(UnscaledValue(ss_ext_tax#14))#33]
+Results [6]: [ss_ticket_number#11, ss_customer_sk#7, ca_city#24 AS bought_city#34, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#12))#31,17,2) AS extended_price#35, MakeDecimal(sum(UnscaledValue(ss_ext_list_price#13))#32,17,2) AS list_price#36, MakeDecimal(sum(UnscaledValue(ss_ext_tax#14))#33,17,2) AS extended_tax#37]
+
+(43) Exchange
+Input [6]: [ss_ticket_number#11, ss_customer_sk#7, bought_city#34, extended_price#35, list_price#36, extended_tax#37]
+Arguments: hashpartitioning(ss_customer_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(44) Sort [codegen id : 15]
+Input [6]: [ss_ticket_number#11, ss_customer_sk#7, bought_city#34, extended_price#35, list_price#36, extended_tax#37]
+Arguments: [ss_customer_sk#7 ASC NULLS FIRST], false, 0
+
+(45) SortMergeJoin [codegen id : 16]
+Left keys [1]: [c_customer_sk#1]
+Right keys [1]: [ss_customer_sk#7]
+Join type: Inner
+Join condition: NOT (ca_city#6 = bought_city#34)
+
+(46) Project [codegen id : 16]
+Output [8]: [c_last_name#4, c_first_name#3, ca_city#6, bought_city#34, ss_ticket_number#11, extended_price#35, extended_tax#37, list_price#36]
+Input [10]: [c_customer_sk#1, c_first_name#3, c_last_name#4, ca_city#6, ss_ticket_number#11, ss_customer_sk#7, bought_city#34, extended_price#35, list_price#36, extended_tax#37]
+
+(47) TakeOrderedAndProject
+Input [8]: [c_last_name#4, c_first_name#3, ca_city#6, bought_city#34, ss_ticket_number#11, extended_price#35, extended_tax#37, list_price#36]
+Arguments: 100, [c_last_name#4 ASC NULLS FIRST, ss_ticket_number#11 ASC NULLS FIRST], [c_last_name#4, c_first_name#3, ca_city#6, bought_city#34, ss_ticket_number#11, extended_price#35, extended_tax#37, list_price#36]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#9 IN dynamicpruning#10
-BroadcastExchange (50)
-+- * Project (49)
-   +- * Filter (48)
-      +- * ColumnarToRow (47)
-         +- Scan parquet spark_catalog.default.date_dim (46)
+Subquery:1 Hosting operator id = 15 Hosting Expression = ss_sold_date_sk#15 IN dynamicpruning#16
+BroadcastExchange (52)
++- * Project (51)
+   +- * Filter (50)
+      +- * ColumnarToRow (49)
+         +- Scan parquet spark_catalog.default.date_dim (48)
 
 
-(46) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#11, d_year#38, d_dom#39]
+(48) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#17, d_year#38, d_dom#39]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_dom), GreaterThanOrEqual(d_dom,1), LessThanOrEqual(d_dom,2), In(d_year, [1999,2000,2001]), In(d_date_sk, [2451180,2451181,2451211,2451212,2451239,2451240,2451270,2451271,2451300,2451301,2451331,2451332,2451361,2451362,2451392,2451393,2451423,2451424,2451453,2451454,2451484,2451485,2451514,2451515,2451545,2451546,2451576,2451577,2451605,2451606,2451636,2451637,2451666,2451667,2451697,2451698,2451727,2451728,2451758,2451759,2451789,2451790,2451819,2451820,2451850,2451851,2451880,2451881,2451911,2451912,2451942,2451943,2451970,2451971,2452001,2452002,2452031,2452032,2452062,2452063,2452092,2452093,2452123,2452124,2452154,2452155,2452184,2452185,2452215,2452216,2452245,2452246]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_dom:int>
 
-(47) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#11, d_year#38, d_dom#39]
+(49) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#17, d_year#38, d_dom#39]
 
-(48) Filter [codegen id : 1]
-Input [3]: [d_date_sk#11, d_year#38, d_dom#39]
-Condition : (((((isnotnull(d_dom#39) AND (d_dom#39 >= 1)) AND (d_dom#39 <= 2)) AND d_year#38 IN (1999,2000,2001)) AND d_date_sk#11 INSET 2451180, 2451181, 2451211, 2451212, 2451239, 2451240, 2451270, 2451271, 2451300, 2451301, 2451331, 2451332, 2451361, 2451362, 2451392, 2451393, 2451423, 2451424, 2451453, 2451454, 2451484, 2451485, 2451514, 2451515, 2451545, 2451546, 2451576, 2451577, 2451605, 2451606, 2451636, 2451637, 2451666, 2451667, 2451697, 2451698, 2451727, 2451728, 2451758, 2451759, 2451789, 2451790, 2451819, 2451820, 2451850, 2451851, 2451880, 2451881, 2451911, 2451912, 2451942, 2451943, 2451970, 2451971, 2452001, 2452002, 2452031, 2452032, 2452062, 2452063, 2452092, 2452093, 2452123, 2452124, 2452154, 2452155, 2452184, 2452185, 2452215, 2452216, 2452245, 2452246) AND isnotnull(d_date_sk#11))
+(50) Filter [codegen id : 1]
+Input [3]: [d_date_sk#17, d_year#38, d_dom#39]
+Condition : (((((isnotnull(d_dom#39) AND (d_dom#39 >= 1)) AND (d_dom#39 <= 2)) AND d_year#38 IN (1999,2000,2001)) AND d_date_sk#17 INSET 2451180, 2451181, 2451211, 2451212, 2451239, 2451240, 2451270, 2451271, 2451300, 2451301, 2451331, 2451332, 2451361, 2451362, 2451392, 2451393, 2451423, 2451424, 2451453, 2451454, 2451484, 2451485, 2451514, 2451515, 2451545, 2451546, 2451576, 2451577, 2451605, 2451606, 2451636, 2451637, 2451666, 2451667, 2451697, 2451698, 2451727, 2451728, 2451758, 2451759, 2451789, 2451790, 2451819, 2451820, 2451850, 2451851, 2451880, 2451881, 2451911, 2451912, 2451942, 2451943, 2451970, 2451971, 2452001, 2452002, 2452031, 2452032, 2452062, 2452063, 2452092, 2452093, 2452123, 2452124, 2452154, 2452155, 2452184, 2452185, 2452215, 2452216, 2452245, 2452246) AND isnotnull(d_date_sk#17))
 
-(49) Project [codegen id : 1]
-Output [1]: [d_date_sk#11]
-Input [3]: [d_date_sk#11, d_year#38, d_dom#39]
+(51) Project [codegen id : 1]
+Output [1]: [d_date_sk#17]
+Input [3]: [d_date_sk#17, d_year#38, d_dom#39]
 
-(50) BroadcastExchange
-Input [1]: [d_date_sk#11]
+(52) BroadcastExchange
+Input [1]: [d_date_sk#17]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q68.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q68.sf100/simplified.txt
@@ -1,79 +1,89 @@
 TakeOrderedAndProject [c_last_name,ss_ticket_number,c_first_name,ca_city,bought_city,extended_price,extended_tax,list_price]
-  WholeStageCodegen (11)
+  WholeStageCodegen (16)
     Project [c_last_name,c_first_name,ca_city,bought_city,ss_ticket_number,extended_price,extended_tax,list_price]
-      SortMergeJoin [c_current_addr_sk,ca_address_sk,ca_city,bought_city]
+      SortMergeJoin [c_customer_sk,ss_customer_sk,ca_city,bought_city]
         InputAdapter
-          WholeStageCodegen (8)
-            Sort [c_current_addr_sk]
+          WholeStageCodegen (6)
+            Sort [c_customer_sk]
               InputAdapter
-                Exchange [c_current_addr_sk] #1
-                  WholeStageCodegen (7)
-                    Project [ss_ticket_number,bought_city,extended_price,list_price,extended_tax,c_current_addr_sk,c_first_name,c_last_name]
-                      BroadcastHashJoin [ss_customer_sk,c_customer_sk]
+                Exchange [c_customer_sk] #1
+                  WholeStageCodegen (5)
+                    Project [c_customer_sk,c_first_name,c_last_name,ca_city]
+                      SortMergeJoin [c_current_addr_sk,ca_address_sk]
                         InputAdapter
-                          BroadcastExchange #2
-                            WholeStageCodegen (6)
-                              HashAggregate [ss_ticket_number,ss_customer_sk,ss_addr_sk,ca_city,sum,sum,sum] [sum(UnscaledValue(ss_ext_sales_price)),sum(UnscaledValue(ss_ext_list_price)),sum(UnscaledValue(ss_ext_tax)),bought_city,extended_price,list_price,extended_tax,sum,sum,sum]
-                                InputAdapter
-                                  Exchange [ss_ticket_number,ss_customer_sk,ss_addr_sk,ca_city] #3
-                                    WholeStageCodegen (5)
-                                      HashAggregate [ss_ticket_number,ss_customer_sk,ss_addr_sk,ca_city,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax] [sum,sum,sum,sum,sum,sum]
-                                        Project [ss_customer_sk,ss_addr_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax,ca_city]
-                                          BroadcastHashJoin [ss_addr_sk,ca_address_sk]
-                                            InputAdapter
-                                              BroadcastExchange #4
-                                                WholeStageCodegen (4)
-                                                  Project [ss_customer_sk,ss_addr_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax]
-                                                    BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
-                                                      Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax]
-                                                        BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                          Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax]
-                                                            BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                              Filter [ss_store_sk,ss_hdemo_sk,ss_addr_sk,ss_customer_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax,ss_sold_date_sk]
-                                                                      SubqueryBroadcast [d_date_sk] #1
-                                                                        BroadcastExchange #5
-                                                                          WholeStageCodegen (1)
-                                                                            Project [d_date_sk]
-                                                                              Filter [d_dom,d_year,d_date_sk]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_dom]
-                                                              InputAdapter
-                                                                ReusedExchange [d_date_sk] #5
-                                                          InputAdapter
-                                                            BroadcastExchange #6
-                                                              WholeStageCodegen (2)
-                                                                Project [s_store_sk]
-                                                                  Filter [s_city,s_store_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.store [s_store_sk,s_city]
-                                                      InputAdapter
-                                                        BroadcastExchange #7
-                                                          WholeStageCodegen (3)
-                                                            Project [hd_demo_sk]
-                                                              Filter [hd_dep_count,hd_vehicle_count,hd_demo_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_dep_count,hd_vehicle_count]
-                                            Filter [ca_address_sk,ca_city]
-                                              ColumnarToRow
-                                                InputAdapter
-                                                  Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_city]
-                        Filter [c_customer_sk,c_current_addr_sk]
-                          ColumnarToRow
+                          WholeStageCodegen (2)
+                            Sort [c_current_addr_sk]
+                              InputAdapter
+                                Exchange [c_current_addr_sk] #2
+                                  WholeStageCodegen (1)
+                                    Filter [c_customer_sk,c_current_addr_sk]
+                                      ColumnarToRow
+                                        InputAdapter
+                                          Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk,c_first_name,c_last_name]
+                        InputAdapter
+                          WholeStageCodegen (4)
+                            Sort [ca_address_sk]
+                              InputAdapter
+                                Exchange [ca_address_sk] #3
+                                  WholeStageCodegen (3)
+                                    Filter [ca_address_sk,ca_city]
+                                      ColumnarToRow
+                                        InputAdapter
+                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_city]
+        InputAdapter
+          WholeStageCodegen (15)
+            Sort [ss_customer_sk]
+              InputAdapter
+                Exchange [ss_customer_sk] #4
+                  WholeStageCodegen (14)
+                    HashAggregate [ss_ticket_number,ss_customer_sk,ss_addr_sk,ca_city,sum,sum,sum] [sum(UnscaledValue(ss_ext_sales_price)),sum(UnscaledValue(ss_ext_list_price)),sum(UnscaledValue(ss_ext_tax)),bought_city,extended_price,list_price,extended_tax,sum,sum,sum]
+                      HashAggregate [ss_ticket_number,ss_customer_sk,ss_addr_sk,ca_city,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax] [sum,sum,sum,sum,sum,sum]
+                        Project [ss_customer_sk,ss_addr_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax,ca_city]
+                          SortMergeJoin [ss_addr_sk,ca_address_sk]
                             InputAdapter
-                              Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk,c_first_name,c_last_name]
-        InputAdapter
-          WholeStageCodegen (10)
-            Sort [ca_address_sk]
-              InputAdapter
-                Exchange [ca_address_sk] #8
-                  WholeStageCodegen (9)
-                    Filter [ca_address_sk,ca_city]
-                      ColumnarToRow
-                        InputAdapter
-                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_city]
+                              WholeStageCodegen (11)
+                                Sort [ss_addr_sk]
+                                  InputAdapter
+                                    Exchange [ss_addr_sk] #5
+                                      WholeStageCodegen (10)
+                                        Project [ss_customer_sk,ss_addr_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax]
+                                          BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
+                                            Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax]
+                                              BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax]
+                                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                    Filter [ss_store_sk,ss_hdemo_sk,ss_addr_sk,ss_customer_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax,ss_sold_date_sk]
+                                                            SubqueryBroadcast [d_date_sk] #1
+                                                              BroadcastExchange #6
+                                                                WholeStageCodegen (1)
+                                                                  Project [d_date_sk]
+                                                                    Filter [d_dom,d_year,d_date_sk]
+                                                                      ColumnarToRow
+                                                                        InputAdapter
+                                                                          Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_dom]
+                                                    InputAdapter
+                                                      ReusedExchange [d_date_sk] #6
+                                                InputAdapter
+                                                  BroadcastExchange #7
+                                                    WholeStageCodegen (8)
+                                                      Project [s_store_sk]
+                                                        Filter [s_city,s_store_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet spark_catalog.default.store [s_store_sk,s_city]
+                                            InputAdapter
+                                              BroadcastExchange #8
+                                                WholeStageCodegen (9)
+                                                  Project [hd_demo_sk]
+                                                    Filter [hd_dep_count,hd_vehicle_count,hd_demo_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_dep_count,hd_vehicle_count]
+                            InputAdapter
+                              WholeStageCodegen (13)
+                                Sort [ca_address_sk]
+                                  InputAdapter
+                                    ReusedExchange [ca_address_sk,ca_city] #3

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q7.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q7.sf100/explain.txt
@@ -19,12 +19,12 @@ TakeOrderedAndProject (30)
                :     :        +- * Project (10)
                :     :           +- * Filter (9)
                :     :              +- * ColumnarToRow (8)
-               :     :                 +- Scan parquet spark_catalog.default.promotion (7)
+               :     :                 +- Scan parquet spark_catalog.default.customer_demographics (7)
                :     +- BroadcastExchange (18)
                :        +- * Project (17)
                :           +- * Filter (16)
                :              +- * ColumnarToRow (15)
-               :                 +- Scan parquet spark_catalog.default.customer_demographics (14)
+               :                 +- Scan parquet spark_catalog.default.promotion (14)
                +- BroadcastExchange (24)
                   +- * Filter (23)
                      +- * ColumnarToRow (22)
@@ -59,69 +59,69 @@ Join condition: None
 Output [7]: [ss_item_sk#1, ss_cdemo_sk#2, ss_promo_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7]
 Input [9]: [ss_item_sk#1, ss_cdemo_sk#2, ss_promo_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, ss_sold_date_sk#8, d_date_sk#10]
 
-(7) Scan parquet spark_catalog.default.promotion
-Output [3]: [p_promo_sk#11, p_channel_email#12, p_channel_event#13]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/promotion]
-PushedFilters: [Or(EqualTo(p_channel_email,N),EqualTo(p_channel_event,N)), IsNotNull(p_promo_sk)]
-ReadSchema: struct<p_promo_sk:int,p_channel_email:string,p_channel_event:string>
-
-(8) ColumnarToRow [codegen id : 2]
-Input [3]: [p_promo_sk#11, p_channel_email#12, p_channel_event#13]
-
-(9) Filter [codegen id : 2]
-Input [3]: [p_promo_sk#11, p_channel_email#12, p_channel_event#13]
-Condition : (((p_channel_email#12 = N) OR (p_channel_event#13 = N)) AND isnotnull(p_promo_sk#11))
-
-(10) Project [codegen id : 2]
-Output [1]: [p_promo_sk#11]
-Input [3]: [p_promo_sk#11, p_channel_email#12, p_channel_event#13]
-
-(11) BroadcastExchange
-Input [1]: [p_promo_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
-
-(12) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [ss_promo_sk#3]
-Right keys [1]: [p_promo_sk#11]
-Join type: Inner
-Join condition: None
-
-(13) Project [codegen id : 5]
-Output [6]: [ss_item_sk#1, ss_cdemo_sk#2, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7]
-Input [8]: [ss_item_sk#1, ss_cdemo_sk#2, ss_promo_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, p_promo_sk#11]
-
-(14) Scan parquet spark_catalog.default.customer_demographics
-Output [4]: [cd_demo_sk#14, cd_gender#15, cd_marital_status#16, cd_education_status#17]
+(7) Scan parquet spark_catalog.default.customer_demographics
+Output [4]: [cd_demo_sk#11, cd_gender#12, cd_marital_status#13, cd_education_status#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_gender), IsNotNull(cd_marital_status), IsNotNull(cd_education_status), EqualTo(cd_gender,F), EqualTo(cd_marital_status,W), EqualTo(cd_education_status,Primary             ), IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_education_status:string>
 
+(8) ColumnarToRow [codegen id : 2]
+Input [4]: [cd_demo_sk#11, cd_gender#12, cd_marital_status#13, cd_education_status#14]
+
+(9) Filter [codegen id : 2]
+Input [4]: [cd_demo_sk#11, cd_gender#12, cd_marital_status#13, cd_education_status#14]
+Condition : ((((((isnotnull(cd_gender#12) AND isnotnull(cd_marital_status#13)) AND isnotnull(cd_education_status#14)) AND (cd_gender#12 = F)) AND (cd_marital_status#13 = W)) AND (cd_education_status#14 = Primary             )) AND isnotnull(cd_demo_sk#11))
+
+(10) Project [codegen id : 2]
+Output [1]: [cd_demo_sk#11]
+Input [4]: [cd_demo_sk#11, cd_gender#12, cd_marital_status#13, cd_education_status#14]
+
+(11) BroadcastExchange
+Input [1]: [cd_demo_sk#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
+
+(12) BroadcastHashJoin [codegen id : 5]
+Left keys [1]: [ss_cdemo_sk#2]
+Right keys [1]: [cd_demo_sk#11]
+Join type: Inner
+Join condition: None
+
+(13) Project [codegen id : 5]
+Output [6]: [ss_item_sk#1, ss_promo_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7]
+Input [8]: [ss_item_sk#1, ss_cdemo_sk#2, ss_promo_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, cd_demo_sk#11]
+
+(14) Scan parquet spark_catalog.default.promotion
+Output [3]: [p_promo_sk#15, p_channel_email#16, p_channel_event#17]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/promotion]
+PushedFilters: [Or(EqualTo(p_channel_email,N),EqualTo(p_channel_event,N)), IsNotNull(p_promo_sk)]
+ReadSchema: struct<p_promo_sk:int,p_channel_email:string,p_channel_event:string>
+
 (15) ColumnarToRow [codegen id : 3]
-Input [4]: [cd_demo_sk#14, cd_gender#15, cd_marital_status#16, cd_education_status#17]
+Input [3]: [p_promo_sk#15, p_channel_email#16, p_channel_event#17]
 
 (16) Filter [codegen id : 3]
-Input [4]: [cd_demo_sk#14, cd_gender#15, cd_marital_status#16, cd_education_status#17]
-Condition : ((((((isnotnull(cd_gender#15) AND isnotnull(cd_marital_status#16)) AND isnotnull(cd_education_status#17)) AND (cd_gender#15 = F)) AND (cd_marital_status#16 = W)) AND (cd_education_status#17 = Primary             )) AND isnotnull(cd_demo_sk#14))
+Input [3]: [p_promo_sk#15, p_channel_email#16, p_channel_event#17]
+Condition : (((p_channel_email#16 = N) OR (p_channel_event#17 = N)) AND isnotnull(p_promo_sk#15))
 
 (17) Project [codegen id : 3]
-Output [1]: [cd_demo_sk#14]
-Input [4]: [cd_demo_sk#14, cd_gender#15, cd_marital_status#16, cd_education_status#17]
+Output [1]: [p_promo_sk#15]
+Input [3]: [p_promo_sk#15, p_channel_email#16, p_channel_event#17]
 
 (18) BroadcastExchange
-Input [1]: [cd_demo_sk#14]
+Input [1]: [p_promo_sk#15]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
 (19) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [ss_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#14]
+Left keys [1]: [ss_promo_sk#3]
+Right keys [1]: [p_promo_sk#15]
 Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 5]
 Output [5]: [ss_item_sk#1, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7]
-Input [7]: [ss_item_sk#1, ss_cdemo_sk#2, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, cd_demo_sk#14]
+Input [7]: [ss_item_sk#1, ss_promo_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, p_promo_sk#15]
 
 (21) Scan parquet spark_catalog.default.item
 Output [2]: [i_item_sk#18, i_item_id#19]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q7.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q7.sf100/simplified.txt
@@ -8,9 +8,9 @@ TakeOrderedAndProject [i_item_id,agg1,agg2,agg3,agg4]
               Project [ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt,i_item_id]
                 BroadcastHashJoin [ss_item_sk,i_item_sk]
                   Project [ss_item_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
-                    BroadcastHashJoin [ss_cdemo_sk,cd_demo_sk]
-                      Project [ss_item_sk,ss_cdemo_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
-                        BroadcastHashJoin [ss_promo_sk,p_promo_sk]
+                    BroadcastHashJoin [ss_promo_sk,p_promo_sk]
+                      Project [ss_item_sk,ss_promo_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
+                        BroadcastHashJoin [ss_cdemo_sk,cd_demo_sk]
                           Project [ss_item_sk,ss_cdemo_sk,ss_promo_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
                             BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                               Filter [ss_cdemo_sk,ss_item_sk,ss_promo_sk]
@@ -30,19 +30,19 @@ TakeOrderedAndProject [i_item_id,agg1,agg2,agg3,agg4]
                           InputAdapter
                             BroadcastExchange #3
                               WholeStageCodegen (2)
-                                Project [p_promo_sk]
-                                  Filter [p_channel_email,p_channel_event,p_promo_sk]
+                                Project [cd_demo_sk]
+                                  Filter [cd_gender,cd_marital_status,cd_education_status,cd_demo_sk]
                                     ColumnarToRow
                                       InputAdapter
-                                        Scan parquet spark_catalog.default.promotion [p_promo_sk,p_channel_email,p_channel_event]
+                                        Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_education_status]
                       InputAdapter
                         BroadcastExchange #4
                           WholeStageCodegen (3)
-                            Project [cd_demo_sk]
-                              Filter [cd_gender,cd_marital_status,cd_education_status,cd_demo_sk]
+                            Project [p_promo_sk]
+                              Filter [p_channel_email,p_channel_event,p_promo_sk]
                                 ColumnarToRow
                                   InputAdapter
-                                    Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_education_status]
+                                    Scan parquet spark_catalog.default.promotion [p_promo_sk,p_channel_email,p_channel_event]
                   InputAdapter
                     BroadcastExchange #5
                       WholeStageCodegen (4)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q73.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q73.sf100/explain.txt
@@ -1,36 +1,39 @@
 == Physical Plan ==
-* Sort (32)
-+- Exchange (31)
-   +- * Project (30)
-      +- * BroadcastHashJoin Inner BuildLeft (29)
-         :- BroadcastExchange (25)
-         :  +- * Filter (24)
-         :     +- * HashAggregate (23)
-         :        +- Exchange (22)
-         :           +- * HashAggregate (21)
-         :              +- * Project (20)
-         :                 +- * BroadcastHashJoin Inner BuildRight (19)
-         :                    :- * Project (13)
-         :                    :  +- * BroadcastHashJoin Inner BuildRight (12)
-         :                    :     :- * Project (6)
-         :                    :     :  +- * BroadcastHashJoin Inner BuildRight (5)
-         :                    :     :     :- * Filter (3)
-         :                    :     :     :  +- * ColumnarToRow (2)
-         :                    :     :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-         :                    :     :     +- ReusedExchange (4)
-         :                    :     +- BroadcastExchange (11)
-         :                    :        +- * Project (10)
-         :                    :           +- * Filter (9)
-         :                    :              +- * ColumnarToRow (8)
-         :                    :                 +- Scan parquet spark_catalog.default.store (7)
-         :                    +- BroadcastExchange (18)
-         :                       +- * Project (17)
-         :                          +- * Filter (16)
-         :                             +- * ColumnarToRow (15)
-         :                                +- Scan parquet spark_catalog.default.household_demographics (14)
-         +- * Filter (28)
-            +- * ColumnarToRow (27)
-               +- Scan parquet spark_catalog.default.customer (26)
+* Sort (35)
++- Exchange (34)
+   +- * Project (33)
+      +- * SortMergeJoin Inner (32)
+         :- * Sort (26)
+         :  +- Exchange (25)
+         :     +- * Filter (24)
+         :        +- * HashAggregate (23)
+         :           +- Exchange (22)
+         :              +- * HashAggregate (21)
+         :                 +- * Project (20)
+         :                    +- * BroadcastHashJoin Inner BuildRight (19)
+         :                       :- * Project (13)
+         :                       :  +- * BroadcastHashJoin Inner BuildRight (12)
+         :                       :     :- * Project (6)
+         :                       :     :  +- * BroadcastHashJoin Inner BuildRight (5)
+         :                       :     :     :- * Filter (3)
+         :                       :     :     :  +- * ColumnarToRow (2)
+         :                       :     :     :     +- Scan parquet spark_catalog.default.store_sales (1)
+         :                       :     :     +- ReusedExchange (4)
+         :                       :     +- BroadcastExchange (11)
+         :                       :        +- * Project (10)
+         :                       :           +- * Filter (9)
+         :                       :              +- * ColumnarToRow (8)
+         :                       :                 +- Scan parquet spark_catalog.default.household_demographics (7)
+         :                       +- BroadcastExchange (18)
+         :                          +- * Project (17)
+         :                             +- * Filter (16)
+         :                                +- * ColumnarToRow (15)
+         :                                   +- Scan parquet spark_catalog.default.store (14)
+         +- * Sort (31)
+            +- Exchange (30)
+               +- * Filter (29)
+                  +- * ColumnarToRow (28)
+                     +- Scan parquet spark_catalog.default.customer (27)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -48,7 +51,7 @@ Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, 
 Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5]
 Condition : ((isnotnull(ss_store_sk#3) AND isnotnull(ss_hdemo_sk#2)) AND isnotnull(ss_customer_sk#1))
 
-(4) ReusedExchange [Reuses operator id: 37]
+(4) ReusedExchange [Reuses operator id: 40]
 Output [1]: [d_date_sk#7]
 
 (5) BroadcastHashJoin [codegen id : 4]
@@ -61,69 +64,69 @@ Join condition: None
 Output [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4]
 Input [6]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5, d_date_sk#7]
 
-(7) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#8, s_county#9]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [In(s_county, [Barrow County,Bronx County,Fairfield County,Ziebach County]), IsNotNull(s_store_sk)]
-ReadSchema: struct<s_store_sk:int,s_county:string>
-
-(8) ColumnarToRow [codegen id : 2]
-Input [2]: [s_store_sk#8, s_county#9]
-
-(9) Filter [codegen id : 2]
-Input [2]: [s_store_sk#8, s_county#9]
-Condition : (s_county#9 IN (Fairfield County,Ziebach County,Bronx County,Barrow County) AND isnotnull(s_store_sk#8))
-
-(10) Project [codegen id : 2]
-Output [1]: [s_store_sk#8]
-Input [2]: [s_store_sk#8, s_county#9]
-
-(11) BroadcastExchange
-Input [1]: [s_store_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
-
-(12) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#8]
-Join type: Inner
-Join condition: None
-
-(13) Project [codegen id : 4]
-Output [3]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4]
-Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, s_store_sk#8]
-
-(14) Scan parquet spark_catalog.default.household_demographics
-Output [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
+(7) Scan parquet spark_catalog.default.household_demographics
+Output [4]: [hd_demo_sk#8, hd_buy_potential#9, hd_dep_count#10, hd_vehicle_count#11]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [IsNotNull(hd_vehicle_count), Or(EqualTo(hd_buy_potential,>10000         ),EqualTo(hd_buy_potential,Unknown        )), GreaterThan(hd_vehicle_count,0), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string,hd_dep_count:int,hd_vehicle_count:int>
 
+(8) ColumnarToRow [codegen id : 2]
+Input [4]: [hd_demo_sk#8, hd_buy_potential#9, hd_dep_count#10, hd_vehicle_count#11]
+
+(9) Filter [codegen id : 2]
+Input [4]: [hd_demo_sk#8, hd_buy_potential#9, hd_dep_count#10, hd_vehicle_count#11]
+Condition : ((((isnotnull(hd_vehicle_count#11) AND ((hd_buy_potential#9 = >10000         ) OR (hd_buy_potential#9 = Unknown        ))) AND (hd_vehicle_count#11 > 0)) AND CASE WHEN (hd_vehicle_count#11 > 0) THEN ((cast(hd_dep_count#10 as double) / cast(hd_vehicle_count#11 as double)) > 1.0) END) AND isnotnull(hd_demo_sk#8))
+
+(10) Project [codegen id : 2]
+Output [1]: [hd_demo_sk#8]
+Input [4]: [hd_demo_sk#8, hd_buy_potential#9, hd_dep_count#10, hd_vehicle_count#11]
+
+(11) BroadcastExchange
+Input [1]: [hd_demo_sk#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
+
+(12) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_hdemo_sk#2]
+Right keys [1]: [hd_demo_sk#8]
+Join type: Inner
+Join condition: None
+
+(13) Project [codegen id : 4]
+Output [3]: [ss_customer_sk#1, ss_store_sk#3, ss_ticket_number#4]
+Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, hd_demo_sk#8]
+
+(14) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#12, s_county#13]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [In(s_county, [Barrow County,Bronx County,Fairfield County,Ziebach County]), IsNotNull(s_store_sk)]
+ReadSchema: struct<s_store_sk:int,s_county:string>
+
 (15) ColumnarToRow [codegen id : 3]
-Input [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
+Input [2]: [s_store_sk#12, s_county#13]
 
 (16) Filter [codegen id : 3]
-Input [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
-Condition : ((((isnotnull(hd_vehicle_count#13) AND ((hd_buy_potential#11 = >10000         ) OR (hd_buy_potential#11 = Unknown        ))) AND (hd_vehicle_count#13 > 0)) AND CASE WHEN (hd_vehicle_count#13 > 0) THEN ((cast(hd_dep_count#12 as double) / cast(hd_vehicle_count#13 as double)) > 1.0) END) AND isnotnull(hd_demo_sk#10))
+Input [2]: [s_store_sk#12, s_county#13]
+Condition : (s_county#13 IN (Fairfield County,Ziebach County,Bronx County,Barrow County) AND isnotnull(s_store_sk#12))
 
 (17) Project [codegen id : 3]
-Output [1]: [hd_demo_sk#10]
-Input [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
+Output [1]: [s_store_sk#12]
+Input [2]: [s_store_sk#12, s_county#13]
 
 (18) BroadcastExchange
-Input [1]: [hd_demo_sk#10]
+Input [1]: [s_store_sk#12]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
 (19) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_hdemo_sk#2]
-Right keys [1]: [hd_demo_sk#10]
+Left keys [1]: [ss_store_sk#3]
+Right keys [1]: [s_store_sk#12]
 Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
 Output [2]: [ss_customer_sk#1, ss_ticket_number#4]
-Input [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4, hd_demo_sk#10]
+Input [4]: [ss_customer_sk#1, ss_store_sk#3, ss_ticket_number#4, s_store_sk#12]
 
 (21) HashAggregate [codegen id : 4]
 Input [2]: [ss_customer_sk#1, ss_ticket_number#4]
@@ -147,72 +150,84 @@ Results [3]: [ss_ticket_number#4, ss_customer_sk#1, count(1)#16 AS cnt#17]
 Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#17]
 Condition : ((cnt#17 >= 1) AND (cnt#17 <= 5))
 
-(25) BroadcastExchange
+(25) Exchange
 Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [plan_id=4]
+Arguments: hashpartitioning(ss_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(26) Scan parquet spark_catalog.default.customer
+(26) Sort [codegen id : 6]
+Input [3]: [ss_ticket_number#4, ss_customer_sk#1, cnt#17]
+Arguments: [ss_customer_sk#1 ASC NULLS FIRST], false, 0
+
+(27) Scan parquet spark_catalog.default.customer
 Output [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk)]
 ReadSchema: struct<c_customer_sk:int,c_salutation:string,c_first_name:string,c_last_name:string,c_preferred_cust_flag:string>
 
-(27) ColumnarToRow
+(28) ColumnarToRow [codegen id : 7]
 Input [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
 
-(28) Filter
+(29) Filter [codegen id : 7]
 Input [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
 Condition : isnotnull(c_customer_sk#18)
 
-(29) BroadcastHashJoin [codegen id : 6]
+(30) Exchange
+Input [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
+Arguments: hashpartitioning(c_customer_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(31) Sort [codegen id : 8]
+Input [5]: [c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
+Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
+
+(32) SortMergeJoin [codegen id : 9]
 Left keys [1]: [ss_customer_sk#1]
 Right keys [1]: [c_customer_sk#18]
 Join type: Inner
 Join condition: None
 
-(30) Project [codegen id : 6]
+(33) Project [codegen id : 9]
 Output [6]: [c_last_name#21, c_first_name#20, c_salutation#19, c_preferred_cust_flag#22, ss_ticket_number#4, cnt#17]
 Input [8]: [ss_ticket_number#4, ss_customer_sk#1, cnt#17, c_customer_sk#18, c_salutation#19, c_first_name#20, c_last_name#21, c_preferred_cust_flag#22]
 
-(31) Exchange
+(34) Exchange
 Input [6]: [c_last_name#21, c_first_name#20, c_salutation#19, c_preferred_cust_flag#22, ss_ticket_number#4, cnt#17]
-Arguments: rangepartitioning(cnt#17 DESC NULLS LAST, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Arguments: rangepartitioning(cnt#17 DESC NULLS LAST, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(32) Sort [codegen id : 7]
+(35) Sort [codegen id : 10]
 Input [6]: [c_last_name#21, c_first_name#20, c_salutation#19, c_preferred_cust_flag#22, ss_ticket_number#4, cnt#17]
 Arguments: [cnt#17 DESC NULLS LAST], true, 0
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#5 IN dynamicpruning#6
-BroadcastExchange (37)
-+- * Project (36)
-   +- * Filter (35)
-      +- * ColumnarToRow (34)
-         +- Scan parquet spark_catalog.default.date_dim (33)
+BroadcastExchange (40)
++- * Project (39)
+   +- * Filter (38)
+      +- * ColumnarToRow (37)
+         +- Scan parquet spark_catalog.default.date_dim (36)
 
 
-(33) Scan parquet spark_catalog.default.date_dim
+(36) Scan parquet spark_catalog.default.date_dim
 Output [3]: [d_date_sk#7, d_year#23, d_dom#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_dom), GreaterThanOrEqual(d_dom,1), LessThanOrEqual(d_dom,2), In(d_year, [1998,1999,2000]), In(d_date_sk, [2450815,2450816,2450846,2450847,2450874,2450875,2450905,2450906,2450935,2450936,2450966,2450967,2450996,2450997,2451027,2451028,2451058,2451059,2451088,2451089,2451119,2451120,2451149,2451150,2451180,2451181,2451211,2451212,2451239,2451240,2451270,2451271,2451300,2451301,2451331,2451332,2451361,2451362,2451392,2451393,2451423,2451424,2451453,2451454,2451484,2451485,2451514,2451515,2451545,2451546,2451576,2451577,2451605,2451606,2451636,2451637,2451666,2451667,2451697,2451698,2451727,2451728,2451758,2451759,2451789,2451790,2451819,2451820,2451850,2451851,2451880,2451881]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_dom:int>
 
-(34) ColumnarToRow [codegen id : 1]
+(37) ColumnarToRow [codegen id : 1]
 Input [3]: [d_date_sk#7, d_year#23, d_dom#24]
 
-(35) Filter [codegen id : 1]
+(38) Filter [codegen id : 1]
 Input [3]: [d_date_sk#7, d_year#23, d_dom#24]
 Condition : (((((isnotnull(d_dom#24) AND (d_dom#24 >= 1)) AND (d_dom#24 <= 2)) AND d_year#23 IN (1998,1999,2000)) AND d_date_sk#7 INSET 2450815, 2450816, 2450846, 2450847, 2450874, 2450875, 2450905, 2450906, 2450935, 2450936, 2450966, 2450967, 2450996, 2450997, 2451027, 2451028, 2451058, 2451059, 2451088, 2451089, 2451119, 2451120, 2451149, 2451150, 2451180, 2451181, 2451211, 2451212, 2451239, 2451240, 2451270, 2451271, 2451300, 2451301, 2451331, 2451332, 2451361, 2451362, 2451392, 2451393, 2451423, 2451424, 2451453, 2451454, 2451484, 2451485, 2451514, 2451515, 2451545, 2451546, 2451576, 2451577, 2451605, 2451606, 2451636, 2451637, 2451666, 2451667, 2451697, 2451698, 2451727, 2451728, 2451758, 2451759, 2451789, 2451790, 2451819, 2451820, 2451850, 2451851, 2451880, 2451881) AND isnotnull(d_date_sk#7))
 
-(36) Project [codegen id : 1]
+(39) Project [codegen id : 1]
 Output [1]: [d_date_sk#7]
 Input [3]: [d_date_sk#7, d_year#23, d_dom#24]
 
-(37) BroadcastExchange
+(40) BroadcastExchange
 Input [1]: [d_date_sk#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q73.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q73.sf100/simplified.txt
@@ -1,56 +1,65 @@
-WholeStageCodegen (7)
+WholeStageCodegen (10)
   Sort [cnt]
     InputAdapter
       Exchange [cnt] #1
-        WholeStageCodegen (6)
+        WholeStageCodegen (9)
           Project [c_last_name,c_first_name,c_salutation,c_preferred_cust_flag,ss_ticket_number,cnt]
-            BroadcastHashJoin [ss_customer_sk,c_customer_sk]
+            SortMergeJoin [ss_customer_sk,c_customer_sk]
               InputAdapter
-                BroadcastExchange #2
-                  WholeStageCodegen (5)
-                    Filter [cnt]
-                      HashAggregate [ss_ticket_number,ss_customer_sk,count] [count(1),cnt,count]
-                        InputAdapter
-                          Exchange [ss_ticket_number,ss_customer_sk] #3
-                            WholeStageCodegen (4)
-                              HashAggregate [ss_ticket_number,ss_customer_sk] [count,count]
-                                Project [ss_customer_sk,ss_ticket_number]
-                                  BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
-                                    Project [ss_customer_sk,ss_hdemo_sk,ss_ticket_number]
-                                      BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                        Project [ss_customer_sk,ss_hdemo_sk,ss_store_sk,ss_ticket_number]
-                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                            Filter [ss_store_sk,ss_hdemo_sk,ss_customer_sk]
-                                              ColumnarToRow
-                                                InputAdapter
-                                                  Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_hdemo_sk,ss_store_sk,ss_ticket_number,ss_sold_date_sk]
-                                                    SubqueryBroadcast [d_date_sk] #1
-                                                      BroadcastExchange #4
-                                                        WholeStageCodegen (1)
-                                                          Project [d_date_sk]
-                                                            Filter [d_dom,d_year,d_date_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_dom]
-                                            InputAdapter
-                                              ReusedExchange [d_date_sk] #4
-                                        InputAdapter
-                                          BroadcastExchange #5
-                                            WholeStageCodegen (2)
-                                              Project [s_store_sk]
-                                                Filter [s_county,s_store_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.store [s_store_sk,s_county]
-                                    InputAdapter
-                                      BroadcastExchange #6
-                                        WholeStageCodegen (3)
-                                          Project [hd_demo_sk]
-                                            Filter [hd_vehicle_count,hd_buy_potential,hd_dep_count,hd_demo_sk]
-                                              ColumnarToRow
-                                                InputAdapter
-                                                  Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_buy_potential,hd_dep_count,hd_vehicle_count]
-              Filter [c_customer_sk]
-                ColumnarToRow
-                  InputAdapter
-                    Scan parquet spark_catalog.default.customer [c_customer_sk,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag]
+                WholeStageCodegen (6)
+                  Sort [ss_customer_sk]
+                    InputAdapter
+                      Exchange [ss_customer_sk] #2
+                        WholeStageCodegen (5)
+                          Filter [cnt]
+                            HashAggregate [ss_ticket_number,ss_customer_sk,count] [count(1),cnt,count]
+                              InputAdapter
+                                Exchange [ss_ticket_number,ss_customer_sk] #3
+                                  WholeStageCodegen (4)
+                                    HashAggregate [ss_ticket_number,ss_customer_sk] [count,count]
+                                      Project [ss_customer_sk,ss_ticket_number]
+                                        BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                          Project [ss_customer_sk,ss_store_sk,ss_ticket_number]
+                                            BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
+                                              Project [ss_customer_sk,ss_hdemo_sk,ss_store_sk,ss_ticket_number]
+                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                  Filter [ss_store_sk,ss_hdemo_sk,ss_customer_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_hdemo_sk,ss_store_sk,ss_ticket_number,ss_sold_date_sk]
+                                                          SubqueryBroadcast [d_date_sk] #1
+                                                            BroadcastExchange #4
+                                                              WholeStageCodegen (1)
+                                                                Project [d_date_sk]
+                                                                  Filter [d_dom,d_year,d_date_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_dom]
+                                                  InputAdapter
+                                                    ReusedExchange [d_date_sk] #4
+                                              InputAdapter
+                                                BroadcastExchange #5
+                                                  WholeStageCodegen (2)
+                                                    Project [hd_demo_sk]
+                                                      Filter [hd_vehicle_count,hd_buy_potential,hd_dep_count,hd_demo_sk]
+                                                        ColumnarToRow
+                                                          InputAdapter
+                                                            Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_buy_potential,hd_dep_count,hd_vehicle_count]
+                                          InputAdapter
+                                            BroadcastExchange #6
+                                              WholeStageCodegen (3)
+                                                Project [s_store_sk]
+                                                  Filter [s_county,s_store_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.store [s_store_sk,s_county]
+              InputAdapter
+                WholeStageCodegen (8)
+                  Sort [c_customer_sk]
+                    InputAdapter
+                      Exchange [c_customer_sk] #7
+                        WholeStageCodegen (7)
+                          Filter [c_customer_sk]
+                            ColumnarToRow
+                              InputAdapter
+                                Scan parquet spark_catalog.default.customer [c_customer_sk,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q89.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q89.sf100/explain.txt
@@ -21,11 +21,11 @@ TakeOrderedAndProject (27)
                               :     +- BroadcastExchange (10)
                               :        +- * Filter (9)
                               :           +- * ColumnarToRow (8)
-                              :              +- Scan parquet spark_catalog.default.store (7)
+                              :              +- Scan parquet spark_catalog.default.item (7)
                               +- BroadcastExchange (16)
                                  +- * Filter (15)
                                     +- * ColumnarToRow (14)
-                                       +- Scan parquet spark_catalog.default.item (13)
+                                       +- Scan parquet spark_catalog.default.store (13)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -56,103 +56,103 @@ Join condition: None
 Output [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_moy#7]
 Input [6]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4, d_date_sk#6, d_moy#7]
 
-(7) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#8, s_store_name#9, s_company_name#10]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_store_sk)]
-ReadSchema: struct<s_store_sk:int,s_store_name:string,s_company_name:string>
-
-(8) ColumnarToRow [codegen id : 2]
-Input [3]: [s_store_sk#8, s_store_name#9, s_company_name#10]
-
-(9) Filter [codegen id : 2]
-Input [3]: [s_store_sk#8, s_store_name#9, s_company_name#10]
-Condition : isnotnull(s_store_sk#8)
-
-(10) BroadcastExchange
-Input [3]: [s_store_sk#8, s_store_name#9, s_company_name#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
-
-(11) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_store_sk#2]
-Right keys [1]: [s_store_sk#8]
-Join type: Inner
-Join condition: None
-
-(12) Project [codegen id : 4]
-Output [5]: [ss_item_sk#1, ss_sales_price#3, d_moy#7, s_store_name#9, s_company_name#10]
-Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_moy#7, s_store_sk#8, s_store_name#9, s_company_name#10]
-
-(13) Scan parquet spark_catalog.default.item
-Output [4]: [i_item_sk#11, i_brand#12, i_class#13, i_category#14]
+(7) Scan parquet spark_catalog.default.item
+Output [4]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [Or(And(In(i_category, [Books                                             ,Electronics                                       ,Home                                              ]),In(i_class, [musical                                           ,parenting                                         ,wallpaper                                         ])),And(In(i_category, [Jewelry                                           ,Men                                               ,Shoes                                             ]),In(i_class, [birdal                                            ,pants                                             ,womens                                            ]))), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand:string,i_class:string,i_category:string>
 
+(8) ColumnarToRow [codegen id : 2]
+Input [4]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11]
+
+(9) Filter [codegen id : 2]
+Input [4]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11]
+Condition : (((i_category#11 IN (Home                                              ,Books                                             ,Electronics                                       ) AND i_class#10 IN (wallpaper                                         ,parenting                                         ,musical                                           )) OR (i_category#11 IN (Shoes                                             ,Jewelry                                           ,Men                                               ) AND i_class#10 IN (womens                                            ,birdal                                            ,pants                                             ))) AND isnotnull(i_item_sk#8))
+
+(10) BroadcastExchange
+Input [4]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
+
+(11) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_item_sk#1]
+Right keys [1]: [i_item_sk#8]
+Join type: Inner
+Join condition: None
+
+(12) Project [codegen id : 4]
+Output [6]: [ss_store_sk#2, ss_sales_price#3, d_moy#7, i_brand#9, i_class#10, i_category#11]
+Input [8]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_moy#7, i_item_sk#8, i_brand#9, i_class#10, i_category#11]
+
+(13) Scan parquet spark_catalog.default.store
+Output [3]: [s_store_sk#12, s_store_name#13, s_company_name#14]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [IsNotNull(s_store_sk)]
+ReadSchema: struct<s_store_sk:int,s_store_name:string,s_company_name:string>
+
 (14) ColumnarToRow [codegen id : 3]
-Input [4]: [i_item_sk#11, i_brand#12, i_class#13, i_category#14]
+Input [3]: [s_store_sk#12, s_store_name#13, s_company_name#14]
 
 (15) Filter [codegen id : 3]
-Input [4]: [i_item_sk#11, i_brand#12, i_class#13, i_category#14]
-Condition : (((i_category#14 IN (Home                                              ,Books                                             ,Electronics                                       ) AND i_class#13 IN (wallpaper                                         ,parenting                                         ,musical                                           )) OR (i_category#14 IN (Shoes                                             ,Jewelry                                           ,Men                                               ) AND i_class#13 IN (womens                                            ,birdal                                            ,pants                                             ))) AND isnotnull(i_item_sk#11))
+Input [3]: [s_store_sk#12, s_store_name#13, s_company_name#14]
+Condition : isnotnull(s_store_sk#12)
 
 (16) BroadcastExchange
-Input [4]: [i_item_sk#11, i_brand#12, i_class#13, i_category#14]
+Input [3]: [s_store_sk#12, s_store_name#13, s_company_name#14]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
 
 (17) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#11]
+Left keys [1]: [ss_store_sk#2]
+Right keys [1]: [s_store_sk#12]
 Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]
-Output [7]: [i_brand#12, i_class#13, i_category#14, ss_sales_price#3, d_moy#7, s_store_name#9, s_company_name#10]
-Input [9]: [ss_item_sk#1, ss_sales_price#3, d_moy#7, s_store_name#9, s_company_name#10, i_item_sk#11, i_brand#12, i_class#13, i_category#14]
+Output [7]: [i_brand#9, i_class#10, i_category#11, ss_sales_price#3, d_moy#7, s_store_name#13, s_company_name#14]
+Input [9]: [ss_store_sk#2, ss_sales_price#3, d_moy#7, i_brand#9, i_class#10, i_category#11, s_store_sk#12, s_store_name#13, s_company_name#14]
 
 (19) HashAggregate [codegen id : 4]
-Input [7]: [i_brand#12, i_class#13, i_category#14, ss_sales_price#3, d_moy#7, s_store_name#9, s_company_name#10]
-Keys [6]: [i_category#14, i_class#13, i_brand#12, s_store_name#9, s_company_name#10, d_moy#7]
+Input [7]: [i_brand#9, i_class#10, i_category#11, ss_sales_price#3, d_moy#7, s_store_name#13, s_company_name#14]
+Keys [6]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7]
 Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#3))]
 Aggregate Attributes [1]: [sum#15]
-Results [7]: [i_category#14, i_class#13, i_brand#12, s_store_name#9, s_company_name#10, d_moy#7, sum#16]
+Results [7]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, sum#16]
 
 (20) Exchange
-Input [7]: [i_category#14, i_class#13, i_brand#12, s_store_name#9, s_company_name#10, d_moy#7, sum#16]
-Arguments: hashpartitioning(i_category#14, i_class#13, i_brand#12, s_store_name#9, s_company_name#10, d_moy#7, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [7]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, sum#16]
+Arguments: hashpartitioning(i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (21) HashAggregate [codegen id : 5]
-Input [7]: [i_category#14, i_class#13, i_brand#12, s_store_name#9, s_company_name#10, d_moy#7, sum#16]
-Keys [6]: [i_category#14, i_class#13, i_brand#12, s_store_name#9, s_company_name#10, d_moy#7]
+Input [7]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, sum#16]
+Keys [6]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7]
 Functions [1]: [sum(UnscaledValue(ss_sales_price#3))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#3))#17]
-Results [8]: [i_category#14, i_class#13, i_brand#12, s_store_name#9, s_company_name#10, d_moy#7, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#17,17,2) AS sum_sales#18, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#17,17,2) AS _w0#19]
+Results [8]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#17,17,2) AS sum_sales#18, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#17,17,2) AS _w0#19]
 
 (22) Exchange
-Input [8]: [i_category#14, i_class#13, i_brand#12, s_store_name#9, s_company_name#10, d_moy#7, sum_sales#18, _w0#19]
-Arguments: hashpartitioning(i_category#14, i_brand#12, s_store_name#9, s_company_name#10, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [8]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, sum_sales#18, _w0#19]
+Arguments: hashpartitioning(i_category#11, i_brand#9, s_store_name#13, s_company_name#14, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (23) Sort [codegen id : 6]
-Input [8]: [i_category#14, i_class#13, i_brand#12, s_store_name#9, s_company_name#10, d_moy#7, sum_sales#18, _w0#19]
-Arguments: [i_category#14 ASC NULLS FIRST, i_brand#12 ASC NULLS FIRST, s_store_name#9 ASC NULLS FIRST, s_company_name#10 ASC NULLS FIRST], false, 0
+Input [8]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, sum_sales#18, _w0#19]
+Arguments: [i_category#11 ASC NULLS FIRST, i_brand#9 ASC NULLS FIRST, s_store_name#13 ASC NULLS FIRST, s_company_name#14 ASC NULLS FIRST], false, 0
 
 (24) Window
-Input [8]: [i_category#14, i_class#13, i_brand#12, s_store_name#9, s_company_name#10, d_moy#7, sum_sales#18, _w0#19]
-Arguments: [avg(_w0#19) windowspecdefinition(i_category#14, i_brand#12, s_store_name#9, s_company_name#10, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_monthly_sales#20], [i_category#14, i_brand#12, s_store_name#9, s_company_name#10]
+Input [8]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, sum_sales#18, _w0#19]
+Arguments: [avg(_w0#19) windowspecdefinition(i_category#11, i_brand#9, s_store_name#13, s_company_name#14, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_monthly_sales#20], [i_category#11, i_brand#9, s_store_name#13, s_company_name#14]
 
 (25) Filter [codegen id : 7]
-Input [9]: [i_category#14, i_class#13, i_brand#12, s_store_name#9, s_company_name#10, d_moy#7, sum_sales#18, _w0#19, avg_monthly_sales#20]
+Input [9]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, sum_sales#18, _w0#19, avg_monthly_sales#20]
 Condition : CASE WHEN NOT (avg_monthly_sales#20 = 0.000000) THEN ((abs((sum_sales#18 - avg_monthly_sales#20)) / avg_monthly_sales#20) > 0.1000000000000000) END
 
 (26) Project [codegen id : 7]
-Output [8]: [i_category#14, i_class#13, i_brand#12, s_store_name#9, s_company_name#10, d_moy#7, sum_sales#18, avg_monthly_sales#20]
-Input [9]: [i_category#14, i_class#13, i_brand#12, s_store_name#9, s_company_name#10, d_moy#7, sum_sales#18, _w0#19, avg_monthly_sales#20]
+Output [8]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, sum_sales#18, avg_monthly_sales#20]
+Input [9]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, sum_sales#18, _w0#19, avg_monthly_sales#20]
 
 (27) TakeOrderedAndProject
-Input [8]: [i_category#14, i_class#13, i_brand#12, s_store_name#9, s_company_name#10, d_moy#7, sum_sales#18, avg_monthly_sales#20]
-Arguments: 100, [(sum_sales#18 - avg_monthly_sales#20) ASC NULLS FIRST, s_store_name#9 ASC NULLS FIRST], [i_category#14, i_class#13, i_brand#12, s_store_name#9, s_company_name#10, d_moy#7, sum_sales#18, avg_monthly_sales#20]
+Input [8]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, sum_sales#18, avg_monthly_sales#20]
+Arguments: 100, [(sum_sales#18 - avg_monthly_sales#20) ASC NULLS FIRST, s_store_name#13 ASC NULLS FIRST], [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, sum_sales#18, avg_monthly_sales#20]
 
 ===== Subqueries =====
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q89.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-modified/q89.sf100/simplified.txt
@@ -15,9 +15,9 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,s_store_name,i_category,i_cla
                             WholeStageCodegen (4)
                               HashAggregate [i_category,i_class,i_brand,s_store_name,s_company_name,d_moy,ss_sales_price] [sum,sum]
                                 Project [i_brand,i_class,i_category,ss_sales_price,d_moy,s_store_name,s_company_name]
-                                  BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                    Project [ss_item_sk,ss_sales_price,d_moy,s_store_name,s_company_name]
-                                      BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                  BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                    Project [ss_store_sk,ss_sales_price,d_moy,i_brand,i_class,i_category]
+                                      BroadcastHashJoin [ss_item_sk,i_item_sk]
                                         Project [ss_item_sk,ss_store_sk,ss_sales_price,d_moy]
                                           BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                             Filter [ss_item_sk,ss_store_sk]
@@ -37,14 +37,14 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,s_store_name,i_category,i_cla
                                         InputAdapter
                                           BroadcastExchange #4
                                             WholeStageCodegen (2)
-                                              Filter [s_store_sk]
+                                              Filter [i_category,i_class,i_item_sk]
                                                 ColumnarToRow
                                                   InputAdapter
-                                                    Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_company_name]
+                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_class,i_category]
                                     InputAdapter
                                       BroadcastExchange #5
                                         WholeStageCodegen (3)
-                                          Filter [i_category,i_class,i_item_sk]
+                                          Filter [s_store_sk]
                                             ColumnarToRow
                                               InputAdapter
-                                                Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_class,i_category]
+                                                Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_company_name]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q13.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q13.sf100/explain.txt
@@ -4,35 +4,35 @@
    +- * HashAggregate (32)
       +- * Project (31)
          +- * BroadcastHashJoin Inner BuildRight (30)
-            :- * Project (24)
-            :  +- * BroadcastHashJoin Inner BuildRight (23)
+            :- * Project (25)
+            :  +- * BroadcastHashJoin Inner BuildRight (24)
             :     :- * Project (18)
             :     :  +- * BroadcastHashJoin Inner BuildRight (17)
-            :     :     :- * Project (15)
-            :     :     :  +- * BroadcastHashJoin Inner BuildRight (14)
-            :     :     :     :- * Project (9)
-            :     :     :     :  +- * BroadcastHashJoin Inner BuildRight (8)
+            :     :     :- * Project (12)
+            :     :     :  +- * BroadcastHashJoin Inner BuildRight (11)
+            :     :     :     :- * Project (6)
+            :     :     :     :  +- * BroadcastHashJoin Inner BuildRight (5)
             :     :     :     :     :- * Filter (3)
             :     :     :     :     :  +- * ColumnarToRow (2)
             :     :     :     :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-            :     :     :     :     +- BroadcastExchange (7)
-            :     :     :     :        +- * Filter (6)
-            :     :     :     :           +- * ColumnarToRow (5)
-            :     :     :     :              +- Scan parquet spark_catalog.default.customer_demographics (4)
-            :     :     :     +- BroadcastExchange (13)
-            :     :     :        +- * Filter (12)
-            :     :     :           +- * ColumnarToRow (11)
-            :     :     :              +- Scan parquet spark_catalog.default.household_demographics (10)
-            :     :     +- ReusedExchange (16)
-            :     +- BroadcastExchange (22)
-            :        +- * Filter (21)
-            :           +- * ColumnarToRow (20)
-            :              +- Scan parquet spark_catalog.default.store (19)
+            :     :     :     :     +- ReusedExchange (4)
+            :     :     :     +- BroadcastExchange (10)
+            :     :     :        +- * Filter (9)
+            :     :     :           +- * ColumnarToRow (8)
+            :     :     :              +- Scan parquet spark_catalog.default.household_demographics (7)
+            :     :     +- BroadcastExchange (16)
+            :     :        +- * Filter (15)
+            :     :           +- * ColumnarToRow (14)
+            :     :              +- Scan parquet spark_catalog.default.customer_demographics (13)
+            :     +- BroadcastExchange (23)
+            :        +- * Project (22)
+            :           +- * Filter (21)
+            :              +- * ColumnarToRow (20)
+            :                 +- Scan parquet spark_catalog.default.customer_address (19)
             +- BroadcastExchange (29)
-               +- * Project (28)
-                  +- * Filter (27)
-                     +- * ColumnarToRow (26)
-                        +- Scan parquet spark_catalog.default.customer_address (25)
+               +- * Filter (28)
+                  +- * ColumnarToRow (27)
+                     +- Scan parquet spark_catalog.default.store (26)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -50,134 +50,134 @@ Input [10]: [ss_cdemo_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_quant
 Input [10]: [ss_cdemo_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_quantity#5, ss_sales_price#6, ss_ext_sales_price#7, ss_ext_wholesale_cost#8, ss_net_profit#9, ss_sold_date_sk#10]
 Condition : (((((isnotnull(ss_store_sk#4) AND isnotnull(ss_addr_sk#3)) AND isnotnull(ss_cdemo_sk#1)) AND isnotnull(ss_hdemo_sk#2)) AND ((((ss_net_profit#9 >= 100.00) AND (ss_net_profit#9 <= 200.00)) OR ((ss_net_profit#9 >= 150.00) AND (ss_net_profit#9 <= 300.00))) OR ((ss_net_profit#9 >= 50.00) AND (ss_net_profit#9 <= 250.00)))) AND ((((ss_sales_price#6 >= 100.00) AND (ss_sales_price#6 <= 150.00)) OR ((ss_sales_price#6 >= 50.00) AND (ss_sales_price#6 <= 100.00))) OR ((ss_sales_price#6 >= 150.00) AND (ss_sales_price#6 <= 200.00))))
 
-(4) Scan parquet spark_catalog.default.customer_demographics
-Output [3]: [cd_demo_sk#12, cd_marital_status#13, cd_education_status#14]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_demographics]
-PushedFilters: [IsNotNull(cd_demo_sk), Or(Or(And(EqualTo(cd_marital_status,M),EqualTo(cd_education_status,Advanced Degree     )),And(EqualTo(cd_marital_status,S),EqualTo(cd_education_status,College             ))),And(EqualTo(cd_marital_status,W),EqualTo(cd_education_status,2 yr Degree         )))]
-ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string,cd_education_status:string>
+(4) ReusedExchange [Reuses operator id: 39]
+Output [1]: [d_date_sk#12]
 
-(5) ColumnarToRow [codegen id : 1]
-Input [3]: [cd_demo_sk#12, cd_marital_status#13, cd_education_status#14]
-
-(6) Filter [codegen id : 1]
-Input [3]: [cd_demo_sk#12, cd_marital_status#13, cd_education_status#14]
-Condition : (isnotnull(cd_demo_sk#12) AND ((((cd_marital_status#13 = M) AND (cd_education_status#14 = Advanced Degree     )) OR ((cd_marital_status#13 = S) AND (cd_education_status#14 = College             ))) OR ((cd_marital_status#13 = W) AND (cd_education_status#14 = 2 yr Degree         ))))
-
-(7) BroadcastExchange
-Input [3]: [cd_demo_sk#12, cd_marital_status#13, cd_education_status#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
-
-(8) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ss_cdemo_sk#1]
-Right keys [1]: [cd_demo_sk#12]
+(5) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [ss_sold_date_sk#10]
+Right keys [1]: [d_date_sk#12]
 Join type: Inner
-Join condition: ((((((cd_marital_status#13 = M) AND (cd_education_status#14 = Advanced Degree     )) AND (ss_sales_price#6 >= 100.00)) AND (ss_sales_price#6 <= 150.00)) OR ((((cd_marital_status#13 = S) AND (cd_education_status#14 = College             )) AND (ss_sales_price#6 >= 50.00)) AND (ss_sales_price#6 <= 100.00))) OR ((((cd_marital_status#13 = W) AND (cd_education_status#14 = 2 yr Degree         )) AND (ss_sales_price#6 >= 150.00)) AND (ss_sales_price#6 <= 200.00)))
+Join condition: None
 
-(9) Project [codegen id : 6]
-Output [11]: [ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_quantity#5, ss_sales_price#6, ss_ext_sales_price#7, ss_ext_wholesale_cost#8, ss_net_profit#9, ss_sold_date_sk#10, cd_marital_status#13, cd_education_status#14]
-Input [13]: [ss_cdemo_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_quantity#5, ss_sales_price#6, ss_ext_sales_price#7, ss_ext_wholesale_cost#8, ss_net_profit#9, ss_sold_date_sk#10, cd_demo_sk#12, cd_marital_status#13, cd_education_status#14]
+(6) Project [codegen id : 6]
+Output [9]: [ss_cdemo_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_quantity#5, ss_sales_price#6, ss_ext_sales_price#7, ss_ext_wholesale_cost#8, ss_net_profit#9]
+Input [11]: [ss_cdemo_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_quantity#5, ss_sales_price#6, ss_ext_sales_price#7, ss_ext_wholesale_cost#8, ss_net_profit#9, ss_sold_date_sk#10, d_date_sk#12]
 
-(10) Scan parquet spark_catalog.default.household_demographics
-Output [2]: [hd_demo_sk#15, hd_dep_count#16]
+(7) Scan parquet spark_catalog.default.household_demographics
+Output [2]: [hd_demo_sk#13, hd_dep_count#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [IsNotNull(hd_demo_sk), Or(EqualTo(hd_dep_count,3),EqualTo(hd_dep_count,1))]
 ReadSchema: struct<hd_demo_sk:int,hd_dep_count:int>
 
-(11) ColumnarToRow [codegen id : 2]
-Input [2]: [hd_demo_sk#15, hd_dep_count#16]
+(8) ColumnarToRow [codegen id : 2]
+Input [2]: [hd_demo_sk#13, hd_dep_count#14]
 
-(12) Filter [codegen id : 2]
-Input [2]: [hd_demo_sk#15, hd_dep_count#16]
-Condition : (isnotnull(hd_demo_sk#15) AND ((hd_dep_count#16 = 3) OR (hd_dep_count#16 = 1)))
+(9) Filter [codegen id : 2]
+Input [2]: [hd_demo_sk#13, hd_dep_count#14]
+Condition : (isnotnull(hd_demo_sk#13) AND ((hd_dep_count#14 = 3) OR (hd_dep_count#14 = 1)))
 
-(13) BroadcastExchange
-Input [2]: [hd_demo_sk#15, hd_dep_count#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
+(10) BroadcastExchange
+Input [2]: [hd_demo_sk#13, hd_dep_count#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
-(14) BroadcastHashJoin [codegen id : 6]
+(11) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ss_hdemo_sk#2]
-Right keys [1]: [hd_demo_sk#15]
-Join type: Inner
-Join condition: (((((((cd_marital_status#13 = M) AND (cd_education_status#14 = Advanced Degree     )) AND (ss_sales_price#6 >= 100.00)) AND (ss_sales_price#6 <= 150.00)) AND (hd_dep_count#16 = 3)) OR (((((cd_marital_status#13 = S) AND (cd_education_status#14 = College             )) AND (ss_sales_price#6 >= 50.00)) AND (ss_sales_price#6 <= 100.00)) AND (hd_dep_count#16 = 1))) OR (((((cd_marital_status#13 = W) AND (cd_education_status#14 = 2 yr Degree         )) AND (ss_sales_price#6 >= 150.00)) AND (ss_sales_price#6 <= 200.00)) AND (hd_dep_count#16 = 1)))
-
-(15) Project [codegen id : 6]
-Output [7]: [ss_addr_sk#3, ss_store_sk#4, ss_quantity#5, ss_ext_sales_price#7, ss_ext_wholesale_cost#8, ss_net_profit#9, ss_sold_date_sk#10]
-Input [13]: [ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_quantity#5, ss_sales_price#6, ss_ext_sales_price#7, ss_ext_wholesale_cost#8, ss_net_profit#9, ss_sold_date_sk#10, cd_marital_status#13, cd_education_status#14, hd_demo_sk#15, hd_dep_count#16]
-
-(16) ReusedExchange [Reuses operator id: 39]
-Output [1]: [d_date_sk#17]
-
-(17) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ss_sold_date_sk#10]
-Right keys [1]: [d_date_sk#17]
+Right keys [1]: [hd_demo_sk#13]
 Join type: Inner
 Join condition: None
+
+(12) Project [codegen id : 6]
+Output [9]: [ss_cdemo_sk#1, ss_addr_sk#3, ss_store_sk#4, ss_quantity#5, ss_sales_price#6, ss_ext_sales_price#7, ss_ext_wholesale_cost#8, ss_net_profit#9, hd_dep_count#14]
+Input [11]: [ss_cdemo_sk#1, ss_hdemo_sk#2, ss_addr_sk#3, ss_store_sk#4, ss_quantity#5, ss_sales_price#6, ss_ext_sales_price#7, ss_ext_wholesale_cost#8, ss_net_profit#9, hd_demo_sk#13, hd_dep_count#14]
+
+(13) Scan parquet spark_catalog.default.customer_demographics
+Output [3]: [cd_demo_sk#15, cd_marital_status#16, cd_education_status#17]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_demographics]
+PushedFilters: [IsNotNull(cd_demo_sk), Or(Or(And(EqualTo(cd_marital_status,M),EqualTo(cd_education_status,Advanced Degree     )),And(EqualTo(cd_marital_status,S),EqualTo(cd_education_status,College             ))),And(EqualTo(cd_marital_status,W),EqualTo(cd_education_status,2 yr Degree         )))]
+ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string,cd_education_status:string>
+
+(14) ColumnarToRow [codegen id : 3]
+Input [3]: [cd_demo_sk#15, cd_marital_status#16, cd_education_status#17]
+
+(15) Filter [codegen id : 3]
+Input [3]: [cd_demo_sk#15, cd_marital_status#16, cd_education_status#17]
+Condition : (isnotnull(cd_demo_sk#15) AND ((((cd_marital_status#16 = M) AND (cd_education_status#17 = Advanced Degree     )) OR ((cd_marital_status#16 = S) AND (cd_education_status#17 = College             ))) OR ((cd_marital_status#16 = W) AND (cd_education_status#17 = 2 yr Degree         ))))
+
+(16) BroadcastExchange
+Input [3]: [cd_demo_sk#15, cd_marital_status#16, cd_education_status#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
+
+(17) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [ss_cdemo_sk#1]
+Right keys [1]: [cd_demo_sk#15]
+Join type: Inner
+Join condition: (((((((cd_marital_status#16 = M) AND (cd_education_status#17 = Advanced Degree     )) AND (ss_sales_price#6 >= 100.00)) AND (ss_sales_price#6 <= 150.00)) OR ((((cd_marital_status#16 = S) AND (cd_education_status#17 = College             )) AND (ss_sales_price#6 >= 50.00)) AND (ss_sales_price#6 <= 100.00))) OR ((((cd_marital_status#16 = W) AND (cd_education_status#17 = 2 yr Degree         )) AND (ss_sales_price#6 >= 150.00)) AND (ss_sales_price#6 <= 200.00))) AND (((((((cd_marital_status#16 = M) AND (cd_education_status#17 = Advanced Degree     )) AND (ss_sales_price#6 >= 100.00)) AND (ss_sales_price#6 <= 150.00)) AND (hd_dep_count#14 = 3)) OR (((((cd_marital_status#16 = S) AND (cd_education_status#17 = College             )) AND (ss_sales_price#6 >= 50.00)) AND (ss_sales_price#6 <= 100.00)) AND (hd_dep_count#14 = 1))) OR (((((cd_marital_status#16 = W) AND (cd_education_status#17 = 2 yr Degree         )) AND (ss_sales_price#6 >= 150.00)) AND (ss_sales_price#6 <= 200.00)) AND (hd_dep_count#14 = 1))))
 
 (18) Project [codegen id : 6]
 Output [6]: [ss_addr_sk#3, ss_store_sk#4, ss_quantity#5, ss_ext_sales_price#7, ss_ext_wholesale_cost#8, ss_net_profit#9]
-Input [8]: [ss_addr_sk#3, ss_store_sk#4, ss_quantity#5, ss_ext_sales_price#7, ss_ext_wholesale_cost#8, ss_net_profit#9, ss_sold_date_sk#10, d_date_sk#17]
+Input [12]: [ss_cdemo_sk#1, ss_addr_sk#3, ss_store_sk#4, ss_quantity#5, ss_sales_price#6, ss_ext_sales_price#7, ss_ext_wholesale_cost#8, ss_net_profit#9, hd_dep_count#14, cd_demo_sk#15, cd_marital_status#16, cd_education_status#17]
 
-(19) Scan parquet spark_catalog.default.store
-Output [1]: [s_store_sk#18]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_store_sk)]
-ReadSchema: struct<s_store_sk:int>
-
-(20) ColumnarToRow [codegen id : 4]
-Input [1]: [s_store_sk#18]
-
-(21) Filter [codegen id : 4]
-Input [1]: [s_store_sk#18]
-Condition : isnotnull(s_store_sk#18)
-
-(22) BroadcastExchange
-Input [1]: [s_store_sk#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
-
-(23) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ss_store_sk#4]
-Right keys [1]: [s_store_sk#18]
-Join type: Inner
-Join condition: None
-
-(24) Project [codegen id : 6]
-Output [5]: [ss_addr_sk#3, ss_quantity#5, ss_ext_sales_price#7, ss_ext_wholesale_cost#8, ss_net_profit#9]
-Input [7]: [ss_addr_sk#3, ss_store_sk#4, ss_quantity#5, ss_ext_sales_price#7, ss_ext_wholesale_cost#8, ss_net_profit#9, s_store_sk#18]
-
-(25) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_address_sk#19, ca_state#20, ca_country#21]
+(19) Scan parquet spark_catalog.default.customer_address
+Output [3]: [ca_address_sk#18, ca_state#19, ca_country#20]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), EqualTo(ca_country,United States), IsNotNull(ca_address_sk), Or(Or(In(ca_state, [OH,TX]),In(ca_state, [KY,NM,OR])),In(ca_state, [MS,TX,VA]))]
 ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_country:string>
 
-(26) ColumnarToRow [codegen id : 5]
-Input [3]: [ca_address_sk#19, ca_state#20, ca_country#21]
+(20) ColumnarToRow [codegen id : 4]
+Input [3]: [ca_address_sk#18, ca_state#19, ca_country#20]
 
-(27) Filter [codegen id : 5]
-Input [3]: [ca_address_sk#19, ca_state#20, ca_country#21]
-Condition : (((isnotnull(ca_country#21) AND (ca_country#21 = United States)) AND isnotnull(ca_address_sk#19)) AND ((ca_state#20 IN (TX,OH) OR ca_state#20 IN (OR,NM,KY)) OR ca_state#20 IN (VA,TX,MS)))
+(21) Filter [codegen id : 4]
+Input [3]: [ca_address_sk#18, ca_state#19, ca_country#20]
+Condition : (((isnotnull(ca_country#20) AND (ca_country#20 = United States)) AND isnotnull(ca_address_sk#18)) AND ((ca_state#19 IN (TX,OH) OR ca_state#19 IN (OR,NM,KY)) OR ca_state#19 IN (VA,TX,MS)))
 
-(28) Project [codegen id : 5]
-Output [2]: [ca_address_sk#19, ca_state#20]
-Input [3]: [ca_address_sk#19, ca_state#20, ca_country#21]
+(22) Project [codegen id : 4]
+Output [2]: [ca_address_sk#18, ca_state#19]
+Input [3]: [ca_address_sk#18, ca_state#19, ca_country#20]
+
+(23) BroadcastExchange
+Input [2]: [ca_address_sk#18, ca_state#19]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
+
+(24) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [ss_addr_sk#3]
+Right keys [1]: [ca_address_sk#18]
+Join type: Inner
+Join condition: ((((ca_state#19 IN (TX,OH) AND (ss_net_profit#9 >= 100.00)) AND (ss_net_profit#9 <= 200.00)) OR ((ca_state#19 IN (OR,NM,KY) AND (ss_net_profit#9 >= 150.00)) AND (ss_net_profit#9 <= 300.00))) OR ((ca_state#19 IN (VA,TX,MS) AND (ss_net_profit#9 >= 50.00)) AND (ss_net_profit#9 <= 250.00)))
+
+(25) Project [codegen id : 6]
+Output [4]: [ss_store_sk#4, ss_quantity#5, ss_ext_sales_price#7, ss_ext_wholesale_cost#8]
+Input [8]: [ss_addr_sk#3, ss_store_sk#4, ss_quantity#5, ss_ext_sales_price#7, ss_ext_wholesale_cost#8, ss_net_profit#9, ca_address_sk#18, ca_state#19]
+
+(26) Scan parquet spark_catalog.default.store
+Output [1]: [s_store_sk#21]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [IsNotNull(s_store_sk)]
+ReadSchema: struct<s_store_sk:int>
+
+(27) ColumnarToRow [codegen id : 5]
+Input [1]: [s_store_sk#21]
+
+(28) Filter [codegen id : 5]
+Input [1]: [s_store_sk#21]
+Condition : isnotnull(s_store_sk#21)
 
 (29) BroadcastExchange
-Input [2]: [ca_address_sk#19, ca_state#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
+Input [1]: [s_store_sk#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
 
 (30) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [ss_addr_sk#3]
-Right keys [1]: [ca_address_sk#19]
+Left keys [1]: [ss_store_sk#4]
+Right keys [1]: [s_store_sk#21]
 Join type: Inner
-Join condition: ((((ca_state#20 IN (TX,OH) AND (ss_net_profit#9 >= 100.00)) AND (ss_net_profit#9 <= 200.00)) OR ((ca_state#20 IN (OR,NM,KY) AND (ss_net_profit#9 >= 150.00)) AND (ss_net_profit#9 <= 300.00))) OR ((ca_state#20 IN (VA,TX,MS) AND (ss_net_profit#9 >= 50.00)) AND (ss_net_profit#9 <= 250.00)))
+Join condition: None
 
 (31) Project [codegen id : 6]
 Output [3]: [ss_quantity#5, ss_ext_sales_price#7, ss_ext_wholesale_cost#8]
-Input [7]: [ss_addr_sk#3, ss_quantity#5, ss_ext_sales_price#7, ss_ext_wholesale_cost#8, ss_net_profit#9, ca_address_sk#19, ca_state#20]
+Input [5]: [ss_store_sk#4, ss_quantity#5, ss_ext_sales_price#7, ss_ext_wholesale_cost#8, s_store_sk#21]
 
 (32) HashAggregate [codegen id : 6]
 Input [3]: [ss_quantity#5, ss_ext_sales_price#7, ss_ext_wholesale_cost#8]
@@ -208,25 +208,25 @@ BroadcastExchange (39)
 
 
 (35) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#17, d_year#44]
+Output [2]: [d_date_sk#12, d_year#44]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (36) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#17, d_year#44]
+Input [2]: [d_date_sk#12, d_year#44]
 
 (37) Filter [codegen id : 1]
-Input [2]: [d_date_sk#17, d_year#44]
-Condition : ((isnotnull(d_year#44) AND (d_year#44 = 2001)) AND isnotnull(d_date_sk#17))
+Input [2]: [d_date_sk#12, d_year#44]
+Condition : ((isnotnull(d_year#44) AND (d_year#44 = 2001)) AND isnotnull(d_date_sk#12))
 
 (38) Project [codegen id : 1]
-Output [1]: [d_date_sk#17]
-Input [2]: [d_date_sk#17, d_year#44]
+Output [1]: [d_date_sk#12]
+Input [2]: [d_date_sk#12, d_year#44]
 
 (39) BroadcastExchange
-Input [1]: [d_date_sk#17]
+Input [1]: [d_date_sk#12]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q13.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q13.sf100/simplified.txt
@@ -5,15 +5,15 @@ WholeStageCodegen (7)
         WholeStageCodegen (6)
           HashAggregate [ss_quantity,ss_ext_sales_price,ss_ext_wholesale_cost] [sum,count,sum,count,sum,count,sum,sum,count,sum,count,sum,count,sum]
             Project [ss_quantity,ss_ext_sales_price,ss_ext_wholesale_cost]
-              BroadcastHashJoin [ss_addr_sk,ca_address_sk,ca_state,ss_net_profit]
-                Project [ss_addr_sk,ss_quantity,ss_ext_sales_price,ss_ext_wholesale_cost,ss_net_profit]
-                  BroadcastHashJoin [ss_store_sk,s_store_sk]
+              BroadcastHashJoin [ss_store_sk,s_store_sk]
+                Project [ss_store_sk,ss_quantity,ss_ext_sales_price,ss_ext_wholesale_cost]
+                  BroadcastHashJoin [ss_addr_sk,ca_address_sk,ca_state,ss_net_profit]
                     Project [ss_addr_sk,ss_store_sk,ss_quantity,ss_ext_sales_price,ss_ext_wholesale_cost,ss_net_profit]
-                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                        Project [ss_addr_sk,ss_store_sk,ss_quantity,ss_ext_sales_price,ss_ext_wholesale_cost,ss_net_profit,ss_sold_date_sk]
-                          BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk,cd_marital_status,cd_education_status,ss_sales_price,hd_dep_count]
-                            Project [ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_quantity,ss_sales_price,ss_ext_sales_price,ss_ext_wholesale_cost,ss_net_profit,ss_sold_date_sk,cd_marital_status,cd_education_status]
-                              BroadcastHashJoin [ss_cdemo_sk,cd_demo_sk,cd_marital_status,cd_education_status,ss_sales_price]
+                      BroadcastHashJoin [ss_cdemo_sk,cd_demo_sk,cd_marital_status,cd_education_status,ss_sales_price,hd_dep_count]
+                        Project [ss_cdemo_sk,ss_addr_sk,ss_store_sk,ss_quantity,ss_sales_price,ss_ext_sales_price,ss_ext_wholesale_cost,ss_net_profit,hd_dep_count]
+                          BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
+                            Project [ss_cdemo_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_quantity,ss_sales_price,ss_ext_sales_price,ss_ext_wholesale_cost,ss_net_profit]
+                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                 Filter [ss_store_sk,ss_addr_sk,ss_cdemo_sk,ss_hdemo_sk,ss_net_profit,ss_sales_price]
                                   ColumnarToRow
                                     InputAdapter
@@ -27,33 +27,33 @@ WholeStageCodegen (7)
                                                     InputAdapter
                                                       Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                 InputAdapter
-                                  BroadcastExchange #3
-                                    WholeStageCodegen (1)
-                                      Filter [cd_demo_sk,cd_marital_status,cd_education_status]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status,cd_education_status]
+                                  ReusedExchange [d_date_sk] #2
                             InputAdapter
-                              BroadcastExchange #4
+                              BroadcastExchange #3
                                 WholeStageCodegen (2)
                                   Filter [hd_demo_sk,hd_dep_count]
                                     ColumnarToRow
                                       InputAdapter
                                         Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_dep_count]
                         InputAdapter
-                          ReusedExchange [d_date_sk] #2
+                          BroadcastExchange #4
+                            WholeStageCodegen (3)
+                              Filter [cd_demo_sk,cd_marital_status,cd_education_status]
+                                ColumnarToRow
+                                  InputAdapter
+                                    Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status,cd_education_status]
                     InputAdapter
                       BroadcastExchange #5
                         WholeStageCodegen (4)
-                          Filter [s_store_sk]
-                            ColumnarToRow
-                              InputAdapter
-                                Scan parquet spark_catalog.default.store [s_store_sk]
+                          Project [ca_address_sk,ca_state]
+                            Filter [ca_country,ca_address_sk,ca_state]
+                              ColumnarToRow
+                                InputAdapter
+                                  Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state,ca_country]
                 InputAdapter
                   BroadcastExchange #6
                     WholeStageCodegen (5)
-                      Project [ca_address_sk,ca_state]
-                        Filter [ca_country,ca_address_sk,ca_state]
-                          ColumnarToRow
-                            InputAdapter
-                              Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state,ca_country]
+                      Filter [s_store_sk]
+                        ColumnarToRow
+                          InputAdapter
+                            Scan parquet spark_catalog.default.store [s_store_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/explain.txt
@@ -7,8 +7,8 @@ TakeOrderedAndProject (90)
    :        +- * HashAggregate (69)
    :           +- * Project (68)
    :              +- * BroadcastHashJoin Inner BuildRight (67)
-   :                 :- * Project (60)
-   :                 :  +- * BroadcastHashJoin Inner BuildRight (59)
+   :                 :- * Project (65)
+   :                 :  +- * BroadcastHashJoin Inner BuildRight (64)
    :                 :     :- * BroadcastHashJoin LeftSemi BuildRight (57)
    :                 :     :  :- * Filter (3)
    :                 :     :  :  +- * ColumnarToRow (2)
@@ -66,13 +66,13 @@ TakeOrderedAndProject (90)
    :                 :     :                             :     :     +- Scan parquet spark_catalog.default.web_sales (41)
    :                 :     :                             :     +- ReusedExchange (44)
    :                 :     :                             +- ReusedExchange (47)
-   :                 :     +- ReusedExchange (58)
-   :                 +- BroadcastExchange (66)
-   :                    +- * BroadcastHashJoin LeftSemi BuildRight (65)
-   :                       :- * Filter (63)
-   :                       :  +- * ColumnarToRow (62)
-   :                       :     +- Scan parquet spark_catalog.default.item (61)
-   :                       +- ReusedExchange (64)
+   :                 :     +- BroadcastExchange (63)
+   :                 :        +- * BroadcastHashJoin LeftSemi BuildRight (62)
+   :                 :           :- * Filter (60)
+   :                 :           :  +- * ColumnarToRow (59)
+   :                 :           :     +- Scan parquet spark_catalog.default.item (58)
+   :                 :           +- ReusedExchange (61)
+   :                 +- ReusedExchange (66)
    +- BroadcastExchange (88)
       +- * Filter (87)
          +- * HashAggregate (86)
@@ -359,76 +359,76 @@ Right keys [1]: [ss_item_sk#35]
 Join type: LeftSemi
 Join condition: None
 
-(58) ReusedExchange [Reuses operator id: 114]
-Output [1]: [d_date_sk#36]
-
-(59) BroadcastHashJoin [codegen id : 37]
-Left keys [1]: [ss_sold_date_sk#4]
-Right keys [1]: [d_date_sk#36]
-Join type: Inner
-Join condition: None
-
-(60) Project [codegen id : 37]
-Output [3]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3]
-Input [5]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4, d_date_sk#36]
-
-(61) Scan parquet spark_catalog.default.item
-Output [4]: [i_item_sk#37, i_brand_id#38, i_class_id#39, i_category_id#40]
+(58) Scan parquet spark_catalog.default.item
+Output [4]: [i_item_sk#36, i_brand_id#37, i_class_id#38, i_category_id#39]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(62) ColumnarToRow [codegen id : 36]
-Input [4]: [i_item_sk#37, i_brand_id#38, i_class_id#39, i_category_id#40]
+(59) ColumnarToRow [codegen id : 35]
+Input [4]: [i_item_sk#36, i_brand_id#37, i_class_id#38, i_category_id#39]
 
-(63) Filter [codegen id : 36]
-Input [4]: [i_item_sk#37, i_brand_id#38, i_class_id#39, i_category_id#40]
-Condition : (((isnotnull(i_item_sk#37) AND isnotnull(i_brand_id#38)) AND isnotnull(i_class_id#39)) AND isnotnull(i_category_id#40))
+(60) Filter [codegen id : 35]
+Input [4]: [i_item_sk#36, i_brand_id#37, i_class_id#38, i_category_id#39]
+Condition : (((isnotnull(i_item_sk#36) AND isnotnull(i_brand_id#37)) AND isnotnull(i_class_id#38)) AND isnotnull(i_category_id#39))
 
-(64) ReusedExchange [Reuses operator id: 56]
+(61) ReusedExchange [Reuses operator id: 56]
 Output [1]: [ss_item_sk#35]
 
-(65) BroadcastHashJoin [codegen id : 36]
-Left keys [1]: [i_item_sk#37]
+(62) BroadcastHashJoin [codegen id : 35]
+Left keys [1]: [i_item_sk#36]
 Right keys [1]: [ss_item_sk#35]
 Join type: LeftSemi
 Join condition: None
 
-(66) BroadcastExchange
-Input [4]: [i_item_sk#37, i_brand_id#38, i_class_id#39, i_category_id#40]
+(63) BroadcastExchange
+Input [4]: [i_item_sk#36, i_brand_id#37, i_class_id#38, i_category_id#39]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=10]
 
-(67) BroadcastHashJoin [codegen id : 37]
+(64) BroadcastHashJoin [codegen id : 37]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#37]
+Right keys [1]: [i_item_sk#36]
+Join type: Inner
+Join condition: None
+
+(65) Project [codegen id : 37]
+Output [6]: [ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4, i_brand_id#37, i_class_id#38, i_category_id#39]
+Input [8]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4, i_item_sk#36, i_brand_id#37, i_class_id#38, i_category_id#39]
+
+(66) ReusedExchange [Reuses operator id: 114]
+Output [1]: [d_date_sk#40]
+
+(67) BroadcastHashJoin [codegen id : 37]
+Left keys [1]: [ss_sold_date_sk#4]
+Right keys [1]: [d_date_sk#40]
 Join type: Inner
 Join condition: None
 
 (68) Project [codegen id : 37]
-Output [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#38, i_class_id#39, i_category_id#40]
-Input [7]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, i_item_sk#37, i_brand_id#38, i_class_id#39, i_category_id#40]
+Output [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#37, i_class_id#38, i_category_id#39]
+Input [7]: [ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4, i_brand_id#37, i_class_id#38, i_category_id#39, d_date_sk#40]
 
 (69) HashAggregate [codegen id : 37]
-Input [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#38, i_class_id#39, i_category_id#40]
-Keys [3]: [i_brand_id#38, i_class_id#39, i_category_id#40]
+Input [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#37, i_class_id#38, i_category_id#39]
+Keys [3]: [i_brand_id#37, i_class_id#38, i_category_id#39]
 Functions [2]: [partial_sum((cast(ss_quantity#2 as decimal(10,0)) * ss_list_price#3)), partial_count(1)]
 Aggregate Attributes [3]: [sum#41, isEmpty#42, count#43]
-Results [6]: [i_brand_id#38, i_class_id#39, i_category_id#40, sum#44, isEmpty#45, count#46]
+Results [6]: [i_brand_id#37, i_class_id#38, i_category_id#39, sum#44, isEmpty#45, count#46]
 
 (70) Exchange
-Input [6]: [i_brand_id#38, i_class_id#39, i_category_id#40, sum#44, isEmpty#45, count#46]
-Arguments: hashpartitioning(i_brand_id#38, i_class_id#39, i_category_id#40, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [6]: [i_brand_id#37, i_class_id#38, i_category_id#39, sum#44, isEmpty#45, count#46]
+Arguments: hashpartitioning(i_brand_id#37, i_class_id#38, i_category_id#39, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (71) HashAggregate [codegen id : 76]
-Input [6]: [i_brand_id#38, i_class_id#39, i_category_id#40, sum#44, isEmpty#45, count#46]
-Keys [3]: [i_brand_id#38, i_class_id#39, i_category_id#40]
+Input [6]: [i_brand_id#37, i_class_id#38, i_category_id#39, sum#44, isEmpty#45, count#46]
+Keys [3]: [i_brand_id#37, i_class_id#38, i_category_id#39]
 Functions [2]: [sum((cast(ss_quantity#2 as decimal(10,0)) * ss_list_price#3)), count(1)]
 Aggregate Attributes [2]: [sum((cast(ss_quantity#2 as decimal(10,0)) * ss_list_price#3))#47, count(1)#48]
-Results [6]: [store AS channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum((cast(ss_quantity#2 as decimal(10,0)) * ss_list_price#3))#47 AS sales#50, count(1)#48 AS number_sales#51]
+Results [6]: [store AS channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum((cast(ss_quantity#2 as decimal(10,0)) * ss_list_price#3))#47 AS sales#50, count(1)#48 AS number_sales#51]
 
 (72) Filter [codegen id : 76]
-Input [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sales#50, number_sales#51]
+Input [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sales#50, number_sales#51]
 Condition : (isnotnull(sales#50) AND (cast(sales#50 as decimal(32,6)) > cast(Subquery scalar-subquery#52, [id=#53] as decimal(32,6))))
 
 (73) Scan parquet spark_catalog.default.store_sales
@@ -455,67 +455,67 @@ Right keys [1]: [ss_item_sk#59]
 Join type: LeftSemi
 Join condition: None
 
-(78) ReusedExchange [Reuses operator id: 128]
-Output [1]: [d_date_sk#60]
+(78) ReusedExchange [Reuses operator id: 63]
+Output [4]: [i_item_sk#60, i_brand_id#61, i_class_id#62, i_category_id#63]
 
 (79) BroadcastHashJoin [codegen id : 74]
-Left keys [1]: [ss_sold_date_sk#57]
-Right keys [1]: [d_date_sk#60]
+Left keys [1]: [ss_item_sk#54]
+Right keys [1]: [i_item_sk#60]
 Join type: Inner
 Join condition: None
 
 (80) Project [codegen id : 74]
-Output [3]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56]
-Input [5]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57, d_date_sk#60]
+Output [6]: [ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57, i_brand_id#61, i_class_id#62, i_category_id#63]
+Input [8]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57, i_item_sk#60, i_brand_id#61, i_class_id#62, i_category_id#63]
 
-(81) ReusedExchange [Reuses operator id: 66]
-Output [4]: [i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64]
+(81) ReusedExchange [Reuses operator id: 128]
+Output [1]: [d_date_sk#64]
 
 (82) BroadcastHashJoin [codegen id : 74]
-Left keys [1]: [ss_item_sk#54]
-Right keys [1]: [i_item_sk#61]
+Left keys [1]: [ss_sold_date_sk#57]
+Right keys [1]: [d_date_sk#64]
 Join type: Inner
 Join condition: None
 
 (83) Project [codegen id : 74]
-Output [5]: [ss_quantity#55, ss_list_price#56, i_brand_id#62, i_class_id#63, i_category_id#64]
-Input [7]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64]
+Output [5]: [ss_quantity#55, ss_list_price#56, i_brand_id#61, i_class_id#62, i_category_id#63]
+Input [7]: [ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57, i_brand_id#61, i_class_id#62, i_category_id#63, d_date_sk#64]
 
 (84) HashAggregate [codegen id : 74]
-Input [5]: [ss_quantity#55, ss_list_price#56, i_brand_id#62, i_class_id#63, i_category_id#64]
-Keys [3]: [i_brand_id#62, i_class_id#63, i_category_id#64]
+Input [5]: [ss_quantity#55, ss_list_price#56, i_brand_id#61, i_class_id#62, i_category_id#63]
+Keys [3]: [i_brand_id#61, i_class_id#62, i_category_id#63]
 Functions [2]: [partial_sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56)), partial_count(1)]
 Aggregate Attributes [3]: [sum#65, isEmpty#66, count#67]
-Results [6]: [i_brand_id#62, i_class_id#63, i_category_id#64, sum#68, isEmpty#69, count#70]
+Results [6]: [i_brand_id#61, i_class_id#62, i_category_id#63, sum#68, isEmpty#69, count#70]
 
 (85) Exchange
-Input [6]: [i_brand_id#62, i_class_id#63, i_category_id#64, sum#68, isEmpty#69, count#70]
-Arguments: hashpartitioning(i_brand_id#62, i_class_id#63, i_category_id#64, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [6]: [i_brand_id#61, i_class_id#62, i_category_id#63, sum#68, isEmpty#69, count#70]
+Arguments: hashpartitioning(i_brand_id#61, i_class_id#62, i_category_id#63, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
 (86) HashAggregate [codegen id : 75]
-Input [6]: [i_brand_id#62, i_class_id#63, i_category_id#64, sum#68, isEmpty#69, count#70]
-Keys [3]: [i_brand_id#62, i_class_id#63, i_category_id#64]
+Input [6]: [i_brand_id#61, i_class_id#62, i_category_id#63, sum#68, isEmpty#69, count#70]
+Keys [3]: [i_brand_id#61, i_class_id#62, i_category_id#63]
 Functions [2]: [sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56)), count(1)]
 Aggregate Attributes [2]: [sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56))#71, count(1)#72]
-Results [6]: [store AS channel#73, i_brand_id#62, i_class_id#63, i_category_id#64, sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56))#71 AS sales#74, count(1)#72 AS number_sales#75]
+Results [6]: [store AS channel#73, i_brand_id#61, i_class_id#62, i_category_id#63, sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56))#71 AS sales#74, count(1)#72 AS number_sales#75]
 
 (87) Filter [codegen id : 75]
-Input [6]: [channel#73, i_brand_id#62, i_class_id#63, i_category_id#64, sales#74, number_sales#75]
+Input [6]: [channel#73, i_brand_id#61, i_class_id#62, i_category_id#63, sales#74, number_sales#75]
 Condition : (isnotnull(sales#74) AND (cast(sales#74 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#52, [id=#53] as decimal(32,6))))
 
 (88) BroadcastExchange
-Input [6]: [channel#73, i_brand_id#62, i_class_id#63, i_category_id#64, sales#74, number_sales#75]
+Input [6]: [channel#73, i_brand_id#61, i_class_id#62, i_category_id#63, sales#74, number_sales#75]
 Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false), [plan_id=13]
 
 (89) BroadcastHashJoin [codegen id : 76]
-Left keys [3]: [i_brand_id#38, i_class_id#39, i_category_id#40]
-Right keys [3]: [i_brand_id#62, i_class_id#63, i_category_id#64]
+Left keys [3]: [i_brand_id#37, i_class_id#38, i_category_id#39]
+Right keys [3]: [i_brand_id#61, i_class_id#62, i_category_id#63]
 Join type: Inner
 Join condition: None
 
 (90) TakeOrderedAndProject
-Input [12]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sales#50, number_sales#51, channel#73, i_brand_id#62, i_class_id#63, i_category_id#64, sales#74, number_sales#75]
-Arguments: 100, [i_brand_id#38 ASC NULLS FIRST, i_class_id#39 ASC NULLS FIRST, i_category_id#40 ASC NULLS FIRST], [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sales#50, number_sales#51, channel#73, i_brand_id#62, i_class_id#63, i_category_id#64, sales#74, number_sales#75]
+Input [12]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sales#50, number_sales#51, channel#73, i_brand_id#61, i_class_id#62, i_category_id#63, sales#74, number_sales#75]
+Arguments: 100, [i_brand_id#37 ASC NULLS FIRST, i_class_id#38 ASC NULLS FIRST, i_category_id#39 ASC NULLS FIRST], [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sales#50, number_sales#51, channel#73, i_brand_id#61, i_class_id#62, i_category_id#63, sales#74, number_sales#75]
 
 ===== Subqueries =====
 
@@ -645,25 +645,25 @@ BroadcastExchange (114)
 
 
 (110) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#36, d_week_seq#100]
+Output [2]: [d_date_sk#40, d_week_seq#100]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_week_seq), EqualTo(d_week_seq,ScalarSubquery#101), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
 (111) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#36, d_week_seq#100]
+Input [2]: [d_date_sk#40, d_week_seq#100]
 
 (112) Filter [codegen id : 1]
-Input [2]: [d_date_sk#36, d_week_seq#100]
-Condition : ((isnotnull(d_week_seq#100) AND (d_week_seq#100 = ReusedSubquery Subquery scalar-subquery#101, [id=#102])) AND isnotnull(d_date_sk#36))
+Input [2]: [d_date_sk#40, d_week_seq#100]
+Condition : ((isnotnull(d_week_seq#100) AND (d_week_seq#100 = ReusedSubquery Subquery scalar-subquery#101, [id=#102])) AND isnotnull(d_date_sk#40))
 
 (113) Project [codegen id : 1]
-Output [1]: [d_date_sk#36]
-Input [2]: [d_date_sk#36, d_week_seq#100]
+Output [1]: [d_date_sk#40]
+Input [2]: [d_date_sk#40, d_week_seq#100]
 
 (114) BroadcastExchange
-Input [1]: [d_date_sk#36]
+Input [1]: [d_date_sk#40]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=15]
 
 Subquery:6 Hosting operator id = 112 Hosting Expression = ReusedSubquery Subquery scalar-subquery#101, [id=#102]
@@ -738,25 +738,25 @@ BroadcastExchange (128)
 
 
 (124) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#60, d_week_seq#108]
+Output [2]: [d_date_sk#64, d_week_seq#108]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_week_seq), EqualTo(d_week_seq,ScalarSubquery#109), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
 (125) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#60, d_week_seq#108]
+Input [2]: [d_date_sk#64, d_week_seq#108]
 
 (126) Filter [codegen id : 1]
-Input [2]: [d_date_sk#60, d_week_seq#108]
-Condition : ((isnotnull(d_week_seq#108) AND (d_week_seq#108 = ReusedSubquery Subquery scalar-subquery#109, [id=#110])) AND isnotnull(d_date_sk#60))
+Input [2]: [d_date_sk#64, d_week_seq#108]
+Condition : ((isnotnull(d_week_seq#108) AND (d_week_seq#108 = ReusedSubquery Subquery scalar-subquery#109, [id=#110])) AND isnotnull(d_date_sk#64))
 
 (127) Project [codegen id : 1]
-Output [1]: [d_date_sk#60]
-Input [2]: [d_date_sk#60, d_week_seq#108]
+Output [1]: [d_date_sk#64]
+Input [2]: [d_date_sk#64, d_week_seq#108]
 
 (128) BroadcastExchange
-Input [1]: [d_date_sk#60]
+Input [1]: [d_date_sk#64]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=17]
 
 Subquery:13 Hosting operator id = 126 Hosting Expression = ReusedSubquery Subquery scalar-subquery#109, [id=#110]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q14b.sf100/simplified.txt
@@ -44,9 +44,9 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
               WholeStageCodegen (37)
                 HashAggregate [i_brand_id,i_class_id,i_category_id,ss_quantity,ss_list_price] [sum,isEmpty,count,sum,isEmpty,count]
                   Project [ss_quantity,ss_list_price,i_brand_id,i_class_id,i_category_id]
-                    BroadcastHashJoin [ss_item_sk,i_item_sk]
-                      Project [ss_item_sk,ss_quantity,ss_list_price]
-                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                      Project [ss_quantity,ss_list_price,ss_sold_date_sk,i_brand_id,i_class_id,i_category_id]
+                        BroadcastHashJoin [ss_item_sk,i_item_sk]
                           BroadcastHashJoin [ss_item_sk,ss_item_sk]
                             Filter [ss_item_sk]
                               ColumnarToRow
@@ -168,17 +168,17 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                                               InputAdapter
                                                                 ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #11
                           InputAdapter
-                            ReusedExchange [d_date_sk] #2
-                      InputAdapter
-                        BroadcastExchange #13
-                          WholeStageCodegen (36)
-                            BroadcastHashJoin [i_item_sk,ss_item_sk]
-                              Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                ColumnarToRow
+                            BroadcastExchange #13
+                              WholeStageCodegen (35)
+                                BroadcastHashJoin [i_item_sk,ss_item_sk]
+                                  Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                    ColumnarToRow
+                                      InputAdapter
+                                        Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
                                   InputAdapter
-                                    Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                              InputAdapter
-                                ReusedExchange [ss_item_sk] #3
+                                    ReusedExchange [ss_item_sk] #3
+                      InputAdapter
+                        ReusedExchange [d_date_sk] #2
       InputAdapter
         BroadcastExchange #15
           WholeStageCodegen (75)
@@ -190,9 +190,9 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                     WholeStageCodegen (74)
                       HashAggregate [i_brand_id,i_class_id,i_category_id,ss_quantity,ss_list_price] [sum,isEmpty,count,sum,isEmpty,count]
                         Project [ss_quantity,ss_list_price,i_brand_id,i_class_id,i_category_id]
-                          BroadcastHashJoin [ss_item_sk,i_item_sk]
-                            Project [ss_item_sk,ss_quantity,ss_list_price]
-                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                            Project [ss_quantity,ss_list_price,ss_sold_date_sk,i_brand_id,i_class_id,i_category_id]
+                              BroadcastHashJoin [ss_item_sk,i_item_sk]
                                 BroadcastHashJoin [ss_item_sk,ss_item_sk]
                                   Filter [ss_item_sk]
                                     ColumnarToRow
@@ -217,6 +217,6 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                   InputAdapter
                                     ReusedExchange [ss_item_sk] #3
                                 InputAdapter
-                                  ReusedExchange [d_date_sk] #17
+                                  ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #13
                             InputAdapter
-                              ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #13
+                              ReusedExchange [d_date_sk] #17

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16.sf100/explain.txt
@@ -33,12 +33,12 @@
                   :     :        +- * Project (23)
                   :     :           +- * Filter (22)
                   :     :              +- * ColumnarToRow (21)
-                  :     :                 +- Scan parquet spark_catalog.default.customer_address (20)
+                  :     :                 +- Scan parquet spark_catalog.default.call_center (20)
                   :     +- BroadcastExchange (31)
                   :        +- * Project (30)
                   :           +- * Filter (29)
                   :              +- * ColumnarToRow (28)
-                  :                 +- Scan parquet spark_catalog.default.call_center (27)
+                  :                 +- Scan parquet spark_catalog.default.customer_address (27)
                   +- BroadcastExchange (38)
                      +- * Project (37)
                         +- * Filter (36)
@@ -58,7 +58,7 @@ Input [8]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_call_center_sk#3, cs_wareho
 
 (3) Filter [codegen id : 1]
 Input [8]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_call_center_sk#3, cs_warehouse_sk#4, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7, cs_sold_date_sk#8]
-Condition : (((((isnotnull(cs_ship_date_sk#1) AND isnotnull(cs_ship_addr_sk#2)) AND isnotnull(cs_call_center_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#10], xxhash64(cs_ship_addr_sk#2, 42))) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(cs_call_center_sk#3, 42))) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(cs_ship_date_sk#1, 42)))
+Condition : (((((isnotnull(cs_ship_date_sk#1) AND isnotnull(cs_ship_addr_sk#2)) AND isnotnull(cs_call_center_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#10], xxhash64(cs_call_center_sk#3, 42))) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(cs_ship_addr_sk#2, 42))) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(cs_ship_date_sk#1, 42)))
 
 (4) Project [codegen id : 1]
 Output [7]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_call_center_sk#3, cs_warehouse_sk#4, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7]
@@ -130,69 +130,69 @@ Right keys [1]: [cr_order_number#18]
 Join type: LeftAnti
 Join condition: None
 
-(20) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#20, ca_state#21]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,GA), IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_state:string>
-
-(21) ColumnarToRow [codegen id : 8]
-Input [2]: [ca_address_sk#20, ca_state#21]
-
-(22) Filter [codegen id : 8]
-Input [2]: [ca_address_sk#20, ca_state#21]
-Condition : ((isnotnull(ca_state#21) AND (ca_state#21 = GA)) AND isnotnull(ca_address_sk#20))
-
-(23) Project [codegen id : 8]
-Output [1]: [ca_address_sk#20]
-Input [2]: [ca_address_sk#20, ca_state#21]
-
-(24) BroadcastExchange
-Input [1]: [ca_address_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
-
-(25) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [cs_ship_addr_sk#2]
-Right keys [1]: [ca_address_sk#20]
-Join type: Inner
-Join condition: None
-
-(26) Project [codegen id : 11]
-Output [5]: [cs_ship_date_sk#1, cs_call_center_sk#3, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7]
-Input [7]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_call_center_sk#3, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7, ca_address_sk#20]
-
-(27) Scan parquet spark_catalog.default.call_center
-Output [2]: [cc_call_center_sk#22, cc_county#23]
+(20) Scan parquet spark_catalog.default.call_center
+Output [2]: [cc_call_center_sk#20, cc_county#21]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/call_center]
 PushedFilters: [IsNotNull(cc_county), EqualTo(cc_county,Williamson County), IsNotNull(cc_call_center_sk)]
 ReadSchema: struct<cc_call_center_sk:int,cc_county:string>
 
+(21) ColumnarToRow [codegen id : 8]
+Input [2]: [cc_call_center_sk#20, cc_county#21]
+
+(22) Filter [codegen id : 8]
+Input [2]: [cc_call_center_sk#20, cc_county#21]
+Condition : ((isnotnull(cc_county#21) AND (cc_county#21 = Williamson County)) AND isnotnull(cc_call_center_sk#20))
+
+(23) Project [codegen id : 8]
+Output [1]: [cc_call_center_sk#20]
+Input [2]: [cc_call_center_sk#20, cc_county#21]
+
+(24) BroadcastExchange
+Input [1]: [cc_call_center_sk#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
+
+(25) BroadcastHashJoin [codegen id : 11]
+Left keys [1]: [cs_call_center_sk#3]
+Right keys [1]: [cc_call_center_sk#20]
+Join type: Inner
+Join condition: None
+
+(26) Project [codegen id : 11]
+Output [5]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7]
+Input [7]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_call_center_sk#3, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7, cc_call_center_sk#20]
+
+(27) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#22, ca_state#23]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,GA), IsNotNull(ca_address_sk)]
+ReadSchema: struct<ca_address_sk:int,ca_state:string>
+
 (28) ColumnarToRow [codegen id : 9]
-Input [2]: [cc_call_center_sk#22, cc_county#23]
+Input [2]: [ca_address_sk#22, ca_state#23]
 
 (29) Filter [codegen id : 9]
-Input [2]: [cc_call_center_sk#22, cc_county#23]
-Condition : ((isnotnull(cc_county#23) AND (cc_county#23 = Williamson County)) AND isnotnull(cc_call_center_sk#22))
+Input [2]: [ca_address_sk#22, ca_state#23]
+Condition : ((isnotnull(ca_state#23) AND (ca_state#23 = GA)) AND isnotnull(ca_address_sk#22))
 
 (30) Project [codegen id : 9]
-Output [1]: [cc_call_center_sk#22]
-Input [2]: [cc_call_center_sk#22, cc_county#23]
+Output [1]: [ca_address_sk#22]
+Input [2]: [ca_address_sk#22, ca_state#23]
 
 (31) BroadcastExchange
-Input [1]: [cc_call_center_sk#22]
+Input [1]: [ca_address_sk#22]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
 (32) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [cs_call_center_sk#3]
-Right keys [1]: [cc_call_center_sk#22]
+Left keys [1]: [cs_ship_addr_sk#2]
+Right keys [1]: [ca_address_sk#22]
 Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 11]
 Output [4]: [cs_ship_date_sk#1, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7]
-Input [6]: [cs_ship_date_sk#1, cs_call_center_sk#3, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7, cc_call_center_sk#22]
+Input [6]: [cs_ship_date_sk#1, cs_ship_addr_sk#2, cs_order_number#5, cs_ext_ship_cost#6, cs_net_profit#7, ca_address_sk#22]
 
 (34) Scan parquet spark_catalog.default.date_dim
 Output [2]: [d_date_sk#24, d_date#25]
@@ -267,31 +267,31 @@ ObjectHashAggregate (52)
       +- * Project (49)
          +- * Filter (48)
             +- * ColumnarToRow (47)
-               +- Scan parquet spark_catalog.default.customer_address (46)
+               +- Scan parquet spark_catalog.default.call_center (46)
 
 
-(46) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#20, ca_state#21]
+(46) Scan parquet spark_catalog.default.call_center
+Output [2]: [cc_call_center_sk#20, cc_county#21]
 Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,GA), IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_state:string>
+Location [not included in comparison]/{warehouse_dir}/call_center]
+PushedFilters: [IsNotNull(cc_county), EqualTo(cc_county,Williamson County), IsNotNull(cc_call_center_sk)]
+ReadSchema: struct<cc_call_center_sk:int,cc_county:string>
 
 (47) ColumnarToRow [codegen id : 1]
-Input [2]: [ca_address_sk#20, ca_state#21]
+Input [2]: [cc_call_center_sk#20, cc_county#21]
 
 (48) Filter [codegen id : 1]
-Input [2]: [ca_address_sk#20, ca_state#21]
-Condition : ((isnotnull(ca_state#21) AND (ca_state#21 = GA)) AND isnotnull(ca_address_sk#20))
+Input [2]: [cc_call_center_sk#20, cc_county#21]
+Condition : ((isnotnull(cc_county#21) AND (cc_county#21 = Williamson County)) AND isnotnull(cc_call_center_sk#20))
 
 (49) Project [codegen id : 1]
-Output [1]: [ca_address_sk#20]
-Input [2]: [ca_address_sk#20, ca_state#21]
+Output [1]: [cc_call_center_sk#20]
+Input [2]: [cc_call_center_sk#20, cc_county#21]
 
 (50) ObjectHashAggregate
-Input [1]: [ca_address_sk#20]
+Input [1]: [cc_call_center_sk#20]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 17961, 333176, 0, 0)]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(cc_call_center_sk#20, 42), 4, 144, 0, 0)]
 Aggregate Attributes [1]: [buf#35]
 Results [1]: [buf#36]
 
@@ -302,9 +302,9 @@ Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 (52) ObjectHashAggregate
 Input [1]: [buf#36]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 17961, 333176, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 17961, 333176, 0, 0)#37]
-Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 17961, 333176, 0, 0)#37 AS bloomFilter#38]
+Functions [1]: [bloom_filter_agg(xxhash64(cc_call_center_sk#20, 42), 4, 144, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cc_call_center_sk#20, 42), 4, 144, 0, 0)#37]
+Results [1]: [bloom_filter_agg(xxhash64(cc_call_center_sk#20, 42), 4, 144, 0, 0)#37 AS bloomFilter#38]
 
 Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#11, [id=#12]
 ObjectHashAggregate (59)
@@ -313,31 +313,31 @@ ObjectHashAggregate (59)
       +- * Project (56)
          +- * Filter (55)
             +- * ColumnarToRow (54)
-               +- Scan parquet spark_catalog.default.call_center (53)
+               +- Scan parquet spark_catalog.default.customer_address (53)
 
 
-(53) Scan parquet spark_catalog.default.call_center
-Output [2]: [cc_call_center_sk#22, cc_county#23]
+(53) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#22, ca_state#23]
 Batched: true
-Location [not included in comparison]/{warehouse_dir}/call_center]
-PushedFilters: [IsNotNull(cc_county), EqualTo(cc_county,Williamson County), IsNotNull(cc_call_center_sk)]
-ReadSchema: struct<cc_call_center_sk:int,cc_county:string>
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,GA), IsNotNull(ca_address_sk)]
+ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
 (54) ColumnarToRow [codegen id : 1]
-Input [2]: [cc_call_center_sk#22, cc_county#23]
+Input [2]: [ca_address_sk#22, ca_state#23]
 
 (55) Filter [codegen id : 1]
-Input [2]: [cc_call_center_sk#22, cc_county#23]
-Condition : ((isnotnull(cc_county#23) AND (cc_county#23 = Williamson County)) AND isnotnull(cc_call_center_sk#22))
+Input [2]: [ca_address_sk#22, ca_state#23]
+Condition : ((isnotnull(ca_state#23) AND (ca_state#23 = GA)) AND isnotnull(ca_address_sk#22))
 
 (56) Project [codegen id : 1]
-Output [1]: [cc_call_center_sk#22]
-Input [2]: [cc_call_center_sk#22, cc_county#23]
+Output [1]: [ca_address_sk#22]
+Input [2]: [ca_address_sk#22, ca_state#23]
 
 (57) ObjectHashAggregate
-Input [1]: [cc_call_center_sk#22]
+Input [1]: [ca_address_sk#22]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(cc_call_center_sk#22, 42), 4, 144, 0, 0)]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#22, 42), 17961, 333176, 0, 0)]
 Aggregate Attributes [1]: [buf#39]
 Results [1]: [buf#40]
 
@@ -348,9 +348,9 @@ Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
 (59) ObjectHashAggregate
 Input [1]: [buf#40]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(cc_call_center_sk#22, 42), 4, 144, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cc_call_center_sk#22, 42), 4, 144, 0, 0)#41]
-Results [1]: [bloom_filter_agg(xxhash64(cc_call_center_sk#22, 42), 4, 144, 0, 0)#41 AS bloomFilter#42]
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#22, 42), 17961, 333176, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#22, 42), 17961, 333176, 0, 0)#41]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#22, 42), 17961, 333176, 0, 0)#41 AS bloomFilter#42]
 
 Subquery:3 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#13, [id=#14]
 ObjectHashAggregate (66)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q16.sf100/simplified.txt
@@ -9,9 +9,9 @@ WholeStageCodegen (12)
                 Project [cs_order_number,cs_ext_ship_cost,cs_net_profit]
                   BroadcastHashJoin [cs_ship_date_sk,d_date_sk]
                     Project [cs_ship_date_sk,cs_order_number,cs_ext_ship_cost,cs_net_profit]
-                      BroadcastHashJoin [cs_call_center_sk,cc_call_center_sk]
-                        Project [cs_ship_date_sk,cs_call_center_sk,cs_order_number,cs_ext_ship_cost,cs_net_profit]
-                          BroadcastHashJoin [cs_ship_addr_sk,ca_address_sk]
+                      BroadcastHashJoin [cs_ship_addr_sk,ca_address_sk]
+                        Project [cs_ship_date_sk,cs_ship_addr_sk,cs_order_number,cs_ext_ship_cost,cs_net_profit]
+                          BroadcastHashJoin [cs_call_center_sk,cc_call_center_sk]
                             SortMergeJoin [cs_order_number,cr_order_number]
                               InputAdapter
                                 WholeStageCodegen (5)
@@ -26,18 +26,8 @@ WholeStageCodegen (12)
                                                   Project [cs_ship_date_sk,cs_ship_addr_sk,cs_call_center_sk,cs_warehouse_sk,cs_order_number,cs_ext_ship_cost,cs_net_profit]
                                                     Filter [cs_ship_date_sk,cs_ship_addr_sk,cs_call_center_sk]
                                                       Subquery #1
-                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 17961, 333176, 0, 0),bloomFilter,buf]
-                                                          Exchange #3
-                                                            ObjectHashAggregate [ca_address_sk] [buf,buf]
-                                                              WholeStageCodegen (1)
-                                                                Project [ca_address_sk]
-                                                                  Filter [ca_state,ca_address_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
-                                                      Subquery #2
                                                         ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(cc_call_center_sk, 42), 4, 144, 0, 0),bloomFilter,buf]
-                                                          Exchange #4
+                                                          Exchange #3
                                                             ObjectHashAggregate [cc_call_center_sk] [buf,buf]
                                                               WholeStageCodegen (1)
                                                                 Project [cc_call_center_sk]
@@ -45,6 +35,16 @@ WholeStageCodegen (12)
                                                                     ColumnarToRow
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.call_center [cc_call_center_sk,cc_county]
+                                                      Subquery #2
+                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 17961, 333176, 0, 0),bloomFilter,buf]
+                                                          Exchange #4
+                                                            ObjectHashAggregate [ca_address_sk] [buf,buf]
+                                                              WholeStageCodegen (1)
+                                                                Project [ca_address_sk]
+                                                                  Filter [ca_state,ca_address_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
                                                       Subquery #3
                                                         ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_date_sk, 42), 73049, 1141755, 0, 0),bloomFilter,buf]
                                                           Exchange #5
@@ -81,19 +81,19 @@ WholeStageCodegen (12)
                             InputAdapter
                               BroadcastExchange #8
                                 WholeStageCodegen (8)
-                                  Project [ca_address_sk]
-                                    Filter [ca_state,ca_address_sk]
+                                  Project [cc_call_center_sk]
+                                    Filter [cc_county,cc_call_center_sk]
                                       ColumnarToRow
                                         InputAdapter
-                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+                                          Scan parquet spark_catalog.default.call_center [cc_call_center_sk,cc_county]
                         InputAdapter
                           BroadcastExchange #9
                             WholeStageCodegen (9)
-                              Project [cc_call_center_sk]
-                                Filter [cc_county,cc_call_center_sk]
+                              Project [ca_address_sk]
+                                Filter [ca_state,ca_address_sk]
                                   ColumnarToRow
                                     InputAdapter
-                                      Scan parquet spark_catalog.default.call_center [cc_call_center_sk,cc_county]
+                                      Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
                     InputAdapter
                       BroadcastExchange #10
                         WholeStageCodegen (10)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17.sf100/explain.txt
@@ -8,38 +8,38 @@ TakeOrderedAndProject (49)
                :- * Sort (35)
                :  +- Exchange (34)
                :     +- * Project (33)
-               :        +- * SortMergeJoin Inner (32)
-               :           :- * Sort (23)
-               :           :  +- Exchange (22)
-               :           :     +- * Project (21)
-               :           :        +- * SortMergeJoin Inner (20)
-               :           :           :- * Sort (14)
-               :           :           :  +- Exchange (13)
-               :           :           :     +- * Project (12)
-               :           :           :        +- * BroadcastHashJoin Inner BuildRight (11)
-               :           :           :           :- * Project (6)
-               :           :           :           :  +- * BroadcastHashJoin Inner BuildRight (5)
-               :           :           :           :     :- * Filter (3)
-               :           :           :           :     :  +- * ColumnarToRow (2)
-               :           :           :           :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-               :           :           :           :     +- ReusedExchange (4)
-               :           :           :           +- BroadcastExchange (10)
-               :           :           :              +- * Filter (9)
-               :           :           :                 +- * ColumnarToRow (8)
-               :           :           :                    +- Scan parquet spark_catalog.default.store (7)
-               :           :           +- * Sort (19)
-               :           :              +- Exchange (18)
-               :           :                 +- * Filter (17)
-               :           :                    +- * ColumnarToRow (16)
-               :           :                       +- Scan parquet spark_catalog.default.item (15)
-               :           +- * Sort (31)
-               :              +- Exchange (30)
-               :                 +- * Project (29)
-               :                    +- * BroadcastHashJoin Inner BuildRight (28)
-               :                       :- * Filter (26)
-               :                       :  +- * ColumnarToRow (25)
-               :                       :     +- Scan parquet spark_catalog.default.store_returns (24)
-               :                       +- ReusedExchange (27)
+               :        +- * BroadcastHashJoin Inner BuildRight (32)
+               :           :- * Project (27)
+               :           :  +- * SortMergeJoin Inner (26)
+               :           :     :- * Sort (20)
+               :           :     :  +- Exchange (19)
+               :           :     :     +- * Project (18)
+               :           :     :        +- * SortMergeJoin Inner (17)
+               :           :     :           :- * Sort (8)
+               :           :     :           :  +- Exchange (7)
+               :           :     :           :     +- * Project (6)
+               :           :     :           :        +- * BroadcastHashJoin Inner BuildRight (5)
+               :           :     :           :           :- * Filter (3)
+               :           :     :           :           :  +- * ColumnarToRow (2)
+               :           :     :           :           :     +- Scan parquet spark_catalog.default.store_sales (1)
+               :           :     :           :           +- ReusedExchange (4)
+               :           :     :           +- * Sort (16)
+               :           :     :              +- Exchange (15)
+               :           :     :                 +- * Project (14)
+               :           :     :                    +- * BroadcastHashJoin Inner BuildRight (13)
+               :           :     :                       :- * Filter (11)
+               :           :     :                       :  +- * ColumnarToRow (10)
+               :           :     :                       :     +- Scan parquet spark_catalog.default.store_returns (9)
+               :           :     :                       +- ReusedExchange (12)
+               :           :     +- * Sort (25)
+               :           :        +- Exchange (24)
+               :           :           +- * Filter (23)
+               :           :              +- * ColumnarToRow (22)
+               :           :                 +- Scan parquet spark_catalog.default.item (21)
+               :           +- BroadcastExchange (31)
+               :              +- * Filter (30)
+               :                 +- * ColumnarToRow (29)
+               :                    +- Scan parquet spark_catalog.default.store (28)
                +- * Sort (43)
                   +- Exchange (42)
                      +- * Project (41)
@@ -58,161 +58,161 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#6), dynamicpruningexpression(ss_sol
 PushedFilters: [IsNotNull(ss_customer_sk), IsNotNull(ss_item_sk), IsNotNull(ss_ticket_number), IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_quantity:int>
 
-(2) ColumnarToRow [codegen id : 3]
+(2) ColumnarToRow [codegen id : 2]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5, ss_sold_date_sk#6]
 
-(3) Filter [codegen id : 3]
+(3) Filter [codegen id : 2]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5, ss_sold_date_sk#6]
 Condition : (((isnotnull(ss_customer_sk#2) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_ticket_number#4)) AND isnotnull(ss_store_sk#3))
 
 (4) ReusedExchange [Reuses operator id: 54]
 Output [1]: [d_date_sk#8]
 
-(5) BroadcastHashJoin [codegen id : 3]
+(5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#6]
 Right keys [1]: [d_date_sk#8]
 Join type: Inner
 Join condition: None
 
-(6) Project [codegen id : 3]
+(6) Project [codegen id : 2]
 Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5]
 Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5, ss_sold_date_sk#6, d_date_sk#8]
 
-(7) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#9, s_state#10]
+(7) Exchange
+Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5]
+Arguments: hashpartitioning(ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4, 5), ENSURE_REQUIREMENTS, [plan_id=1]
+
+(8) Sort [codegen id : 3]
+Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5]
+Arguments: [ss_customer_sk#2 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST, ss_ticket_number#4 ASC NULLS FIRST], false, 0
+
+(9) Scan parquet spark_catalog.default.store_returns
+Output [5]: [sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_return_quantity#12, sr_returned_date_sk#13]
 Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_store_sk)]
-ReadSchema: struct<s_store_sk:int,s_state:string>
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(sr_returned_date_sk#13), dynamicpruningexpression(sr_returned_date_sk#13 IN dynamicpruning#14)]
+PushedFilters: [IsNotNull(sr_customer_sk), IsNotNull(sr_item_sk), IsNotNull(sr_ticket_number)]
+ReadSchema: struct<sr_item_sk:int,sr_customer_sk:int,sr_ticket_number:int,sr_return_quantity:int>
 
-(8) ColumnarToRow [codegen id : 2]
-Input [2]: [s_store_sk#9, s_state#10]
+(10) ColumnarToRow [codegen id : 5]
+Input [5]: [sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_return_quantity#12, sr_returned_date_sk#13]
 
-(9) Filter [codegen id : 2]
-Input [2]: [s_store_sk#9, s_state#10]
-Condition : isnotnull(s_store_sk#9)
+(11) Filter [codegen id : 5]
+Input [5]: [sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_return_quantity#12, sr_returned_date_sk#13]
+Condition : ((isnotnull(sr_customer_sk#10) AND isnotnull(sr_item_sk#9)) AND isnotnull(sr_ticket_number#11))
 
-(10) BroadcastExchange
-Input [2]: [s_store_sk#9, s_state#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
+(12) ReusedExchange [Reuses operator id: 59]
+Output [1]: [d_date_sk#15]
 
-(11) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#9]
+(13) BroadcastHashJoin [codegen id : 5]
+Left keys [1]: [sr_returned_date_sk#13]
+Right keys [1]: [d_date_sk#15]
 Join type: Inner
 Join condition: None
 
-(12) Project [codegen id : 3]
-Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#10]
-Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5, s_store_sk#9, s_state#10]
+(14) Project [codegen id : 5]
+Output [4]: [sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_return_quantity#12]
+Input [6]: [sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_return_quantity#12, sr_returned_date_sk#13, d_date_sk#15]
 
-(13) Exchange
-Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#10]
-Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+(15) Exchange
+Input [4]: [sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_return_quantity#12]
+Arguments: hashpartitioning(sr_customer_sk#10, sr_item_sk#9, sr_ticket_number#11, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(14) Sort [codegen id : 4]
-Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#10]
+(16) Sort [codegen id : 6]
+Input [4]: [sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_return_quantity#12]
+Arguments: [sr_customer_sk#10 ASC NULLS FIRST, sr_item_sk#9 ASC NULLS FIRST, sr_ticket_number#11 ASC NULLS FIRST], false, 0
+
+(17) SortMergeJoin [codegen id : 7]
+Left keys [3]: [ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4]
+Right keys [3]: [sr_customer_sk#10, sr_item_sk#9, sr_ticket_number#11]
+Join type: Inner
+Join condition: None
+
+(18) Project [codegen id : 7]
+Output [6]: [ss_item_sk#1, ss_store_sk#3, ss_quantity#5, sr_item_sk#9, sr_customer_sk#10, sr_return_quantity#12]
+Input [9]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5, sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_return_quantity#12]
+
+(19) Exchange
+Input [6]: [ss_item_sk#1, ss_store_sk#3, ss_quantity#5, sr_item_sk#9, sr_customer_sk#10, sr_return_quantity#12]
+Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(20) Sort [codegen id : 8]
+Input [6]: [ss_item_sk#1, ss_store_sk#3, ss_quantity#5, sr_item_sk#9, sr_customer_sk#10, sr_return_quantity#12]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(15) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#11, i_item_id#12, i_item_desc#13]
+(21) Scan parquet spark_catalog.default.item
+Output [3]: [i_item_sk#16, i_item_id#17, i_item_desc#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string,i_item_desc:string>
 
-(16) ColumnarToRow [codegen id : 5]
-Input [3]: [i_item_sk#11, i_item_id#12, i_item_desc#13]
+(22) ColumnarToRow [codegen id : 9]
+Input [3]: [i_item_sk#16, i_item_id#17, i_item_desc#18]
 
-(17) Filter [codegen id : 5]
-Input [3]: [i_item_sk#11, i_item_id#12, i_item_desc#13]
-Condition : isnotnull(i_item_sk#11)
+(23) Filter [codegen id : 9]
+Input [3]: [i_item_sk#16, i_item_id#17, i_item_desc#18]
+Condition : isnotnull(i_item_sk#16)
 
-(18) Exchange
-Input [3]: [i_item_sk#11, i_item_id#12, i_item_desc#13]
-Arguments: hashpartitioning(i_item_sk#11, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+(24) Exchange
+Input [3]: [i_item_sk#16, i_item_id#17, i_item_desc#18]
+Arguments: hashpartitioning(i_item_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(19) Sort [codegen id : 6]
-Input [3]: [i_item_sk#11, i_item_id#12, i_item_desc#13]
-Arguments: [i_item_sk#11 ASC NULLS FIRST], false, 0
+(25) Sort [codegen id : 10]
+Input [3]: [i_item_sk#16, i_item_id#17, i_item_desc#18]
+Arguments: [i_item_sk#16 ASC NULLS FIRST], false, 0
 
-(20) SortMergeJoin [codegen id : 7]
+(26) SortMergeJoin [codegen id : 12]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#11]
+Right keys [1]: [i_item_sk#16]
 Join type: Inner
 Join condition: None
 
-(21) Project [codegen id : 7]
-Output [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#10, i_item_id#12, i_item_desc#13]
-Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#10, i_item_sk#11, i_item_id#12, i_item_desc#13]
+(27) Project [codegen id : 12]
+Output [7]: [ss_store_sk#3, ss_quantity#5, sr_item_sk#9, sr_customer_sk#10, sr_return_quantity#12, i_item_id#17, i_item_desc#18]
+Input [9]: [ss_item_sk#1, ss_store_sk#3, ss_quantity#5, sr_item_sk#9, sr_customer_sk#10, sr_return_quantity#12, i_item_sk#16, i_item_id#17, i_item_desc#18]
 
-(22) Exchange
-Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#10, i_item_id#12, i_item_desc#13]
-Arguments: hashpartitioning(ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(23) Sort [codegen id : 8]
-Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#10, i_item_id#12, i_item_desc#13]
-Arguments: [ss_customer_sk#2 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST, ss_ticket_number#4 ASC NULLS FIRST], false, 0
-
-(24) Scan parquet spark_catalog.default.store_returns
-Output [5]: [sr_item_sk#14, sr_customer_sk#15, sr_ticket_number#16, sr_return_quantity#17, sr_returned_date_sk#18]
+(28) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#19, s_state#20]
 Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(sr_returned_date_sk#18), dynamicpruningexpression(sr_returned_date_sk#18 IN dynamicpruning#19)]
-PushedFilters: [IsNotNull(sr_customer_sk), IsNotNull(sr_item_sk), IsNotNull(sr_ticket_number)]
-ReadSchema: struct<sr_item_sk:int,sr_customer_sk:int,sr_ticket_number:int,sr_return_quantity:int>
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [IsNotNull(s_store_sk)]
+ReadSchema: struct<s_store_sk:int,s_state:string>
 
-(25) ColumnarToRow [codegen id : 10]
-Input [5]: [sr_item_sk#14, sr_customer_sk#15, sr_ticket_number#16, sr_return_quantity#17, sr_returned_date_sk#18]
+(29) ColumnarToRow [codegen id : 11]
+Input [2]: [s_store_sk#19, s_state#20]
 
-(26) Filter [codegen id : 10]
-Input [5]: [sr_item_sk#14, sr_customer_sk#15, sr_ticket_number#16, sr_return_quantity#17, sr_returned_date_sk#18]
-Condition : ((isnotnull(sr_customer_sk#15) AND isnotnull(sr_item_sk#14)) AND isnotnull(sr_ticket_number#16))
+(30) Filter [codegen id : 11]
+Input [2]: [s_store_sk#19, s_state#20]
+Condition : isnotnull(s_store_sk#19)
 
-(27) ReusedExchange [Reuses operator id: 59]
-Output [1]: [d_date_sk#20]
+(31) BroadcastExchange
+Input [2]: [s_store_sk#19, s_state#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
 
-(28) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [sr_returned_date_sk#18]
-Right keys [1]: [d_date_sk#20]
-Join type: Inner
-Join condition: None
-
-(29) Project [codegen id : 10]
-Output [4]: [sr_item_sk#14, sr_customer_sk#15, sr_ticket_number#16, sr_return_quantity#17]
-Input [6]: [sr_item_sk#14, sr_customer_sk#15, sr_ticket_number#16, sr_return_quantity#17, sr_returned_date_sk#18, d_date_sk#20]
-
-(30) Exchange
-Input [4]: [sr_item_sk#14, sr_customer_sk#15, sr_ticket_number#16, sr_return_quantity#17]
-Arguments: hashpartitioning(sr_customer_sk#15, sr_item_sk#14, sr_ticket_number#16, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(31) Sort [codegen id : 11]
-Input [4]: [sr_item_sk#14, sr_customer_sk#15, sr_ticket_number#16, sr_return_quantity#17]
-Arguments: [sr_customer_sk#15 ASC NULLS FIRST, sr_item_sk#14 ASC NULLS FIRST, sr_ticket_number#16 ASC NULLS FIRST], false, 0
-
-(32) SortMergeJoin [codegen id : 12]
-Left keys [3]: [ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4]
-Right keys [3]: [sr_customer_sk#15, sr_item_sk#14, sr_ticket_number#16]
+(32) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [ss_store_sk#3]
+Right keys [1]: [s_store_sk#19]
 Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 12]
-Output [7]: [ss_quantity#5, s_state#10, i_item_id#12, i_item_desc#13, sr_item_sk#14, sr_customer_sk#15, sr_return_quantity#17]
-Input [11]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_state#10, i_item_id#12, i_item_desc#13, sr_item_sk#14, sr_customer_sk#15, sr_ticket_number#16, sr_return_quantity#17]
+Output [7]: [ss_quantity#5, sr_item_sk#9, sr_customer_sk#10, sr_return_quantity#12, i_item_id#17, i_item_desc#18, s_state#20]
+Input [9]: [ss_store_sk#3, ss_quantity#5, sr_item_sk#9, sr_customer_sk#10, sr_return_quantity#12, i_item_id#17, i_item_desc#18, s_store_sk#19, s_state#20]
 
 (34) Exchange
-Input [7]: [ss_quantity#5, s_state#10, i_item_id#12, i_item_desc#13, sr_item_sk#14, sr_customer_sk#15, sr_return_quantity#17]
-Arguments: hashpartitioning(sr_customer_sk#15, sr_item_sk#14, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [7]: [ss_quantity#5, sr_item_sk#9, sr_customer_sk#10, sr_return_quantity#12, i_item_id#17, i_item_desc#18, s_state#20]
+Arguments: hashpartitioning(sr_customer_sk#10, sr_item_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (35) Sort [codegen id : 13]
-Input [7]: [ss_quantity#5, s_state#10, i_item_id#12, i_item_desc#13, sr_item_sk#14, sr_customer_sk#15, sr_return_quantity#17]
-Arguments: [sr_customer_sk#15 ASC NULLS FIRST, sr_item_sk#14 ASC NULLS FIRST], false, 0
+Input [7]: [ss_quantity#5, sr_item_sk#9, sr_customer_sk#10, sr_return_quantity#12, i_item_id#17, i_item_desc#18, s_state#20]
+Arguments: [sr_customer_sk#10 ASC NULLS FIRST, sr_item_sk#9 ASC NULLS FIRST], false, 0
 
 (36) Scan parquet spark_catalog.default.catalog_sales
 Output [4]: [cs_bill_customer_sk#21, cs_item_sk#22, cs_quantity#23, cs_sold_date_sk#24]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#24), dynamicpruningexpression(cs_sold_date_sk#24 IN dynamicpruning#19)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#24), dynamicpruningexpression(cs_sold_date_sk#24 IN dynamicpruning#14)]
 PushedFilters: [IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int,cs_item_sk:int,cs_quantity:int>
 
@@ -245,36 +245,36 @@ Input [3]: [cs_bill_customer_sk#21, cs_item_sk#22, cs_quantity#23]
 Arguments: [cs_bill_customer_sk#21 ASC NULLS FIRST, cs_item_sk#22 ASC NULLS FIRST], false, 0
 
 (44) SortMergeJoin [codegen id : 17]
-Left keys [2]: [sr_customer_sk#15, sr_item_sk#14]
+Left keys [2]: [sr_customer_sk#10, sr_item_sk#9]
 Right keys [2]: [cs_bill_customer_sk#21, cs_item_sk#22]
 Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 17]
-Output [6]: [ss_quantity#5, sr_return_quantity#17, cs_quantity#23, s_state#10, i_item_id#12, i_item_desc#13]
-Input [10]: [ss_quantity#5, s_state#10, i_item_id#12, i_item_desc#13, sr_item_sk#14, sr_customer_sk#15, sr_return_quantity#17, cs_bill_customer_sk#21, cs_item_sk#22, cs_quantity#23]
+Output [6]: [ss_quantity#5, sr_return_quantity#12, cs_quantity#23, s_state#20, i_item_id#17, i_item_desc#18]
+Input [10]: [ss_quantity#5, sr_item_sk#9, sr_customer_sk#10, sr_return_quantity#12, i_item_id#17, i_item_desc#18, s_state#20, cs_bill_customer_sk#21, cs_item_sk#22, cs_quantity#23]
 
 (46) HashAggregate [codegen id : 17]
-Input [6]: [ss_quantity#5, sr_return_quantity#17, cs_quantity#23, s_state#10, i_item_id#12, i_item_desc#13]
-Keys [3]: [i_item_id#12, i_item_desc#13, s_state#10]
-Functions [9]: [partial_count(ss_quantity#5), partial_avg(ss_quantity#5), partial_stddev_samp(cast(ss_quantity#5 as double)), partial_count(sr_return_quantity#17), partial_avg(sr_return_quantity#17), partial_stddev_samp(cast(sr_return_quantity#17 as double)), partial_count(cs_quantity#23), partial_avg(cs_quantity#23), partial_stddev_samp(cast(cs_quantity#23 as double))]
+Input [6]: [ss_quantity#5, sr_return_quantity#12, cs_quantity#23, s_state#20, i_item_id#17, i_item_desc#18]
+Keys [3]: [i_item_id#17, i_item_desc#18, s_state#20]
+Functions [9]: [partial_count(ss_quantity#5), partial_avg(ss_quantity#5), partial_stddev_samp(cast(ss_quantity#5 as double)), partial_count(sr_return_quantity#12), partial_avg(sr_return_quantity#12), partial_stddev_samp(cast(sr_return_quantity#12 as double)), partial_count(cs_quantity#23), partial_avg(cs_quantity#23), partial_stddev_samp(cast(cs_quantity#23 as double))]
 Aggregate Attributes [18]: [count#26, sum#27, count#28, n#29, avg#30, m2#31, count#32, sum#33, count#34, n#35, avg#36, m2#37, count#38, sum#39, count#40, n#41, avg#42, m2#43]
-Results [21]: [i_item_id#12, i_item_desc#13, s_state#10, count#44, sum#45, count#46, n#47, avg#48, m2#49, count#50, sum#51, count#52, n#53, avg#54, m2#55, count#56, sum#57, count#58, n#59, avg#60, m2#61]
+Results [21]: [i_item_id#17, i_item_desc#18, s_state#20, count#44, sum#45, count#46, n#47, avg#48, m2#49, count#50, sum#51, count#52, n#53, avg#54, m2#55, count#56, sum#57, count#58, n#59, avg#60, m2#61]
 
 (47) Exchange
-Input [21]: [i_item_id#12, i_item_desc#13, s_state#10, count#44, sum#45, count#46, n#47, avg#48, m2#49, count#50, sum#51, count#52, n#53, avg#54, m2#55, count#56, sum#57, count#58, n#59, avg#60, m2#61]
-Arguments: hashpartitioning(i_item_id#12, i_item_desc#13, s_state#10, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [21]: [i_item_id#17, i_item_desc#18, s_state#20, count#44, sum#45, count#46, n#47, avg#48, m2#49, count#50, sum#51, count#52, n#53, avg#54, m2#55, count#56, sum#57, count#58, n#59, avg#60, m2#61]
+Arguments: hashpartitioning(i_item_id#17, i_item_desc#18, s_state#20, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (48) HashAggregate [codegen id : 18]
-Input [21]: [i_item_id#12, i_item_desc#13, s_state#10, count#44, sum#45, count#46, n#47, avg#48, m2#49, count#50, sum#51, count#52, n#53, avg#54, m2#55, count#56, sum#57, count#58, n#59, avg#60, m2#61]
-Keys [3]: [i_item_id#12, i_item_desc#13, s_state#10]
-Functions [9]: [count(ss_quantity#5), avg(ss_quantity#5), stddev_samp(cast(ss_quantity#5 as double)), count(sr_return_quantity#17), avg(sr_return_quantity#17), stddev_samp(cast(sr_return_quantity#17 as double)), count(cs_quantity#23), avg(cs_quantity#23), stddev_samp(cast(cs_quantity#23 as double))]
-Aggregate Attributes [9]: [count(ss_quantity#5)#62, avg(ss_quantity#5)#63, stddev_samp(cast(ss_quantity#5 as double))#64, count(sr_return_quantity#17)#65, avg(sr_return_quantity#17)#66, stddev_samp(cast(sr_return_quantity#17 as double))#67, count(cs_quantity#23)#68, avg(cs_quantity#23)#69, stddev_samp(cast(cs_quantity#23 as double))#70]
-Results [15]: [i_item_id#12, i_item_desc#13, s_state#10, count(ss_quantity#5)#62 AS store_sales_quantitycount#71, avg(ss_quantity#5)#63 AS store_sales_quantityave#72, stddev_samp(cast(ss_quantity#5 as double))#64 AS store_sales_quantitystdev#73, (stddev_samp(cast(ss_quantity#5 as double))#64 / avg(ss_quantity#5)#63) AS store_sales_quantitycov#74, count(sr_return_quantity#17)#65 AS as_store_returns_quantitycount#75, avg(sr_return_quantity#17)#66 AS as_store_returns_quantityave#76, stddev_samp(cast(sr_return_quantity#17 as double))#67 AS as_store_returns_quantitystdev#77, (stddev_samp(cast(sr_return_quantity#17 as double))#67 / avg(sr_return_quantity#17)#66) AS store_returns_quantitycov#78, count(cs_quantity#23)#68 AS catalog_sales_quantitycount#79, avg(cs_quantity#23)#69 AS catalog_sales_quantityave#80, (stddev_samp(cast(cs_quantity#23 as double))#70 / avg(cs_quantity#23)#69) AS catalog_sales_quantitystdev#81, (stddev_samp(cast(cs_quantity#23 as double))#70 / avg(cs_quantity#23)#69) AS catalog_sales_quantitycov#82]
+Input [21]: [i_item_id#17, i_item_desc#18, s_state#20, count#44, sum#45, count#46, n#47, avg#48, m2#49, count#50, sum#51, count#52, n#53, avg#54, m2#55, count#56, sum#57, count#58, n#59, avg#60, m2#61]
+Keys [3]: [i_item_id#17, i_item_desc#18, s_state#20]
+Functions [9]: [count(ss_quantity#5), avg(ss_quantity#5), stddev_samp(cast(ss_quantity#5 as double)), count(sr_return_quantity#12), avg(sr_return_quantity#12), stddev_samp(cast(sr_return_quantity#12 as double)), count(cs_quantity#23), avg(cs_quantity#23), stddev_samp(cast(cs_quantity#23 as double))]
+Aggregate Attributes [9]: [count(ss_quantity#5)#62, avg(ss_quantity#5)#63, stddev_samp(cast(ss_quantity#5 as double))#64, count(sr_return_quantity#12)#65, avg(sr_return_quantity#12)#66, stddev_samp(cast(sr_return_quantity#12 as double))#67, count(cs_quantity#23)#68, avg(cs_quantity#23)#69, stddev_samp(cast(cs_quantity#23 as double))#70]
+Results [15]: [i_item_id#17, i_item_desc#18, s_state#20, count(ss_quantity#5)#62 AS store_sales_quantitycount#71, avg(ss_quantity#5)#63 AS store_sales_quantityave#72, stddev_samp(cast(ss_quantity#5 as double))#64 AS store_sales_quantitystdev#73, (stddev_samp(cast(ss_quantity#5 as double))#64 / avg(ss_quantity#5)#63) AS store_sales_quantitycov#74, count(sr_return_quantity#12)#65 AS as_store_returns_quantitycount#75, avg(sr_return_quantity#12)#66 AS as_store_returns_quantityave#76, stddev_samp(cast(sr_return_quantity#12 as double))#67 AS as_store_returns_quantitystdev#77, (stddev_samp(cast(sr_return_quantity#12 as double))#67 / avg(sr_return_quantity#12)#66) AS store_returns_quantitycov#78, count(cs_quantity#23)#68 AS catalog_sales_quantitycount#79, avg(cs_quantity#23)#69 AS catalog_sales_quantityave#80, (stddev_samp(cast(cs_quantity#23 as double))#70 / avg(cs_quantity#23)#69) AS catalog_sales_quantitystdev#81, (stddev_samp(cast(cs_quantity#23 as double))#70 / avg(cs_quantity#23)#69) AS catalog_sales_quantitycov#82]
 
 (49) TakeOrderedAndProject
-Input [15]: [i_item_id#12, i_item_desc#13, s_state#10, store_sales_quantitycount#71, store_sales_quantityave#72, store_sales_quantitystdev#73, store_sales_quantitycov#74, as_store_returns_quantitycount#75, as_store_returns_quantityave#76, as_store_returns_quantitystdev#77, store_returns_quantitycov#78, catalog_sales_quantitycount#79, catalog_sales_quantityave#80, catalog_sales_quantitystdev#81, catalog_sales_quantitycov#82]
-Arguments: 100, [i_item_id#12 ASC NULLS FIRST, i_item_desc#13 ASC NULLS FIRST, s_state#10 ASC NULLS FIRST], [i_item_id#12, i_item_desc#13, s_state#10, store_sales_quantitycount#71, store_sales_quantityave#72, store_sales_quantitystdev#73, store_sales_quantitycov#74, as_store_returns_quantitycount#75, as_store_returns_quantityave#76, as_store_returns_quantitystdev#77, store_returns_quantitycov#78, catalog_sales_quantitycount#79, catalog_sales_quantityave#80, catalog_sales_quantitystdev#81, catalog_sales_quantitycov#82]
+Input [15]: [i_item_id#17, i_item_desc#18, s_state#20, store_sales_quantitycount#71, store_sales_quantityave#72, store_sales_quantitystdev#73, store_sales_quantitycov#74, as_store_returns_quantitycount#75, as_store_returns_quantityave#76, as_store_returns_quantitystdev#77, store_returns_quantitycov#78, catalog_sales_quantitycount#79, catalog_sales_quantityave#80, catalog_sales_quantitystdev#81, catalog_sales_quantitycov#82]
+Arguments: 100, [i_item_id#17 ASC NULLS FIRST, i_item_desc#18 ASC NULLS FIRST, s_state#20 ASC NULLS FIRST], [i_item_id#17, i_item_desc#18, s_state#20, store_sales_quantitycount#71, store_sales_quantityave#72, store_sales_quantitystdev#73, store_sales_quantitycov#74, as_store_returns_quantitycount#75, as_store_returns_quantityave#76, as_store_returns_quantitystdev#77, store_returns_quantitycov#78, catalog_sales_quantitycount#79, catalog_sales_quantityave#80, catalog_sales_quantitystdev#81, catalog_sales_quantitycov#82]
 
 ===== Subqueries =====
 
@@ -308,7 +308,7 @@ Input [2]: [d_date_sk#8, d_quarter_name#83]
 Input [1]: [d_date_sk#8]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
-Subquery:2 Hosting operator id = 24 Hosting Expression = sr_returned_date_sk#18 IN dynamicpruning#19
+Subquery:2 Hosting operator id = 9 Hosting Expression = sr_returned_date_sk#13 IN dynamicpruning#14
 BroadcastExchange (59)
 +- * Project (58)
    +- * Filter (57)
@@ -317,27 +317,27 @@ BroadcastExchange (59)
 
 
 (55) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#20, d_quarter_name#84]
+Output [2]: [d_date_sk#15, d_quarter_name#84]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_quarter_name, [2001Q1,2001Q2,2001Q3]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_quarter_name:string>
 
 (56) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#20, d_quarter_name#84]
+Input [2]: [d_date_sk#15, d_quarter_name#84]
 
 (57) Filter [codegen id : 1]
-Input [2]: [d_date_sk#20, d_quarter_name#84]
-Condition : (d_quarter_name#84 IN (2001Q1,2001Q2,2001Q3) AND isnotnull(d_date_sk#20))
+Input [2]: [d_date_sk#15, d_quarter_name#84]
+Condition : (d_quarter_name#84 IN (2001Q1,2001Q2,2001Q3) AND isnotnull(d_date_sk#15))
 
 (58) Project [codegen id : 1]
-Output [1]: [d_date_sk#20]
-Input [2]: [d_date_sk#20, d_quarter_name#84]
+Output [1]: [d_date_sk#15]
+Input [2]: [d_date_sk#15, d_quarter_name#84]
 
 (59) BroadcastExchange
-Input [1]: [d_date_sk#20]
+Input [1]: [d_date_sk#15]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
-Subquery:3 Hosting operator id = 36 Hosting Expression = cs_sold_date_sk#24 IN dynamicpruning#19
+Subquery:3 Hosting operator id = 36 Hosting Expression = cs_sold_date_sk#24 IN dynamicpruning#14
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q17.sf100/simplified.txt
@@ -13,24 +13,24 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_state,store_sales_quantitycount,s
                         InputAdapter
                           Exchange [sr_customer_sk,sr_item_sk] #2
                             WholeStageCodegen (12)
-                              Project [ss_quantity,s_state,i_item_id,i_item_desc,sr_item_sk,sr_customer_sk,sr_return_quantity]
-                                SortMergeJoin [ss_customer_sk,ss_item_sk,ss_ticket_number,sr_customer_sk,sr_item_sk,sr_ticket_number]
-                                  InputAdapter
-                                    WholeStageCodegen (8)
-                                      Sort [ss_customer_sk,ss_item_sk,ss_ticket_number]
-                                        InputAdapter
-                                          Exchange [ss_customer_sk,ss_item_sk,ss_ticket_number] #3
-                                            WholeStageCodegen (7)
-                                              Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_quantity,s_state,i_item_id,i_item_desc]
-                                                SortMergeJoin [ss_item_sk,i_item_sk]
-                                                  InputAdapter
-                                                    WholeStageCodegen (4)
-                                                      Sort [ss_item_sk]
-                                                        InputAdapter
-                                                          Exchange [ss_item_sk] #4
-                                                            WholeStageCodegen (3)
-                                                              Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_quantity,s_state]
-                                                                BroadcastHashJoin [ss_store_sk,s_store_sk]
+                              Project [ss_quantity,sr_item_sk,sr_customer_sk,sr_return_quantity,i_item_id,i_item_desc,s_state]
+                                BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                  Project [ss_store_sk,ss_quantity,sr_item_sk,sr_customer_sk,sr_return_quantity,i_item_id,i_item_desc]
+                                    SortMergeJoin [ss_item_sk,i_item_sk]
+                                      InputAdapter
+                                        WholeStageCodegen (8)
+                                          Sort [ss_item_sk]
+                                            InputAdapter
+                                              Exchange [ss_item_sk] #3
+                                                WholeStageCodegen (7)
+                                                  Project [ss_item_sk,ss_store_sk,ss_quantity,sr_item_sk,sr_customer_sk,sr_return_quantity]
+                                                    SortMergeJoin [ss_customer_sk,ss_item_sk,ss_ticket_number,sr_customer_sk,sr_item_sk,sr_ticket_number]
+                                                      InputAdapter
+                                                        WholeStageCodegen (3)
+                                                          Sort [ss_customer_sk,ss_item_sk,ss_ticket_number]
+                                                            InputAdapter
+                                                              Exchange [ss_customer_sk,ss_item_sk,ss_ticket_number] #4
+                                                                WholeStageCodegen (2)
                                                                   Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_quantity]
                                                                     BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                       Filter [ss_customer_sk,ss_item_sk,ss_ticket_number,ss_store_sk]
@@ -47,45 +47,45 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_state,store_sales_quantitycount,s
                                                                                             Scan parquet spark_catalog.default.date_dim [d_date_sk,d_quarter_name]
                                                                       InputAdapter
                                                                         ReusedExchange [d_date_sk] #5
-                                                                  InputAdapter
-                                                                    BroadcastExchange #6
-                                                                      WholeStageCodegen (2)
-                                                                        Filter [s_store_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet spark_catalog.default.store [s_store_sk,s_state]
-                                                  InputAdapter
-                                                    WholeStageCodegen (6)
-                                                      Sort [i_item_sk]
-                                                        InputAdapter
-                                                          Exchange [i_item_sk] #7
-                                                            WholeStageCodegen (5)
-                                                              Filter [i_item_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc]
-                                  InputAdapter
-                                    WholeStageCodegen (11)
-                                      Sort [sr_customer_sk,sr_item_sk,sr_ticket_number]
-                                        InputAdapter
-                                          Exchange [sr_customer_sk,sr_item_sk,sr_ticket_number] #8
-                                            WholeStageCodegen (10)
-                                              Project [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_return_quantity]
-                                                BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
-                                                  Filter [sr_customer_sk,sr_item_sk,sr_ticket_number]
+                                                      InputAdapter
+                                                        WholeStageCodegen (6)
+                                                          Sort [sr_customer_sk,sr_item_sk,sr_ticket_number]
+                                                            InputAdapter
+                                                              Exchange [sr_customer_sk,sr_item_sk,sr_ticket_number] #6
+                                                                WholeStageCodegen (5)
+                                                                  Project [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_return_quantity]
+                                                                    BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
+                                                                      Filter [sr_customer_sk,sr_item_sk,sr_ticket_number]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_return_quantity,sr_returned_date_sk]
+                                                                              SubqueryBroadcast [d_date_sk] #2
+                                                                                BroadcastExchange #7
+                                                                                  WholeStageCodegen (1)
+                                                                                    Project [d_date_sk]
+                                                                                      Filter [d_quarter_name,d_date_sk]
+                                                                                        ColumnarToRow
+                                                                                          InputAdapter
+                                                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_quarter_name]
+                                                                      InputAdapter
+                                                                        ReusedExchange [d_date_sk] #7
+                                      InputAdapter
+                                        WholeStageCodegen (10)
+                                          Sort [i_item_sk]
+                                            InputAdapter
+                                              Exchange [i_item_sk] #8
+                                                WholeStageCodegen (9)
+                                                  Filter [i_item_sk]
                                                     ColumnarToRow
                                                       InputAdapter
-                                                        Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_return_quantity,sr_returned_date_sk]
-                                                          SubqueryBroadcast [d_date_sk] #2
-                                                            BroadcastExchange #9
-                                                              WholeStageCodegen (1)
-                                                                Project [d_date_sk]
-                                                                  Filter [d_quarter_name,d_date_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_quarter_name]
-                                                  InputAdapter
-                                                    ReusedExchange [d_date_sk] #9
+                                                        Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc]
+                                  InputAdapter
+                                    BroadcastExchange #9
+                                      WholeStageCodegen (11)
+                                        Filter [s_store_sk]
+                                          ColumnarToRow
+                                            InputAdapter
+                                              Scan parquet spark_catalog.default.store [s_store_sk,s_state]
                   InputAdapter
                     WholeStageCodegen (16)
                       Sort [cs_bill_customer_sk,cs_item_sk]
@@ -100,4 +100,4 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_state,store_sales_quantitycount,s
                                         Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_sold_date_sk]
                                           ReusedSubquery [d_date_sk] #2
                                   InputAdapter
-                                    ReusedExchange [d_date_sk] #9
+                                    ReusedExchange [d_date_sk] #7

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q18.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q18.sf100/explain.txt
@@ -12,17 +12,17 @@ TakeOrderedAndProject (49)
                   :        +- * BroadcastHashJoin Inner BuildRight (18)
                   :           :- * Project (13)
                   :           :  +- * BroadcastHashJoin Inner BuildRight (12)
-                  :           :     :- * Project (10)
-                  :           :     :  +- * BroadcastHashJoin Inner BuildRight (9)
+                  :           :     :- * Project (6)
+                  :           :     :  +- * BroadcastHashJoin Inner BuildRight (5)
                   :           :     :     :- * Filter (3)
                   :           :     :     :  +- * ColumnarToRow (2)
                   :           :     :     :     +- Scan parquet spark_catalog.default.catalog_sales (1)
-                  :           :     :     +- BroadcastExchange (8)
-                  :           :     :        +- * Project (7)
-                  :           :     :           +- * Filter (6)
-                  :           :     :              +- * ColumnarToRow (5)
-                  :           :     :                 +- Scan parquet spark_catalog.default.customer_demographics (4)
-                  :           :     +- ReusedExchange (11)
+                  :           :     :     +- ReusedExchange (4)
+                  :           :     +- BroadcastExchange (11)
+                  :           :        +- * Project (10)
+                  :           :           +- * Filter (9)
+                  :           :              +- * ColumnarToRow (8)
+                  :           :                 +- Scan parquet spark_catalog.default.customer_demographics (7)
                   :           +- BroadcastExchange (17)
                   :              +- * Filter (16)
                   :                 +- * ColumnarToRow (15)
@@ -65,50 +65,50 @@ Input [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity
 Input [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9]
 Condition : ((isnotnull(cs_bill_cdemo_sk#2) AND isnotnull(cs_bill_customer_sk#1)) AND isnotnull(cs_item_sk#3))
 
-(4) Scan parquet spark_catalog.default.customer_demographics
-Output [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
+(4) ReusedExchange [Reuses operator id: 54]
+Output [1]: [d_date_sk#11]
+
+(5) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [cs_sold_date_sk#9]
+Right keys [1]: [d_date_sk#11]
+Join type: Inner
+Join condition: None
+
+(6) Project [codegen id : 4]
+Output [8]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8]
+Input [10]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, d_date_sk#11]
+
+(7) Scan parquet spark_catalog.default.customer_demographics
+Output [4]: [cd_demo_sk#12, cd_gender#13, cd_education_status#14, cd_dep_count#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_gender), IsNotNull(cd_education_status), EqualTo(cd_gender,F), EqualTo(cd_education_status,Unknown             ), IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_education_status:string,cd_dep_count:int>
 
-(5) ColumnarToRow [codegen id : 1]
-Input [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
+(8) ColumnarToRow [codegen id : 2]
+Input [4]: [cd_demo_sk#12, cd_gender#13, cd_education_status#14, cd_dep_count#15]
 
-(6) Filter [codegen id : 1]
-Input [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
-Condition : ((((isnotnull(cd_gender#12) AND isnotnull(cd_education_status#13)) AND (cd_gender#12 = F)) AND (cd_education_status#13 = Unknown             )) AND isnotnull(cd_demo_sk#11))
+(9) Filter [codegen id : 2]
+Input [4]: [cd_demo_sk#12, cd_gender#13, cd_education_status#14, cd_dep_count#15]
+Condition : ((((isnotnull(cd_gender#13) AND isnotnull(cd_education_status#14)) AND (cd_gender#13 = F)) AND (cd_education_status#14 = Unknown             )) AND isnotnull(cd_demo_sk#12))
 
-(7) Project [codegen id : 1]
-Output [2]: [cd_demo_sk#11, cd_dep_count#14]
-Input [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
+(10) Project [codegen id : 2]
+Output [2]: [cd_demo_sk#12, cd_dep_count#15]
+Input [4]: [cd_demo_sk#12, cd_gender#13, cd_education_status#14, cd_dep_count#15]
 
-(8) BroadcastExchange
-Input [2]: [cd_demo_sk#11, cd_dep_count#14]
+(11) BroadcastExchange
+Input [2]: [cd_demo_sk#12, cd_dep_count#15]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(9) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [cs_bill_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#11]
-Join type: Inner
-Join condition: None
-
-(10) Project [codegen id : 4]
-Output [9]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#14]
-Input [11]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_demo_sk#11, cd_dep_count#14]
-
-(11) ReusedExchange [Reuses operator id: 54]
-Output [1]: [d_date_sk#15]
-
 (12) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [cs_sold_date_sk#9]
-Right keys [1]: [d_date_sk#15]
+Left keys [1]: [cs_bill_cdemo_sk#2]
+Right keys [1]: [cd_demo_sk#12]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
-Output [8]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14]
-Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#14, d_date_sk#15]
+Output [8]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#15]
+Input [10]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_demo_sk#12, cd_dep_count#15]
 
 (14) Scan parquet spark_catalog.default.item
 Output [2]: [i_item_sk#16, i_item_id#17]
@@ -135,15 +135,15 @@ Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]
-Output [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17]
-Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_sk#16, i_item_id#17]
+Output [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#15, i_item_id#17]
+Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#15, i_item_sk#16, i_item_id#17]
 
 (20) Exchange
-Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17]
+Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#15, i_item_id#17]
 Arguments: hashpartitioning(cs_bill_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (21) Sort [codegen id : 5]
-Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17]
+Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#15, i_item_id#17]
 Arguments: [cs_bill_customer_sk#1 ASC NULLS FIRST], false, 0
 
 (22) Scan parquet spark_catalog.default.customer
@@ -247,17 +247,17 @@ Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 13]
-Output [11]: [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#17, ca_country#26, ca_state#25, ca_county#24]
-Input [13]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17, c_customer_sk#18, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
+Output [11]: [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#15, c_birth_year#22, i_item_id#17, ca_country#26, ca_state#25, ca_county#24]
+Input [13]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#15, i_item_id#17, c_customer_sk#18, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
 
 (45) Expand [codegen id : 13]
-Input [11]: [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#17, ca_country#26, ca_state#25, ca_county#24]
-Arguments: [[cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#17, ca_country#26, ca_state#25, ca_county#24, 0], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#17, ca_country#26, ca_state#25, null, 1], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#17, ca_country#26, null, null, 3], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#17, null, null, null, 7], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, null, null, null, null, 15]], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32]
+Input [11]: [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#15, c_birth_year#22, i_item_id#17, ca_country#26, ca_state#25, ca_county#24]
+Arguments: [[cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#15, c_birth_year#22, i_item_id#17, ca_country#26, ca_state#25, ca_county#24, 0], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#15, c_birth_year#22, i_item_id#17, ca_country#26, ca_state#25, null, 1], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#15, c_birth_year#22, i_item_id#17, ca_country#26, null, null, 3], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#15, c_birth_year#22, i_item_id#17, null, null, null, 7], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#15, c_birth_year#22, null, null, null, null, 15]], [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#15, c_birth_year#22, i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32]
 
 (46) HashAggregate [codegen id : 13]
-Input [12]: [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, c_birth_year#22, i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32]
+Input [12]: [cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#15, c_birth_year#22, i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32]
 Keys [5]: [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32]
-Functions [7]: [partial_avg(cast(cs_quantity#4 as decimal(12,2))), partial_avg(cast(cs_list_price#5 as decimal(12,2))), partial_avg(cast(cs_coupon_amt#7 as decimal(12,2))), partial_avg(cast(cs_sales_price#6 as decimal(12,2))), partial_avg(cast(cs_net_profit#8 as decimal(12,2))), partial_avg(cast(c_birth_year#22 as decimal(12,2))), partial_avg(cast(cd_dep_count#14 as decimal(12,2)))]
+Functions [7]: [partial_avg(cast(cs_quantity#4 as decimal(12,2))), partial_avg(cast(cs_list_price#5 as decimal(12,2))), partial_avg(cast(cs_coupon_amt#7 as decimal(12,2))), partial_avg(cast(cs_sales_price#6 as decimal(12,2))), partial_avg(cast(cs_net_profit#8 as decimal(12,2))), partial_avg(cast(c_birth_year#22 as decimal(12,2))), partial_avg(cast(cd_dep_count#15 as decimal(12,2)))]
 Aggregate Attributes [14]: [sum#33, count#34, sum#35, count#36, sum#37, count#38, sum#39, count#40, sum#41, count#42, sum#43, count#44, sum#45, count#46]
 Results [19]: [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32, sum#47, count#48, sum#49, count#50, sum#51, count#52, sum#53, count#54, sum#55, count#56, sum#57, count#58, sum#59, count#60]
 
@@ -268,9 +268,9 @@ Arguments: hashpartitioning(i_item_id#28, ca_country#29, ca_state#30, ca_county#
 (48) HashAggregate [codegen id : 14]
 Input [19]: [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32, sum#47, count#48, sum#49, count#50, sum#51, count#52, sum#53, count#54, sum#55, count#56, sum#57, count#58, sum#59, count#60]
 Keys [5]: [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, spark_grouping_id#32]
-Functions [7]: [avg(cast(cs_quantity#4 as decimal(12,2))), avg(cast(cs_list_price#5 as decimal(12,2))), avg(cast(cs_coupon_amt#7 as decimal(12,2))), avg(cast(cs_sales_price#6 as decimal(12,2))), avg(cast(cs_net_profit#8 as decimal(12,2))), avg(cast(c_birth_year#22 as decimal(12,2))), avg(cast(cd_dep_count#14 as decimal(12,2)))]
-Aggregate Attributes [7]: [avg(cast(cs_quantity#4 as decimal(12,2)))#61, avg(cast(cs_list_price#5 as decimal(12,2)))#62, avg(cast(cs_coupon_amt#7 as decimal(12,2)))#63, avg(cast(cs_sales_price#6 as decimal(12,2)))#64, avg(cast(cs_net_profit#8 as decimal(12,2)))#65, avg(cast(c_birth_year#22 as decimal(12,2)))#66, avg(cast(cd_dep_count#14 as decimal(12,2)))#67]
-Results [11]: [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, avg(cast(cs_quantity#4 as decimal(12,2)))#61 AS agg1#68, avg(cast(cs_list_price#5 as decimal(12,2)))#62 AS agg2#69, avg(cast(cs_coupon_amt#7 as decimal(12,2)))#63 AS agg3#70, avg(cast(cs_sales_price#6 as decimal(12,2)))#64 AS agg4#71, avg(cast(cs_net_profit#8 as decimal(12,2)))#65 AS agg5#72, avg(cast(c_birth_year#22 as decimal(12,2)))#66 AS agg6#73, avg(cast(cd_dep_count#14 as decimal(12,2)))#67 AS agg7#74]
+Functions [7]: [avg(cast(cs_quantity#4 as decimal(12,2))), avg(cast(cs_list_price#5 as decimal(12,2))), avg(cast(cs_coupon_amt#7 as decimal(12,2))), avg(cast(cs_sales_price#6 as decimal(12,2))), avg(cast(cs_net_profit#8 as decimal(12,2))), avg(cast(c_birth_year#22 as decimal(12,2))), avg(cast(cd_dep_count#15 as decimal(12,2)))]
+Aggregate Attributes [7]: [avg(cast(cs_quantity#4 as decimal(12,2)))#61, avg(cast(cs_list_price#5 as decimal(12,2)))#62, avg(cast(cs_coupon_amt#7 as decimal(12,2)))#63, avg(cast(cs_sales_price#6 as decimal(12,2)))#64, avg(cast(cs_net_profit#8 as decimal(12,2)))#65, avg(cast(c_birth_year#22 as decimal(12,2)))#66, avg(cast(cd_dep_count#15 as decimal(12,2)))#67]
+Results [11]: [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, avg(cast(cs_quantity#4 as decimal(12,2)))#61 AS agg1#68, avg(cast(cs_list_price#5 as decimal(12,2)))#62 AS agg2#69, avg(cast(cs_coupon_amt#7 as decimal(12,2)))#63 AS agg3#70, avg(cast(cs_sales_price#6 as decimal(12,2)))#64 AS agg4#71, avg(cast(cs_net_profit#8 as decimal(12,2)))#65 AS agg5#72, avg(cast(c_birth_year#22 as decimal(12,2)))#66 AS agg6#73, avg(cast(cd_dep_count#15 as decimal(12,2)))#67 AS agg7#74]
 
 (49) TakeOrderedAndProject
 Input [11]: [i_item_id#28, ca_country#29, ca_state#30, ca_county#31, agg1#68, agg2#69, agg3#70, agg4#71, agg5#72, agg6#73, agg7#74]
@@ -287,25 +287,25 @@ BroadcastExchange (54)
 
 
 (50) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#15, d_year#75]
+Output [2]: [d_date_sk#11, d_year#75]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,1998), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (51) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#15, d_year#75]
+Input [2]: [d_date_sk#11, d_year#75]
 
 (52) Filter [codegen id : 1]
-Input [2]: [d_date_sk#15, d_year#75]
-Condition : ((isnotnull(d_year#75) AND (d_year#75 = 1998)) AND isnotnull(d_date_sk#15))
+Input [2]: [d_date_sk#11, d_year#75]
+Condition : ((isnotnull(d_year#75) AND (d_year#75 = 1998)) AND isnotnull(d_date_sk#11))
 
 (53) Project [codegen id : 1]
-Output [1]: [d_date_sk#15]
-Input [2]: [d_date_sk#15, d_year#75]
+Output [1]: [d_date_sk#11]
+Input [2]: [d_date_sk#11, d_year#75]
 
 (54) BroadcastExchange
-Input [1]: [d_date_sk#15]
+Input [1]: [d_date_sk#11]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q18.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q18.sf100/simplified.txt
@@ -17,9 +17,9 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                 Project [cs_bill_customer_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cd_dep_count,i_item_id]
                                   BroadcastHashJoin [cs_item_sk,i_item_sk]
                                     Project [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cd_dep_count]
-                                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                        Project [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk,cd_dep_count]
-                                          BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
+                                      BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
+                                        Project [cs_bill_customer_sk,cs_bill_cdemo_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit]
+                                          BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                             Filter [cs_bill_cdemo_sk,cs_bill_customer_sk,cs_item_sk]
                                               ColumnarToRow
                                                 InputAdapter
@@ -33,15 +33,15 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                             InputAdapter
-                                              BroadcastExchange #4
-                                                WholeStageCodegen (1)
-                                                  Project [cd_demo_sk,cd_dep_count]
-                                                    Filter [cd_gender,cd_education_status,cd_demo_sk]
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_education_status,cd_dep_count]
+                                              ReusedExchange [d_date_sk] #3
                                         InputAdapter
-                                          ReusedExchange [d_date_sk] #3
+                                          BroadcastExchange #4
+                                            WholeStageCodegen (2)
+                                              Project [cd_demo_sk,cd_dep_count]
+                                                Filter [cd_gender,cd_education_status,cd_demo_sk]
+                                                  ColumnarToRow
+                                                    InputAdapter
+                                                      Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_education_status,cd_dep_count]
                                     InputAdapter
                                       BroadcastExchange #5
                                         WholeStageCodegen (3)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19.sf100/explain.txt
@@ -1,267 +1,267 @@
 == Physical Plan ==
-TakeOrderedAndProject (41)
-+- * HashAggregate (40)
-   +- Exchange (39)
-      +- * HashAggregate (38)
-         +- * Project (37)
-            +- * SortMergeJoin Inner (36)
-               :- * Sort (21)
-               :  +- Exchange (20)
-               :     +- * Project (19)
-               :        +- * BroadcastHashJoin Inner BuildRight (18)
-               :           :- * Project (13)
-               :           :  +- * BroadcastHashJoin Inner BuildRight (12)
-               :           :     :- * Project (10)
-               :           :     :  +- * BroadcastHashJoin Inner BuildRight (9)
-               :           :     :     :- * Filter (3)
-               :           :     :     :  +- * ColumnarToRow (2)
-               :           :     :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-               :           :     :     +- BroadcastExchange (8)
-               :           :     :        +- * Project (7)
-               :           :     :           +- * Filter (6)
-               :           :     :              +- * ColumnarToRow (5)
-               :           :     :                 +- Scan parquet spark_catalog.default.item (4)
-               :           :     +- ReusedExchange (11)
-               :           +- BroadcastExchange (17)
-               :              +- * Filter (16)
-               :                 +- * ColumnarToRow (15)
-               :                    +- Scan parquet spark_catalog.default.store (14)
-               +- * Sort (35)
-                  +- Exchange (34)
-                     +- * Project (33)
-                        +- * SortMergeJoin Inner (32)
-                           :- * Sort (26)
-                           :  +- Exchange (25)
-                           :     +- * Filter (24)
-                           :        +- * ColumnarToRow (23)
-                           :           +- Scan parquet spark_catalog.default.customer (22)
-                           +- * Sort (31)
-                              +- Exchange (30)
-                                 +- * Filter (29)
-                                    +- * ColumnarToRow (28)
-                                       +- Scan parquet spark_catalog.default.customer_address (27)
+TakeOrderedAndProject (45)
++- * HashAggregate (44)
+   +- Exchange (43)
+      +- * HashAggregate (42)
+         +- * Project (41)
+            +- * BroadcastHashJoin Inner BuildRight (40)
+               :- * Project (35)
+               :  +- * SortMergeJoin Inner (34)
+               :     :- * Sort (19)
+               :     :  +- Exchange (18)
+               :     :     +- * Project (17)
+               :     :        +- * BroadcastHashJoin Inner BuildRight (16)
+               :     :           :- * Project (10)
+               :     :           :  +- * BroadcastHashJoin Inner BuildLeft (9)
+               :     :           :     :- BroadcastExchange (5)
+               :     :           :     :  +- * Project (4)
+               :     :           :     :     +- * Filter (3)
+               :     :           :     :        +- * ColumnarToRow (2)
+               :     :           :     :           +- Scan parquet spark_catalog.default.date_dim (1)
+               :     :           :     +- * Filter (8)
+               :     :           :        +- * ColumnarToRow (7)
+               :     :           :           +- Scan parquet spark_catalog.default.store_sales (6)
+               :     :           +- BroadcastExchange (15)
+               :     :              +- * Project (14)
+               :     :                 +- * Filter (13)
+               :     :                    +- * ColumnarToRow (12)
+               :     :                       +- Scan parquet spark_catalog.default.item (11)
+               :     +- * Sort (33)
+               :        +- Exchange (32)
+               :           +- * Project (31)
+               :              +- * SortMergeJoin Inner (30)
+               :                 :- * Sort (24)
+               :                 :  +- Exchange (23)
+               :                 :     +- * Filter (22)
+               :                 :        +- * ColumnarToRow (21)
+               :                 :           +- Scan parquet spark_catalog.default.customer (20)
+               :                 +- * Sort (29)
+               :                    +- Exchange (28)
+               :                       +- * Filter (27)
+               :                          +- * ColumnarToRow (26)
+               :                             +- Scan parquet spark_catalog.default.customer_address (25)
+               +- BroadcastExchange (39)
+                  +- * Filter (38)
+                     +- * ColumnarToRow (37)
+                        +- Scan parquet spark_catalog.default.store (36)
 
 
-(1) Scan parquet spark_catalog.default.store_sales
-Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5]
+(1) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#1, d_year#2, d_moy#3]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/date_dim]
+PushedFilters: [IsNotNull(d_moy), IsNotNull(d_year), EqualTo(d_moy,11), EqualTo(d_year,1998), IsNotNull(d_date_sk)]
+ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
+
+(2) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
+
+(3) Filter [codegen id : 1]
+Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
+Condition : ((((isnotnull(d_moy#3) AND isnotnull(d_year#2)) AND (d_moy#3 = 11)) AND (d_year#2 = 1998)) AND isnotnull(d_date_sk#1))
+
+(4) Project [codegen id : 1]
+Output [1]: [d_date_sk#1]
+Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
+
+(5) BroadcastExchange
+Input [1]: [d_date_sk#1]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
+
+(6) Scan parquet spark_catalog.default.store_sales
+Output [5]: [ss_item_sk#4, ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7, ss_sold_date_sk#8]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#5), dynamicpruningexpression(ss_sold_date_sk#5 IN dynamicpruning#6)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#8), dynamicpruningexpression(ss_sold_date_sk#8 IN dynamicpruning#9)]
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_customer_sk), IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ext_sales_price:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 4]
-Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5]
+(7) ColumnarToRow
+Input [5]: [ss_item_sk#4, ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7, ss_sold_date_sk#8]
 
-(3) Filter [codegen id : 4]
-Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5]
-Condition : ((isnotnull(ss_item_sk#1) AND isnotnull(ss_customer_sk#2)) AND isnotnull(ss_store_sk#3))
+(8) Filter
+Input [5]: [ss_item_sk#4, ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7, ss_sold_date_sk#8]
+Condition : ((isnotnull(ss_item_sk#4) AND isnotnull(ss_customer_sk#5)) AND isnotnull(ss_store_sk#6))
 
-(4) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#7, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11, i_manager_id#12]
+(9) BroadcastHashJoin [codegen id : 3]
+Left keys [1]: [d_date_sk#1]
+Right keys [1]: [ss_sold_date_sk#8]
+Join type: Inner
+Join condition: None
+
+(10) Project [codegen id : 3]
+Output [4]: [ss_item_sk#4, ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7]
+Input [6]: [d_date_sk#1, ss_item_sk#4, ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7, ss_sold_date_sk#8]
+
+(11) Scan parquet spark_catalog.default.item
+Output [6]: [i_item_sk#10, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14, i_manager_id#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_manager_id), EqualTo(i_manager_id,8), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_brand:string,i_manufact_id:int,i_manufact:string,i_manager_id:int>
 
-(5) ColumnarToRow [codegen id : 1]
-Input [6]: [i_item_sk#7, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11, i_manager_id#12]
+(12) ColumnarToRow [codegen id : 2]
+Input [6]: [i_item_sk#10, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14, i_manager_id#15]
 
-(6) Filter [codegen id : 1]
-Input [6]: [i_item_sk#7, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11, i_manager_id#12]
-Condition : ((isnotnull(i_manager_id#12) AND (i_manager_id#12 = 8)) AND isnotnull(i_item_sk#7))
+(13) Filter [codegen id : 2]
+Input [6]: [i_item_sk#10, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14, i_manager_id#15]
+Condition : ((isnotnull(i_manager_id#15) AND (i_manager_id#15 = 8)) AND isnotnull(i_item_sk#10))
 
-(7) Project [codegen id : 1]
-Output [5]: [i_item_sk#7, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11]
-Input [6]: [i_item_sk#7, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11, i_manager_id#12]
+(14) Project [codegen id : 2]
+Output [5]: [i_item_sk#10, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14]
+Input [6]: [i_item_sk#10, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14, i_manager_id#15]
 
-(8) BroadcastExchange
-Input [5]: [i_item_sk#7, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
+(15) BroadcastExchange
+Input [5]: [i_item_sk#10, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
-(9) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#7]
+(16) BroadcastHashJoin [codegen id : 3]
+Left keys [1]: [ss_item_sk#4]
+Right keys [1]: [i_item_sk#10]
 Join type: Inner
 Join condition: None
 
-(10) Project [codegen id : 4]
-Output [8]: [ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11]
-Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5, i_item_sk#7, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11]
+(17) Project [codegen id : 3]
+Output [7]: [ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14]
+Input [9]: [ss_item_sk#4, ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7, i_item_sk#10, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14]
 
-(11) ReusedExchange [Reuses operator id: 46]
-Output [1]: [d_date_sk#13]
+(18) Exchange
+Input [7]: [ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14]
+Arguments: hashpartitioning(ss_customer_sk#5, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(12) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#5]
-Right keys [1]: [d_date_sk#13]
-Join type: Inner
-Join condition: None
+(19) Sort [codegen id : 4]
+Input [7]: [ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14]
+Arguments: [ss_customer_sk#5 ASC NULLS FIRST], false, 0
 
-(13) Project [codegen id : 4]
-Output [7]: [ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11]
-Input [9]: [ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, ss_sold_date_sk#5, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11, d_date_sk#13]
-
-(14) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#14, s_zip#15]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_zip), IsNotNull(s_store_sk)]
-ReadSchema: struct<s_store_sk:int,s_zip:string>
-
-(15) ColumnarToRow [codegen id : 3]
-Input [2]: [s_store_sk#14, s_zip#15]
-
-(16) Filter [codegen id : 3]
-Input [2]: [s_store_sk#14, s_zip#15]
-Condition : (isnotnull(s_zip#15) AND isnotnull(s_store_sk#14))
-
-(17) BroadcastExchange
-Input [2]: [s_store_sk#14, s_zip#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
-
-(18) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#14]
-Join type: Inner
-Join condition: None
-
-(19) Project [codegen id : 4]
-Output [7]: [ss_customer_sk#2, ss_ext_sales_price#4, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11, s_zip#15]
-Input [9]: [ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#4, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11, s_store_sk#14, s_zip#15]
-
-(20) Exchange
-Input [7]: [ss_customer_sk#2, ss_ext_sales_price#4, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11, s_zip#15]
-Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=3]
-
-(21) Sort [codegen id : 5]
-Input [7]: [ss_customer_sk#2, ss_ext_sales_price#4, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11, s_zip#15]
-Arguments: [ss_customer_sk#2 ASC NULLS FIRST], false, 0
-
-(22) Scan parquet spark_catalog.default.customer
+(20) Scan parquet spark_catalog.default.customer
 Output [2]: [c_customer_sk#16, c_current_addr_sk#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
 
-(23) ColumnarToRow [codegen id : 6]
+(21) ColumnarToRow [codegen id : 5]
 Input [2]: [c_customer_sk#16, c_current_addr_sk#17]
 
-(24) Filter [codegen id : 6]
+(22) Filter [codegen id : 5]
 Input [2]: [c_customer_sk#16, c_current_addr_sk#17]
 Condition : (isnotnull(c_customer_sk#16) AND isnotnull(c_current_addr_sk#17))
 
-(25) Exchange
+(23) Exchange
 Input [2]: [c_customer_sk#16, c_current_addr_sk#17]
 Arguments: hashpartitioning(c_current_addr_sk#17, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(26) Sort [codegen id : 7]
+(24) Sort [codegen id : 6]
 Input [2]: [c_customer_sk#16, c_current_addr_sk#17]
 Arguments: [c_current_addr_sk#17 ASC NULLS FIRST], false, 0
 
-(27) Scan parquet spark_catalog.default.customer_address
+(25) Scan parquet spark_catalog.default.customer_address
 Output [2]: [ca_address_sk#18, ca_zip#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_address_sk:int,ca_zip:string>
 
-(28) ColumnarToRow [codegen id : 8]
+(26) ColumnarToRow [codegen id : 7]
 Input [2]: [ca_address_sk#18, ca_zip#19]
 
-(29) Filter [codegen id : 8]
+(27) Filter [codegen id : 7]
 Input [2]: [ca_address_sk#18, ca_zip#19]
 Condition : (isnotnull(ca_address_sk#18) AND isnotnull(ca_zip#19))
 
-(30) Exchange
+(28) Exchange
 Input [2]: [ca_address_sk#18, ca_zip#19]
 Arguments: hashpartitioning(ca_address_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(31) Sort [codegen id : 9]
+(29) Sort [codegen id : 8]
 Input [2]: [ca_address_sk#18, ca_zip#19]
 Arguments: [ca_address_sk#18 ASC NULLS FIRST], false, 0
 
-(32) SortMergeJoin [codegen id : 10]
+(30) SortMergeJoin [codegen id : 9]
 Left keys [1]: [c_current_addr_sk#17]
 Right keys [1]: [ca_address_sk#18]
 Join type: Inner
 Join condition: None
 
-(33) Project [codegen id : 10]
+(31) Project [codegen id : 9]
 Output [2]: [c_customer_sk#16, ca_zip#19]
 Input [4]: [c_customer_sk#16, c_current_addr_sk#17, ca_address_sk#18, ca_zip#19]
 
-(34) Exchange
+(32) Exchange
 Input [2]: [c_customer_sk#16, ca_zip#19]
 Arguments: hashpartitioning(c_customer_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(35) Sort [codegen id : 11]
+(33) Sort [codegen id : 10]
 Input [2]: [c_customer_sk#16, ca_zip#19]
 Arguments: [c_customer_sk#16 ASC NULLS FIRST], false, 0
 
-(36) SortMergeJoin [codegen id : 12]
-Left keys [1]: [ss_customer_sk#2]
+(34) SortMergeJoin [codegen id : 12]
+Left keys [1]: [ss_customer_sk#5]
 Right keys [1]: [c_customer_sk#16]
 Join type: Inner
-Join condition: NOT (substr(ca_zip#19, 1, 5) = substr(s_zip#15, 1, 5))
+Join condition: None
 
-(37) Project [codegen id : 12]
-Output [5]: [ss_ext_sales_price#4, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11]
-Input [9]: [ss_customer_sk#2, ss_ext_sales_price#4, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11, s_zip#15, c_customer_sk#16, ca_zip#19]
+(35) Project [codegen id : 12]
+Output [7]: [ss_store_sk#6, ss_ext_sales_price#7, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14, ca_zip#19]
+Input [9]: [ss_customer_sk#5, ss_store_sk#6, ss_ext_sales_price#7, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14, c_customer_sk#16, ca_zip#19]
 
-(38) HashAggregate [codegen id : 12]
-Input [5]: [ss_ext_sales_price#4, i_brand_id#8, i_brand#9, i_manufact_id#10, i_manufact#11]
-Keys [4]: [i_brand#9, i_brand_id#8, i_manufact_id#10, i_manufact#11]
-Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#4))]
-Aggregate Attributes [1]: [sum#20]
-Results [5]: [i_brand#9, i_brand_id#8, i_manufact_id#10, i_manufact#11, sum#21]
+(36) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#20, s_zip#21]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [IsNotNull(s_zip), IsNotNull(s_store_sk)]
+ReadSchema: struct<s_store_sk:int,s_zip:string>
 
-(39) Exchange
-Input [5]: [i_brand#9, i_brand_id#8, i_manufact_id#10, i_manufact#11, sum#21]
-Arguments: hashpartitioning(i_brand#9, i_brand_id#8, i_manufact_id#10, i_manufact#11, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(37) ColumnarToRow [codegen id : 11]
+Input [2]: [s_store_sk#20, s_zip#21]
 
-(40) HashAggregate [codegen id : 13]
-Input [5]: [i_brand#9, i_brand_id#8, i_manufact_id#10, i_manufact#11, sum#21]
-Keys [4]: [i_brand#9, i_brand_id#8, i_manufact_id#10, i_manufact#11]
-Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#4))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#4))#22]
-Results [5]: [i_brand_id#8 AS brand_id#23, i_brand#9 AS brand#24, i_manufact_id#10, i_manufact#11, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#4))#22,17,2) AS ext_price#25]
+(38) Filter [codegen id : 11]
+Input [2]: [s_store_sk#20, s_zip#21]
+Condition : (isnotnull(s_zip#21) AND isnotnull(s_store_sk#20))
 
-(41) TakeOrderedAndProject
-Input [5]: [brand_id#23, brand#24, i_manufact_id#10, i_manufact#11, ext_price#25]
-Arguments: 100, [ext_price#25 DESC NULLS LAST, brand#24 ASC NULLS FIRST, brand_id#23 ASC NULLS FIRST, i_manufact_id#10 ASC NULLS FIRST, i_manufact#11 ASC NULLS FIRST], [brand_id#23, brand#24, i_manufact_id#10, i_manufact#11, ext_price#25]
+(39) BroadcastExchange
+Input [2]: [s_store_sk#20, s_zip#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
+
+(40) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [ss_store_sk#6]
+Right keys [1]: [s_store_sk#20]
+Join type: Inner
+Join condition: NOT (substr(ca_zip#19, 1, 5) = substr(s_zip#21, 1, 5))
+
+(41) Project [codegen id : 12]
+Output [5]: [ss_ext_sales_price#7, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14]
+Input [9]: [ss_store_sk#6, ss_ext_sales_price#7, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14, ca_zip#19, s_store_sk#20, s_zip#21]
+
+(42) HashAggregate [codegen id : 12]
+Input [5]: [ss_ext_sales_price#7, i_brand_id#11, i_brand#12, i_manufact_id#13, i_manufact#14]
+Keys [4]: [i_brand#12, i_brand_id#11, i_manufact_id#13, i_manufact#14]
+Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#7))]
+Aggregate Attributes [1]: [sum#22]
+Results [5]: [i_brand#12, i_brand_id#11, i_manufact_id#13, i_manufact#14, sum#23]
+
+(43) Exchange
+Input [5]: [i_brand#12, i_brand_id#11, i_manufact_id#13, i_manufact#14, sum#23]
+Arguments: hashpartitioning(i_brand#12, i_brand_id#11, i_manufact_id#13, i_manufact#14, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(44) HashAggregate [codegen id : 13]
+Input [5]: [i_brand#12, i_brand_id#11, i_manufact_id#13, i_manufact#14, sum#23]
+Keys [4]: [i_brand#12, i_brand_id#11, i_manufact_id#13, i_manufact#14]
+Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#7))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#7))#24]
+Results [5]: [i_brand_id#11 AS brand_id#25, i_brand#12 AS brand#26, i_manufact_id#13, i_manufact#14, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#7))#24,17,2) AS ext_price#27]
+
+(45) TakeOrderedAndProject
+Input [5]: [brand_id#25, brand#26, i_manufact_id#13, i_manufact#14, ext_price#27]
+Arguments: 100, [ext_price#27 DESC NULLS LAST, brand#26 ASC NULLS FIRST, brand_id#25 ASC NULLS FIRST, i_manufact_id#13 ASC NULLS FIRST, i_manufact#14 ASC NULLS FIRST], [brand_id#25, brand#26, i_manufact_id#13, i_manufact#14, ext_price#27]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#5 IN dynamicpruning#6
-BroadcastExchange (46)
-+- * Project (45)
-   +- * Filter (44)
-      +- * ColumnarToRow (43)
-         +- Scan parquet spark_catalog.default.date_dim (42)
+Subquery:1 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
+ReusedExchange (46)
 
 
-(42) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#13, d_year#26, d_moy#27]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_moy), IsNotNull(d_year), EqualTo(d_moy,11), EqualTo(d_year,1998), IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
-
-(43) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#13, d_year#26, d_moy#27]
-
-(44) Filter [codegen id : 1]
-Input [3]: [d_date_sk#13, d_year#26, d_moy#27]
-Condition : ((((isnotnull(d_moy#27) AND isnotnull(d_year#26)) AND (d_moy#27 = 11)) AND (d_year#26 = 1998)) AND isnotnull(d_date_sk#13))
-
-(45) Project [codegen id : 1]
-Output [1]: [d_date_sk#13]
-Input [3]: [d_date_sk#13, d_year#26, d_moy#27]
-
-(46) BroadcastExchange
-Input [1]: [d_date_sk#13]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+(46) ReusedExchange [Reuses operator id: 5]
+Output [1]: [d_date_sk#1]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q19.sf100/simplified.txt
@@ -6,73 +6,73 @@ TakeOrderedAndProject [ext_price,brand,brand_id,i_manufact_id,i_manufact]
           WholeStageCodegen (12)
             HashAggregate [i_brand,i_brand_id,i_manufact_id,i_manufact,ss_ext_sales_price] [sum,sum]
               Project [ss_ext_sales_price,i_brand_id,i_brand,i_manufact_id,i_manufact]
-                SortMergeJoin [ss_customer_sk,c_customer_sk,ca_zip,s_zip]
-                  InputAdapter
-                    WholeStageCodegen (5)
-                      Sort [ss_customer_sk]
-                        InputAdapter
-                          Exchange [ss_customer_sk] #2
-                            WholeStageCodegen (4)
-                              Project [ss_customer_sk,ss_ext_sales_price,i_brand_id,i_brand,i_manufact_id,i_manufact,s_zip]
-                                BroadcastHashJoin [ss_store_sk,s_store_sk]
+                BroadcastHashJoin [ss_store_sk,s_store_sk,ca_zip,s_zip]
+                  Project [ss_store_sk,ss_ext_sales_price,i_brand_id,i_brand,i_manufact_id,i_manufact,ca_zip]
+                    SortMergeJoin [ss_customer_sk,c_customer_sk]
+                      InputAdapter
+                        WholeStageCodegen (4)
+                          Sort [ss_customer_sk]
+                            InputAdapter
+                              Exchange [ss_customer_sk] #2
+                                WholeStageCodegen (3)
                                   Project [ss_customer_sk,ss_store_sk,ss_ext_sales_price,i_brand_id,i_brand,i_manufact_id,i_manufact]
-                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                      Project [ss_customer_sk,ss_store_sk,ss_ext_sales_price,ss_sold_date_sk,i_brand_id,i_brand,i_manufact_id,i_manufact]
-                                        BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                    BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                      Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ext_sales_price]
+                                        BroadcastHashJoin [d_date_sk,ss_sold_date_sk]
+                                          InputAdapter
+                                            BroadcastExchange #3
+                                              WholeStageCodegen (1)
+                                                Project [d_date_sk]
+                                                  Filter [d_moy,d_year,d_date_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
                                           Filter [ss_item_sk,ss_customer_sk,ss_store_sk]
                                             ColumnarToRow
                                               InputAdapter
                                                 Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ext_sales_price,ss_sold_date_sk]
                                                   SubqueryBroadcast [d_date_sk] #1
-                                                    BroadcastExchange #3
-                                                      WholeStageCodegen (1)
-                                                        Project [d_date_sk]
-                                                          Filter [d_moy,d_year,d_date_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
-                                          InputAdapter
-                                            BroadcastExchange #4
-                                              WholeStageCodegen (1)
-                                                Project [i_item_sk,i_brand_id,i_brand,i_manufact_id,i_manufact]
-                                                  Filter [i_manager_id,i_item_sk]
+                                                    ReusedExchange [d_date_sk] #3
+                                      InputAdapter
+                                        BroadcastExchange #4
+                                          WholeStageCodegen (2)
+                                            Project [i_item_sk,i_brand_id,i_brand,i_manufact_id,i_manufact]
+                                              Filter [i_manager_id,i_item_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_brand,i_manufact_id,i_manufact,i_manager_id]
+                      InputAdapter
+                        WholeStageCodegen (10)
+                          Sort [c_customer_sk]
+                            InputAdapter
+                              Exchange [c_customer_sk] #5
+                                WholeStageCodegen (9)
+                                  Project [c_customer_sk,ca_zip]
+                                    SortMergeJoin [c_current_addr_sk,ca_address_sk]
+                                      InputAdapter
+                                        WholeStageCodegen (6)
+                                          Sort [c_current_addr_sk]
+                                            InputAdapter
+                                              Exchange [c_current_addr_sk] #6
+                                                WholeStageCodegen (5)
+                                                  Filter [c_customer_sk,c_current_addr_sk]
                                                     ColumnarToRow
                                                       InputAdapter
-                                                        Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_brand,i_manufact_id,i_manufact,i_manager_id]
+                                                        Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
                                       InputAdapter
-                                        ReusedExchange [d_date_sk] #3
-                                  InputAdapter
-                                    BroadcastExchange #5
-                                      WholeStageCodegen (3)
-                                        Filter [s_zip,s_store_sk]
-                                          ColumnarToRow
+                                        WholeStageCodegen (8)
+                                          Sort [ca_address_sk]
                                             InputAdapter
-                                              Scan parquet spark_catalog.default.store [s_store_sk,s_zip]
+                                              Exchange [ca_address_sk] #7
+                                                WholeStageCodegen (7)
+                                                  Filter [ca_address_sk,ca_zip]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_zip]
                   InputAdapter
-                    WholeStageCodegen (11)
-                      Sort [c_customer_sk]
-                        InputAdapter
-                          Exchange [c_customer_sk] #6
-                            WholeStageCodegen (10)
-                              Project [c_customer_sk,ca_zip]
-                                SortMergeJoin [c_current_addr_sk,ca_address_sk]
-                                  InputAdapter
-                                    WholeStageCodegen (7)
-                                      Sort [c_current_addr_sk]
-                                        InputAdapter
-                                          Exchange [c_current_addr_sk] #7
-                                            WholeStageCodegen (6)
-                                              Filter [c_customer_sk,c_current_addr_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
-                                  InputAdapter
-                                    WholeStageCodegen (9)
-                                      Sort [ca_address_sk]
-                                        InputAdapter
-                                          Exchange [ca_address_sk] #8
-                                            WholeStageCodegen (8)
-                                              Filter [ca_address_sk,ca_zip]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_zip]
+                    BroadcastExchange #8
+                      WholeStageCodegen (11)
+                        Filter [s_zip,s_store_sk]
+                          ColumnarToRow
+                            InputAdapter
+                              Scan parquet spark_catalog.default.store [s_store_sk,s_zip]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q21.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q21.sf100/explain.txt
@@ -6,8 +6,8 @@ TakeOrderedAndProject (24)
          +- * HashAggregate (20)
             +- * Project (19)
                +- * BroadcastHashJoin Inner BuildRight (18)
-                  :- * Project (13)
-                  :  +- * BroadcastHashJoin Inner BuildRight (12)
+                  :- * Project (16)
+                  :  +- * BroadcastHashJoin Inner BuildRight (15)
                   :     :- * Project (10)
                   :     :  +- * BroadcastHashJoin Inner BuildRight (9)
                   :     :     :- * Filter (3)
@@ -18,11 +18,11 @@ TakeOrderedAndProject (24)
                   :     :           +- * Filter (6)
                   :     :              +- * ColumnarToRow (5)
                   :     :                 +- Scan parquet spark_catalog.default.item (4)
-                  :     +- ReusedExchange (11)
-                  +- BroadcastExchange (17)
-                     +- * Filter (16)
-                        +- * ColumnarToRow (15)
-                           +- Scan parquet spark_catalog.default.warehouse (14)
+                  :     +- BroadcastExchange (14)
+                  :        +- * Filter (13)
+                  :           +- * ColumnarToRow (12)
+                  :              +- Scan parquet spark_catalog.default.warehouse (11)
+                  +- ReusedExchange (17)
 
 
 (1) Scan parquet spark_catalog.default.inventory
@@ -72,72 +72,72 @@ Join condition: None
 Output [4]: [inv_warehouse_sk#2, inv_quantity_on_hand#3, inv_date_sk#4, i_item_id#7]
 Input [6]: [inv_item_sk#1, inv_warehouse_sk#2, inv_quantity_on_hand#3, inv_date_sk#4, i_item_sk#6, i_item_id#7]
 
-(11) ReusedExchange [Reuses operator id: 28]
-Output [2]: [d_date_sk#9, d_date#10]
-
-(12) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [inv_date_sk#4]
-Right keys [1]: [d_date_sk#9]
-Join type: Inner
-Join condition: None
-
-(13) Project [codegen id : 4]
-Output [4]: [inv_warehouse_sk#2, inv_quantity_on_hand#3, i_item_id#7, d_date#10]
-Input [6]: [inv_warehouse_sk#2, inv_quantity_on_hand#3, inv_date_sk#4, i_item_id#7, d_date_sk#9, d_date#10]
-
-(14) Scan parquet spark_catalog.default.warehouse
-Output [2]: [w_warehouse_sk#11, w_warehouse_name#12]
+(11) Scan parquet spark_catalog.default.warehouse
+Output [2]: [w_warehouse_sk#9, w_warehouse_name#10]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/warehouse]
 PushedFilters: [IsNotNull(w_warehouse_sk)]
 ReadSchema: struct<w_warehouse_sk:int,w_warehouse_name:string>
 
-(15) ColumnarToRow [codegen id : 3]
-Input [2]: [w_warehouse_sk#11, w_warehouse_name#12]
+(12) ColumnarToRow [codegen id : 2]
+Input [2]: [w_warehouse_sk#9, w_warehouse_name#10]
 
-(16) Filter [codegen id : 3]
-Input [2]: [w_warehouse_sk#11, w_warehouse_name#12]
-Condition : isnotnull(w_warehouse_sk#11)
+(13) Filter [codegen id : 2]
+Input [2]: [w_warehouse_sk#9, w_warehouse_name#10]
+Condition : isnotnull(w_warehouse_sk#9)
 
-(17) BroadcastExchange
-Input [2]: [w_warehouse_sk#11, w_warehouse_name#12]
+(14) BroadcastExchange
+Input [2]: [w_warehouse_sk#9, w_warehouse_name#10]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
 
-(18) BroadcastHashJoin [codegen id : 4]
+(15) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [inv_warehouse_sk#2]
-Right keys [1]: [w_warehouse_sk#11]
+Right keys [1]: [w_warehouse_sk#9]
+Join type: Inner
+Join condition: None
+
+(16) Project [codegen id : 4]
+Output [4]: [inv_quantity_on_hand#3, inv_date_sk#4, i_item_id#7, w_warehouse_name#10]
+Input [6]: [inv_warehouse_sk#2, inv_quantity_on_hand#3, inv_date_sk#4, i_item_id#7, w_warehouse_sk#9, w_warehouse_name#10]
+
+(17) ReusedExchange [Reuses operator id: 28]
+Output [2]: [d_date_sk#11, d_date#12]
+
+(18) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [inv_date_sk#4]
+Right keys [1]: [d_date_sk#11]
 Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]
-Output [4]: [inv_quantity_on_hand#3, w_warehouse_name#12, i_item_id#7, d_date#10]
-Input [6]: [inv_warehouse_sk#2, inv_quantity_on_hand#3, i_item_id#7, d_date#10, w_warehouse_sk#11, w_warehouse_name#12]
+Output [4]: [inv_quantity_on_hand#3, w_warehouse_name#10, i_item_id#7, d_date#12]
+Input [6]: [inv_quantity_on_hand#3, inv_date_sk#4, i_item_id#7, w_warehouse_name#10, d_date_sk#11, d_date#12]
 
 (20) HashAggregate [codegen id : 4]
-Input [4]: [inv_quantity_on_hand#3, w_warehouse_name#12, i_item_id#7, d_date#10]
-Keys [2]: [w_warehouse_name#12, i_item_id#7]
-Functions [2]: [partial_sum(CASE WHEN (d_date#10 < 2000-03-11) THEN inv_quantity_on_hand#3 ELSE 0 END), partial_sum(CASE WHEN (d_date#10 >= 2000-03-11) THEN inv_quantity_on_hand#3 ELSE 0 END)]
+Input [4]: [inv_quantity_on_hand#3, w_warehouse_name#10, i_item_id#7, d_date#12]
+Keys [2]: [w_warehouse_name#10, i_item_id#7]
+Functions [2]: [partial_sum(CASE WHEN (d_date#12 < 2000-03-11) THEN inv_quantity_on_hand#3 ELSE 0 END), partial_sum(CASE WHEN (d_date#12 >= 2000-03-11) THEN inv_quantity_on_hand#3 ELSE 0 END)]
 Aggregate Attributes [2]: [sum#13, sum#14]
-Results [4]: [w_warehouse_name#12, i_item_id#7, sum#15, sum#16]
+Results [4]: [w_warehouse_name#10, i_item_id#7, sum#15, sum#16]
 
 (21) Exchange
-Input [4]: [w_warehouse_name#12, i_item_id#7, sum#15, sum#16]
-Arguments: hashpartitioning(w_warehouse_name#12, i_item_id#7, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [4]: [w_warehouse_name#10, i_item_id#7, sum#15, sum#16]
+Arguments: hashpartitioning(w_warehouse_name#10, i_item_id#7, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (22) HashAggregate [codegen id : 5]
-Input [4]: [w_warehouse_name#12, i_item_id#7, sum#15, sum#16]
-Keys [2]: [w_warehouse_name#12, i_item_id#7]
-Functions [2]: [sum(CASE WHEN (d_date#10 < 2000-03-11) THEN inv_quantity_on_hand#3 ELSE 0 END), sum(CASE WHEN (d_date#10 >= 2000-03-11) THEN inv_quantity_on_hand#3 ELSE 0 END)]
-Aggregate Attributes [2]: [sum(CASE WHEN (d_date#10 < 2000-03-11) THEN inv_quantity_on_hand#3 ELSE 0 END)#17, sum(CASE WHEN (d_date#10 >= 2000-03-11) THEN inv_quantity_on_hand#3 ELSE 0 END)#18]
-Results [4]: [w_warehouse_name#12, i_item_id#7, sum(CASE WHEN (d_date#10 < 2000-03-11) THEN inv_quantity_on_hand#3 ELSE 0 END)#17 AS inv_before#19, sum(CASE WHEN (d_date#10 >= 2000-03-11) THEN inv_quantity_on_hand#3 ELSE 0 END)#18 AS inv_after#20]
+Input [4]: [w_warehouse_name#10, i_item_id#7, sum#15, sum#16]
+Keys [2]: [w_warehouse_name#10, i_item_id#7]
+Functions [2]: [sum(CASE WHEN (d_date#12 < 2000-03-11) THEN inv_quantity_on_hand#3 ELSE 0 END), sum(CASE WHEN (d_date#12 >= 2000-03-11) THEN inv_quantity_on_hand#3 ELSE 0 END)]
+Aggregate Attributes [2]: [sum(CASE WHEN (d_date#12 < 2000-03-11) THEN inv_quantity_on_hand#3 ELSE 0 END)#17, sum(CASE WHEN (d_date#12 >= 2000-03-11) THEN inv_quantity_on_hand#3 ELSE 0 END)#18]
+Results [4]: [w_warehouse_name#10, i_item_id#7, sum(CASE WHEN (d_date#12 < 2000-03-11) THEN inv_quantity_on_hand#3 ELSE 0 END)#17 AS inv_before#19, sum(CASE WHEN (d_date#12 >= 2000-03-11) THEN inv_quantity_on_hand#3 ELSE 0 END)#18 AS inv_after#20]
 
 (23) Filter [codegen id : 5]
-Input [4]: [w_warehouse_name#12, i_item_id#7, inv_before#19, inv_after#20]
+Input [4]: [w_warehouse_name#10, i_item_id#7, inv_before#19, inv_after#20]
 Condition : (CASE WHEN (inv_before#19 > 0) THEN ((cast(inv_after#20 as double) / cast(inv_before#19 as double)) >= 0.666667) END AND CASE WHEN (inv_before#19 > 0) THEN ((cast(inv_after#20 as double) / cast(inv_before#19 as double)) <= 1.5) END)
 
 (24) TakeOrderedAndProject
-Input [4]: [w_warehouse_name#12, i_item_id#7, inv_before#19, inv_after#20]
-Arguments: 100, [w_warehouse_name#12 ASC NULLS FIRST, i_item_id#7 ASC NULLS FIRST], [w_warehouse_name#12, i_item_id#7, inv_before#19, inv_after#20]
+Input [4]: [w_warehouse_name#10, i_item_id#7, inv_before#19, inv_after#20]
+Arguments: 100, [w_warehouse_name#10 ASC NULLS FIRST, i_item_id#7 ASC NULLS FIRST], [w_warehouse_name#10, i_item_id#7, inv_before#19, inv_after#20]
 
 ===== Subqueries =====
 
@@ -149,21 +149,21 @@ BroadcastExchange (28)
 
 
 (25) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#9, d_date#10]
+Output [2]: [d_date_sk#11, d_date#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-02-10), LessThanOrEqual(d_date,2000-04-10), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (26) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#9, d_date#10]
+Input [2]: [d_date_sk#11, d_date#12]
 
 (27) Filter [codegen id : 1]
-Input [2]: [d_date_sk#9, d_date#10]
-Condition : (((isnotnull(d_date#10) AND (d_date#10 >= 2000-02-10)) AND (d_date#10 <= 2000-04-10)) AND isnotnull(d_date_sk#9))
+Input [2]: [d_date_sk#11, d_date#12]
+Condition : (((isnotnull(d_date#12) AND (d_date#12 >= 2000-02-10)) AND (d_date#12 <= 2000-04-10)) AND isnotnull(d_date_sk#11))
 
 (28) BroadcastExchange
-Input [2]: [d_date_sk#9, d_date#10]
+Input [2]: [d_date_sk#11, d_date#12]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q21.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q21.sf100/simplified.txt
@@ -7,9 +7,9 @@ TakeOrderedAndProject [w_warehouse_name,i_item_id,inv_before,inv_after]
             WholeStageCodegen (4)
               HashAggregate [w_warehouse_name,i_item_id,d_date,inv_quantity_on_hand] [sum,sum,sum,sum]
                 Project [inv_quantity_on_hand,w_warehouse_name,i_item_id,d_date]
-                  BroadcastHashJoin [inv_warehouse_sk,w_warehouse_sk]
-                    Project [inv_warehouse_sk,inv_quantity_on_hand,i_item_id,d_date]
-                      BroadcastHashJoin [inv_date_sk,d_date_sk]
+                  BroadcastHashJoin [inv_date_sk,d_date_sk]
+                    Project [inv_quantity_on_hand,inv_date_sk,i_item_id,w_warehouse_name]
+                      BroadcastHashJoin [inv_warehouse_sk,w_warehouse_sk]
                         Project [inv_warehouse_sk,inv_quantity_on_hand,inv_date_sk,i_item_id]
                           BroadcastHashJoin [inv_item_sk,i_item_sk]
                             Filter [inv_warehouse_sk,inv_item_sk]
@@ -32,11 +32,11 @@ TakeOrderedAndProject [w_warehouse_name,i_item_id,inv_before,inv_after]
                                         InputAdapter
                                           Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_current_price]
                         InputAdapter
-                          ReusedExchange [d_date_sk,d_date] #2
+                          BroadcastExchange #4
+                            WholeStageCodegen (2)
+                              Filter [w_warehouse_sk]
+                                ColumnarToRow
+                                  InputAdapter
+                                    Scan parquet spark_catalog.default.warehouse [w_warehouse_sk,w_warehouse_name]
                     InputAdapter
-                      BroadcastExchange #4
-                        WholeStageCodegen (3)
-                          Filter [w_warehouse_sk]
-                            ColumnarToRow
-                              InputAdapter
-                                Scan parquet spark_catalog.default.warehouse [w_warehouse_sk,w_warehouse_name]
+                      ReusedExchange [d_date_sk,d_date] #2

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/explain.txt
@@ -1,53 +1,56 @@
 == Physical Plan ==
-* Filter (49)
-+- * HashAggregate (48)
-   +- Exchange (47)
-      +- * HashAggregate (46)
-         +- * HashAggregate (45)
-            +- Exchange (44)
-               +- * HashAggregate (43)
-                  +- * Project (42)
-                     +- * BroadcastHashJoin Inner BuildRight (41)
-                        :- * Project (29)
-                        :  +- * SortMergeJoin Inner (28)
-                        :     :- * Sort (21)
-                        :     :  +- Exchange (20)
-                        :     :     +- * Project (19)
-                        :     :        +- * SortMergeJoin Inner (18)
-                        :     :           :- * Sort (12)
-                        :     :           :  +- Exchange (11)
-                        :     :           :     +- * Project (10)
-                        :     :           :        +- * BroadcastHashJoin Inner BuildRight (9)
-                        :     :           :           :- * Project (4)
-                        :     :           :           :  +- * Filter (3)
-                        :     :           :           :     +- * ColumnarToRow (2)
-                        :     :           :           :        +- Scan parquet spark_catalog.default.store_sales (1)
-                        :     :           :           +- BroadcastExchange (8)
-                        :     :           :              +- * Filter (7)
-                        :     :           :                 +- * ColumnarToRow (6)
-                        :     :           :                    +- Scan parquet spark_catalog.default.item (5)
-                        :     :           +- * Sort (17)
-                        :     :              +- Exchange (16)
-                        :     :                 +- * Filter (15)
-                        :     :                    +- * ColumnarToRow (14)
-                        :     :                       +- Scan parquet spark_catalog.default.customer (13)
-                        :     +- * Sort (27)
-                        :        +- Exchange (26)
-                        :           +- * Project (25)
-                        :              +- * Filter (24)
-                        :                 +- * ColumnarToRow (23)
-                        :                    +- Scan parquet spark_catalog.default.store_returns (22)
-                        +- BroadcastExchange (40)
-                           +- * Project (39)
-                              +- * BroadcastHashJoin Inner BuildLeft (38)
-                                 :- BroadcastExchange (34)
-                                 :  +- * Project (33)
-                                 :     +- * Filter (32)
-                                 :        +- * ColumnarToRow (31)
-                                 :           +- Scan parquet spark_catalog.default.store (30)
-                                 +- * Filter (37)
-                                    +- * ColumnarToRow (36)
-                                       +- Scan parquet spark_catalog.default.customer_address (35)
+* Filter (52)
++- * HashAggregate (51)
+   +- Exchange (50)
+      +- * HashAggregate (49)
+         +- * HashAggregate (48)
+            +- Exchange (47)
+               +- * HashAggregate (46)
+                  +- * Project (45)
+                     +- * SortMergeJoin Inner (44)
+                        :- * Sort (31)
+                        :  +- Exchange (30)
+                        :     +- * Project (29)
+                        :        +- * SortMergeJoin Inner (28)
+                        :           :- * Sort (21)
+                        :           :  +- Exchange (20)
+                        :           :     +- * Project (19)
+                        :           :        +- * SortMergeJoin Inner (18)
+                        :           :           :- * Sort (12)
+                        :           :           :  +- Exchange (11)
+                        :           :           :     +- * Project (10)
+                        :           :           :        +- * BroadcastHashJoin Inner BuildRight (9)
+                        :           :           :           :- * Project (4)
+                        :           :           :           :  +- * Filter (3)
+                        :           :           :           :     +- * ColumnarToRow (2)
+                        :           :           :           :        +- Scan parquet spark_catalog.default.store_sales (1)
+                        :           :           :           +- BroadcastExchange (8)
+                        :           :           :              +- * Filter (7)
+                        :           :           :                 +- * ColumnarToRow (6)
+                        :           :           :                    +- Scan parquet spark_catalog.default.item (5)
+                        :           :           +- * Sort (17)
+                        :           :              +- Exchange (16)
+                        :           :                 +- * Filter (15)
+                        :           :                    +- * ColumnarToRow (14)
+                        :           :                       +- Scan parquet spark_catalog.default.customer (13)
+                        :           +- * Sort (27)
+                        :              +- Exchange (26)
+                        :                 +- * Project (25)
+                        :                    +- * Filter (24)
+                        :                       +- * ColumnarToRow (23)
+                        :                          +- Scan parquet spark_catalog.default.store_returns (22)
+                        +- * Sort (43)
+                           +- Exchange (42)
+                              +- * Project (41)
+                                 +- * BroadcastHashJoin Inner BuildLeft (40)
+                                    :- BroadcastExchange (36)
+                                    :  +- * Project (35)
+                                    :     +- * Filter (34)
+                                    :        +- * ColumnarToRow (33)
+                                    :           +- Scan parquet spark_catalog.default.store (32)
+                                    +- * Filter (39)
+                                       +- * ColumnarToRow (38)
+                                          +- Scan parquet spark_catalog.default.customer_address (37)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -170,428 +173,385 @@ Arguments: hashpartitioning(sr_ticket_number#20, sr_item_sk#19, 5), ENSURE_REQUI
 Input [2]: [sr_item_sk#19, sr_ticket_number#20]
 Arguments: [sr_ticket_number#20 ASC NULLS FIRST, sr_item_sk#19 ASC NULLS FIRST], false, 0
 
-(28) SortMergeJoin [codegen id : 12]
+(28) SortMergeJoin [codegen id : 10]
 Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
 Right keys [2]: [sr_ticket_number#20, sr_item_sk#19]
 Join type: Inner
 Join condition: None
 
-(29) Project [codegen id : 12]
+(29) Project [codegen id : 10]
 Output [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
 Input [14]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, sr_item_sk#19, sr_ticket_number#20]
 
-(30) Scan parquet spark_catalog.default.store
+(30) Exchange
+Input [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: hashpartitioning(ss_store_sk#3, c_birth_country#18, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(31) Sort [codegen id : 11]
+Input [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: [ss_store_sk#3 ASC NULLS FIRST, c_birth_country#18 ASC NULLS FIRST], false, 0
+
+(32) Scan parquet spark_catalog.default.store
 Output [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
 
-(31) ColumnarToRow [codegen id : 10]
+(33) ColumnarToRow [codegen id : 12]
 Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 
-(32) Filter [codegen id : 10]
+(34) Filter [codegen id : 12]
 Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 Condition : (((isnotnull(s_market_id#24) AND (s_market_id#24 = 8)) AND isnotnull(s_store_sk#22)) AND isnotnull(s_zip#26))
 
-(33) Project [codegen id : 10]
+(35) Project [codegen id : 12]
 Output [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
 Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 
-(34) BroadcastExchange
+(36) BroadcastExchange
 Input [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
-Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [plan_id=6]
+Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [plan_id=7]
 
-(35) Scan parquet spark_catalog.default.customer_address
+(37) Scan parquet spark_catalog.default.customer_address
 Output [3]: [ca_state#27, ca_zip#28, ca_country#29]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
 
-(36) ColumnarToRow
+(38) ColumnarToRow
 Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
 
-(37) Filter
+(39) Filter
 Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
 Condition : (isnotnull(ca_country#29) AND isnotnull(ca_zip#28))
 
-(38) BroadcastHashJoin [codegen id : 11]
+(40) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [s_zip#26]
 Right keys [1]: [ca_zip#28]
 Join type: Inner
 Join condition: None
 
-(39) Project [codegen id : 11]
+(41) Project [codegen id : 13]
 Output [5]: [s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
 Input [7]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26, ca_state#27, ca_zip#28, ca_country#29]
 
-(40) BroadcastExchange
+(42) Exchange
 Input [5]: [s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], upper(input[4, string, true])),false), [plan_id=7]
+Arguments: hashpartitioning(s_store_sk#22, upper(ca_country#29), 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(41) BroadcastHashJoin [codegen id : 12]
+(43) Sort [codegen id : 14]
+Input [5]: [s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
+Arguments: [s_store_sk#22 ASC NULLS FIRST, upper(ca_country#29) ASC NULLS FIRST], false, 0
+
+(44) SortMergeJoin [codegen id : 15]
 Left keys [2]: [ss_store_sk#3, c_birth_country#18]
 Right keys [2]: [s_store_sk#22, upper(ca_country#29)]
 Join type: Inner
 Join condition: None
 
-(42) Project [codegen id : 12]
+(45) Project [codegen id : 15]
 Output [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
 Input [15]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
 
-(43) HashAggregate [codegen id : 12]
+(46) HashAggregate [codegen id : 15]
 Input [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
 Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
 Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#5))]
 Aggregate Attributes [1]: [sum#30]
 Results [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
 
-(44) Exchange
+(47) Exchange
 Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
-Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(45) HashAggregate [codegen id : 13]
+(48) HashAggregate [codegen id : 16]
 Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
 Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
 Functions [1]: [sum(UnscaledValue(ss_net_paid#5))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#32]
 Results [4]: [c_last_name#17, c_first_name#16, s_store_name#23, MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#32,17,2) AS netpaid#33]
 
-(46) HashAggregate [codegen id : 13]
+(49) HashAggregate [codegen id : 16]
 Input [4]: [c_last_name#17, c_first_name#16, s_store_name#23, netpaid#33]
 Keys [3]: [c_last_name#17, c_first_name#16, s_store_name#23]
 Functions [1]: [partial_sum(netpaid#33)]
 Aggregate Attributes [2]: [sum#34, isEmpty#35]
 Results [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
 
-(47) Exchange
+(50) Exchange
 Input [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
-Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(48) HashAggregate [codegen id : 14]
+(51) HashAggregate [codegen id : 17]
 Input [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
 Keys [3]: [c_last_name#17, c_first_name#16, s_store_name#23]
 Functions [1]: [sum(netpaid#33)]
 Aggregate Attributes [1]: [sum(netpaid#33)#38]
 Results [4]: [c_last_name#17, c_first_name#16, s_store_name#23, sum(netpaid#33)#38 AS paid#39]
 
-(49) Filter [codegen id : 14]
+(52) Filter [codegen id : 17]
 Input [4]: [c_last_name#17, c_first_name#16, s_store_name#23, paid#39]
 Condition : (isnotnull(paid#39) AND (cast(paid#39 as decimal(33,8)) > cast(Subquery scalar-subquery#40, [id=#41] as decimal(33,8))))
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#40, [id=#41]
-* HashAggregate (96)
-+- Exchange (95)
-   +- * HashAggregate (94)
-      +- * HashAggregate (93)
-         +- Exchange (92)
-            +- * HashAggregate (91)
-               +- * Project (90)
-                  +- * SortMergeJoin Inner (89)
-                     :- * Sort (83)
-                     :  +- Exchange (82)
-                     :     +- * Project (81)
-                     :        +- * SortMergeJoin Inner (80)
-                     :           :- * Sort (77)
-                     :           :  +- Exchange (76)
-                     :           :     +- * Project (75)
-                     :           :        +- * SortMergeJoin Inner (74)
-                     :           :           :- * Sort (71)
-                     :           :           :  +- Exchange (70)
-                     :           :           :     +- * Project (69)
-                     :           :           :        +- * SortMergeJoin Inner (68)
-                     :           :           :           :- * Sort (62)
-                     :           :           :           :  +- Exchange (61)
-                     :           :           :           :     +- * Project (60)
-                     :           :           :           :        +- * BroadcastHashJoin Inner BuildRight (59)
-                     :           :           :           :           :- * Project (53)
-                     :           :           :           :           :  +- * Filter (52)
-                     :           :           :           :           :     +- * ColumnarToRow (51)
-                     :           :           :           :           :        +- Scan parquet spark_catalog.default.store_sales (50)
-                     :           :           :           :           +- BroadcastExchange (58)
-                     :           :           :           :              +- * Project (57)
-                     :           :           :           :                 +- * Filter (56)
-                     :           :           :           :                    +- * ColumnarToRow (55)
-                     :           :           :           :                       +- Scan parquet spark_catalog.default.store (54)
-                     :           :           :           +- * Sort (67)
-                     :           :           :              +- Exchange (66)
-                     :           :           :                 +- * Filter (65)
-                     :           :           :                    +- * ColumnarToRow (64)
-                     :           :           :                       +- Scan parquet spark_catalog.default.item (63)
-                     :           :           +- * Sort (73)
-                     :           :              +- ReusedExchange (72)
-                     :           +- * Sort (79)
-                     :              +- ReusedExchange (78)
-                     +- * Sort (88)
-                        +- Exchange (87)
-                           +- * Filter (86)
-                              +- * ColumnarToRow (85)
-                                 +- Scan parquet spark_catalog.default.customer_address (84)
+Subquery:1 Hosting operator id = 52 Hosting Expression = Subquery scalar-subquery#40, [id=#41]
+* HashAggregate (89)
++- Exchange (88)
+   +- * HashAggregate (87)
+      +- * HashAggregate (86)
+         +- Exchange (85)
+            +- * HashAggregate (84)
+               +- * Project (83)
+                  +- * SortMergeJoin Inner (82)
+                     :- * Sort (79)
+                     :  +- Exchange (78)
+                     :     +- * Project (77)
+                     :        +- * SortMergeJoin Inner (76)
+                     :           :- * Sort (73)
+                     :           :  +- Exchange (72)
+                     :           :     +- * Project (71)
+                     :           :        +- * SortMergeJoin Inner (70)
+                     :           :           :- * Sort (64)
+                     :           :           :  +- Exchange (63)
+                     :           :           :     +- * Project (62)
+                     :           :           :        +- * SortMergeJoin Inner (61)
+                     :           :           :           :- * Sort (58)
+                     :           :           :           :  +- Exchange (57)
+                     :           :           :           :     +- * Project (56)
+                     :           :           :           :        +- * Filter (55)
+                     :           :           :           :           +- * ColumnarToRow (54)
+                     :           :           :           :              +- Scan parquet spark_catalog.default.store_sales (53)
+                     :           :           :           +- * Sort (60)
+                     :           :           :              +- ReusedExchange (59)
+                     :           :           +- * Sort (69)
+                     :           :              +- Exchange (68)
+                     :           :                 +- * Filter (67)
+                     :           :                    +- * ColumnarToRow (66)
+                     :           :                       +- Scan parquet spark_catalog.default.item (65)
+                     :           +- * Sort (75)
+                     :              +- ReusedExchange (74)
+                     +- * Sort (81)
+                        +- ReusedExchange (80)
 
 
-(50) Scan parquet spark_catalog.default.store_sales
+(53) Scan parquet spark_catalog.default.store_sales
 Output [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_ticket_number), IsNotNull(ss_item_sk), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_net_paid:decimal(7,2)>
 
-(51) ColumnarToRow [codegen id : 2]
+(54) ColumnarToRow [codegen id : 1]
 Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
 
-(52) Filter [codegen id : 2]
+(55) Filter [codegen id : 1]
 Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
-Condition : (((isnotnull(ss_ticket_number#45) AND isnotnull(ss_item_sk#42)) AND isnotnull(ss_store_sk#44)) AND isnotnull(ss_customer_sk#43))
+Condition : ((((isnotnull(ss_ticket_number#45) AND isnotnull(ss_item_sk#42)) AND isnotnull(ss_store_sk#44)) AND isnotnull(ss_customer_sk#43)) AND might_contain(ReusedSubquery Subquery scalar-subquery#7, [id=#8], xxhash64(ss_store_sk#44, 42)))
 
-(53) Project [codegen id : 2]
+(56) Project [codegen id : 1]
 Output [5]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46]
 Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
 
-(54) Scan parquet spark_catalog.default.store
-Output [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
-ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
+(57) Exchange
+Input [5]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46]
+Arguments: hashpartitioning(ss_customer_sk#43, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(55) ColumnarToRow [codegen id : 1]
-Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
+(58) Sort [codegen id : 2]
+Input [5]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46]
+Arguments: [ss_customer_sk#43 ASC NULLS FIRST], false, 0
 
-(56) Filter [codegen id : 1]
-Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
-Condition : (((isnotnull(s_market_id#50) AND (s_market_id#50 = 8)) AND isnotnull(s_store_sk#48)) AND isnotnull(s_zip#52))
+(59) ReusedExchange [Reuses operator id: 16]
+Output [4]: [c_customer_sk#48, c_first_name#49, c_last_name#50, c_birth_country#51]
 
-(57) Project [codegen id : 1]
-Output [4]: [s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
-Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
+(60) Sort [codegen id : 4]
+Input [4]: [c_customer_sk#48, c_first_name#49, c_last_name#50, c_birth_country#51]
+Arguments: [c_customer_sk#48 ASC NULLS FIRST], false, 0
 
-(58) BroadcastExchange
-Input [4]: [s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
-
-(59) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_store_sk#44]
-Right keys [1]: [s_store_sk#48]
+(61) SortMergeJoin [codegen id : 5]
+Left keys [1]: [ss_customer_sk#43]
+Right keys [1]: [c_customer_sk#48]
 Join type: Inner
 Join condition: None
 
-(60) Project [codegen id : 2]
-Output [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
-Input [9]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
+(62) Project [codegen id : 5]
+Output [7]: [ss_item_sk#42, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51]
+Input [9]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, c_customer_sk#48, c_first_name#49, c_last_name#50, c_birth_country#51]
 
-(61) Exchange
-Input [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
-Arguments: hashpartitioning(ss_item_sk#42, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+(63) Exchange
+Input [7]: [ss_item_sk#42, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51]
+Arguments: hashpartitioning(ss_item_sk#42, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(62) Sort [codegen id : 3]
-Input [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
+(64) Sort [codegen id : 6]
+Input [7]: [ss_item_sk#42, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51]
 Arguments: [ss_item_sk#42 ASC NULLS FIRST], false, 0
 
-(63) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+(65) Scan parquet spark_catalog.default.item
+Output [6]: [i_item_sk#52, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
-(64) ColumnarToRow [codegen id : 4]
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+(66) ColumnarToRow [codegen id : 7]
+Input [6]: [i_item_sk#52, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
 
-(65) Filter [codegen id : 4]
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Condition : isnotnull(i_item_sk#53)
+(67) Filter [codegen id : 7]
+Input [6]: [i_item_sk#52, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
+Condition : isnotnull(i_item_sk#52)
 
-(66) Exchange
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: hashpartitioning(i_item_sk#53, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+(68) Exchange
+Input [6]: [i_item_sk#52, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
+Arguments: hashpartitioning(i_item_sk#52, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(67) Sort [codegen id : 5]
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: [i_item_sk#53 ASC NULLS FIRST], false, 0
+(69) Sort [codegen id : 8]
+Input [6]: [i_item_sk#52, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
+Arguments: [i_item_sk#52 ASC NULLS FIRST], false, 0
 
-(68) SortMergeJoin [codegen id : 6]
+(70) SortMergeJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#42]
-Right keys [1]: [i_item_sk#53]
+Right keys [1]: [i_item_sk#52]
 Join type: Inner
 Join condition: None
 
-(69) Project [codegen id : 6]
-Output [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Input [13]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+(71) Project [codegen id : 9]
+Output [12]: [ss_item_sk#42, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
+Input [13]: [ss_item_sk#42, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51, i_item_sk#52, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
 
-(70) Exchange
-Input [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: hashpartitioning(ss_customer_sk#43, 5), ENSURE_REQUIREMENTS, [plan_id=13]
-
-(71) Sort [codegen id : 7]
-Input [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: [ss_customer_sk#43 ASC NULLS FIRST], false, 0
-
-(72) ReusedExchange [Reuses operator id: 16]
-Output [4]: [c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
-
-(73) Sort [codegen id : 9]
-Input [4]: [c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: [c_customer_sk#59 ASC NULLS FIRST], false, 0
-
-(74) SortMergeJoin [codegen id : 10]
-Left keys [1]: [ss_customer_sk#43]
-Right keys [1]: [c_customer_sk#59]
-Join type: Inner
-Join condition: None
-
-(75) Project [codegen id : 10]
-Output [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Input [16]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
-
-(76) Exchange
-Input [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
+(72) Exchange
+Input [12]: [ss_item_sk#42, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
 Arguments: hashpartitioning(ss_ticket_number#45, ss_item_sk#42, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
-(77) Sort [codegen id : 11]
-Input [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
+(73) Sort [codegen id : 10]
+Input [12]: [ss_item_sk#42, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
 Arguments: [ss_ticket_number#45 ASC NULLS FIRST, ss_item_sk#42 ASC NULLS FIRST], false, 0
 
-(78) ReusedExchange [Reuses operator id: 26]
-Output [2]: [sr_item_sk#63, sr_ticket_number#64]
+(74) ReusedExchange [Reuses operator id: 26]
+Output [2]: [sr_item_sk#58, sr_ticket_number#59]
 
-(79) Sort [codegen id : 13]
-Input [2]: [sr_item_sk#63, sr_ticket_number#64]
-Arguments: [sr_ticket_number#64 ASC NULLS FIRST, sr_item_sk#63 ASC NULLS FIRST], false, 0
+(75) Sort [codegen id : 12]
+Input [2]: [sr_item_sk#58, sr_ticket_number#59]
+Arguments: [sr_ticket_number#59 ASC NULLS FIRST, sr_item_sk#58 ASC NULLS FIRST], false, 0
 
-(80) SortMergeJoin [codegen id : 14]
+(76) SortMergeJoin [codegen id : 13]
 Left keys [2]: [ss_ticket_number#45, ss_item_sk#42]
-Right keys [2]: [sr_ticket_number#64, sr_item_sk#63]
+Right keys [2]: [sr_ticket_number#59, sr_item_sk#58]
 Join type: Inner
 Join condition: None
 
-(81) Project [codegen id : 14]
-Output [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Input [16]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62, sr_item_sk#63, sr_ticket_number#64]
+(77) Project [codegen id : 13]
+Output [10]: [ss_store_sk#44, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
+Input [14]: [ss_item_sk#42, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57, sr_item_sk#58, sr_ticket_number#59]
 
-(82) Exchange
-Input [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: hashpartitioning(c_birth_country#62, s_zip#52, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+(78) Exchange
+Input [10]: [ss_store_sk#44, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
+Arguments: hashpartitioning(ss_store_sk#44, c_birth_country#51, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
-(83) Sort [codegen id : 15]
-Input [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: [c_birth_country#62 ASC NULLS FIRST, s_zip#52 ASC NULLS FIRST], false, 0
+(79) Sort [codegen id : 14]
+Input [10]: [ss_store_sk#44, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
+Arguments: [ss_store_sk#44 ASC NULLS FIRST, c_birth_country#51 ASC NULLS FIRST], false, 0
 
-(84) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_state#65, ca_zip#66, ca_country#67]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
-ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
+(80) ReusedExchange [Reuses operator id: 42]
+Output [5]: [s_store_sk#60, s_store_name#61, s_state#62, ca_state#63, ca_country#64]
 
-(85) ColumnarToRow [codegen id : 16]
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
+(81) Sort [codegen id : 17]
+Input [5]: [s_store_sk#60, s_store_name#61, s_state#62, ca_state#63, ca_country#64]
+Arguments: [s_store_sk#60 ASC NULLS FIRST, upper(ca_country#64) ASC NULLS FIRST], false, 0
 
-(86) Filter [codegen id : 16]
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
-Condition : (isnotnull(ca_country#67) AND isnotnull(ca_zip#66))
-
-(87) Exchange
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
-Arguments: hashpartitioning(upper(ca_country#67), ca_zip#66, 5), ENSURE_REQUIREMENTS, [plan_id=16]
-
-(88) Sort [codegen id : 17]
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
-Arguments: [upper(ca_country#67) ASC NULLS FIRST, ca_zip#66 ASC NULLS FIRST], false, 0
-
-(89) SortMergeJoin [codegen id : 18]
-Left keys [2]: [c_birth_country#62, s_zip#52]
-Right keys [2]: [upper(ca_country#67), ca_zip#66]
+(82) SortMergeJoin [codegen id : 18]
+Left keys [2]: [ss_store_sk#44, c_birth_country#51]
+Right keys [2]: [s_store_sk#60, upper(ca_country#64)]
 Join type: Inner
 Join condition: None
 
-(90) Project [codegen id : 18]
-Output [11]: [ss_net_paid#46, s_store_name#49, s_state#51, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, ca_state#65]
-Input [15]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62, ca_state#65, ca_zip#66, ca_country#67]
+(83) Project [codegen id : 18]
+Output [11]: [ss_net_paid#46, s_store_name#61, s_state#62, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57, c_first_name#49, c_last_name#50, ca_state#63]
+Input [15]: [ss_store_sk#44, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57, s_store_sk#60, s_store_name#61, s_state#62, ca_state#63, ca_country#64]
 
-(91) HashAggregate [codegen id : 18]
-Input [11]: [ss_net_paid#46, s_store_name#49, s_state#51, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, ca_state#65]
-Keys [10]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55]
+(84) HashAggregate [codegen id : 18]
+Input [11]: [ss_net_paid#46, s_store_name#61, s_state#62, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57, c_first_name#49, c_last_name#50, ca_state#63]
+Keys [10]: [c_last_name#50, c_first_name#49, s_store_name#61, ca_state#63, s_state#62, i_color#55, i_current_price#53, i_manager_id#57, i_units#56, i_size#54]
 Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#46))]
-Aggregate Attributes [1]: [sum#68]
-Results [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
+Aggregate Attributes [1]: [sum#65]
+Results [11]: [c_last_name#50, c_first_name#49, s_store_name#61, ca_state#63, s_state#62, i_color#55, i_current_price#53, i_manager_id#57, i_units#56, i_size#54, sum#66]
 
-(92) Exchange
-Input [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
-Arguments: hashpartitioning(c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+(85) Exchange
+Input [11]: [c_last_name#50, c_first_name#49, s_store_name#61, ca_state#63, s_state#62, i_color#55, i_current_price#53, i_manager_id#57, i_units#56, i_size#54, sum#66]
+Arguments: hashpartitioning(c_last_name#50, c_first_name#49, s_store_name#61, ca_state#63, s_state#62, i_color#55, i_current_price#53, i_manager_id#57, i_units#56, i_size#54, 5), ENSURE_REQUIREMENTS, [plan_id=16]
 
-(93) HashAggregate [codegen id : 19]
-Input [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
-Keys [10]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55]
+(86) HashAggregate [codegen id : 19]
+Input [11]: [c_last_name#50, c_first_name#49, s_store_name#61, ca_state#63, s_state#62, i_color#55, i_current_price#53, i_manager_id#57, i_units#56, i_size#54, sum#66]
+Keys [10]: [c_last_name#50, c_first_name#49, s_store_name#61, ca_state#63, s_state#62, i_color#55, i_current_price#53, i_manager_id#57, i_units#56, i_size#54]
 Functions [1]: [sum(UnscaledValue(ss_net_paid#46))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#46))#32]
-Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#46))#32,17,2) AS netpaid#70]
+Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#46))#32,17,2) AS netpaid#67]
 
-(94) HashAggregate [codegen id : 19]
-Input [1]: [netpaid#70]
+(87) HashAggregate [codegen id : 19]
+Input [1]: [netpaid#67]
 Keys: []
-Functions [1]: [partial_avg(netpaid#70)]
-Aggregate Attributes [2]: [sum#71, count#72]
-Results [2]: [sum#73, count#74]
+Functions [1]: [partial_avg(netpaid#67)]
+Aggregate Attributes [2]: [sum#68, count#69]
+Results [2]: [sum#70, count#71]
 
-(95) Exchange
-Input [2]: [sum#73, count#74]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=18]
+(88) Exchange
+Input [2]: [sum#70, count#71]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=17]
 
-(96) HashAggregate [codegen id : 20]
-Input [2]: [sum#73, count#74]
+(89) HashAggregate [codegen id : 20]
+Input [2]: [sum#70, count#71]
 Keys: []
-Functions [1]: [avg(netpaid#70)]
-Aggregate Attributes [1]: [avg(netpaid#70)#75]
-Results [1]: [(0.05 * avg(netpaid#70)#75) AS (0.05 * avg(netpaid))#76]
+Functions [1]: [avg(netpaid#67)]
+Aggregate Attributes [1]: [avg(netpaid#67)#72]
+Results [1]: [(0.05 * avg(netpaid#67)#72) AS (0.05 * avg(netpaid))#73]
 
-Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
-ObjectHashAggregate (103)
-+- Exchange (102)
-   +- ObjectHashAggregate (101)
-      +- * Project (100)
-         +- * Filter (99)
-            +- * ColumnarToRow (98)
-               +- Scan parquet spark_catalog.default.store (97)
+Subquery:2 Hosting operator id = 55 Hosting Expression = ReusedSubquery Subquery scalar-subquery#7, [id=#8]
+
+Subquery:3 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
+ObjectHashAggregate (96)
++- Exchange (95)
+   +- ObjectHashAggregate (94)
+      +- * Project (93)
+         +- * Filter (92)
+            +- * ColumnarToRow (91)
+               +- Scan parquet spark_catalog.default.store (90)
 
 
-(97) Scan parquet spark_catalog.default.store
+(90) Scan parquet spark_catalog.default.store
 Output [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_market_id:int,s_zip:string>
 
-(98) ColumnarToRow [codegen id : 1]
+(91) ColumnarToRow [codegen id : 1]
 Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
 
-(99) Filter [codegen id : 1]
+(92) Filter [codegen id : 1]
 Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
 Condition : (((isnotnull(s_market_id#24) AND (s_market_id#24 = 8)) AND isnotnull(s_store_sk#22)) AND isnotnull(s_zip#26))
 
-(100) Project [codegen id : 1]
+(93) Project [codegen id : 1]
 Output [1]: [s_store_sk#22]
 Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
 
-(101) ObjectHashAggregate
+(94) ObjectHashAggregate
 Input [1]: [s_store_sk#22]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)]
-Aggregate Attributes [1]: [buf#77]
-Results [1]: [buf#78]
+Aggregate Attributes [1]: [buf#74]
+Results [1]: [buf#75]
 
-(102) Exchange
-Input [1]: [buf#78]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=19]
+(95) Exchange
+Input [1]: [buf#75]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=18]
 
-(103) ObjectHashAggregate
-Input [1]: [buf#78]
+(96) ObjectHashAggregate
+Input [1]: [buf#75]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)#79]
-Results [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)#79 AS bloomFilter#80]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)#76]
+Results [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)#76 AS bloomFilter#77]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24a.sf100/simplified.txt
@@ -1,181 +1,176 @@
-WholeStageCodegen (14)
+WholeStageCodegen (17)
   Filter [paid]
     Subquery #2
       WholeStageCodegen (20)
         HashAggregate [sum,count] [avg(netpaid),(0.05 * avg(netpaid)),sum,count]
           InputAdapter
-            Exchange #11
+            Exchange #12
               WholeStageCodegen (19)
                 HashAggregate [netpaid] [sum,count,sum,count]
                   HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,sum] [sum(UnscaledValue(ss_net_paid)),netpaid,sum]
                     InputAdapter
-                      Exchange [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size] #12
+                      Exchange [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size] #13
                         WholeStageCodegen (18)
                           HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,ss_net_paid] [sum,sum]
                             Project [ss_net_paid,s_store_name,s_state,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,ca_state]
-                              SortMergeJoin [c_birth_country,s_zip,ca_country,ca_zip]
+                              SortMergeJoin [ss_store_sk,c_birth_country,s_store_sk,ca_country]
                                 InputAdapter
-                                  WholeStageCodegen (15)
-                                    Sort [c_birth_country,s_zip]
+                                  WholeStageCodegen (14)
+                                    Sort [ss_store_sk,c_birth_country]
                                       InputAdapter
-                                        Exchange [c_birth_country,s_zip] #13
-                                          WholeStageCodegen (14)
-                                            Project [ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
+                                        Exchange [ss_store_sk,c_birth_country] #14
+                                          WholeStageCodegen (13)
+                                            Project [ss_store_sk,ss_net_paid,c_first_name,c_last_name,c_birth_country,i_current_price,i_size,i_color,i_units,i_manager_id]
                                               SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
                                                 InputAdapter
-                                                  WholeStageCodegen (11)
+                                                  WholeStageCodegen (10)
                                                     Sort [ss_ticket_number,ss_item_sk]
                                                       InputAdapter
-                                                        Exchange [ss_ticket_number,ss_item_sk] #14
-                                                          WholeStageCodegen (10)
-                                                            Project [ss_item_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
-                                                              SortMergeJoin [ss_customer_sk,c_customer_sk]
+                                                        Exchange [ss_ticket_number,ss_item_sk] #15
+                                                          WholeStageCodegen (9)
+                                                            Project [ss_item_sk,ss_store_sk,ss_ticket_number,ss_net_paid,c_first_name,c_last_name,c_birth_country,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                              SortMergeJoin [ss_item_sk,i_item_sk]
                                                                 InputAdapter
-                                                                  WholeStageCodegen (7)
-                                                                    Sort [ss_customer_sk]
+                                                                  WholeStageCodegen (6)
+                                                                    Sort [ss_item_sk]
                                                                       InputAdapter
-                                                                        Exchange [ss_customer_sk] #15
-                                                                          WholeStageCodegen (6)
-                                                                            Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id]
-                                                                              SortMergeJoin [ss_item_sk,i_item_sk]
+                                                                        Exchange [ss_item_sk] #16
+                                                                          WholeStageCodegen (5)
+                                                                            Project [ss_item_sk,ss_store_sk,ss_ticket_number,ss_net_paid,c_first_name,c_last_name,c_birth_country]
+                                                                              SortMergeJoin [ss_customer_sk,c_customer_sk]
                                                                                 InputAdapter
-                                                                                  WholeStageCodegen (3)
-                                                                                    Sort [ss_item_sk]
+                                                                                  WholeStageCodegen (2)
+                                                                                    Sort [ss_customer_sk]
                                                                                       InputAdapter
-                                                                                        Exchange [ss_item_sk] #16
-                                                                                          WholeStageCodegen (2)
-                                                                                            Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip]
-                                                                                              BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                                                                Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
-                                                                                                  Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
-                                                                                                    ColumnarToRow
-                                                                                                      InputAdapter
-                                                                                                        Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
-                                                                                                InputAdapter
-                                                                                                  BroadcastExchange #17
-                                                                                                    WholeStageCodegen (1)
-                                                                                                      Project [s_store_sk,s_store_name,s_state,s_zip]
-                                                                                                        Filter [s_market_id,s_store_sk,s_zip]
-                                                                                                          ColumnarToRow
-                                                                                                            InputAdapter
-                                                                                                              Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_market_id,s_state,s_zip]
+                                                                                        Exchange [ss_customer_sk] #17
+                                                                                          WholeStageCodegen (1)
+                                                                                            Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
+                                                                                              Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
+                                                                                                ReusedSubquery [bloomFilter] #1
+                                                                                                ColumnarToRow
+                                                                                                  InputAdapter
+                                                                                                    Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
                                                                                 InputAdapter
-                                                                                  WholeStageCodegen (5)
-                                                                                    Sort [i_item_sk]
+                                                                                  WholeStageCodegen (4)
+                                                                                    Sort [c_customer_sk]
                                                                                       InputAdapter
-                                                                                        Exchange [i_item_sk] #18
-                                                                                          WholeStageCodegen (4)
-                                                                                            Filter [i_item_sk]
-                                                                                              ColumnarToRow
-                                                                                                InputAdapter
-                                                                                                  Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name,c_birth_country] #8
                                                                 InputAdapter
-                                                                  WholeStageCodegen (9)
-                                                                    Sort [c_customer_sk]
+                                                                  WholeStageCodegen (8)
+                                                                    Sort [i_item_sk]
                                                                       InputAdapter
-                                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name,c_birth_country] #7
+                                                                        Exchange [i_item_sk] #18
+                                                                          WholeStageCodegen (7)
+                                                                            Filter [i_item_sk]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
                                                 InputAdapter
-                                                  WholeStageCodegen (13)
+                                                  WholeStageCodegen (12)
                                                     Sort [sr_ticket_number,sr_item_sk]
                                                       InputAdapter
-                                                        ReusedExchange [sr_item_sk,sr_ticket_number] #8
+                                                        ReusedExchange [sr_item_sk,sr_ticket_number] #9
                                 InputAdapter
                                   WholeStageCodegen (17)
-                                    Sort [ca_country,ca_zip]
+                                    Sort [s_store_sk,ca_country]
                                       InputAdapter
-                                        Exchange [ca_country,ca_zip] #19
-                                          WholeStageCodegen (16)
-                                            Filter [ca_country,ca_zip]
-                                              ColumnarToRow
-                                                InputAdapter
-                                                  Scan parquet spark_catalog.default.customer_address [ca_state,ca_zip,ca_country]
+                                        ReusedExchange [s_store_sk,s_store_name,s_state,ca_state,ca_country] #10
     HashAggregate [c_last_name,c_first_name,s_store_name,sum,isEmpty] [sum(netpaid),paid,sum,isEmpty]
       InputAdapter
         Exchange [c_last_name,c_first_name,s_store_name] #1
-          WholeStageCodegen (13)
+          WholeStageCodegen (16)
             HashAggregate [c_last_name,c_first_name,s_store_name,netpaid] [sum,isEmpty,sum,isEmpty]
               HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,sum] [sum(UnscaledValue(ss_net_paid)),netpaid,sum]
                 InputAdapter
                   Exchange [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size] #2
-                    WholeStageCodegen (12)
+                    WholeStageCodegen (15)
                       HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,ss_net_paid] [sum,sum]
                         Project [ss_net_paid,s_store_name,s_state,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,ca_state]
-                          BroadcastHashJoin [ss_store_sk,c_birth_country,s_store_sk,ca_country]
-                            Project [ss_store_sk,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
-                              SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
-                                InputAdapter
-                                  WholeStageCodegen (7)
-                                    Sort [ss_ticket_number,ss_item_sk]
-                                      InputAdapter
-                                        Exchange [ss_ticket_number,ss_item_sk] #3
-                                          WholeStageCodegen (6)
-                                            Project [ss_item_sk,ss_store_sk,ss_ticket_number,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
-                                              SortMergeJoin [ss_customer_sk,c_customer_sk]
-                                                InputAdapter
-                                                  WholeStageCodegen (3)
-                                                    Sort [ss_customer_sk]
-                                                      InputAdapter
-                                                        Exchange [ss_customer_sk] #4
-                                                          WholeStageCodegen (2)
-                                                            Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id]
-                                                              BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
-                                                                  Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
-                                                                    Subquery #1
-                                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(s_store_sk, 42), 40, 1250, 0, 0),bloomFilter,buf]
-                                                                        Exchange #5
-                                                                          ObjectHashAggregate [s_store_sk] [buf,buf]
-                                                                            WholeStageCodegen (1)
-                                                                              Project [s_store_sk]
-                                                                                Filter [s_market_id,s_store_sk,s_zip]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet spark_catalog.default.store [s_store_sk,s_market_id,s_zip]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
-                                                                InputAdapter
-                                                                  BroadcastExchange #6
-                                                                    WholeStageCodegen (1)
-                                                                      Filter [i_color,i_item_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
-                                                InputAdapter
-                                                  WholeStageCodegen (5)
-                                                    Sort [c_customer_sk]
-                                                      InputAdapter
-                                                        Exchange [c_customer_sk] #7
-                                                          WholeStageCodegen (4)
-                                                            Filter [c_customer_sk,c_birth_country]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name,c_birth_country]
-                                InputAdapter
-                                  WholeStageCodegen (9)
-                                    Sort [sr_ticket_number,sr_item_sk]
-                                      InputAdapter
-                                        Exchange [sr_ticket_number,sr_item_sk] #8
-                                          WholeStageCodegen (8)
-                                            Project [sr_item_sk,sr_ticket_number]
-                                              Filter [sr_ticket_number,sr_item_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_returned_date_sk]
+                          SortMergeJoin [ss_store_sk,c_birth_country,s_store_sk,ca_country]
                             InputAdapter
-                              BroadcastExchange #9
-                                WholeStageCodegen (11)
-                                  Project [s_store_sk,s_store_name,s_state,ca_state,ca_country]
-                                    BroadcastHashJoin [s_zip,ca_zip]
-                                      InputAdapter
-                                        BroadcastExchange #10
-                                          WholeStageCodegen (10)
-                                            Project [s_store_sk,s_store_name,s_state,s_zip]
-                                              Filter [s_market_id,s_store_sk,s_zip]
-                                                ColumnarToRow
+                              WholeStageCodegen (11)
+                                Sort [ss_store_sk,c_birth_country]
+                                  InputAdapter
+                                    Exchange [ss_store_sk,c_birth_country] #3
+                                      WholeStageCodegen (10)
+                                        Project [ss_store_sk,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
+                                          SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
+                                            InputAdapter
+                                              WholeStageCodegen (7)
+                                                Sort [ss_ticket_number,ss_item_sk]
                                                   InputAdapter
-                                                    Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_market_id,s_state,s_zip]
-                                      Filter [ca_country,ca_zip]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.customer_address [ca_state,ca_zip,ca_country]
+                                                    Exchange [ss_ticket_number,ss_item_sk] #4
+                                                      WholeStageCodegen (6)
+                                                        Project [ss_item_sk,ss_store_sk,ss_ticket_number,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
+                                                          SortMergeJoin [ss_customer_sk,c_customer_sk]
+                                                            InputAdapter
+                                                              WholeStageCodegen (3)
+                                                                Sort [ss_customer_sk]
+                                                                  InputAdapter
+                                                                    Exchange [ss_customer_sk] #5
+                                                                      WholeStageCodegen (2)
+                                                                        Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                                          BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                            Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
+                                                                              Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
+                                                                                Subquery #1
+                                                                                  ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(s_store_sk, 42), 40, 1250, 0, 0),bloomFilter,buf]
+                                                                                    Exchange #6
+                                                                                      ObjectHashAggregate [s_store_sk] [buf,buf]
+                                                                                        WholeStageCodegen (1)
+                                                                                          Project [s_store_sk]
+                                                                                            Filter [s_market_id,s_store_sk,s_zip]
+                                                                                              ColumnarToRow
+                                                                                                InputAdapter
+                                                                                                  Scan parquet spark_catalog.default.store [s_store_sk,s_market_id,s_zip]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
+                                                                            InputAdapter
+                                                                              BroadcastExchange #7
+                                                                                WholeStageCodegen (1)
+                                                                                  Filter [i_color,i_item_sk]
+                                                                                    ColumnarToRow
+                                                                                      InputAdapter
+                                                                                        Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                            InputAdapter
+                                                              WholeStageCodegen (5)
+                                                                Sort [c_customer_sk]
+                                                                  InputAdapter
+                                                                    Exchange [c_customer_sk] #8
+                                                                      WholeStageCodegen (4)
+                                                                        Filter [c_customer_sk,c_birth_country]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name,c_birth_country]
+                                            InputAdapter
+                                              WholeStageCodegen (9)
+                                                Sort [sr_ticket_number,sr_item_sk]
+                                                  InputAdapter
+                                                    Exchange [sr_ticket_number,sr_item_sk] #9
+                                                      WholeStageCodegen (8)
+                                                        Project [sr_item_sk,sr_ticket_number]
+                                                          Filter [sr_ticket_number,sr_item_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_returned_date_sk]
+                            InputAdapter
+                              WholeStageCodegen (14)
+                                Sort [s_store_sk,ca_country]
+                                  InputAdapter
+                                    Exchange [s_store_sk,ca_country] #10
+                                      WholeStageCodegen (13)
+                                        Project [s_store_sk,s_store_name,s_state,ca_state,ca_country]
+                                          BroadcastHashJoin [s_zip,ca_zip]
+                                            InputAdapter
+                                              BroadcastExchange #11
+                                                WholeStageCodegen (12)
+                                                  Project [s_store_sk,s_store_name,s_state,s_zip]
+                                                    Filter [s_market_id,s_store_sk,s_zip]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_market_id,s_state,s_zip]
+                                            Filter [ca_country,ca_zip]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.customer_address [ca_state,ca_zip,ca_country]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/explain.txt
@@ -1,53 +1,56 @@
 == Physical Plan ==
-* Filter (49)
-+- * HashAggregate (48)
-   +- Exchange (47)
-      +- * HashAggregate (46)
-         +- * HashAggregate (45)
-            +- Exchange (44)
-               +- * HashAggregate (43)
-                  +- * Project (42)
-                     +- * BroadcastHashJoin Inner BuildRight (41)
-                        :- * Project (29)
-                        :  +- * SortMergeJoin Inner (28)
-                        :     :- * Sort (21)
-                        :     :  +- Exchange (20)
-                        :     :     +- * Project (19)
-                        :     :        +- * SortMergeJoin Inner (18)
-                        :     :           :- * Sort (12)
-                        :     :           :  +- Exchange (11)
-                        :     :           :     +- * Project (10)
-                        :     :           :        +- * BroadcastHashJoin Inner BuildRight (9)
-                        :     :           :           :- * Project (4)
-                        :     :           :           :  +- * Filter (3)
-                        :     :           :           :     +- * ColumnarToRow (2)
-                        :     :           :           :        +- Scan parquet spark_catalog.default.store_sales (1)
-                        :     :           :           +- BroadcastExchange (8)
-                        :     :           :              +- * Filter (7)
-                        :     :           :                 +- * ColumnarToRow (6)
-                        :     :           :                    +- Scan parquet spark_catalog.default.item (5)
-                        :     :           +- * Sort (17)
-                        :     :              +- Exchange (16)
-                        :     :                 +- * Filter (15)
-                        :     :                    +- * ColumnarToRow (14)
-                        :     :                       +- Scan parquet spark_catalog.default.customer (13)
-                        :     +- * Sort (27)
-                        :        +- Exchange (26)
-                        :           +- * Project (25)
-                        :              +- * Filter (24)
-                        :                 +- * ColumnarToRow (23)
-                        :                    +- Scan parquet spark_catalog.default.store_returns (22)
-                        +- BroadcastExchange (40)
-                           +- * Project (39)
-                              +- * BroadcastHashJoin Inner BuildLeft (38)
-                                 :- BroadcastExchange (34)
-                                 :  +- * Project (33)
-                                 :     +- * Filter (32)
-                                 :        +- * ColumnarToRow (31)
-                                 :           +- Scan parquet spark_catalog.default.store (30)
-                                 +- * Filter (37)
-                                    +- * ColumnarToRow (36)
-                                       +- Scan parquet spark_catalog.default.customer_address (35)
+* Filter (52)
++- * HashAggregate (51)
+   +- Exchange (50)
+      +- * HashAggregate (49)
+         +- * HashAggregate (48)
+            +- Exchange (47)
+               +- * HashAggregate (46)
+                  +- * Project (45)
+                     +- * SortMergeJoin Inner (44)
+                        :- * Sort (31)
+                        :  +- Exchange (30)
+                        :     +- * Project (29)
+                        :        +- * SortMergeJoin Inner (28)
+                        :           :- * Sort (21)
+                        :           :  +- Exchange (20)
+                        :           :     +- * Project (19)
+                        :           :        +- * SortMergeJoin Inner (18)
+                        :           :           :- * Sort (12)
+                        :           :           :  +- Exchange (11)
+                        :           :           :     +- * Project (10)
+                        :           :           :        +- * BroadcastHashJoin Inner BuildRight (9)
+                        :           :           :           :- * Project (4)
+                        :           :           :           :  +- * Filter (3)
+                        :           :           :           :     +- * ColumnarToRow (2)
+                        :           :           :           :        +- Scan parquet spark_catalog.default.store_sales (1)
+                        :           :           :           +- BroadcastExchange (8)
+                        :           :           :              +- * Filter (7)
+                        :           :           :                 +- * ColumnarToRow (6)
+                        :           :           :                    +- Scan parquet spark_catalog.default.item (5)
+                        :           :           +- * Sort (17)
+                        :           :              +- Exchange (16)
+                        :           :                 +- * Filter (15)
+                        :           :                    +- * ColumnarToRow (14)
+                        :           :                       +- Scan parquet spark_catalog.default.customer (13)
+                        :           +- * Sort (27)
+                        :              +- Exchange (26)
+                        :                 +- * Project (25)
+                        :                    +- * Filter (24)
+                        :                       +- * ColumnarToRow (23)
+                        :                          +- Scan parquet spark_catalog.default.store_returns (22)
+                        +- * Sort (43)
+                           +- Exchange (42)
+                              +- * Project (41)
+                                 +- * BroadcastHashJoin Inner BuildLeft (40)
+                                    :- BroadcastExchange (36)
+                                    :  +- * Project (35)
+                                    :     +- * Filter (34)
+                                    :        +- * ColumnarToRow (33)
+                                    :           +- Scan parquet spark_catalog.default.store (32)
+                                    +- * Filter (39)
+                                       +- * ColumnarToRow (38)
+                                          +- Scan parquet spark_catalog.default.customer_address (37)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -170,428 +173,385 @@ Arguments: hashpartitioning(sr_ticket_number#20, sr_item_sk#19, 5), ENSURE_REQUI
 Input [2]: [sr_item_sk#19, sr_ticket_number#20]
 Arguments: [sr_ticket_number#20 ASC NULLS FIRST, sr_item_sk#19 ASC NULLS FIRST], false, 0
 
-(28) SortMergeJoin [codegen id : 12]
+(28) SortMergeJoin [codegen id : 10]
 Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
 Right keys [2]: [sr_ticket_number#20, sr_item_sk#19]
 Join type: Inner
 Join condition: None
 
-(29) Project [codegen id : 12]
+(29) Project [codegen id : 10]
 Output [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
 Input [14]: [ss_item_sk#1, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, sr_item_sk#19, sr_ticket_number#20]
 
-(30) Scan parquet spark_catalog.default.store
+(30) Exchange
+Input [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: hashpartitioning(ss_store_sk#3, c_birth_country#18, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(31) Sort [codegen id : 11]
+Input [10]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18]
+Arguments: [ss_store_sk#3 ASC NULLS FIRST, c_birth_country#18 ASC NULLS FIRST], false, 0
+
+(32) Scan parquet spark_catalog.default.store
 Output [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
 
-(31) ColumnarToRow [codegen id : 10]
+(33) ColumnarToRow [codegen id : 12]
 Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 
-(32) Filter [codegen id : 10]
+(34) Filter [codegen id : 12]
 Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 Condition : (((isnotnull(s_market_id#24) AND (s_market_id#24 = 8)) AND isnotnull(s_store_sk#22)) AND isnotnull(s_zip#26))
 
-(33) Project [codegen id : 10]
+(35) Project [codegen id : 12]
 Output [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
 Input [5]: [s_store_sk#22, s_store_name#23, s_market_id#24, s_state#25, s_zip#26]
 
-(34) BroadcastExchange
+(36) BroadcastExchange
 Input [4]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26]
-Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [plan_id=6]
+Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [plan_id=7]
 
-(35) Scan parquet spark_catalog.default.customer_address
+(37) Scan parquet spark_catalog.default.customer_address
 Output [3]: [ca_state#27, ca_zip#28, ca_country#29]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
 ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
 
-(36) ColumnarToRow
+(38) ColumnarToRow
 Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
 
-(37) Filter
+(39) Filter
 Input [3]: [ca_state#27, ca_zip#28, ca_country#29]
 Condition : (isnotnull(ca_country#29) AND isnotnull(ca_zip#28))
 
-(38) BroadcastHashJoin [codegen id : 11]
+(40) BroadcastHashJoin [codegen id : 13]
 Left keys [1]: [s_zip#26]
 Right keys [1]: [ca_zip#28]
 Join type: Inner
 Join condition: None
 
-(39) Project [codegen id : 11]
+(41) Project [codegen id : 13]
 Output [5]: [s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
 Input [7]: [s_store_sk#22, s_store_name#23, s_state#25, s_zip#26, ca_state#27, ca_zip#28, ca_country#29]
 
-(40) BroadcastExchange
+(42) Exchange
 Input [5]: [s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
-Arguments: HashedRelationBroadcastMode(List(input[0, int, true], upper(input[4, string, true])),false), [plan_id=7]
+Arguments: hashpartitioning(s_store_sk#22, upper(ca_country#29), 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(41) BroadcastHashJoin [codegen id : 12]
+(43) Sort [codegen id : 14]
+Input [5]: [s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
+Arguments: [s_store_sk#22 ASC NULLS FIRST, upper(ca_country#29) ASC NULLS FIRST], false, 0
+
+(44) SortMergeJoin [codegen id : 15]
 Left keys [2]: [ss_store_sk#3, c_birth_country#18]
 Right keys [2]: [s_store_sk#22, upper(ca_country#29)]
 Join type: Inner
 Join condition: None
 
-(42) Project [codegen id : 12]
+(45) Project [codegen id : 15]
 Output [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
 Input [15]: [ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, c_birth_country#18, s_store_sk#22, s_store_name#23, s_state#25, ca_state#27, ca_country#29]
 
-(43) HashAggregate [codegen id : 12]
+(46) HashAggregate [codegen id : 15]
 Input [11]: [ss_net_paid#5, s_store_name#23, s_state#25, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#16, c_last_name#17, ca_state#27]
 Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
 Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#5))]
 Aggregate Attributes [1]: [sum#30]
 Results [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
 
-(44) Exchange
+(47) Exchange
 Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
-Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(45) HashAggregate [codegen id : 13]
+(48) HashAggregate [codegen id : 16]
 Input [11]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#31]
 Keys [10]: [c_last_name#17, c_first_name#16, s_store_name#23, ca_state#27, s_state#25, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
 Functions [1]: [sum(UnscaledValue(ss_net_paid#5))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#32]
 Results [4]: [c_last_name#17, c_first_name#16, s_store_name#23, MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#32,17,2) AS netpaid#33]
 
-(46) HashAggregate [codegen id : 13]
+(49) HashAggregate [codegen id : 16]
 Input [4]: [c_last_name#17, c_first_name#16, s_store_name#23, netpaid#33]
 Keys [3]: [c_last_name#17, c_first_name#16, s_store_name#23]
 Functions [1]: [partial_sum(netpaid#33)]
 Aggregate Attributes [2]: [sum#34, isEmpty#35]
 Results [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
 
-(47) Exchange
+(50) Exchange
 Input [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
-Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Arguments: hashpartitioning(c_last_name#17, c_first_name#16, s_store_name#23, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(48) HashAggregate [codegen id : 14]
+(51) HashAggregate [codegen id : 17]
 Input [5]: [c_last_name#17, c_first_name#16, s_store_name#23, sum#36, isEmpty#37]
 Keys [3]: [c_last_name#17, c_first_name#16, s_store_name#23]
 Functions [1]: [sum(netpaid#33)]
 Aggregate Attributes [1]: [sum(netpaid#33)#38]
 Results [4]: [c_last_name#17, c_first_name#16, s_store_name#23, sum(netpaid#33)#38 AS paid#39]
 
-(49) Filter [codegen id : 14]
+(52) Filter [codegen id : 17]
 Input [4]: [c_last_name#17, c_first_name#16, s_store_name#23, paid#39]
 Condition : (isnotnull(paid#39) AND (cast(paid#39 as decimal(33,8)) > cast(Subquery scalar-subquery#40, [id=#41] as decimal(33,8))))
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 49 Hosting Expression = Subquery scalar-subquery#40, [id=#41]
-* HashAggregate (96)
-+- Exchange (95)
-   +- * HashAggregate (94)
-      +- * HashAggregate (93)
-         +- Exchange (92)
-            +- * HashAggregate (91)
-               +- * Project (90)
-                  +- * SortMergeJoin Inner (89)
-                     :- * Sort (83)
-                     :  +- Exchange (82)
-                     :     +- * Project (81)
-                     :        +- * SortMergeJoin Inner (80)
-                     :           :- * Sort (77)
-                     :           :  +- Exchange (76)
-                     :           :     +- * Project (75)
-                     :           :        +- * SortMergeJoin Inner (74)
-                     :           :           :- * Sort (71)
-                     :           :           :  +- Exchange (70)
-                     :           :           :     +- * Project (69)
-                     :           :           :        +- * SortMergeJoin Inner (68)
-                     :           :           :           :- * Sort (62)
-                     :           :           :           :  +- Exchange (61)
-                     :           :           :           :     +- * Project (60)
-                     :           :           :           :        +- * BroadcastHashJoin Inner BuildRight (59)
-                     :           :           :           :           :- * Project (53)
-                     :           :           :           :           :  +- * Filter (52)
-                     :           :           :           :           :     +- * ColumnarToRow (51)
-                     :           :           :           :           :        +- Scan parquet spark_catalog.default.store_sales (50)
-                     :           :           :           :           +- BroadcastExchange (58)
-                     :           :           :           :              +- * Project (57)
-                     :           :           :           :                 +- * Filter (56)
-                     :           :           :           :                    +- * ColumnarToRow (55)
-                     :           :           :           :                       +- Scan parquet spark_catalog.default.store (54)
-                     :           :           :           +- * Sort (67)
-                     :           :           :              +- Exchange (66)
-                     :           :           :                 +- * Filter (65)
-                     :           :           :                    +- * ColumnarToRow (64)
-                     :           :           :                       +- Scan parquet spark_catalog.default.item (63)
-                     :           :           +- * Sort (73)
-                     :           :              +- ReusedExchange (72)
-                     :           +- * Sort (79)
-                     :              +- ReusedExchange (78)
-                     +- * Sort (88)
-                        +- Exchange (87)
-                           +- * Filter (86)
-                              +- * ColumnarToRow (85)
-                                 +- Scan parquet spark_catalog.default.customer_address (84)
+Subquery:1 Hosting operator id = 52 Hosting Expression = Subquery scalar-subquery#40, [id=#41]
+* HashAggregate (89)
++- Exchange (88)
+   +- * HashAggregate (87)
+      +- * HashAggregate (86)
+         +- Exchange (85)
+            +- * HashAggregate (84)
+               +- * Project (83)
+                  +- * SortMergeJoin Inner (82)
+                     :- * Sort (79)
+                     :  +- Exchange (78)
+                     :     +- * Project (77)
+                     :        +- * SortMergeJoin Inner (76)
+                     :           :- * Sort (73)
+                     :           :  +- Exchange (72)
+                     :           :     +- * Project (71)
+                     :           :        +- * SortMergeJoin Inner (70)
+                     :           :           :- * Sort (64)
+                     :           :           :  +- Exchange (63)
+                     :           :           :     +- * Project (62)
+                     :           :           :        +- * SortMergeJoin Inner (61)
+                     :           :           :           :- * Sort (58)
+                     :           :           :           :  +- Exchange (57)
+                     :           :           :           :     +- * Project (56)
+                     :           :           :           :        +- * Filter (55)
+                     :           :           :           :           +- * ColumnarToRow (54)
+                     :           :           :           :              +- Scan parquet spark_catalog.default.store_sales (53)
+                     :           :           :           +- * Sort (60)
+                     :           :           :              +- ReusedExchange (59)
+                     :           :           +- * Sort (69)
+                     :           :              +- Exchange (68)
+                     :           :                 +- * Filter (67)
+                     :           :                    +- * ColumnarToRow (66)
+                     :           :                       +- Scan parquet spark_catalog.default.item (65)
+                     :           +- * Sort (75)
+                     :              +- ReusedExchange (74)
+                     +- * Sort (81)
+                        +- ReusedExchange (80)
 
 
-(50) Scan parquet spark_catalog.default.store_sales
+(53) Scan parquet spark_catalog.default.store_sales
 Output [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_ticket_number), IsNotNull(ss_item_sk), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_net_paid:decimal(7,2)>
 
-(51) ColumnarToRow [codegen id : 2]
+(54) ColumnarToRow [codegen id : 1]
 Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
 
-(52) Filter [codegen id : 2]
+(55) Filter [codegen id : 1]
 Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
-Condition : (((isnotnull(ss_ticket_number#45) AND isnotnull(ss_item_sk#42)) AND isnotnull(ss_store_sk#44)) AND isnotnull(ss_customer_sk#43))
+Condition : ((((isnotnull(ss_ticket_number#45) AND isnotnull(ss_item_sk#42)) AND isnotnull(ss_store_sk#44)) AND isnotnull(ss_customer_sk#43)) AND might_contain(ReusedSubquery Subquery scalar-subquery#7, [id=#8], xxhash64(ss_store_sk#44, 42)))
 
-(53) Project [codegen id : 2]
+(56) Project [codegen id : 1]
 Output [5]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46]
 Input [6]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, ss_sold_date_sk#47]
 
-(54) Scan parquet spark_catalog.default.store
-Output [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
-ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
+(57) Exchange
+Input [5]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46]
+Arguments: hashpartitioning(ss_customer_sk#43, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
-(55) ColumnarToRow [codegen id : 1]
-Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
+(58) Sort [codegen id : 2]
+Input [5]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46]
+Arguments: [ss_customer_sk#43 ASC NULLS FIRST], false, 0
 
-(56) Filter [codegen id : 1]
-Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
-Condition : (((isnotnull(s_market_id#50) AND (s_market_id#50 = 8)) AND isnotnull(s_store_sk#48)) AND isnotnull(s_zip#52))
+(59) ReusedExchange [Reuses operator id: 16]
+Output [4]: [c_customer_sk#48, c_first_name#49, c_last_name#50, c_birth_country#51]
 
-(57) Project [codegen id : 1]
-Output [4]: [s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
-Input [5]: [s_store_sk#48, s_store_name#49, s_market_id#50, s_state#51, s_zip#52]
+(60) Sort [codegen id : 4]
+Input [4]: [c_customer_sk#48, c_first_name#49, c_last_name#50, c_birth_country#51]
+Arguments: [c_customer_sk#48 ASC NULLS FIRST], false, 0
 
-(58) BroadcastExchange
-Input [4]: [s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
-
-(59) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [ss_store_sk#44]
-Right keys [1]: [s_store_sk#48]
+(61) SortMergeJoin [codegen id : 5]
+Left keys [1]: [ss_customer_sk#43]
+Right keys [1]: [c_customer_sk#48]
 Join type: Inner
 Join condition: None
 
-(60) Project [codegen id : 2]
-Output [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
-Input [9]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, s_store_sk#48, s_store_name#49, s_state#51, s_zip#52]
+(62) Project [codegen id : 5]
+Output [7]: [ss_item_sk#42, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51]
+Input [9]: [ss_item_sk#42, ss_customer_sk#43, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, c_customer_sk#48, c_first_name#49, c_last_name#50, c_birth_country#51]
 
-(61) Exchange
-Input [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
-Arguments: hashpartitioning(ss_item_sk#42, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+(63) Exchange
+Input [7]: [ss_item_sk#42, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51]
+Arguments: hashpartitioning(ss_item_sk#42, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(62) Sort [codegen id : 3]
-Input [7]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52]
+(64) Sort [codegen id : 6]
+Input [7]: [ss_item_sk#42, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51]
 Arguments: [ss_item_sk#42 ASC NULLS FIRST], false, 0
 
-(63) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+(65) Scan parquet spark_catalog.default.item
+Output [6]: [i_item_sk#52, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
-(64) ColumnarToRow [codegen id : 4]
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+(66) ColumnarToRow [codegen id : 7]
+Input [6]: [i_item_sk#52, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
 
-(65) Filter [codegen id : 4]
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Condition : isnotnull(i_item_sk#53)
+(67) Filter [codegen id : 7]
+Input [6]: [i_item_sk#52, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
+Condition : isnotnull(i_item_sk#52)
 
-(66) Exchange
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: hashpartitioning(i_item_sk#53, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+(68) Exchange
+Input [6]: [i_item_sk#52, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
+Arguments: hashpartitioning(i_item_sk#52, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(67) Sort [codegen id : 5]
-Input [6]: [i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: [i_item_sk#53 ASC NULLS FIRST], false, 0
+(69) Sort [codegen id : 8]
+Input [6]: [i_item_sk#52, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
+Arguments: [i_item_sk#52 ASC NULLS FIRST], false, 0
 
-(68) SortMergeJoin [codegen id : 6]
+(70) SortMergeJoin [codegen id : 9]
 Left keys [1]: [ss_item_sk#42]
-Right keys [1]: [i_item_sk#53]
+Right keys [1]: [i_item_sk#52]
 Join type: Inner
 Join condition: None
 
-(69) Project [codegen id : 6]
-Output [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Input [13]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_item_sk#53, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
+(71) Project [codegen id : 9]
+Output [12]: [ss_item_sk#42, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
+Input [13]: [ss_item_sk#42, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51, i_item_sk#52, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
 
-(70) Exchange
-Input [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: hashpartitioning(ss_customer_sk#43, 5), ENSURE_REQUIREMENTS, [plan_id=13]
-
-(71) Sort [codegen id : 7]
-Input [12]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58]
-Arguments: [ss_customer_sk#43 ASC NULLS FIRST], false, 0
-
-(72) ReusedExchange [Reuses operator id: 16]
-Output [4]: [c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
-
-(73) Sort [codegen id : 9]
-Input [4]: [c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: [c_customer_sk#59 ASC NULLS FIRST], false, 0
-
-(74) SortMergeJoin [codegen id : 10]
-Left keys [1]: [ss_customer_sk#43]
-Right keys [1]: [c_customer_sk#59]
-Join type: Inner
-Join condition: None
-
-(75) Project [codegen id : 10]
-Output [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Input [16]: [ss_item_sk#42, ss_customer_sk#43, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_customer_sk#59, c_first_name#60, c_last_name#61, c_birth_country#62]
-
-(76) Exchange
-Input [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
+(72) Exchange
+Input [12]: [ss_item_sk#42, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
 Arguments: hashpartitioning(ss_ticket_number#45, ss_item_sk#42, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
-(77) Sort [codegen id : 11]
-Input [14]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
+(73) Sort [codegen id : 10]
+Input [12]: [ss_item_sk#42, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
 Arguments: [ss_ticket_number#45 ASC NULLS FIRST, ss_item_sk#42 ASC NULLS FIRST], false, 0
 
-(78) ReusedExchange [Reuses operator id: 26]
-Output [2]: [sr_item_sk#63, sr_ticket_number#64]
+(74) ReusedExchange [Reuses operator id: 26]
+Output [2]: [sr_item_sk#58, sr_ticket_number#59]
 
-(79) Sort [codegen id : 13]
-Input [2]: [sr_item_sk#63, sr_ticket_number#64]
-Arguments: [sr_ticket_number#64 ASC NULLS FIRST, sr_item_sk#63 ASC NULLS FIRST], false, 0
+(75) Sort [codegen id : 12]
+Input [2]: [sr_item_sk#58, sr_ticket_number#59]
+Arguments: [sr_ticket_number#59 ASC NULLS FIRST, sr_item_sk#58 ASC NULLS FIRST], false, 0
 
-(80) SortMergeJoin [codegen id : 14]
+(76) SortMergeJoin [codegen id : 13]
 Left keys [2]: [ss_ticket_number#45, ss_item_sk#42]
-Right keys [2]: [sr_ticket_number#64, sr_item_sk#63]
+Right keys [2]: [sr_ticket_number#59, sr_item_sk#58]
 Join type: Inner
 Join condition: None
 
-(81) Project [codegen id : 14]
-Output [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Input [16]: [ss_item_sk#42, ss_ticket_number#45, ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62, sr_item_sk#63, sr_ticket_number#64]
+(77) Project [codegen id : 13]
+Output [10]: [ss_store_sk#44, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
+Input [14]: [ss_item_sk#42, ss_store_sk#44, ss_ticket_number#45, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57, sr_item_sk#58, sr_ticket_number#59]
 
-(82) Exchange
-Input [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: hashpartitioning(c_birth_country#62, s_zip#52, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+(78) Exchange
+Input [10]: [ss_store_sk#44, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
+Arguments: hashpartitioning(ss_store_sk#44, c_birth_country#51, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
-(83) Sort [codegen id : 15]
-Input [12]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62]
-Arguments: [c_birth_country#62 ASC NULLS FIRST, s_zip#52 ASC NULLS FIRST], false, 0
+(79) Sort [codegen id : 14]
+Input [10]: [ss_store_sk#44, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57]
+Arguments: [ss_store_sk#44 ASC NULLS FIRST, c_birth_country#51 ASC NULLS FIRST], false, 0
 
-(84) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_state#65, ca_zip#66, ca_country#67]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_country), IsNotNull(ca_zip)]
-ReadSchema: struct<ca_state:string,ca_zip:string,ca_country:string>
+(80) ReusedExchange [Reuses operator id: 42]
+Output [5]: [s_store_sk#60, s_store_name#61, s_state#62, ca_state#63, ca_country#64]
 
-(85) ColumnarToRow [codegen id : 16]
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
+(81) Sort [codegen id : 17]
+Input [5]: [s_store_sk#60, s_store_name#61, s_state#62, ca_state#63, ca_country#64]
+Arguments: [s_store_sk#60 ASC NULLS FIRST, upper(ca_country#64) ASC NULLS FIRST], false, 0
 
-(86) Filter [codegen id : 16]
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
-Condition : (isnotnull(ca_country#67) AND isnotnull(ca_zip#66))
-
-(87) Exchange
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
-Arguments: hashpartitioning(upper(ca_country#67), ca_zip#66, 5), ENSURE_REQUIREMENTS, [plan_id=16]
-
-(88) Sort [codegen id : 17]
-Input [3]: [ca_state#65, ca_zip#66, ca_country#67]
-Arguments: [upper(ca_country#67) ASC NULLS FIRST, ca_zip#66 ASC NULLS FIRST], false, 0
-
-(89) SortMergeJoin [codegen id : 18]
-Left keys [2]: [c_birth_country#62, s_zip#52]
-Right keys [2]: [upper(ca_country#67), ca_zip#66]
+(82) SortMergeJoin [codegen id : 18]
+Left keys [2]: [ss_store_sk#44, c_birth_country#51]
+Right keys [2]: [s_store_sk#60, upper(ca_country#64)]
 Join type: Inner
 Join condition: None
 
-(90) Project [codegen id : 18]
-Output [11]: [ss_net_paid#46, s_store_name#49, s_state#51, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, ca_state#65]
-Input [15]: [ss_net_paid#46, s_store_name#49, s_state#51, s_zip#52, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, c_birth_country#62, ca_state#65, ca_zip#66, ca_country#67]
+(83) Project [codegen id : 18]
+Output [11]: [ss_net_paid#46, s_store_name#61, s_state#62, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57, c_first_name#49, c_last_name#50, ca_state#63]
+Input [15]: [ss_store_sk#44, ss_net_paid#46, c_first_name#49, c_last_name#50, c_birth_country#51, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57, s_store_sk#60, s_store_name#61, s_state#62, ca_state#63, ca_country#64]
 
-(91) HashAggregate [codegen id : 18]
-Input [11]: [ss_net_paid#46, s_store_name#49, s_state#51, i_current_price#54, i_size#55, i_color#56, i_units#57, i_manager_id#58, c_first_name#60, c_last_name#61, ca_state#65]
-Keys [10]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55]
+(84) HashAggregate [codegen id : 18]
+Input [11]: [ss_net_paid#46, s_store_name#61, s_state#62, i_current_price#53, i_size#54, i_color#55, i_units#56, i_manager_id#57, c_first_name#49, c_last_name#50, ca_state#63]
+Keys [10]: [c_last_name#50, c_first_name#49, s_store_name#61, ca_state#63, s_state#62, i_color#55, i_current_price#53, i_manager_id#57, i_units#56, i_size#54]
 Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#46))]
-Aggregate Attributes [1]: [sum#68]
-Results [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
+Aggregate Attributes [1]: [sum#65]
+Results [11]: [c_last_name#50, c_first_name#49, s_store_name#61, ca_state#63, s_state#62, i_color#55, i_current_price#53, i_manager_id#57, i_units#56, i_size#54, sum#66]
 
-(92) Exchange
-Input [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
-Arguments: hashpartitioning(c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+(85) Exchange
+Input [11]: [c_last_name#50, c_first_name#49, s_store_name#61, ca_state#63, s_state#62, i_color#55, i_current_price#53, i_manager_id#57, i_units#56, i_size#54, sum#66]
+Arguments: hashpartitioning(c_last_name#50, c_first_name#49, s_store_name#61, ca_state#63, s_state#62, i_color#55, i_current_price#53, i_manager_id#57, i_units#56, i_size#54, 5), ENSURE_REQUIREMENTS, [plan_id=16]
 
-(93) HashAggregate [codegen id : 19]
-Input [11]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55, sum#69]
-Keys [10]: [c_last_name#61, c_first_name#60, s_store_name#49, ca_state#65, s_state#51, i_color#56, i_current_price#54, i_manager_id#58, i_units#57, i_size#55]
+(86) HashAggregate [codegen id : 19]
+Input [11]: [c_last_name#50, c_first_name#49, s_store_name#61, ca_state#63, s_state#62, i_color#55, i_current_price#53, i_manager_id#57, i_units#56, i_size#54, sum#66]
+Keys [10]: [c_last_name#50, c_first_name#49, s_store_name#61, ca_state#63, s_state#62, i_color#55, i_current_price#53, i_manager_id#57, i_units#56, i_size#54]
 Functions [1]: [sum(UnscaledValue(ss_net_paid#46))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#46))#32]
-Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#46))#32,17,2) AS netpaid#70]
+Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#46))#32,17,2) AS netpaid#67]
 
-(94) HashAggregate [codegen id : 19]
-Input [1]: [netpaid#70]
+(87) HashAggregate [codegen id : 19]
+Input [1]: [netpaid#67]
 Keys: []
-Functions [1]: [partial_avg(netpaid#70)]
-Aggregate Attributes [2]: [sum#71, count#72]
-Results [2]: [sum#73, count#74]
+Functions [1]: [partial_avg(netpaid#67)]
+Aggregate Attributes [2]: [sum#68, count#69]
+Results [2]: [sum#70, count#71]
 
-(95) Exchange
-Input [2]: [sum#73, count#74]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=18]
+(88) Exchange
+Input [2]: [sum#70, count#71]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=17]
 
-(96) HashAggregate [codegen id : 20]
-Input [2]: [sum#73, count#74]
+(89) HashAggregate [codegen id : 20]
+Input [2]: [sum#70, count#71]
 Keys: []
-Functions [1]: [avg(netpaid#70)]
-Aggregate Attributes [1]: [avg(netpaid#70)#75]
-Results [1]: [(0.05 * avg(netpaid#70)#75) AS (0.05 * avg(netpaid))#76]
+Functions [1]: [avg(netpaid#67)]
+Aggregate Attributes [1]: [avg(netpaid#67)#72]
+Results [1]: [(0.05 * avg(netpaid#67)#72) AS (0.05 * avg(netpaid))#73]
 
-Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
-ObjectHashAggregate (103)
-+- Exchange (102)
-   +- ObjectHashAggregate (101)
-      +- * Project (100)
-         +- * Filter (99)
-            +- * ColumnarToRow (98)
-               +- Scan parquet spark_catalog.default.store (97)
+Subquery:2 Hosting operator id = 55 Hosting Expression = ReusedSubquery Subquery scalar-subquery#7, [id=#8]
+
+Subquery:3 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
+ObjectHashAggregate (96)
++- Exchange (95)
+   +- ObjectHashAggregate (94)
+      +- * Project (93)
+         +- * Filter (92)
+            +- * ColumnarToRow (91)
+               +- Scan parquet spark_catalog.default.store (90)
 
 
-(97) Scan parquet spark_catalog.default.store
+(90) Scan parquet spark_catalog.default.store
 Output [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
 ReadSchema: struct<s_store_sk:int,s_market_id:int,s_zip:string>
 
-(98) ColumnarToRow [codegen id : 1]
+(91) ColumnarToRow [codegen id : 1]
 Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
 
-(99) Filter [codegen id : 1]
+(92) Filter [codegen id : 1]
 Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
 Condition : (((isnotnull(s_market_id#24) AND (s_market_id#24 = 8)) AND isnotnull(s_store_sk#22)) AND isnotnull(s_zip#26))
 
-(100) Project [codegen id : 1]
+(93) Project [codegen id : 1]
 Output [1]: [s_store_sk#22]
 Input [3]: [s_store_sk#22, s_market_id#24, s_zip#26]
 
-(101) ObjectHashAggregate
+(94) ObjectHashAggregate
 Input [1]: [s_store_sk#22]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)]
-Aggregate Attributes [1]: [buf#77]
-Results [1]: [buf#78]
+Aggregate Attributes [1]: [buf#74]
+Results [1]: [buf#75]
 
-(102) Exchange
-Input [1]: [buf#78]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=19]
+(95) Exchange
+Input [1]: [buf#75]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=18]
 
-(103) ObjectHashAggregate
-Input [1]: [buf#78]
+(96) ObjectHashAggregate
+Input [1]: [buf#75]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)#79]
-Results [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)#79 AS bloomFilter#80]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)#76]
+Results [1]: [bloom_filter_agg(xxhash64(s_store_sk#22, 42), 40, 1250, 0, 0)#76 AS bloomFilter#77]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q24b.sf100/simplified.txt
@@ -1,181 +1,176 @@
-WholeStageCodegen (14)
+WholeStageCodegen (17)
   Filter [paid]
     Subquery #2
       WholeStageCodegen (20)
         HashAggregate [sum,count] [avg(netpaid),(0.05 * avg(netpaid)),sum,count]
           InputAdapter
-            Exchange #11
+            Exchange #12
               WholeStageCodegen (19)
                 HashAggregate [netpaid] [sum,count,sum,count]
                   HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,sum] [sum(UnscaledValue(ss_net_paid)),netpaid,sum]
                     InputAdapter
-                      Exchange [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size] #12
+                      Exchange [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size] #13
                         WholeStageCodegen (18)
                           HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,ss_net_paid] [sum,sum]
                             Project [ss_net_paid,s_store_name,s_state,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,ca_state]
-                              SortMergeJoin [c_birth_country,s_zip,ca_country,ca_zip]
+                              SortMergeJoin [ss_store_sk,c_birth_country,s_store_sk,ca_country]
                                 InputAdapter
-                                  WholeStageCodegen (15)
-                                    Sort [c_birth_country,s_zip]
+                                  WholeStageCodegen (14)
+                                    Sort [ss_store_sk,c_birth_country]
                                       InputAdapter
-                                        Exchange [c_birth_country,s_zip] #13
-                                          WholeStageCodegen (14)
-                                            Project [ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
+                                        Exchange [ss_store_sk,c_birth_country] #14
+                                          WholeStageCodegen (13)
+                                            Project [ss_store_sk,ss_net_paid,c_first_name,c_last_name,c_birth_country,i_current_price,i_size,i_color,i_units,i_manager_id]
                                               SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
                                                 InputAdapter
-                                                  WholeStageCodegen (11)
+                                                  WholeStageCodegen (10)
                                                     Sort [ss_ticket_number,ss_item_sk]
                                                       InputAdapter
-                                                        Exchange [ss_ticket_number,ss_item_sk] #14
-                                                          WholeStageCodegen (10)
-                                                            Project [ss_item_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
-                                                              SortMergeJoin [ss_customer_sk,c_customer_sk]
+                                                        Exchange [ss_ticket_number,ss_item_sk] #15
+                                                          WholeStageCodegen (9)
+                                                            Project [ss_item_sk,ss_store_sk,ss_ticket_number,ss_net_paid,c_first_name,c_last_name,c_birth_country,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                              SortMergeJoin [ss_item_sk,i_item_sk]
                                                                 InputAdapter
-                                                                  WholeStageCodegen (7)
-                                                                    Sort [ss_customer_sk]
+                                                                  WholeStageCodegen (6)
+                                                                    Sort [ss_item_sk]
                                                                       InputAdapter
-                                                                        Exchange [ss_customer_sk] #15
-                                                                          WholeStageCodegen (6)
-                                                                            Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip,i_current_price,i_size,i_color,i_units,i_manager_id]
-                                                                              SortMergeJoin [ss_item_sk,i_item_sk]
+                                                                        Exchange [ss_item_sk] #16
+                                                                          WholeStageCodegen (5)
+                                                                            Project [ss_item_sk,ss_store_sk,ss_ticket_number,ss_net_paid,c_first_name,c_last_name,c_birth_country]
+                                                                              SortMergeJoin [ss_customer_sk,c_customer_sk]
                                                                                 InputAdapter
-                                                                                  WholeStageCodegen (3)
-                                                                                    Sort [ss_item_sk]
+                                                                                  WholeStageCodegen (2)
+                                                                                    Sort [ss_customer_sk]
                                                                                       InputAdapter
-                                                                                        Exchange [ss_item_sk] #16
-                                                                                          WholeStageCodegen (2)
-                                                                                            Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_paid,s_store_name,s_state,s_zip]
-                                                                                              BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                                                                Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
-                                                                                                  Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
-                                                                                                    ColumnarToRow
-                                                                                                      InputAdapter
-                                                                                                        Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
-                                                                                                InputAdapter
-                                                                                                  BroadcastExchange #17
-                                                                                                    WholeStageCodegen (1)
-                                                                                                      Project [s_store_sk,s_store_name,s_state,s_zip]
-                                                                                                        Filter [s_market_id,s_store_sk,s_zip]
-                                                                                                          ColumnarToRow
-                                                                                                            InputAdapter
-                                                                                                              Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_market_id,s_state,s_zip]
+                                                                                        Exchange [ss_customer_sk] #17
+                                                                                          WholeStageCodegen (1)
+                                                                                            Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
+                                                                                              Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
+                                                                                                ReusedSubquery [bloomFilter] #1
+                                                                                                ColumnarToRow
+                                                                                                  InputAdapter
+                                                                                                    Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
                                                                                 InputAdapter
-                                                                                  WholeStageCodegen (5)
-                                                                                    Sort [i_item_sk]
+                                                                                  WholeStageCodegen (4)
+                                                                                    Sort [c_customer_sk]
                                                                                       InputAdapter
-                                                                                        Exchange [i_item_sk] #18
-                                                                                          WholeStageCodegen (4)
-                                                                                            Filter [i_item_sk]
-                                                                                              ColumnarToRow
-                                                                                                InputAdapter
-                                                                                                  Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name,c_birth_country] #8
                                                                 InputAdapter
-                                                                  WholeStageCodegen (9)
-                                                                    Sort [c_customer_sk]
+                                                                  WholeStageCodegen (8)
+                                                                    Sort [i_item_sk]
                                                                       InputAdapter
-                                                                        ReusedExchange [c_customer_sk,c_first_name,c_last_name,c_birth_country] #7
+                                                                        Exchange [i_item_sk] #18
+                                                                          WholeStageCodegen (7)
+                                                                            Filter [i_item_sk]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
                                                 InputAdapter
-                                                  WholeStageCodegen (13)
+                                                  WholeStageCodegen (12)
                                                     Sort [sr_ticket_number,sr_item_sk]
                                                       InputAdapter
-                                                        ReusedExchange [sr_item_sk,sr_ticket_number] #8
+                                                        ReusedExchange [sr_item_sk,sr_ticket_number] #9
                                 InputAdapter
                                   WholeStageCodegen (17)
-                                    Sort [ca_country,ca_zip]
+                                    Sort [s_store_sk,ca_country]
                                       InputAdapter
-                                        Exchange [ca_country,ca_zip] #19
-                                          WholeStageCodegen (16)
-                                            Filter [ca_country,ca_zip]
-                                              ColumnarToRow
-                                                InputAdapter
-                                                  Scan parquet spark_catalog.default.customer_address [ca_state,ca_zip,ca_country]
+                                        ReusedExchange [s_store_sk,s_store_name,s_state,ca_state,ca_country] #10
     HashAggregate [c_last_name,c_first_name,s_store_name,sum,isEmpty] [sum(netpaid),paid,sum,isEmpty]
       InputAdapter
         Exchange [c_last_name,c_first_name,s_store_name] #1
-          WholeStageCodegen (13)
+          WholeStageCodegen (16)
             HashAggregate [c_last_name,c_first_name,s_store_name,netpaid] [sum,isEmpty,sum,isEmpty]
               HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,sum] [sum(UnscaledValue(ss_net_paid)),netpaid,sum]
                 InputAdapter
                   Exchange [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size] #2
-                    WholeStageCodegen (12)
+                    WholeStageCodegen (15)
                       HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,ss_net_paid] [sum,sum]
                         Project [ss_net_paid,s_store_name,s_state,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,ca_state]
-                          BroadcastHashJoin [ss_store_sk,c_birth_country,s_store_sk,ca_country]
-                            Project [ss_store_sk,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
-                              SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
-                                InputAdapter
-                                  WholeStageCodegen (7)
-                                    Sort [ss_ticket_number,ss_item_sk]
-                                      InputAdapter
-                                        Exchange [ss_ticket_number,ss_item_sk] #3
-                                          WholeStageCodegen (6)
-                                            Project [ss_item_sk,ss_store_sk,ss_ticket_number,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
-                                              SortMergeJoin [ss_customer_sk,c_customer_sk]
-                                                InputAdapter
-                                                  WholeStageCodegen (3)
-                                                    Sort [ss_customer_sk]
-                                                      InputAdapter
-                                                        Exchange [ss_customer_sk] #4
-                                                          WholeStageCodegen (2)
-                                                            Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id]
-                                                              BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                                Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
-                                                                  Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
-                                                                    Subquery #1
-                                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(s_store_sk, 42), 40, 1250, 0, 0),bloomFilter,buf]
-                                                                        Exchange #5
-                                                                          ObjectHashAggregate [s_store_sk] [buf,buf]
-                                                                            WholeStageCodegen (1)
-                                                                              Project [s_store_sk]
-                                                                                Filter [s_market_id,s_store_sk,s_zip]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet spark_catalog.default.store [s_store_sk,s_market_id,s_zip]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
-                                                                InputAdapter
-                                                                  BroadcastExchange #6
-                                                                    WholeStageCodegen (1)
-                                                                      Filter [i_color,i_item_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
-                                                InputAdapter
-                                                  WholeStageCodegen (5)
-                                                    Sort [c_customer_sk]
-                                                      InputAdapter
-                                                        Exchange [c_customer_sk] #7
-                                                          WholeStageCodegen (4)
-                                                            Filter [c_customer_sk,c_birth_country]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name,c_birth_country]
-                                InputAdapter
-                                  WholeStageCodegen (9)
-                                    Sort [sr_ticket_number,sr_item_sk]
-                                      InputAdapter
-                                        Exchange [sr_ticket_number,sr_item_sk] #8
-                                          WholeStageCodegen (8)
-                                            Project [sr_item_sk,sr_ticket_number]
-                                              Filter [sr_ticket_number,sr_item_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_returned_date_sk]
+                          SortMergeJoin [ss_store_sk,c_birth_country,s_store_sk,ca_country]
                             InputAdapter
-                              BroadcastExchange #9
-                                WholeStageCodegen (11)
-                                  Project [s_store_sk,s_store_name,s_state,ca_state,ca_country]
-                                    BroadcastHashJoin [s_zip,ca_zip]
-                                      InputAdapter
-                                        BroadcastExchange #10
-                                          WholeStageCodegen (10)
-                                            Project [s_store_sk,s_store_name,s_state,s_zip]
-                                              Filter [s_market_id,s_store_sk,s_zip]
-                                                ColumnarToRow
+                              WholeStageCodegen (11)
+                                Sort [ss_store_sk,c_birth_country]
+                                  InputAdapter
+                                    Exchange [ss_store_sk,c_birth_country] #3
+                                      WholeStageCodegen (10)
+                                        Project [ss_store_sk,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
+                                          SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
+                                            InputAdapter
+                                              WholeStageCodegen (7)
+                                                Sort [ss_ticket_number,ss_item_sk]
                                                   InputAdapter
-                                                    Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_market_id,s_state,s_zip]
-                                      Filter [ca_country,ca_zip]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.customer_address [ca_state,ca_zip,ca_country]
+                                                    Exchange [ss_ticket_number,ss_item_sk] #4
+                                                      WholeStageCodegen (6)
+                                                        Project [ss_item_sk,ss_store_sk,ss_ticket_number,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,c_birth_country]
+                                                          SortMergeJoin [ss_customer_sk,c_customer_sk]
+                                                            InputAdapter
+                                                              WholeStageCodegen (3)
+                                                                Sort [ss_customer_sk]
+                                                                  InputAdapter
+                                                                    Exchange [ss_customer_sk] #5
+                                                                      WholeStageCodegen (2)
+                                                                        Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                                          BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                            Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
+                                                                              Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
+                                                                                Subquery #1
+                                                                                  ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(s_store_sk, 42), 40, 1250, 0, 0),bloomFilter,buf]
+                                                                                    Exchange #6
+                                                                                      ObjectHashAggregate [s_store_sk] [buf,buf]
+                                                                                        WholeStageCodegen (1)
+                                                                                          Project [s_store_sk]
+                                                                                            Filter [s_market_id,s_store_sk,s_zip]
+                                                                                              ColumnarToRow
+                                                                                                InputAdapter
+                                                                                                  Scan parquet spark_catalog.default.store [s_store_sk,s_market_id,s_zip]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
+                                                                            InputAdapter
+                                                                              BroadcastExchange #7
+                                                                                WholeStageCodegen (1)
+                                                                                  Filter [i_color,i_item_sk]
+                                                                                    ColumnarToRow
+                                                                                      InputAdapter
+                                                                                        Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                            InputAdapter
+                                                              WholeStageCodegen (5)
+                                                                Sort [c_customer_sk]
+                                                                  InputAdapter
+                                                                    Exchange [c_customer_sk] #8
+                                                                      WholeStageCodegen (4)
+                                                                        Filter [c_customer_sk,c_birth_country]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet spark_catalog.default.customer [c_customer_sk,c_first_name,c_last_name,c_birth_country]
+                                            InputAdapter
+                                              WholeStageCodegen (9)
+                                                Sort [sr_ticket_number,sr_item_sk]
+                                                  InputAdapter
+                                                    Exchange [sr_ticket_number,sr_item_sk] #9
+                                                      WholeStageCodegen (8)
+                                                        Project [sr_item_sk,sr_ticket_number]
+                                                          Filter [sr_ticket_number,sr_item_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_returned_date_sk]
+                            InputAdapter
+                              WholeStageCodegen (14)
+                                Sort [s_store_sk,ca_country]
+                                  InputAdapter
+                                    Exchange [s_store_sk,ca_country] #10
+                                      WholeStageCodegen (13)
+                                        Project [s_store_sk,s_store_name,s_state,ca_state,ca_country]
+                                          BroadcastHashJoin [s_zip,ca_zip]
+                                            InputAdapter
+                                              BroadcastExchange #11
+                                                WholeStageCodegen (12)
+                                                  Project [s_store_sk,s_store_name,s_state,s_zip]
+                                                    Filter [s_market_id,s_store_sk,s_zip]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_market_id,s_state,s_zip]
+                                            Filter [ca_country,ca_zip]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.customer_address [ca_state,ca_zip,ca_country]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25.sf100/explain.txt
@@ -8,38 +8,38 @@ TakeOrderedAndProject (49)
                :- * Sort (35)
                :  +- Exchange (34)
                :     +- * Project (33)
-               :        +- * SortMergeJoin Inner (32)
-               :           :- * Sort (23)
-               :           :  +- Exchange (22)
-               :           :     +- * Project (21)
-               :           :        +- * SortMergeJoin Inner (20)
-               :           :           :- * Sort (14)
-               :           :           :  +- Exchange (13)
-               :           :           :     +- * Project (12)
-               :           :           :        +- * BroadcastHashJoin Inner BuildRight (11)
-               :           :           :           :- * Project (6)
-               :           :           :           :  +- * BroadcastHashJoin Inner BuildRight (5)
-               :           :           :           :     :- * Filter (3)
-               :           :           :           :     :  +- * ColumnarToRow (2)
-               :           :           :           :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-               :           :           :           :     +- ReusedExchange (4)
-               :           :           :           +- BroadcastExchange (10)
-               :           :           :              +- * Filter (9)
-               :           :           :                 +- * ColumnarToRow (8)
-               :           :           :                    +- Scan parquet spark_catalog.default.store (7)
-               :           :           +- * Sort (19)
-               :           :              +- Exchange (18)
-               :           :                 +- * Filter (17)
-               :           :                    +- * ColumnarToRow (16)
-               :           :                       +- Scan parquet spark_catalog.default.item (15)
-               :           +- * Sort (31)
-               :              +- Exchange (30)
-               :                 +- * Project (29)
-               :                    +- * BroadcastHashJoin Inner BuildRight (28)
-               :                       :- * Filter (26)
-               :                       :  +- * ColumnarToRow (25)
-               :                       :     +- Scan parquet spark_catalog.default.store_returns (24)
-               :                       +- ReusedExchange (27)
+               :        +- * BroadcastHashJoin Inner BuildRight (32)
+               :           :- * Project (27)
+               :           :  +- * SortMergeJoin Inner (26)
+               :           :     :- * Sort (20)
+               :           :     :  +- Exchange (19)
+               :           :     :     +- * Project (18)
+               :           :     :        +- * SortMergeJoin Inner (17)
+               :           :     :           :- * Sort (8)
+               :           :     :           :  +- Exchange (7)
+               :           :     :           :     +- * Project (6)
+               :           :     :           :        +- * BroadcastHashJoin Inner BuildRight (5)
+               :           :     :           :           :- * Filter (3)
+               :           :     :           :           :  +- * ColumnarToRow (2)
+               :           :     :           :           :     +- Scan parquet spark_catalog.default.store_sales (1)
+               :           :     :           :           +- ReusedExchange (4)
+               :           :     :           +- * Sort (16)
+               :           :     :              +- Exchange (15)
+               :           :     :                 +- * Project (14)
+               :           :     :                    +- * BroadcastHashJoin Inner BuildRight (13)
+               :           :     :                       :- * Filter (11)
+               :           :     :                       :  +- * ColumnarToRow (10)
+               :           :     :                       :     +- Scan parquet spark_catalog.default.store_returns (9)
+               :           :     :                       +- ReusedExchange (12)
+               :           :     +- * Sort (25)
+               :           :        +- Exchange (24)
+               :           :           +- * Filter (23)
+               :           :              +- * ColumnarToRow (22)
+               :           :                 +- Scan parquet spark_catalog.default.item (21)
+               :           +- BroadcastExchange (31)
+               :              +- * Filter (30)
+               :                 +- * ColumnarToRow (29)
+               :                    +- Scan parquet spark_catalog.default.store (28)
                +- * Sort (43)
                   +- Exchange (42)
                      +- * Project (41)
@@ -58,161 +58,161 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#6), dynamicpruningexpression(ss_sol
 PushedFilters: [IsNotNull(ss_customer_sk), IsNotNull(ss_item_sk), IsNotNull(ss_ticket_number), IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_net_profit:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 3]
+(2) ColumnarToRow [codegen id : 2]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_profit#5, ss_sold_date_sk#6]
 
-(3) Filter [codegen id : 3]
+(3) Filter [codegen id : 2]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_profit#5, ss_sold_date_sk#6]
 Condition : (((isnotnull(ss_customer_sk#2) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_ticket_number#4)) AND isnotnull(ss_store_sk#3))
 
 (4) ReusedExchange [Reuses operator id: 54]
 Output [1]: [d_date_sk#8]
 
-(5) BroadcastHashJoin [codegen id : 3]
+(5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#6]
 Right keys [1]: [d_date_sk#8]
 Join type: Inner
 Join condition: None
 
-(6) Project [codegen id : 3]
+(6) Project [codegen id : 2]
 Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_profit#5]
 Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_profit#5, ss_sold_date_sk#6, d_date_sk#8]
 
-(7) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#9, s_store_id#10, s_store_name#11]
+(7) Exchange
+Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_profit#5]
+Arguments: hashpartitioning(ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4, 5), ENSURE_REQUIREMENTS, [plan_id=1]
+
+(8) Sort [codegen id : 3]
+Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_profit#5]
+Arguments: [ss_customer_sk#2 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST, ss_ticket_number#4 ASC NULLS FIRST], false, 0
+
+(9) Scan parquet spark_catalog.default.store_returns
+Output [5]: [sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_net_loss#12, sr_returned_date_sk#13]
 Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_store_sk)]
-ReadSchema: struct<s_store_sk:int,s_store_id:string,s_store_name:string>
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(sr_returned_date_sk#13), dynamicpruningexpression(sr_returned_date_sk#13 IN dynamicpruning#14)]
+PushedFilters: [IsNotNull(sr_customer_sk), IsNotNull(sr_item_sk), IsNotNull(sr_ticket_number)]
+ReadSchema: struct<sr_item_sk:int,sr_customer_sk:int,sr_ticket_number:int,sr_net_loss:decimal(7,2)>
 
-(8) ColumnarToRow [codegen id : 2]
-Input [3]: [s_store_sk#9, s_store_id#10, s_store_name#11]
+(10) ColumnarToRow [codegen id : 5]
+Input [5]: [sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_net_loss#12, sr_returned_date_sk#13]
 
-(9) Filter [codegen id : 2]
-Input [3]: [s_store_sk#9, s_store_id#10, s_store_name#11]
-Condition : isnotnull(s_store_sk#9)
+(11) Filter [codegen id : 5]
+Input [5]: [sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_net_loss#12, sr_returned_date_sk#13]
+Condition : ((isnotnull(sr_customer_sk#10) AND isnotnull(sr_item_sk#9)) AND isnotnull(sr_ticket_number#11))
 
-(10) BroadcastExchange
-Input [3]: [s_store_sk#9, s_store_id#10, s_store_name#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
+(12) ReusedExchange [Reuses operator id: 59]
+Output [1]: [d_date_sk#15]
 
-(11) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#9]
+(13) BroadcastHashJoin [codegen id : 5]
+Left keys [1]: [sr_returned_date_sk#13]
+Right keys [1]: [d_date_sk#15]
 Join type: Inner
 Join condition: None
 
-(12) Project [codegen id : 3]
-Output [6]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#10, s_store_name#11]
-Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_profit#5, s_store_sk#9, s_store_id#10, s_store_name#11]
+(14) Project [codegen id : 5]
+Output [4]: [sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_net_loss#12]
+Input [6]: [sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_net_loss#12, sr_returned_date_sk#13, d_date_sk#15]
 
-(13) Exchange
-Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#10, s_store_name#11]
-Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+(15) Exchange
+Input [4]: [sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_net_loss#12]
+Arguments: hashpartitioning(sr_customer_sk#10, sr_item_sk#9, sr_ticket_number#11, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(14) Sort [codegen id : 4]
-Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#10, s_store_name#11]
+(16) Sort [codegen id : 6]
+Input [4]: [sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_net_loss#12]
+Arguments: [sr_customer_sk#10 ASC NULLS FIRST, sr_item_sk#9 ASC NULLS FIRST, sr_ticket_number#11 ASC NULLS FIRST], false, 0
+
+(17) SortMergeJoin [codegen id : 7]
+Left keys [3]: [ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4]
+Right keys [3]: [sr_customer_sk#10, sr_item_sk#9, sr_ticket_number#11]
+Join type: Inner
+Join condition: None
+
+(18) Project [codegen id : 7]
+Output [6]: [ss_item_sk#1, ss_store_sk#3, ss_net_profit#5, sr_item_sk#9, sr_customer_sk#10, sr_net_loss#12]
+Input [9]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_profit#5, sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_net_loss#12]
+
+(19) Exchange
+Input [6]: [ss_item_sk#1, ss_store_sk#3, ss_net_profit#5, sr_item_sk#9, sr_customer_sk#10, sr_net_loss#12]
+Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(20) Sort [codegen id : 8]
+Input [6]: [ss_item_sk#1, ss_store_sk#3, ss_net_profit#5, sr_item_sk#9, sr_customer_sk#10, sr_net_loss#12]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(15) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#12, i_item_id#13, i_item_desc#14]
+(21) Scan parquet spark_catalog.default.item
+Output [3]: [i_item_sk#16, i_item_id#17, i_item_desc#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string,i_item_desc:string>
 
-(16) ColumnarToRow [codegen id : 5]
-Input [3]: [i_item_sk#12, i_item_id#13, i_item_desc#14]
+(22) ColumnarToRow [codegen id : 9]
+Input [3]: [i_item_sk#16, i_item_id#17, i_item_desc#18]
 
-(17) Filter [codegen id : 5]
-Input [3]: [i_item_sk#12, i_item_id#13, i_item_desc#14]
-Condition : isnotnull(i_item_sk#12)
+(23) Filter [codegen id : 9]
+Input [3]: [i_item_sk#16, i_item_id#17, i_item_desc#18]
+Condition : isnotnull(i_item_sk#16)
 
-(18) Exchange
-Input [3]: [i_item_sk#12, i_item_id#13, i_item_desc#14]
-Arguments: hashpartitioning(i_item_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+(24) Exchange
+Input [3]: [i_item_sk#16, i_item_id#17, i_item_desc#18]
+Arguments: hashpartitioning(i_item_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(19) Sort [codegen id : 6]
-Input [3]: [i_item_sk#12, i_item_id#13, i_item_desc#14]
-Arguments: [i_item_sk#12 ASC NULLS FIRST], false, 0
+(25) Sort [codegen id : 10]
+Input [3]: [i_item_sk#16, i_item_id#17, i_item_desc#18]
+Arguments: [i_item_sk#16 ASC NULLS FIRST], false, 0
 
-(20) SortMergeJoin [codegen id : 7]
+(26) SortMergeJoin [codegen id : 12]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#12]
+Right keys [1]: [i_item_sk#16]
 Join type: Inner
 Join condition: None
 
-(21) Project [codegen id : 7]
-Output [8]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14]
-Input [9]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#10, s_store_name#11, i_item_sk#12, i_item_id#13, i_item_desc#14]
+(27) Project [codegen id : 12]
+Output [7]: [ss_store_sk#3, ss_net_profit#5, sr_item_sk#9, sr_customer_sk#10, sr_net_loss#12, i_item_id#17, i_item_desc#18]
+Input [9]: [ss_item_sk#1, ss_store_sk#3, ss_net_profit#5, sr_item_sk#9, sr_customer_sk#10, sr_net_loss#12, i_item_sk#16, i_item_id#17, i_item_desc#18]
 
-(22) Exchange
-Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14]
-Arguments: hashpartitioning(ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(23) Sort [codegen id : 8]
-Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14]
-Arguments: [ss_customer_sk#2 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST, ss_ticket_number#4 ASC NULLS FIRST], false, 0
-
-(24) Scan parquet spark_catalog.default.store_returns
-Output [5]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_net_loss#18, sr_returned_date_sk#19]
+(28) Scan parquet spark_catalog.default.store
+Output [3]: [s_store_sk#19, s_store_id#20, s_store_name#21]
 Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(sr_returned_date_sk#19), dynamicpruningexpression(sr_returned_date_sk#19 IN dynamicpruning#20)]
-PushedFilters: [IsNotNull(sr_customer_sk), IsNotNull(sr_item_sk), IsNotNull(sr_ticket_number)]
-ReadSchema: struct<sr_item_sk:int,sr_customer_sk:int,sr_ticket_number:int,sr_net_loss:decimal(7,2)>
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [IsNotNull(s_store_sk)]
+ReadSchema: struct<s_store_sk:int,s_store_id:string,s_store_name:string>
 
-(25) ColumnarToRow [codegen id : 10]
-Input [5]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_net_loss#18, sr_returned_date_sk#19]
+(29) ColumnarToRow [codegen id : 11]
+Input [3]: [s_store_sk#19, s_store_id#20, s_store_name#21]
 
-(26) Filter [codegen id : 10]
-Input [5]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_net_loss#18, sr_returned_date_sk#19]
-Condition : ((isnotnull(sr_customer_sk#16) AND isnotnull(sr_item_sk#15)) AND isnotnull(sr_ticket_number#17))
+(30) Filter [codegen id : 11]
+Input [3]: [s_store_sk#19, s_store_id#20, s_store_name#21]
+Condition : isnotnull(s_store_sk#19)
 
-(27) ReusedExchange [Reuses operator id: 59]
-Output [1]: [d_date_sk#21]
+(31) BroadcastExchange
+Input [3]: [s_store_sk#19, s_store_id#20, s_store_name#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
 
-(28) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [sr_returned_date_sk#19]
-Right keys [1]: [d_date_sk#21]
-Join type: Inner
-Join condition: None
-
-(29) Project [codegen id : 10]
-Output [4]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_net_loss#18]
-Input [6]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_net_loss#18, sr_returned_date_sk#19, d_date_sk#21]
-
-(30) Exchange
-Input [4]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_net_loss#18]
-Arguments: hashpartitioning(sr_customer_sk#16, sr_item_sk#15, sr_ticket_number#17, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(31) Sort [codegen id : 11]
-Input [4]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_net_loss#18]
-Arguments: [sr_customer_sk#16 ASC NULLS FIRST, sr_item_sk#15 ASC NULLS FIRST, sr_ticket_number#17 ASC NULLS FIRST], false, 0
-
-(32) SortMergeJoin [codegen id : 12]
-Left keys [3]: [ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4]
-Right keys [3]: [sr_customer_sk#16, sr_item_sk#15, sr_ticket_number#17]
+(32) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [ss_store_sk#3]
+Right keys [1]: [s_store_sk#19]
 Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 12]
-Output [8]: [ss_net_profit#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14, sr_item_sk#15, sr_customer_sk#16, sr_net_loss#18]
-Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_net_profit#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14, sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_net_loss#18]
+Output [8]: [ss_net_profit#5, sr_item_sk#9, sr_customer_sk#10, sr_net_loss#12, i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21]
+Input [10]: [ss_store_sk#3, ss_net_profit#5, sr_item_sk#9, sr_customer_sk#10, sr_net_loss#12, i_item_id#17, i_item_desc#18, s_store_sk#19, s_store_id#20, s_store_name#21]
 
 (34) Exchange
-Input [8]: [ss_net_profit#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14, sr_item_sk#15, sr_customer_sk#16, sr_net_loss#18]
-Arguments: hashpartitioning(sr_customer_sk#16, sr_item_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [8]: [ss_net_profit#5, sr_item_sk#9, sr_customer_sk#10, sr_net_loss#12, i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21]
+Arguments: hashpartitioning(sr_customer_sk#10, sr_item_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (35) Sort [codegen id : 13]
-Input [8]: [ss_net_profit#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14, sr_item_sk#15, sr_customer_sk#16, sr_net_loss#18]
-Arguments: [sr_customer_sk#16 ASC NULLS FIRST, sr_item_sk#15 ASC NULLS FIRST], false, 0
+Input [8]: [ss_net_profit#5, sr_item_sk#9, sr_customer_sk#10, sr_net_loss#12, i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21]
+Arguments: [sr_customer_sk#10 ASC NULLS FIRST, sr_item_sk#9 ASC NULLS FIRST], false, 0
 
 (36) Scan parquet spark_catalog.default.catalog_sales
 Output [4]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_net_profit#24, cs_sold_date_sk#25]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#25), dynamicpruningexpression(cs_sold_date_sk#25 IN dynamicpruning#20)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#25), dynamicpruningexpression(cs_sold_date_sk#25 IN dynamicpruning#14)]
 PushedFilters: [IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int,cs_item_sk:int,cs_net_profit:decimal(7,2)>
 
@@ -245,36 +245,36 @@ Input [3]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_net_profit#24]
 Arguments: [cs_bill_customer_sk#22 ASC NULLS FIRST, cs_item_sk#23 ASC NULLS FIRST], false, 0
 
 (44) SortMergeJoin [codegen id : 17]
-Left keys [2]: [sr_customer_sk#16, sr_item_sk#15]
+Left keys [2]: [sr_customer_sk#10, sr_item_sk#9]
 Right keys [2]: [cs_bill_customer_sk#22, cs_item_sk#23]
 Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 17]
-Output [7]: [ss_net_profit#5, sr_net_loss#18, cs_net_profit#24, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14]
-Input [11]: [ss_net_profit#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14, sr_item_sk#15, sr_customer_sk#16, sr_net_loss#18, cs_bill_customer_sk#22, cs_item_sk#23, cs_net_profit#24]
+Output [7]: [ss_net_profit#5, sr_net_loss#12, cs_net_profit#24, s_store_id#20, s_store_name#21, i_item_id#17, i_item_desc#18]
+Input [11]: [ss_net_profit#5, sr_item_sk#9, sr_customer_sk#10, sr_net_loss#12, i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21, cs_bill_customer_sk#22, cs_item_sk#23, cs_net_profit#24]
 
 (46) HashAggregate [codegen id : 17]
-Input [7]: [ss_net_profit#5, sr_net_loss#18, cs_net_profit#24, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14]
-Keys [4]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11]
-Functions [3]: [partial_sum(UnscaledValue(ss_net_profit#5)), partial_sum(UnscaledValue(sr_net_loss#18)), partial_sum(UnscaledValue(cs_net_profit#24))]
+Input [7]: [ss_net_profit#5, sr_net_loss#12, cs_net_profit#24, s_store_id#20, s_store_name#21, i_item_id#17, i_item_desc#18]
+Keys [4]: [i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21]
+Functions [3]: [partial_sum(UnscaledValue(ss_net_profit#5)), partial_sum(UnscaledValue(sr_net_loss#12)), partial_sum(UnscaledValue(cs_net_profit#24))]
 Aggregate Attributes [3]: [sum#27, sum#28, sum#29]
-Results [7]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, sum#30, sum#31, sum#32]
+Results [7]: [i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21, sum#30, sum#31, sum#32]
 
 (47) Exchange
-Input [7]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, sum#30, sum#31, sum#32]
-Arguments: hashpartitioning(i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [7]: [i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21, sum#30, sum#31, sum#32]
+Arguments: hashpartitioning(i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (48) HashAggregate [codegen id : 18]
-Input [7]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, sum#30, sum#31, sum#32]
-Keys [4]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11]
-Functions [3]: [sum(UnscaledValue(ss_net_profit#5)), sum(UnscaledValue(sr_net_loss#18)), sum(UnscaledValue(cs_net_profit#24))]
-Aggregate Attributes [3]: [sum(UnscaledValue(ss_net_profit#5))#33, sum(UnscaledValue(sr_net_loss#18))#34, sum(UnscaledValue(cs_net_profit#24))#35]
-Results [7]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, MakeDecimal(sum(UnscaledValue(ss_net_profit#5))#33,17,2) AS store_sales_profit#36, MakeDecimal(sum(UnscaledValue(sr_net_loss#18))#34,17,2) AS store_returns_loss#37, MakeDecimal(sum(UnscaledValue(cs_net_profit#24))#35,17,2) AS catalog_sales_profit#38]
+Input [7]: [i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21, sum#30, sum#31, sum#32]
+Keys [4]: [i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21]
+Functions [3]: [sum(UnscaledValue(ss_net_profit#5)), sum(UnscaledValue(sr_net_loss#12)), sum(UnscaledValue(cs_net_profit#24))]
+Aggregate Attributes [3]: [sum(UnscaledValue(ss_net_profit#5))#33, sum(UnscaledValue(sr_net_loss#12))#34, sum(UnscaledValue(cs_net_profit#24))#35]
+Results [7]: [i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21, MakeDecimal(sum(UnscaledValue(ss_net_profit#5))#33,17,2) AS store_sales_profit#36, MakeDecimal(sum(UnscaledValue(sr_net_loss#12))#34,17,2) AS store_returns_loss#37, MakeDecimal(sum(UnscaledValue(cs_net_profit#24))#35,17,2) AS catalog_sales_profit#38]
 
 (49) TakeOrderedAndProject
-Input [7]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, store_sales_profit#36, store_returns_loss#37, catalog_sales_profit#38]
-Arguments: 100, [i_item_id#13 ASC NULLS FIRST, i_item_desc#14 ASC NULLS FIRST, s_store_id#10 ASC NULLS FIRST, s_store_name#11 ASC NULLS FIRST], [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, store_sales_profit#36, store_returns_loss#37, catalog_sales_profit#38]
+Input [7]: [i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21, store_sales_profit#36, store_returns_loss#37, catalog_sales_profit#38]
+Arguments: 100, [i_item_id#17 ASC NULLS FIRST, i_item_desc#18 ASC NULLS FIRST, s_store_id#20 ASC NULLS FIRST, s_store_name#21 ASC NULLS FIRST], [i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21, store_sales_profit#36, store_returns_loss#37, catalog_sales_profit#38]
 
 ===== Subqueries =====
 
@@ -308,7 +308,7 @@ Input [3]: [d_date_sk#8, d_year#39, d_moy#40]
 Input [1]: [d_date_sk#8]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
-Subquery:2 Hosting operator id = 24 Hosting Expression = sr_returned_date_sk#19 IN dynamicpruning#20
+Subquery:2 Hosting operator id = 9 Hosting Expression = sr_returned_date_sk#13 IN dynamicpruning#14
 BroadcastExchange (59)
 +- * Project (58)
    +- * Filter (57)
@@ -317,27 +317,27 @@ BroadcastExchange (59)
 
 
 (55) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#21, d_year#41, d_moy#42]
+Output [3]: [d_date_sk#15, d_year#41, d_moy#42]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_moy), IsNotNull(d_year), GreaterThanOrEqual(d_moy,4), LessThanOrEqual(d_moy,10), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (56) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#21, d_year#41, d_moy#42]
+Input [3]: [d_date_sk#15, d_year#41, d_moy#42]
 
 (57) Filter [codegen id : 1]
-Input [3]: [d_date_sk#21, d_year#41, d_moy#42]
-Condition : (((((isnotnull(d_moy#42) AND isnotnull(d_year#41)) AND (d_moy#42 >= 4)) AND (d_moy#42 <= 10)) AND (d_year#41 = 2001)) AND isnotnull(d_date_sk#21))
+Input [3]: [d_date_sk#15, d_year#41, d_moy#42]
+Condition : (((((isnotnull(d_moy#42) AND isnotnull(d_year#41)) AND (d_moy#42 >= 4)) AND (d_moy#42 <= 10)) AND (d_year#41 = 2001)) AND isnotnull(d_date_sk#15))
 
 (58) Project [codegen id : 1]
-Output [1]: [d_date_sk#21]
-Input [3]: [d_date_sk#21, d_year#41, d_moy#42]
+Output [1]: [d_date_sk#15]
+Input [3]: [d_date_sk#15, d_year#41, d_moy#42]
 
 (59) BroadcastExchange
-Input [1]: [d_date_sk#21]
+Input [1]: [d_date_sk#15]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
-Subquery:3 Hosting operator id = 36 Hosting Expression = cs_sold_date_sk#25 IN dynamicpruning#20
+Subquery:3 Hosting operator id = 36 Hosting Expression = cs_sold_date_sk#25 IN dynamicpruning#14
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q25.sf100/simplified.txt
@@ -13,24 +13,24 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_store_id,s_store_name,store_sales
                         InputAdapter
                           Exchange [sr_customer_sk,sr_item_sk] #2
                             WholeStageCodegen (12)
-                              Project [ss_net_profit,s_store_id,s_store_name,i_item_id,i_item_desc,sr_item_sk,sr_customer_sk,sr_net_loss]
-                                SortMergeJoin [ss_customer_sk,ss_item_sk,ss_ticket_number,sr_customer_sk,sr_item_sk,sr_ticket_number]
-                                  InputAdapter
-                                    WholeStageCodegen (8)
-                                      Sort [ss_customer_sk,ss_item_sk,ss_ticket_number]
-                                        InputAdapter
-                                          Exchange [ss_customer_sk,ss_item_sk,ss_ticket_number] #3
-                                            WholeStageCodegen (7)
-                                              Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_profit,s_store_id,s_store_name,i_item_id,i_item_desc]
-                                                SortMergeJoin [ss_item_sk,i_item_sk]
-                                                  InputAdapter
-                                                    WholeStageCodegen (4)
-                                                      Sort [ss_item_sk]
-                                                        InputAdapter
-                                                          Exchange [ss_item_sk] #4
-                                                            WholeStageCodegen (3)
-                                                              Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_net_profit,s_store_id,s_store_name]
-                                                                BroadcastHashJoin [ss_store_sk,s_store_sk]
+                              Project [ss_net_profit,sr_item_sk,sr_customer_sk,sr_net_loss,i_item_id,i_item_desc,s_store_id,s_store_name]
+                                BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                  Project [ss_store_sk,ss_net_profit,sr_item_sk,sr_customer_sk,sr_net_loss,i_item_id,i_item_desc]
+                                    SortMergeJoin [ss_item_sk,i_item_sk]
+                                      InputAdapter
+                                        WholeStageCodegen (8)
+                                          Sort [ss_item_sk]
+                                            InputAdapter
+                                              Exchange [ss_item_sk] #3
+                                                WholeStageCodegen (7)
+                                                  Project [ss_item_sk,ss_store_sk,ss_net_profit,sr_item_sk,sr_customer_sk,sr_net_loss]
+                                                    SortMergeJoin [ss_customer_sk,ss_item_sk,ss_ticket_number,sr_customer_sk,sr_item_sk,sr_ticket_number]
+                                                      InputAdapter
+                                                        WholeStageCodegen (3)
+                                                          Sort [ss_customer_sk,ss_item_sk,ss_ticket_number]
+                                                            InputAdapter
+                                                              Exchange [ss_customer_sk,ss_item_sk,ss_ticket_number] #4
+                                                                WholeStageCodegen (2)
                                                                   Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_profit]
                                                                     BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                       Filter [ss_customer_sk,ss_item_sk,ss_ticket_number,ss_store_sk]
@@ -47,45 +47,45 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_store_id,s_store_name,store_sales
                                                                                             Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
                                                                       InputAdapter
                                                                         ReusedExchange [d_date_sk] #5
-                                                                  InputAdapter
-                                                                    BroadcastExchange #6
-                                                                      WholeStageCodegen (2)
-                                                                        Filter [s_store_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet spark_catalog.default.store [s_store_sk,s_store_id,s_store_name]
-                                                  InputAdapter
-                                                    WholeStageCodegen (6)
-                                                      Sort [i_item_sk]
-                                                        InputAdapter
-                                                          Exchange [i_item_sk] #7
-                                                            WholeStageCodegen (5)
-                                                              Filter [i_item_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc]
-                                  InputAdapter
-                                    WholeStageCodegen (11)
-                                      Sort [sr_customer_sk,sr_item_sk,sr_ticket_number]
-                                        InputAdapter
-                                          Exchange [sr_customer_sk,sr_item_sk,sr_ticket_number] #8
-                                            WholeStageCodegen (10)
-                                              Project [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_net_loss]
-                                                BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
-                                                  Filter [sr_customer_sk,sr_item_sk,sr_ticket_number]
+                                                      InputAdapter
+                                                        WholeStageCodegen (6)
+                                                          Sort [sr_customer_sk,sr_item_sk,sr_ticket_number]
+                                                            InputAdapter
+                                                              Exchange [sr_customer_sk,sr_item_sk,sr_ticket_number] #6
+                                                                WholeStageCodegen (5)
+                                                                  Project [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_net_loss]
+                                                                    BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
+                                                                      Filter [sr_customer_sk,sr_item_sk,sr_ticket_number]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_net_loss,sr_returned_date_sk]
+                                                                              SubqueryBroadcast [d_date_sk] #2
+                                                                                BroadcastExchange #7
+                                                                                  WholeStageCodegen (1)
+                                                                                    Project [d_date_sk]
+                                                                                      Filter [d_moy,d_year,d_date_sk]
+                                                                                        ColumnarToRow
+                                                                                          InputAdapter
+                                                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                                                                      InputAdapter
+                                                                        ReusedExchange [d_date_sk] #7
+                                      InputAdapter
+                                        WholeStageCodegen (10)
+                                          Sort [i_item_sk]
+                                            InputAdapter
+                                              Exchange [i_item_sk] #8
+                                                WholeStageCodegen (9)
+                                                  Filter [i_item_sk]
                                                     ColumnarToRow
                                                       InputAdapter
-                                                        Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_net_loss,sr_returned_date_sk]
-                                                          SubqueryBroadcast [d_date_sk] #2
-                                                            BroadcastExchange #9
-                                                              WholeStageCodegen (1)
-                                                                Project [d_date_sk]
-                                                                  Filter [d_moy,d_year,d_date_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
-                                                  InputAdapter
-                                                    ReusedExchange [d_date_sk] #9
+                                                        Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc]
+                                  InputAdapter
+                                    BroadcastExchange #9
+                                      WholeStageCodegen (11)
+                                        Filter [s_store_sk]
+                                          ColumnarToRow
+                                            InputAdapter
+                                              Scan parquet spark_catalog.default.store [s_store_sk,s_store_id,s_store_name]
                   InputAdapter
                     WholeStageCodegen (16)
                       Sort [cs_bill_customer_sk,cs_item_sk]
@@ -100,4 +100,4 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_store_id,s_store_name,store_sales
                                         Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_net_profit,cs_sold_date_sk]
                                           ReusedSubquery [d_date_sk] #2
                                   InputAdapter
-                                    ReusedExchange [d_date_sk] #9
+                                    ReusedExchange [d_date_sk] #7

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q26.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q26.sf100/explain.txt
@@ -7,8 +7,8 @@ TakeOrderedAndProject (30)
             +- * BroadcastHashJoin Inner BuildRight (25)
                :- * Project (20)
                :  +- * BroadcastHashJoin Inner BuildRight (19)
-               :     :- * Project (17)
-               :     :  +- * BroadcastHashJoin Inner BuildRight (16)
+               :     :- * Project (13)
+               :     :  +- * BroadcastHashJoin Inner BuildRight (12)
                :     :     :- * Project (10)
                :     :     :  +- * BroadcastHashJoin Inner BuildRight (9)
                :     :     :     :- * Filter (3)
@@ -18,13 +18,13 @@ TakeOrderedAndProject (30)
                :     :     :        +- * Project (7)
                :     :     :           +- * Filter (6)
                :     :     :              +- * ColumnarToRow (5)
-               :     :     :                 +- Scan parquet spark_catalog.default.customer_demographics (4)
-               :     :     +- BroadcastExchange (15)
-               :     :        +- * Project (14)
-               :     :           +- * Filter (13)
-               :     :              +- * ColumnarToRow (12)
-               :     :                 +- Scan parquet spark_catalog.default.promotion (11)
-               :     +- ReusedExchange (18)
+               :     :     :                 +- Scan parquet spark_catalog.default.promotion (4)
+               :     :     +- ReusedExchange (11)
+               :     +- BroadcastExchange (18)
+               :        +- * Project (17)
+               :           +- * Filter (16)
+               :              +- * ColumnarToRow (15)
+               :                 +- Scan parquet spark_catalog.default.customer_demographics (14)
                +- BroadcastExchange (24)
                   +- * Filter (23)
                      +- * ColumnarToRow (22)
@@ -46,82 +46,82 @@ Input [8]: [cs_bill_cdemo_sk#1, cs_item_sk#2, cs_promo_sk#3, cs_quantity#4, cs_l
 Input [8]: [cs_bill_cdemo_sk#1, cs_item_sk#2, cs_promo_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_sold_date_sk#8]
 Condition : ((isnotnull(cs_bill_cdemo_sk#1) AND isnotnull(cs_item_sk#2)) AND isnotnull(cs_promo_sk#3))
 
-(4) Scan parquet spark_catalog.default.customer_demographics
-Output [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_status#13]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_demographics]
-PushedFilters: [IsNotNull(cd_gender), IsNotNull(cd_marital_status), IsNotNull(cd_education_status), EqualTo(cd_gender,M), EqualTo(cd_marital_status,S), EqualTo(cd_education_status,College             ), IsNotNull(cd_demo_sk)]
-ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_education_status:string>
-
-(5) ColumnarToRow [codegen id : 1]
-Input [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_status#13]
-
-(6) Filter [codegen id : 1]
-Input [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_status#13]
-Condition : ((((((isnotnull(cd_gender#11) AND isnotnull(cd_marital_status#12)) AND isnotnull(cd_education_status#13)) AND (cd_gender#11 = M)) AND (cd_marital_status#12 = S)) AND (cd_education_status#13 = College             )) AND isnotnull(cd_demo_sk#10))
-
-(7) Project [codegen id : 1]
-Output [1]: [cd_demo_sk#10]
-Input [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_status#13]
-
-(8) BroadcastExchange
-Input [1]: [cd_demo_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
-
-(9) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [cs_bill_cdemo_sk#1]
-Right keys [1]: [cd_demo_sk#10]
-Join type: Inner
-Join condition: None
-
-(10) Project [codegen id : 5]
-Output [7]: [cs_item_sk#2, cs_promo_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_sold_date_sk#8]
-Input [9]: [cs_bill_cdemo_sk#1, cs_item_sk#2, cs_promo_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_sold_date_sk#8, cd_demo_sk#10]
-
-(11) Scan parquet spark_catalog.default.promotion
-Output [3]: [p_promo_sk#14, p_channel_email#15, p_channel_event#16]
+(4) Scan parquet spark_catalog.default.promotion
+Output [3]: [p_promo_sk#10, p_channel_email#11, p_channel_event#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/promotion]
 PushedFilters: [Or(EqualTo(p_channel_email,N),EqualTo(p_channel_event,N)), IsNotNull(p_promo_sk)]
 ReadSchema: struct<p_promo_sk:int,p_channel_email:string,p_channel_event:string>
 
-(12) ColumnarToRow [codegen id : 2]
-Input [3]: [p_promo_sk#14, p_channel_email#15, p_channel_event#16]
+(5) ColumnarToRow [codegen id : 1]
+Input [3]: [p_promo_sk#10, p_channel_email#11, p_channel_event#12]
 
-(13) Filter [codegen id : 2]
-Input [3]: [p_promo_sk#14, p_channel_email#15, p_channel_event#16]
-Condition : (((p_channel_email#15 = N) OR (p_channel_event#16 = N)) AND isnotnull(p_promo_sk#14))
+(6) Filter [codegen id : 1]
+Input [3]: [p_promo_sk#10, p_channel_email#11, p_channel_event#12]
+Condition : (((p_channel_email#11 = N) OR (p_channel_event#12 = N)) AND isnotnull(p_promo_sk#10))
 
-(14) Project [codegen id : 2]
-Output [1]: [p_promo_sk#14]
-Input [3]: [p_promo_sk#14, p_channel_email#15, p_channel_event#16]
+(7) Project [codegen id : 1]
+Output [1]: [p_promo_sk#10]
+Input [3]: [p_promo_sk#10, p_channel_email#11, p_channel_event#12]
 
-(15) BroadcastExchange
-Input [1]: [p_promo_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
+(8) BroadcastExchange
+Input [1]: [p_promo_sk#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(16) BroadcastHashJoin [codegen id : 5]
+(9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [cs_promo_sk#3]
-Right keys [1]: [p_promo_sk#14]
+Right keys [1]: [p_promo_sk#10]
 Join type: Inner
 Join condition: None
 
-(17) Project [codegen id : 5]
-Output [6]: [cs_item_sk#2, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_sold_date_sk#8]
-Input [8]: [cs_item_sk#2, cs_promo_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_sold_date_sk#8, p_promo_sk#14]
+(10) Project [codegen id : 5]
+Output [7]: [cs_bill_cdemo_sk#1, cs_item_sk#2, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_sold_date_sk#8]
+Input [9]: [cs_bill_cdemo_sk#1, cs_item_sk#2, cs_promo_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_sold_date_sk#8, p_promo_sk#10]
 
-(18) ReusedExchange [Reuses operator id: 35]
-Output [1]: [d_date_sk#17]
+(11) ReusedExchange [Reuses operator id: 35]
+Output [1]: [d_date_sk#13]
+
+(12) BroadcastHashJoin [codegen id : 5]
+Left keys [1]: [cs_sold_date_sk#8]
+Right keys [1]: [d_date_sk#13]
+Join type: Inner
+Join condition: None
+
+(13) Project [codegen id : 5]
+Output [6]: [cs_bill_cdemo_sk#1, cs_item_sk#2, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7]
+Input [8]: [cs_bill_cdemo_sk#1, cs_item_sk#2, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_sold_date_sk#8, d_date_sk#13]
+
+(14) Scan parquet spark_catalog.default.customer_demographics
+Output [4]: [cd_demo_sk#14, cd_gender#15, cd_marital_status#16, cd_education_status#17]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_demographics]
+PushedFilters: [IsNotNull(cd_gender), IsNotNull(cd_marital_status), IsNotNull(cd_education_status), EqualTo(cd_gender,M), EqualTo(cd_marital_status,S), EqualTo(cd_education_status,College             ), IsNotNull(cd_demo_sk)]
+ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_education_status:string>
+
+(15) ColumnarToRow [codegen id : 3]
+Input [4]: [cd_demo_sk#14, cd_gender#15, cd_marital_status#16, cd_education_status#17]
+
+(16) Filter [codegen id : 3]
+Input [4]: [cd_demo_sk#14, cd_gender#15, cd_marital_status#16, cd_education_status#17]
+Condition : ((((((isnotnull(cd_gender#15) AND isnotnull(cd_marital_status#16)) AND isnotnull(cd_education_status#17)) AND (cd_gender#15 = M)) AND (cd_marital_status#16 = S)) AND (cd_education_status#17 = College             )) AND isnotnull(cd_demo_sk#14))
+
+(17) Project [codegen id : 3]
+Output [1]: [cd_demo_sk#14]
+Input [4]: [cd_demo_sk#14, cd_gender#15, cd_marital_status#16, cd_education_status#17]
+
+(18) BroadcastExchange
+Input [1]: [cd_demo_sk#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
 (19) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [cs_sold_date_sk#8]
-Right keys [1]: [d_date_sk#17]
+Left keys [1]: [cs_bill_cdemo_sk#1]
+Right keys [1]: [cd_demo_sk#14]
 Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 5]
 Output [5]: [cs_item_sk#2, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7]
-Input [7]: [cs_item_sk#2, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_sold_date_sk#8, d_date_sk#17]
+Input [7]: [cs_bill_cdemo_sk#1, cs_item_sk#2, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cd_demo_sk#14]
 
 (21) Scan parquet spark_catalog.default.item
 Output [2]: [i_item_sk#18, i_item_id#19]
@@ -184,25 +184,25 @@ BroadcastExchange (35)
 
 
 (31) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#17, d_year#44]
+Output [2]: [d_date_sk#13, d_year#44]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (32) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#17, d_year#44]
+Input [2]: [d_date_sk#13, d_year#44]
 
 (33) Filter [codegen id : 1]
-Input [2]: [d_date_sk#17, d_year#44]
-Condition : ((isnotnull(d_year#44) AND (d_year#44 = 2000)) AND isnotnull(d_date_sk#17))
+Input [2]: [d_date_sk#13, d_year#44]
+Condition : ((isnotnull(d_year#44) AND (d_year#44 = 2000)) AND isnotnull(d_date_sk#13))
 
 (34) Project [codegen id : 1]
-Output [1]: [d_date_sk#17]
-Input [2]: [d_date_sk#17, d_year#44]
+Output [1]: [d_date_sk#13]
+Input [2]: [d_date_sk#13, d_year#44]
 
 (35) BroadcastExchange
-Input [1]: [d_date_sk#17]
+Input [1]: [d_date_sk#13]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q26.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q26.sf100/simplified.txt
@@ -8,11 +8,11 @@ TakeOrderedAndProject [i_item_id,agg1,agg2,agg3,agg4]
               Project [cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,i_item_id]
                 BroadcastHashJoin [cs_item_sk,i_item_sk]
                   Project [cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt]
-                    BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                      Project [cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_sold_date_sk]
-                        BroadcastHashJoin [cs_promo_sk,p_promo_sk]
-                          Project [cs_item_sk,cs_promo_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_sold_date_sk]
-                            BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
+                    BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
+                      Project [cs_bill_cdemo_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt]
+                        BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                          Project [cs_bill_cdemo_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_sold_date_sk]
+                            BroadcastHashJoin [cs_promo_sk,p_promo_sk]
                               Filter [cs_bill_cdemo_sk,cs_item_sk,cs_promo_sk]
                                 ColumnarToRow
                                   InputAdapter
@@ -28,21 +28,21 @@ TakeOrderedAndProject [i_item_id,agg1,agg2,agg3,agg4]
                               InputAdapter
                                 BroadcastExchange #3
                                   WholeStageCodegen (1)
-                                    Project [cd_demo_sk]
-                                      Filter [cd_gender,cd_marital_status,cd_education_status,cd_demo_sk]
+                                    Project [p_promo_sk]
+                                      Filter [p_channel_email,p_channel_event,p_promo_sk]
                                         ColumnarToRow
                                           InputAdapter
-                                            Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_education_status]
+                                            Scan parquet spark_catalog.default.promotion [p_promo_sk,p_channel_email,p_channel_event]
                           InputAdapter
-                            BroadcastExchange #4
-                              WholeStageCodegen (2)
-                                Project [p_promo_sk]
-                                  Filter [p_channel_email,p_channel_event,p_promo_sk]
-                                    ColumnarToRow
-                                      InputAdapter
-                                        Scan parquet spark_catalog.default.promotion [p_promo_sk,p_channel_email,p_channel_event]
+                            ReusedExchange [d_date_sk] #2
                       InputAdapter
-                        ReusedExchange [d_date_sk] #2
+                        BroadcastExchange #4
+                          WholeStageCodegen (3)
+                            Project [cd_demo_sk]
+                              Filter [cd_gender,cd_marital_status,cd_education_status,cd_demo_sk]
+                                ColumnarToRow
+                                  InputAdapter
+                                    Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_education_status]
                   InputAdapter
                     BroadcastExchange #5
                       WholeStageCodegen (4)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q27.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q27.sf100/explain.txt
@@ -10,17 +10,17 @@ TakeOrderedAndProject (30)
                   :  +- * BroadcastHashJoin Inner BuildRight (18)
                   :     :- * Project (13)
                   :     :  +- * BroadcastHashJoin Inner BuildRight (12)
-                  :     :     :- * Project (10)
-                  :     :     :  +- * BroadcastHashJoin Inner BuildRight (9)
+                  :     :     :- * Project (6)
+                  :     :     :  +- * BroadcastHashJoin Inner BuildRight (5)
                   :     :     :     :- * Filter (3)
                   :     :     :     :  +- * ColumnarToRow (2)
                   :     :     :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-                  :     :     :     +- BroadcastExchange (8)
-                  :     :     :        +- * Project (7)
-                  :     :     :           +- * Filter (6)
-                  :     :     :              +- * ColumnarToRow (5)
-                  :     :     :                 +- Scan parquet spark_catalog.default.customer_demographics (4)
-                  :     :     +- ReusedExchange (11)
+                  :     :     :     +- ReusedExchange (4)
+                  :     :     +- BroadcastExchange (11)
+                  :     :        +- * Project (10)
+                  :     :           +- * Filter (9)
+                  :     :              +- * ColumnarToRow (8)
+                  :     :                 +- Scan parquet spark_catalog.default.customer_demographics (7)
                   :     +- BroadcastExchange (17)
                   :        +- * Filter (16)
                   :           +- * ColumnarToRow (15)
@@ -46,50 +46,50 @@ Input [8]: [ss_item_sk#1, ss_cdemo_sk#2, ss_store_sk#3, ss_quantity#4, ss_list_p
 Input [8]: [ss_item_sk#1, ss_cdemo_sk#2, ss_store_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, ss_sold_date_sk#8]
 Condition : ((isnotnull(ss_cdemo_sk#2) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_item_sk#1))
 
-(4) Scan parquet spark_catalog.default.customer_demographics
-Output [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_status#13]
+(4) ReusedExchange [Reuses operator id: 35]
+Output [1]: [d_date_sk#10]
+
+(5) BroadcastHashJoin [codegen id : 5]
+Left keys [1]: [ss_sold_date_sk#8]
+Right keys [1]: [d_date_sk#10]
+Join type: Inner
+Join condition: None
+
+(6) Project [codegen id : 5]
+Output [7]: [ss_item_sk#1, ss_cdemo_sk#2, ss_store_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7]
+Input [9]: [ss_item_sk#1, ss_cdemo_sk#2, ss_store_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, ss_sold_date_sk#8, d_date_sk#10]
+
+(7) Scan parquet spark_catalog.default.customer_demographics
+Output [4]: [cd_demo_sk#11, cd_gender#12, cd_marital_status#13, cd_education_status#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_gender), IsNotNull(cd_marital_status), IsNotNull(cd_education_status), EqualTo(cd_gender,M), EqualTo(cd_marital_status,S), EqualTo(cd_education_status,College             ), IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_education_status:string>
 
-(5) ColumnarToRow [codegen id : 1]
-Input [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_status#13]
+(8) ColumnarToRow [codegen id : 2]
+Input [4]: [cd_demo_sk#11, cd_gender#12, cd_marital_status#13, cd_education_status#14]
 
-(6) Filter [codegen id : 1]
-Input [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_status#13]
-Condition : ((((((isnotnull(cd_gender#11) AND isnotnull(cd_marital_status#12)) AND isnotnull(cd_education_status#13)) AND (cd_gender#11 = M)) AND (cd_marital_status#12 = S)) AND (cd_education_status#13 = College             )) AND isnotnull(cd_demo_sk#10))
+(9) Filter [codegen id : 2]
+Input [4]: [cd_demo_sk#11, cd_gender#12, cd_marital_status#13, cd_education_status#14]
+Condition : ((((((isnotnull(cd_gender#12) AND isnotnull(cd_marital_status#13)) AND isnotnull(cd_education_status#14)) AND (cd_gender#12 = M)) AND (cd_marital_status#13 = S)) AND (cd_education_status#14 = College             )) AND isnotnull(cd_demo_sk#11))
 
-(7) Project [codegen id : 1]
-Output [1]: [cd_demo_sk#10]
-Input [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_status#13]
+(10) Project [codegen id : 2]
+Output [1]: [cd_demo_sk#11]
+Input [4]: [cd_demo_sk#11, cd_gender#12, cd_marital_status#13, cd_education_status#14]
 
-(8) BroadcastExchange
-Input [1]: [cd_demo_sk#10]
+(11) BroadcastExchange
+Input [1]: [cd_demo_sk#11]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(9) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [ss_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#10]
-Join type: Inner
-Join condition: None
-
-(10) Project [codegen id : 5]
-Output [7]: [ss_item_sk#1, ss_store_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, ss_sold_date_sk#8]
-Input [9]: [ss_item_sk#1, ss_cdemo_sk#2, ss_store_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, ss_sold_date_sk#8, cd_demo_sk#10]
-
-(11) ReusedExchange [Reuses operator id: 35]
-Output [1]: [d_date_sk#14]
-
 (12) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [ss_sold_date_sk#8]
-Right keys [1]: [d_date_sk#14]
+Left keys [1]: [ss_cdemo_sk#2]
+Right keys [1]: [cd_demo_sk#11]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 5]
 Output [6]: [ss_item_sk#1, ss_store_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7]
-Input [8]: [ss_item_sk#1, ss_store_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, ss_sold_date_sk#8, d_date_sk#14]
+Input [8]: [ss_item_sk#1, ss_cdemo_sk#2, ss_store_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, cd_demo_sk#11]
 
 (14) Scan parquet spark_catalog.default.store
 Output [2]: [s_store_sk#15, s_state#16]
@@ -184,25 +184,25 @@ BroadcastExchange (35)
 
 
 (31) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#14, d_year#47]
+Output [2]: [d_date_sk#10, d_year#47]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2002), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (32) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#14, d_year#47]
+Input [2]: [d_date_sk#10, d_year#47]
 
 (33) Filter [codegen id : 1]
-Input [2]: [d_date_sk#14, d_year#47]
-Condition : ((isnotnull(d_year#47) AND (d_year#47 = 2002)) AND isnotnull(d_date_sk#14))
+Input [2]: [d_date_sk#10, d_year#47]
+Condition : ((isnotnull(d_year#47) AND (d_year#47 = 2002)) AND isnotnull(d_date_sk#10))
 
 (34) Project [codegen id : 1]
-Output [1]: [d_date_sk#14]
-Input [2]: [d_date_sk#14, d_year#47]
+Output [1]: [d_date_sk#10]
+Input [2]: [d_date_sk#10, d_year#47]
 
 (35) BroadcastExchange
-Input [1]: [d_date_sk#14]
+Input [1]: [d_date_sk#10]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q27.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q27.sf100/simplified.txt
@@ -11,9 +11,9 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                     Project [ss_item_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt,s_state]
                       BroadcastHashJoin [ss_store_sk,s_store_sk]
                         Project [ss_item_sk,ss_store_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
-                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                            Project [ss_item_sk,ss_store_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt,ss_sold_date_sk]
-                              BroadcastHashJoin [ss_cdemo_sk,cd_demo_sk]
+                          BroadcastHashJoin [ss_cdemo_sk,cd_demo_sk]
+                            Project [ss_item_sk,ss_cdemo_sk,ss_store_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
+                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                 Filter [ss_cdemo_sk,ss_store_sk,ss_item_sk]
                                   ColumnarToRow
                                     InputAdapter
@@ -27,15 +27,15 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                                                     InputAdapter
                                                       Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                 InputAdapter
-                                  BroadcastExchange #3
-                                    WholeStageCodegen (1)
-                                      Project [cd_demo_sk]
-                                        Filter [cd_gender,cd_marital_status,cd_education_status,cd_demo_sk]
-                                          ColumnarToRow
-                                            InputAdapter
-                                              Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_education_status]
+                                  ReusedExchange [d_date_sk] #2
                             InputAdapter
-                              ReusedExchange [d_date_sk] #2
+                              BroadcastExchange #3
+                                WholeStageCodegen (2)
+                                  Project [cd_demo_sk]
+                                    Filter [cd_gender,cd_marital_status,cd_education_status,cd_demo_sk]
+                                      ColumnarToRow
+                                        InputAdapter
+                                          Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_education_status]
                         InputAdapter
                           BroadcastExchange #4
                             WholeStageCodegen (3)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29.sf100/explain.txt
@@ -8,38 +8,38 @@ TakeOrderedAndProject (49)
                :- * Sort (35)
                :  +- Exchange (34)
                :     +- * Project (33)
-               :        +- * SortMergeJoin Inner (32)
-               :           :- * Sort (23)
-               :           :  +- Exchange (22)
-               :           :     +- * Project (21)
-               :           :        +- * SortMergeJoin Inner (20)
-               :           :           :- * Sort (14)
-               :           :           :  +- Exchange (13)
-               :           :           :     +- * Project (12)
-               :           :           :        +- * BroadcastHashJoin Inner BuildRight (11)
-               :           :           :           :- * Project (6)
-               :           :           :           :  +- * BroadcastHashJoin Inner BuildRight (5)
-               :           :           :           :     :- * Filter (3)
-               :           :           :           :     :  +- * ColumnarToRow (2)
-               :           :           :           :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-               :           :           :           :     +- ReusedExchange (4)
-               :           :           :           +- BroadcastExchange (10)
-               :           :           :              +- * Filter (9)
-               :           :           :                 +- * ColumnarToRow (8)
-               :           :           :                    +- Scan parquet spark_catalog.default.store (7)
-               :           :           +- * Sort (19)
-               :           :              +- Exchange (18)
-               :           :                 +- * Filter (17)
-               :           :                    +- * ColumnarToRow (16)
-               :           :                       +- Scan parquet spark_catalog.default.item (15)
-               :           +- * Sort (31)
-               :              +- Exchange (30)
-               :                 +- * Project (29)
-               :                    +- * BroadcastHashJoin Inner BuildRight (28)
-               :                       :- * Filter (26)
-               :                       :  +- * ColumnarToRow (25)
-               :                       :     +- Scan parquet spark_catalog.default.store_returns (24)
-               :                       +- ReusedExchange (27)
+               :        +- * BroadcastHashJoin Inner BuildRight (32)
+               :           :- * Project (27)
+               :           :  +- * SortMergeJoin Inner (26)
+               :           :     :- * Sort (20)
+               :           :     :  +- Exchange (19)
+               :           :     :     +- * Project (18)
+               :           :     :        +- * SortMergeJoin Inner (17)
+               :           :     :           :- * Sort (8)
+               :           :     :           :  +- Exchange (7)
+               :           :     :           :     +- * Project (6)
+               :           :     :           :        +- * BroadcastHashJoin Inner BuildRight (5)
+               :           :     :           :           :- * Filter (3)
+               :           :     :           :           :  +- * ColumnarToRow (2)
+               :           :     :           :           :     +- Scan parquet spark_catalog.default.store_sales (1)
+               :           :     :           :           +- ReusedExchange (4)
+               :           :     :           +- * Sort (16)
+               :           :     :              +- Exchange (15)
+               :           :     :                 +- * Project (14)
+               :           :     :                    +- * BroadcastHashJoin Inner BuildRight (13)
+               :           :     :                       :- * Filter (11)
+               :           :     :                       :  +- * ColumnarToRow (10)
+               :           :     :                       :     +- Scan parquet spark_catalog.default.store_returns (9)
+               :           :     :                       +- ReusedExchange (12)
+               :           :     +- * Sort (25)
+               :           :        +- Exchange (24)
+               :           :           +- * Filter (23)
+               :           :              +- * ColumnarToRow (22)
+               :           :                 +- Scan parquet spark_catalog.default.item (21)
+               :           +- BroadcastExchange (31)
+               :              +- * Filter (30)
+               :                 +- * ColumnarToRow (29)
+               :                    +- Scan parquet spark_catalog.default.store (28)
                +- * Sort (43)
                   +- Exchange (42)
                      +- * Project (41)
@@ -58,155 +58,155 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#6), dynamicpruningexpression(ss_sol
 PushedFilters: [IsNotNull(ss_customer_sk), IsNotNull(ss_item_sk), IsNotNull(ss_ticket_number), IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_quantity:int>
 
-(2) ColumnarToRow [codegen id : 3]
+(2) ColumnarToRow [codegen id : 2]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5, ss_sold_date_sk#6]
 
-(3) Filter [codegen id : 3]
+(3) Filter [codegen id : 2]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5, ss_sold_date_sk#6]
 Condition : (((isnotnull(ss_customer_sk#2) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_ticket_number#4)) AND isnotnull(ss_store_sk#3))
 
 (4) ReusedExchange [Reuses operator id: 54]
 Output [1]: [d_date_sk#8]
 
-(5) BroadcastHashJoin [codegen id : 3]
+(5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#6]
 Right keys [1]: [d_date_sk#8]
 Join type: Inner
 Join condition: None
 
-(6) Project [codegen id : 3]
+(6) Project [codegen id : 2]
 Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5]
 Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5, ss_sold_date_sk#6, d_date_sk#8]
 
-(7) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#9, s_store_id#10, s_store_name#11]
+(7) Exchange
+Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5]
+Arguments: hashpartitioning(ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4, 5), ENSURE_REQUIREMENTS, [plan_id=1]
+
+(8) Sort [codegen id : 3]
+Input [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5]
+Arguments: [ss_customer_sk#2 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST, ss_ticket_number#4 ASC NULLS FIRST], false, 0
+
+(9) Scan parquet spark_catalog.default.store_returns
+Output [5]: [sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_return_quantity#12, sr_returned_date_sk#13]
 Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_store_sk)]
-ReadSchema: struct<s_store_sk:int,s_store_id:string,s_store_name:string>
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(sr_returned_date_sk#13), dynamicpruningexpression(sr_returned_date_sk#13 IN dynamicpruning#14)]
+PushedFilters: [IsNotNull(sr_customer_sk), IsNotNull(sr_item_sk), IsNotNull(sr_ticket_number)]
+ReadSchema: struct<sr_item_sk:int,sr_customer_sk:int,sr_ticket_number:int,sr_return_quantity:int>
 
-(8) ColumnarToRow [codegen id : 2]
-Input [3]: [s_store_sk#9, s_store_id#10, s_store_name#11]
+(10) ColumnarToRow [codegen id : 5]
+Input [5]: [sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_return_quantity#12, sr_returned_date_sk#13]
 
-(9) Filter [codegen id : 2]
-Input [3]: [s_store_sk#9, s_store_id#10, s_store_name#11]
-Condition : isnotnull(s_store_sk#9)
+(11) Filter [codegen id : 5]
+Input [5]: [sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_return_quantity#12, sr_returned_date_sk#13]
+Condition : ((isnotnull(sr_customer_sk#10) AND isnotnull(sr_item_sk#9)) AND isnotnull(sr_ticket_number#11))
 
-(10) BroadcastExchange
-Input [3]: [s_store_sk#9, s_store_id#10, s_store_name#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
+(12) ReusedExchange [Reuses operator id: 59]
+Output [1]: [d_date_sk#15]
 
-(11) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#9]
+(13) BroadcastHashJoin [codegen id : 5]
+Left keys [1]: [sr_returned_date_sk#13]
+Right keys [1]: [d_date_sk#15]
 Join type: Inner
 Join condition: None
 
-(12) Project [codegen id : 3]
-Output [6]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#10, s_store_name#11]
-Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5, s_store_sk#9, s_store_id#10, s_store_name#11]
+(14) Project [codegen id : 5]
+Output [4]: [sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_return_quantity#12]
+Input [6]: [sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_return_quantity#12, sr_returned_date_sk#13, d_date_sk#15]
 
-(13) Exchange
-Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#10, s_store_name#11]
-Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+(15) Exchange
+Input [4]: [sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_return_quantity#12]
+Arguments: hashpartitioning(sr_customer_sk#10, sr_item_sk#9, sr_ticket_number#11, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(14) Sort [codegen id : 4]
-Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#10, s_store_name#11]
+(16) Sort [codegen id : 6]
+Input [4]: [sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_return_quantity#12]
+Arguments: [sr_customer_sk#10 ASC NULLS FIRST, sr_item_sk#9 ASC NULLS FIRST, sr_ticket_number#11 ASC NULLS FIRST], false, 0
+
+(17) SortMergeJoin [codegen id : 7]
+Left keys [3]: [ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4]
+Right keys [3]: [sr_customer_sk#10, sr_item_sk#9, sr_ticket_number#11]
+Join type: Inner
+Join condition: None
+
+(18) Project [codegen id : 7]
+Output [6]: [ss_item_sk#1, ss_store_sk#3, ss_quantity#5, sr_item_sk#9, sr_customer_sk#10, sr_return_quantity#12]
+Input [9]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_quantity#5, sr_item_sk#9, sr_customer_sk#10, sr_ticket_number#11, sr_return_quantity#12]
+
+(19) Exchange
+Input [6]: [ss_item_sk#1, ss_store_sk#3, ss_quantity#5, sr_item_sk#9, sr_customer_sk#10, sr_return_quantity#12]
+Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(20) Sort [codegen id : 8]
+Input [6]: [ss_item_sk#1, ss_store_sk#3, ss_quantity#5, sr_item_sk#9, sr_customer_sk#10, sr_return_quantity#12]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(15) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#12, i_item_id#13, i_item_desc#14]
+(21) Scan parquet spark_catalog.default.item
+Output [3]: [i_item_sk#16, i_item_id#17, i_item_desc#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string,i_item_desc:string>
 
-(16) ColumnarToRow [codegen id : 5]
-Input [3]: [i_item_sk#12, i_item_id#13, i_item_desc#14]
+(22) ColumnarToRow [codegen id : 9]
+Input [3]: [i_item_sk#16, i_item_id#17, i_item_desc#18]
 
-(17) Filter [codegen id : 5]
-Input [3]: [i_item_sk#12, i_item_id#13, i_item_desc#14]
-Condition : isnotnull(i_item_sk#12)
+(23) Filter [codegen id : 9]
+Input [3]: [i_item_sk#16, i_item_id#17, i_item_desc#18]
+Condition : isnotnull(i_item_sk#16)
 
-(18) Exchange
-Input [3]: [i_item_sk#12, i_item_id#13, i_item_desc#14]
-Arguments: hashpartitioning(i_item_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+(24) Exchange
+Input [3]: [i_item_sk#16, i_item_id#17, i_item_desc#18]
+Arguments: hashpartitioning(i_item_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(19) Sort [codegen id : 6]
-Input [3]: [i_item_sk#12, i_item_id#13, i_item_desc#14]
-Arguments: [i_item_sk#12 ASC NULLS FIRST], false, 0
+(25) Sort [codegen id : 10]
+Input [3]: [i_item_sk#16, i_item_id#17, i_item_desc#18]
+Arguments: [i_item_sk#16 ASC NULLS FIRST], false, 0
 
-(20) SortMergeJoin [codegen id : 7]
+(26) SortMergeJoin [codegen id : 12]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#12]
+Right keys [1]: [i_item_sk#16]
 Join type: Inner
 Join condition: None
 
-(21) Project [codegen id : 7]
-Output [8]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14]
-Input [9]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#10, s_store_name#11, i_item_sk#12, i_item_id#13, i_item_desc#14]
+(27) Project [codegen id : 12]
+Output [7]: [ss_store_sk#3, ss_quantity#5, sr_item_sk#9, sr_customer_sk#10, sr_return_quantity#12, i_item_id#17, i_item_desc#18]
+Input [9]: [ss_item_sk#1, ss_store_sk#3, ss_quantity#5, sr_item_sk#9, sr_customer_sk#10, sr_return_quantity#12, i_item_sk#16, i_item_id#17, i_item_desc#18]
 
-(22) Exchange
-Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14]
-Arguments: hashpartitioning(ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(23) Sort [codegen id : 8]
-Input [8]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14]
-Arguments: [ss_customer_sk#2 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST, ss_ticket_number#4 ASC NULLS FIRST], false, 0
-
-(24) Scan parquet spark_catalog.default.store_returns
-Output [5]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_return_quantity#18, sr_returned_date_sk#19]
+(28) Scan parquet spark_catalog.default.store
+Output [3]: [s_store_sk#19, s_store_id#20, s_store_name#21]
 Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(sr_returned_date_sk#19), dynamicpruningexpression(sr_returned_date_sk#19 IN dynamicpruning#20)]
-PushedFilters: [IsNotNull(sr_customer_sk), IsNotNull(sr_item_sk), IsNotNull(sr_ticket_number)]
-ReadSchema: struct<sr_item_sk:int,sr_customer_sk:int,sr_ticket_number:int,sr_return_quantity:int>
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [IsNotNull(s_store_sk)]
+ReadSchema: struct<s_store_sk:int,s_store_id:string,s_store_name:string>
 
-(25) ColumnarToRow [codegen id : 10]
-Input [5]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_return_quantity#18, sr_returned_date_sk#19]
+(29) ColumnarToRow [codegen id : 11]
+Input [3]: [s_store_sk#19, s_store_id#20, s_store_name#21]
 
-(26) Filter [codegen id : 10]
-Input [5]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_return_quantity#18, sr_returned_date_sk#19]
-Condition : ((isnotnull(sr_customer_sk#16) AND isnotnull(sr_item_sk#15)) AND isnotnull(sr_ticket_number#17))
+(30) Filter [codegen id : 11]
+Input [3]: [s_store_sk#19, s_store_id#20, s_store_name#21]
+Condition : isnotnull(s_store_sk#19)
 
-(27) ReusedExchange [Reuses operator id: 59]
-Output [1]: [d_date_sk#21]
+(31) BroadcastExchange
+Input [3]: [s_store_sk#19, s_store_id#20, s_store_name#21]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
 
-(28) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [sr_returned_date_sk#19]
-Right keys [1]: [d_date_sk#21]
-Join type: Inner
-Join condition: None
-
-(29) Project [codegen id : 10]
-Output [4]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_return_quantity#18]
-Input [6]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_return_quantity#18, sr_returned_date_sk#19, d_date_sk#21]
-
-(30) Exchange
-Input [4]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_return_quantity#18]
-Arguments: hashpartitioning(sr_customer_sk#16, sr_item_sk#15, sr_ticket_number#17, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(31) Sort [codegen id : 11]
-Input [4]: [sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_return_quantity#18]
-Arguments: [sr_customer_sk#16 ASC NULLS FIRST, sr_item_sk#15 ASC NULLS FIRST, sr_ticket_number#17 ASC NULLS FIRST], false, 0
-
-(32) SortMergeJoin [codegen id : 12]
-Left keys [3]: [ss_customer_sk#2, ss_item_sk#1, ss_ticket_number#4]
-Right keys [3]: [sr_customer_sk#16, sr_item_sk#15, sr_ticket_number#17]
+(32) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [ss_store_sk#3]
+Right keys [1]: [s_store_sk#19]
 Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 12]
-Output [8]: [ss_quantity#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14, sr_item_sk#15, sr_customer_sk#16, sr_return_quantity#18]
-Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_ticket_number#4, ss_quantity#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14, sr_item_sk#15, sr_customer_sk#16, sr_ticket_number#17, sr_return_quantity#18]
+Output [8]: [ss_quantity#5, sr_item_sk#9, sr_customer_sk#10, sr_return_quantity#12, i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21]
+Input [10]: [ss_store_sk#3, ss_quantity#5, sr_item_sk#9, sr_customer_sk#10, sr_return_quantity#12, i_item_id#17, i_item_desc#18, s_store_sk#19, s_store_id#20, s_store_name#21]
 
 (34) Exchange
-Input [8]: [ss_quantity#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14, sr_item_sk#15, sr_customer_sk#16, sr_return_quantity#18]
-Arguments: hashpartitioning(sr_customer_sk#16, sr_item_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [8]: [ss_quantity#5, sr_item_sk#9, sr_customer_sk#10, sr_return_quantity#12, i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21]
+Arguments: hashpartitioning(sr_customer_sk#10, sr_item_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (35) Sort [codegen id : 13]
-Input [8]: [ss_quantity#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14, sr_item_sk#15, sr_customer_sk#16, sr_return_quantity#18]
-Arguments: [sr_customer_sk#16 ASC NULLS FIRST, sr_item_sk#15 ASC NULLS FIRST], false, 0
+Input [8]: [ss_quantity#5, sr_item_sk#9, sr_customer_sk#10, sr_return_quantity#12, i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21]
+Arguments: [sr_customer_sk#10 ASC NULLS FIRST, sr_item_sk#9 ASC NULLS FIRST], false, 0
 
 (36) Scan parquet spark_catalog.default.catalog_sales
 Output [4]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_quantity#24, cs_sold_date_sk#25]
@@ -245,36 +245,36 @@ Input [3]: [cs_bill_customer_sk#22, cs_item_sk#23, cs_quantity#24]
 Arguments: [cs_bill_customer_sk#22 ASC NULLS FIRST, cs_item_sk#23 ASC NULLS FIRST], false, 0
 
 (44) SortMergeJoin [codegen id : 17]
-Left keys [2]: [sr_customer_sk#16, sr_item_sk#15]
+Left keys [2]: [sr_customer_sk#10, sr_item_sk#9]
 Right keys [2]: [cs_bill_customer_sk#22, cs_item_sk#23]
 Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 17]
-Output [7]: [ss_quantity#5, sr_return_quantity#18, cs_quantity#24, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14]
-Input [11]: [ss_quantity#5, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14, sr_item_sk#15, sr_customer_sk#16, sr_return_quantity#18, cs_bill_customer_sk#22, cs_item_sk#23, cs_quantity#24]
+Output [7]: [ss_quantity#5, sr_return_quantity#12, cs_quantity#24, s_store_id#20, s_store_name#21, i_item_id#17, i_item_desc#18]
+Input [11]: [ss_quantity#5, sr_item_sk#9, sr_customer_sk#10, sr_return_quantity#12, i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21, cs_bill_customer_sk#22, cs_item_sk#23, cs_quantity#24]
 
 (46) HashAggregate [codegen id : 17]
-Input [7]: [ss_quantity#5, sr_return_quantity#18, cs_quantity#24, s_store_id#10, s_store_name#11, i_item_id#13, i_item_desc#14]
-Keys [4]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11]
-Functions [3]: [partial_sum(ss_quantity#5), partial_sum(sr_return_quantity#18), partial_sum(cs_quantity#24)]
+Input [7]: [ss_quantity#5, sr_return_quantity#12, cs_quantity#24, s_store_id#20, s_store_name#21, i_item_id#17, i_item_desc#18]
+Keys [4]: [i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21]
+Functions [3]: [partial_sum(ss_quantity#5), partial_sum(sr_return_quantity#12), partial_sum(cs_quantity#24)]
 Aggregate Attributes [3]: [sum#28, sum#29, sum#30]
-Results [7]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, sum#31, sum#32, sum#33]
+Results [7]: [i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21, sum#31, sum#32, sum#33]
 
 (47) Exchange
-Input [7]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, sum#31, sum#32, sum#33]
-Arguments: hashpartitioning(i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [7]: [i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21, sum#31, sum#32, sum#33]
+Arguments: hashpartitioning(i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (48) HashAggregate [codegen id : 18]
-Input [7]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, sum#31, sum#32, sum#33]
-Keys [4]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11]
-Functions [3]: [sum(ss_quantity#5), sum(sr_return_quantity#18), sum(cs_quantity#24)]
-Aggregate Attributes [3]: [sum(ss_quantity#5)#34, sum(sr_return_quantity#18)#35, sum(cs_quantity#24)#36]
-Results [7]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, sum(ss_quantity#5)#34 AS store_sales_quantity#37, sum(sr_return_quantity#18)#35 AS store_returns_quantity#38, sum(cs_quantity#24)#36 AS catalog_sales_quantity#39]
+Input [7]: [i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21, sum#31, sum#32, sum#33]
+Keys [4]: [i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21]
+Functions [3]: [sum(ss_quantity#5), sum(sr_return_quantity#12), sum(cs_quantity#24)]
+Aggregate Attributes [3]: [sum(ss_quantity#5)#34, sum(sr_return_quantity#12)#35, sum(cs_quantity#24)#36]
+Results [7]: [i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21, sum(ss_quantity#5)#34 AS store_sales_quantity#37, sum(sr_return_quantity#12)#35 AS store_returns_quantity#38, sum(cs_quantity#24)#36 AS catalog_sales_quantity#39]
 
 (49) TakeOrderedAndProject
-Input [7]: [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, store_sales_quantity#37, store_returns_quantity#38, catalog_sales_quantity#39]
-Arguments: 100, [i_item_id#13 ASC NULLS FIRST, i_item_desc#14 ASC NULLS FIRST, s_store_id#10 ASC NULLS FIRST, s_store_name#11 ASC NULLS FIRST], [i_item_id#13, i_item_desc#14, s_store_id#10, s_store_name#11, store_sales_quantity#37, store_returns_quantity#38, catalog_sales_quantity#39]
+Input [7]: [i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21, store_sales_quantity#37, store_returns_quantity#38, catalog_sales_quantity#39]
+Arguments: 100, [i_item_id#17 ASC NULLS FIRST, i_item_desc#18 ASC NULLS FIRST, s_store_id#20 ASC NULLS FIRST, s_store_name#21 ASC NULLS FIRST], [i_item_id#17, i_item_desc#18, s_store_id#20, s_store_name#21, store_sales_quantity#37, store_returns_quantity#38, catalog_sales_quantity#39]
 
 ===== Subqueries =====
 
@@ -308,7 +308,7 @@ Input [3]: [d_date_sk#8, d_year#40, d_moy#41]
 Input [1]: [d_date_sk#8]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
-Subquery:2 Hosting operator id = 24 Hosting Expression = sr_returned_date_sk#19 IN dynamicpruning#20
+Subquery:2 Hosting operator id = 9 Hosting Expression = sr_returned_date_sk#13 IN dynamicpruning#14
 BroadcastExchange (59)
 +- * Project (58)
    +- * Filter (57)
@@ -317,25 +317,25 @@ BroadcastExchange (59)
 
 
 (55) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#21, d_year#42, d_moy#43]
+Output [3]: [d_date_sk#15, d_year#42, d_moy#43]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_moy), IsNotNull(d_year), GreaterThanOrEqual(d_moy,9), LessThanOrEqual(d_moy,12), EqualTo(d_year,1999), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (56) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#21, d_year#42, d_moy#43]
+Input [3]: [d_date_sk#15, d_year#42, d_moy#43]
 
 (57) Filter [codegen id : 1]
-Input [3]: [d_date_sk#21, d_year#42, d_moy#43]
-Condition : (((((isnotnull(d_moy#43) AND isnotnull(d_year#42)) AND (d_moy#43 >= 9)) AND (d_moy#43 <= 12)) AND (d_year#42 = 1999)) AND isnotnull(d_date_sk#21))
+Input [3]: [d_date_sk#15, d_year#42, d_moy#43]
+Condition : (((((isnotnull(d_moy#43) AND isnotnull(d_year#42)) AND (d_moy#43 >= 9)) AND (d_moy#43 <= 12)) AND (d_year#42 = 1999)) AND isnotnull(d_date_sk#15))
 
 (58) Project [codegen id : 1]
-Output [1]: [d_date_sk#21]
-Input [3]: [d_date_sk#21, d_year#42, d_moy#43]
+Output [1]: [d_date_sk#15]
+Input [3]: [d_date_sk#15, d_year#42, d_moy#43]
 
 (59) BroadcastExchange
-Input [1]: [d_date_sk#21]
+Input [1]: [d_date_sk#15]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
 Subquery:3 Hosting operator id = 36 Hosting Expression = cs_sold_date_sk#25 IN dynamicpruning#26

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q29.sf100/simplified.txt
@@ -13,24 +13,24 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_store_id,s_store_name,store_sales
                         InputAdapter
                           Exchange [sr_customer_sk,sr_item_sk] #2
                             WholeStageCodegen (12)
-                              Project [ss_quantity,s_store_id,s_store_name,i_item_id,i_item_desc,sr_item_sk,sr_customer_sk,sr_return_quantity]
-                                SortMergeJoin [ss_customer_sk,ss_item_sk,ss_ticket_number,sr_customer_sk,sr_item_sk,sr_ticket_number]
-                                  InputAdapter
-                                    WholeStageCodegen (8)
-                                      Sort [ss_customer_sk,ss_item_sk,ss_ticket_number]
-                                        InputAdapter
-                                          Exchange [ss_customer_sk,ss_item_sk,ss_ticket_number] #3
-                                            WholeStageCodegen (7)
-                                              Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_quantity,s_store_id,s_store_name,i_item_id,i_item_desc]
-                                                SortMergeJoin [ss_item_sk,i_item_sk]
-                                                  InputAdapter
-                                                    WholeStageCodegen (4)
-                                                      Sort [ss_item_sk]
-                                                        InputAdapter
-                                                          Exchange [ss_item_sk] #4
-                                                            WholeStageCodegen (3)
-                                                              Project [ss_item_sk,ss_customer_sk,ss_ticket_number,ss_quantity,s_store_id,s_store_name]
-                                                                BroadcastHashJoin [ss_store_sk,s_store_sk]
+                              Project [ss_quantity,sr_item_sk,sr_customer_sk,sr_return_quantity,i_item_id,i_item_desc,s_store_id,s_store_name]
+                                BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                  Project [ss_store_sk,ss_quantity,sr_item_sk,sr_customer_sk,sr_return_quantity,i_item_id,i_item_desc]
+                                    SortMergeJoin [ss_item_sk,i_item_sk]
+                                      InputAdapter
+                                        WholeStageCodegen (8)
+                                          Sort [ss_item_sk]
+                                            InputAdapter
+                                              Exchange [ss_item_sk] #3
+                                                WholeStageCodegen (7)
+                                                  Project [ss_item_sk,ss_store_sk,ss_quantity,sr_item_sk,sr_customer_sk,sr_return_quantity]
+                                                    SortMergeJoin [ss_customer_sk,ss_item_sk,ss_ticket_number,sr_customer_sk,sr_item_sk,sr_ticket_number]
+                                                      InputAdapter
+                                                        WholeStageCodegen (3)
+                                                          Sort [ss_customer_sk,ss_item_sk,ss_ticket_number]
+                                                            InputAdapter
+                                                              Exchange [ss_customer_sk,ss_item_sk,ss_ticket_number] #4
+                                                                WholeStageCodegen (2)
                                                                   Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_quantity]
                                                                     BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                       Filter [ss_customer_sk,ss_item_sk,ss_ticket_number,ss_store_sk]
@@ -47,45 +47,45 @@ TakeOrderedAndProject [i_item_id,i_item_desc,s_store_id,s_store_name,store_sales
                                                                                             Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
                                                                       InputAdapter
                                                                         ReusedExchange [d_date_sk] #5
-                                                                  InputAdapter
-                                                                    BroadcastExchange #6
-                                                                      WholeStageCodegen (2)
-                                                                        Filter [s_store_sk]
-                                                                          ColumnarToRow
-                                                                            InputAdapter
-                                                                              Scan parquet spark_catalog.default.store [s_store_sk,s_store_id,s_store_name]
-                                                  InputAdapter
-                                                    WholeStageCodegen (6)
-                                                      Sort [i_item_sk]
-                                                        InputAdapter
-                                                          Exchange [i_item_sk] #7
-                                                            WholeStageCodegen (5)
-                                                              Filter [i_item_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc]
-                                  InputAdapter
-                                    WholeStageCodegen (11)
-                                      Sort [sr_customer_sk,sr_item_sk,sr_ticket_number]
-                                        InputAdapter
-                                          Exchange [sr_customer_sk,sr_item_sk,sr_ticket_number] #8
-                                            WholeStageCodegen (10)
-                                              Project [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_return_quantity]
-                                                BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
-                                                  Filter [sr_customer_sk,sr_item_sk,sr_ticket_number]
+                                                      InputAdapter
+                                                        WholeStageCodegen (6)
+                                                          Sort [sr_customer_sk,sr_item_sk,sr_ticket_number]
+                                                            InputAdapter
+                                                              Exchange [sr_customer_sk,sr_item_sk,sr_ticket_number] #6
+                                                                WholeStageCodegen (5)
+                                                                  Project [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_return_quantity]
+                                                                    BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
+                                                                      Filter [sr_customer_sk,sr_item_sk,sr_ticket_number]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_return_quantity,sr_returned_date_sk]
+                                                                              SubqueryBroadcast [d_date_sk] #2
+                                                                                BroadcastExchange #7
+                                                                                  WholeStageCodegen (1)
+                                                                                    Project [d_date_sk]
+                                                                                      Filter [d_moy,d_year,d_date_sk]
+                                                                                        ColumnarToRow
+                                                                                          InputAdapter
+                                                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                                                                      InputAdapter
+                                                                        ReusedExchange [d_date_sk] #7
+                                      InputAdapter
+                                        WholeStageCodegen (10)
+                                          Sort [i_item_sk]
+                                            InputAdapter
+                                              Exchange [i_item_sk] #8
+                                                WholeStageCodegen (9)
+                                                  Filter [i_item_sk]
                                                     ColumnarToRow
                                                       InputAdapter
-                                                        Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_customer_sk,sr_ticket_number,sr_return_quantity,sr_returned_date_sk]
-                                                          SubqueryBroadcast [d_date_sk] #2
-                                                            BroadcastExchange #9
-                                                              WholeStageCodegen (1)
-                                                                Project [d_date_sk]
-                                                                  Filter [d_moy,d_year,d_date_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
-                                                  InputAdapter
-                                                    ReusedExchange [d_date_sk] #9
+                                                        Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc]
+                                  InputAdapter
+                                    BroadcastExchange #9
+                                      WholeStageCodegen (11)
+                                        Filter [s_store_sk]
+                                          ColumnarToRow
+                                            InputAdapter
+                                              Scan parquet spark_catalog.default.store [s_store_sk,s_store_id,s_store_name]
                   InputAdapter
                     WholeStageCodegen (16)
                       Sort [cs_bill_customer_sk,cs_item_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q30.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q30.sf100/explain.txt
@@ -1,354 +1,369 @@
 == Physical Plan ==
-TakeOrderedAndProject (55)
-+- * Project (54)
-   +- * BroadcastHashJoin Inner BuildRight (53)
-      :- * Project (32)
-      :  +- * BroadcastHashJoin Inner BuildLeft (31)
-      :     :- BroadcastExchange (11)
-      :     :  +- * Project (10)
-      :     :     +- * BroadcastHashJoin Inner BuildRight (9)
-      :     :        :- * Filter (3)
-      :     :        :  +- * ColumnarToRow (2)
-      :     :        :     +- Scan parquet spark_catalog.default.customer (1)
-      :     :        +- BroadcastExchange (8)
-      :     :           +- * Project (7)
-      :     :              +- * Filter (6)
-      :     :                 +- * ColumnarToRow (5)
-      :     :                    +- Scan parquet spark_catalog.default.customer_address (4)
-      :     +- * Filter (30)
-      :        +- * HashAggregate (29)
-      :           +- Exchange (28)
-      :              +- * HashAggregate (27)
-      :                 +- * Project (26)
-      :                    +- * SortMergeJoin Inner (25)
-      :                       :- * Sort (19)
-      :                       :  +- Exchange (18)
-      :                       :     +- * Project (17)
-      :                       :        +- * BroadcastHashJoin Inner BuildRight (16)
-      :                       :           :- * Filter (14)
-      :                       :           :  +- * ColumnarToRow (13)
-      :                       :           :     +- Scan parquet spark_catalog.default.web_returns (12)
-      :                       :           +- ReusedExchange (15)
-      :                       +- * Sort (24)
-      :                          +- Exchange (23)
-      :                             +- * Filter (22)
-      :                                +- * ColumnarToRow (21)
-      :                                   +- Scan parquet spark_catalog.default.customer_address (20)
-      +- BroadcastExchange (52)
-         +- * Filter (51)
-            +- * HashAggregate (50)
-               +- Exchange (49)
-                  +- * HashAggregate (48)
-                     +- * HashAggregate (47)
-                        +- Exchange (46)
-                           +- * HashAggregate (45)
-                              +- * Project (44)
-                                 +- * SortMergeJoin Inner (43)
-                                    :- * Sort (40)
-                                    :  +- Exchange (39)
-                                    :     +- * Project (38)
-                                    :        +- * BroadcastHashJoin Inner BuildRight (37)
-                                    :           :- * Filter (35)
-                                    :           :  +- * ColumnarToRow (34)
-                                    :           :     +- Scan parquet spark_catalog.default.web_returns (33)
-                                    :           +- ReusedExchange (36)
-                                    +- * Sort (42)
-                                       +- ReusedExchange (41)
+TakeOrderedAndProject (58)
++- * Project (57)
+   +- * SortMergeJoin Inner (56)
+      :- * Sort (43)
+      :  +- Exchange (42)
+      :     +- * Project (41)
+      :        +- * BroadcastHashJoin Inner BuildRight (40)
+      :           :- * Filter (19)
+      :           :  +- * HashAggregate (18)
+      :           :     +- Exchange (17)
+      :           :        +- * HashAggregate (16)
+      :           :           +- * Project (15)
+      :           :              +- * SortMergeJoin Inner (14)
+      :           :                 :- * Sort (8)
+      :           :                 :  +- Exchange (7)
+      :           :                 :     +- * Project (6)
+      :           :                 :        +- * BroadcastHashJoin Inner BuildRight (5)
+      :           :                 :           :- * Filter (3)
+      :           :                 :           :  +- * ColumnarToRow (2)
+      :           :                 :           :     +- Scan parquet spark_catalog.default.web_returns (1)
+      :           :                 :           +- ReusedExchange (4)
+      :           :                 +- * Sort (13)
+      :           :                    +- Exchange (12)
+      :           :                       +- * Filter (11)
+      :           :                          +- * ColumnarToRow (10)
+      :           :                             +- Scan parquet spark_catalog.default.customer_address (9)
+      :           +- BroadcastExchange (39)
+      :              +- * Filter (38)
+      :                 +- * HashAggregate (37)
+      :                    +- Exchange (36)
+      :                       +- * HashAggregate (35)
+      :                          +- * HashAggregate (34)
+      :                             +- Exchange (33)
+      :                                +- * HashAggregate (32)
+      :                                   +- * Project (31)
+      :                                      +- * SortMergeJoin Inner (30)
+      :                                         :- * Sort (27)
+      :                                         :  +- Exchange (26)
+      :                                         :     +- * Project (25)
+      :                                         :        +- * BroadcastHashJoin Inner BuildRight (24)
+      :                                         :           :- * Filter (22)
+      :                                         :           :  +- * ColumnarToRow (21)
+      :                                         :           :     +- Scan parquet spark_catalog.default.web_returns (20)
+      :                                         :           +- ReusedExchange (23)
+      :                                         +- * Sort (29)
+      :                                            +- ReusedExchange (28)
+      +- * Sort (55)
+         +- Exchange (54)
+            +- * Project (53)
+               +- * BroadcastHashJoin Inner BuildRight (52)
+                  :- * Filter (46)
+                  :  +- * ColumnarToRow (45)
+                  :     +- Scan parquet spark_catalog.default.customer (44)
+                  +- BroadcastExchange (51)
+                     +- * Project (50)
+                        +- * Filter (49)
+                           +- * ColumnarToRow (48)
+                              +- Scan parquet spark_catalog.default.customer_address (47)
 
 
-(1) Scan parquet spark_catalog.default.customer
-Output [14]: [c_customer_sk#1, c_customer_id#2, c_current_addr_sk#3, c_salutation#4, c_first_name#5, c_last_name#6, c_preferred_cust_flag#7, c_birth_day#8, c_birth_month#9, c_birth_year#10, c_birth_country#11, c_login#12, c_email_address#13, c_last_review_date#14]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer]
-PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
-ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_current_addr_sk:int,c_salutation:string,c_first_name:string,c_last_name:string,c_preferred_cust_flag:string,c_birth_day:int,c_birth_month:int,c_birth_year:int,c_birth_country:string,c_login:string,c_email_address:string,c_last_review_date:int>
-
-(2) ColumnarToRow [codegen id : 2]
-Input [14]: [c_customer_sk#1, c_customer_id#2, c_current_addr_sk#3, c_salutation#4, c_first_name#5, c_last_name#6, c_preferred_cust_flag#7, c_birth_day#8, c_birth_month#9, c_birth_year#10, c_birth_country#11, c_login#12, c_email_address#13, c_last_review_date#14]
-
-(3) Filter [codegen id : 2]
-Input [14]: [c_customer_sk#1, c_customer_id#2, c_current_addr_sk#3, c_salutation#4, c_first_name#5, c_last_name#6, c_preferred_cust_flag#7, c_birth_day#8, c_birth_month#9, c_birth_year#10, c_birth_country#11, c_login#12, c_email_address#13, c_last_review_date#14]
-Condition : (isnotnull(c_customer_sk#1) AND isnotnull(c_current_addr_sk#3))
-
-(4) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#15, ca_state#16]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,GA), IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_state:string>
-
-(5) ColumnarToRow [codegen id : 1]
-Input [2]: [ca_address_sk#15, ca_state#16]
-
-(6) Filter [codegen id : 1]
-Input [2]: [ca_address_sk#15, ca_state#16]
-Condition : ((isnotnull(ca_state#16) AND (ca_state#16 = GA)) AND isnotnull(ca_address_sk#15))
-
-(7) Project [codegen id : 1]
-Output [1]: [ca_address_sk#15]
-Input [2]: [ca_address_sk#15, ca_state#16]
-
-(8) BroadcastExchange
-Input [1]: [ca_address_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
-
-(9) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [c_current_addr_sk#3]
-Right keys [1]: [ca_address_sk#15]
-Join type: Inner
-Join condition: None
-
-(10) Project [codegen id : 2]
-Output [13]: [c_customer_sk#1, c_customer_id#2, c_salutation#4, c_first_name#5, c_last_name#6, c_preferred_cust_flag#7, c_birth_day#8, c_birth_month#9, c_birth_year#10, c_birth_country#11, c_login#12, c_email_address#13, c_last_review_date#14]
-Input [15]: [c_customer_sk#1, c_customer_id#2, c_current_addr_sk#3, c_salutation#4, c_first_name#5, c_last_name#6, c_preferred_cust_flag#7, c_birth_day#8, c_birth_month#9, c_birth_year#10, c_birth_country#11, c_login#12, c_email_address#13, c_last_review_date#14, ca_address_sk#15]
-
-(11) BroadcastExchange
-Input [13]: [c_customer_sk#1, c_customer_id#2, c_salutation#4, c_first_name#5, c_last_name#6, c_preferred_cust_flag#7, c_birth_day#8, c_birth_month#9, c_birth_year#10, c_birth_country#11, c_login#12, c_email_address#13, c_last_review_date#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
-
-(12) Scan parquet spark_catalog.default.web_returns
-Output [4]: [wr_returning_customer_sk#17, wr_returning_addr_sk#18, wr_return_amt#19, wr_returned_date_sk#20]
+(1) Scan parquet spark_catalog.default.web_returns
+Output [4]: [wr_returning_customer_sk#1, wr_returning_addr_sk#2, wr_return_amt#3, wr_returned_date_sk#4]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(wr_returned_date_sk#20), dynamicpruningexpression(wr_returned_date_sk#20 IN dynamicpruning#21)]
+PartitionFilters: [isnotnull(wr_returned_date_sk#4), dynamicpruningexpression(wr_returned_date_sk#4 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(wr_returning_addr_sk), IsNotNull(wr_returning_customer_sk)]
 ReadSchema: struct<wr_returning_customer_sk:int,wr_returning_addr_sk:int,wr_return_amt:decimal(7,2)>
 
-(13) ColumnarToRow [codegen id : 4]
-Input [4]: [wr_returning_customer_sk#17, wr_returning_addr_sk#18, wr_return_amt#19, wr_returned_date_sk#20]
+(2) ColumnarToRow [codegen id : 2]
+Input [4]: [wr_returning_customer_sk#1, wr_returning_addr_sk#2, wr_return_amt#3, wr_returned_date_sk#4]
 
-(14) Filter [codegen id : 4]
-Input [4]: [wr_returning_customer_sk#17, wr_returning_addr_sk#18, wr_return_amt#19, wr_returned_date_sk#20]
-Condition : (isnotnull(wr_returning_addr_sk#18) AND isnotnull(wr_returning_customer_sk#17))
+(3) Filter [codegen id : 2]
+Input [4]: [wr_returning_customer_sk#1, wr_returning_addr_sk#2, wr_return_amt#3, wr_returned_date_sk#4]
+Condition : (isnotnull(wr_returning_addr_sk#2) AND isnotnull(wr_returning_customer_sk#1))
 
-(15) ReusedExchange [Reuses operator id: 60]
-Output [1]: [d_date_sk#22]
+(4) ReusedExchange [Reuses operator id: 63]
+Output [1]: [d_date_sk#6]
 
-(16) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [wr_returned_date_sk#20]
-Right keys [1]: [d_date_sk#22]
+(5) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [wr_returned_date_sk#4]
+Right keys [1]: [d_date_sk#6]
 Join type: Inner
 Join condition: None
 
-(17) Project [codegen id : 4]
-Output [3]: [wr_returning_customer_sk#17, wr_returning_addr_sk#18, wr_return_amt#19]
-Input [5]: [wr_returning_customer_sk#17, wr_returning_addr_sk#18, wr_return_amt#19, wr_returned_date_sk#20, d_date_sk#22]
+(6) Project [codegen id : 2]
+Output [3]: [wr_returning_customer_sk#1, wr_returning_addr_sk#2, wr_return_amt#3]
+Input [5]: [wr_returning_customer_sk#1, wr_returning_addr_sk#2, wr_return_amt#3, wr_returned_date_sk#4, d_date_sk#6]
 
-(18) Exchange
-Input [3]: [wr_returning_customer_sk#17, wr_returning_addr_sk#18, wr_return_amt#19]
-Arguments: hashpartitioning(wr_returning_addr_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+(7) Exchange
+Input [3]: [wr_returning_customer_sk#1, wr_returning_addr_sk#2, wr_return_amt#3]
+Arguments: hashpartitioning(wr_returning_addr_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 
-(19) Sort [codegen id : 5]
-Input [3]: [wr_returning_customer_sk#17, wr_returning_addr_sk#18, wr_return_amt#19]
-Arguments: [wr_returning_addr_sk#18 ASC NULLS FIRST], false, 0
+(8) Sort [codegen id : 3]
+Input [3]: [wr_returning_customer_sk#1, wr_returning_addr_sk#2, wr_return_amt#3]
+Arguments: [wr_returning_addr_sk#2 ASC NULLS FIRST], false, 0
 
-(20) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#23, ca_state#24]
+(9) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#7, ca_state#8]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_state)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(21) ColumnarToRow [codegen id : 6]
-Input [2]: [ca_address_sk#23, ca_state#24]
+(10) ColumnarToRow [codegen id : 4]
+Input [2]: [ca_address_sk#7, ca_state#8]
 
-(22) Filter [codegen id : 6]
-Input [2]: [ca_address_sk#23, ca_state#24]
-Condition : (isnotnull(ca_address_sk#23) AND isnotnull(ca_state#24))
+(11) Filter [codegen id : 4]
+Input [2]: [ca_address_sk#7, ca_state#8]
+Condition : (isnotnull(ca_address_sk#7) AND isnotnull(ca_state#8))
 
-(23) Exchange
-Input [2]: [ca_address_sk#23, ca_state#24]
-Arguments: hashpartitioning(ca_address_sk#23, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+(12) Exchange
+Input [2]: [ca_address_sk#7, ca_state#8]
+Arguments: hashpartitioning(ca_address_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(24) Sort [codegen id : 7]
-Input [2]: [ca_address_sk#23, ca_state#24]
-Arguments: [ca_address_sk#23 ASC NULLS FIRST], false, 0
+(13) Sort [codegen id : 5]
+Input [2]: [ca_address_sk#7, ca_state#8]
+Arguments: [ca_address_sk#7 ASC NULLS FIRST], false, 0
 
-(25) SortMergeJoin [codegen id : 8]
-Left keys [1]: [wr_returning_addr_sk#18]
-Right keys [1]: [ca_address_sk#23]
+(14) SortMergeJoin [codegen id : 6]
+Left keys [1]: [wr_returning_addr_sk#2]
+Right keys [1]: [ca_address_sk#7]
 Join type: Inner
 Join condition: None
 
-(26) Project [codegen id : 8]
-Output [3]: [wr_returning_customer_sk#17, wr_return_amt#19, ca_state#24]
-Input [5]: [wr_returning_customer_sk#17, wr_returning_addr_sk#18, wr_return_amt#19, ca_address_sk#23, ca_state#24]
+(15) Project [codegen id : 6]
+Output [3]: [wr_returning_customer_sk#1, wr_return_amt#3, ca_state#8]
+Input [5]: [wr_returning_customer_sk#1, wr_returning_addr_sk#2, wr_return_amt#3, ca_address_sk#7, ca_state#8]
 
-(27) HashAggregate [codegen id : 8]
-Input [3]: [wr_returning_customer_sk#17, wr_return_amt#19, ca_state#24]
-Keys [2]: [wr_returning_customer_sk#17, ca_state#24]
-Functions [1]: [partial_sum(UnscaledValue(wr_return_amt#19))]
-Aggregate Attributes [1]: [sum#25]
-Results [3]: [wr_returning_customer_sk#17, ca_state#24, sum#26]
+(16) HashAggregate [codegen id : 6]
+Input [3]: [wr_returning_customer_sk#1, wr_return_amt#3, ca_state#8]
+Keys [2]: [wr_returning_customer_sk#1, ca_state#8]
+Functions [1]: [partial_sum(UnscaledValue(wr_return_amt#3))]
+Aggregate Attributes [1]: [sum#9]
+Results [3]: [wr_returning_customer_sk#1, ca_state#8, sum#10]
 
-(28) Exchange
-Input [3]: [wr_returning_customer_sk#17, ca_state#24, sum#26]
-Arguments: hashpartitioning(wr_returning_customer_sk#17, ca_state#24, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(17) Exchange
+Input [3]: [wr_returning_customer_sk#1, ca_state#8, sum#10]
+Arguments: hashpartitioning(wr_returning_customer_sk#1, ca_state#8, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(29) HashAggregate
-Input [3]: [wr_returning_customer_sk#17, ca_state#24, sum#26]
-Keys [2]: [wr_returning_customer_sk#17, ca_state#24]
-Functions [1]: [sum(UnscaledValue(wr_return_amt#19))]
-Aggregate Attributes [1]: [sum(UnscaledValue(wr_return_amt#19))#27]
-Results [3]: [wr_returning_customer_sk#17 AS ctr_customer_sk#28, ca_state#24 AS ctr_state#29, MakeDecimal(sum(UnscaledValue(wr_return_amt#19))#27,17,2) AS ctr_total_return#30]
+(18) HashAggregate [codegen id : 15]
+Input [3]: [wr_returning_customer_sk#1, ca_state#8, sum#10]
+Keys [2]: [wr_returning_customer_sk#1, ca_state#8]
+Functions [1]: [sum(UnscaledValue(wr_return_amt#3))]
+Aggregate Attributes [1]: [sum(UnscaledValue(wr_return_amt#3))#11]
+Results [3]: [wr_returning_customer_sk#1 AS ctr_customer_sk#12, ca_state#8 AS ctr_state#13, MakeDecimal(sum(UnscaledValue(wr_return_amt#3))#11,17,2) AS ctr_total_return#14]
 
-(30) Filter
-Input [3]: [ctr_customer_sk#28, ctr_state#29, ctr_total_return#30]
-Condition : isnotnull(ctr_total_return#30)
+(19) Filter [codegen id : 15]
+Input [3]: [ctr_customer_sk#12, ctr_state#13, ctr_total_return#14]
+Condition : isnotnull(ctr_total_return#14)
 
-(31) BroadcastHashJoin [codegen id : 17]
-Left keys [1]: [c_customer_sk#1]
-Right keys [1]: [ctr_customer_sk#28]
-Join type: Inner
-Join condition: None
-
-(32) Project [codegen id : 17]
-Output [14]: [c_customer_id#2, c_salutation#4, c_first_name#5, c_last_name#6, c_preferred_cust_flag#7, c_birth_day#8, c_birth_month#9, c_birth_year#10, c_birth_country#11, c_login#12, c_email_address#13, c_last_review_date#14, ctr_state#29, ctr_total_return#30]
-Input [16]: [c_customer_sk#1, c_customer_id#2, c_salutation#4, c_first_name#5, c_last_name#6, c_preferred_cust_flag#7, c_birth_day#8, c_birth_month#9, c_birth_year#10, c_birth_country#11, c_login#12, c_email_address#13, c_last_review_date#14, ctr_customer_sk#28, ctr_state#29, ctr_total_return#30]
-
-(33) Scan parquet spark_catalog.default.web_returns
-Output [4]: [wr_returning_customer_sk#31, wr_returning_addr_sk#32, wr_return_amt#33, wr_returned_date_sk#34]
+(20) Scan parquet spark_catalog.default.web_returns
+Output [4]: [wr_returning_customer_sk#15, wr_returning_addr_sk#16, wr_return_amt#17, wr_returned_date_sk#18]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(wr_returned_date_sk#34), dynamicpruningexpression(wr_returned_date_sk#34 IN dynamicpruning#21)]
+PartitionFilters: [isnotnull(wr_returned_date_sk#18), dynamicpruningexpression(wr_returned_date_sk#18 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(wr_returning_addr_sk)]
 ReadSchema: struct<wr_returning_customer_sk:int,wr_returning_addr_sk:int,wr_return_amt:decimal(7,2)>
 
-(34) ColumnarToRow [codegen id : 10]
-Input [4]: [wr_returning_customer_sk#31, wr_returning_addr_sk#32, wr_return_amt#33, wr_returned_date_sk#34]
+(21) ColumnarToRow [codegen id : 8]
+Input [4]: [wr_returning_customer_sk#15, wr_returning_addr_sk#16, wr_return_amt#17, wr_returned_date_sk#18]
 
-(35) Filter [codegen id : 10]
-Input [4]: [wr_returning_customer_sk#31, wr_returning_addr_sk#32, wr_return_amt#33, wr_returned_date_sk#34]
-Condition : isnotnull(wr_returning_addr_sk#32)
+(22) Filter [codegen id : 8]
+Input [4]: [wr_returning_customer_sk#15, wr_returning_addr_sk#16, wr_return_amt#17, wr_returned_date_sk#18]
+Condition : isnotnull(wr_returning_addr_sk#16)
 
-(36) ReusedExchange [Reuses operator id: 60]
-Output [1]: [d_date_sk#35]
+(23) ReusedExchange [Reuses operator id: 63]
+Output [1]: [d_date_sk#19]
 
-(37) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [wr_returned_date_sk#34]
-Right keys [1]: [d_date_sk#35]
+(24) BroadcastHashJoin [codegen id : 8]
+Left keys [1]: [wr_returned_date_sk#18]
+Right keys [1]: [d_date_sk#19]
 Join type: Inner
 Join condition: None
 
-(38) Project [codegen id : 10]
-Output [3]: [wr_returning_customer_sk#31, wr_returning_addr_sk#32, wr_return_amt#33]
-Input [5]: [wr_returning_customer_sk#31, wr_returning_addr_sk#32, wr_return_amt#33, wr_returned_date_sk#34, d_date_sk#35]
+(25) Project [codegen id : 8]
+Output [3]: [wr_returning_customer_sk#15, wr_returning_addr_sk#16, wr_return_amt#17]
+Input [5]: [wr_returning_customer_sk#15, wr_returning_addr_sk#16, wr_return_amt#17, wr_returned_date_sk#18, d_date_sk#19]
 
-(39) Exchange
-Input [3]: [wr_returning_customer_sk#31, wr_returning_addr_sk#32, wr_return_amt#33]
-Arguments: hashpartitioning(wr_returning_addr_sk#32, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+(26) Exchange
+Input [3]: [wr_returning_customer_sk#15, wr_returning_addr_sk#16, wr_return_amt#17]
+Arguments: hashpartitioning(wr_returning_addr_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(40) Sort [codegen id : 11]
-Input [3]: [wr_returning_customer_sk#31, wr_returning_addr_sk#32, wr_return_amt#33]
-Arguments: [wr_returning_addr_sk#32 ASC NULLS FIRST], false, 0
+(27) Sort [codegen id : 9]
+Input [3]: [wr_returning_customer_sk#15, wr_returning_addr_sk#16, wr_return_amt#17]
+Arguments: [wr_returning_addr_sk#16 ASC NULLS FIRST], false, 0
 
-(41) ReusedExchange [Reuses operator id: 23]
-Output [2]: [ca_address_sk#36, ca_state#37]
+(28) ReusedExchange [Reuses operator id: 12]
+Output [2]: [ca_address_sk#20, ca_state#21]
 
-(42) Sort [codegen id : 13]
-Input [2]: [ca_address_sk#36, ca_state#37]
-Arguments: [ca_address_sk#36 ASC NULLS FIRST], false, 0
+(29) Sort [codegen id : 11]
+Input [2]: [ca_address_sk#20, ca_state#21]
+Arguments: [ca_address_sk#20 ASC NULLS FIRST], false, 0
 
-(43) SortMergeJoin [codegen id : 14]
-Left keys [1]: [wr_returning_addr_sk#32]
-Right keys [1]: [ca_address_sk#36]
+(30) SortMergeJoin [codegen id : 12]
+Left keys [1]: [wr_returning_addr_sk#16]
+Right keys [1]: [ca_address_sk#20]
 Join type: Inner
 Join condition: None
 
-(44) Project [codegen id : 14]
-Output [3]: [wr_returning_customer_sk#31, wr_return_amt#33, ca_state#37]
-Input [5]: [wr_returning_customer_sk#31, wr_returning_addr_sk#32, wr_return_amt#33, ca_address_sk#36, ca_state#37]
+(31) Project [codegen id : 12]
+Output [3]: [wr_returning_customer_sk#15, wr_return_amt#17, ca_state#21]
+Input [5]: [wr_returning_customer_sk#15, wr_returning_addr_sk#16, wr_return_amt#17, ca_address_sk#20, ca_state#21]
 
-(45) HashAggregate [codegen id : 14]
-Input [3]: [wr_returning_customer_sk#31, wr_return_amt#33, ca_state#37]
-Keys [2]: [wr_returning_customer_sk#31, ca_state#37]
-Functions [1]: [partial_sum(UnscaledValue(wr_return_amt#33))]
-Aggregate Attributes [1]: [sum#38]
-Results [3]: [wr_returning_customer_sk#31, ca_state#37, sum#39]
+(32) HashAggregate [codegen id : 12]
+Input [3]: [wr_returning_customer_sk#15, wr_return_amt#17, ca_state#21]
+Keys [2]: [wr_returning_customer_sk#15, ca_state#21]
+Functions [1]: [partial_sum(UnscaledValue(wr_return_amt#17))]
+Aggregate Attributes [1]: [sum#22]
+Results [3]: [wr_returning_customer_sk#15, ca_state#21, sum#23]
 
-(46) Exchange
-Input [3]: [wr_returning_customer_sk#31, ca_state#37, sum#39]
-Arguments: hashpartitioning(wr_returning_customer_sk#31, ca_state#37, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(33) Exchange
+Input [3]: [wr_returning_customer_sk#15, ca_state#21, sum#23]
+Arguments: hashpartitioning(wr_returning_customer_sk#15, ca_state#21, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(47) HashAggregate [codegen id : 15]
-Input [3]: [wr_returning_customer_sk#31, ca_state#37, sum#39]
-Keys [2]: [wr_returning_customer_sk#31, ca_state#37]
-Functions [1]: [sum(UnscaledValue(wr_return_amt#33))]
-Aggregate Attributes [1]: [sum(UnscaledValue(wr_return_amt#33))#27]
-Results [2]: [ca_state#37 AS ctr_state#40, MakeDecimal(sum(UnscaledValue(wr_return_amt#33))#27,17,2) AS ctr_total_return#41]
+(34) HashAggregate [codegen id : 13]
+Input [3]: [wr_returning_customer_sk#15, ca_state#21, sum#23]
+Keys [2]: [wr_returning_customer_sk#15, ca_state#21]
+Functions [1]: [sum(UnscaledValue(wr_return_amt#17))]
+Aggregate Attributes [1]: [sum(UnscaledValue(wr_return_amt#17))#11]
+Results [2]: [ca_state#21 AS ctr_state#24, MakeDecimal(sum(UnscaledValue(wr_return_amt#17))#11,17,2) AS ctr_total_return#25]
 
-(48) HashAggregate [codegen id : 15]
-Input [2]: [ctr_state#40, ctr_total_return#41]
-Keys [1]: [ctr_state#40]
-Functions [1]: [partial_avg(ctr_total_return#41)]
-Aggregate Attributes [2]: [sum#42, count#43]
-Results [3]: [ctr_state#40, sum#44, count#45]
+(35) HashAggregate [codegen id : 13]
+Input [2]: [ctr_state#24, ctr_total_return#25]
+Keys [1]: [ctr_state#24]
+Functions [1]: [partial_avg(ctr_total_return#25)]
+Aggregate Attributes [2]: [sum#26, count#27]
+Results [3]: [ctr_state#24, sum#28, count#29]
 
-(49) Exchange
-Input [3]: [ctr_state#40, sum#44, count#45]
-Arguments: hashpartitioning(ctr_state#40, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+(36) Exchange
+Input [3]: [ctr_state#24, sum#28, count#29]
+Arguments: hashpartitioning(ctr_state#24, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(50) HashAggregate [codegen id : 16]
-Input [3]: [ctr_state#40, sum#44, count#45]
-Keys [1]: [ctr_state#40]
-Functions [1]: [avg(ctr_total_return#41)]
-Aggregate Attributes [1]: [avg(ctr_total_return#41)#46]
-Results [2]: [(avg(ctr_total_return#41)#46 * 1.2) AS (avg(ctr_total_return) * 1.2)#47, ctr_state#40]
+(37) HashAggregate [codegen id : 14]
+Input [3]: [ctr_state#24, sum#28, count#29]
+Keys [1]: [ctr_state#24]
+Functions [1]: [avg(ctr_total_return#25)]
+Aggregate Attributes [1]: [avg(ctr_total_return#25)#30]
+Results [2]: [(avg(ctr_total_return#25)#30 * 1.2) AS (avg(ctr_total_return) * 1.2)#31, ctr_state#24]
 
-(51) Filter [codegen id : 16]
-Input [2]: [(avg(ctr_total_return) * 1.2)#47, ctr_state#40]
-Condition : isnotnull((avg(ctr_total_return) * 1.2)#47)
+(38) Filter [codegen id : 14]
+Input [2]: [(avg(ctr_total_return) * 1.2)#31, ctr_state#24]
+Condition : isnotnull((avg(ctr_total_return) * 1.2)#31)
 
-(52) BroadcastExchange
-Input [2]: [(avg(ctr_total_return) * 1.2)#47, ctr_state#40]
-Arguments: HashedRelationBroadcastMode(List(input[1, string, true]),false), [plan_id=9]
+(39) BroadcastExchange
+Input [2]: [(avg(ctr_total_return) * 1.2)#31, ctr_state#24]
+Arguments: HashedRelationBroadcastMode(List(input[1, string, true]),false), [plan_id=7]
 
-(53) BroadcastHashJoin [codegen id : 17]
-Left keys [1]: [ctr_state#29]
-Right keys [1]: [ctr_state#40]
+(40) BroadcastHashJoin [codegen id : 15]
+Left keys [1]: [ctr_state#13]
+Right keys [1]: [ctr_state#24]
 Join type: Inner
-Join condition: (cast(ctr_total_return#30 as decimal(24,7)) > (avg(ctr_total_return) * 1.2)#47)
+Join condition: (cast(ctr_total_return#14 as decimal(24,7)) > (avg(ctr_total_return) * 1.2)#31)
 
-(54) Project [codegen id : 17]
-Output [13]: [c_customer_id#2, c_salutation#4, c_first_name#5, c_last_name#6, c_preferred_cust_flag#7, c_birth_day#8, c_birth_month#9, c_birth_year#10, c_birth_country#11, c_login#12, c_email_address#13, c_last_review_date#14, ctr_total_return#30]
-Input [16]: [c_customer_id#2, c_salutation#4, c_first_name#5, c_last_name#6, c_preferred_cust_flag#7, c_birth_day#8, c_birth_month#9, c_birth_year#10, c_birth_country#11, c_login#12, c_email_address#13, c_last_review_date#14, ctr_state#29, ctr_total_return#30, (avg(ctr_total_return) * 1.2)#47, ctr_state#40]
+(41) Project [codegen id : 15]
+Output [2]: [ctr_customer_sk#12, ctr_total_return#14]
+Input [5]: [ctr_customer_sk#12, ctr_state#13, ctr_total_return#14, (avg(ctr_total_return) * 1.2)#31, ctr_state#24]
 
-(55) TakeOrderedAndProject
-Input [13]: [c_customer_id#2, c_salutation#4, c_first_name#5, c_last_name#6, c_preferred_cust_flag#7, c_birth_day#8, c_birth_month#9, c_birth_year#10, c_birth_country#11, c_login#12, c_email_address#13, c_last_review_date#14, ctr_total_return#30]
-Arguments: 100, [c_customer_id#2 ASC NULLS FIRST, c_salutation#4 ASC NULLS FIRST, c_first_name#5 ASC NULLS FIRST, c_last_name#6 ASC NULLS FIRST, c_preferred_cust_flag#7 ASC NULLS FIRST, c_birth_day#8 ASC NULLS FIRST, c_birth_month#9 ASC NULLS FIRST, c_birth_year#10 ASC NULLS FIRST, c_birth_country#11 ASC NULLS FIRST, c_login#12 ASC NULLS FIRST, c_email_address#13 ASC NULLS FIRST, c_last_review_date#14 ASC NULLS FIRST, ctr_total_return#30 ASC NULLS FIRST], [c_customer_id#2, c_salutation#4, c_first_name#5, c_last_name#6, c_preferred_cust_flag#7, c_birth_day#8, c_birth_month#9, c_birth_year#10, c_birth_country#11, c_login#12, c_email_address#13, c_last_review_date#14, ctr_total_return#30]
+(42) Exchange
+Input [2]: [ctr_customer_sk#12, ctr_total_return#14]
+Arguments: hashpartitioning(ctr_customer_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(43) Sort [codegen id : 16]
+Input [2]: [ctr_customer_sk#12, ctr_total_return#14]
+Arguments: [ctr_customer_sk#12 ASC NULLS FIRST], false, 0
+
+(44) Scan parquet spark_catalog.default.customer
+Output [14]: [c_customer_sk#32, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date#45]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
+ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_current_addr_sk:int,c_salutation:string,c_first_name:string,c_last_name:string,c_preferred_cust_flag:string,c_birth_day:int,c_birth_month:int,c_birth_year:int,c_birth_country:string,c_login:string,c_email_address:string,c_last_review_date:int>
+
+(45) ColumnarToRow [codegen id : 18]
+Input [14]: [c_customer_sk#32, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date#45]
+
+(46) Filter [codegen id : 18]
+Input [14]: [c_customer_sk#32, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date#45]
+Condition : (isnotnull(c_customer_sk#32) AND isnotnull(c_current_addr_sk#34))
+
+(47) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#46, ca_state#47]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,GA), IsNotNull(ca_address_sk)]
+ReadSchema: struct<ca_address_sk:int,ca_state:string>
+
+(48) ColumnarToRow [codegen id : 17]
+Input [2]: [ca_address_sk#46, ca_state#47]
+
+(49) Filter [codegen id : 17]
+Input [2]: [ca_address_sk#46, ca_state#47]
+Condition : ((isnotnull(ca_state#47) AND (ca_state#47 = GA)) AND isnotnull(ca_address_sk#46))
+
+(50) Project [codegen id : 17]
+Output [1]: [ca_address_sk#46]
+Input [2]: [ca_address_sk#46, ca_state#47]
+
+(51) BroadcastExchange
+Input [1]: [ca_address_sk#46]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
+
+(52) BroadcastHashJoin [codegen id : 18]
+Left keys [1]: [c_current_addr_sk#34]
+Right keys [1]: [ca_address_sk#46]
+Join type: Inner
+Join condition: None
+
+(53) Project [codegen id : 18]
+Output [13]: [c_customer_sk#32, c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date#45]
+Input [15]: [c_customer_sk#32, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date#45, ca_address_sk#46]
+
+(54) Exchange
+Input [13]: [c_customer_sk#32, c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date#45]
+Arguments: hashpartitioning(c_customer_sk#32, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+
+(55) Sort [codegen id : 19]
+Input [13]: [c_customer_sk#32, c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date#45]
+Arguments: [c_customer_sk#32 ASC NULLS FIRST], false, 0
+
+(56) SortMergeJoin [codegen id : 20]
+Left keys [1]: [ctr_customer_sk#12]
+Right keys [1]: [c_customer_sk#32]
+Join type: Inner
+Join condition: None
+
+(57) Project [codegen id : 20]
+Output [13]: [c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date#45, ctr_total_return#14]
+Input [15]: [ctr_customer_sk#12, ctr_total_return#14, c_customer_sk#32, c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date#45]
+
+(58) TakeOrderedAndProject
+Input [13]: [c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date#45, ctr_total_return#14]
+Arguments: 100, [c_customer_id#33 ASC NULLS FIRST, c_salutation#35 ASC NULLS FIRST, c_first_name#36 ASC NULLS FIRST, c_last_name#37 ASC NULLS FIRST, c_preferred_cust_flag#38 ASC NULLS FIRST, c_birth_day#39 ASC NULLS FIRST, c_birth_month#40 ASC NULLS FIRST, c_birth_year#41 ASC NULLS FIRST, c_birth_country#42 ASC NULLS FIRST, c_login#43 ASC NULLS FIRST, c_email_address#44 ASC NULLS FIRST, c_last_review_date#45 ASC NULLS FIRST, ctr_total_return#14 ASC NULLS FIRST], [c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, c_preferred_cust_flag#38, c_birth_day#39, c_birth_month#40, c_birth_year#41, c_birth_country#42, c_login#43, c_email_address#44, c_last_review_date#45, ctr_total_return#14]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 12 Hosting Expression = wr_returned_date_sk#20 IN dynamicpruning#21
-BroadcastExchange (60)
-+- * Project (59)
-   +- * Filter (58)
-      +- * ColumnarToRow (57)
-         +- Scan parquet spark_catalog.default.date_dim (56)
+Subquery:1 Hosting operator id = 1 Hosting Expression = wr_returned_date_sk#4 IN dynamicpruning#5
+BroadcastExchange (63)
++- * Project (62)
+   +- * Filter (61)
+      +- * ColumnarToRow (60)
+         +- Scan parquet spark_catalog.default.date_dim (59)
 
 
-(56) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#22, d_year#48]
+(59) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#6, d_year#48]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2002), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(57) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#22, d_year#48]
+(60) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#6, d_year#48]
 
-(58) Filter [codegen id : 1]
-Input [2]: [d_date_sk#22, d_year#48]
-Condition : ((isnotnull(d_year#48) AND (d_year#48 = 2002)) AND isnotnull(d_date_sk#22))
+(61) Filter [codegen id : 1]
+Input [2]: [d_date_sk#6, d_year#48]
+Condition : ((isnotnull(d_year#48) AND (d_year#48 = 2002)) AND isnotnull(d_date_sk#6))
 
-(59) Project [codegen id : 1]
-Output [1]: [d_date_sk#22]
-Input [2]: [d_date_sk#22, d_year#48]
+(62) Project [codegen id : 1]
+Output [1]: [d_date_sk#6]
+Input [2]: [d_date_sk#6, d_year#48]
 
-(60) BroadcastExchange
-Input [1]: [d_date_sk#22]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
+(63) BroadcastExchange
+Input [1]: [d_date_sk#6]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
-Subquery:2 Hosting operator id = 33 Hosting Expression = wr_returned_date_sk#34 IN dynamicpruning#21
+Subquery:2 Hosting operator id = 20 Hosting Expression = wr_returned_date_sk#18 IN dynamicpruning#5
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q30.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q30.sf100/simplified.txt
@@ -1,99 +1,108 @@
 TakeOrderedAndProject [c_customer_id,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_day,c_birth_month,c_birth_year,c_birth_country,c_login,c_email_address,c_last_review_date,ctr_total_return]
-  WholeStageCodegen (17)
+  WholeStageCodegen (20)
     Project [c_customer_id,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_day,c_birth_month,c_birth_year,c_birth_country,c_login,c_email_address,c_last_review_date,ctr_total_return]
-      BroadcastHashJoin [ctr_state,ctr_state,ctr_total_return,(avg(ctr_total_return) * 1.2)]
-        Project [c_customer_id,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_day,c_birth_month,c_birth_year,c_birth_country,c_login,c_email_address,c_last_review_date,ctr_state,ctr_total_return]
-          BroadcastHashJoin [c_customer_sk,ctr_customer_sk]
-            InputAdapter
-              BroadcastExchange #1
-                WholeStageCodegen (2)
-                  Project [c_customer_sk,c_customer_id,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_day,c_birth_month,c_birth_year,c_birth_country,c_login,c_email_address,c_last_review_date]
-                    BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
-                      Filter [c_customer_sk,c_current_addr_sk]
-                        ColumnarToRow
-                          InputAdapter
-                            Scan parquet spark_catalog.default.customer [c_customer_sk,c_customer_id,c_current_addr_sk,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_day,c_birth_month,c_birth_year,c_birth_country,c_login,c_email_address,c_last_review_date]
-                      InputAdapter
-                        BroadcastExchange #2
-                          WholeStageCodegen (1)
-                            Project [ca_address_sk]
-                              Filter [ca_state,ca_address_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
-            Filter [ctr_total_return]
-              HashAggregate [wr_returning_customer_sk,ca_state,sum] [sum(UnscaledValue(wr_return_amt)),ctr_customer_sk,ctr_state,ctr_total_return,sum]
-                InputAdapter
-                  Exchange [wr_returning_customer_sk,ca_state] #3
-                    WholeStageCodegen (8)
-                      HashAggregate [wr_returning_customer_sk,ca_state,wr_return_amt] [sum,sum]
-                        Project [wr_returning_customer_sk,wr_return_amt,ca_state]
-                          SortMergeJoin [wr_returning_addr_sk,ca_address_sk]
-                            InputAdapter
-                              WholeStageCodegen (5)
-                                Sort [wr_returning_addr_sk]
-                                  InputAdapter
-                                    Exchange [wr_returning_addr_sk] #4
-                                      WholeStageCodegen (4)
-                                        Project [wr_returning_customer_sk,wr_returning_addr_sk,wr_return_amt]
-                                          BroadcastHashJoin [wr_returned_date_sk,d_date_sk]
-                                            Filter [wr_returning_addr_sk,wr_returning_customer_sk]
-                                              ColumnarToRow
-                                                InputAdapter
-                                                  Scan parquet spark_catalog.default.web_returns [wr_returning_customer_sk,wr_returning_addr_sk,wr_return_amt,wr_returned_date_sk]
-                                                    SubqueryBroadcast [d_date_sk] #1
-                                                      BroadcastExchange #5
-                                                        WholeStageCodegen (1)
-                                                          Project [d_date_sk]
-                                                            Filter [d_year,d_date_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
-                                            InputAdapter
-                                              ReusedExchange [d_date_sk] #5
-                            InputAdapter
-                              WholeStageCodegen (7)
-                                Sort [ca_address_sk]
-                                  InputAdapter
-                                    Exchange [ca_address_sk] #6
-                                      WholeStageCodegen (6)
-                                        Filter [ca_address_sk,ca_state]
-                                          ColumnarToRow
-                                            InputAdapter
-                                              Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+      SortMergeJoin [ctr_customer_sk,c_customer_sk]
         InputAdapter
-          BroadcastExchange #7
-            WholeStageCodegen (16)
-              Filter [(avg(ctr_total_return) * 1.2)]
-                HashAggregate [ctr_state,sum,count] [avg(ctr_total_return),(avg(ctr_total_return) * 1.2),sum,count]
-                  InputAdapter
-                    Exchange [ctr_state] #8
-                      WholeStageCodegen (15)
-                        HashAggregate [ctr_state,ctr_total_return] [sum,count,sum,count]
-                          HashAggregate [wr_returning_customer_sk,ca_state,sum] [sum(UnscaledValue(wr_return_amt)),ctr_state,ctr_total_return,sum]
+          WholeStageCodegen (16)
+            Sort [ctr_customer_sk]
+              InputAdapter
+                Exchange [ctr_customer_sk] #1
+                  WholeStageCodegen (15)
+                    Project [ctr_customer_sk,ctr_total_return]
+                      BroadcastHashJoin [ctr_state,ctr_state,ctr_total_return,(avg(ctr_total_return) * 1.2)]
+                        Filter [ctr_total_return]
+                          HashAggregate [wr_returning_customer_sk,ca_state,sum] [sum(UnscaledValue(wr_return_amt)),ctr_customer_sk,ctr_state,ctr_total_return,sum]
                             InputAdapter
-                              Exchange [wr_returning_customer_sk,ca_state] #9
-                                WholeStageCodegen (14)
+                              Exchange [wr_returning_customer_sk,ca_state] #2
+                                WholeStageCodegen (6)
                                   HashAggregate [wr_returning_customer_sk,ca_state,wr_return_amt] [sum,sum]
                                     Project [wr_returning_customer_sk,wr_return_amt,ca_state]
                                       SortMergeJoin [wr_returning_addr_sk,ca_address_sk]
                                         InputAdapter
-                                          WholeStageCodegen (11)
+                                          WholeStageCodegen (3)
                                             Sort [wr_returning_addr_sk]
                                               InputAdapter
-                                                Exchange [wr_returning_addr_sk] #10
-                                                  WholeStageCodegen (10)
+                                                Exchange [wr_returning_addr_sk] #3
+                                                  WholeStageCodegen (2)
                                                     Project [wr_returning_customer_sk,wr_returning_addr_sk,wr_return_amt]
                                                       BroadcastHashJoin [wr_returned_date_sk,d_date_sk]
-                                                        Filter [wr_returning_addr_sk]
+                                                        Filter [wr_returning_addr_sk,wr_returning_customer_sk]
                                                           ColumnarToRow
                                                             InputAdapter
                                                               Scan parquet spark_catalog.default.web_returns [wr_returning_customer_sk,wr_returning_addr_sk,wr_return_amt,wr_returned_date_sk]
-                                                                ReusedSubquery [d_date_sk] #1
+                                                                SubqueryBroadcast [d_date_sk] #1
+                                                                  BroadcastExchange #4
+                                                                    WholeStageCodegen (1)
+                                                                      Project [d_date_sk]
+                                                                        Filter [d_year,d_date_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                                         InputAdapter
-                                                          ReusedExchange [d_date_sk] #5
+                                                          ReusedExchange [d_date_sk] #4
                                         InputAdapter
-                                          WholeStageCodegen (13)
+                                          WholeStageCodegen (5)
                                             Sort [ca_address_sk]
                                               InputAdapter
-                                                ReusedExchange [ca_address_sk,ca_state] #6
+                                                Exchange [ca_address_sk] #5
+                                                  WholeStageCodegen (4)
+                                                    Filter [ca_address_sk,ca_state]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+                        InputAdapter
+                          BroadcastExchange #6
+                            WholeStageCodegen (14)
+                              Filter [(avg(ctr_total_return) * 1.2)]
+                                HashAggregate [ctr_state,sum,count] [avg(ctr_total_return),(avg(ctr_total_return) * 1.2),sum,count]
+                                  InputAdapter
+                                    Exchange [ctr_state] #7
+                                      WholeStageCodegen (13)
+                                        HashAggregate [ctr_state,ctr_total_return] [sum,count,sum,count]
+                                          HashAggregate [wr_returning_customer_sk,ca_state,sum] [sum(UnscaledValue(wr_return_amt)),ctr_state,ctr_total_return,sum]
+                                            InputAdapter
+                                              Exchange [wr_returning_customer_sk,ca_state] #8
+                                                WholeStageCodegen (12)
+                                                  HashAggregate [wr_returning_customer_sk,ca_state,wr_return_amt] [sum,sum]
+                                                    Project [wr_returning_customer_sk,wr_return_amt,ca_state]
+                                                      SortMergeJoin [wr_returning_addr_sk,ca_address_sk]
+                                                        InputAdapter
+                                                          WholeStageCodegen (9)
+                                                            Sort [wr_returning_addr_sk]
+                                                              InputAdapter
+                                                                Exchange [wr_returning_addr_sk] #9
+                                                                  WholeStageCodegen (8)
+                                                                    Project [wr_returning_customer_sk,wr_returning_addr_sk,wr_return_amt]
+                                                                      BroadcastHashJoin [wr_returned_date_sk,d_date_sk]
+                                                                        Filter [wr_returning_addr_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet spark_catalog.default.web_returns [wr_returning_customer_sk,wr_returning_addr_sk,wr_return_amt,wr_returned_date_sk]
+                                                                                ReusedSubquery [d_date_sk] #1
+                                                                        InputAdapter
+                                                                          ReusedExchange [d_date_sk] #4
+                                                        InputAdapter
+                                                          WholeStageCodegen (11)
+                                                            Sort [ca_address_sk]
+                                                              InputAdapter
+                                                                ReusedExchange [ca_address_sk,ca_state] #5
+        InputAdapter
+          WholeStageCodegen (19)
+            Sort [c_customer_sk]
+              InputAdapter
+                Exchange [c_customer_sk] #10
+                  WholeStageCodegen (18)
+                    Project [c_customer_sk,c_customer_id,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_day,c_birth_month,c_birth_year,c_birth_country,c_login,c_email_address,c_last_review_date]
+                      BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
+                        Filter [c_customer_sk,c_current_addr_sk]
+                          ColumnarToRow
+                            InputAdapter
+                              Scan parquet spark_catalog.default.customer [c_customer_sk,c_customer_id,c_current_addr_sk,c_salutation,c_first_name,c_last_name,c_preferred_cust_flag,c_birth_day,c_birth_month,c_birth_year,c_birth_country,c_login,c_email_address,c_last_review_date]
+                        InputAdapter
+                          BroadcastExchange #11
+                            WholeStageCodegen (17)
+                              Project [ca_address_sk]
+                                Filter [ca_state,ca_address_sk]
+                                  ColumnarToRow
+                                    InputAdapter
+                                      Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q33.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q33.sf100/explain.txt
@@ -9,29 +9,29 @@ TakeOrderedAndProject (63)
             :     +- * HashAggregate (26)
             :        +- * Project (25)
             :           +- * BroadcastHashJoin Inner BuildRight (24)
-            :              :- * Project (18)
-            :              :  +- * BroadcastHashJoin Inner BuildRight (17)
+            :              :- * Project (13)
+            :              :  +- * BroadcastHashJoin Inner BuildRight (12)
             :              :     :- * Project (6)
             :              :     :  +- * BroadcastHashJoin Inner BuildRight (5)
             :              :     :     :- * Filter (3)
             :              :     :     :  +- * ColumnarToRow (2)
             :              :     :     :     +- Scan parquet spark_catalog.default.store_sales (1)
             :              :     :     +- ReusedExchange (4)
-            :              :     +- BroadcastExchange (16)
-            :              :        +- * BroadcastHashJoin LeftSemi BuildRight (15)
-            :              :           :- * Filter (9)
-            :              :           :  +- * ColumnarToRow (8)
-            :              :           :     +- Scan parquet spark_catalog.default.item (7)
-            :              :           +- BroadcastExchange (14)
-            :              :              +- * Project (13)
-            :              :                 +- * Filter (12)
-            :              :                    +- * ColumnarToRow (11)
-            :              :                       +- Scan parquet spark_catalog.default.item (10)
+            :              :     +- BroadcastExchange (11)
+            :              :        +- * Project (10)
+            :              :           +- * Filter (9)
+            :              :              +- * ColumnarToRow (8)
+            :              :                 +- Scan parquet spark_catalog.default.customer_address (7)
             :              +- BroadcastExchange (23)
-            :                 +- * Project (22)
-            :                    +- * Filter (21)
-            :                       +- * ColumnarToRow (20)
-            :                          +- Scan parquet spark_catalog.default.customer_address (19)
+            :                 +- * BroadcastHashJoin LeftSemi BuildRight (22)
+            :                    :- * Filter (16)
+            :                    :  +- * ColumnarToRow (15)
+            :                    :     +- Scan parquet spark_catalog.default.item (14)
+            :                    +- BroadcastExchange (21)
+            :                       +- * Project (20)
+            :                          +- * Filter (19)
+            :                             +- * ColumnarToRow (18)
+            :                                +- Scan parquet spark_catalog.default.item (17)
             :- * HashAggregate (43)
             :  +- Exchange (42)
             :     +- * HashAggregate (41)
@@ -92,111 +92,111 @@ Join condition: None
 Output [3]: [ss_item_sk#1, ss_addr_sk#2, ss_ext_sales_price#3]
 Input [5]: [ss_item_sk#1, ss_addr_sk#2, ss_ext_sales_price#3, ss_sold_date_sk#4, d_date_sk#6]
 
-(7) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#7, i_manufact_id#8]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_manufact_id:int>
-
-(8) ColumnarToRow [codegen id : 3]
-Input [2]: [i_item_sk#7, i_manufact_id#8]
-
-(9) Filter [codegen id : 3]
-Input [2]: [i_item_sk#7, i_manufact_id#8]
-Condition : isnotnull(i_item_sk#7)
-
-(10) Scan parquet spark_catalog.default.item
-Output [2]: [i_category#9, i_manufact_id#10]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_category), EqualTo(i_category,Electronics                                       )]
-ReadSchema: struct<i_category:string,i_manufact_id:int>
-
-(11) ColumnarToRow [codegen id : 2]
-Input [2]: [i_category#9, i_manufact_id#10]
-
-(12) Filter [codegen id : 2]
-Input [2]: [i_category#9, i_manufact_id#10]
-Condition : (isnotnull(i_category#9) AND (i_category#9 = Electronics                                       ))
-
-(13) Project [codegen id : 2]
-Output [1]: [i_manufact_id#10]
-Input [2]: [i_category#9, i_manufact_id#10]
-
-(14) BroadcastExchange
-Input [1]: [i_manufact_id#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
-
-(15) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [i_manufact_id#8]
-Right keys [1]: [i_manufact_id#10]
-Join type: LeftSemi
-Join condition: None
-
-(16) BroadcastExchange
-Input [2]: [i_item_sk#7, i_manufact_id#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
-
-(17) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#7]
-Join type: Inner
-Join condition: None
-
-(18) Project [codegen id : 5]
-Output [3]: [ss_addr_sk#2, ss_ext_sales_price#3, i_manufact_id#8]
-Input [5]: [ss_item_sk#1, ss_addr_sk#2, ss_ext_sales_price#3, i_item_sk#7, i_manufact_id#8]
-
-(19) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#11, ca_gmt_offset#12]
+(7) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#7, ca_gmt_offset#8]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_gmt_offset), EqualTo(ca_gmt_offset,-5.00), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_gmt_offset:decimal(5,2)>
 
-(20) ColumnarToRow [codegen id : 4]
-Input [2]: [ca_address_sk#11, ca_gmt_offset#12]
+(8) ColumnarToRow [codegen id : 2]
+Input [2]: [ca_address_sk#7, ca_gmt_offset#8]
 
-(21) Filter [codegen id : 4]
-Input [2]: [ca_address_sk#11, ca_gmt_offset#12]
-Condition : ((isnotnull(ca_gmt_offset#12) AND (ca_gmt_offset#12 = -5.00)) AND isnotnull(ca_address_sk#11))
+(9) Filter [codegen id : 2]
+Input [2]: [ca_address_sk#7, ca_gmt_offset#8]
+Condition : ((isnotnull(ca_gmt_offset#8) AND (ca_gmt_offset#8 = -5.00)) AND isnotnull(ca_address_sk#7))
 
-(22) Project [codegen id : 4]
-Output [1]: [ca_address_sk#11]
-Input [2]: [ca_address_sk#11, ca_gmt_offset#12]
+(10) Project [codegen id : 2]
+Output [1]: [ca_address_sk#7]
+Input [2]: [ca_address_sk#7, ca_gmt_offset#8]
+
+(11) BroadcastExchange
+Input [1]: [ca_address_sk#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
+
+(12) BroadcastHashJoin [codegen id : 5]
+Left keys [1]: [ss_addr_sk#2]
+Right keys [1]: [ca_address_sk#7]
+Join type: Inner
+Join condition: None
+
+(13) Project [codegen id : 5]
+Output [2]: [ss_item_sk#1, ss_ext_sales_price#3]
+Input [4]: [ss_item_sk#1, ss_addr_sk#2, ss_ext_sales_price#3, ca_address_sk#7]
+
+(14) Scan parquet spark_catalog.default.item
+Output [2]: [i_item_sk#9, i_manufact_id#10]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_manufact_id:int>
+
+(15) ColumnarToRow [codegen id : 4]
+Input [2]: [i_item_sk#9, i_manufact_id#10]
+
+(16) Filter [codegen id : 4]
+Input [2]: [i_item_sk#9, i_manufact_id#10]
+Condition : isnotnull(i_item_sk#9)
+
+(17) Scan parquet spark_catalog.default.item
+Output [2]: [i_category#11, i_manufact_id#12]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_category), EqualTo(i_category,Electronics                                       )]
+ReadSchema: struct<i_category:string,i_manufact_id:int>
+
+(18) ColumnarToRow [codegen id : 3]
+Input [2]: [i_category#11, i_manufact_id#12]
+
+(19) Filter [codegen id : 3]
+Input [2]: [i_category#11, i_manufact_id#12]
+Condition : (isnotnull(i_category#11) AND (i_category#11 = Electronics                                       ))
+
+(20) Project [codegen id : 3]
+Output [1]: [i_manufact_id#12]
+Input [2]: [i_category#11, i_manufact_id#12]
+
+(21) BroadcastExchange
+Input [1]: [i_manufact_id#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
+
+(22) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [i_manufact_id#10]
+Right keys [1]: [i_manufact_id#12]
+Join type: LeftSemi
+Join condition: None
 
 (23) BroadcastExchange
-Input [1]: [ca_address_sk#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
+Input [2]: [i_item_sk#9, i_manufact_id#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
 
 (24) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [ss_addr_sk#2]
-Right keys [1]: [ca_address_sk#11]
+Left keys [1]: [ss_item_sk#1]
+Right keys [1]: [i_item_sk#9]
 Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 5]
-Output [2]: [ss_ext_sales_price#3, i_manufact_id#8]
-Input [4]: [ss_addr_sk#2, ss_ext_sales_price#3, i_manufact_id#8, ca_address_sk#11]
+Output [2]: [ss_ext_sales_price#3, i_manufact_id#10]
+Input [4]: [ss_item_sk#1, ss_ext_sales_price#3, i_item_sk#9, i_manufact_id#10]
 
 (26) HashAggregate [codegen id : 5]
-Input [2]: [ss_ext_sales_price#3, i_manufact_id#8]
-Keys [1]: [i_manufact_id#8]
+Input [2]: [ss_ext_sales_price#3, i_manufact_id#10]
+Keys [1]: [i_manufact_id#10]
 Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#3))]
 Aggregate Attributes [1]: [sum#13]
-Results [2]: [i_manufact_id#8, sum#14]
+Results [2]: [i_manufact_id#10, sum#14]
 
 (27) Exchange
-Input [2]: [i_manufact_id#8, sum#14]
-Arguments: hashpartitioning(i_manufact_id#8, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [2]: [i_manufact_id#10, sum#14]
+Arguments: hashpartitioning(i_manufact_id#10, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (28) HashAggregate [codegen id : 6]
-Input [2]: [i_manufact_id#8, sum#14]
-Keys [1]: [i_manufact_id#8]
+Input [2]: [i_manufact_id#10, sum#14]
+Keys [1]: [i_manufact_id#10]
 Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#3))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#3))#15]
-Results [2]: [i_manufact_id#8, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#3))#15,17,2) AS total_sales#16]
+Results [2]: [i_manufact_id#10, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#3))#15,17,2) AS total_sales#16]
 
 (29) Scan parquet spark_catalog.default.catalog_sales
 Output [4]: [cs_bill_addr_sk#17, cs_item_sk#18, cs_ext_sales_price#19, cs_sold_date_sk#20]
@@ -226,7 +226,7 @@ Join condition: None
 Output [3]: [cs_bill_addr_sk#17, cs_item_sk#18, cs_ext_sales_price#19]
 Input [5]: [cs_bill_addr_sk#17, cs_item_sk#18, cs_ext_sales_price#19, cs_sold_date_sk#20, d_date_sk#21]
 
-(35) ReusedExchange [Reuses operator id: 16]
+(35) ReusedExchange [Reuses operator id: 23]
 Output [2]: [i_item_sk#22, i_manufact_id#23]
 
 (36) BroadcastHashJoin [codegen id : 11]
@@ -239,7 +239,7 @@ Join condition: None
 Output [3]: [cs_bill_addr_sk#17, cs_ext_sales_price#19, i_manufact_id#23]
 Input [5]: [cs_bill_addr_sk#17, cs_item_sk#18, cs_ext_sales_price#19, i_item_sk#22, i_manufact_id#23]
 
-(38) ReusedExchange [Reuses operator id: 23]
+(38) ReusedExchange [Reuses operator id: 11]
 Output [1]: [ca_address_sk#24]
 
 (39) BroadcastHashJoin [codegen id : 11]
@@ -298,7 +298,7 @@ Join condition: None
 Output [3]: [ws_item_sk#29, ws_bill_addr_sk#30, ws_ext_sales_price#31]
 Input [5]: [ws_item_sk#29, ws_bill_addr_sk#30, ws_ext_sales_price#31, ws_sold_date_sk#32, d_date_sk#33]
 
-(50) ReusedExchange [Reuses operator id: 16]
+(50) ReusedExchange [Reuses operator id: 23]
 Output [2]: [i_item_sk#34, i_manufact_id#35]
 
 (51) BroadcastHashJoin [codegen id : 17]
@@ -311,7 +311,7 @@ Join condition: None
 Output [3]: [ws_bill_addr_sk#30, ws_ext_sales_price#31, i_manufact_id#35]
 Input [5]: [ws_item_sk#29, ws_bill_addr_sk#30, ws_ext_sales_price#31, i_item_sk#34, i_manufact_id#35]
 
-(53) ReusedExchange [Reuses operator id: 23]
+(53) ReusedExchange [Reuses operator id: 11]
 Output [1]: [ca_address_sk#36]
 
 (54) BroadcastHashJoin [codegen id : 17]
@@ -345,26 +345,26 @@ Results [2]: [i_manufact_id#35, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price
 (59) Union
 
 (60) HashAggregate [codegen id : 19]
-Input [2]: [i_manufact_id#8, total_sales#16]
-Keys [1]: [i_manufact_id#8]
+Input [2]: [i_manufact_id#10, total_sales#16]
+Keys [1]: [i_manufact_id#10]
 Functions [1]: [partial_sum(total_sales#16)]
 Aggregate Attributes [2]: [sum#41, isEmpty#42]
-Results [3]: [i_manufact_id#8, sum#43, isEmpty#44]
+Results [3]: [i_manufact_id#10, sum#43, isEmpty#44]
 
 (61) Exchange
-Input [3]: [i_manufact_id#8, sum#43, isEmpty#44]
-Arguments: hashpartitioning(i_manufact_id#8, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Input [3]: [i_manufact_id#10, sum#43, isEmpty#44]
+Arguments: hashpartitioning(i_manufact_id#10, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
 (62) HashAggregate [codegen id : 20]
-Input [3]: [i_manufact_id#8, sum#43, isEmpty#44]
-Keys [1]: [i_manufact_id#8]
+Input [3]: [i_manufact_id#10, sum#43, isEmpty#44]
+Keys [1]: [i_manufact_id#10]
 Functions [1]: [sum(total_sales#16)]
 Aggregate Attributes [1]: [sum(total_sales#16)#45]
-Results [2]: [i_manufact_id#8, sum(total_sales#16)#45 AS total_sales#46]
+Results [2]: [i_manufact_id#10, sum(total_sales#16)#45 AS total_sales#46]
 
 (63) TakeOrderedAndProject
-Input [2]: [i_manufact_id#8, total_sales#46]
-Arguments: 100, [total_sales#46 ASC NULLS FIRST], [i_manufact_id#8, total_sales#46]
+Input [2]: [i_manufact_id#10, total_sales#46]
+Arguments: 100, [total_sales#46 ASC NULLS FIRST], [i_manufact_id#10, total_sales#46]
 
 ===== Subqueries =====
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q33.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q33.sf100/simplified.txt
@@ -14,9 +14,9 @@ TakeOrderedAndProject [total_sales,i_manufact_id]
                           WholeStageCodegen (5)
                             HashAggregate [i_manufact_id,ss_ext_sales_price] [sum,sum]
                               Project [ss_ext_sales_price,i_manufact_id]
-                                BroadcastHashJoin [ss_addr_sk,ca_address_sk]
-                                  Project [ss_addr_sk,ss_ext_sales_price,i_manufact_id]
-                                    BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                  Project [ss_item_sk,ss_ext_sales_price]
+                                    BroadcastHashJoin [ss_addr_sk,ca_address_sk]
                                       Project [ss_item_sk,ss_addr_sk,ss_ext_sales_price]
                                         BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                           Filter [ss_addr_sk,ss_item_sk]
@@ -35,28 +35,28 @@ TakeOrderedAndProject [total_sales,i_manufact_id]
                                             ReusedExchange [d_date_sk] #3
                                       InputAdapter
                                         BroadcastExchange #4
-                                          WholeStageCodegen (3)
-                                            BroadcastHashJoin [i_manufact_id,i_manufact_id]
-                                              Filter [i_item_sk]
+                                          WholeStageCodegen (2)
+                                            Project [ca_address_sk]
+                                              Filter [ca_gmt_offset,ca_address_sk]
                                                 ColumnarToRow
                                                   InputAdapter
-                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_manufact_id]
-                                              InputAdapter
-                                                BroadcastExchange #5
-                                                  WholeStageCodegen (2)
-                                                    Project [i_manufact_id]
-                                                      Filter [i_category]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.item [i_category,i_manufact_id]
+                                                    Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_gmt_offset]
                                   InputAdapter
-                                    BroadcastExchange #6
+                                    BroadcastExchange #5
                                       WholeStageCodegen (4)
-                                        Project [ca_address_sk]
-                                          Filter [ca_gmt_offset,ca_address_sk]
+                                        BroadcastHashJoin [i_manufact_id,i_manufact_id]
+                                          Filter [i_item_sk]
                                             ColumnarToRow
                                               InputAdapter
-                                                Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_gmt_offset]
+                                                Scan parquet spark_catalog.default.item [i_item_sk,i_manufact_id]
+                                          InputAdapter
+                                            BroadcastExchange #6
+                                              WholeStageCodegen (3)
+                                                Project [i_manufact_id]
+                                                  Filter [i_category]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.item [i_category,i_manufact_id]
                   WholeStageCodegen (12)
                     HashAggregate [i_manufact_id,sum] [sum(UnscaledValue(cs_ext_sales_price)),total_sales,sum]
                       InputAdapter
@@ -77,9 +77,9 @@ TakeOrderedAndProject [total_sales,i_manufact_id]
                                           InputAdapter
                                             ReusedExchange [d_date_sk] #3
                                       InputAdapter
-                                        ReusedExchange [i_item_sk,i_manufact_id] #4
+                                        ReusedExchange [i_item_sk,i_manufact_id] #5
                                   InputAdapter
-                                    ReusedExchange [ca_address_sk] #6
+                                    ReusedExchange [ca_address_sk] #4
                   WholeStageCodegen (18)
                     HashAggregate [i_manufact_id,sum] [sum(UnscaledValue(ws_ext_sales_price)),total_sales,sum]
                       InputAdapter
@@ -100,6 +100,6 @@ TakeOrderedAndProject [total_sales,i_manufact_id]
                                           InputAdapter
                                             ReusedExchange [d_date_sk] #3
                                       InputAdapter
-                                        ReusedExchange [i_item_sk,i_manufact_id] #4
+                                        ReusedExchange [i_item_sk,i_manufact_id] #5
                                   InputAdapter
-                                    ReusedExchange [ca_address_sk] #6
+                                    ReusedExchange [ca_address_sk] #4

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q34.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q34.sf100/explain.txt
@@ -13,17 +13,17 @@
          :                    +- * BroadcastHashJoin Inner BuildRight (19)
          :                       :- * Project (13)
          :                       :  +- * BroadcastHashJoin Inner BuildRight (12)
-         :                       :     :- * Project (6)
-         :                       :     :  +- * BroadcastHashJoin Inner BuildRight (5)
+         :                       :     :- * Project (10)
+         :                       :     :  +- * BroadcastHashJoin Inner BuildRight (9)
          :                       :     :     :- * Filter (3)
          :                       :     :     :  +- * ColumnarToRow (2)
          :                       :     :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-         :                       :     :     +- ReusedExchange (4)
-         :                       :     +- BroadcastExchange (11)
-         :                       :        +- * Project (10)
-         :                       :           +- * Filter (9)
-         :                       :              +- * ColumnarToRow (8)
-         :                       :                 +- Scan parquet spark_catalog.default.store (7)
+         :                       :     :     +- BroadcastExchange (8)
+         :                       :     :        +- * Project (7)
+         :                       :     :           +- * Filter (6)
+         :                       :     :              +- * ColumnarToRow (5)
+         :                       :     :                 +- Scan parquet spark_catalog.default.store (4)
+         :                       :     +- ReusedExchange (11)
          :                       +- BroadcastExchange (18)
          :                          +- * Project (17)
          :                             +- * Filter (16)
@@ -51,50 +51,50 @@ Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, 
 Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5]
 Condition : ((isnotnull(ss_store_sk#3) AND isnotnull(ss_hdemo_sk#2)) AND isnotnull(ss_customer_sk#1))
 
-(4) ReusedExchange [Reuses operator id: 40]
-Output [1]: [d_date_sk#7]
-
-(5) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#5]
-Right keys [1]: [d_date_sk#7]
-Join type: Inner
-Join condition: None
-
-(6) Project [codegen id : 4]
-Output [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4]
-Input [6]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5, d_date_sk#7]
-
-(7) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#8, s_county#9]
+(4) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#7, s_county#8]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_county), EqualTo(s_county,Williamson County), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_county:string>
 
-(8) ColumnarToRow [codegen id : 2]
-Input [2]: [s_store_sk#8, s_county#9]
+(5) ColumnarToRow [codegen id : 1]
+Input [2]: [s_store_sk#7, s_county#8]
 
-(9) Filter [codegen id : 2]
-Input [2]: [s_store_sk#8, s_county#9]
-Condition : ((isnotnull(s_county#9) AND (s_county#9 = Williamson County)) AND isnotnull(s_store_sk#8))
+(6) Filter [codegen id : 1]
+Input [2]: [s_store_sk#7, s_county#8]
+Condition : ((isnotnull(s_county#8) AND (s_county#8 = Williamson County)) AND isnotnull(s_store_sk#7))
 
-(10) Project [codegen id : 2]
-Output [1]: [s_store_sk#8]
-Input [2]: [s_store_sk#8, s_county#9]
+(7) Project [codegen id : 1]
+Output [1]: [s_store_sk#7]
+Input [2]: [s_store_sk#7, s_county#8]
 
-(11) BroadcastExchange
-Input [1]: [s_store_sk#8]
+(8) BroadcastExchange
+Input [1]: [s_store_sk#7]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(12) BroadcastHashJoin [codegen id : 4]
+(9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#8]
+Right keys [1]: [s_store_sk#7]
+Join type: Inner
+Join condition: None
+
+(10) Project [codegen id : 4]
+Output [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4, ss_sold_date_sk#5]
+Input [6]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5, s_store_sk#7]
+
+(11) ReusedExchange [Reuses operator id: 40]
+Output [1]: [d_date_sk#9]
+
+(12) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_sold_date_sk#5]
+Right keys [1]: [d_date_sk#9]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
 Output [3]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4]
-Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, s_store_sk#8]
+Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4, ss_sold_date_sk#5, d_date_sk#9]
 
 (14) Scan parquet spark_catalog.default.household_demographics
 Output [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
@@ -209,25 +209,25 @@ BroadcastExchange (40)
 
 
 (36) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#7, d_year#23, d_dom#24]
+Output [3]: [d_date_sk#9, d_year#23, d_dom#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [Or(And(GreaterThanOrEqual(d_dom,1),LessThanOrEqual(d_dom,3)),And(GreaterThanOrEqual(d_dom,25),LessThanOrEqual(d_dom,28))), In(d_year, [1999,2000,2001]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_dom:int>
 
 (37) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#7, d_year#23, d_dom#24]
+Input [3]: [d_date_sk#9, d_year#23, d_dom#24]
 
 (38) Filter [codegen id : 1]
-Input [3]: [d_date_sk#7, d_year#23, d_dom#24]
-Condition : (((((d_dom#24 >= 1) AND (d_dom#24 <= 3)) OR ((d_dom#24 >= 25) AND (d_dom#24 <= 28))) AND d_year#23 IN (1999,2000,2001)) AND isnotnull(d_date_sk#7))
+Input [3]: [d_date_sk#9, d_year#23, d_dom#24]
+Condition : (((((d_dom#24 >= 1) AND (d_dom#24 <= 3)) OR ((d_dom#24 >= 25) AND (d_dom#24 <= 28))) AND d_year#23 IN (1999,2000,2001)) AND isnotnull(d_date_sk#9))
 
 (39) Project [codegen id : 1]
-Output [1]: [d_date_sk#7]
-Input [3]: [d_date_sk#7, d_year#23, d_dom#24]
+Output [1]: [d_date_sk#9]
+Input [3]: [d_date_sk#9, d_year#23, d_dom#24]
 
 (40) BroadcastExchange
-Input [1]: [d_date_sk#7]
+Input [1]: [d_date_sk#9]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q34.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q34.sf100/simplified.txt
@@ -20,9 +20,9 @@ WholeStageCodegen (10)
                                       Project [ss_customer_sk,ss_ticket_number]
                                         BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
                                           Project [ss_customer_sk,ss_hdemo_sk,ss_ticket_number]
-                                            BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                              Project [ss_customer_sk,ss_hdemo_sk,ss_store_sk,ss_ticket_number]
-                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                            BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                              Project [ss_customer_sk,ss_hdemo_sk,ss_ticket_number,ss_sold_date_sk]
+                                                BroadcastHashJoin [ss_store_sk,s_store_sk]
                                                   Filter [ss_store_sk,ss_hdemo_sk,ss_customer_sk]
                                                     ColumnarToRow
                                                       InputAdapter
@@ -36,15 +36,15 @@ WholeStageCodegen (10)
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_dom]
                                                   InputAdapter
-                                                    ReusedExchange [d_date_sk] #4
+                                                    BroadcastExchange #5
+                                                      WholeStageCodegen (1)
+                                                        Project [s_store_sk]
+                                                          Filter [s_county,s_store_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet spark_catalog.default.store [s_store_sk,s_county]
                                               InputAdapter
-                                                BroadcastExchange #5
-                                                  WholeStageCodegen (2)
-                                                    Project [s_store_sk]
-                                                      Filter [s_county,s_store_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.store [s_store_sk,s_county]
+                                                ReusedExchange [d_date_sk] #4
                                           InputAdapter
                                             BroadcastExchange #6
                                               WholeStageCodegen (3)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q36.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q36.sf100/explain.txt
@@ -12,17 +12,17 @@ TakeOrderedAndProject (28)
                            +- * BroadcastHashJoin Inner BuildRight (18)
                               :- * Project (13)
                               :  +- * BroadcastHashJoin Inner BuildRight (12)
-                              :     :- * Project (6)
-                              :     :  +- * BroadcastHashJoin Inner BuildRight (5)
+                              :     :- * Project (10)
+                              :     :  +- * BroadcastHashJoin Inner BuildRight (9)
                               :     :     :- * Filter (3)
                               :     :     :  +- * ColumnarToRow (2)
                               :     :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-                              :     :     +- ReusedExchange (4)
-                              :     +- BroadcastExchange (11)
-                              :        +- * Project (10)
-                              :           +- * Filter (9)
-                              :              +- * ColumnarToRow (8)
-                              :                 +- Scan parquet spark_catalog.default.store (7)
+                              :     :     +- BroadcastExchange (8)
+                              :     :        +- * Project (7)
+                              :     :           +- * Filter (6)
+                              :     :              +- * ColumnarToRow (5)
+                              :     :                 +- Scan parquet spark_catalog.default.store (4)
+                              :     +- ReusedExchange (11)
                               +- BroadcastExchange (17)
                                  +- * Filter (16)
                                     +- * ColumnarToRow (15)
@@ -44,50 +44,50 @@ Input [5]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, ss_net_profit#4, 
 Input [5]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, ss_net_profit#4, ss_sold_date_sk#5]
 Condition : (isnotnull(ss_item_sk#1) AND isnotnull(ss_store_sk#2))
 
-(4) ReusedExchange [Reuses operator id: 33]
-Output [1]: [d_date_sk#7]
-
-(5) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#5]
-Right keys [1]: [d_date_sk#7]
-Join type: Inner
-Join condition: None
-
-(6) Project [codegen id : 4]
-Output [4]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, ss_net_profit#4]
-Input [6]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, ss_net_profit#4, ss_sold_date_sk#5, d_date_sk#7]
-
-(7) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#8, s_state#9]
+(4) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#7, s_state#8]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_state), EqualTo(s_state,TN), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_state:string>
 
-(8) ColumnarToRow [codegen id : 2]
-Input [2]: [s_store_sk#8, s_state#9]
+(5) ColumnarToRow [codegen id : 1]
+Input [2]: [s_store_sk#7, s_state#8]
 
-(9) Filter [codegen id : 2]
-Input [2]: [s_store_sk#8, s_state#9]
-Condition : ((isnotnull(s_state#9) AND (s_state#9 = TN)) AND isnotnull(s_store_sk#8))
+(6) Filter [codegen id : 1]
+Input [2]: [s_store_sk#7, s_state#8]
+Condition : ((isnotnull(s_state#8) AND (s_state#8 = TN)) AND isnotnull(s_store_sk#7))
 
-(10) Project [codegen id : 2]
-Output [1]: [s_store_sk#8]
-Input [2]: [s_store_sk#8, s_state#9]
+(7) Project [codegen id : 1]
+Output [1]: [s_store_sk#7]
+Input [2]: [s_store_sk#7, s_state#8]
 
-(11) BroadcastExchange
-Input [1]: [s_store_sk#8]
+(8) BroadcastExchange
+Input [1]: [s_store_sk#7]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(12) BroadcastHashJoin [codegen id : 4]
+(9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#2]
-Right keys [1]: [s_store_sk#8]
+Right keys [1]: [s_store_sk#7]
+Join type: Inner
+Join condition: None
+
+(10) Project [codegen id : 4]
+Output [4]: [ss_item_sk#1, ss_ext_sales_price#3, ss_net_profit#4, ss_sold_date_sk#5]
+Input [6]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, ss_net_profit#4, ss_sold_date_sk#5, s_store_sk#7]
+
+(11) ReusedExchange [Reuses operator id: 33]
+Output [1]: [d_date_sk#9]
+
+(12) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_sold_date_sk#5]
+Right keys [1]: [d_date_sk#9]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
 Output [3]: [ss_item_sk#1, ss_ext_sales_price#3, ss_net_profit#4]
-Input [5]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, ss_net_profit#4, s_store_sk#8]
+Input [5]: [ss_item_sk#1, ss_ext_sales_price#3, ss_net_profit#4, ss_sold_date_sk#5, d_date_sk#9]
 
 (14) Scan parquet spark_catalog.default.item
 Output [3]: [i_item_sk#10, i_class#11, i_category#12]
@@ -170,25 +170,25 @@ BroadcastExchange (33)
 
 
 (29) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#7, d_year#28]
+Output [2]: [d_date_sk#9, d_year#28]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (30) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#7, d_year#28]
+Input [2]: [d_date_sk#9, d_year#28]
 
 (31) Filter [codegen id : 1]
-Input [2]: [d_date_sk#7, d_year#28]
-Condition : ((isnotnull(d_year#28) AND (d_year#28 = 2001)) AND isnotnull(d_date_sk#7))
+Input [2]: [d_date_sk#9, d_year#28]
+Condition : ((isnotnull(d_year#28) AND (d_year#28 = 2001)) AND isnotnull(d_date_sk#9))
 
 (32) Project [codegen id : 1]
-Output [1]: [d_date_sk#7]
-Input [2]: [d_date_sk#7, d_year#28]
+Output [1]: [d_date_sk#9]
+Input [2]: [d_date_sk#9, d_year#28]
 
 (33) BroadcastExchange
-Input [1]: [d_date_sk#7]
+Input [1]: [d_date_sk#9]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q36.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q36.sf100/simplified.txt
@@ -17,9 +17,9 @@ TakeOrderedAndProject [lochierarchy,i_category,rank_within_parent,gross_margin,i
                                 Project [ss_ext_sales_price,ss_net_profit,i_category,i_class]
                                   BroadcastHashJoin [ss_item_sk,i_item_sk]
                                     Project [ss_item_sk,ss_ext_sales_price,ss_net_profit]
-                                      BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                        Project [ss_item_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit]
-                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                        Project [ss_item_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk]
+                                          BroadcastHashJoin [ss_store_sk,s_store_sk]
                                             Filter [ss_item_sk,ss_store_sk]
                                               ColumnarToRow
                                                 InputAdapter
@@ -33,15 +33,15 @@ TakeOrderedAndProject [lochierarchy,i_category,rank_within_parent,gross_margin,i
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                             InputAdapter
-                                              ReusedExchange [d_date_sk] #3
+                                              BroadcastExchange #4
+                                                WholeStageCodegen (1)
+                                                  Project [s_store_sk]
+                                                    Filter [s_state,s_store_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet spark_catalog.default.store [s_store_sk,s_state]
                                         InputAdapter
-                                          BroadcastExchange #4
-                                            WholeStageCodegen (2)
-                                              Project [s_store_sk]
-                                                Filter [s_state,s_store_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.store [s_store_sk,s_state]
+                                          ReusedExchange [d_date_sk] #3
                                     InputAdapter
                                       BroadcastExchange #5
                                         WholeStageCodegen (3)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/explain.txt
@@ -5,28 +5,28 @@ TakeOrderedAndProject (28)
       +- * HashAggregate (25)
          +- * Project (24)
             +- * SortMergeJoin Inner (23)
-               :- * Sort (16)
-               :  +- Exchange (15)
-               :     +- * Project (14)
-               :        +- * BroadcastHashJoin Inner BuildRight (13)
-               :           :- * Project (11)
-               :           :  +- * BroadcastHashJoin Inner BuildLeft (10)
-               :           :     :- BroadcastExchange (5)
-               :           :     :  +- * Project (4)
-               :           :     :     +- * Filter (3)
-               :           :     :        +- * ColumnarToRow (2)
-               :           :     :           +- Scan parquet spark_catalog.default.item (1)
-               :           :     +- * Project (9)
-               :           :        +- * Filter (8)
-               :           :           +- * ColumnarToRow (7)
-               :           :              +- Scan parquet spark_catalog.default.inventory (6)
-               :           +- ReusedExchange (12)
+               :- * Sort (13)
+               :  +- Exchange (12)
+               :     +- * Project (11)
+               :        +- * BroadcastHashJoin Inner BuildLeft (10)
+               :           :- BroadcastExchange (5)
+               :           :  +- * Project (4)
+               :           :     +- * Filter (3)
+               :           :        +- * ColumnarToRow (2)
+               :           :           +- Scan parquet spark_catalog.default.item (1)
+               :           +- * Project (9)
+               :              +- * Filter (8)
+               :                 +- * ColumnarToRow (7)
+               :                    +- Scan parquet spark_catalog.default.catalog_sales (6)
                +- * Sort (22)
                   +- Exchange (21)
                      +- * Project (20)
-                        +- * Filter (19)
-                           +- * ColumnarToRow (18)
-                              +- Scan parquet spark_catalog.default.catalog_sales (17)
+                        +- * BroadcastHashJoin Inner BuildRight (19)
+                           :- * Project (17)
+                           :  +- * Filter (16)
+                           :     +- * ColumnarToRow (15)
+                           :        +- Scan parquet spark_catalog.default.inventory (14)
+                           +- ReusedExchange (18)
 
 
 (1) Scan parquet spark_catalog.default.item
@@ -51,91 +51,91 @@ Input [5]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, i_manufa
 Input [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(6) Scan parquet spark_catalog.default.inventory
-Output [3]: [inv_item_sk#6, inv_quantity_on_hand#7, inv_date_sk#8]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(inv_date_sk#8), dynamicpruningexpression(inv_date_sk#8 IN dynamicpruning#9)]
-PushedFilters: [IsNotNull(inv_quantity_on_hand), GreaterThanOrEqual(inv_quantity_on_hand,100), LessThanOrEqual(inv_quantity_on_hand,500), IsNotNull(inv_item_sk)]
-ReadSchema: struct<inv_item_sk:int,inv_quantity_on_hand:int>
-
-(7) ColumnarToRow
-Input [3]: [inv_item_sk#6, inv_quantity_on_hand#7, inv_date_sk#8]
-
-(8) Filter
-Input [3]: [inv_item_sk#6, inv_quantity_on_hand#7, inv_date_sk#8]
-Condition : (((isnotnull(inv_quantity_on_hand#7) AND (inv_quantity_on_hand#7 >= 100)) AND (inv_quantity_on_hand#7 <= 500)) AND isnotnull(inv_item_sk#6))
-
-(9) Project
-Output [2]: [inv_item_sk#6, inv_date_sk#8]
-Input [3]: [inv_item_sk#6, inv_quantity_on_hand#7, inv_date_sk#8]
-
-(10) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [i_item_sk#1]
-Right keys [1]: [inv_item_sk#6]
-Join type: Inner
-Join condition: None
-
-(11) Project [codegen id : 3]
-Output [5]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, inv_date_sk#8]
-Input [6]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, inv_item_sk#6, inv_date_sk#8]
-
-(12) ReusedExchange [Reuses operator id: 33]
-Output [1]: [d_date_sk#10]
-
-(13) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [inv_date_sk#8]
-Right keys [1]: [d_date_sk#10]
-Join type: Inner
-Join condition: None
-
-(14) Project [codegen id : 3]
-Output [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
-Input [6]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, inv_date_sk#8, d_date_sk#10]
-
-(15) Exchange
-Input [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
-Arguments: hashpartitioning(i_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
-
-(16) Sort [codegen id : 4]
-Input [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
-Arguments: [i_item_sk#1 ASC NULLS FIRST], false, 0
-
-(17) Scan parquet spark_catalog.default.catalog_sales
-Output [2]: [cs_item_sk#11, cs_sold_date_sk#12]
+(6) Scan parquet spark_catalog.default.catalog_sales
+Output [2]: [cs_item_sk#6, cs_sold_date_sk#7]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_sales]
 PushedFilters: [IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_item_sk:int>
 
-(18) ColumnarToRow [codegen id : 5]
-Input [2]: [cs_item_sk#11, cs_sold_date_sk#12]
+(7) ColumnarToRow
+Input [2]: [cs_item_sk#6, cs_sold_date_sk#7]
 
-(19) Filter [codegen id : 5]
-Input [2]: [cs_item_sk#11, cs_sold_date_sk#12]
-Condition : (isnotnull(cs_item_sk#11) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(cs_item_sk#11, 42)))
+(8) Filter
+Input [2]: [cs_item_sk#6, cs_sold_date_sk#7]
+Condition : isnotnull(cs_item_sk#6)
+
+(9) Project
+Output [1]: [cs_item_sk#6]
+Input [2]: [cs_item_sk#6, cs_sold_date_sk#7]
+
+(10) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [i_item_sk#1]
+Right keys [1]: [cs_item_sk#6]
+Join type: Inner
+Join condition: None
+
+(11) Project [codegen id : 2]
+Output [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
+Input [5]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, cs_item_sk#6]
+
+(12) Exchange
+Input [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
+Arguments: hashpartitioning(i_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+
+(13) Sort [codegen id : 3]
+Input [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
+Arguments: [i_item_sk#1 ASC NULLS FIRST], false, 0
+
+(14) Scan parquet spark_catalog.default.inventory
+Output [3]: [inv_item_sk#8, inv_quantity_on_hand#9, inv_date_sk#10]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(inv_date_sk#10), dynamicpruningexpression(inv_date_sk#10 IN dynamicpruning#11)]
+PushedFilters: [IsNotNull(inv_quantity_on_hand), GreaterThanOrEqual(inv_quantity_on_hand,100), LessThanOrEqual(inv_quantity_on_hand,500), IsNotNull(inv_item_sk)]
+ReadSchema: struct<inv_item_sk:int,inv_quantity_on_hand:int>
+
+(15) ColumnarToRow [codegen id : 5]
+Input [3]: [inv_item_sk#8, inv_quantity_on_hand#9, inv_date_sk#10]
+
+(16) Filter [codegen id : 5]
+Input [3]: [inv_item_sk#8, inv_quantity_on_hand#9, inv_date_sk#10]
+Condition : (((isnotnull(inv_quantity_on_hand#9) AND (inv_quantity_on_hand#9 >= 100)) AND (inv_quantity_on_hand#9 <= 500)) AND isnotnull(inv_item_sk#8))
+
+(17) Project [codegen id : 5]
+Output [2]: [inv_item_sk#8, inv_date_sk#10]
+Input [3]: [inv_item_sk#8, inv_quantity_on_hand#9, inv_date_sk#10]
+
+(18) ReusedExchange [Reuses operator id: 33]
+Output [1]: [d_date_sk#12]
+
+(19) BroadcastHashJoin [codegen id : 5]
+Left keys [1]: [inv_date_sk#10]
+Right keys [1]: [d_date_sk#12]
+Join type: Inner
+Join condition: None
 
 (20) Project [codegen id : 5]
-Output [1]: [cs_item_sk#11]
-Input [2]: [cs_item_sk#11, cs_sold_date_sk#12]
+Output [1]: [inv_item_sk#8]
+Input [3]: [inv_item_sk#8, inv_date_sk#10, d_date_sk#12]
 
 (21) Exchange
-Input [1]: [cs_item_sk#11]
-Arguments: hashpartitioning(cs_item_sk#11, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [1]: [inv_item_sk#8]
+Arguments: hashpartitioning(inv_item_sk#8, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (22) Sort [codegen id : 6]
-Input [1]: [cs_item_sk#11]
-Arguments: [cs_item_sk#11 ASC NULLS FIRST], false, 0
+Input [1]: [inv_item_sk#8]
+Arguments: [inv_item_sk#8 ASC NULLS FIRST], false, 0
 
 (23) SortMergeJoin [codegen id : 7]
 Left keys [1]: [i_item_sk#1]
-Right keys [1]: [cs_item_sk#11]
+Right keys [1]: [inv_item_sk#8]
 Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 7]
 Output [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
-Input [5]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, cs_item_sk#11]
+Input [5]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, inv_item_sk#8]
 
 (25) HashAggregate [codegen id : 7]
 Input [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
@@ -161,7 +161,7 @@ Arguments: 100, [i_item_id#2 ASC NULLS FIRST], [i_item_id#2, i_item_desc#3, i_cu
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 6 Hosting Expression = inv_date_sk#8 IN dynamicpruning#9
+Subquery:1 Hosting operator id = 14 Hosting Expression = inv_date_sk#10 IN dynamicpruning#11
 BroadcastExchange (33)
 +- * Project (32)
    +- * Filter (31)
@@ -170,71 +170,25 @@ BroadcastExchange (33)
 
 
 (29) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#10, d_date#15]
+Output [2]: [d_date_sk#12, d_date#13]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-02-01), LessThanOrEqual(d_date,2000-04-01), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (30) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#10, d_date#15]
+Input [2]: [d_date_sk#12, d_date#13]
 
 (31) Filter [codegen id : 1]
-Input [2]: [d_date_sk#10, d_date#15]
-Condition : (((isnotnull(d_date#15) AND (d_date#15 >= 2000-02-01)) AND (d_date#15 <= 2000-04-01)) AND isnotnull(d_date_sk#10))
+Input [2]: [d_date_sk#12, d_date#13]
+Condition : (((isnotnull(d_date#13) AND (d_date#13 >= 2000-02-01)) AND (d_date#13 <= 2000-04-01)) AND isnotnull(d_date_sk#12))
 
 (32) Project [codegen id : 1]
-Output [1]: [d_date_sk#10]
-Input [2]: [d_date_sk#10, d_date#15]
+Output [1]: [d_date_sk#12]
+Input [2]: [d_date_sk#12, d_date#13]
 
 (33) BroadcastExchange
-Input [1]: [d_date_sk#10]
+Input [1]: [d_date_sk#12]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
-
-Subquery:2 Hosting operator id = 19 Hosting Expression = Subquery scalar-subquery#13, [id=#14]
-ObjectHashAggregate (40)
-+- Exchange (39)
-   +- ObjectHashAggregate (38)
-      +- * Project (37)
-         +- * Filter (36)
-            +- * ColumnarToRow (35)
-               +- Scan parquet spark_catalog.default.item (34)
-
-
-(34) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_current_price), GreaterThanOrEqual(i_current_price,68.00), LessThanOrEqual(i_current_price,98.00), In(i_manufact_id, [677,694,808,940]), IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_manufact_id:int>
-
-(35) ColumnarToRow [codegen id : 1]
-Input [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
-
-(36) Filter [codegen id : 1]
-Input [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
-Condition : ((((isnotnull(i_current_price#4) AND (i_current_price#4 >= 68.00)) AND (i_current_price#4 <= 98.00)) AND i_manufact_id#5 IN (677,940,694,808)) AND isnotnull(i_item_sk#1))
-
-(37) Project [codegen id : 1]
-Output [1]: [i_item_sk#1]
-Input [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
-
-(38) ObjectHashAggregate
-Input [1]: [i_item_sk#1]
-Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)]
-Aggregate Attributes [1]: [buf#16]
-Results [1]: [buf#17]
-
-(39) Exchange
-Input [1]: [buf#17]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
-
-(40) ObjectHashAggregate
-Input [1]: [buf#17]
-Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)#18]
-Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)#18 AS bloomFilter#19]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q37.sf100/simplified.txt
@@ -6,58 +6,48 @@ TakeOrderedAndProject [i_item_id,i_item_desc,i_current_price]
           WholeStageCodegen (7)
             HashAggregate [i_item_id,i_item_desc,i_current_price]
               Project [i_item_id,i_item_desc,i_current_price]
-                SortMergeJoin [i_item_sk,cs_item_sk]
+                SortMergeJoin [i_item_sk,inv_item_sk]
                   InputAdapter
-                    WholeStageCodegen (4)
+                    WholeStageCodegen (3)
                       Sort [i_item_sk]
                         InputAdapter
                           Exchange [i_item_sk] #2
-                            WholeStageCodegen (3)
+                            WholeStageCodegen (2)
                               Project [i_item_sk,i_item_id,i_item_desc,i_current_price]
-                                BroadcastHashJoin [inv_date_sk,d_date_sk]
-                                  Project [i_item_sk,i_item_id,i_item_desc,i_current_price,inv_date_sk]
-                                    BroadcastHashJoin [i_item_sk,inv_item_sk]
-                                      InputAdapter
-                                        BroadcastExchange #3
-                                          WholeStageCodegen (1)
-                                            Project [i_item_sk,i_item_id,i_item_desc,i_current_price]
-                                              Filter [i_current_price,i_manufact_id,i_item_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_manufact_id]
-                                      Project [inv_item_sk,inv_date_sk]
-                                        Filter [inv_quantity_on_hand,inv_item_sk]
-                                          ColumnarToRow
-                                            InputAdapter
-                                              Scan parquet spark_catalog.default.inventory [inv_item_sk,inv_quantity_on_hand,inv_date_sk]
-                                                SubqueryBroadcast [d_date_sk] #1
-                                                  BroadcastExchange #4
-                                                    WholeStageCodegen (1)
-                                                      Project [d_date_sk]
-                                                        Filter [d_date,d_date_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
+                                BroadcastHashJoin [i_item_sk,cs_item_sk]
                                   InputAdapter
-                                    ReusedExchange [d_date_sk] #4
+                                    BroadcastExchange #3
+                                      WholeStageCodegen (1)
+                                        Project [i_item_sk,i_item_id,i_item_desc,i_current_price]
+                                          Filter [i_current_price,i_manufact_id,i_item_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_manufact_id]
+                                  Project [cs_item_sk]
+                                    Filter [cs_item_sk]
+                                      ColumnarToRow
+                                        InputAdapter
+                                          Scan parquet spark_catalog.default.catalog_sales [cs_item_sk,cs_sold_date_sk]
                   InputAdapter
                     WholeStageCodegen (6)
-                      Sort [cs_item_sk]
+                      Sort [inv_item_sk]
                         InputAdapter
-                          Exchange [cs_item_sk] #5
+                          Exchange [inv_item_sk] #4
                             WholeStageCodegen (5)
-                              Project [cs_item_sk]
-                                Filter [cs_item_sk]
-                                  Subquery #2
-                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 239, 6582, 0, 0),bloomFilter,buf]
-                                      Exchange #6
-                                        ObjectHashAggregate [i_item_sk] [buf,buf]
-                                          WholeStageCodegen (1)
-                                            Project [i_item_sk]
-                                              Filter [i_current_price,i_manufact_id,i_item_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_manufact_id]
-                                  ColumnarToRow
-                                    InputAdapter
-                                      Scan parquet spark_catalog.default.catalog_sales [cs_item_sk,cs_sold_date_sk]
+                              Project [inv_item_sk]
+                                BroadcastHashJoin [inv_date_sk,d_date_sk]
+                                  Project [inv_item_sk,inv_date_sk]
+                                    Filter [inv_quantity_on_hand,inv_item_sk]
+                                      ColumnarToRow
+                                        InputAdapter
+                                          Scan parquet spark_catalog.default.inventory [inv_item_sk,inv_quantity_on_hand,inv_date_sk]
+                                            SubqueryBroadcast [d_date_sk] #1
+                                              BroadcastExchange #5
+                                                WholeStageCodegen (1)
+                                                  Project [d_date_sk]
+                                                    Filter [d_date,d_date_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
+                                  InputAdapter
+                                    ReusedExchange [d_date_sk] #5

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q40.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q40.sf100/explain.txt
@@ -5,10 +5,10 @@ TakeOrderedAndProject (33)
       +- * HashAggregate (30)
          +- * Project (29)
             +- * BroadcastHashJoin Inner BuildRight (28)
-               :- * Project (23)
-               :  +- * BroadcastHashJoin Inner BuildRight (22)
-               :     :- * Project (20)
-               :     :  +- * BroadcastHashJoin Inner BuildRight (19)
+               :- * Project (26)
+               :  +- * BroadcastHashJoin Inner BuildRight (25)
+               :     :- * Project (19)
+               :     :  +- * BroadcastHashJoin Inner BuildRight (18)
                :     :     :- * Project (13)
                :     :     :  +- * SortMergeJoin LeftOuter (12)
                :     :     :     :- * Sort (5)
@@ -22,16 +22,16 @@ TakeOrderedAndProject (33)
                :     :     :              +- * Filter (8)
                :     :     :                 +- * ColumnarToRow (7)
                :     :     :                    +- Scan parquet spark_catalog.default.catalog_returns (6)
-               :     :     +- BroadcastExchange (18)
-               :     :        +- * Project (17)
-               :     :           +- * Filter (16)
-               :     :              +- * ColumnarToRow (15)
-               :     :                 +- Scan parquet spark_catalog.default.item (14)
-               :     +- ReusedExchange (21)
-               +- BroadcastExchange (27)
-                  +- * Filter (26)
-                     +- * ColumnarToRow (25)
-                        +- Scan parquet spark_catalog.default.warehouse (24)
+               :     :     +- BroadcastExchange (17)
+               :     :        +- * Filter (16)
+               :     :           +- * ColumnarToRow (15)
+               :     :              +- Scan parquet spark_catalog.default.warehouse (14)
+               :     +- BroadcastExchange (24)
+               :        +- * Project (23)
+               :           +- * Filter (22)
+               :              +- * ColumnarToRow (21)
+               :                 +- Scan parquet spark_catalog.default.item (20)
+               +- ReusedExchange (27)
 
 
 (1) Scan parquet spark_catalog.default.catalog_sales
@@ -93,100 +93,100 @@ Join condition: None
 Output [5]: [cs_warehouse_sk#1, cs_item_sk#2, cs_sales_price#4, cs_sold_date_sk#5, cr_refunded_cash#11]
 Input [8]: [cs_warehouse_sk#1, cs_item_sk#2, cs_order_number#3, cs_sales_price#4, cs_sold_date_sk#5, cr_item_sk#9, cr_order_number#10, cr_refunded_cash#11]
 
-(14) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#13, i_item_id#14, i_current_price#15]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_current_price), GreaterThanOrEqual(i_current_price,0.99), LessThanOrEqual(i_current_price,1.49), IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_item_id:string,i_current_price:decimal(7,2)>
-
-(15) ColumnarToRow [codegen id : 5]
-Input [3]: [i_item_sk#13, i_item_id#14, i_current_price#15]
-
-(16) Filter [codegen id : 5]
-Input [3]: [i_item_sk#13, i_item_id#14, i_current_price#15]
-Condition : (((isnotnull(i_current_price#15) AND (i_current_price#15 >= 0.99)) AND (i_current_price#15 <= 1.49)) AND isnotnull(i_item_sk#13))
-
-(17) Project [codegen id : 5]
-Output [2]: [i_item_sk#13, i_item_id#14]
-Input [3]: [i_item_sk#13, i_item_id#14, i_current_price#15]
-
-(18) BroadcastExchange
-Input [2]: [i_item_sk#13, i_item_id#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
-
-(19) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [cs_item_sk#2]
-Right keys [1]: [i_item_sk#13]
-Join type: Inner
-Join condition: None
-
-(20) Project [codegen id : 8]
-Output [5]: [cs_warehouse_sk#1, cs_sales_price#4, cs_sold_date_sk#5, cr_refunded_cash#11, i_item_id#14]
-Input [7]: [cs_warehouse_sk#1, cs_item_sk#2, cs_sales_price#4, cs_sold_date_sk#5, cr_refunded_cash#11, i_item_sk#13, i_item_id#14]
-
-(21) ReusedExchange [Reuses operator id: 44]
-Output [2]: [d_date_sk#16, d_date#17]
-
-(22) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [cs_sold_date_sk#5]
-Right keys [1]: [d_date_sk#16]
-Join type: Inner
-Join condition: None
-
-(23) Project [codegen id : 8]
-Output [5]: [cs_warehouse_sk#1, cs_sales_price#4, cr_refunded_cash#11, i_item_id#14, d_date#17]
-Input [7]: [cs_warehouse_sk#1, cs_sales_price#4, cs_sold_date_sk#5, cr_refunded_cash#11, i_item_id#14, d_date_sk#16, d_date#17]
-
-(24) Scan parquet spark_catalog.default.warehouse
-Output [2]: [w_warehouse_sk#18, w_state#19]
+(14) Scan parquet spark_catalog.default.warehouse
+Output [2]: [w_warehouse_sk#13, w_state#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/warehouse]
 PushedFilters: [IsNotNull(w_warehouse_sk)]
 ReadSchema: struct<w_warehouse_sk:int,w_state:string>
 
-(25) ColumnarToRow [codegen id : 7]
-Input [2]: [w_warehouse_sk#18, w_state#19]
+(15) ColumnarToRow [codegen id : 5]
+Input [2]: [w_warehouse_sk#13, w_state#14]
 
-(26) Filter [codegen id : 7]
-Input [2]: [w_warehouse_sk#18, w_state#19]
-Condition : isnotnull(w_warehouse_sk#18)
+(16) Filter [codegen id : 5]
+Input [2]: [w_warehouse_sk#13, w_state#14]
+Condition : isnotnull(w_warehouse_sk#13)
 
-(27) BroadcastExchange
-Input [2]: [w_warehouse_sk#18, w_state#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
+(17) BroadcastExchange
+Input [2]: [w_warehouse_sk#13, w_state#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
+
+(18) BroadcastHashJoin [codegen id : 8]
+Left keys [1]: [cs_warehouse_sk#1]
+Right keys [1]: [w_warehouse_sk#13]
+Join type: Inner
+Join condition: None
+
+(19) Project [codegen id : 8]
+Output [5]: [cs_item_sk#2, cs_sales_price#4, cs_sold_date_sk#5, cr_refunded_cash#11, w_state#14]
+Input [7]: [cs_warehouse_sk#1, cs_item_sk#2, cs_sales_price#4, cs_sold_date_sk#5, cr_refunded_cash#11, w_warehouse_sk#13, w_state#14]
+
+(20) Scan parquet spark_catalog.default.item
+Output [3]: [i_item_sk#15, i_item_id#16, i_current_price#17]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_current_price), GreaterThanOrEqual(i_current_price,0.99), LessThanOrEqual(i_current_price,1.49), IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_item_id:string,i_current_price:decimal(7,2)>
+
+(21) ColumnarToRow [codegen id : 6]
+Input [3]: [i_item_sk#15, i_item_id#16, i_current_price#17]
+
+(22) Filter [codegen id : 6]
+Input [3]: [i_item_sk#15, i_item_id#16, i_current_price#17]
+Condition : (((isnotnull(i_current_price#17) AND (i_current_price#17 >= 0.99)) AND (i_current_price#17 <= 1.49)) AND isnotnull(i_item_sk#15))
+
+(23) Project [codegen id : 6]
+Output [2]: [i_item_sk#15, i_item_id#16]
+Input [3]: [i_item_sk#15, i_item_id#16, i_current_price#17]
+
+(24) BroadcastExchange
+Input [2]: [i_item_sk#15, i_item_id#16]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
+
+(25) BroadcastHashJoin [codegen id : 8]
+Left keys [1]: [cs_item_sk#2]
+Right keys [1]: [i_item_sk#15]
+Join type: Inner
+Join condition: None
+
+(26) Project [codegen id : 8]
+Output [5]: [cs_sales_price#4, cs_sold_date_sk#5, cr_refunded_cash#11, w_state#14, i_item_id#16]
+Input [7]: [cs_item_sk#2, cs_sales_price#4, cs_sold_date_sk#5, cr_refunded_cash#11, w_state#14, i_item_sk#15, i_item_id#16]
+
+(27) ReusedExchange [Reuses operator id: 44]
+Output [2]: [d_date_sk#18, d_date#19]
 
 (28) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [cs_warehouse_sk#1]
-Right keys [1]: [w_warehouse_sk#18]
+Left keys [1]: [cs_sold_date_sk#5]
+Right keys [1]: [d_date_sk#18]
 Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 8]
-Output [5]: [cs_sales_price#4, cr_refunded_cash#11, w_state#19, i_item_id#14, d_date#17]
-Input [7]: [cs_warehouse_sk#1, cs_sales_price#4, cr_refunded_cash#11, i_item_id#14, d_date#17, w_warehouse_sk#18, w_state#19]
+Output [5]: [cs_sales_price#4, cr_refunded_cash#11, w_state#14, i_item_id#16, d_date#19]
+Input [7]: [cs_sales_price#4, cs_sold_date_sk#5, cr_refunded_cash#11, w_state#14, i_item_id#16, d_date_sk#18, d_date#19]
 
 (30) HashAggregate [codegen id : 8]
-Input [5]: [cs_sales_price#4, cr_refunded_cash#11, w_state#19, i_item_id#14, d_date#17]
-Keys [2]: [w_state#19, i_item_id#14]
-Functions [2]: [partial_sum(CASE WHEN (d_date#17 < 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END), partial_sum(CASE WHEN (d_date#17 >= 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END)]
+Input [5]: [cs_sales_price#4, cr_refunded_cash#11, w_state#14, i_item_id#16, d_date#19]
+Keys [2]: [w_state#14, i_item_id#16]
+Functions [2]: [partial_sum(CASE WHEN (d_date#19 < 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END), partial_sum(CASE WHEN (d_date#19 >= 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END)]
 Aggregate Attributes [4]: [sum#20, isEmpty#21, sum#22, isEmpty#23]
-Results [6]: [w_state#19, i_item_id#14, sum#24, isEmpty#25, sum#26, isEmpty#27]
+Results [6]: [w_state#14, i_item_id#16, sum#24, isEmpty#25, sum#26, isEmpty#27]
 
 (31) Exchange
-Input [6]: [w_state#19, i_item_id#14, sum#24, isEmpty#25, sum#26, isEmpty#27]
-Arguments: hashpartitioning(w_state#19, i_item_id#14, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [6]: [w_state#14, i_item_id#16, sum#24, isEmpty#25, sum#26, isEmpty#27]
+Arguments: hashpartitioning(w_state#14, i_item_id#16, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (32) HashAggregate [codegen id : 9]
-Input [6]: [w_state#19, i_item_id#14, sum#24, isEmpty#25, sum#26, isEmpty#27]
-Keys [2]: [w_state#19, i_item_id#14]
-Functions [2]: [sum(CASE WHEN (d_date#17 < 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END), sum(CASE WHEN (d_date#17 >= 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END)]
-Aggregate Attributes [2]: [sum(CASE WHEN (d_date#17 < 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END)#28, sum(CASE WHEN (d_date#17 >= 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END)#29]
-Results [4]: [w_state#19, i_item_id#14, sum(CASE WHEN (d_date#17 < 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END)#28 AS sales_before#30, sum(CASE WHEN (d_date#17 >= 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END)#29 AS sales_after#31]
+Input [6]: [w_state#14, i_item_id#16, sum#24, isEmpty#25, sum#26, isEmpty#27]
+Keys [2]: [w_state#14, i_item_id#16]
+Functions [2]: [sum(CASE WHEN (d_date#19 < 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END), sum(CASE WHEN (d_date#19 >= 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END)]
+Aggregate Attributes [2]: [sum(CASE WHEN (d_date#19 < 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END)#28, sum(CASE WHEN (d_date#19 >= 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END)#29]
+Results [4]: [w_state#14, i_item_id#16, sum(CASE WHEN (d_date#19 < 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END)#28 AS sales_before#30, sum(CASE WHEN (d_date#19 >= 2000-03-11) THEN (cs_sales_price#4 - coalesce(cast(cr_refunded_cash#11 as decimal(12,2)), 0.00)) ELSE 0.00 END)#29 AS sales_after#31]
 
 (33) TakeOrderedAndProject
-Input [4]: [w_state#19, i_item_id#14, sales_before#30, sales_after#31]
-Arguments: 100, [w_state#19 ASC NULLS FIRST, i_item_id#14 ASC NULLS FIRST], [w_state#19, i_item_id#14, sales_before#30, sales_after#31]
+Input [4]: [w_state#14, i_item_id#16, sales_before#30, sales_after#31]
+Arguments: 100, [w_state#14 ASC NULLS FIRST, i_item_id#16 ASC NULLS FIRST], [w_state#14, i_item_id#16, sales_before#30, sales_after#31]
 
 ===== Subqueries =====
 
@@ -201,27 +201,27 @@ ObjectHashAggregate (40)
 
 
 (34) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#13, i_current_price#15]
+Output [2]: [i_item_sk#15, i_current_price#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_current_price), GreaterThanOrEqual(i_current_price,0.99), LessThanOrEqual(i_current_price,1.49), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2)>
 
 (35) ColumnarToRow [codegen id : 1]
-Input [2]: [i_item_sk#13, i_current_price#15]
+Input [2]: [i_item_sk#15, i_current_price#17]
 
 (36) Filter [codegen id : 1]
-Input [2]: [i_item_sk#13, i_current_price#15]
-Condition : (((isnotnull(i_current_price#15) AND (i_current_price#15 >= 0.99)) AND (i_current_price#15 <= 1.49)) AND isnotnull(i_item_sk#13))
+Input [2]: [i_item_sk#15, i_current_price#17]
+Condition : (((isnotnull(i_current_price#17) AND (i_current_price#17 >= 0.99)) AND (i_current_price#17 <= 1.49)) AND isnotnull(i_item_sk#15))
 
 (37) Project [codegen id : 1]
-Output [1]: [i_item_sk#13]
-Input [2]: [i_item_sk#13, i_current_price#15]
+Output [1]: [i_item_sk#15]
+Input [2]: [i_item_sk#15, i_current_price#17]
 
 (38) ObjectHashAggregate
-Input [1]: [i_item_sk#13]
+Input [1]: [i_item_sk#15]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#13, 42), 1019, 24988, 0, 0)]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#15, 42), 1019, 24988, 0, 0)]
 Aggregate Attributes [1]: [buf#32]
 Results [1]: [buf#33]
 
@@ -232,9 +232,9 @@ Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
 (40) ObjectHashAggregate
 Input [1]: [buf#33]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#13, 42), 1019, 24988, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#13, 42), 1019, 24988, 0, 0)#34]
-Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#13, 42), 1019, 24988, 0, 0)#34 AS bloomFilter#35]
+Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#15, 42), 1019, 24988, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#15, 42), 1019, 24988, 0, 0)#34]
+Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#15, 42), 1019, 24988, 0, 0)#34 AS bloomFilter#35]
 
 Subquery:2 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#5 IN dynamicpruning#6
 BroadcastExchange (44)
@@ -244,21 +244,21 @@ BroadcastExchange (44)
 
 
 (41) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#16, d_date#17]
+Output [2]: [d_date_sk#18, d_date#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-02-10), LessThanOrEqual(d_date,2000-04-10), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (42) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#16, d_date#17]
+Input [2]: [d_date_sk#18, d_date#19]
 
 (43) Filter [codegen id : 1]
-Input [2]: [d_date_sk#16, d_date#17]
-Condition : (((isnotnull(d_date#17) AND (d_date#17 >= 2000-02-10)) AND (d_date#17 <= 2000-04-10)) AND isnotnull(d_date_sk#16))
+Input [2]: [d_date_sk#18, d_date#19]
+Condition : (((isnotnull(d_date#19) AND (d_date#19 >= 2000-02-10)) AND (d_date#19 <= 2000-04-10)) AND isnotnull(d_date_sk#18))
 
 (44) BroadcastExchange
-Input [2]: [d_date_sk#16, d_date#17]
+Input [2]: [d_date_sk#18, d_date#19]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q40.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q40.sf100/simplified.txt
@@ -6,11 +6,11 @@ TakeOrderedAndProject [w_state,i_item_id,sales_before,sales_after]
           WholeStageCodegen (8)
             HashAggregate [w_state,i_item_id,d_date,cs_sales_price,cr_refunded_cash] [sum,isEmpty,sum,isEmpty,sum,isEmpty,sum,isEmpty]
               Project [cs_sales_price,cr_refunded_cash,w_state,i_item_id,d_date]
-                BroadcastHashJoin [cs_warehouse_sk,w_warehouse_sk]
-                  Project [cs_warehouse_sk,cs_sales_price,cr_refunded_cash,i_item_id,d_date]
-                    BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                      Project [cs_warehouse_sk,cs_sales_price,cs_sold_date_sk,cr_refunded_cash,i_item_id]
-                        BroadcastHashJoin [cs_item_sk,i_item_sk]
+                BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                  Project [cs_sales_price,cs_sold_date_sk,cr_refunded_cash,w_state,i_item_id]
+                    BroadcastHashJoin [cs_item_sk,i_item_sk]
+                      Project [cs_item_sk,cs_sales_price,cs_sold_date_sk,cr_refunded_cash,w_state]
+                        BroadcastHashJoin [cs_warehouse_sk,w_warehouse_sk]
                           Project [cs_warehouse_sk,cs_item_sk,cs_sales_price,cs_sold_date_sk,cr_refunded_cash]
                             SortMergeJoin [cs_order_number,cs_item_sk,cr_order_number,cr_item_sk]
                               InputAdapter
@@ -54,17 +54,17 @@ TakeOrderedAndProject [w_state,i_item_id,sales_before,sales_after]
                           InputAdapter
                             BroadcastExchange #6
                               WholeStageCodegen (5)
-                                Project [i_item_sk,i_item_id]
-                                  Filter [i_current_price,i_item_sk]
-                                    ColumnarToRow
-                                      InputAdapter
-                                        Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_current_price]
+                                Filter [w_warehouse_sk]
+                                  ColumnarToRow
+                                    InputAdapter
+                                      Scan parquet spark_catalog.default.warehouse [w_warehouse_sk,w_state]
                       InputAdapter
-                        ReusedExchange [d_date_sk,d_date] #3
+                        BroadcastExchange #7
+                          WholeStageCodegen (6)
+                            Project [i_item_sk,i_item_id]
+                              Filter [i_current_price,i_item_sk]
+                                ColumnarToRow
+                                  InputAdapter
+                                    Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_current_price]
                   InputAdapter
-                    BroadcastExchange #7
-                      WholeStageCodegen (7)
-                        Filter [w_warehouse_sk]
-                          ColumnarToRow
-                            InputAdapter
-                              Scan parquet spark_catalog.default.warehouse [w_warehouse_sk,w_state]
+                    ReusedExchange [d_date_sk,d_date] #3

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q42.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q42.sf100/explain.txt
@@ -1,135 +1,135 @@
 == Physical Plan ==
-TakeOrderedAndProject (17)
-+- * HashAggregate (16)
-   +- Exchange (15)
-      +- * HashAggregate (14)
-         +- * Project (13)
-            +- * BroadcastHashJoin Inner BuildRight (12)
+TakeOrderedAndProject (21)
++- * HashAggregate (20)
+   +- Exchange (19)
+      +- * HashAggregate (18)
+         +- * Project (17)
+            +- * BroadcastHashJoin Inner BuildRight (16)
                :- * Project (10)
-               :  +- * BroadcastHashJoin Inner BuildRight (9)
-               :     :- * Filter (3)
-               :     :  +- * ColumnarToRow (2)
-               :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-               :     +- BroadcastExchange (8)
-               :        +- * Project (7)
-               :           +- * Filter (6)
-               :              +- * ColumnarToRow (5)
-               :                 +- Scan parquet spark_catalog.default.item (4)
-               +- ReusedExchange (11)
+               :  +- * BroadcastHashJoin Inner BuildLeft (9)
+               :     :- BroadcastExchange (5)
+               :     :  +- * Project (4)
+               :     :     +- * Filter (3)
+               :     :        +- * ColumnarToRow (2)
+               :     :           +- Scan parquet spark_catalog.default.date_dim (1)
+               :     +- * Filter (8)
+               :        +- * ColumnarToRow (7)
+               :           +- Scan parquet spark_catalog.default.store_sales (6)
+               +- BroadcastExchange (15)
+                  +- * Project (14)
+                     +- * Filter (13)
+                        +- * ColumnarToRow (12)
+                           +- Scan parquet spark_catalog.default.item (11)
 
 
-(1) Scan parquet spark_catalog.default.store_sales
-Output [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#3), dynamicpruningexpression(ss_sold_date_sk#3 IN dynamicpruning#4)]
-PushedFilters: [IsNotNull(ss_item_sk)]
-ReadSchema: struct<ss_item_sk:int,ss_ext_sales_price:decimal(7,2)>
-
-(2) ColumnarToRow [codegen id : 3]
-Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
-
-(3) Filter [codegen id : 3]
-Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
-Condition : isnotnull(ss_item_sk#1)
-
-(4) Scan parquet spark_catalog.default.item
-Output [4]: [i_item_sk#5, i_category_id#6, i_category#7, i_manager_id#8]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_manager_id), EqualTo(i_manager_id,1), IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_category_id:int,i_category:string,i_manager_id:int>
-
-(5) ColumnarToRow [codegen id : 1]
-Input [4]: [i_item_sk#5, i_category_id#6, i_category#7, i_manager_id#8]
-
-(6) Filter [codegen id : 1]
-Input [4]: [i_item_sk#5, i_category_id#6, i_category#7, i_manager_id#8]
-Condition : ((isnotnull(i_manager_id#8) AND (i_manager_id#8 = 1)) AND isnotnull(i_item_sk#5))
-
-(7) Project [codegen id : 1]
-Output [3]: [i_item_sk#5, i_category_id#6, i_category#7]
-Input [4]: [i_item_sk#5, i_category_id#6, i_category#7, i_manager_id#8]
-
-(8) BroadcastExchange
-Input [3]: [i_item_sk#5, i_category_id#6, i_category#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
-
-(9) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#5]
-Join type: Inner
-Join condition: None
-
-(10) Project [codegen id : 3]
-Output [4]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_category_id#6, i_category#7]
-Input [6]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_sk#5, i_category_id#6, i_category#7]
-
-(11) ReusedExchange [Reuses operator id: 22]
-Output [2]: [d_date_sk#9, d_year#10]
-
-(12) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_sold_date_sk#3]
-Right keys [1]: [d_date_sk#9]
-Join type: Inner
-Join condition: None
-
-(13) Project [codegen id : 3]
-Output [4]: [d_year#10, ss_ext_sales_price#2, i_category_id#6, i_category#7]
-Input [6]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_category_id#6, i_category#7, d_date_sk#9, d_year#10]
-
-(14) HashAggregate [codegen id : 3]
-Input [4]: [d_year#10, ss_ext_sales_price#2, i_category_id#6, i_category#7]
-Keys [3]: [d_year#10, i_category_id#6, i_category#7]
-Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum#11]
-Results [4]: [d_year#10, i_category_id#6, i_category#7, sum#12]
-
-(15) Exchange
-Input [4]: [d_year#10, i_category_id#6, i_category#7, sum#12]
-Arguments: hashpartitioning(d_year#10, i_category_id#6, i_category#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
-
-(16) HashAggregate [codegen id : 4]
-Input [4]: [d_year#10, i_category_id#6, i_category#7, sum#12]
-Keys [3]: [d_year#10, i_category_id#6, i_category#7]
-Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#2))#13]
-Results [4]: [d_year#10, i_category_id#6, i_category#7, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#13,17,2) AS sum(ss_ext_sales_price)#14]
-
-(17) TakeOrderedAndProject
-Input [4]: [d_year#10, i_category_id#6, i_category#7, sum(ss_ext_sales_price)#14]
-Arguments: 100, [sum(ss_ext_sales_price)#14 DESC NULLS LAST, d_year#10 ASC NULLS FIRST, i_category_id#6 ASC NULLS FIRST, i_category#7 ASC NULLS FIRST], [d_year#10, i_category_id#6, i_category#7, sum(ss_ext_sales_price)#14]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#3 IN dynamicpruning#4
-BroadcastExchange (22)
-+- * Project (21)
-   +- * Filter (20)
-      +- * ColumnarToRow (19)
-         +- Scan parquet spark_catalog.default.date_dim (18)
-
-
-(18) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#9, d_year#10, d_moy#15]
+(1) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#1, d_year#2, d_moy#3]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_moy), IsNotNull(d_year), EqualTo(d_moy,11), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(19) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#9, d_year#10, d_moy#15]
+(2) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
 
-(20) Filter [codegen id : 1]
-Input [3]: [d_date_sk#9, d_year#10, d_moy#15]
-Condition : ((((isnotnull(d_moy#15) AND isnotnull(d_year#10)) AND (d_moy#15 = 11)) AND (d_year#10 = 2000)) AND isnotnull(d_date_sk#9))
+(3) Filter [codegen id : 1]
+Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
+Condition : ((((isnotnull(d_moy#3) AND isnotnull(d_year#2)) AND (d_moy#3 = 11)) AND (d_year#2 = 2000)) AND isnotnull(d_date_sk#1))
 
-(21) Project [codegen id : 1]
-Output [2]: [d_date_sk#9, d_year#10]
-Input [3]: [d_date_sk#9, d_year#10, d_moy#15]
+(4) Project [codegen id : 1]
+Output [2]: [d_date_sk#1, d_year#2]
+Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
 
-(22) BroadcastExchange
-Input [2]: [d_date_sk#9, d_year#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
+(5) BroadcastExchange
+Input [2]: [d_date_sk#1, d_year#2]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
+
+(6) Scan parquet spark_catalog.default.store_sales
+Output [3]: [ss_item_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ss_sold_date_sk#6), dynamicpruningexpression(ss_sold_date_sk#6 IN dynamicpruning#7)]
+PushedFilters: [IsNotNull(ss_item_sk)]
+ReadSchema: struct<ss_item_sk:int,ss_ext_sales_price:decimal(7,2)>
+
+(7) ColumnarToRow
+Input [3]: [ss_item_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6]
+
+(8) Filter
+Input [3]: [ss_item_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6]
+Condition : isnotnull(ss_item_sk#4)
+
+(9) BroadcastHashJoin [codegen id : 3]
+Left keys [1]: [d_date_sk#1]
+Right keys [1]: [ss_sold_date_sk#6]
+Join type: Inner
+Join condition: None
+
+(10) Project [codegen id : 3]
+Output [3]: [d_year#2, ss_item_sk#4, ss_ext_sales_price#5]
+Input [5]: [d_date_sk#1, d_year#2, ss_item_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6]
+
+(11) Scan parquet spark_catalog.default.item
+Output [4]: [i_item_sk#8, i_category_id#9, i_category#10, i_manager_id#11]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_manager_id), EqualTo(i_manager_id,1), IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_category_id:int,i_category:string,i_manager_id:int>
+
+(12) ColumnarToRow [codegen id : 2]
+Input [4]: [i_item_sk#8, i_category_id#9, i_category#10, i_manager_id#11]
+
+(13) Filter [codegen id : 2]
+Input [4]: [i_item_sk#8, i_category_id#9, i_category#10, i_manager_id#11]
+Condition : ((isnotnull(i_manager_id#11) AND (i_manager_id#11 = 1)) AND isnotnull(i_item_sk#8))
+
+(14) Project [codegen id : 2]
+Output [3]: [i_item_sk#8, i_category_id#9, i_category#10]
+Input [4]: [i_item_sk#8, i_category_id#9, i_category#10, i_manager_id#11]
+
+(15) BroadcastExchange
+Input [3]: [i_item_sk#8, i_category_id#9, i_category#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
+
+(16) BroadcastHashJoin [codegen id : 3]
+Left keys [1]: [ss_item_sk#4]
+Right keys [1]: [i_item_sk#8]
+Join type: Inner
+Join condition: None
+
+(17) Project [codegen id : 3]
+Output [4]: [d_year#2, ss_ext_sales_price#5, i_category_id#9, i_category#10]
+Input [6]: [d_year#2, ss_item_sk#4, ss_ext_sales_price#5, i_item_sk#8, i_category_id#9, i_category#10]
+
+(18) HashAggregate [codegen id : 3]
+Input [4]: [d_year#2, ss_ext_sales_price#5, i_category_id#9, i_category#10]
+Keys [3]: [d_year#2, i_category_id#9, i_category#10]
+Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#5))]
+Aggregate Attributes [1]: [sum#12]
+Results [4]: [d_year#2, i_category_id#9, i_category#10, sum#13]
+
+(19) Exchange
+Input [4]: [d_year#2, i_category_id#9, i_category#10, sum#13]
+Arguments: hashpartitioning(d_year#2, i_category_id#9, i_category#10, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(20) HashAggregate [codegen id : 4]
+Input [4]: [d_year#2, i_category_id#9, i_category#10, sum#13]
+Keys [3]: [d_year#2, i_category_id#9, i_category#10]
+Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#5))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#5))#14]
+Results [4]: [d_year#2, i_category_id#9, i_category#10, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#5))#14,17,2) AS sum(ss_ext_sales_price)#15]
+
+(21) TakeOrderedAndProject
+Input [4]: [d_year#2, i_category_id#9, i_category#10, sum(ss_ext_sales_price)#15]
+Arguments: 100, [sum(ss_ext_sales_price)#15 DESC NULLS LAST, d_year#2 ASC NULLS FIRST, i_category_id#9 ASC NULLS FIRST, i_category#10 ASC NULLS FIRST], [d_year#2, i_category_id#9, i_category#10, sum(ss_ext_sales_price)#15]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#6 IN dynamicpruning#7
+ReusedExchange (22)
+
+
+(22) ReusedExchange [Reuses operator id: 5]
+Output [2]: [d_date_sk#1, d_year#2]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q42.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q42.sf100/simplified.txt
@@ -6,28 +6,28 @@ TakeOrderedAndProject [sum(ss_ext_sales_price),d_year,i_category_id,i_category]
           WholeStageCodegen (3)
             HashAggregate [d_year,i_category_id,i_category,ss_ext_sales_price] [sum,sum]
               Project [d_year,ss_ext_sales_price,i_category_id,i_category]
-                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                  Project [ss_ext_sales_price,ss_sold_date_sk,i_category_id,i_category]
-                    BroadcastHashJoin [ss_item_sk,i_item_sk]
+                BroadcastHashJoin [ss_item_sk,i_item_sk]
+                  Project [d_year,ss_item_sk,ss_ext_sales_price]
+                    BroadcastHashJoin [d_date_sk,ss_sold_date_sk]
+                      InputAdapter
+                        BroadcastExchange #2
+                          WholeStageCodegen (1)
+                            Project [d_date_sk,d_year]
+                              Filter [d_moy,d_year,d_date_sk]
+                                ColumnarToRow
+                                  InputAdapter
+                                    Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
                       Filter [ss_item_sk]
                         ColumnarToRow
                           InputAdapter
                             Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_ext_sales_price,ss_sold_date_sk]
                               SubqueryBroadcast [d_date_sk] #1
-                                BroadcastExchange #2
-                                  WholeStageCodegen (1)
-                                    Project [d_date_sk,d_year]
-                                      Filter [d_moy,d_year,d_date_sk]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
-                      InputAdapter
-                        BroadcastExchange #3
-                          WholeStageCodegen (1)
-                            Project [i_item_sk,i_category_id,i_category]
-                              Filter [i_manager_id,i_item_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.item [i_item_sk,i_category_id,i_category,i_manager_id]
+                                ReusedExchange [d_date_sk,d_year] #2
                   InputAdapter
-                    ReusedExchange [d_date_sk,d_year] #2
+                    BroadcastExchange #3
+                      WholeStageCodegen (2)
+                        Project [i_item_sk,i_category_id,i_category]
+                          Filter [i_manager_id,i_item_sk]
+                            ColumnarToRow
+                              InputAdapter
+                                Scan parquet spark_catalog.default.item [i_item_sk,i_category_id,i_category,i_manager_id]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q46.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q46.sf100/explain.txt
@@ -28,17 +28,17 @@ TakeOrderedAndProject (47)
                         :        +- * BroadcastHashJoin Inner BuildRight (33)
                         :           :- * Project (27)
                         :           :  +- * BroadcastHashJoin Inner BuildRight (26)
-                        :           :     :- * Project (20)
-                        :           :     :  +- * BroadcastHashJoin Inner BuildRight (19)
+                        :           :     :- * Project (24)
+                        :           :     :  +- * BroadcastHashJoin Inner BuildRight (23)
                         :           :     :     :- * Filter (17)
                         :           :     :     :  +- * ColumnarToRow (16)
                         :           :     :     :     +- Scan parquet spark_catalog.default.store_sales (15)
-                        :           :     :     +- ReusedExchange (18)
-                        :           :     +- BroadcastExchange (25)
-                        :           :        +- * Project (24)
-                        :           :           +- * Filter (23)
-                        :           :              +- * ColumnarToRow (22)
-                        :           :                 +- Scan parquet spark_catalog.default.store (21)
+                        :           :     :     +- BroadcastExchange (22)
+                        :           :     :        +- * Project (21)
+                        :           :     :           +- * Filter (20)
+                        :           :     :              +- * ColumnarToRow (19)
+                        :           :     :                 +- Scan parquet spark_catalog.default.store (18)
+                        :           :     +- ReusedExchange (25)
                         :           +- BroadcastExchange (32)
                         :              +- * Project (31)
                         :                 +- * Filter (30)
@@ -125,50 +125,50 @@ Input [8]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ti
 Input [8]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, ss_sold_date_sk#14]
 Condition : (((isnotnull(ss_store_sk#10) AND isnotnull(ss_hdemo_sk#8)) AND isnotnull(ss_addr_sk#9)) AND isnotnull(ss_customer_sk#7))
 
-(18) ReusedExchange [Reuses operator id: 52]
-Output [1]: [d_date_sk#16]
-
-(19) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [ss_sold_date_sk#14]
-Right keys [1]: [d_date_sk#16]
-Join type: Inner
-Join condition: None
-
-(20) Project [codegen id : 10]
-Output [7]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13]
-Input [9]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, ss_sold_date_sk#14, d_date_sk#16]
-
-(21) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#17, s_city#18]
+(18) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#16, s_city#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [In(s_city, [Fairview,Midway]), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_city:string>
 
-(22) ColumnarToRow [codegen id : 8]
-Input [2]: [s_store_sk#17, s_city#18]
+(19) ColumnarToRow [codegen id : 7]
+Input [2]: [s_store_sk#16, s_city#17]
 
-(23) Filter [codegen id : 8]
-Input [2]: [s_store_sk#17, s_city#18]
-Condition : (s_city#18 IN (Fairview,Midway) AND isnotnull(s_store_sk#17))
+(20) Filter [codegen id : 7]
+Input [2]: [s_store_sk#16, s_city#17]
+Condition : (s_city#17 IN (Fairview,Midway) AND isnotnull(s_store_sk#16))
 
-(24) Project [codegen id : 8]
-Output [1]: [s_store_sk#17]
-Input [2]: [s_store_sk#17, s_city#18]
+(21) Project [codegen id : 7]
+Output [1]: [s_store_sk#16]
+Input [2]: [s_store_sk#16, s_city#17]
 
-(25) BroadcastExchange
-Input [1]: [s_store_sk#17]
+(22) BroadcastExchange
+Input [1]: [s_store_sk#16]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
-(26) BroadcastHashJoin [codegen id : 10]
+(23) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_store_sk#10]
-Right keys [1]: [s_store_sk#17]
+Right keys [1]: [s_store_sk#16]
+Join type: Inner
+Join condition: None
+
+(24) Project [codegen id : 10]
+Output [7]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, ss_sold_date_sk#14]
+Input [9]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, ss_sold_date_sk#14, s_store_sk#16]
+
+(25) ReusedExchange [Reuses operator id: 52]
+Output [1]: [d_date_sk#18]
+
+(26) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ss_sold_date_sk#14]
+Right keys [1]: [d_date_sk#18]
 Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 10]
 Output [6]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13]
-Input [8]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, s_store_sk#17]
+Input [8]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_ticket_number#11, ss_coupon_amt#12, ss_net_profit#13, ss_sold_date_sk#14, d_date_sk#18]
 
 (28) Scan parquet spark_catalog.default.household_demographics
 Output [3]: [hd_demo_sk#19, hd_dep_count#20, hd_vehicle_count#21]
@@ -274,25 +274,25 @@ BroadcastExchange (52)
 
 
 (48) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#16, d_year#33, d_dow#34]
+Output [3]: [d_date_sk#18, d_year#33, d_dow#34]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_dow, [0,6]), In(d_year, [1999,2000,2001]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_dow:int>
 
 (49) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#16, d_year#33, d_dow#34]
+Input [3]: [d_date_sk#18, d_year#33, d_dow#34]
 
 (50) Filter [codegen id : 1]
-Input [3]: [d_date_sk#16, d_year#33, d_dow#34]
-Condition : ((d_dow#34 IN (6,0) AND d_year#33 IN (1999,2000,2001)) AND isnotnull(d_date_sk#16))
+Input [3]: [d_date_sk#18, d_year#33, d_dow#34]
+Condition : ((d_dow#34 IN (6,0) AND d_year#33 IN (1999,2000,2001)) AND isnotnull(d_date_sk#18))
 
 (51) Project [codegen id : 1]
-Output [1]: [d_date_sk#16]
-Input [3]: [d_date_sk#16, d_year#33, d_dow#34]
+Output [1]: [d_date_sk#18]
+Input [3]: [d_date_sk#18, d_year#33, d_dow#34]
 
 (52) BroadcastExchange
-Input [1]: [d_date_sk#16]
+Input [1]: [d_date_sk#18]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q46.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q46.sf100/simplified.txt
@@ -49,9 +49,9 @@ TakeOrderedAndProject [c_last_name,c_first_name,ca_city,bought_city,ss_ticket_nu
                                         Project [ss_customer_sk,ss_addr_sk,ss_ticket_number,ss_coupon_amt,ss_net_profit]
                                           BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
                                             Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_ticket_number,ss_coupon_amt,ss_net_profit]
-                                              BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_coupon_amt,ss_net_profit]
-                                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_ticket_number,ss_coupon_amt,ss_net_profit,ss_sold_date_sk]
+                                                  BroadcastHashJoin [ss_store_sk,s_store_sk]
                                                     Filter [ss_store_sk,ss_hdemo_sk,ss_addr_sk,ss_customer_sk]
                                                       ColumnarToRow
                                                         InputAdapter
@@ -65,15 +65,15 @@ TakeOrderedAndProject [c_last_name,c_first_name,ca_city,bought_city,ss_ticket_nu
                                                                         InputAdapter
                                                                           Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_dow]
                                                     InputAdapter
-                                                      ReusedExchange [d_date_sk] #6
+                                                      BroadcastExchange #7
+                                                        WholeStageCodegen (7)
+                                                          Project [s_store_sk]
+                                                            Filter [s_city,s_store_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet spark_catalog.default.store [s_store_sk,s_city]
                                                 InputAdapter
-                                                  BroadcastExchange #7
-                                                    WholeStageCodegen (8)
-                                                      Project [s_store_sk]
-                                                        Filter [s_city,s_store_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.store [s_store_sk,s_city]
+                                                  ReusedExchange [d_date_sk] #6
                                             InputAdapter
                                               BroadcastExchange #8
                                                 WholeStageCodegen (9)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47.sf100/explain.txt
@@ -17,26 +17,26 @@ TakeOrderedAndProject (52)
       :     :                             +- Exchange (23)
       :     :                                +- * HashAggregate (22)
       :     :                                   +- * Project (21)
-      :     :                                      +- * SortMergeJoin Inner (20)
-      :     :                                         :- * Sort (14)
-      :     :                                         :  +- Exchange (13)
-      :     :                                         :     +- * Project (12)
-      :     :                                         :        +- * BroadcastHashJoin Inner BuildRight (11)
-      :     :                                         :           :- * Project (6)
-      :     :                                         :           :  +- * BroadcastHashJoin Inner BuildRight (5)
-      :     :                                         :           :     :- * Filter (3)
-      :     :                                         :           :     :  +- * ColumnarToRow (2)
-      :     :                                         :           :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-      :     :                                         :           :     +- ReusedExchange (4)
-      :     :                                         :           +- BroadcastExchange (10)
-      :     :                                         :              +- * Filter (9)
-      :     :                                         :                 +- * ColumnarToRow (8)
-      :     :                                         :                    +- Scan parquet spark_catalog.default.store (7)
-      :     :                                         +- * Sort (19)
-      :     :                                            +- Exchange (18)
-      :     :                                               +- * Filter (17)
-      :     :                                                  +- * ColumnarToRow (16)
-      :     :                                                     +- Scan parquet spark_catalog.default.item (15)
+      :     :                                      +- * BroadcastHashJoin Inner BuildRight (20)
+      :     :                                         :- * Project (15)
+      :     :                                         :  +- * SortMergeJoin Inner (14)
+      :     :                                         :     :- * Sort (8)
+      :     :                                         :     :  +- Exchange (7)
+      :     :                                         :     :     +- * Project (6)
+      :     :                                         :     :        +- * BroadcastHashJoin Inner BuildRight (5)
+      :     :                                         :     :           :- * Filter (3)
+      :     :                                         :     :           :  +- * ColumnarToRow (2)
+      :     :                                         :     :           :     +- Scan parquet spark_catalog.default.store_sales (1)
+      :     :                                         :     :           +- ReusedExchange (4)
+      :     :                                         :     +- * Sort (13)
+      :     :                                         :        +- Exchange (12)
+      :     :                                         :           +- * Filter (11)
+      :     :                                         :              +- * ColumnarToRow (10)
+      :     :                                         :                 +- Scan parquet spark_catalog.default.item (9)
+      :     :                                         +- BroadcastExchange (19)
+      :     :                                            +- * Filter (18)
+      :     :                                               +- * ColumnarToRow (17)
+      :     :                                                  +- Scan parquet spark_catalog.default.store (16)
       :     +- * Sort (41)
       :        +- Exchange (40)
       :           +- * Project (39)
@@ -61,147 +61,147 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#4), dynamicpruningexpression(ss_sol
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_store_sk:int,ss_sales_price:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 3]
+(2) ColumnarToRow [codegen id : 2]
 Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
 
-(3) Filter [codegen id : 3]
+(3) Filter [codegen id : 2]
 Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
 Condition : (isnotnull(ss_item_sk#1) AND isnotnull(ss_store_sk#2))
 
 (4) ReusedExchange [Reuses operator id: 56]
 Output [3]: [d_date_sk#6, d_year#7, d_moy#8]
 
-(5) BroadcastHashJoin [codegen id : 3]
+(5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#6]
 Join type: Inner
 Join condition: None
 
-(6) Project [codegen id : 3]
+(6) Project [codegen id : 2]
 Output [5]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_year#7, d_moy#8]
 Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4, d_date_sk#6, d_year#7, d_moy#8]
 
-(7) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#9, s_store_name#10, s_company_name#11]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_store_name), IsNotNull(s_company_name)]
-ReadSchema: struct<s_store_sk:int,s_store_name:string,s_company_name:string>
+(7) Exchange
+Input [5]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_year#7, d_moy#8]
+Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 
-(8) ColumnarToRow [codegen id : 2]
-Input [3]: [s_store_sk#9, s_store_name#10, s_company_name#11]
-
-(9) Filter [codegen id : 2]
-Input [3]: [s_store_sk#9, s_store_name#10, s_company_name#11]
-Condition : ((isnotnull(s_store_sk#9) AND isnotnull(s_store_name#10)) AND isnotnull(s_company_name#11))
-
-(10) BroadcastExchange
-Input [3]: [s_store_sk#9, s_store_name#10, s_company_name#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
-
-(11) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_store_sk#2]
-Right keys [1]: [s_store_sk#9]
-Join type: Inner
-Join condition: None
-
-(12) Project [codegen id : 3]
-Output [6]: [ss_item_sk#1, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11]
-Input [8]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_year#7, d_moy#8, s_store_sk#9, s_store_name#10, s_company_name#11]
-
-(13) Exchange
-Input [6]: [ss_item_sk#1, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11]
-Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
-
-(14) Sort [codegen id : 4]
-Input [6]: [ss_item_sk#1, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11]
+(8) Sort [codegen id : 3]
+Input [5]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_year#7, d_moy#8]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(15) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#12, i_brand#13, i_category#14]
+(9) Scan parquet spark_catalog.default.item
+Output [3]: [i_item_sk#9, i_brand#10, i_category#11]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_category), IsNotNull(i_brand)]
 ReadSchema: struct<i_item_sk:int,i_brand:string,i_category:string>
 
-(16) ColumnarToRow [codegen id : 5]
-Input [3]: [i_item_sk#12, i_brand#13, i_category#14]
+(10) ColumnarToRow [codegen id : 4]
+Input [3]: [i_item_sk#9, i_brand#10, i_category#11]
 
-(17) Filter [codegen id : 5]
-Input [3]: [i_item_sk#12, i_brand#13, i_category#14]
-Condition : ((isnotnull(i_item_sk#12) AND isnotnull(i_category#14)) AND isnotnull(i_brand#13))
+(11) Filter [codegen id : 4]
+Input [3]: [i_item_sk#9, i_brand#10, i_category#11]
+Condition : ((isnotnull(i_item_sk#9) AND isnotnull(i_category#11)) AND isnotnull(i_brand#10))
 
-(18) Exchange
-Input [3]: [i_item_sk#12, i_brand#13, i_category#14]
-Arguments: hashpartitioning(i_item_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+(12) Exchange
+Input [3]: [i_item_sk#9, i_brand#10, i_category#11]
+Arguments: hashpartitioning(i_item_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(19) Sort [codegen id : 6]
-Input [3]: [i_item_sk#12, i_brand#13, i_category#14]
-Arguments: [i_item_sk#12 ASC NULLS FIRST], false, 0
+(13) Sort [codegen id : 5]
+Input [3]: [i_item_sk#9, i_brand#10, i_category#11]
+Arguments: [i_item_sk#9 ASC NULLS FIRST], false, 0
 
-(20) SortMergeJoin [codegen id : 7]
+(14) SortMergeJoin [codegen id : 7]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#12]
+Right keys [1]: [i_item_sk#9]
+Join type: Inner
+Join condition: None
+
+(15) Project [codegen id : 7]
+Output [6]: [ss_store_sk#2, ss_sales_price#3, d_year#7, d_moy#8, i_brand#10, i_category#11]
+Input [8]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_year#7, d_moy#8, i_item_sk#9, i_brand#10, i_category#11]
+
+(16) Scan parquet spark_catalog.default.store
+Output [3]: [s_store_sk#12, s_store_name#13, s_company_name#14]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_store_name), IsNotNull(s_company_name)]
+ReadSchema: struct<s_store_sk:int,s_store_name:string,s_company_name:string>
+
+(17) ColumnarToRow [codegen id : 6]
+Input [3]: [s_store_sk#12, s_store_name#13, s_company_name#14]
+
+(18) Filter [codegen id : 6]
+Input [3]: [s_store_sk#12, s_store_name#13, s_company_name#14]
+Condition : ((isnotnull(s_store_sk#12) AND isnotnull(s_store_name#13)) AND isnotnull(s_company_name#14))
+
+(19) BroadcastExchange
+Input [3]: [s_store_sk#12, s_store_name#13, s_company_name#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
+
+(20) BroadcastHashJoin [codegen id : 7]
+Left keys [1]: [ss_store_sk#2]
+Right keys [1]: [s_store_sk#12]
 Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 7]
-Output [7]: [i_brand#13, i_category#14, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11]
-Input [9]: [ss_item_sk#1, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11, i_item_sk#12, i_brand#13, i_category#14]
+Output [7]: [i_brand#10, i_category#11, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#13, s_company_name#14]
+Input [9]: [ss_store_sk#2, ss_sales_price#3, d_year#7, d_moy#8, i_brand#10, i_category#11, s_store_sk#12, s_store_name#13, s_company_name#14]
 
 (22) HashAggregate [codegen id : 7]
-Input [7]: [i_brand#13, i_category#14, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11]
-Keys [6]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8]
+Input [7]: [i_brand#10, i_category#11, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#13, s_company_name#14]
+Keys [6]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8]
 Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#3))]
 Aggregate Attributes [1]: [sum#15]
-Results [7]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum#16]
+Results [7]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum#16]
 
 (23) Exchange
-Input [7]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum#16]
-Arguments: hashpartitioning(i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [7]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum#16]
+Arguments: hashpartitioning(i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (24) HashAggregate [codegen id : 8]
-Input [7]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum#16]
-Keys [6]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8]
+Input [7]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum#16]
+Keys [6]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8]
 Functions [1]: [sum(UnscaledValue(ss_sales_price#3))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#3))#17]
-Results [8]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#17,17,2) AS sum_sales#18, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#17,17,2) AS _w0#19]
+Results [8]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#17,17,2) AS sum_sales#18, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#17,17,2) AS _w0#19]
 
 (25) Exchange
-Input [8]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19]
-Arguments: hashpartitioning(i_category#14, i_brand#13, s_store_name#10, s_company_name#11, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [8]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, _w0#19]
+Arguments: hashpartitioning(i_category#11, i_brand#10, s_store_name#13, s_company_name#14, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (26) Sort [codegen id : 9]
-Input [8]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19]
-Arguments: [i_category#14 ASC NULLS FIRST, i_brand#13 ASC NULLS FIRST, s_store_name#10 ASC NULLS FIRST, s_company_name#11 ASC NULLS FIRST, d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST], false, 0
+Input [8]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, _w0#19]
+Arguments: [i_category#11 ASC NULLS FIRST, i_brand#10 ASC NULLS FIRST, s_store_name#13 ASC NULLS FIRST, s_company_name#14 ASC NULLS FIRST, d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST], false, 0
 
 (27) Window
-Input [8]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19]
-Arguments: [rank(d_year#7, d_moy#8) windowspecdefinition(i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#20], [i_category#14, i_brand#13, s_store_name#10, s_company_name#11], [d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST]
+Input [8]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, _w0#19]
+Arguments: [rank(d_year#7, d_moy#8) windowspecdefinition(i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#20], [i_category#11, i_brand#10, s_store_name#13, s_company_name#14], [d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST]
 
 (28) Filter [codegen id : 10]
-Input [9]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20]
+Input [9]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20]
 Condition : (isnotnull(d_year#7) AND (d_year#7 = 1999))
 
 (29) Window
-Input [9]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20]
-Arguments: [avg(_w0#19) windowspecdefinition(i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_monthly_sales#21], [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7]
+Input [9]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20]
+Arguments: [avg(_w0#19) windowspecdefinition(i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_monthly_sales#21], [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7]
 
 (30) Filter [codegen id : 11]
-Input [10]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20, avg_monthly_sales#21]
+Input [10]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20, avg_monthly_sales#21]
 Condition : ((isnotnull(avg_monthly_sales#21) AND (avg_monthly_sales#21 > 0.000000)) AND CASE WHEN (avg_monthly_sales#21 > 0.000000) THEN ((abs((sum_sales#18 - avg_monthly_sales#21)) / avg_monthly_sales#21) > 0.1000000000000000) END)
 
 (31) Project [codegen id : 11]
-Output [9]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20]
-Input [10]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20, avg_monthly_sales#21]
+Output [9]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20]
+Input [10]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20, avg_monthly_sales#21]
 
 (32) Exchange
-Input [9]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20]
-Arguments: hashpartitioning(i_category#14, i_brand#13, s_store_name#10, s_company_name#11, rn#20, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [9]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20]
+Arguments: hashpartitioning(i_category#11, i_brand#10, s_store_name#13, s_company_name#14, rn#20, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (33) Sort [codegen id : 12]
-Input [9]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20]
-Arguments: [i_category#14 ASC NULLS FIRST, i_brand#13 ASC NULLS FIRST, s_store_name#10 ASC NULLS FIRST, s_company_name#11 ASC NULLS FIRST, rn#20 ASC NULLS FIRST], false, 0
+Input [9]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20]
+Arguments: [i_category#11 ASC NULLS FIRST, i_brand#10 ASC NULLS FIRST, s_store_name#13 ASC NULLS FIRST, s_company_name#14 ASC NULLS FIRST, rn#20 ASC NULLS FIRST], false, 0
 
 (34) ReusedExchange [Reuses operator id: 23]
 Output [7]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, d_year#26, d_moy#27, sum#28]
@@ -238,14 +238,14 @@ Input [6]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, sum_s
 Arguments: [i_category#22 ASC NULLS FIRST, i_brand#23 ASC NULLS FIRST, s_store_name#24 ASC NULLS FIRST, s_company_name#25 ASC NULLS FIRST, (rn#31 + 1) ASC NULLS FIRST], false, 0
 
 (42) SortMergeJoin [codegen id : 24]
-Left keys [5]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, rn#20]
+Left keys [5]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, rn#20]
 Right keys [5]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, (rn#31 + 1)]
 Join type: Inner
 Join condition: None
 
 (43) Project [codegen id : 24]
-Output [10]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20, sum_sales#30]
-Input [15]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20, i_category#22, i_brand#23, s_store_name#24, s_company_name#25, sum_sales#30, rn#31]
+Output [10]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20, sum_sales#30]
+Input [15]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20, i_category#22, i_brand#23, s_store_name#24, s_company_name#25, sum_sales#30, rn#31]
 
 (44) ReusedExchange [Reuses operator id: 36]
 Output [7]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, d_year#36, d_moy#37, sum_sales#38]
@@ -271,18 +271,18 @@ Input [6]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, sum_s
 Arguments: [i_category#32 ASC NULLS FIRST, i_brand#33 ASC NULLS FIRST, s_store_name#34 ASC NULLS FIRST, s_company_name#35 ASC NULLS FIRST, (rn#39 - 1) ASC NULLS FIRST], false, 0
 
 (50) SortMergeJoin [codegen id : 36]
-Left keys [5]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, rn#20]
+Left keys [5]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, rn#20]
 Right keys [5]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, (rn#39 - 1)]
 Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 36]
-Output [10]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, avg_monthly_sales#21, sum_sales#18, sum_sales#30 AS psum#40, sum_sales#38 AS nsum#41]
-Input [16]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20, sum_sales#30, i_category#32, i_brand#33, s_store_name#34, s_company_name#35, sum_sales#38, rn#39]
+Output [10]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, avg_monthly_sales#21, sum_sales#18, sum_sales#30 AS psum#40, sum_sales#38 AS nsum#41]
+Input [16]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20, sum_sales#30, i_category#32, i_brand#33, s_store_name#34, s_company_name#35, sum_sales#38, rn#39]
 
 (52) TakeOrderedAndProject
-Input [10]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, avg_monthly_sales#21, sum_sales#18, psum#40, nsum#41]
-Arguments: 100, [(sum_sales#18 - avg_monthly_sales#21) ASC NULLS FIRST, s_store_name#10 ASC NULLS FIRST], [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, avg_monthly_sales#21, sum_sales#18, psum#40, nsum#41]
+Input [10]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, avg_monthly_sales#21, sum_sales#18, psum#40, nsum#41]
+Arguments: 100, [(sum_sales#18 - avg_monthly_sales#21) ASC NULLS FIRST, s_store_name#13 ASC NULLS FIRST], [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, avg_monthly_sales#21, sum_sales#18, psum#40, nsum#41]
 
 ===== Subqueries =====
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q47.sf100/simplified.txt
@@ -31,15 +31,15 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,s_store_name,i_category,i_bra
                                                             WholeStageCodegen (7)
                                                               HashAggregate [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy,ss_sales_price] [sum,sum]
                                                                 Project [i_brand,i_category,ss_sales_price,d_year,d_moy,s_store_name,s_company_name]
-                                                                  SortMergeJoin [ss_item_sk,i_item_sk]
-                                                                    InputAdapter
-                                                                      WholeStageCodegen (4)
-                                                                        Sort [ss_item_sk]
-                                                                          InputAdapter
-                                                                            Exchange [ss_item_sk] #4
-                                                                              WholeStageCodegen (3)
-                                                                                Project [ss_item_sk,ss_sales_price,d_year,d_moy,s_store_name,s_company_name]
-                                                                                  BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                                  BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                                    Project [ss_store_sk,ss_sales_price,d_year,d_moy,i_brand,i_category]
+                                                                      SortMergeJoin [ss_item_sk,i_item_sk]
+                                                                        InputAdapter
+                                                                          WholeStageCodegen (3)
+                                                                            Sort [ss_item_sk]
+                                                                              InputAdapter
+                                                                                Exchange [ss_item_sk] #4
+                                                                                  WholeStageCodegen (2)
                                                                                     Project [ss_item_sk,ss_store_sk,ss_sales_price,d_year,d_moy]
                                                                                       BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                                         Filter [ss_item_sk,ss_store_sk]
@@ -55,23 +55,23 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,s_store_name,i_category,i_bra
                                                                                                             Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
                                                                                         InputAdapter
                                                                                           ReusedExchange [d_date_sk,d_year,d_moy] #5
-                                                                                    InputAdapter
-                                                                                      BroadcastExchange #6
-                                                                                        WholeStageCodegen (2)
-                                                                                          Filter [s_store_sk,s_store_name,s_company_name]
-                                                                                            ColumnarToRow
-                                                                                              InputAdapter
-                                                                                                Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_company_name]
+                                                                        InputAdapter
+                                                                          WholeStageCodegen (5)
+                                                                            Sort [i_item_sk]
+                                                                              InputAdapter
+                                                                                Exchange [i_item_sk] #6
+                                                                                  WholeStageCodegen (4)
+                                                                                    Filter [i_item_sk,i_category,i_brand]
+                                                                                      ColumnarToRow
+                                                                                        InputAdapter
+                                                                                          Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_category]
                                                                     InputAdapter
-                                                                      WholeStageCodegen (6)
-                                                                        Sort [i_item_sk]
-                                                                          InputAdapter
-                                                                            Exchange [i_item_sk] #7
-                                                                              WholeStageCodegen (5)
-                                                                                Filter [i_item_sk,i_category,i_brand]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_category]
+                                                                      BroadcastExchange #7
+                                                                        WholeStageCodegen (6)
+                                                                          Filter [s_store_sk,s_store_name,s_company_name]
+                                                                            ColumnarToRow
+                                                                              InputAdapter
+                                                                                Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_company_name]
                 InputAdapter
                   WholeStageCodegen (23)
                     Sort [i_category,i_brand,s_store_name,s_company_name,rn]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q50.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q50.sf100/explain.txt
@@ -25,11 +25,11 @@ TakeOrderedAndProject (31)
                :     +- BroadcastExchange (19)
                :        +- * Filter (18)
                :           +- * ColumnarToRow (17)
-               :              +- Scan parquet spark_catalog.default.date_dim (16)
+               :              +- Scan parquet spark_catalog.default.store (16)
                +- BroadcastExchange (25)
                   +- * Filter (24)
                      +- * ColumnarToRow (23)
-                        +- Scan parquet spark_catalog.default.store (22)
+                        +- Scan parquet spark_catalog.default.date_dim (22)
 
 
 (1) Scan parquet spark_catalog.default.store_returns
@@ -101,83 +101,83 @@ Join condition: None
 Output [3]: [sr_returned_date_sk#4, ss_store_sk#9, ss_sold_date_sk#11]
 Input [9]: [sr_item_sk#1, sr_customer_sk#2, sr_ticket_number#3, sr_returned_date_sk#4, ss_item_sk#7, ss_customer_sk#8, ss_store_sk#9, ss_ticket_number#10, ss_sold_date_sk#11]
 
-(16) Scan parquet spark_catalog.default.date_dim
-Output [1]: [d_date_sk#12]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int>
-
-(17) ColumnarToRow [codegen id : 6]
-Input [1]: [d_date_sk#12]
-
-(18) Filter [codegen id : 6]
-Input [1]: [d_date_sk#12]
-Condition : isnotnull(d_date_sk#12)
-
-(19) BroadcastExchange
-Input [1]: [d_date_sk#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
-
-(20) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ss_sold_date_sk#11]
-Right keys [1]: [d_date_sk#12]
-Join type: Inner
-Join condition: None
-
-(21) Project [codegen id : 8]
-Output [3]: [sr_returned_date_sk#4, ss_store_sk#9, ss_sold_date_sk#11]
-Input [4]: [sr_returned_date_sk#4, ss_store_sk#9, ss_sold_date_sk#11, d_date_sk#12]
-
-(22) Scan parquet spark_catalog.default.store
-Output [11]: [s_store_sk#13, s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23]
+(16) Scan parquet spark_catalog.default.store
+Output [11]: [s_store_sk#12, s_store_name#13, s_company_id#14, s_street_number#15, s_street_name#16, s_street_type#17, s_suite_number#18, s_city#19, s_county#20, s_state#21, s_zip#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string,s_company_id:int,s_street_number:string,s_street_name:string,s_street_type:string,s_suite_number:string,s_city:string,s_county:string,s_state:string,s_zip:string>
 
+(17) ColumnarToRow [codegen id : 6]
+Input [11]: [s_store_sk#12, s_store_name#13, s_company_id#14, s_street_number#15, s_street_name#16, s_street_type#17, s_suite_number#18, s_city#19, s_county#20, s_state#21, s_zip#22]
+
+(18) Filter [codegen id : 6]
+Input [11]: [s_store_sk#12, s_store_name#13, s_company_id#14, s_street_number#15, s_street_name#16, s_street_type#17, s_suite_number#18, s_city#19, s_county#20, s_state#21, s_zip#22]
+Condition : isnotnull(s_store_sk#12)
+
+(19) BroadcastExchange
+Input [11]: [s_store_sk#12, s_store_name#13, s_company_id#14, s_street_number#15, s_street_name#16, s_street_type#17, s_suite_number#18, s_city#19, s_county#20, s_state#21, s_zip#22]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
+
+(20) BroadcastHashJoin [codegen id : 8]
+Left keys [1]: [ss_store_sk#9]
+Right keys [1]: [s_store_sk#12]
+Join type: Inner
+Join condition: None
+
+(21) Project [codegen id : 8]
+Output [12]: [sr_returned_date_sk#4, ss_sold_date_sk#11, s_store_name#13, s_company_id#14, s_street_number#15, s_street_name#16, s_street_type#17, s_suite_number#18, s_city#19, s_county#20, s_state#21, s_zip#22]
+Input [14]: [sr_returned_date_sk#4, ss_store_sk#9, ss_sold_date_sk#11, s_store_sk#12, s_store_name#13, s_company_id#14, s_street_number#15, s_street_name#16, s_street_type#17, s_suite_number#18, s_city#19, s_county#20, s_state#21, s_zip#22]
+
+(22) Scan parquet spark_catalog.default.date_dim
+Output [1]: [d_date_sk#23]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/date_dim]
+PushedFilters: [IsNotNull(d_date_sk)]
+ReadSchema: struct<d_date_sk:int>
+
 (23) ColumnarToRow [codegen id : 7]
-Input [11]: [s_store_sk#13, s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23]
+Input [1]: [d_date_sk#23]
 
 (24) Filter [codegen id : 7]
-Input [11]: [s_store_sk#13, s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23]
-Condition : isnotnull(s_store_sk#13)
+Input [1]: [d_date_sk#23]
+Condition : isnotnull(d_date_sk#23)
 
 (25) BroadcastExchange
-Input [11]: [s_store_sk#13, s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23]
+Input [1]: [d_date_sk#23]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
 
 (26) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ss_store_sk#9]
-Right keys [1]: [s_store_sk#13]
+Left keys [1]: [ss_sold_date_sk#11]
+Right keys [1]: [d_date_sk#23]
 Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 8]
-Output [12]: [ss_sold_date_sk#11, sr_returned_date_sk#4, s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23]
-Input [14]: [sr_returned_date_sk#4, ss_store_sk#9, ss_sold_date_sk#11, s_store_sk#13, s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23]
+Output [12]: [ss_sold_date_sk#11, sr_returned_date_sk#4, s_store_name#13, s_company_id#14, s_street_number#15, s_street_name#16, s_street_type#17, s_suite_number#18, s_city#19, s_county#20, s_state#21, s_zip#22]
+Input [13]: [sr_returned_date_sk#4, ss_sold_date_sk#11, s_store_name#13, s_company_id#14, s_street_number#15, s_street_name#16, s_street_type#17, s_suite_number#18, s_city#19, s_county#20, s_state#21, s_zip#22, d_date_sk#23]
 
 (28) HashAggregate [codegen id : 8]
-Input [12]: [ss_sold_date_sk#11, sr_returned_date_sk#4, s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23]
-Keys [10]: [s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23]
+Input [12]: [ss_sold_date_sk#11, sr_returned_date_sk#4, s_store_name#13, s_company_id#14, s_street_number#15, s_street_name#16, s_street_type#17, s_suite_number#18, s_city#19, s_county#20, s_state#21, s_zip#22]
+Keys [10]: [s_store_name#13, s_company_id#14, s_street_number#15, s_street_name#16, s_street_type#17, s_suite_number#18, s_city#19, s_county#20, s_state#21, s_zip#22]
 Functions [5]: [partial_sum(CASE WHEN ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 30) THEN 1 ELSE 0 END), partial_sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 30) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 60)) THEN 1 ELSE 0 END), partial_sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 60) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 90)) THEN 1 ELSE 0 END), partial_sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 90) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 120)) THEN 1 ELSE 0 END), partial_sum(CASE WHEN ((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 120) THEN 1 ELSE 0 END)]
 Aggregate Attributes [5]: [sum#24, sum#25, sum#26, sum#27, sum#28]
-Results [15]: [s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23, sum#29, sum#30, sum#31, sum#32, sum#33]
+Results [15]: [s_store_name#13, s_company_id#14, s_street_number#15, s_street_name#16, s_street_type#17, s_suite_number#18, s_city#19, s_county#20, s_state#21, s_zip#22, sum#29, sum#30, sum#31, sum#32, sum#33]
 
 (29) Exchange
-Input [15]: [s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23, sum#29, sum#30, sum#31, sum#32, sum#33]
-Arguments: hashpartitioning(s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [15]: [s_store_name#13, s_company_id#14, s_street_number#15, s_street_name#16, s_street_type#17, s_suite_number#18, s_city#19, s_county#20, s_state#21, s_zip#22, sum#29, sum#30, sum#31, sum#32, sum#33]
+Arguments: hashpartitioning(s_store_name#13, s_company_id#14, s_street_number#15, s_street_name#16, s_street_type#17, s_suite_number#18, s_city#19, s_county#20, s_state#21, s_zip#22, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (30) HashAggregate [codegen id : 9]
-Input [15]: [s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23, sum#29, sum#30, sum#31, sum#32, sum#33]
-Keys [10]: [s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23]
+Input [15]: [s_store_name#13, s_company_id#14, s_street_number#15, s_street_name#16, s_street_type#17, s_suite_number#18, s_city#19, s_county#20, s_state#21, s_zip#22, sum#29, sum#30, sum#31, sum#32, sum#33]
+Keys [10]: [s_store_name#13, s_company_id#14, s_street_number#15, s_street_name#16, s_street_type#17, s_suite_number#18, s_city#19, s_county#20, s_state#21, s_zip#22]
 Functions [5]: [sum(CASE WHEN ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 30) THEN 1 ELSE 0 END), sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 30) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 60)) THEN 1 ELSE 0 END), sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 60) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 90)) THEN 1 ELSE 0 END), sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 90) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 120)) THEN 1 ELSE 0 END), sum(CASE WHEN ((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 120) THEN 1 ELSE 0 END)]
 Aggregate Attributes [5]: [sum(CASE WHEN ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 30) THEN 1 ELSE 0 END)#34, sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 30) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 60)) THEN 1 ELSE 0 END)#35, sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 60) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 90)) THEN 1 ELSE 0 END)#36, sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 90) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 120)) THEN 1 ELSE 0 END)#37, sum(CASE WHEN ((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 120) THEN 1 ELSE 0 END)#38]
-Results [15]: [s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23, sum(CASE WHEN ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 30) THEN 1 ELSE 0 END)#34 AS 30 days #39, sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 30) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 60)) THEN 1 ELSE 0 END)#35 AS 31 - 60 days #40, sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 60) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 90)) THEN 1 ELSE 0 END)#36 AS 61 - 90 days #41, sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 90) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 120)) THEN 1 ELSE 0 END)#37 AS 91 - 120 days #42, sum(CASE WHEN ((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 120) THEN 1 ELSE 0 END)#38 AS >120 days #43]
+Results [15]: [s_store_name#13, s_company_id#14, s_street_number#15, s_street_name#16, s_street_type#17, s_suite_number#18, s_city#19, s_county#20, s_state#21, s_zip#22, sum(CASE WHEN ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 30) THEN 1 ELSE 0 END)#34 AS 30 days #39, sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 30) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 60)) THEN 1 ELSE 0 END)#35 AS 31 - 60 days #40, sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 60) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 90)) THEN 1 ELSE 0 END)#36 AS 61 - 90 days #41, sum(CASE WHEN (((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 90) AND ((sr_returned_date_sk#4 - ss_sold_date_sk#11) <= 120)) THEN 1 ELSE 0 END)#37 AS 91 - 120 days #42, sum(CASE WHEN ((sr_returned_date_sk#4 - ss_sold_date_sk#11) > 120) THEN 1 ELSE 0 END)#38 AS >120 days #43]
 
 (31) TakeOrderedAndProject
-Input [15]: [s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23, 30 days #39, 31 - 60 days #40, 61 - 90 days #41, 91 - 120 days #42, >120 days #43]
-Arguments: 100, [s_store_name#14 ASC NULLS FIRST, s_company_id#15 ASC NULLS FIRST, s_street_number#16 ASC NULLS FIRST, s_street_name#17 ASC NULLS FIRST, s_street_type#18 ASC NULLS FIRST, s_suite_number#19 ASC NULLS FIRST, s_city#20 ASC NULLS FIRST, s_county#21 ASC NULLS FIRST, s_state#22 ASC NULLS FIRST, s_zip#23 ASC NULLS FIRST], [s_store_name#14, s_company_id#15, s_street_number#16, s_street_name#17, s_street_type#18, s_suite_number#19, s_city#20, s_county#21, s_state#22, s_zip#23, 30 days #39, 31 - 60 days #40, 61 - 90 days #41, 91 - 120 days #42, >120 days #43]
+Input [15]: [s_store_name#13, s_company_id#14, s_street_number#15, s_street_name#16, s_street_type#17, s_suite_number#18, s_city#19, s_county#20, s_state#21, s_zip#22, 30 days #39, 31 - 60 days #40, 61 - 90 days #41, 91 - 120 days #42, >120 days #43]
+Arguments: 100, [s_store_name#13 ASC NULLS FIRST, s_company_id#14 ASC NULLS FIRST, s_street_number#15 ASC NULLS FIRST, s_street_name#16 ASC NULLS FIRST, s_street_type#17 ASC NULLS FIRST, s_suite_number#18 ASC NULLS FIRST, s_city#19 ASC NULLS FIRST, s_county#20 ASC NULLS FIRST, s_state#21 ASC NULLS FIRST, s_zip#22 ASC NULLS FIRST], [s_store_name#13, s_company_id#14, s_street_number#15, s_street_name#16, s_street_type#17, s_suite_number#18, s_city#19, s_county#20, s_state#21, s_zip#22, 30 days #39, 31 - 60 days #40, 61 - 90 days #41, 91 - 120 days #42, >120 days #43]
 
 ===== Subqueries =====
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q50.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q50.sf100/simplified.txt
@@ -6,9 +6,9 @@ TakeOrderedAndProject [s_store_name,s_company_id,s_street_number,s_street_name,s
           WholeStageCodegen (8)
             HashAggregate [s_store_name,s_company_id,s_street_number,s_street_name,s_street_type,s_suite_number,s_city,s_county,s_state,s_zip,sr_returned_date_sk,ss_sold_date_sk] [sum,sum,sum,sum,sum,sum,sum,sum,sum,sum]
               Project [ss_sold_date_sk,sr_returned_date_sk,s_store_name,s_company_id,s_street_number,s_street_name,s_street_type,s_suite_number,s_city,s_county,s_state,s_zip]
-                BroadcastHashJoin [ss_store_sk,s_store_sk]
-                  Project [sr_returned_date_sk,ss_store_sk,ss_sold_date_sk]
-                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                  Project [sr_returned_date_sk,ss_sold_date_sk,s_store_name,s_company_id,s_street_number,s_street_name,s_street_type,s_suite_number,s_city,s_county,s_state,s_zip]
+                    BroadcastHashJoin [ss_store_sk,s_store_sk]
                       Project [sr_returned_date_sk,ss_store_sk,ss_sold_date_sk]
                         SortMergeJoin [sr_ticket_number,sr_item_sk,sr_customer_sk,ss_ticket_number,ss_item_sk,ss_customer_sk]
                           InputAdapter
@@ -46,14 +46,14 @@ TakeOrderedAndProject [s_store_name,s_company_id,s_street_number,s_street_name,s
                       InputAdapter
                         BroadcastExchange #5
                           WholeStageCodegen (6)
-                            Filter [d_date_sk]
+                            Filter [s_store_sk]
                               ColumnarToRow
                                 InputAdapter
-                                  Scan parquet spark_catalog.default.date_dim [d_date_sk]
+                                  Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_company_id,s_street_number,s_street_name,s_street_type,s_suite_number,s_city,s_county,s_state,s_zip]
                   InputAdapter
                     BroadcastExchange #6
                       WholeStageCodegen (7)
-                        Filter [s_store_sk]
+                        Filter [d_date_sk]
                           ColumnarToRow
                             InputAdapter
-                              Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_company_id,s_street_number,s_street_name,s_street_type,s_suite_number,s_city,s_county,s_state,s_zip]
+                              Scan parquet spark_catalog.default.date_dim [d_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q52.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q52.sf100/explain.txt
@@ -1,135 +1,135 @@
 == Physical Plan ==
-TakeOrderedAndProject (17)
-+- * HashAggregate (16)
-   +- Exchange (15)
-      +- * HashAggregate (14)
-         +- * Project (13)
-            +- * BroadcastHashJoin Inner BuildRight (12)
+TakeOrderedAndProject (21)
++- * HashAggregate (20)
+   +- Exchange (19)
+      +- * HashAggregate (18)
+         +- * Project (17)
+            +- * BroadcastHashJoin Inner BuildRight (16)
                :- * Project (10)
-               :  +- * BroadcastHashJoin Inner BuildRight (9)
-               :     :- * Filter (3)
-               :     :  +- * ColumnarToRow (2)
-               :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-               :     +- BroadcastExchange (8)
-               :        +- * Project (7)
-               :           +- * Filter (6)
-               :              +- * ColumnarToRow (5)
-               :                 +- Scan parquet spark_catalog.default.item (4)
-               +- ReusedExchange (11)
+               :  +- * BroadcastHashJoin Inner BuildLeft (9)
+               :     :- BroadcastExchange (5)
+               :     :  +- * Project (4)
+               :     :     +- * Filter (3)
+               :     :        +- * ColumnarToRow (2)
+               :     :           +- Scan parquet spark_catalog.default.date_dim (1)
+               :     +- * Filter (8)
+               :        +- * ColumnarToRow (7)
+               :           +- Scan parquet spark_catalog.default.store_sales (6)
+               +- BroadcastExchange (15)
+                  +- * Project (14)
+                     +- * Filter (13)
+                        +- * ColumnarToRow (12)
+                           +- Scan parquet spark_catalog.default.item (11)
 
 
-(1) Scan parquet spark_catalog.default.store_sales
-Output [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#3), dynamicpruningexpression(ss_sold_date_sk#3 IN dynamicpruning#4)]
-PushedFilters: [IsNotNull(ss_item_sk)]
-ReadSchema: struct<ss_item_sk:int,ss_ext_sales_price:decimal(7,2)>
-
-(2) ColumnarToRow [codegen id : 3]
-Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
-
-(3) Filter [codegen id : 3]
-Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
-Condition : isnotnull(ss_item_sk#1)
-
-(4) Scan parquet spark_catalog.default.item
-Output [4]: [i_item_sk#5, i_brand_id#6, i_brand#7, i_manager_id#8]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_manager_id), EqualTo(i_manager_id,1), IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_brand:string,i_manager_id:int>
-
-(5) ColumnarToRow [codegen id : 1]
-Input [4]: [i_item_sk#5, i_brand_id#6, i_brand#7, i_manager_id#8]
-
-(6) Filter [codegen id : 1]
-Input [4]: [i_item_sk#5, i_brand_id#6, i_brand#7, i_manager_id#8]
-Condition : ((isnotnull(i_manager_id#8) AND (i_manager_id#8 = 1)) AND isnotnull(i_item_sk#5))
-
-(7) Project [codegen id : 1]
-Output [3]: [i_item_sk#5, i_brand_id#6, i_brand#7]
-Input [4]: [i_item_sk#5, i_brand_id#6, i_brand#7, i_manager_id#8]
-
-(8) BroadcastExchange
-Input [3]: [i_item_sk#5, i_brand_id#6, i_brand#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
-
-(9) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#5]
-Join type: Inner
-Join condition: None
-
-(10) Project [codegen id : 3]
-Output [4]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_brand_id#6, i_brand#7]
-Input [6]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_sk#5, i_brand_id#6, i_brand#7]
-
-(11) ReusedExchange [Reuses operator id: 22]
-Output [2]: [d_date_sk#9, d_year#10]
-
-(12) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_sold_date_sk#3]
-Right keys [1]: [d_date_sk#9]
-Join type: Inner
-Join condition: None
-
-(13) Project [codegen id : 3]
-Output [4]: [d_year#10, ss_ext_sales_price#2, i_brand_id#6, i_brand#7]
-Input [6]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_brand_id#6, i_brand#7, d_date_sk#9, d_year#10]
-
-(14) HashAggregate [codegen id : 3]
-Input [4]: [d_year#10, ss_ext_sales_price#2, i_brand_id#6, i_brand#7]
-Keys [3]: [d_year#10, i_brand#7, i_brand_id#6]
-Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum#11]
-Results [4]: [d_year#10, i_brand#7, i_brand_id#6, sum#12]
-
-(15) Exchange
-Input [4]: [d_year#10, i_brand#7, i_brand_id#6, sum#12]
-Arguments: hashpartitioning(d_year#10, i_brand#7, i_brand_id#6, 5), ENSURE_REQUIREMENTS, [plan_id=2]
-
-(16) HashAggregate [codegen id : 4]
-Input [4]: [d_year#10, i_brand#7, i_brand_id#6, sum#12]
-Keys [3]: [d_year#10, i_brand#7, i_brand_id#6]
-Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#2))#13]
-Results [4]: [d_year#10, i_brand_id#6 AS brand_id#14, i_brand#7 AS brand#15, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#13,17,2) AS ext_price#16]
-
-(17) TakeOrderedAndProject
-Input [4]: [d_year#10, brand_id#14, brand#15, ext_price#16]
-Arguments: 100, [d_year#10 ASC NULLS FIRST, ext_price#16 DESC NULLS LAST, brand_id#14 ASC NULLS FIRST], [d_year#10, brand_id#14, brand#15, ext_price#16]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#3 IN dynamicpruning#4
-BroadcastExchange (22)
-+- * Project (21)
-   +- * Filter (20)
-      +- * ColumnarToRow (19)
-         +- Scan parquet spark_catalog.default.date_dim (18)
-
-
-(18) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#9, d_year#10, d_moy#17]
+(1) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#1, d_year#2, d_moy#3]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_moy), IsNotNull(d_year), EqualTo(d_moy,11), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(19) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#9, d_year#10, d_moy#17]
+(2) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
 
-(20) Filter [codegen id : 1]
-Input [3]: [d_date_sk#9, d_year#10, d_moy#17]
-Condition : ((((isnotnull(d_moy#17) AND isnotnull(d_year#10)) AND (d_moy#17 = 11)) AND (d_year#10 = 2000)) AND isnotnull(d_date_sk#9))
+(3) Filter [codegen id : 1]
+Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
+Condition : ((((isnotnull(d_moy#3) AND isnotnull(d_year#2)) AND (d_moy#3 = 11)) AND (d_year#2 = 2000)) AND isnotnull(d_date_sk#1))
 
-(21) Project [codegen id : 1]
-Output [2]: [d_date_sk#9, d_year#10]
-Input [3]: [d_date_sk#9, d_year#10, d_moy#17]
+(4) Project [codegen id : 1]
+Output [2]: [d_date_sk#1, d_year#2]
+Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
 
-(22) BroadcastExchange
-Input [2]: [d_date_sk#9, d_year#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
+(5) BroadcastExchange
+Input [2]: [d_date_sk#1, d_year#2]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
+
+(6) Scan parquet spark_catalog.default.store_sales
+Output [3]: [ss_item_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ss_sold_date_sk#6), dynamicpruningexpression(ss_sold_date_sk#6 IN dynamicpruning#7)]
+PushedFilters: [IsNotNull(ss_item_sk)]
+ReadSchema: struct<ss_item_sk:int,ss_ext_sales_price:decimal(7,2)>
+
+(7) ColumnarToRow
+Input [3]: [ss_item_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6]
+
+(8) Filter
+Input [3]: [ss_item_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6]
+Condition : isnotnull(ss_item_sk#4)
+
+(9) BroadcastHashJoin [codegen id : 3]
+Left keys [1]: [d_date_sk#1]
+Right keys [1]: [ss_sold_date_sk#6]
+Join type: Inner
+Join condition: None
+
+(10) Project [codegen id : 3]
+Output [3]: [d_year#2, ss_item_sk#4, ss_ext_sales_price#5]
+Input [5]: [d_date_sk#1, d_year#2, ss_item_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6]
+
+(11) Scan parquet spark_catalog.default.item
+Output [4]: [i_item_sk#8, i_brand_id#9, i_brand#10, i_manager_id#11]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_manager_id), EqualTo(i_manager_id,1), IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_brand:string,i_manager_id:int>
+
+(12) ColumnarToRow [codegen id : 2]
+Input [4]: [i_item_sk#8, i_brand_id#9, i_brand#10, i_manager_id#11]
+
+(13) Filter [codegen id : 2]
+Input [4]: [i_item_sk#8, i_brand_id#9, i_brand#10, i_manager_id#11]
+Condition : ((isnotnull(i_manager_id#11) AND (i_manager_id#11 = 1)) AND isnotnull(i_item_sk#8))
+
+(14) Project [codegen id : 2]
+Output [3]: [i_item_sk#8, i_brand_id#9, i_brand#10]
+Input [4]: [i_item_sk#8, i_brand_id#9, i_brand#10, i_manager_id#11]
+
+(15) BroadcastExchange
+Input [3]: [i_item_sk#8, i_brand_id#9, i_brand#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
+
+(16) BroadcastHashJoin [codegen id : 3]
+Left keys [1]: [ss_item_sk#4]
+Right keys [1]: [i_item_sk#8]
+Join type: Inner
+Join condition: None
+
+(17) Project [codegen id : 3]
+Output [4]: [d_year#2, ss_ext_sales_price#5, i_brand_id#9, i_brand#10]
+Input [6]: [d_year#2, ss_item_sk#4, ss_ext_sales_price#5, i_item_sk#8, i_brand_id#9, i_brand#10]
+
+(18) HashAggregate [codegen id : 3]
+Input [4]: [d_year#2, ss_ext_sales_price#5, i_brand_id#9, i_brand#10]
+Keys [3]: [d_year#2, i_brand#10, i_brand_id#9]
+Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#5))]
+Aggregate Attributes [1]: [sum#12]
+Results [4]: [d_year#2, i_brand#10, i_brand_id#9, sum#13]
+
+(19) Exchange
+Input [4]: [d_year#2, i_brand#10, i_brand_id#9, sum#13]
+Arguments: hashpartitioning(d_year#2, i_brand#10, i_brand_id#9, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(20) HashAggregate [codegen id : 4]
+Input [4]: [d_year#2, i_brand#10, i_brand_id#9, sum#13]
+Keys [3]: [d_year#2, i_brand#10, i_brand_id#9]
+Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#5))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#5))#14]
+Results [4]: [d_year#2, i_brand_id#9 AS brand_id#15, i_brand#10 AS brand#16, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#5))#14,17,2) AS ext_price#17]
+
+(21) TakeOrderedAndProject
+Input [4]: [d_year#2, brand_id#15, brand#16, ext_price#17]
+Arguments: 100, [d_year#2 ASC NULLS FIRST, ext_price#17 DESC NULLS LAST, brand_id#15 ASC NULLS FIRST], [d_year#2, brand_id#15, brand#16, ext_price#17]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#6 IN dynamicpruning#7
+ReusedExchange (22)
+
+
+(22) ReusedExchange [Reuses operator id: 5]
+Output [2]: [d_date_sk#1, d_year#2]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q52.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q52.sf100/simplified.txt
@@ -6,28 +6,28 @@ TakeOrderedAndProject [d_year,ext_price,brand_id,brand]
           WholeStageCodegen (3)
             HashAggregate [d_year,i_brand,i_brand_id,ss_ext_sales_price] [sum,sum]
               Project [d_year,ss_ext_sales_price,i_brand_id,i_brand]
-                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                  Project [ss_ext_sales_price,ss_sold_date_sk,i_brand_id,i_brand]
-                    BroadcastHashJoin [ss_item_sk,i_item_sk]
+                BroadcastHashJoin [ss_item_sk,i_item_sk]
+                  Project [d_year,ss_item_sk,ss_ext_sales_price]
+                    BroadcastHashJoin [d_date_sk,ss_sold_date_sk]
+                      InputAdapter
+                        BroadcastExchange #2
+                          WholeStageCodegen (1)
+                            Project [d_date_sk,d_year]
+                              Filter [d_moy,d_year,d_date_sk]
+                                ColumnarToRow
+                                  InputAdapter
+                                    Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
                       Filter [ss_item_sk]
                         ColumnarToRow
                           InputAdapter
                             Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_ext_sales_price,ss_sold_date_sk]
                               SubqueryBroadcast [d_date_sk] #1
-                                BroadcastExchange #2
-                                  WholeStageCodegen (1)
-                                    Project [d_date_sk,d_year]
-                                      Filter [d_moy,d_year,d_date_sk]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
-                      InputAdapter
-                        BroadcastExchange #3
-                          WholeStageCodegen (1)
-                            Project [i_item_sk,i_brand_id,i_brand]
-                              Filter [i_manager_id,i_item_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_brand,i_manager_id]
+                                ReusedExchange [d_date_sk,d_year] #2
                   InputAdapter
-                    ReusedExchange [d_date_sk,d_year] #2
+                    BroadcastExchange #3
+                      WholeStageCodegen (2)
+                        Project [i_item_sk,i_brand_id,i_brand]
+                          Filter [i_manager_id,i_item_sk]
+                            ColumnarToRow
+                              InputAdapter
+                                Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_brand,i_manager_id]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q53.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q53.sf100/explain.txt
@@ -10,158 +10,158 @@ TakeOrderedAndProject (28)
                      +- * HashAggregate (20)
                         +- * Project (19)
                            +- * BroadcastHashJoin Inner BuildRight (18)
-                              :- * Project (16)
-                              :  +- * BroadcastHashJoin Inner BuildRight (15)
-                              :     :- * Project (10)
-                              :     :  +- * BroadcastHashJoin Inner BuildLeft (9)
-                              :     :     :- BroadcastExchange (5)
-                              :     :     :  +- * Project (4)
-                              :     :     :     +- * Filter (3)
-                              :     :     :        +- * ColumnarToRow (2)
-                              :     :     :           +- Scan parquet spark_catalog.default.item (1)
-                              :     :     +- * Filter (8)
-                              :     :        +- * ColumnarToRow (7)
-                              :     :           +- Scan parquet spark_catalog.default.store_sales (6)
-                              :     +- BroadcastExchange (14)
-                              :        +- * Filter (13)
-                              :           +- * ColumnarToRow (12)
-                              :              +- Scan parquet spark_catalog.default.store (11)
-                              +- ReusedExchange (17)
+                              :- * Project (13)
+                              :  +- * BroadcastHashJoin Inner BuildRight (12)
+                              :     :- * Project (6)
+                              :     :  +- * BroadcastHashJoin Inner BuildRight (5)
+                              :     :     :- * Filter (3)
+                              :     :     :  +- * ColumnarToRow (2)
+                              :     :     :     +- Scan parquet spark_catalog.default.store_sales (1)
+                              :     :     +- ReusedExchange (4)
+                              :     +- BroadcastExchange (11)
+                              :        +- * Project (10)
+                              :           +- * Filter (9)
+                              :              +- * ColumnarToRow (8)
+                              :                 +- Scan parquet spark_catalog.default.item (7)
+                              +- BroadcastExchange (17)
+                                 +- * Filter (16)
+                                    +- * ColumnarToRow (15)
+                                       +- Scan parquet spark_catalog.default.store (14)
 
 
-(1) Scan parquet spark_catalog.default.item
-Output [5]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4, i_manufact_id#5]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [Or(And(And(In(i_category, [Books                                             ,Children                                          ,Electronics                                       ]),In(i_class, [personal                                          ,portable                                          ,reference                                         ,self-help                                         ])),In(i_brand, [exportiunivamalg #6                               ,scholaramalgamalg #7                             ,scholaramalgamalg #8                              ,scholaramalgamalg #6                              ])),And(And(In(i_category, [Men                                               ,Music                                             ,Women                                             ]),In(i_class, [accessories                                       ,classical                                         ,fragrances                                        ,pants                                             ])),In(i_brand, [amalgimporto #9                                   ,edu packscholar #9                                ,exportiimporto #9                                 ,importoamalg #9                                   ]))), IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_brand:string,i_class:string,i_category:string,i_manufact_id:int>
-
-(2) ColumnarToRow [codegen id : 1]
-Input [5]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4, i_manufact_id#5]
-
-(3) Filter [codegen id : 1]
-Input [5]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4, i_manufact_id#5]
-Condition : ((((i_category#4 IN (Books                                             ,Children                                          ,Electronics                                       ) AND i_class#3 IN (personal                                          ,portable                                          ,reference                                         ,self-help                                         )) AND i_brand#2 IN (scholaramalgamalg #7                             ,scholaramalgamalg #8                              ,exportiunivamalg #6                               ,scholaramalgamalg #6                              )) OR ((i_category#4 IN (Women                                             ,Music                                             ,Men                                               ) AND i_class#3 IN (accessories                                       ,classical                                         ,fragrances                                        ,pants                                             )) AND i_brand#2 IN (amalgimporto #9                                   ,edu packscholar #9                                ,exportiimporto #9                                 ,importoamalg #9                                   ))) AND isnotnull(i_item_sk#1))
-
-(4) Project [codegen id : 1]
-Output [2]: [i_item_sk#1, i_manufact_id#5]
-Input [5]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4, i_manufact_id#5]
-
-(5) BroadcastExchange
-Input [2]: [i_item_sk#1, i_manufact_id#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
-
-(6) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_item_sk#10, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
+(1) Scan parquet spark_catalog.default.store_sales
+Output [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#13), dynamicpruningexpression(ss_sold_date_sk#13 IN dynamicpruning#14)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#4), dynamicpruningexpression(ss_sold_date_sk#4 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_store_sk:int,ss_sales_price:decimal(7,2)>
 
-(7) ColumnarToRow
-Input [4]: [ss_item_sk#10, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
+(2) ColumnarToRow [codegen id : 4]
+Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
 
-(8) Filter
-Input [4]: [ss_item_sk#10, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
-Condition : (isnotnull(ss_item_sk#10) AND isnotnull(ss_store_sk#11))
+(3) Filter [codegen id : 4]
+Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
+Condition : (isnotnull(ss_item_sk#1) AND isnotnull(ss_store_sk#2))
 
-(9) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [i_item_sk#1]
-Right keys [1]: [ss_item_sk#10]
+(4) ReusedExchange [Reuses operator id: 33]
+Output [2]: [d_date_sk#6, d_qoy#7]
+
+(5) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_sold_date_sk#4]
+Right keys [1]: [d_date_sk#6]
 Join type: Inner
 Join condition: None
 
-(10) Project [codegen id : 4]
-Output [4]: [i_manufact_id#5, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
-Input [6]: [i_item_sk#1, i_manufact_id#5, ss_item_sk#10, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
+(6) Project [codegen id : 4]
+Output [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_qoy#7]
+Input [6]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4, d_date_sk#6, d_qoy#7]
 
-(11) Scan parquet spark_catalog.default.store
-Output [1]: [s_store_sk#15]
+(7) Scan parquet spark_catalog.default.item
+Output [5]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11, i_manufact_id#12]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [Or(And(And(In(i_category, [Books                                             ,Children                                          ,Electronics                                       ]),In(i_class, [personal                                          ,portable                                          ,reference                                         ,self-help                                         ])),In(i_brand, [exportiunivamalg #13                               ,scholaramalgamalg #14                             ,scholaramalgamalg #15                              ,scholaramalgamalg #13                              ])),And(And(In(i_category, [Men                                               ,Music                                             ,Women                                             ]),In(i_class, [accessories                                       ,classical                                         ,fragrances                                        ,pants                                             ])),In(i_brand, [amalgimporto #16                                   ,edu packscholar #16                                ,exportiimporto #16                                 ,importoamalg #16                                   ]))), IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_brand:string,i_class:string,i_category:string,i_manufact_id:int>
+
+(8) ColumnarToRow [codegen id : 2]
+Input [5]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11, i_manufact_id#12]
+
+(9) Filter [codegen id : 2]
+Input [5]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11, i_manufact_id#12]
+Condition : ((((i_category#11 IN (Books                                             ,Children                                          ,Electronics                                       ) AND i_class#10 IN (personal                                          ,portable                                          ,reference                                         ,self-help                                         )) AND i_brand#9 IN (scholaramalgamalg #14                             ,scholaramalgamalg #15                              ,exportiunivamalg #13                               ,scholaramalgamalg #13                              )) OR ((i_category#11 IN (Women                                             ,Music                                             ,Men                                               ) AND i_class#10 IN (accessories                                       ,classical                                         ,fragrances                                        ,pants                                             )) AND i_brand#9 IN (amalgimporto #16                                   ,edu packscholar #16                                ,exportiimporto #16                                 ,importoamalg #16                                   ))) AND isnotnull(i_item_sk#8))
+
+(10) Project [codegen id : 2]
+Output [2]: [i_item_sk#8, i_manufact_id#12]
+Input [5]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11, i_manufact_id#12]
+
+(11) BroadcastExchange
+Input [2]: [i_item_sk#8, i_manufact_id#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
+
+(12) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_item_sk#1]
+Right keys [1]: [i_item_sk#8]
+Join type: Inner
+Join condition: None
+
+(13) Project [codegen id : 4]
+Output [4]: [ss_store_sk#2, ss_sales_price#3, d_qoy#7, i_manufact_id#12]
+Input [6]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_qoy#7, i_item_sk#8, i_manufact_id#12]
+
+(14) Scan parquet spark_catalog.default.store
+Output [1]: [s_store_sk#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int>
 
-(12) ColumnarToRow [codegen id : 2]
-Input [1]: [s_store_sk#15]
+(15) ColumnarToRow [codegen id : 3]
+Input [1]: [s_store_sk#17]
 
-(13) Filter [codegen id : 2]
-Input [1]: [s_store_sk#15]
-Condition : isnotnull(s_store_sk#15)
+(16) Filter [codegen id : 3]
+Input [1]: [s_store_sk#17]
+Condition : isnotnull(s_store_sk#17)
 
-(14) BroadcastExchange
-Input [1]: [s_store_sk#15]
+(17) BroadcastExchange
+Input [1]: [s_store_sk#17]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
 
-(15) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_store_sk#11]
-Right keys [1]: [s_store_sk#15]
-Join type: Inner
-Join condition: None
-
-(16) Project [codegen id : 4]
-Output [3]: [i_manufact_id#5, ss_sales_price#12, ss_sold_date_sk#13]
-Input [5]: [i_manufact_id#5, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13, s_store_sk#15]
-
-(17) ReusedExchange [Reuses operator id: 33]
-Output [2]: [d_date_sk#16, d_qoy#17]
-
 (18) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#13]
-Right keys [1]: [d_date_sk#16]
+Left keys [1]: [ss_store_sk#2]
+Right keys [1]: [s_store_sk#17]
 Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]
-Output [3]: [i_manufact_id#5, ss_sales_price#12, d_qoy#17]
-Input [5]: [i_manufact_id#5, ss_sales_price#12, ss_sold_date_sk#13, d_date_sk#16, d_qoy#17]
+Output [3]: [i_manufact_id#12, ss_sales_price#3, d_qoy#7]
+Input [5]: [ss_store_sk#2, ss_sales_price#3, d_qoy#7, i_manufact_id#12, s_store_sk#17]
 
 (20) HashAggregate [codegen id : 4]
-Input [3]: [i_manufact_id#5, ss_sales_price#12, d_qoy#17]
-Keys [2]: [i_manufact_id#5, d_qoy#17]
-Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#12))]
+Input [3]: [i_manufact_id#12, ss_sales_price#3, d_qoy#7]
+Keys [2]: [i_manufact_id#12, d_qoy#7]
+Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#3))]
 Aggregate Attributes [1]: [sum#18]
-Results [3]: [i_manufact_id#5, d_qoy#17, sum#19]
+Results [3]: [i_manufact_id#12, d_qoy#7, sum#19]
 
 (21) Exchange
-Input [3]: [i_manufact_id#5, d_qoy#17, sum#19]
-Arguments: hashpartitioning(i_manufact_id#5, d_qoy#17, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [3]: [i_manufact_id#12, d_qoy#7, sum#19]
+Arguments: hashpartitioning(i_manufact_id#12, d_qoy#7, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (22) HashAggregate [codegen id : 5]
-Input [3]: [i_manufact_id#5, d_qoy#17, sum#19]
-Keys [2]: [i_manufact_id#5, d_qoy#17]
-Functions [1]: [sum(UnscaledValue(ss_sales_price#12))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#12))#20]
-Results [3]: [i_manufact_id#5, MakeDecimal(sum(UnscaledValue(ss_sales_price#12))#20,17,2) AS sum_sales#21, MakeDecimal(sum(UnscaledValue(ss_sales_price#12))#20,17,2) AS _w0#22]
+Input [3]: [i_manufact_id#12, d_qoy#7, sum#19]
+Keys [2]: [i_manufact_id#12, d_qoy#7]
+Functions [1]: [sum(UnscaledValue(ss_sales_price#3))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#3))#20]
+Results [3]: [i_manufact_id#12, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#20,17,2) AS sum_sales#21, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#20,17,2) AS _w0#22]
 
 (23) Exchange
-Input [3]: [i_manufact_id#5, sum_sales#21, _w0#22]
-Arguments: hashpartitioning(i_manufact_id#5, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [3]: [i_manufact_id#12, sum_sales#21, _w0#22]
+Arguments: hashpartitioning(i_manufact_id#12, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (24) Sort [codegen id : 6]
-Input [3]: [i_manufact_id#5, sum_sales#21, _w0#22]
-Arguments: [i_manufact_id#5 ASC NULLS FIRST], false, 0
+Input [3]: [i_manufact_id#12, sum_sales#21, _w0#22]
+Arguments: [i_manufact_id#12 ASC NULLS FIRST], false, 0
 
 (25) Window
-Input [3]: [i_manufact_id#5, sum_sales#21, _w0#22]
-Arguments: [avg(_w0#22) windowspecdefinition(i_manufact_id#5, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_quarterly_sales#23], [i_manufact_id#5]
+Input [3]: [i_manufact_id#12, sum_sales#21, _w0#22]
+Arguments: [avg(_w0#22) windowspecdefinition(i_manufact_id#12, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_quarterly_sales#23], [i_manufact_id#12]
 
 (26) Filter [codegen id : 7]
-Input [4]: [i_manufact_id#5, sum_sales#21, _w0#22, avg_quarterly_sales#23]
+Input [4]: [i_manufact_id#12, sum_sales#21, _w0#22, avg_quarterly_sales#23]
 Condition : CASE WHEN (avg_quarterly_sales#23 > 0.000000) THEN ((abs((sum_sales#21 - avg_quarterly_sales#23)) / avg_quarterly_sales#23) > 0.1000000000000000) ELSE false END
 
 (27) Project [codegen id : 7]
-Output [3]: [i_manufact_id#5, sum_sales#21, avg_quarterly_sales#23]
-Input [4]: [i_manufact_id#5, sum_sales#21, _w0#22, avg_quarterly_sales#23]
+Output [3]: [i_manufact_id#12, sum_sales#21, avg_quarterly_sales#23]
+Input [4]: [i_manufact_id#12, sum_sales#21, _w0#22, avg_quarterly_sales#23]
 
 (28) TakeOrderedAndProject
-Input [3]: [i_manufact_id#5, sum_sales#21, avg_quarterly_sales#23]
-Arguments: 100, [avg_quarterly_sales#23 ASC NULLS FIRST, sum_sales#21 ASC NULLS FIRST, i_manufact_id#5 ASC NULLS FIRST], [i_manufact_id#5, sum_sales#21, avg_quarterly_sales#23]
+Input [3]: [i_manufact_id#12, sum_sales#21, avg_quarterly_sales#23]
+Arguments: 100, [avg_quarterly_sales#23 ASC NULLS FIRST, sum_sales#21 ASC NULLS FIRST, i_manufact_id#12 ASC NULLS FIRST], [i_manufact_id#12, sum_sales#21, avg_quarterly_sales#23]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#13 IN dynamicpruning#14
+Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
 BroadcastExchange (33)
 +- * Project (32)
    +- * Filter (31)
@@ -170,25 +170,25 @@ BroadcastExchange (33)
 
 
 (29) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#16, d_month_seq#24, d_qoy#17]
+Output [3]: [d_date_sk#6, d_month_seq#24, d_qoy#7]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_month_seq, [1200,1201,1202,1203,1204,1205,1206,1207,1208,1209,1210,1211]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int,d_qoy:int>
 
 (30) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#16, d_month_seq#24, d_qoy#17]
+Input [3]: [d_date_sk#6, d_month_seq#24, d_qoy#7]
 
 (31) Filter [codegen id : 1]
-Input [3]: [d_date_sk#16, d_month_seq#24, d_qoy#17]
-Condition : (d_month_seq#24 INSET 1200, 1201, 1202, 1203, 1204, 1205, 1206, 1207, 1208, 1209, 1210, 1211 AND isnotnull(d_date_sk#16))
+Input [3]: [d_date_sk#6, d_month_seq#24, d_qoy#7]
+Condition : (d_month_seq#24 INSET 1200, 1201, 1202, 1203, 1204, 1205, 1206, 1207, 1208, 1209, 1210, 1211 AND isnotnull(d_date_sk#6))
 
 (32) Project [codegen id : 1]
-Output [2]: [d_date_sk#16, d_qoy#17]
-Input [3]: [d_date_sk#16, d_month_seq#24, d_qoy#17]
+Output [2]: [d_date_sk#6, d_qoy#7]
+Input [3]: [d_date_sk#6, d_month_seq#24, d_qoy#7]
 
 (33) BroadcastExchange
-Input [2]: [d_date_sk#16, d_qoy#17]
+Input [2]: [d_date_sk#6, d_qoy#7]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q53.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q53.sf100/simplified.txt
@@ -15,37 +15,37 @@ TakeOrderedAndProject [avg_quarterly_sales,sum_sales,i_manufact_id]
                             WholeStageCodegen (4)
                               HashAggregate [i_manufact_id,d_qoy,ss_sales_price] [sum,sum]
                                 Project [i_manufact_id,ss_sales_price,d_qoy]
-                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                    Project [i_manufact_id,ss_sales_price,ss_sold_date_sk]
-                                      BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                        Project [i_manufact_id,ss_store_sk,ss_sales_price,ss_sold_date_sk]
-                                          BroadcastHashJoin [i_item_sk,ss_item_sk]
-                                            InputAdapter
-                                              BroadcastExchange #3
-                                                WholeStageCodegen (1)
-                                                  Project [i_item_sk,i_manufact_id]
-                                                    Filter [i_category,i_class,i_brand,i_item_sk]
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_class,i_category,i_manufact_id]
+                                  BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                    Project [ss_store_sk,ss_sales_price,d_qoy,i_manufact_id]
+                                      BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                        Project [ss_item_sk,ss_store_sk,ss_sales_price,d_qoy]
+                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                             Filter [ss_item_sk,ss_store_sk]
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_sales_price,ss_sold_date_sk]
                                                     SubqueryBroadcast [d_date_sk] #1
-                                                      BroadcastExchange #4
+                                                      BroadcastExchange #3
                                                         WholeStageCodegen (1)
                                                           Project [d_date_sk,d_qoy]
                                                             Filter [d_month_seq,d_date_sk]
                                                               ColumnarToRow
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.date_dim [d_date_sk,d_month_seq,d_qoy]
+                                            InputAdapter
+                                              ReusedExchange [d_date_sk,d_qoy] #3
                                         InputAdapter
-                                          BroadcastExchange #5
+                                          BroadcastExchange #4
                                             WholeStageCodegen (2)
-                                              Filter [s_store_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.store [s_store_sk]
+                                              Project [i_item_sk,i_manufact_id]
+                                                Filter [i_category,i_class,i_brand,i_item_sk]
+                                                  ColumnarToRow
+                                                    InputAdapter
+                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_class,i_category,i_manufact_id]
                                     InputAdapter
-                                      ReusedExchange [d_date_sk,d_qoy] #4
+                                      BroadcastExchange #5
+                                        WholeStageCodegen (3)
+                                          Filter [s_store_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet spark_catalog.default.store [s_store_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/explain.txt
@@ -1,63 +1,67 @@
 == Physical Plan ==
-TakeOrderedAndProject (59)
-+- * HashAggregate (58)
-   +- Exchange (57)
-      +- * HashAggregate (56)
-         +- * HashAggregate (55)
-            +- * HashAggregate (54)
-               +- * Project (53)
-                  +- * SortMergeJoin Inner (52)
-                     :- * Sort (43)
-                     :  +- * Project (42)
-                     :     +- * BroadcastHashJoin Inner BuildLeft (41)
-                     :        :- BroadcastExchange (10)
-                     :        :  +- * Project (9)
-                     :        :     +- * BroadcastHashJoin Inner BuildRight (8)
-                     :        :        :- * Filter (3)
-                     :        :        :  +- * ColumnarToRow (2)
-                     :        :        :     +- Scan parquet spark_catalog.default.customer_address (1)
-                     :        :        +- BroadcastExchange (7)
-                     :        :           +- * Filter (6)
-                     :        :              +- * ColumnarToRow (5)
-                     :        :                 +- Scan parquet spark_catalog.default.store (4)
-                     :        +- * HashAggregate (40)
-                     :           +- * HashAggregate (39)
-                     :              +- * Project (38)
-                     :                 +- * SortMergeJoin Inner (37)
-                     :                    :- * Sort (31)
-                     :                    :  +- Exchange (30)
-                     :                    :     +- * Project (29)
-                     :                    :        +- * BroadcastHashJoin Inner BuildRight (28)
-                     :                    :           :- * Project (22)
-                     :                    :           :  +- * BroadcastHashJoin Inner BuildRight (21)
-                     :                    :           :     :- Union (19)
-                     :                    :           :     :  :- * Project (14)
-                     :                    :           :     :  :  +- * Filter (13)
-                     :                    :           :     :  :     +- * ColumnarToRow (12)
-                     :                    :           :     :  :        +- Scan parquet spark_catalog.default.catalog_sales (11)
-                     :                    :           :     :  +- * Project (18)
-                     :                    :           :     :     +- * Filter (17)
-                     :                    :           :     :        +- * ColumnarToRow (16)
-                     :                    :           :     :           +- Scan parquet spark_catalog.default.web_sales (15)
-                     :                    :           :     +- ReusedExchange (20)
-                     :                    :           +- BroadcastExchange (27)
-                     :                    :              +- * Project (26)
-                     :                    :                 +- * Filter (25)
-                     :                    :                    +- * ColumnarToRow (24)
-                     :                    :                       +- Scan parquet spark_catalog.default.item (23)
-                     :                    +- * Sort (36)
-                     :                       +- Exchange (35)
-                     :                          +- * Filter (34)
-                     :                             +- * ColumnarToRow (33)
-                     :                                +- Scan parquet spark_catalog.default.customer (32)
-                     +- * Sort (51)
-                        +- Exchange (50)
-                           +- * Project (49)
-                              +- * BroadcastHashJoin Inner BuildRight (48)
-                                 :- * Filter (46)
-                                 :  +- * ColumnarToRow (45)
-                                 :     +- Scan parquet spark_catalog.default.store_sales (44)
-                                 +- ReusedExchange (47)
+TakeOrderedAndProject (63)
++- * HashAggregate (62)
+   +- Exchange (61)
+      +- * HashAggregate (60)
+         +- * HashAggregate (59)
+            +- * HashAggregate (58)
+               +- * Project (57)
+                  +- * SortMergeJoin Inner (56)
+                     :- * Sort (47)
+                     :  +- Exchange (46)
+                     :     +- * Project (45)
+                     :        +- * SortMergeJoin Inner (44)
+                     :           :- * Sort (11)
+                     :           :  +- Exchange (10)
+                     :           :     +- * Project (9)
+                     :           :        +- * BroadcastHashJoin Inner BuildRight (8)
+                     :           :           :- * Filter (3)
+                     :           :           :  +- * ColumnarToRow (2)
+                     :           :           :     +- Scan parquet spark_catalog.default.customer_address (1)
+                     :           :           +- BroadcastExchange (7)
+                     :           :              +- * Filter (6)
+                     :           :                 +- * ColumnarToRow (5)
+                     :           :                    +- Scan parquet spark_catalog.default.store (4)
+                     :           +- * Sort (43)
+                     :              +- Exchange (42)
+                     :                 +- * HashAggregate (41)
+                     :                    +- * HashAggregate (40)
+                     :                       +- * Project (39)
+                     :                          +- * SortMergeJoin Inner (38)
+                     :                             :- * Sort (32)
+                     :                             :  +- Exchange (31)
+                     :                             :     +- * Project (30)
+                     :                             :        +- * BroadcastHashJoin Inner BuildRight (29)
+                     :                             :           :- * Project (23)
+                     :                             :           :  +- * BroadcastHashJoin Inner BuildRight (22)
+                     :                             :           :     :- Union (20)
+                     :                             :           :     :  :- * Project (15)
+                     :                             :           :     :  :  +- * Filter (14)
+                     :                             :           :     :  :     +- * ColumnarToRow (13)
+                     :                             :           :     :  :        +- Scan parquet spark_catalog.default.catalog_sales (12)
+                     :                             :           :     :  +- * Project (19)
+                     :                             :           :     :     +- * Filter (18)
+                     :                             :           :     :        +- * ColumnarToRow (17)
+                     :                             :           :     :           +- Scan parquet spark_catalog.default.web_sales (16)
+                     :                             :           :     +- ReusedExchange (21)
+                     :                             :           +- BroadcastExchange (28)
+                     :                             :              +- * Project (27)
+                     :                             :                 +- * Filter (26)
+                     :                             :                    +- * ColumnarToRow (25)
+                     :                             :                       +- Scan parquet spark_catalog.default.item (24)
+                     :                             +- * Sort (37)
+                     :                                +- Exchange (36)
+                     :                                   +- * Filter (35)
+                     :                                      +- * ColumnarToRow (34)
+                     :                                         +- Scan parquet spark_catalog.default.customer (33)
+                     +- * Sort (55)
+                        +- Exchange (54)
+                           +- * Project (53)
+                              +- * BroadcastHashJoin Inner BuildRight (52)
+                                 :- * Filter (50)
+                                 :  +- * ColumnarToRow (49)
+                                 :     +- Scan parquet spark_catalog.default.store_sales (48)
+                                 +- ReusedExchange (51)
 
 
 (1) Scan parquet spark_catalog.default.customer_address
@@ -102,11 +106,15 @@ Join condition: None
 Output [1]: [ca_address_sk#1]
 Input [5]: [ca_address_sk#1, ca_county#2, ca_state#3, s_county#4, s_state#5]
 
-(10) BroadcastExchange
+(10) Exchange
 Input [1]: [ca_address_sk#1]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
+Arguments: hashpartitioning(ca_address_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(11) Scan parquet spark_catalog.default.catalog_sales
+(11) Sort [codegen id : 3]
+Input [1]: [ca_address_sk#1]
+Arguments: [ca_address_sk#1 ASC NULLS FIRST], false, 0
+
+(12) Scan parquet spark_catalog.default.catalog_sales
 Output [3]: [cs_bill_customer_sk#6, cs_item_sk#7, cs_sold_date_sk#8]
 Batched: true
 Location: InMemoryFileIndex []
@@ -114,18 +122,18 @@ PartitionFilters: [isnotnull(cs_sold_date_sk#8), dynamicpruningexpression(cs_sol
 PushedFilters: [IsNotNull(cs_item_sk), IsNotNull(cs_bill_customer_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int,cs_item_sk:int>
 
-(12) ColumnarToRow [codegen id : 3]
+(13) ColumnarToRow [codegen id : 4]
 Input [3]: [cs_bill_customer_sk#6, cs_item_sk#7, cs_sold_date_sk#8]
 
-(13) Filter [codegen id : 3]
+(14) Filter [codegen id : 4]
 Input [3]: [cs_bill_customer_sk#6, cs_item_sk#7, cs_sold_date_sk#8]
 Condition : (isnotnull(cs_item_sk#7) AND isnotnull(cs_bill_customer_sk#6))
 
-(14) Project [codegen id : 3]
+(15) Project [codegen id : 4]
 Output [3]: [cs_sold_date_sk#8 AS sold_date_sk#10, cs_bill_customer_sk#6 AS customer_sk#11, cs_item_sk#7 AS item_sk#12]
 Input [3]: [cs_bill_customer_sk#6, cs_item_sk#7, cs_sold_date_sk#8]
 
-(15) Scan parquet spark_catalog.default.web_sales
+(16) Scan parquet spark_catalog.default.web_sales
 Output [3]: [ws_item_sk#13, ws_bill_customer_sk#14, ws_sold_date_sk#15]
 Batched: true
 Location: InMemoryFileIndex []
@@ -133,133 +141,145 @@ PartitionFilters: [isnotnull(ws_sold_date_sk#15), dynamicpruningexpression(ws_so
 PushedFilters: [IsNotNull(ws_item_sk), IsNotNull(ws_bill_customer_sk)]
 ReadSchema: struct<ws_item_sk:int,ws_bill_customer_sk:int>
 
-(16) ColumnarToRow [codegen id : 4]
+(17) ColumnarToRow [codegen id : 5]
 Input [3]: [ws_item_sk#13, ws_bill_customer_sk#14, ws_sold_date_sk#15]
 
-(17) Filter [codegen id : 4]
+(18) Filter [codegen id : 5]
 Input [3]: [ws_item_sk#13, ws_bill_customer_sk#14, ws_sold_date_sk#15]
 Condition : (isnotnull(ws_item_sk#13) AND isnotnull(ws_bill_customer_sk#14))
 
-(18) Project [codegen id : 4]
+(19) Project [codegen id : 5]
 Output [3]: [ws_sold_date_sk#15 AS sold_date_sk#16, ws_bill_customer_sk#14 AS customer_sk#17, ws_item_sk#13 AS item_sk#18]
 Input [3]: [ws_item_sk#13, ws_bill_customer_sk#14, ws_sold_date_sk#15]
 
-(19) Union
+(20) Union
 
-(20) ReusedExchange [Reuses operator id: 64]
+(21) ReusedExchange [Reuses operator id: 68]
 Output [1]: [d_date_sk#19]
 
-(21) BroadcastHashJoin [codegen id : 7]
+(22) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [sold_date_sk#10]
 Right keys [1]: [d_date_sk#19]
 Join type: Inner
 Join condition: None
 
-(22) Project [codegen id : 7]
+(23) Project [codegen id : 8]
 Output [2]: [customer_sk#11, item_sk#12]
 Input [4]: [sold_date_sk#10, customer_sk#11, item_sk#12, d_date_sk#19]
 
-(23) Scan parquet spark_catalog.default.item
+(24) Scan parquet spark_catalog.default.item
 Output [3]: [i_item_sk#20, i_class#21, i_category#22]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_category), IsNotNull(i_class), EqualTo(i_category,Women                                             ), EqualTo(i_class,maternity                                         ), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_class:string,i_category:string>
 
-(24) ColumnarToRow [codegen id : 6]
+(25) ColumnarToRow [codegen id : 7]
 Input [3]: [i_item_sk#20, i_class#21, i_category#22]
 
-(25) Filter [codegen id : 6]
+(26) Filter [codegen id : 7]
 Input [3]: [i_item_sk#20, i_class#21, i_category#22]
 Condition : ((((isnotnull(i_category#22) AND isnotnull(i_class#21)) AND (i_category#22 = Women                                             )) AND (i_class#21 = maternity                                         )) AND isnotnull(i_item_sk#20))
 
-(26) Project [codegen id : 6]
+(27) Project [codegen id : 7]
 Output [1]: [i_item_sk#20]
 Input [3]: [i_item_sk#20, i_class#21, i_category#22]
 
-(27) BroadcastExchange
+(28) BroadcastExchange
 Input [1]: [i_item_sk#20]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
 
-(28) BroadcastHashJoin [codegen id : 7]
+(29) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [item_sk#12]
 Right keys [1]: [i_item_sk#20]
 Join type: Inner
 Join condition: None
 
-(29) Project [codegen id : 7]
+(30) Project [codegen id : 8]
 Output [1]: [customer_sk#11]
 Input [3]: [customer_sk#11, item_sk#12, i_item_sk#20]
 
-(30) Exchange
+(31) Exchange
 Input [1]: [customer_sk#11]
 Arguments: hashpartitioning(customer_sk#11, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(31) Sort [codegen id : 8]
+(32) Sort [codegen id : 9]
 Input [1]: [customer_sk#11]
 Arguments: [customer_sk#11 ASC NULLS FIRST], false, 0
 
-(32) Scan parquet spark_catalog.default.customer
+(33) Scan parquet spark_catalog.default.customer
 Output [2]: [c_customer_sk#23, c_current_addr_sk#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
 
-(33) ColumnarToRow [codegen id : 9]
+(34) ColumnarToRow [codegen id : 10]
 Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
 
-(34) Filter [codegen id : 9]
+(35) Filter [codegen id : 10]
 Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
 Condition : (isnotnull(c_customer_sk#23) AND isnotnull(c_current_addr_sk#24))
 
-(35) Exchange
+(36) Exchange
 Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
 Arguments: hashpartitioning(c_customer_sk#23, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(36) Sort [codegen id : 10]
+(37) Sort [codegen id : 11]
 Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
 Arguments: [c_customer_sk#23 ASC NULLS FIRST], false, 0
 
-(37) SortMergeJoin
+(38) SortMergeJoin [codegen id : 12]
 Left keys [1]: [customer_sk#11]
 Right keys [1]: [c_customer_sk#23]
 Join type: Inner
 Join condition: None
 
-(38) Project
+(39) Project [codegen id : 12]
 Output [2]: [c_customer_sk#23, c_current_addr_sk#24]
 Input [3]: [customer_sk#11, c_customer_sk#23, c_current_addr_sk#24]
 
-(39) HashAggregate
+(40) HashAggregate [codegen id : 12]
 Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
 Keys [2]: [c_customer_sk#23, c_current_addr_sk#24]
 Functions: []
 Aggregate Attributes: []
 Results [2]: [c_customer_sk#23, c_current_addr_sk#24]
 
-(40) HashAggregate
+(41) HashAggregate [codegen id : 12]
 Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
 Keys [2]: [c_customer_sk#23, c_current_addr_sk#24]
 Functions: []
 Aggregate Attributes: []
 Results [2]: [c_customer_sk#23, c_current_addr_sk#24]
 
-(41) BroadcastHashJoin [codegen id : 11]
+(42) Exchange
+Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
+Arguments: hashpartitioning(c_current_addr_sk#24, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(43) Sort [codegen id : 13]
+Input [2]: [c_customer_sk#23, c_current_addr_sk#24]
+Arguments: [c_current_addr_sk#24 ASC NULLS FIRST], false, 0
+
+(44) SortMergeJoin [codegen id : 14]
 Left keys [1]: [ca_address_sk#1]
 Right keys [1]: [c_current_addr_sk#24]
 Join type: Inner
 Join condition: None
 
-(42) Project [codegen id : 11]
+(45) Project [codegen id : 14]
 Output [1]: [c_customer_sk#23]
 Input [3]: [ca_address_sk#1, c_customer_sk#23, c_current_addr_sk#24]
 
-(43) Sort [codegen id : 11]
+(46) Exchange
+Input [1]: [c_customer_sk#23]
+Arguments: hashpartitioning(c_customer_sk#23, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(47) Sort [codegen id : 15]
 Input [1]: [c_customer_sk#23]
 Arguments: [c_customer_sk#23 ASC NULLS FIRST], false, 0
 
-(44) Scan parquet spark_catalog.default.store_sales
+(48) Scan parquet spark_catalog.default.store_sales
 Output [3]: [ss_customer_sk#25, ss_ext_sales_price#26, ss_sold_date_sk#27]
 Batched: true
 Location: InMemoryFileIndex []
@@ -267,234 +287,234 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#27), dynamicpruningexpression(ss_so
 PushedFilters: [IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_customer_sk:int,ss_ext_sales_price:decimal(7,2)>
 
-(45) ColumnarToRow [codegen id : 13]
+(49) ColumnarToRow [codegen id : 17]
 Input [3]: [ss_customer_sk#25, ss_ext_sales_price#26, ss_sold_date_sk#27]
 
-(46) Filter [codegen id : 13]
+(50) Filter [codegen id : 17]
 Input [3]: [ss_customer_sk#25, ss_ext_sales_price#26, ss_sold_date_sk#27]
 Condition : isnotnull(ss_customer_sk#25)
 
-(47) ReusedExchange [Reuses operator id: 69]
+(51) ReusedExchange [Reuses operator id: 73]
 Output [1]: [d_date_sk#29]
 
-(48) BroadcastHashJoin [codegen id : 13]
+(52) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ss_sold_date_sk#27]
 Right keys [1]: [d_date_sk#29]
 Join type: Inner
 Join condition: None
 
-(49) Project [codegen id : 13]
+(53) Project [codegen id : 17]
 Output [2]: [ss_customer_sk#25, ss_ext_sales_price#26]
 Input [4]: [ss_customer_sk#25, ss_ext_sales_price#26, ss_sold_date_sk#27, d_date_sk#29]
 
-(50) Exchange
+(54) Exchange
 Input [2]: [ss_customer_sk#25, ss_ext_sales_price#26]
-Arguments: hashpartitioning(ss_customer_sk#25, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Arguments: hashpartitioning(ss_customer_sk#25, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(51) Sort [codegen id : 14]
+(55) Sort [codegen id : 18]
 Input [2]: [ss_customer_sk#25, ss_ext_sales_price#26]
 Arguments: [ss_customer_sk#25 ASC NULLS FIRST], false, 0
 
-(52) SortMergeJoin [codegen id : 15]
+(56) SortMergeJoin [codegen id : 19]
 Left keys [1]: [c_customer_sk#23]
 Right keys [1]: [ss_customer_sk#25]
 Join type: Inner
 Join condition: None
 
-(53) Project [codegen id : 15]
+(57) Project [codegen id : 19]
 Output [2]: [c_customer_sk#23, ss_ext_sales_price#26]
 Input [3]: [c_customer_sk#23, ss_customer_sk#25, ss_ext_sales_price#26]
 
-(54) HashAggregate [codegen id : 15]
+(58) HashAggregate [codegen id : 19]
 Input [2]: [c_customer_sk#23, ss_ext_sales_price#26]
 Keys [1]: [c_customer_sk#23]
 Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#26))]
 Aggregate Attributes [1]: [sum#30]
 Results [2]: [c_customer_sk#23, sum#31]
 
-(55) HashAggregate [codegen id : 15]
+(59) HashAggregate [codegen id : 19]
 Input [2]: [c_customer_sk#23, sum#31]
 Keys [1]: [c_customer_sk#23]
 Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#26))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#26))#32]
 Results [1]: [cast((MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#26))#32,17,2) / 50) as int) AS segment#33]
 
-(56) HashAggregate [codegen id : 15]
+(60) HashAggregate [codegen id : 19]
 Input [1]: [segment#33]
 Keys [1]: [segment#33]
 Functions [1]: [partial_count(1)]
 Aggregate Attributes [1]: [count#34]
 Results [2]: [segment#33, count#35]
 
-(57) Exchange
+(61) Exchange
 Input [2]: [segment#33, count#35]
-Arguments: hashpartitioning(segment#33, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Arguments: hashpartitioning(segment#33, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(58) HashAggregate [codegen id : 16]
+(62) HashAggregate [codegen id : 20]
 Input [2]: [segment#33, count#35]
 Keys [1]: [segment#33]
 Functions [1]: [count(1)]
 Aggregate Attributes [1]: [count(1)#36]
 Results [3]: [segment#33, count(1)#36 AS num_customers#37, (segment#33 * 50) AS segment_base#38]
 
-(59) TakeOrderedAndProject
+(63) TakeOrderedAndProject
 Input [3]: [segment#33, num_customers#37, segment_base#38]
 Arguments: 100, [segment#33 ASC NULLS FIRST, num_customers#37 ASC NULLS FIRST], [segment#33, num_customers#37, segment_base#38]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 11 Hosting Expression = cs_sold_date_sk#8 IN dynamicpruning#9
-BroadcastExchange (64)
-+- * Project (63)
-   +- * Filter (62)
-      +- * ColumnarToRow (61)
-         +- Scan parquet spark_catalog.default.date_dim (60)
+Subquery:1 Hosting operator id = 12 Hosting Expression = cs_sold_date_sk#8 IN dynamicpruning#9
+BroadcastExchange (68)
++- * Project (67)
+   +- * Filter (66)
+      +- * ColumnarToRow (65)
+         +- Scan parquet spark_catalog.default.date_dim (64)
 
 
-(60) Scan parquet spark_catalog.default.date_dim
+(64) Scan parquet spark_catalog.default.date_dim
 Output [3]: [d_date_sk#19, d_year#39, d_moy#40]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_moy), IsNotNull(d_year), EqualTo(d_moy,12), EqualTo(d_year,1998), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(61) ColumnarToRow [codegen id : 1]
+(65) ColumnarToRow [codegen id : 1]
 Input [3]: [d_date_sk#19, d_year#39, d_moy#40]
 
-(62) Filter [codegen id : 1]
+(66) Filter [codegen id : 1]
 Input [3]: [d_date_sk#19, d_year#39, d_moy#40]
 Condition : ((((isnotnull(d_moy#40) AND isnotnull(d_year#39)) AND (d_moy#40 = 12)) AND (d_year#39 = 1998)) AND isnotnull(d_date_sk#19))
 
-(63) Project [codegen id : 1]
+(67) Project [codegen id : 1]
 Output [1]: [d_date_sk#19]
 Input [3]: [d_date_sk#19, d_year#39, d_moy#40]
 
-(64) BroadcastExchange
+(68) BroadcastExchange
 Input [1]: [d_date_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
-Subquery:2 Hosting operator id = 15 Hosting Expression = ws_sold_date_sk#15 IN dynamicpruning#9
+Subquery:2 Hosting operator id = 16 Hosting Expression = ws_sold_date_sk#15 IN dynamicpruning#9
 
-Subquery:3 Hosting operator id = 44 Hosting Expression = ss_sold_date_sk#27 IN dynamicpruning#28
-BroadcastExchange (69)
-+- * Project (68)
-   +- * Filter (67)
-      +- * ColumnarToRow (66)
-         +- Scan parquet spark_catalog.default.date_dim (65)
+Subquery:3 Hosting operator id = 48 Hosting Expression = ss_sold_date_sk#27 IN dynamicpruning#28
+BroadcastExchange (73)
++- * Project (72)
+   +- * Filter (71)
+      +- * ColumnarToRow (70)
+         +- Scan parquet spark_catalog.default.date_dim (69)
 
 
-(65) Scan parquet spark_catalog.default.date_dim
+(69) Scan parquet spark_catalog.default.date_dim
 Output [2]: [d_date_sk#29, d_month_seq#41]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,ScalarSubquery#42), LessThanOrEqual(d_month_seq,ScalarSubquery#43), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int>
 
-(66) ColumnarToRow [codegen id : 1]
+(70) ColumnarToRow [codegen id : 1]
 Input [2]: [d_date_sk#29, d_month_seq#41]
 
-(67) Filter [codegen id : 1]
+(71) Filter [codegen id : 1]
 Input [2]: [d_date_sk#29, d_month_seq#41]
 Condition : (((isnotnull(d_month_seq#41) AND (d_month_seq#41 >= ReusedSubquery Subquery scalar-subquery#42, [id=#44])) AND (d_month_seq#41 <= ReusedSubquery Subquery scalar-subquery#43, [id=#45])) AND isnotnull(d_date_sk#29))
 
-(68) Project [codegen id : 1]
+(72) Project [codegen id : 1]
 Output [1]: [d_date_sk#29]
 Input [2]: [d_date_sk#29, d_month_seq#41]
 
-(69) BroadcastExchange
+(73) BroadcastExchange
 Input [1]: [d_date_sk#29]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
-Subquery:4 Hosting operator id = 67 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#44]
+Subquery:4 Hosting operator id = 71 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#44]
 
-Subquery:5 Hosting operator id = 67 Hosting Expression = ReusedSubquery Subquery scalar-subquery#43, [id=#45]
+Subquery:5 Hosting operator id = 71 Hosting Expression = ReusedSubquery Subquery scalar-subquery#43, [id=#45]
 
-Subquery:6 Hosting operator id = 65 Hosting Expression = Subquery scalar-subquery#42, [id=#44]
-* HashAggregate (76)
-+- Exchange (75)
-   +- * HashAggregate (74)
-      +- * Project (73)
-         +- * Filter (72)
-            +- * ColumnarToRow (71)
-               +- Scan parquet spark_catalog.default.date_dim (70)
+Subquery:6 Hosting operator id = 69 Hosting Expression = Subquery scalar-subquery#42, [id=#44]
+* HashAggregate (80)
++- Exchange (79)
+   +- * HashAggregate (78)
+      +- * Project (77)
+         +- * Filter (76)
+            +- * ColumnarToRow (75)
+               +- Scan parquet spark_catalog.default.date_dim (74)
 
 
-(70) Scan parquet spark_catalog.default.date_dim
+(74) Scan parquet spark_catalog.default.date_dim
 Output [3]: [d_month_seq#46, d_year#47, d_moy#48]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,1998), EqualTo(d_moy,12)]
 ReadSchema: struct<d_month_seq:int,d_year:int,d_moy:int>
 
-(71) ColumnarToRow [codegen id : 1]
+(75) ColumnarToRow [codegen id : 1]
 Input [3]: [d_month_seq#46, d_year#47, d_moy#48]
 
-(72) Filter [codegen id : 1]
+(76) Filter [codegen id : 1]
 Input [3]: [d_month_seq#46, d_year#47, d_moy#48]
 Condition : (((isnotnull(d_year#47) AND isnotnull(d_moy#48)) AND (d_year#47 = 1998)) AND (d_moy#48 = 12))
 
-(73) Project [codegen id : 1]
+(77) Project [codegen id : 1]
 Output [1]: [(d_month_seq#46 + 1) AS (d_month_seq + 1)#49]
 Input [3]: [d_month_seq#46, d_year#47, d_moy#48]
 
-(74) HashAggregate [codegen id : 1]
+(78) HashAggregate [codegen id : 1]
 Input [1]: [(d_month_seq + 1)#49]
 Keys [1]: [(d_month_seq + 1)#49]
 Functions: []
 Aggregate Attributes: []
 Results [1]: [(d_month_seq + 1)#49]
 
-(75) Exchange
+(79) Exchange
 Input [1]: [(d_month_seq + 1)#49]
-Arguments: hashpartitioning((d_month_seq + 1)#49, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Arguments: hashpartitioning((d_month_seq + 1)#49, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(76) HashAggregate [codegen id : 2]
+(80) HashAggregate [codegen id : 2]
 Input [1]: [(d_month_seq + 1)#49]
 Keys [1]: [(d_month_seq + 1)#49]
 Functions: []
 Aggregate Attributes: []
 Results [1]: [(d_month_seq + 1)#49]
 
-Subquery:7 Hosting operator id = 65 Hosting Expression = Subquery scalar-subquery#43, [id=#45]
-* HashAggregate (83)
-+- Exchange (82)
-   +- * HashAggregate (81)
-      +- * Project (80)
-         +- * Filter (79)
-            +- * ColumnarToRow (78)
-               +- Scan parquet spark_catalog.default.date_dim (77)
+Subquery:7 Hosting operator id = 69 Hosting Expression = Subquery scalar-subquery#43, [id=#45]
+* HashAggregate (87)
++- Exchange (86)
+   +- * HashAggregate (85)
+      +- * Project (84)
+         +- * Filter (83)
+            +- * ColumnarToRow (82)
+               +- Scan parquet spark_catalog.default.date_dim (81)
 
 
-(77) Scan parquet spark_catalog.default.date_dim
+(81) Scan parquet spark_catalog.default.date_dim
 Output [3]: [d_month_seq#50, d_year#51, d_moy#52]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,1998), EqualTo(d_moy,12)]
 ReadSchema: struct<d_month_seq:int,d_year:int,d_moy:int>
 
-(78) ColumnarToRow [codegen id : 1]
+(82) ColumnarToRow [codegen id : 1]
 Input [3]: [d_month_seq#50, d_year#51, d_moy#52]
 
-(79) Filter [codegen id : 1]
+(83) Filter [codegen id : 1]
 Input [3]: [d_month_seq#50, d_year#51, d_moy#52]
 Condition : (((isnotnull(d_year#51) AND isnotnull(d_moy#52)) AND (d_year#51 = 1998)) AND (d_moy#52 = 12))
 
-(80) Project [codegen id : 1]
+(84) Project [codegen id : 1]
 Output [1]: [(d_month_seq#50 + 3) AS (d_month_seq + 3)#53]
 Input [3]: [d_month_seq#50, d_year#51, d_moy#52]
 
-(81) HashAggregate [codegen id : 1]
+(85) HashAggregate [codegen id : 1]
 Input [1]: [(d_month_seq + 3)#53]
 Keys [1]: [(d_month_seq + 3)#53]
 Functions: []
 Aggregate Attributes: []
 Results [1]: [(d_month_seq + 3)#53]
 
-(82) Exchange
+(86) Exchange
 Input [1]: [(d_month_seq + 3)#53]
-Arguments: hashpartitioning((d_month_seq + 3)#53, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Arguments: hashpartitioning((d_month_seq + 3)#53, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(83) HashAggregate [codegen id : 2]
+(87) HashAggregate [codegen id : 2]
 Input [1]: [(d_month_seq + 3)#53]
 Keys [1]: [(d_month_seq + 3)#53]
 Functions: []

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q54.sf100/simplified.txt
@@ -1,98 +1,110 @@
 TakeOrderedAndProject [segment,num_customers,segment_base]
-  WholeStageCodegen (16)
+  WholeStageCodegen (20)
     HashAggregate [segment,count] [count(1),num_customers,segment_base,count]
       InputAdapter
         Exchange [segment] #1
-          WholeStageCodegen (15)
+          WholeStageCodegen (19)
             HashAggregate [segment] [count,count]
               HashAggregate [c_customer_sk,sum] [sum(UnscaledValue(ss_ext_sales_price)),segment,sum]
                 HashAggregate [c_customer_sk,ss_ext_sales_price] [sum,sum]
                   Project [c_customer_sk,ss_ext_sales_price]
                     SortMergeJoin [c_customer_sk,ss_customer_sk]
                       InputAdapter
-                        WholeStageCodegen (11)
+                        WholeStageCodegen (15)
                           Sort [c_customer_sk]
-                            Project [c_customer_sk]
-                              BroadcastHashJoin [ca_address_sk,c_current_addr_sk]
-                                InputAdapter
-                                  BroadcastExchange #2
-                                    WholeStageCodegen (2)
-                                      Project [ca_address_sk]
-                                        BroadcastHashJoin [ca_county,ca_state,s_county,s_state]
-                                          Filter [ca_address_sk,ca_county,ca_state]
-                                            ColumnarToRow
-                                              InputAdapter
-                                                Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county,ca_state]
-                                          InputAdapter
-                                            BroadcastExchange #3
-                                              WholeStageCodegen (1)
-                                                Filter [s_county,s_state]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.store [s_county,s_state]
-                                HashAggregate [c_customer_sk,c_current_addr_sk]
-                                  HashAggregate [c_customer_sk,c_current_addr_sk]
-                                    Project [c_customer_sk,c_current_addr_sk]
-                                      SortMergeJoin [customer_sk,c_customer_sk]
-                                        InputAdapter
-                                          WholeStageCodegen (8)
-                                            Sort [customer_sk]
-                                              InputAdapter
-                                                Exchange [customer_sk] #4
-                                                  WholeStageCodegen (7)
-                                                    Project [customer_sk]
-                                                      BroadcastHashJoin [item_sk,i_item_sk]
-                                                        Project [customer_sk,item_sk]
-                                                          BroadcastHashJoin [sold_date_sk,d_date_sk]
-                                                            InputAdapter
-                                                              Union
-                                                                WholeStageCodegen (3)
-                                                                  Project [cs_sold_date_sk,cs_bill_customer_sk,cs_item_sk]
-                                                                    Filter [cs_item_sk,cs_bill_customer_sk]
-                                                                      ColumnarToRow
-                                                                        InputAdapter
-                                                                          Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_sold_date_sk]
-                                                                            SubqueryBroadcast [d_date_sk] #1
-                                                                              BroadcastExchange #5
-                                                                                WholeStageCodegen (1)
-                                                                                  Project [d_date_sk]
-                                                                                    Filter [d_moy,d_year,d_date_sk]
-                                                                                      ColumnarToRow
-                                                                                        InputAdapter
-                                                                                          Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
-                                                                WholeStageCodegen (4)
-                                                                  Project [ws_sold_date_sk,ws_bill_customer_sk,ws_item_sk]
-                                                                    Filter [ws_item_sk,ws_bill_customer_sk]
-                                                                      ColumnarToRow
-                                                                        InputAdapter
-                                                                          Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_bill_customer_sk,ws_sold_date_sk]
-                                                                            ReusedSubquery [d_date_sk] #1
-                                                            InputAdapter
-                                                              ReusedExchange [d_date_sk] #5
-                                                        InputAdapter
-                                                          BroadcastExchange #6
-                                                            WholeStageCodegen (6)
-                                                              Project [i_item_sk]
-                                                                Filter [i_category,i_class,i_item_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_class,i_category]
-                                        InputAdapter
-                                          WholeStageCodegen (10)
-                                            Sort [c_customer_sk]
-                                              InputAdapter
-                                                Exchange [c_customer_sk] #7
-                                                  WholeStageCodegen (9)
-                                                    Filter [c_customer_sk,c_current_addr_sk]
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
+                            InputAdapter
+                              Exchange [c_customer_sk] #2
+                                WholeStageCodegen (14)
+                                  Project [c_customer_sk]
+                                    SortMergeJoin [ca_address_sk,c_current_addr_sk]
+                                      InputAdapter
+                                        WholeStageCodegen (3)
+                                          Sort [ca_address_sk]
+                                            InputAdapter
+                                              Exchange [ca_address_sk] #3
+                                                WholeStageCodegen (2)
+                                                  Project [ca_address_sk]
+                                                    BroadcastHashJoin [ca_county,ca_state,s_county,s_state]
+                                                      Filter [ca_address_sk,ca_county,ca_state]
+                                                        ColumnarToRow
+                                                          InputAdapter
+                                                            Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county,ca_state]
+                                                      InputAdapter
+                                                        BroadcastExchange #4
+                                                          WholeStageCodegen (1)
+                                                            Filter [s_county,s_state]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet spark_catalog.default.store [s_county,s_state]
+                                      InputAdapter
+                                        WholeStageCodegen (13)
+                                          Sort [c_current_addr_sk]
+                                            InputAdapter
+                                              Exchange [c_current_addr_sk] #5
+                                                WholeStageCodegen (12)
+                                                  HashAggregate [c_customer_sk,c_current_addr_sk]
+                                                    HashAggregate [c_customer_sk,c_current_addr_sk]
+                                                      Project [c_customer_sk,c_current_addr_sk]
+                                                        SortMergeJoin [customer_sk,c_customer_sk]
+                                                          InputAdapter
+                                                            WholeStageCodegen (9)
+                                                              Sort [customer_sk]
+                                                                InputAdapter
+                                                                  Exchange [customer_sk] #6
+                                                                    WholeStageCodegen (8)
+                                                                      Project [customer_sk]
+                                                                        BroadcastHashJoin [item_sk,i_item_sk]
+                                                                          Project [customer_sk,item_sk]
+                                                                            BroadcastHashJoin [sold_date_sk,d_date_sk]
+                                                                              InputAdapter
+                                                                                Union
+                                                                                  WholeStageCodegen (4)
+                                                                                    Project [cs_sold_date_sk,cs_bill_customer_sk,cs_item_sk]
+                                                                                      Filter [cs_item_sk,cs_bill_customer_sk]
+                                                                                        ColumnarToRow
+                                                                                          InputAdapter
+                                                                                            Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_item_sk,cs_sold_date_sk]
+                                                                                              SubqueryBroadcast [d_date_sk] #1
+                                                                                                BroadcastExchange #7
+                                                                                                  WholeStageCodegen (1)
+                                                                                                    Project [d_date_sk]
+                                                                                                      Filter [d_moy,d_year,d_date_sk]
+                                                                                                        ColumnarToRow
+                                                                                                          InputAdapter
+                                                                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                                                                                  WholeStageCodegen (5)
+                                                                                    Project [ws_sold_date_sk,ws_bill_customer_sk,ws_item_sk]
+                                                                                      Filter [ws_item_sk,ws_bill_customer_sk]
+                                                                                        ColumnarToRow
+                                                                                          InputAdapter
+                                                                                            Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_bill_customer_sk,ws_sold_date_sk]
+                                                                                              ReusedSubquery [d_date_sk] #1
+                                                                              InputAdapter
+                                                                                ReusedExchange [d_date_sk] #7
+                                                                          InputAdapter
+                                                                            BroadcastExchange #8
+                                                                              WholeStageCodegen (7)
+                                                                                Project [i_item_sk]
+                                                                                  Filter [i_category,i_class,i_item_sk]
+                                                                                    ColumnarToRow
+                                                                                      InputAdapter
+                                                                                        Scan parquet spark_catalog.default.item [i_item_sk,i_class,i_category]
+                                                          InputAdapter
+                                                            WholeStageCodegen (11)
+                                                              Sort [c_customer_sk]
+                                                                InputAdapter
+                                                                  Exchange [c_customer_sk] #9
+                                                                    WholeStageCodegen (10)
+                                                                      Filter [c_customer_sk,c_current_addr_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
                       InputAdapter
-                        WholeStageCodegen (14)
+                        WholeStageCodegen (18)
                           Sort [ss_customer_sk]
                             InputAdapter
-                              Exchange [ss_customer_sk] #8
-                                WholeStageCodegen (13)
+                              Exchange [ss_customer_sk] #10
+                                WholeStageCodegen (17)
                                   Project [ss_customer_sk,ss_ext_sales_price]
                                     BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                       Filter [ss_customer_sk]
@@ -100,7 +112,7 @@ TakeOrderedAndProject [segment,num_customers,segment_base]
                                           InputAdapter
                                             Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_ext_sales_price,ss_sold_date_sk]
                                               SubqueryBroadcast [d_date_sk] #2
-                                                BroadcastExchange #9
+                                                BroadcastExchange #11
                                                   WholeStageCodegen (1)
                                                     Project [d_date_sk]
                                                       Filter [d_month_seq,d_date_sk]
@@ -113,7 +125,7 @@ TakeOrderedAndProject [segment,num_customers,segment_base]
                                                                 WholeStageCodegen (2)
                                                                   HashAggregate [(d_month_seq + 1)]
                                                                     InputAdapter
-                                                                      Exchange [(d_month_seq + 1)] #10
+                                                                      Exchange [(d_month_seq + 1)] #12
                                                                         WholeStageCodegen (1)
                                                                           HashAggregate [(d_month_seq + 1)]
                                                                             Project [d_month_seq]
@@ -125,7 +137,7 @@ TakeOrderedAndProject [segment,num_customers,segment_base]
                                                                 WholeStageCodegen (2)
                                                                   HashAggregate [(d_month_seq + 3)]
                                                                     InputAdapter
-                                                                      Exchange [(d_month_seq + 3)] #11
+                                                                      Exchange [(d_month_seq + 3)] #13
                                                                         WholeStageCodegen (1)
                                                                           HashAggregate [(d_month_seq + 3)]
                                                                             Project [d_month_seq]
@@ -134,4 +146,4 @@ TakeOrderedAndProject [segment,num_customers,segment_base]
                                                                                   InputAdapter
                                                                                     Scan parquet spark_catalog.default.date_dim [d_month_seq,d_year,d_moy]
                                       InputAdapter
-                                        ReusedExchange [d_date_sk] #9
+                                        ReusedExchange [d_date_sk] #11

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q55.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q55.sf100/explain.txt
@@ -1,135 +1,135 @@
 == Physical Plan ==
-TakeOrderedAndProject (17)
-+- * HashAggregate (16)
-   +- Exchange (15)
-      +- * HashAggregate (14)
-         +- * Project (13)
-            +- * BroadcastHashJoin Inner BuildRight (12)
+TakeOrderedAndProject (21)
++- * HashAggregate (20)
+   +- Exchange (19)
+      +- * HashAggregate (18)
+         +- * Project (17)
+            +- * BroadcastHashJoin Inner BuildRight (16)
                :- * Project (10)
-               :  +- * BroadcastHashJoin Inner BuildRight (9)
-               :     :- * Filter (3)
-               :     :  +- * ColumnarToRow (2)
-               :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-               :     +- BroadcastExchange (8)
-               :        +- * Project (7)
-               :           +- * Filter (6)
-               :              +- * ColumnarToRow (5)
-               :                 +- Scan parquet spark_catalog.default.item (4)
-               +- ReusedExchange (11)
+               :  +- * BroadcastHashJoin Inner BuildLeft (9)
+               :     :- BroadcastExchange (5)
+               :     :  +- * Project (4)
+               :     :     +- * Filter (3)
+               :     :        +- * ColumnarToRow (2)
+               :     :           +- Scan parquet spark_catalog.default.date_dim (1)
+               :     +- * Filter (8)
+               :        +- * ColumnarToRow (7)
+               :           +- Scan parquet spark_catalog.default.store_sales (6)
+               +- BroadcastExchange (15)
+                  +- * Project (14)
+                     +- * Filter (13)
+                        +- * ColumnarToRow (12)
+                           +- Scan parquet spark_catalog.default.item (11)
 
 
-(1) Scan parquet spark_catalog.default.store_sales
-Output [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#3), dynamicpruningexpression(ss_sold_date_sk#3 IN dynamicpruning#4)]
-PushedFilters: [IsNotNull(ss_item_sk)]
-ReadSchema: struct<ss_item_sk:int,ss_ext_sales_price:decimal(7,2)>
-
-(2) ColumnarToRow [codegen id : 3]
-Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
-
-(3) Filter [codegen id : 3]
-Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
-Condition : isnotnull(ss_item_sk#1)
-
-(4) Scan parquet spark_catalog.default.item
-Output [4]: [i_item_sk#5, i_brand_id#6, i_brand#7, i_manager_id#8]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_manager_id), EqualTo(i_manager_id,28), IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_brand:string,i_manager_id:int>
-
-(5) ColumnarToRow [codegen id : 1]
-Input [4]: [i_item_sk#5, i_brand_id#6, i_brand#7, i_manager_id#8]
-
-(6) Filter [codegen id : 1]
-Input [4]: [i_item_sk#5, i_brand_id#6, i_brand#7, i_manager_id#8]
-Condition : ((isnotnull(i_manager_id#8) AND (i_manager_id#8 = 28)) AND isnotnull(i_item_sk#5))
-
-(7) Project [codegen id : 1]
-Output [3]: [i_item_sk#5, i_brand_id#6, i_brand#7]
-Input [4]: [i_item_sk#5, i_brand_id#6, i_brand#7, i_manager_id#8]
-
-(8) BroadcastExchange
-Input [3]: [i_item_sk#5, i_brand_id#6, i_brand#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
-
-(9) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#5]
-Join type: Inner
-Join condition: None
-
-(10) Project [codegen id : 3]
-Output [4]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_brand_id#6, i_brand#7]
-Input [6]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_sk#5, i_brand_id#6, i_brand#7]
-
-(11) ReusedExchange [Reuses operator id: 22]
-Output [1]: [d_date_sk#9]
-
-(12) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_sold_date_sk#3]
-Right keys [1]: [d_date_sk#9]
-Join type: Inner
-Join condition: None
-
-(13) Project [codegen id : 3]
-Output [3]: [ss_ext_sales_price#2, i_brand_id#6, i_brand#7]
-Input [5]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_brand_id#6, i_brand#7, d_date_sk#9]
-
-(14) HashAggregate [codegen id : 3]
-Input [3]: [ss_ext_sales_price#2, i_brand_id#6, i_brand#7]
-Keys [2]: [i_brand#7, i_brand_id#6]
-Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum#10]
-Results [3]: [i_brand#7, i_brand_id#6, sum#11]
-
-(15) Exchange
-Input [3]: [i_brand#7, i_brand_id#6, sum#11]
-Arguments: hashpartitioning(i_brand#7, i_brand_id#6, 5), ENSURE_REQUIREMENTS, [plan_id=2]
-
-(16) HashAggregate [codegen id : 4]
-Input [3]: [i_brand#7, i_brand_id#6, sum#11]
-Keys [2]: [i_brand#7, i_brand_id#6]
-Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#2))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#2))#12]
-Results [3]: [i_brand_id#6 AS brand_id#13, i_brand#7 AS brand#14, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#12,17,2) AS ext_price#15]
-
-(17) TakeOrderedAndProject
-Input [3]: [brand_id#13, brand#14, ext_price#15]
-Arguments: 100, [ext_price#15 DESC NULLS LAST, brand_id#13 ASC NULLS FIRST], [brand_id#13, brand#14, ext_price#15]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#3 IN dynamicpruning#4
-BroadcastExchange (22)
-+- * Project (21)
-   +- * Filter (20)
-      +- * ColumnarToRow (19)
-         +- Scan parquet spark_catalog.default.date_dim (18)
-
-
-(18) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#9, d_year#16, d_moy#17]
+(1) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#1, d_year#2, d_moy#3]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_moy), IsNotNull(d_year), EqualTo(d_moy,11), EqualTo(d_year,1999), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(19) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#9, d_year#16, d_moy#17]
+(2) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
 
-(20) Filter [codegen id : 1]
-Input [3]: [d_date_sk#9, d_year#16, d_moy#17]
-Condition : ((((isnotnull(d_moy#17) AND isnotnull(d_year#16)) AND (d_moy#17 = 11)) AND (d_year#16 = 1999)) AND isnotnull(d_date_sk#9))
+(3) Filter [codegen id : 1]
+Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
+Condition : ((((isnotnull(d_moy#3) AND isnotnull(d_year#2)) AND (d_moy#3 = 11)) AND (d_year#2 = 1999)) AND isnotnull(d_date_sk#1))
 
-(21) Project [codegen id : 1]
-Output [1]: [d_date_sk#9]
-Input [3]: [d_date_sk#9, d_year#16, d_moy#17]
+(4) Project [codegen id : 1]
+Output [1]: [d_date_sk#1]
+Input [3]: [d_date_sk#1, d_year#2, d_moy#3]
 
-(22) BroadcastExchange
-Input [1]: [d_date_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
+(5) BroadcastExchange
+Input [1]: [d_date_sk#1]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
+
+(6) Scan parquet spark_catalog.default.store_sales
+Output [3]: [ss_item_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ss_sold_date_sk#6), dynamicpruningexpression(ss_sold_date_sk#6 IN dynamicpruning#7)]
+PushedFilters: [IsNotNull(ss_item_sk)]
+ReadSchema: struct<ss_item_sk:int,ss_ext_sales_price:decimal(7,2)>
+
+(7) ColumnarToRow
+Input [3]: [ss_item_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6]
+
+(8) Filter
+Input [3]: [ss_item_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6]
+Condition : isnotnull(ss_item_sk#4)
+
+(9) BroadcastHashJoin [codegen id : 3]
+Left keys [1]: [d_date_sk#1]
+Right keys [1]: [ss_sold_date_sk#6]
+Join type: Inner
+Join condition: None
+
+(10) Project [codegen id : 3]
+Output [2]: [ss_item_sk#4, ss_ext_sales_price#5]
+Input [4]: [d_date_sk#1, ss_item_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6]
+
+(11) Scan parquet spark_catalog.default.item
+Output [4]: [i_item_sk#8, i_brand_id#9, i_brand#10, i_manager_id#11]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [IsNotNull(i_manager_id), EqualTo(i_manager_id,28), IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_brand:string,i_manager_id:int>
+
+(12) ColumnarToRow [codegen id : 2]
+Input [4]: [i_item_sk#8, i_brand_id#9, i_brand#10, i_manager_id#11]
+
+(13) Filter [codegen id : 2]
+Input [4]: [i_item_sk#8, i_brand_id#9, i_brand#10, i_manager_id#11]
+Condition : ((isnotnull(i_manager_id#11) AND (i_manager_id#11 = 28)) AND isnotnull(i_item_sk#8))
+
+(14) Project [codegen id : 2]
+Output [3]: [i_item_sk#8, i_brand_id#9, i_brand#10]
+Input [4]: [i_item_sk#8, i_brand_id#9, i_brand#10, i_manager_id#11]
+
+(15) BroadcastExchange
+Input [3]: [i_item_sk#8, i_brand_id#9, i_brand#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
+
+(16) BroadcastHashJoin [codegen id : 3]
+Left keys [1]: [ss_item_sk#4]
+Right keys [1]: [i_item_sk#8]
+Join type: Inner
+Join condition: None
+
+(17) Project [codegen id : 3]
+Output [3]: [ss_ext_sales_price#5, i_brand_id#9, i_brand#10]
+Input [5]: [ss_item_sk#4, ss_ext_sales_price#5, i_item_sk#8, i_brand_id#9, i_brand#10]
+
+(18) HashAggregate [codegen id : 3]
+Input [3]: [ss_ext_sales_price#5, i_brand_id#9, i_brand#10]
+Keys [2]: [i_brand#10, i_brand_id#9]
+Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#5))]
+Aggregate Attributes [1]: [sum#12]
+Results [3]: [i_brand#10, i_brand_id#9, sum#13]
+
+(19) Exchange
+Input [3]: [i_brand#10, i_brand_id#9, sum#13]
+Arguments: hashpartitioning(i_brand#10, i_brand_id#9, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+
+(20) HashAggregate [codegen id : 4]
+Input [3]: [i_brand#10, i_brand_id#9, sum#13]
+Keys [2]: [i_brand#10, i_brand_id#9]
+Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#5))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#5))#14]
+Results [3]: [i_brand_id#9 AS brand_id#15, i_brand#10 AS brand#16, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#5))#14,17,2) AS ext_price#17]
+
+(21) TakeOrderedAndProject
+Input [3]: [brand_id#15, brand#16, ext_price#17]
+Arguments: 100, [ext_price#17 DESC NULLS LAST, brand_id#15 ASC NULLS FIRST], [brand_id#15, brand#16, ext_price#17]
+
+===== Subqueries =====
+
+Subquery:1 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#6 IN dynamicpruning#7
+ReusedExchange (22)
+
+
+(22) ReusedExchange [Reuses operator id: 5]
+Output [1]: [d_date_sk#1]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q55.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q55.sf100/simplified.txt
@@ -6,28 +6,28 @@ TakeOrderedAndProject [ext_price,brand_id,brand]
           WholeStageCodegen (3)
             HashAggregate [i_brand,i_brand_id,ss_ext_sales_price] [sum,sum]
               Project [ss_ext_sales_price,i_brand_id,i_brand]
-                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                  Project [ss_ext_sales_price,ss_sold_date_sk,i_brand_id,i_brand]
-                    BroadcastHashJoin [ss_item_sk,i_item_sk]
+                BroadcastHashJoin [ss_item_sk,i_item_sk]
+                  Project [ss_item_sk,ss_ext_sales_price]
+                    BroadcastHashJoin [d_date_sk,ss_sold_date_sk]
+                      InputAdapter
+                        BroadcastExchange #2
+                          WholeStageCodegen (1)
+                            Project [d_date_sk]
+                              Filter [d_moy,d_year,d_date_sk]
+                                ColumnarToRow
+                                  InputAdapter
+                                    Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
                       Filter [ss_item_sk]
                         ColumnarToRow
                           InputAdapter
                             Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_ext_sales_price,ss_sold_date_sk]
                               SubqueryBroadcast [d_date_sk] #1
-                                BroadcastExchange #2
-                                  WholeStageCodegen (1)
-                                    Project [d_date_sk]
-                                      Filter [d_moy,d_year,d_date_sk]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
-                      InputAdapter
-                        BroadcastExchange #3
-                          WholeStageCodegen (1)
-                            Project [i_item_sk,i_brand_id,i_brand]
-                              Filter [i_manager_id,i_item_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_brand,i_manager_id]
+                                ReusedExchange [d_date_sk] #2
                   InputAdapter
-                    ReusedExchange [d_date_sk] #2
+                    BroadcastExchange #3
+                      WholeStageCodegen (2)
+                        Project [i_item_sk,i_brand_id,i_brand]
+                          Filter [i_manager_id,i_item_sk]
+                            ColumnarToRow
+                              InputAdapter
+                                Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_brand,i_manager_id]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q58.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q58.sf100/explain.txt
@@ -10,16 +10,16 @@ TakeOrderedAndProject (49)
       :     :        +- * HashAggregate (13)
       :     :           +- * Project (12)
       :     :              +- * BroadcastHashJoin Inner BuildRight (11)
-      :     :                 :- * Project (6)
-      :     :                 :  +- * BroadcastHashJoin Inner BuildRight (5)
+      :     :                 :- * Project (9)
+      :     :                 :  +- * BroadcastHashJoin Inner BuildRight (8)
       :     :                 :     :- * Filter (3)
       :     :                 :     :  +- * ColumnarToRow (2)
       :     :                 :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-      :     :                 :     +- ReusedExchange (4)
-      :     :                 +- BroadcastExchange (10)
-      :     :                    +- * Filter (9)
-      :     :                       +- * ColumnarToRow (8)
-      :     :                          +- Scan parquet spark_catalog.default.item (7)
+      :     :                 :     +- BroadcastExchange (7)
+      :     :                 :        +- * Filter (6)
+      :     :                 :           +- * ColumnarToRow (5)
+      :     :                 :              +- Scan parquet spark_catalog.default.item (4)
+      :     :                 +- ReusedExchange (10)
       :     +- BroadcastExchange (30)
       :        +- * Filter (29)
       :           +- * HashAggregate (28)
@@ -65,64 +65,64 @@ Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
 Input [3]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3]
 Condition : isnotnull(ss_item_sk#1)
 
-(4) ReusedExchange [Reuses operator id: 60]
-Output [1]: [d_date_sk#5]
-
-(5) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#3]
-Right keys [1]: [d_date_sk#5]
-Join type: Inner
-Join condition: None
-
-(6) Project [codegen id : 4]
-Output [2]: [ss_item_sk#1, ss_ext_sales_price#2]
-Input [4]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3, d_date_sk#5]
-
-(7) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#6, i_item_id#7]
+(4) Scan parquet spark_catalog.default.item
+Output [2]: [i_item_sk#5, i_item_id#6]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_item_id)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string>
 
-(8) ColumnarToRow [codegen id : 3]
-Input [2]: [i_item_sk#6, i_item_id#7]
+(5) ColumnarToRow [codegen id : 1]
+Input [2]: [i_item_sk#5, i_item_id#6]
 
-(9) Filter [codegen id : 3]
-Input [2]: [i_item_sk#6, i_item_id#7]
-Condition : (isnotnull(i_item_sk#6) AND isnotnull(i_item_id#7))
+(6) Filter [codegen id : 1]
+Input [2]: [i_item_sk#5, i_item_id#6]
+Condition : (isnotnull(i_item_sk#5) AND isnotnull(i_item_id#6))
 
-(10) BroadcastExchange
-Input [2]: [i_item_sk#6, i_item_id#7]
+(7) BroadcastExchange
+Input [2]: [i_item_sk#5, i_item_id#6]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
-(11) BroadcastHashJoin [codegen id : 4]
+(8) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#6]
+Right keys [1]: [i_item_sk#5]
+Join type: Inner
+Join condition: None
+
+(9) Project [codegen id : 4]
+Output [3]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_id#6]
+Input [5]: [ss_item_sk#1, ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_sk#5, i_item_id#6]
+
+(10) ReusedExchange [Reuses operator id: 60]
+Output [1]: [d_date_sk#7]
+
+(11) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_sold_date_sk#3]
+Right keys [1]: [d_date_sk#7]
 Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 4]
-Output [2]: [ss_ext_sales_price#2, i_item_id#7]
-Input [4]: [ss_item_sk#1, ss_ext_sales_price#2, i_item_sk#6, i_item_id#7]
+Output [2]: [ss_ext_sales_price#2, i_item_id#6]
+Input [4]: [ss_ext_sales_price#2, ss_sold_date_sk#3, i_item_id#6, d_date_sk#7]
 
 (13) HashAggregate [codegen id : 4]
-Input [2]: [ss_ext_sales_price#2, i_item_id#7]
-Keys [1]: [i_item_id#7]
+Input [2]: [ss_ext_sales_price#2, i_item_id#6]
+Keys [1]: [i_item_id#6]
 Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#2))]
 Aggregate Attributes [1]: [sum#8]
-Results [2]: [i_item_id#7, sum#9]
+Results [2]: [i_item_id#6, sum#9]
 
 (14) Exchange
-Input [2]: [i_item_id#7, sum#9]
-Arguments: hashpartitioning(i_item_id#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [2]: [i_item_id#6, sum#9]
+Arguments: hashpartitioning(i_item_id#6, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (15) HashAggregate [codegen id : 15]
-Input [2]: [i_item_id#7, sum#9]
-Keys [1]: [i_item_id#7]
+Input [2]: [i_item_id#6, sum#9]
+Keys [1]: [i_item_id#6]
 Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#2))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#2))#10]
-Results [2]: [i_item_id#7 AS item_id#11, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#10,17,2) AS ss_item_rev#12]
+Results [2]: [i_item_id#6 AS item_id#11, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#10,17,2) AS ss_item_rev#12]
 
 (16) Filter [codegen id : 15]
 Input [2]: [item_id#11, ss_item_rev#12]
@@ -143,49 +143,49 @@ Input [3]: [cs_item_sk#13, cs_ext_sales_price#14, cs_sold_date_sk#15]
 Input [3]: [cs_item_sk#13, cs_ext_sales_price#14, cs_sold_date_sk#15]
 Condition : isnotnull(cs_item_sk#13)
 
-(20) ReusedExchange [Reuses operator id: 60]
-Output [1]: [d_date_sk#16]
+(20) ReusedExchange [Reuses operator id: 7]
+Output [2]: [i_item_sk#16, i_item_id#17]
 
 (21) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [cs_sold_date_sk#15]
-Right keys [1]: [d_date_sk#16]
+Left keys [1]: [cs_item_sk#13]
+Right keys [1]: [i_item_sk#16]
 Join type: Inner
 Join condition: None
 
 (22) Project [codegen id : 8]
-Output [2]: [cs_item_sk#13, cs_ext_sales_price#14]
-Input [4]: [cs_item_sk#13, cs_ext_sales_price#14, cs_sold_date_sk#15, d_date_sk#16]
+Output [3]: [cs_ext_sales_price#14, cs_sold_date_sk#15, i_item_id#17]
+Input [5]: [cs_item_sk#13, cs_ext_sales_price#14, cs_sold_date_sk#15, i_item_sk#16, i_item_id#17]
 
-(23) ReusedExchange [Reuses operator id: 10]
-Output [2]: [i_item_sk#17, i_item_id#18]
+(23) ReusedExchange [Reuses operator id: 60]
+Output [1]: [d_date_sk#18]
 
 (24) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [cs_item_sk#13]
-Right keys [1]: [i_item_sk#17]
+Left keys [1]: [cs_sold_date_sk#15]
+Right keys [1]: [d_date_sk#18]
 Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 8]
-Output [2]: [cs_ext_sales_price#14, i_item_id#18]
-Input [4]: [cs_item_sk#13, cs_ext_sales_price#14, i_item_sk#17, i_item_id#18]
+Output [2]: [cs_ext_sales_price#14, i_item_id#17]
+Input [4]: [cs_ext_sales_price#14, cs_sold_date_sk#15, i_item_id#17, d_date_sk#18]
 
 (26) HashAggregate [codegen id : 8]
-Input [2]: [cs_ext_sales_price#14, i_item_id#18]
-Keys [1]: [i_item_id#18]
+Input [2]: [cs_ext_sales_price#14, i_item_id#17]
+Keys [1]: [i_item_id#17]
 Functions [1]: [partial_sum(UnscaledValue(cs_ext_sales_price#14))]
 Aggregate Attributes [1]: [sum#19]
-Results [2]: [i_item_id#18, sum#20]
+Results [2]: [i_item_id#17, sum#20]
 
 (27) Exchange
-Input [2]: [i_item_id#18, sum#20]
-Arguments: hashpartitioning(i_item_id#18, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [2]: [i_item_id#17, sum#20]
+Arguments: hashpartitioning(i_item_id#17, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (28) HashAggregate [codegen id : 9]
-Input [2]: [i_item_id#18, sum#20]
-Keys [1]: [i_item_id#18]
+Input [2]: [i_item_id#17, sum#20]
+Keys [1]: [i_item_id#17]
 Functions [1]: [sum(UnscaledValue(cs_ext_sales_price#14))]
 Aggregate Attributes [1]: [sum(UnscaledValue(cs_ext_sales_price#14))#21]
-Results [2]: [i_item_id#18 AS item_id#22, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#14))#21,17,2) AS cs_item_rev#23]
+Results [2]: [i_item_id#17 AS item_id#22, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#14))#21,17,2) AS cs_item_rev#23]
 
 (29) Filter [codegen id : 9]
 Input [2]: [item_id#22, cs_item_rev#23]
@@ -220,49 +220,49 @@ Input [3]: [ws_item_sk#24, ws_ext_sales_price#25, ws_sold_date_sk#26]
 Input [3]: [ws_item_sk#24, ws_ext_sales_price#25, ws_sold_date_sk#26]
 Condition : isnotnull(ws_item_sk#24)
 
-(36) ReusedExchange [Reuses operator id: 60]
-Output [1]: [d_date_sk#27]
+(36) ReusedExchange [Reuses operator id: 7]
+Output [2]: [i_item_sk#27, i_item_id#28]
 
 (37) BroadcastHashJoin [codegen id : 13]
-Left keys [1]: [ws_sold_date_sk#26]
-Right keys [1]: [d_date_sk#27]
+Left keys [1]: [ws_item_sk#24]
+Right keys [1]: [i_item_sk#27]
 Join type: Inner
 Join condition: None
 
 (38) Project [codegen id : 13]
-Output [2]: [ws_item_sk#24, ws_ext_sales_price#25]
-Input [4]: [ws_item_sk#24, ws_ext_sales_price#25, ws_sold_date_sk#26, d_date_sk#27]
+Output [3]: [ws_ext_sales_price#25, ws_sold_date_sk#26, i_item_id#28]
+Input [5]: [ws_item_sk#24, ws_ext_sales_price#25, ws_sold_date_sk#26, i_item_sk#27, i_item_id#28]
 
-(39) ReusedExchange [Reuses operator id: 10]
-Output [2]: [i_item_sk#28, i_item_id#29]
+(39) ReusedExchange [Reuses operator id: 60]
+Output [1]: [d_date_sk#29]
 
 (40) BroadcastHashJoin [codegen id : 13]
-Left keys [1]: [ws_item_sk#24]
-Right keys [1]: [i_item_sk#28]
+Left keys [1]: [ws_sold_date_sk#26]
+Right keys [1]: [d_date_sk#29]
 Join type: Inner
 Join condition: None
 
 (41) Project [codegen id : 13]
-Output [2]: [ws_ext_sales_price#25, i_item_id#29]
-Input [4]: [ws_item_sk#24, ws_ext_sales_price#25, i_item_sk#28, i_item_id#29]
+Output [2]: [ws_ext_sales_price#25, i_item_id#28]
+Input [4]: [ws_ext_sales_price#25, ws_sold_date_sk#26, i_item_id#28, d_date_sk#29]
 
 (42) HashAggregate [codegen id : 13]
-Input [2]: [ws_ext_sales_price#25, i_item_id#29]
-Keys [1]: [i_item_id#29]
+Input [2]: [ws_ext_sales_price#25, i_item_id#28]
+Keys [1]: [i_item_id#28]
 Functions [1]: [partial_sum(UnscaledValue(ws_ext_sales_price#25))]
 Aggregate Attributes [1]: [sum#30]
-Results [2]: [i_item_id#29, sum#31]
+Results [2]: [i_item_id#28, sum#31]
 
 (43) Exchange
-Input [2]: [i_item_id#29, sum#31]
-Arguments: hashpartitioning(i_item_id#29, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [2]: [i_item_id#28, sum#31]
+Arguments: hashpartitioning(i_item_id#28, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (44) HashAggregate [codegen id : 14]
-Input [2]: [i_item_id#29, sum#31]
-Keys [1]: [i_item_id#29]
+Input [2]: [i_item_id#28, sum#31]
+Keys [1]: [i_item_id#28]
 Functions [1]: [sum(UnscaledValue(ws_ext_sales_price#25))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ws_ext_sales_price#25))#32]
-Results [2]: [i_item_id#29 AS item_id#33, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#25))#32,17,2) AS ws_item_rev#34]
+Results [2]: [i_item_id#28 AS item_id#33, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#25))#32,17,2) AS ws_item_rev#34]
 
 (45) Filter [codegen id : 14]
 Input [2]: [item_id#33, ws_item_rev#34]
@@ -303,18 +303,18 @@ BroadcastExchange (60)
 
 
 (50) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#5, d_date#39]
+Output [2]: [d_date_sk#7, d_date#39]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (51) ColumnarToRow [codegen id : 2]
-Input [2]: [d_date_sk#5, d_date#39]
+Input [2]: [d_date_sk#7, d_date#39]
 
 (52) Filter [codegen id : 2]
-Input [2]: [d_date_sk#5, d_date#39]
-Condition : isnotnull(d_date_sk#5)
+Input [2]: [d_date_sk#7, d_date#39]
+Condition : isnotnull(d_date_sk#7)
 
 (53) Scan parquet spark_catalog.default.date_dim
 Output [2]: [d_date#40, d_week_seq#41]
@@ -345,11 +345,11 @@ Join type: LeftSemi
 Join condition: None
 
 (59) Project [codegen id : 2]
-Output [1]: [d_date_sk#5]
-Input [2]: [d_date_sk#5, d_date#39]
+Output [1]: [d_date_sk#7]
+Input [2]: [d_date_sk#7, d_date#39]
 
 (60) BroadcastExchange
-Input [1]: [d_date_sk#5]
+Input [1]: [d_date_sk#7]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 
 Subquery:2 Hosting operator id = 55 Hosting Expression = ReusedSubquery Subquery scalar-subquery#42, [id=#43]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q58.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q58.sf100/simplified.txt
@@ -11,9 +11,9 @@ TakeOrderedAndProject [item_id,ss_item_rev,ss_dev,cs_item_rev,cs_dev,ws_item_rev
                     WholeStageCodegen (4)
                       HashAggregate [i_item_id,ss_ext_sales_price] [sum,sum]
                         Project [ss_ext_sales_price,i_item_id]
-                          BroadcastHashJoin [ss_item_sk,i_item_sk]
-                            Project [ss_item_sk,ss_ext_sales_price]
-                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                            Project [ss_ext_sales_price,ss_sold_date_sk,i_item_id]
+                              BroadcastHashJoin [ss_item_sk,i_item_sk]
                                 Filter [ss_item_sk]
                                   ColumnarToRow
                                     InputAdapter
@@ -44,14 +44,14 @@ TakeOrderedAndProject [item_id,ss_item_rev,ss_dev,cs_item_rev,cs_dev,ws_item_rev
                                                                             InputAdapter
                                                                               Scan parquet spark_catalog.default.date_dim [d_date,d_week_seq]
                                 InputAdapter
-                                  ReusedExchange [d_date_sk] #2
+                                  BroadcastExchange #4
+                                    WholeStageCodegen (1)
+                                      Filter [i_item_sk,i_item_id]
+                                        ColumnarToRow
+                                          InputAdapter
+                                            Scan parquet spark_catalog.default.item [i_item_sk,i_item_id]
                             InputAdapter
-                              BroadcastExchange #4
-                                WholeStageCodegen (3)
-                                  Filter [i_item_sk,i_item_id]
-                                    ColumnarToRow
-                                      InputAdapter
-                                        Scan parquet spark_catalog.default.item [i_item_sk,i_item_id]
+                              ReusedExchange [d_date_sk] #2
             InputAdapter
               BroadcastExchange #5
                 WholeStageCodegen (9)
@@ -62,18 +62,18 @@ TakeOrderedAndProject [item_id,ss_item_rev,ss_dev,cs_item_rev,cs_dev,ws_item_rev
                           WholeStageCodegen (8)
                             HashAggregate [i_item_id,cs_ext_sales_price] [sum,sum]
                               Project [cs_ext_sales_price,i_item_id]
-                                BroadcastHashJoin [cs_item_sk,i_item_sk]
-                                  Project [cs_item_sk,cs_ext_sales_price]
-                                    BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                  Project [cs_ext_sales_price,cs_sold_date_sk,i_item_id]
+                                    BroadcastHashJoin [cs_item_sk,i_item_sk]
                                       Filter [cs_item_sk]
                                         ColumnarToRow
                                           InputAdapter
                                             Scan parquet spark_catalog.default.catalog_sales [cs_item_sk,cs_ext_sales_price,cs_sold_date_sk]
                                               ReusedSubquery [d_date_sk] #1
                                       InputAdapter
-                                        ReusedExchange [d_date_sk] #2
+                                        ReusedExchange [i_item_sk,i_item_id] #4
                                   InputAdapter
-                                    ReusedExchange [i_item_sk,i_item_id] #4
+                                    ReusedExchange [d_date_sk] #2
         InputAdapter
           BroadcastExchange #7
             WholeStageCodegen (14)
@@ -84,15 +84,15 @@ TakeOrderedAndProject [item_id,ss_item_rev,ss_dev,cs_item_rev,cs_dev,ws_item_rev
                       WholeStageCodegen (13)
                         HashAggregate [i_item_id,ws_ext_sales_price] [sum,sum]
                           Project [ws_ext_sales_price,i_item_id]
-                            BroadcastHashJoin [ws_item_sk,i_item_sk]
-                              Project [ws_item_sk,ws_ext_sales_price]
-                                BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                            BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                              Project [ws_ext_sales_price,ws_sold_date_sk,i_item_id]
+                                BroadcastHashJoin [ws_item_sk,i_item_sk]
                                   Filter [ws_item_sk]
                                     ColumnarToRow
                                       InputAdapter
                                         Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_ext_sales_price,ws_sold_date_sk]
                                           ReusedSubquery [d_date_sk] #1
                                   InputAdapter
-                                    ReusedExchange [d_date_sk] #2
+                                    ReusedExchange [i_item_sk,i_item_id] #4
                               InputAdapter
-                                ReusedExchange [i_item_sk,i_item_id] #4
+                                ReusedExchange [d_date_sk] #2

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q59.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q59.sf100/explain.txt
@@ -1,58 +1,61 @@
 == Physical Plan ==
-TakeOrderedAndProject (54)
-+- * Project (53)
-   +- * BroadcastHashJoin Inner BuildRight (52)
-      :- * Project (25)
-      :  +- * BroadcastHashJoin Inner BuildRight (24)
-      :     :- * Project (18)
-      :     :  +- * BroadcastHashJoin Inner BuildRight (17)
-      :     :     :- * HashAggregate (12)
-      :     :     :  +- Exchange (11)
-      :     :     :     +- * HashAggregate (10)
-      :     :     :        +- * Project (9)
-      :     :     :           +- * BroadcastHashJoin Inner BuildRight (8)
-      :     :     :              :- * Filter (3)
-      :     :     :              :  +- * ColumnarToRow (2)
-      :     :     :              :     +- Scan parquet spark_catalog.default.store_sales (1)
-      :     :     :              +- BroadcastExchange (7)
-      :     :     :                 +- * Filter (6)
-      :     :     :                    +- * ColumnarToRow (5)
-      :     :     :                       +- Scan parquet spark_catalog.default.date_dim (4)
-      :     :     +- BroadcastExchange (16)
-      :     :        +- * Filter (15)
-      :     :           +- * ColumnarToRow (14)
-      :     :              +- Scan parquet spark_catalog.default.store (13)
-      :     +- BroadcastExchange (23)
-      :        +- * Project (22)
-      :           +- * Filter (21)
-      :              +- * ColumnarToRow (20)
-      :                 +- Scan parquet spark_catalog.default.date_dim (19)
-      +- BroadcastExchange (51)
-         +- * Project (50)
-            +- * BroadcastHashJoin Inner BuildRight (49)
-               :- * Project (43)
-               :  +- * BroadcastHashJoin Inner BuildRight (42)
-               :     :- * HashAggregate (37)
-               :     :  +- Exchange (36)
-               :     :     +- * HashAggregate (35)
-               :     :        +- * Project (34)
-               :     :           +- * BroadcastHashJoin Inner BuildRight (33)
-               :     :              :- * Filter (28)
-               :     :              :  +- * ColumnarToRow (27)
-               :     :              :     +- Scan parquet spark_catalog.default.store_sales (26)
-               :     :              +- BroadcastExchange (32)
-               :     :                 +- * Filter (31)
-               :     :                    +- * ColumnarToRow (30)
-               :     :                       +- Scan parquet spark_catalog.default.date_dim (29)
-               :     +- BroadcastExchange (41)
-               :        +- * Filter (40)
-               :           +- * ColumnarToRow (39)
-               :              +- Scan parquet spark_catalog.default.store (38)
-               +- BroadcastExchange (48)
-                  +- * Project (47)
-                     +- * Filter (46)
-                        +- * ColumnarToRow (45)
-                           +- Scan parquet spark_catalog.default.date_dim (44)
+TakeOrderedAndProject (57)
++- * Project (56)
+   +- * SortMergeJoin Inner (55)
+      :- * Sort (27)
+      :  +- Exchange (26)
+      :     +- * Project (25)
+      :        +- * BroadcastHashJoin Inner BuildRight (24)
+      :           :- * Project (18)
+      :           :  +- * BroadcastHashJoin Inner BuildRight (17)
+      :           :     :- * HashAggregate (12)
+      :           :     :  +- Exchange (11)
+      :           :     :     +- * HashAggregate (10)
+      :           :     :        +- * Project (9)
+      :           :     :           +- * BroadcastHashJoin Inner BuildRight (8)
+      :           :     :              :- * Filter (3)
+      :           :     :              :  +- * ColumnarToRow (2)
+      :           :     :              :     +- Scan parquet spark_catalog.default.store_sales (1)
+      :           :     :              +- BroadcastExchange (7)
+      :           :     :                 +- * Filter (6)
+      :           :     :                    +- * ColumnarToRow (5)
+      :           :     :                       +- Scan parquet spark_catalog.default.date_dim (4)
+      :           :     +- BroadcastExchange (16)
+      :           :        +- * Filter (15)
+      :           :           +- * ColumnarToRow (14)
+      :           :              +- Scan parquet spark_catalog.default.store (13)
+      :           +- BroadcastExchange (23)
+      :              +- * Project (22)
+      :                 +- * Filter (21)
+      :                    +- * ColumnarToRow (20)
+      :                       +- Scan parquet spark_catalog.default.date_dim (19)
+      +- * Sort (54)
+         +- Exchange (53)
+            +- * Project (52)
+               +- * BroadcastHashJoin Inner BuildRight (51)
+                  :- * Project (45)
+                  :  +- * BroadcastHashJoin Inner BuildRight (44)
+                  :     :- * HashAggregate (39)
+                  :     :  +- Exchange (38)
+                  :     :     +- * HashAggregate (37)
+                  :     :        +- * Project (36)
+                  :     :           +- * BroadcastHashJoin Inner BuildRight (35)
+                  :     :              :- * Filter (30)
+                  :     :              :  +- * ColumnarToRow (29)
+                  :     :              :     +- Scan parquet spark_catalog.default.store_sales (28)
+                  :     :              +- BroadcastExchange (34)
+                  :     :                 +- * Filter (33)
+                  :     :                    +- * ColumnarToRow (32)
+                  :     :                       +- Scan parquet spark_catalog.default.date_dim (31)
+                  :     +- BroadcastExchange (43)
+                  :        +- * Filter (42)
+                  :           +- * ColumnarToRow (41)
+                  :              +- Scan parquet spark_catalog.default.store (40)
+                  +- BroadcastExchange (50)
+                     +- * Project (49)
+                        +- * Filter (48)
+                           +- * ColumnarToRow (47)
+                              +- Scan parquet spark_catalog.default.date_dim (46)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -109,7 +112,7 @@ Results [9]: [d_week_seq#5, ss_store_sk#1, sum#16, sum#17, sum#18, sum#19, sum#2
 Input [9]: [d_week_seq#5, ss_store_sk#1, sum#16, sum#17, sum#18, sum#19, sum#20, sum#21, sum#22]
 Arguments: hashpartitioning(d_week_seq#5, ss_store_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(12) HashAggregate [codegen id : 10]
+(12) HashAggregate [codegen id : 5]
 Input [9]: [d_week_seq#5, ss_store_sk#1, sum#16, sum#17, sum#18, sum#19, sum#20, sum#21, sum#22]
 Keys [2]: [d_week_seq#5, ss_store_sk#1]
 Functions [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#6 = Sunday   ) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Monday   ) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Tuesday  ) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Wednesday) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Thursday ) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Friday   ) THEN ss_sales_price#2 END)), sum(UnscaledValue(CASE WHEN (d_day_name#6 = Saturday ) THEN ss_sales_price#2 END))]
@@ -134,13 +137,13 @@ Condition : (isnotnull(s_store_sk#37) AND isnotnull(s_store_id#38))
 Input [3]: [s_store_sk#37, s_store_id#38, s_store_name#39]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
 
-(17) BroadcastHashJoin [codegen id : 10]
+(17) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#1]
 Right keys [1]: [s_store_sk#37]
 Join type: Inner
 Join condition: None
 
-(18) Project [codegen id : 10]
+(18) Project [codegen id : 5]
 Output [10]: [d_week_seq#5, sun_sales#30, mon_sales#31, tue_sales#32, wed_sales#33, thu_sales#34, fri_sales#35, sat_sales#36, s_store_id#38, s_store_name#39]
 Input [12]: [d_week_seq#5, ss_store_sk#1, sun_sales#30, mon_sales#31, tue_sales#32, wed_sales#33, thu_sales#34, fri_sales#35, sat_sales#36, s_store_sk#37, s_store_id#38, s_store_name#39]
 
@@ -166,17 +169,25 @@ Input [2]: [d_month_seq#40, d_week_seq#41]
 Input [1]: [d_week_seq#41]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
-(24) BroadcastHashJoin [codegen id : 10]
+(24) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [d_week_seq#5]
 Right keys [1]: [d_week_seq#41]
 Join type: Inner
 Join condition: None
 
-(25) Project [codegen id : 10]
+(25) Project [codegen id : 5]
 Output [10]: [s_store_name#39 AS s_store_name1#42, d_week_seq#5 AS d_week_seq1#43, s_store_id#38 AS s_store_id1#44, sun_sales#30 AS sun_sales1#45, mon_sales#31 AS mon_sales1#46, tue_sales#32 AS tue_sales1#47, wed_sales#33 AS wed_sales1#48, thu_sales#34 AS thu_sales1#49, fri_sales#35 AS fri_sales1#50, sat_sales#36 AS sat_sales1#51]
 Input [11]: [d_week_seq#5, sun_sales#30, mon_sales#31, tue_sales#32, wed_sales#33, thu_sales#34, fri_sales#35, sat_sales#36, s_store_id#38, s_store_name#39, d_week_seq#41]
 
-(26) Scan parquet spark_catalog.default.store_sales
+(26) Exchange
+Input [10]: [s_store_name1#42, d_week_seq1#43, s_store_id1#44, sun_sales1#45, mon_sales1#46, tue_sales1#47, wed_sales1#48, thu_sales1#49, fri_sales1#50, sat_sales1#51]
+Arguments: hashpartitioning(s_store_id1#44, d_week_seq1#43, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(27) Sort [codegen id : 6]
+Input [10]: [s_store_name1#42, d_week_seq1#43, s_store_id1#44, sun_sales1#45, mon_sales1#46, tue_sales1#47, wed_sales1#48, thu_sales1#49, fri_sales1#50, sat_sales1#51]
+Arguments: [s_store_id1#44 ASC NULLS FIRST, d_week_seq1#43 ASC NULLS FIRST], false, 0
+
+(28) Scan parquet spark_catalog.default.store_sales
 Output [3]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54]
 Batched: true
 Location: InMemoryFileIndex []
@@ -184,225 +195,229 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#54)]
 PushedFilters: [IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_store_sk:int,ss_sales_price:decimal(7,2)>
 
-(27) ColumnarToRow [codegen id : 6]
+(29) ColumnarToRow [codegen id : 8]
 Input [3]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54]
 
-(28) Filter [codegen id : 6]
+(30) Filter [codegen id : 8]
 Input [3]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54]
 Condition : isnotnull(ss_store_sk#52)
 
-(29) Scan parquet spark_catalog.default.date_dim
+(31) Scan parquet spark_catalog.default.date_dim
 Output [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date_sk), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int,d_day_name:string>
 
-(30) ColumnarToRow [codegen id : 5]
+(32) ColumnarToRow [codegen id : 7]
 Input [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
 
-(31) Filter [codegen id : 5]
+(33) Filter [codegen id : 7]
 Input [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
 Condition : ((isnotnull(d_date_sk#55) AND isnotnull(d_week_seq#56)) AND might_contain(Subquery scalar-subquery#58, [id=#59], xxhash64(d_week_seq#56, 42)))
 
-(32) BroadcastExchange
+(34) BroadcastExchange
 Input [3]: [d_date_sk#55, d_week_seq#56, d_day_name#57]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=6]
 
-(33) BroadcastHashJoin [codegen id : 6]
+(35) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [ss_sold_date_sk#54]
 Right keys [1]: [d_date_sk#55]
 Join type: Inner
 Join condition: None
 
-(34) Project [codegen id : 6]
+(36) Project [codegen id : 8]
 Output [4]: [ss_store_sk#52, ss_sales_price#53, d_week_seq#56, d_day_name#57]
 Input [6]: [ss_store_sk#52, ss_sales_price#53, ss_sold_date_sk#54, d_date_sk#55, d_week_seq#56, d_day_name#57]
 
-(35) HashAggregate [codegen id : 6]
+(37) HashAggregate [codegen id : 8]
 Input [4]: [ss_store_sk#52, ss_sales_price#53, d_week_seq#56, d_day_name#57]
 Keys [2]: [d_week_seq#56, ss_store_sk#52]
 Functions [7]: [partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Tuesday  ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END)), partial_sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))]
 Aggregate Attributes [7]: [sum#60, sum#61, sum#62, sum#63, sum#64, sum#65, sum#66]
 Results [9]: [d_week_seq#56, ss_store_sk#52, sum#67, sum#68, sum#69, sum#70, sum#71, sum#72, sum#73]
 
-(36) Exchange
+(38) Exchange
 Input [9]: [d_week_seq#56, ss_store_sk#52, sum#67, sum#68, sum#69, sum#70, sum#71, sum#72, sum#73]
-Arguments: hashpartitioning(d_week_seq#56, ss_store_sk#52, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Arguments: hashpartitioning(d_week_seq#56, ss_store_sk#52, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(37) HashAggregate [codegen id : 9]
+(39) HashAggregate [codegen id : 11]
 Input [9]: [d_week_seq#56, ss_store_sk#52, sum#67, sum#68, sum#69, sum#70, sum#71, sum#72, sum#73]
 Keys [2]: [d_week_seq#56, ss_store_sk#52]
 Functions [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Tuesday  ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END)), sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))]
 Aggregate Attributes [7]: [sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END))#23, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END))#24, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Tuesday  ) THEN ss_sales_price#53 END))#25, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END))#26, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END))#27, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END))#28, sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))#29]
 Results [9]: [d_week_seq#56, ss_store_sk#52, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Sunday   ) THEN ss_sales_price#53 END))#23,17,2) AS sun_sales#74, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Monday   ) THEN ss_sales_price#53 END))#24,17,2) AS mon_sales#75, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Tuesday  ) THEN ss_sales_price#53 END))#25,17,2) AS tue_sales#76, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Wednesday) THEN ss_sales_price#53 END))#26,17,2) AS wed_sales#77, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Thursday ) THEN ss_sales_price#53 END))#27,17,2) AS thu_sales#78, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Friday   ) THEN ss_sales_price#53 END))#28,17,2) AS fri_sales#79, MakeDecimal(sum(UnscaledValue(CASE WHEN (d_day_name#57 = Saturday ) THEN ss_sales_price#53 END))#29,17,2) AS sat_sales#80]
 
-(38) Scan parquet spark_catalog.default.store
+(40) Scan parquet spark_catalog.default.store
 Output [2]: [s_store_sk#81, s_store_id#82]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_store_id)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string>
 
-(39) ColumnarToRow [codegen id : 7]
+(41) ColumnarToRow [codegen id : 9]
 Input [2]: [s_store_sk#81, s_store_id#82]
 
-(40) Filter [codegen id : 7]
+(42) Filter [codegen id : 9]
 Input [2]: [s_store_sk#81, s_store_id#82]
 Condition : (isnotnull(s_store_sk#81) AND isnotnull(s_store_id#82))
 
-(41) BroadcastExchange
+(43) BroadcastExchange
 Input [2]: [s_store_sk#81, s_store_id#82]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=8]
 
-(42) BroadcastHashJoin [codegen id : 9]
+(44) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_store_sk#52]
 Right keys [1]: [s_store_sk#81]
 Join type: Inner
 Join condition: None
 
-(43) Project [codegen id : 9]
+(45) Project [codegen id : 11]
 Output [9]: [d_week_seq#56, sun_sales#74, mon_sales#75, tue_sales#76, wed_sales#77, thu_sales#78, fri_sales#79, sat_sales#80, s_store_id#82]
 Input [11]: [d_week_seq#56, ss_store_sk#52, sun_sales#74, mon_sales#75, tue_sales#76, wed_sales#77, thu_sales#78, fri_sales#79, sat_sales#80, s_store_sk#81, s_store_id#82]
 
-(44) Scan parquet spark_catalog.default.date_dim
+(46) Scan parquet spark_catalog.default.date_dim
 Output [2]: [d_month_seq#83, d_week_seq#84]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1224), LessThanOrEqual(d_month_seq,1235), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_month_seq:int,d_week_seq:int>
 
-(45) ColumnarToRow [codegen id : 8]
+(47) ColumnarToRow [codegen id : 10]
 Input [2]: [d_month_seq#83, d_week_seq#84]
 
-(46) Filter [codegen id : 8]
+(48) Filter [codegen id : 10]
 Input [2]: [d_month_seq#83, d_week_seq#84]
 Condition : (((isnotnull(d_month_seq#83) AND (d_month_seq#83 >= 1224)) AND (d_month_seq#83 <= 1235)) AND isnotnull(d_week_seq#84))
 
-(47) Project [codegen id : 8]
+(49) Project [codegen id : 10]
 Output [1]: [d_week_seq#84]
 Input [2]: [d_month_seq#83, d_week_seq#84]
 
-(48) BroadcastExchange
+(50) BroadcastExchange
 Input [1]: [d_week_seq#84]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
-(49) BroadcastHashJoin [codegen id : 9]
+(51) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [d_week_seq#56]
 Right keys [1]: [d_week_seq#84]
 Join type: Inner
 Join condition: None
 
-(50) Project [codegen id : 9]
+(52) Project [codegen id : 11]
 Output [9]: [d_week_seq#56 AS d_week_seq2#85, s_store_id#82 AS s_store_id2#86, sun_sales#74 AS sun_sales2#87, mon_sales#75 AS mon_sales2#88, tue_sales#76 AS tue_sales2#89, wed_sales#77 AS wed_sales2#90, thu_sales#78 AS thu_sales2#91, fri_sales#79 AS fri_sales2#92, sat_sales#80 AS sat_sales2#93]
 Input [10]: [d_week_seq#56, sun_sales#74, mon_sales#75, tue_sales#76, wed_sales#77, thu_sales#78, fri_sales#79, sat_sales#80, s_store_id#82, d_week_seq#84]
 
-(51) BroadcastExchange
+(53) Exchange
 Input [9]: [d_week_seq2#85, s_store_id2#86, sun_sales2#87, mon_sales2#88, tue_sales2#89, wed_sales2#90, thu_sales2#91, fri_sales2#92, sat_sales2#93]
-Arguments: HashedRelationBroadcastMode(List(input[1, string, true], (input[0, int, true] - 52)),false), [plan_id=9]
+Arguments: hashpartitioning(s_store_id2#86, (d_week_seq2#85 - 52), 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(52) BroadcastHashJoin [codegen id : 10]
+(54) Sort [codegen id : 12]
+Input [9]: [d_week_seq2#85, s_store_id2#86, sun_sales2#87, mon_sales2#88, tue_sales2#89, wed_sales2#90, thu_sales2#91, fri_sales2#92, sat_sales2#93]
+Arguments: [s_store_id2#86 ASC NULLS FIRST, (d_week_seq2#85 - 52) ASC NULLS FIRST], false, 0
+
+(55) SortMergeJoin [codegen id : 13]
 Left keys [2]: [s_store_id1#44, d_week_seq1#43]
 Right keys [2]: [s_store_id2#86, (d_week_seq2#85 - 52)]
 Join type: Inner
 Join condition: None
 
-(53) Project [codegen id : 10]
+(56) Project [codegen id : 13]
 Output [10]: [s_store_name1#42, s_store_id1#44, d_week_seq1#43, (sun_sales1#45 / sun_sales2#87) AS (sun_sales1 / sun_sales2)#94, (mon_sales1#46 / mon_sales2#88) AS (mon_sales1 / mon_sales2)#95, (tue_sales1#47 / tue_sales2#89) AS (tue_sales1 / tue_sales2)#96, (wed_sales1#48 / wed_sales2#90) AS (wed_sales1 / wed_sales2)#97, (thu_sales1#49 / thu_sales2#91) AS (thu_sales1 / thu_sales2)#98, (fri_sales1#50 / fri_sales2#92) AS (fri_sales1 / fri_sales2)#99, (sat_sales1#51 / sat_sales2#93) AS (sat_sales1 / sat_sales2)#100]
 Input [19]: [s_store_name1#42, d_week_seq1#43, s_store_id1#44, sun_sales1#45, mon_sales1#46, tue_sales1#47, wed_sales1#48, thu_sales1#49, fri_sales1#50, sat_sales1#51, d_week_seq2#85, s_store_id2#86, sun_sales2#87, mon_sales2#88, tue_sales2#89, wed_sales2#90, thu_sales2#91, fri_sales2#92, sat_sales2#93]
 
-(54) TakeOrderedAndProject
+(57) TakeOrderedAndProject
 Input [10]: [s_store_name1#42, s_store_id1#44, d_week_seq1#43, (sun_sales1 / sun_sales2)#94, (mon_sales1 / mon_sales2)#95, (tue_sales1 / tue_sales2)#96, (wed_sales1 / wed_sales2)#97, (thu_sales1 / thu_sales2)#98, (fri_sales1 / fri_sales2)#99, (sat_sales1 / sat_sales2)#100]
 Arguments: 100, [s_store_name1#42 ASC NULLS FIRST, s_store_id1#44 ASC NULLS FIRST, d_week_seq1#43 ASC NULLS FIRST], [s_store_name1#42, s_store_id1#44, d_week_seq1#43, (sun_sales1 / sun_sales2)#94, (mon_sales1 / mon_sales2)#95, (tue_sales1 / tue_sales2)#96, (wed_sales1 / wed_sales2)#97, (thu_sales1 / thu_sales2)#98, (fri_sales1 / fri_sales2)#99, (sat_sales1 / sat_sales2)#100]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 6 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
-ObjectHashAggregate (61)
-+- Exchange (60)
-   +- ObjectHashAggregate (59)
-      +- * Project (58)
-         +- * Filter (57)
-            +- * ColumnarToRow (56)
-               +- Scan parquet spark_catalog.default.date_dim (55)
+ObjectHashAggregate (64)
++- Exchange (63)
+   +- ObjectHashAggregate (62)
+      +- * Project (61)
+         +- * Filter (60)
+            +- * ColumnarToRow (59)
+               +- Scan parquet spark_catalog.default.date_dim (58)
 
 
-(55) Scan parquet spark_catalog.default.date_dim
+(58) Scan parquet spark_catalog.default.date_dim
 Output [2]: [d_month_seq#40, d_week_seq#41]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1212), LessThanOrEqual(d_month_seq,1223), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_month_seq:int,d_week_seq:int>
 
-(56) ColumnarToRow [codegen id : 1]
+(59) ColumnarToRow [codegen id : 1]
 Input [2]: [d_month_seq#40, d_week_seq#41]
 
-(57) Filter [codegen id : 1]
+(60) Filter [codegen id : 1]
 Input [2]: [d_month_seq#40, d_week_seq#41]
 Condition : (((isnotnull(d_month_seq#40) AND (d_month_seq#40 >= 1212)) AND (d_month_seq#40 <= 1223)) AND isnotnull(d_week_seq#41))
 
-(58) Project [codegen id : 1]
+(61) Project [codegen id : 1]
 Output [1]: [d_week_seq#41]
 Input [2]: [d_month_seq#40, d_week_seq#41]
 
-(59) ObjectHashAggregate
+(62) ObjectHashAggregate
 Input [1]: [d_week_seq#41]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)]
 Aggregate Attributes [1]: [buf#101]
 Results [1]: [buf#102]
 
-(60) Exchange
+(63) Exchange
 Input [1]: [buf#102]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=10]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
 
-(61) ObjectHashAggregate
+(64) ObjectHashAggregate
 Input [1]: [buf#102]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)]
 Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)#103]
 Results [1]: [bloom_filter_agg(xxhash64(d_week_seq#41, 42), 335, 8990, 0, 0)#103 AS bloomFilter#104]
 
-Subquery:2 Hosting operator id = 31 Hosting Expression = Subquery scalar-subquery#58, [id=#59]
-ObjectHashAggregate (68)
-+- Exchange (67)
-   +- ObjectHashAggregate (66)
-      +- * Project (65)
-         +- * Filter (64)
-            +- * ColumnarToRow (63)
-               +- Scan parquet spark_catalog.default.date_dim (62)
+Subquery:2 Hosting operator id = 33 Hosting Expression = Subquery scalar-subquery#58, [id=#59]
+ObjectHashAggregate (71)
++- Exchange (70)
+   +- ObjectHashAggregate (69)
+      +- * Project (68)
+         +- * Filter (67)
+            +- * ColumnarToRow (66)
+               +- Scan parquet spark_catalog.default.date_dim (65)
 
 
-(62) Scan parquet spark_catalog.default.date_dim
+(65) Scan parquet spark_catalog.default.date_dim
 Output [2]: [d_month_seq#83, d_week_seq#84]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), GreaterThanOrEqual(d_month_seq,1224), LessThanOrEqual(d_month_seq,1235), IsNotNull(d_week_seq)]
 ReadSchema: struct<d_month_seq:int,d_week_seq:int>
 
-(63) ColumnarToRow [codegen id : 1]
+(66) ColumnarToRow [codegen id : 1]
 Input [2]: [d_month_seq#83, d_week_seq#84]
 
-(64) Filter [codegen id : 1]
+(67) Filter [codegen id : 1]
 Input [2]: [d_month_seq#83, d_week_seq#84]
 Condition : (((isnotnull(d_month_seq#83) AND (d_month_seq#83 >= 1224)) AND (d_month_seq#83 <= 1235)) AND isnotnull(d_week_seq#84))
 
-(65) Project [codegen id : 1]
+(68) Project [codegen id : 1]
 Output [1]: [d_week_seq#84]
 Input [2]: [d_month_seq#83, d_week_seq#84]
 
-(66) ObjectHashAggregate
+(69) ObjectHashAggregate
 Input [1]: [d_week_seq#84]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(d_week_seq#84, 42), 335, 8990, 0, 0)]
 Aggregate Attributes [1]: [buf#105]
 Results [1]: [buf#106]
 
-(67) Exchange
+(70) Exchange
 Input [1]: [buf#106]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
 
-(68) ObjectHashAggregate
+(71) ObjectHashAggregate
 Input [1]: [buf#106]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(d_week_seq#84, 42), 335, 8990, 0, 0)]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q59.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q59.sf100/simplified.txt
@@ -1,101 +1,110 @@
 TakeOrderedAndProject [s_store_name1,s_store_id1,d_week_seq1,(sun_sales1 / sun_sales2),(mon_sales1 / mon_sales2),(tue_sales1 / tue_sales2),(wed_sales1 / wed_sales2),(thu_sales1 / thu_sales2),(fri_sales1 / fri_sales2),(sat_sales1 / sat_sales2)]
-  WholeStageCodegen (10)
+  WholeStageCodegen (13)
     Project [s_store_name1,s_store_id1,d_week_seq1,sun_sales1,sun_sales2,mon_sales1,mon_sales2,tue_sales1,tue_sales2,wed_sales1,wed_sales2,thu_sales1,thu_sales2,fri_sales1,fri_sales2,sat_sales1,sat_sales2]
-      BroadcastHashJoin [s_store_id1,d_week_seq1,s_store_id2,d_week_seq2]
-        Project [s_store_name,d_week_seq,s_store_id,sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales]
-          BroadcastHashJoin [d_week_seq,d_week_seq]
-            Project [d_week_seq,sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales,s_store_id,s_store_name]
-              BroadcastHashJoin [ss_store_sk,s_store_sk]
-                HashAggregate [d_week_seq,ss_store_sk,sum,sum,sum,sum,sum,sum,sum] [sum(UnscaledValue(CASE WHEN (d_day_name = Sunday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Monday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Tuesday  ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Wednesday) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Thursday ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Friday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Saturday ) THEN ss_sales_price END)),sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales,sum,sum,sum,sum,sum,sum,sum]
-                  InputAdapter
-                    Exchange [d_week_seq,ss_store_sk] #1
-                      WholeStageCodegen (2)
-                        HashAggregate [d_week_seq,ss_store_sk,d_day_name,ss_sales_price] [sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum]
-                          Project [ss_store_sk,ss_sales_price,d_week_seq,d_day_name]
-                            BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                              Filter [ss_store_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_sales_price,ss_sold_date_sk]
-                              InputAdapter
-                                BroadcastExchange #2
-                                  WholeStageCodegen (1)
-                                    Filter [d_date_sk,d_week_seq]
-                                      Subquery #1
-                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_week_seq, 42), 335, 8990, 0, 0),bloomFilter,buf]
-                                          Exchange #3
-                                            ObjectHashAggregate [d_week_seq] [buf,buf]
-                                              WholeStageCodegen (1)
-                                                Project [d_week_seq]
-                                                  Filter [d_month_seq,d_week_seq]
-                                                    ColumnarToRow
-                                                      InputAdapter
-                                                        Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
-                                      ColumnarToRow
-                                        InputAdapter
-                                          Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq,d_day_name]
-                InputAdapter
-                  BroadcastExchange #4
-                    WholeStageCodegen (3)
-                      Filter [s_store_sk,s_store_id]
-                        ColumnarToRow
-                          InputAdapter
-                            Scan parquet spark_catalog.default.store [s_store_sk,s_store_id,s_store_name]
-            InputAdapter
-              BroadcastExchange #5
-                WholeStageCodegen (4)
-                  Project [d_week_seq]
-                    Filter [d_month_seq,d_week_seq]
-                      ColumnarToRow
-                        InputAdapter
-                          Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
+      SortMergeJoin [s_store_id1,d_week_seq1,s_store_id2,d_week_seq2]
         InputAdapter
-          BroadcastExchange #6
-            WholeStageCodegen (9)
-              Project [d_week_seq,s_store_id,sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales]
-                BroadcastHashJoin [d_week_seq,d_week_seq]
-                  Project [d_week_seq,sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales,s_store_id]
-                    BroadcastHashJoin [ss_store_sk,s_store_sk]
-                      HashAggregate [d_week_seq,ss_store_sk,sum,sum,sum,sum,sum,sum,sum] [sum(UnscaledValue(CASE WHEN (d_day_name = Sunday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Monday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Tuesday  ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Wednesday) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Thursday ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Friday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Saturday ) THEN ss_sales_price END)),sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales,sum,sum,sum,sum,sum,sum,sum]
-                        InputAdapter
-                          Exchange [d_week_seq,ss_store_sk] #7
-                            WholeStageCodegen (6)
-                              HashAggregate [d_week_seq,ss_store_sk,d_day_name,ss_sales_price] [sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum]
-                                Project [ss_store_sk,ss_sales_price,d_week_seq,d_day_name]
-                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                    Filter [ss_store_sk]
-                                      ColumnarToRow
-                                        InputAdapter
-                                          Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_sales_price,ss_sold_date_sk]
-                                    InputAdapter
-                                      BroadcastExchange #8
-                                        WholeStageCodegen (5)
-                                          Filter [d_date_sk,d_week_seq]
-                                            Subquery #2
-                                              ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_week_seq, 42), 335, 8990, 0, 0),bloomFilter,buf]
-                                                Exchange #9
-                                                  ObjectHashAggregate [d_week_seq] [buf,buf]
-                                                    WholeStageCodegen (1)
-                                                      Project [d_week_seq]
-                                                        Filter [d_month_seq,d_week_seq]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
+          WholeStageCodegen (6)
+            Sort [s_store_id1,d_week_seq1]
+              InputAdapter
+                Exchange [s_store_id1,d_week_seq1] #1
+                  WholeStageCodegen (5)
+                    Project [s_store_name,d_week_seq,s_store_id,sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales]
+                      BroadcastHashJoin [d_week_seq,d_week_seq]
+                        Project [d_week_seq,sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales,s_store_id,s_store_name]
+                          BroadcastHashJoin [ss_store_sk,s_store_sk]
+                            HashAggregate [d_week_seq,ss_store_sk,sum,sum,sum,sum,sum,sum,sum] [sum(UnscaledValue(CASE WHEN (d_day_name = Sunday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Monday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Tuesday  ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Wednesday) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Thursday ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Friday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Saturday ) THEN ss_sales_price END)),sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales,sum,sum,sum,sum,sum,sum,sum]
+                              InputAdapter
+                                Exchange [d_week_seq,ss_store_sk] #2
+                                  WholeStageCodegen (2)
+                                    HashAggregate [d_week_seq,ss_store_sk,d_day_name,ss_sales_price] [sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum]
+                                      Project [ss_store_sk,ss_sales_price,d_week_seq,d_day_name]
+                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                          Filter [ss_store_sk]
                                             ColumnarToRow
                                               InputAdapter
-                                                Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq,d_day_name]
-                      InputAdapter
-                        BroadcastExchange #10
-                          WholeStageCodegen (7)
-                            Filter [s_store_sk,s_store_id]
-                              ColumnarToRow
-                                InputAdapter
-                                  Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
-                  InputAdapter
-                    BroadcastExchange #11
-                      WholeStageCodegen (8)
-                        Project [d_week_seq]
-                          Filter [d_month_seq,d_week_seq]
-                            ColumnarToRow
+                                                Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_sales_price,ss_sold_date_sk]
+                                          InputAdapter
+                                            BroadcastExchange #3
+                                              WholeStageCodegen (1)
+                                                Filter [d_date_sk,d_week_seq]
+                                                  Subquery #1
+                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_week_seq, 42), 335, 8990, 0, 0),bloomFilter,buf]
+                                                      Exchange #4
+                                                        ObjectHashAggregate [d_week_seq] [buf,buf]
+                                                          WholeStageCodegen (1)
+                                                            Project [d_week_seq]
+                                                              Filter [d_month_seq,d_week_seq]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
+                                                  ColumnarToRow
+                                                    InputAdapter
+                                                      Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq,d_day_name]
+                            InputAdapter
+                              BroadcastExchange #5
+                                WholeStageCodegen (3)
+                                  Filter [s_store_sk,s_store_id]
+                                    ColumnarToRow
+                                      InputAdapter
+                                        Scan parquet spark_catalog.default.store [s_store_sk,s_store_id,s_store_name]
+                        InputAdapter
+                          BroadcastExchange #6
+                            WholeStageCodegen (4)
+                              Project [d_week_seq]
+                                Filter [d_month_seq,d_week_seq]
+                                  ColumnarToRow
+                                    InputAdapter
+                                      Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
+        InputAdapter
+          WholeStageCodegen (12)
+            Sort [s_store_id2,d_week_seq2]
+              InputAdapter
+                Exchange [s_store_id2,d_week_seq2] #7
+                  WholeStageCodegen (11)
+                    Project [d_week_seq,s_store_id,sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales]
+                      BroadcastHashJoin [d_week_seq,d_week_seq]
+                        Project [d_week_seq,sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales,s_store_id]
+                          BroadcastHashJoin [ss_store_sk,s_store_sk]
+                            HashAggregate [d_week_seq,ss_store_sk,sum,sum,sum,sum,sum,sum,sum] [sum(UnscaledValue(CASE WHEN (d_day_name = Sunday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Monday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Tuesday  ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Wednesday) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Thursday ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Friday   ) THEN ss_sales_price END)),sum(UnscaledValue(CASE WHEN (d_day_name = Saturday ) THEN ss_sales_price END)),sun_sales,mon_sales,tue_sales,wed_sales,thu_sales,fri_sales,sat_sales,sum,sum,sum,sum,sum,sum,sum]
                               InputAdapter
-                                Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
+                                Exchange [d_week_seq,ss_store_sk] #8
+                                  WholeStageCodegen (8)
+                                    HashAggregate [d_week_seq,ss_store_sk,d_day_name,ss_sales_price] [sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum,sum]
+                                      Project [ss_store_sk,ss_sales_price,d_week_seq,d_day_name]
+                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                          Filter [ss_store_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet spark_catalog.default.store_sales [ss_store_sk,ss_sales_price,ss_sold_date_sk]
+                                          InputAdapter
+                                            BroadcastExchange #9
+                                              WholeStageCodegen (7)
+                                                Filter [d_date_sk,d_week_seq]
+                                                  Subquery #2
+                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_week_seq, 42), 335, 8990, 0, 0),bloomFilter,buf]
+                                                      Exchange #10
+                                                        ObjectHashAggregate [d_week_seq] [buf,buf]
+                                                          WholeStageCodegen (1)
+                                                            Project [d_week_seq]
+                                                              Filter [d_month_seq,d_week_seq]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]
+                                                  ColumnarToRow
+                                                    InputAdapter
+                                                      Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq,d_day_name]
+                            InputAdapter
+                              BroadcastExchange #11
+                                WholeStageCodegen (9)
+                                  Filter [s_store_sk,s_store_id]
+                                    ColumnarToRow
+                                      InputAdapter
+                                        Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
+                        InputAdapter
+                          BroadcastExchange #12
+                            WholeStageCodegen (10)
+                              Project [d_week_seq]
+                                Filter [d_month_seq,d_week_seq]
+                                  ColumnarToRow
+                                    InputAdapter
+                                      Scan parquet spark_catalog.default.date_dim [d_month_seq,d_week_seq]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q6.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q6.sf100/explain.txt
@@ -5,45 +5,45 @@ TakeOrderedAndProject (45)
       +- Exchange (42)
          +- * HashAggregate (41)
             +- * Project (40)
-               +- * SortMergeJoin Inner (39)
-                  :- * Sort (24)
-                  :  +- Exchange (23)
-                  :     +- * Project (22)
-                  :        +- * BroadcastHashJoin Inner BuildRight (21)
-                  :           :- * Project (19)
-                  :           :  +- * BroadcastHashJoin Inner BuildLeft (18)
-                  :           :     :- BroadcastExchange (14)
-                  :           :     :  +- * Project (13)
-                  :           :     :     +- * BroadcastHashJoin Inner BuildRight (12)
-                  :           :     :        :- * Filter (3)
-                  :           :     :        :  +- * ColumnarToRow (2)
-                  :           :     :        :     +- Scan parquet spark_catalog.default.item (1)
-                  :           :     :        +- BroadcastExchange (11)
-                  :           :     :           +- * Filter (10)
-                  :           :     :              +- * HashAggregate (9)
-                  :           :     :                 +- Exchange (8)
-                  :           :     :                    +- * HashAggregate (7)
-                  :           :     :                       +- * Filter (6)
-                  :           :     :                          +- * ColumnarToRow (5)
-                  :           :     :                             +- Scan parquet spark_catalog.default.item (4)
-                  :           :     +- * Filter (17)
-                  :           :        +- * ColumnarToRow (16)
-                  :           :           +- Scan parquet spark_catalog.default.store_sales (15)
-                  :           +- ReusedExchange (20)
-                  +- * Sort (38)
-                     +- Exchange (37)
-                        +- * Project (36)
-                           +- * SortMergeJoin Inner (35)
-                              :- * Sort (29)
-                              :  +- Exchange (28)
-                              :     +- * Filter (27)
-                              :        +- * ColumnarToRow (26)
-                              :           +- Scan parquet spark_catalog.default.customer_address (25)
-                              +- * Sort (34)
-                                 +- Exchange (33)
-                                    +- * Filter (32)
-                                       +- * ColumnarToRow (31)
-                                          +- Scan parquet spark_catalog.default.customer (30)
+               +- * BroadcastHashJoin Inner BuildRight (39)
+                  :- * Project (37)
+                  :  +- * SortMergeJoin Inner (36)
+                  :     :- * Sort (21)
+                  :     :  +- Exchange (20)
+                  :     :     +- * Project (19)
+                  :     :        +- * BroadcastHashJoin Inner BuildLeft (18)
+                  :     :           :- BroadcastExchange (14)
+                  :     :           :  +- * Project (13)
+                  :     :           :     +- * BroadcastHashJoin Inner BuildRight (12)
+                  :     :           :        :- * Filter (3)
+                  :     :           :        :  +- * ColumnarToRow (2)
+                  :     :           :        :     +- Scan parquet spark_catalog.default.item (1)
+                  :     :           :        +- BroadcastExchange (11)
+                  :     :           :           +- * Filter (10)
+                  :     :           :              +- * HashAggregate (9)
+                  :     :           :                 +- Exchange (8)
+                  :     :           :                    +- * HashAggregate (7)
+                  :     :           :                       +- * Filter (6)
+                  :     :           :                          +- * ColumnarToRow (5)
+                  :     :           :                             +- Scan parquet spark_catalog.default.item (4)
+                  :     :           +- * Filter (17)
+                  :     :              +- * ColumnarToRow (16)
+                  :     :                 +- Scan parquet spark_catalog.default.store_sales (15)
+                  :     +- * Sort (35)
+                  :        +- Exchange (34)
+                  :           +- * Project (33)
+                  :              +- * SortMergeJoin Inner (32)
+                  :                 :- * Sort (26)
+                  :                 :  +- Exchange (25)
+                  :                 :     +- * Filter (24)
+                  :                 :        +- * ColumnarToRow (23)
+                  :                 :           +- Scan parquet spark_catalog.default.customer_address (22)
+                  :                 +- * Sort (31)
+                  :                    +- Exchange (30)
+                  :                       +- * Filter (29)
+                  :                          +- * ColumnarToRow (28)
+                  :                             +- Scan parquet spark_catalog.default.customer (27)
+                  +- ReusedExchange (38)
 
 
 (1) Scan parquet spark_catalog.default.item
@@ -129,126 +129,126 @@ Input [3]: [ss_item_sk#12, ss_customer_sk#13, ss_sold_date_sk#14]
 Input [3]: [ss_item_sk#12, ss_customer_sk#13, ss_sold_date_sk#14]
 Condition : (isnotnull(ss_customer_sk#13) AND isnotnull(ss_item_sk#12))
 
-(18) BroadcastHashJoin [codegen id : 5]
+(18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [ss_item_sk#12]
 Join type: Inner
 Join condition: None
 
-(19) Project [codegen id : 5]
+(19) Project [codegen id : 4]
 Output [2]: [ss_customer_sk#13, ss_sold_date_sk#14]
 Input [4]: [i_item_sk#1, ss_item_sk#12, ss_customer_sk#13, ss_sold_date_sk#14]
 
-(20) ReusedExchange [Reuses operator id: 50]
-Output [1]: [d_date_sk#16]
-
-(21) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [ss_sold_date_sk#14]
-Right keys [1]: [d_date_sk#16]
-Join type: Inner
-Join condition: None
-
-(22) Project [codegen id : 5]
-Output [1]: [ss_customer_sk#13]
-Input [3]: [ss_customer_sk#13, ss_sold_date_sk#14, d_date_sk#16]
-
-(23) Exchange
-Input [1]: [ss_customer_sk#13]
+(20) Exchange
+Input [2]: [ss_customer_sk#13, ss_sold_date_sk#14]
 Arguments: hashpartitioning(ss_customer_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(24) Sort [codegen id : 6]
-Input [1]: [ss_customer_sk#13]
+(21) Sort [codegen id : 5]
+Input [2]: [ss_customer_sk#13, ss_sold_date_sk#14]
 Arguments: [ss_customer_sk#13 ASC NULLS FIRST], false, 0
 
-(25) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#17, ca_state#18]
+(22) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#16, ca_state#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(26) ColumnarToRow [codegen id : 7]
-Input [2]: [ca_address_sk#17, ca_state#18]
+(23) ColumnarToRow [codegen id : 6]
+Input [2]: [ca_address_sk#16, ca_state#17]
 
-(27) Filter [codegen id : 7]
-Input [2]: [ca_address_sk#17, ca_state#18]
-Condition : isnotnull(ca_address_sk#17)
+(24) Filter [codegen id : 6]
+Input [2]: [ca_address_sk#16, ca_state#17]
+Condition : isnotnull(ca_address_sk#16)
 
-(28) Exchange
-Input [2]: [ca_address_sk#17, ca_state#18]
-Arguments: hashpartitioning(ca_address_sk#17, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(25) Exchange
+Input [2]: [ca_address_sk#16, ca_state#17]
+Arguments: hashpartitioning(ca_address_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(29) Sort [codegen id : 8]
-Input [2]: [ca_address_sk#17, ca_state#18]
-Arguments: [ca_address_sk#17 ASC NULLS FIRST], false, 0
+(26) Sort [codegen id : 7]
+Input [2]: [ca_address_sk#16, ca_state#17]
+Arguments: [ca_address_sk#16 ASC NULLS FIRST], false, 0
 
-(30) Scan parquet spark_catalog.default.customer
-Output [2]: [c_customer_sk#19, c_current_addr_sk#20]
+(27) Scan parquet spark_catalog.default.customer
+Output [2]: [c_customer_sk#18, c_current_addr_sk#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_current_addr_sk), IsNotNull(c_customer_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
 
-(31) ColumnarToRow [codegen id : 9]
-Input [2]: [c_customer_sk#19, c_current_addr_sk#20]
+(28) ColumnarToRow [codegen id : 8]
+Input [2]: [c_customer_sk#18, c_current_addr_sk#19]
 
-(32) Filter [codegen id : 9]
-Input [2]: [c_customer_sk#19, c_current_addr_sk#20]
-Condition : (isnotnull(c_current_addr_sk#20) AND isnotnull(c_customer_sk#19))
+(29) Filter [codegen id : 8]
+Input [2]: [c_customer_sk#18, c_current_addr_sk#19]
+Condition : (isnotnull(c_current_addr_sk#19) AND isnotnull(c_customer_sk#18))
 
-(33) Exchange
-Input [2]: [c_customer_sk#19, c_current_addr_sk#20]
-Arguments: hashpartitioning(c_current_addr_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+(30) Exchange
+Input [2]: [c_customer_sk#18, c_current_addr_sk#19]
+Arguments: hashpartitioning(c_current_addr_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(34) Sort [codegen id : 10]
-Input [2]: [c_customer_sk#19, c_current_addr_sk#20]
-Arguments: [c_current_addr_sk#20 ASC NULLS FIRST], false, 0
+(31) Sort [codegen id : 9]
+Input [2]: [c_customer_sk#18, c_current_addr_sk#19]
+Arguments: [c_current_addr_sk#19 ASC NULLS FIRST], false, 0
 
-(35) SortMergeJoin [codegen id : 11]
-Left keys [1]: [ca_address_sk#17]
-Right keys [1]: [c_current_addr_sk#20]
+(32) SortMergeJoin [codegen id : 10]
+Left keys [1]: [ca_address_sk#16]
+Right keys [1]: [c_current_addr_sk#19]
 Join type: Inner
 Join condition: None
 
-(36) Project [codegen id : 11]
-Output [2]: [ca_state#18, c_customer_sk#19]
-Input [4]: [ca_address_sk#17, ca_state#18, c_customer_sk#19, c_current_addr_sk#20]
+(33) Project [codegen id : 10]
+Output [2]: [ca_state#17, c_customer_sk#18]
+Input [4]: [ca_address_sk#16, ca_state#17, c_customer_sk#18, c_current_addr_sk#19]
 
-(37) Exchange
-Input [2]: [ca_state#18, c_customer_sk#19]
-Arguments: hashpartitioning(c_customer_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(34) Exchange
+Input [2]: [ca_state#17, c_customer_sk#18]
+Arguments: hashpartitioning(c_customer_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(38) Sort [codegen id : 12]
-Input [2]: [ca_state#18, c_customer_sk#19]
-Arguments: [c_customer_sk#19 ASC NULLS FIRST], false, 0
+(35) Sort [codegen id : 11]
+Input [2]: [ca_state#17, c_customer_sk#18]
+Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
 
-(39) SortMergeJoin [codegen id : 13]
+(36) SortMergeJoin [codegen id : 13]
 Left keys [1]: [ss_customer_sk#13]
-Right keys [1]: [c_customer_sk#19]
+Right keys [1]: [c_customer_sk#18]
+Join type: Inner
+Join condition: None
+
+(37) Project [codegen id : 13]
+Output [2]: [ss_sold_date_sk#14, ca_state#17]
+Input [4]: [ss_customer_sk#13, ss_sold_date_sk#14, ca_state#17, c_customer_sk#18]
+
+(38) ReusedExchange [Reuses operator id: 50]
+Output [1]: [d_date_sk#20]
+
+(39) BroadcastHashJoin [codegen id : 13]
+Left keys [1]: [ss_sold_date_sk#14]
+Right keys [1]: [d_date_sk#20]
 Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 13]
-Output [1]: [ca_state#18]
-Input [3]: [ss_customer_sk#13, ca_state#18, c_customer_sk#19]
+Output [1]: [ca_state#17]
+Input [3]: [ss_sold_date_sk#14, ca_state#17, d_date_sk#20]
 
 (41) HashAggregate [codegen id : 13]
-Input [1]: [ca_state#18]
-Keys [1]: [ca_state#18]
+Input [1]: [ca_state#17]
+Keys [1]: [ca_state#17]
 Functions [1]: [partial_count(1)]
 Aggregate Attributes [1]: [count#21]
-Results [2]: [ca_state#18, count#22]
+Results [2]: [ca_state#17, count#22]
 
 (42) Exchange
-Input [2]: [ca_state#18, count#22]
-Arguments: hashpartitioning(ca_state#18, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [2]: [ca_state#17, count#22]
+Arguments: hashpartitioning(ca_state#17, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (43) HashAggregate [codegen id : 14]
-Input [2]: [ca_state#18, count#22]
-Keys [1]: [ca_state#18]
+Input [2]: [ca_state#17, count#22]
+Keys [1]: [ca_state#17]
 Functions [1]: [count(1)]
 Aggregate Attributes [1]: [count(1)#23]
-Results [2]: [ca_state#18 AS state#24, count(1)#23 AS cnt#25]
+Results [2]: [ca_state#17 AS state#24, count(1)#23 AS cnt#25]
 
 (44) Filter [codegen id : 14]
 Input [2]: [state#24, cnt#25]
@@ -269,25 +269,25 @@ BroadcastExchange (50)
 
 
 (46) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#16, d_month_seq#26]
+Output [2]: [d_date_sk#20, d_month_seq#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), EqualTo(d_month_seq,ScalarSubquery#27), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int>
 
 (47) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#16, d_month_seq#26]
+Input [2]: [d_date_sk#20, d_month_seq#26]
 
 (48) Filter [codegen id : 1]
-Input [2]: [d_date_sk#16, d_month_seq#26]
-Condition : ((isnotnull(d_month_seq#26) AND (d_month_seq#26 = ReusedSubquery Subquery scalar-subquery#27, [id=#28])) AND isnotnull(d_date_sk#16))
+Input [2]: [d_date_sk#20, d_month_seq#26]
+Condition : ((isnotnull(d_month_seq#26) AND (d_month_seq#26 = ReusedSubquery Subquery scalar-subquery#27, [id=#28])) AND isnotnull(d_date_sk#20))
 
 (49) Project [codegen id : 1]
-Output [1]: [d_date_sk#16]
-Input [2]: [d_date_sk#16, d_month_seq#26]
+Output [1]: [d_date_sk#20]
+Input [2]: [d_date_sk#20, d_month_seq#26]
 
 (50) BroadcastExchange
-Input [1]: [d_date_sk#16]
+Input [1]: [d_date_sk#20]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
 Subquery:2 Hosting operator id = 48 Hosting Expression = ReusedSubquery Subquery scalar-subquery#27, [id=#28]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q6.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q6.sf100/simplified.txt
@@ -7,15 +7,15 @@ TakeOrderedAndProject [cnt,state]
             WholeStageCodegen (13)
               HashAggregate [ca_state] [count,count]
                 Project [ca_state]
-                  SortMergeJoin [ss_customer_sk,c_customer_sk]
-                    InputAdapter
-                      WholeStageCodegen (6)
-                        Sort [ss_customer_sk]
-                          InputAdapter
-                            Exchange [ss_customer_sk] #2
-                              WholeStageCodegen (5)
-                                Project [ss_customer_sk]
-                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                    Project [ss_sold_date_sk,ca_state]
+                      SortMergeJoin [ss_customer_sk,c_customer_sk]
+                        InputAdapter
+                          WholeStageCodegen (5)
+                            Sort [ss_customer_sk]
+                              InputAdapter
+                                Exchange [ss_customer_sk] #2
+                                  WholeStageCodegen (4)
                                     Project [ss_customer_sk,ss_sold_date_sk]
                                       BroadcastHashJoin [i_item_sk,ss_item_sk]
                                         InputAdapter
@@ -65,33 +65,33 @@ TakeOrderedAndProject [cnt,state]
                                                                                   ColumnarToRow
                                                                                     InputAdapter
                                                                                       Scan parquet spark_catalog.default.date_dim [d_month_seq,d_year,d_moy]
-                                    InputAdapter
-                                      ReusedExchange [d_date_sk] #6
+                        InputAdapter
+                          WholeStageCodegen (11)
+                            Sort [c_customer_sk]
+                              InputAdapter
+                                Exchange [c_customer_sk] #8
+                                  WholeStageCodegen (10)
+                                    Project [ca_state,c_customer_sk]
+                                      SortMergeJoin [ca_address_sk,c_current_addr_sk]
+                                        InputAdapter
+                                          WholeStageCodegen (7)
+                                            Sort [ca_address_sk]
+                                              InputAdapter
+                                                Exchange [ca_address_sk] #9
+                                                  WholeStageCodegen (6)
+                                                    Filter [ca_address_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+                                        InputAdapter
+                                          WholeStageCodegen (9)
+                                            Sort [c_current_addr_sk]
+                                              InputAdapter
+                                                Exchange [c_current_addr_sk] #10
+                                                  WholeStageCodegen (8)
+                                                    Filter [c_current_addr_sk,c_customer_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
                     InputAdapter
-                      WholeStageCodegen (12)
-                        Sort [c_customer_sk]
-                          InputAdapter
-                            Exchange [c_customer_sk] #8
-                              WholeStageCodegen (11)
-                                Project [ca_state,c_customer_sk]
-                                  SortMergeJoin [ca_address_sk,c_current_addr_sk]
-                                    InputAdapter
-                                      WholeStageCodegen (8)
-                                        Sort [ca_address_sk]
-                                          InputAdapter
-                                            Exchange [ca_address_sk] #9
-                                              WholeStageCodegen (7)
-                                                Filter [ca_address_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
-                                    InputAdapter
-                                      WholeStageCodegen (10)
-                                        Sort [c_current_addr_sk]
-                                          InputAdapter
-                                            Exchange [c_current_addr_sk] #10
-                                              WholeStageCodegen (9)
-                                                Filter [c_current_addr_sk,c_customer_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
+                      ReusedExchange [d_date_sk] #6

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q61.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q61.sf100/explain.txt
@@ -1,68 +1,74 @@
 == Physical Plan ==
-* Project (64)
-+- * BroadcastNestedLoopJoin Inner BuildRight (63)
-   :- * HashAggregate (43)
-   :  +- Exchange (42)
-   :     +- * HashAggregate (41)
-   :        +- * Project (40)
-   :           +- * BroadcastHashJoin Inner BuildRight (39)
-   :              :- * Project (27)
-   :              :  +- * BroadcastHashJoin Inner BuildRight (26)
-   :              :     :- * Project (20)
-   :              :     :  +- * BroadcastHashJoin Inner BuildRight (19)
-   :              :     :     :- * Project (13)
-   :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (12)
-   :              :     :     :     :- * Project (6)
-   :              :     :     :     :  +- * BroadcastHashJoin Inner BuildRight (5)
-   :              :     :     :     :     :- * Filter (3)
-   :              :     :     :     :     :  +- * ColumnarToRow (2)
-   :              :     :     :     :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-   :              :     :     :     :     +- ReusedExchange (4)
-   :              :     :     :     +- BroadcastExchange (11)
-   :              :     :     :        +- * Project (10)
-   :              :     :     :           +- * Filter (9)
-   :              :     :     :              +- * ColumnarToRow (8)
-   :              :     :     :                 +- Scan parquet spark_catalog.default.item (7)
-   :              :     :     +- BroadcastExchange (18)
-   :              :     :        +- * Project (17)
-   :              :     :           +- * Filter (16)
-   :              :     :              +- * ColumnarToRow (15)
-   :              :     :                 +- Scan parquet spark_catalog.default.promotion (14)
-   :              :     +- BroadcastExchange (25)
-   :              :        +- * Project (24)
-   :              :           +- * Filter (23)
-   :              :              +- * ColumnarToRow (22)
-   :              :                 +- Scan parquet spark_catalog.default.store (21)
-   :              +- BroadcastExchange (38)
-   :                 +- * Project (37)
-   :                    +- * BroadcastHashJoin Inner BuildRight (36)
-   :                       :- * Filter (30)
-   :                       :  +- * ColumnarToRow (29)
-   :                       :     +- Scan parquet spark_catalog.default.customer (28)
-   :                       +- BroadcastExchange (35)
-   :                          +- * Project (34)
-   :                             +- * Filter (33)
-   :                                +- * ColumnarToRow (32)
-   :                                   +- Scan parquet spark_catalog.default.customer_address (31)
-   +- BroadcastExchange (62)
-      +- * HashAggregate (61)
-         +- Exchange (60)
-            +- * HashAggregate (59)
-               +- * Project (58)
-                  +- * BroadcastHashJoin Inner BuildRight (57)
-                     :- * Project (55)
-                     :  +- * BroadcastHashJoin Inner BuildRight (54)
-                     :     :- * Project (52)
-                     :     :  +- * BroadcastHashJoin Inner BuildRight (51)
-                     :     :     :- * Project (49)
-                     :     :     :  +- * BroadcastHashJoin Inner BuildRight (48)
-                     :     :     :     :- * Filter (46)
-                     :     :     :     :  +- * ColumnarToRow (45)
-                     :     :     :     :     +- Scan parquet spark_catalog.default.store_sales (44)
-                     :     :     :     +- ReusedExchange (47)
-                     :     :     +- ReusedExchange (50)
-                     :     +- ReusedExchange (53)
-                     +- ReusedExchange (56)
+* Project (70)
++- * BroadcastNestedLoopJoin Inner BuildRight (69)
+   :- * HashAggregate (46)
+   :  +- Exchange (45)
+   :     +- * HashAggregate (44)
+   :        +- * Project (43)
+   :           +- * SortMergeJoin Inner (42)
+   :              :- * Sort (29)
+   :              :  +- Exchange (28)
+   :              :     +- * Project (27)
+   :              :        +- * BroadcastHashJoin Inner BuildRight (26)
+   :              :           :- * Project (20)
+   :              :           :  +- * BroadcastHashJoin Inner BuildRight (19)
+   :              :           :     :- * Project (13)
+   :              :           :     :  +- * BroadcastHashJoin Inner BuildRight (12)
+   :              :           :     :     :- * Project (10)
+   :              :           :     :     :  +- * BroadcastHashJoin Inner BuildRight (9)
+   :              :           :     :     :     :- * Filter (3)
+   :              :           :     :     :     :  +- * ColumnarToRow (2)
+   :              :           :     :     :     :     +- Scan parquet spark_catalog.default.store_sales (1)
+   :              :           :     :     :     +- BroadcastExchange (8)
+   :              :           :     :     :        +- * Project (7)
+   :              :           :     :     :           +- * Filter (6)
+   :              :           :     :     :              +- * ColumnarToRow (5)
+   :              :           :     :     :                 +- Scan parquet spark_catalog.default.item (4)
+   :              :           :     :     +- ReusedExchange (11)
+   :              :           :     +- BroadcastExchange (18)
+   :              :           :        +- * Project (17)
+   :              :           :           +- * Filter (16)
+   :              :           :              +- * ColumnarToRow (15)
+   :              :           :                 +- Scan parquet spark_catalog.default.promotion (14)
+   :              :           +- BroadcastExchange (25)
+   :              :              +- * Project (24)
+   :              :                 +- * Filter (23)
+   :              :                    +- * ColumnarToRow (22)
+   :              :                       +- Scan parquet spark_catalog.default.store (21)
+   :              +- * Sort (41)
+   :                 +- Exchange (40)
+   :                    +- * Project (39)
+   :                       +- * BroadcastHashJoin Inner BuildRight (38)
+   :                          :- * Filter (32)
+   :                          :  +- * ColumnarToRow (31)
+   :                          :     +- Scan parquet spark_catalog.default.customer (30)
+   :                          +- BroadcastExchange (37)
+   :                             +- * Project (36)
+   :                                +- * Filter (35)
+   :                                   +- * ColumnarToRow (34)
+   :                                      +- Scan parquet spark_catalog.default.customer_address (33)
+   +- BroadcastExchange (68)
+      +- * HashAggregate (67)
+         +- Exchange (66)
+            +- * HashAggregate (65)
+               +- * Project (64)
+                  +- * SortMergeJoin Inner (63)
+                     :- * Sort (60)
+                     :  +- Exchange (59)
+                     :     +- * Project (58)
+                     :        +- * BroadcastHashJoin Inner BuildRight (57)
+                     :           :- * Project (55)
+                     :           :  +- * BroadcastHashJoin Inner BuildRight (54)
+                     :           :     :- * Project (52)
+                     :           :     :  +- * BroadcastHashJoin Inner BuildRight (51)
+                     :           :     :     :- * Filter (49)
+                     :           :     :     :  +- * ColumnarToRow (48)
+                     :           :     :     :     +- Scan parquet spark_catalog.default.store_sales (47)
+                     :           :     :     +- ReusedExchange (50)
+                     :           :     +- ReusedExchange (53)
+                     :           +- ReusedExchange (56)
+                     +- * Sort (62)
+                        +- ReusedExchange (61)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -73,57 +79,57 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#6), dynamicpruningexpression(ss_sol
 PushedFilters: [IsNotNull(ss_store_sk), IsNotNull(ss_promo_sk), IsNotNull(ss_customer_sk), IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_promo_sk:int,ss_ext_sales_price:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 7]
+(2) ColumnarToRow [codegen id : 5]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_promo_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6]
 
-(3) Filter [codegen id : 7]
+(3) Filter [codegen id : 5]
 Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_promo_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6]
 Condition : (((isnotnull(ss_store_sk#3) AND isnotnull(ss_promo_sk#4)) AND isnotnull(ss_customer_sk#2)) AND isnotnull(ss_item_sk#1))
 
-(4) ReusedExchange [Reuses operator id: 69]
-Output [1]: [d_date_sk#8]
-
-(5) BroadcastHashJoin [codegen id : 7]
-Left keys [1]: [ss_sold_date_sk#6]
-Right keys [1]: [d_date_sk#8]
-Join type: Inner
-Join condition: None
-
-(6) Project [codegen id : 7]
-Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_promo_sk#4, ss_ext_sales_price#5]
-Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_promo_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6, d_date_sk#8]
-
-(7) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#9, i_category#10]
+(4) Scan parquet spark_catalog.default.item
+Output [2]: [i_item_sk#8, i_category#9]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_category), EqualTo(i_category,Jewelry                                           ), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_category:string>
 
-(8) ColumnarToRow [codegen id : 2]
-Input [2]: [i_item_sk#9, i_category#10]
+(5) ColumnarToRow [codegen id : 1]
+Input [2]: [i_item_sk#8, i_category#9]
 
-(9) Filter [codegen id : 2]
-Input [2]: [i_item_sk#9, i_category#10]
-Condition : ((isnotnull(i_category#10) AND (i_category#10 = Jewelry                                           )) AND isnotnull(i_item_sk#9))
+(6) Filter [codegen id : 1]
+Input [2]: [i_item_sk#8, i_category#9]
+Condition : ((isnotnull(i_category#9) AND (i_category#9 = Jewelry                                           )) AND isnotnull(i_item_sk#8))
 
-(10) Project [codegen id : 2]
-Output [1]: [i_item_sk#9]
-Input [2]: [i_item_sk#9, i_category#10]
+(7) Project [codegen id : 1]
+Output [1]: [i_item_sk#8]
+Input [2]: [i_item_sk#8, i_category#9]
 
-(11) BroadcastExchange
-Input [1]: [i_item_sk#9]
+(8) BroadcastExchange
+Input [1]: [i_item_sk#8]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(12) BroadcastHashJoin [codegen id : 7]
+(9) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#9]
+Right keys [1]: [i_item_sk#8]
 Join type: Inner
 Join condition: None
 
-(13) Project [codegen id : 7]
+(10) Project [codegen id : 5]
+Output [5]: [ss_customer_sk#2, ss_store_sk#3, ss_promo_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6]
+Input [7]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_promo_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6, i_item_sk#8]
+
+(11) ReusedExchange [Reuses operator id: 75]
+Output [1]: [d_date_sk#10]
+
+(12) BroadcastHashJoin [codegen id : 5]
+Left keys [1]: [ss_sold_date_sk#6]
+Right keys [1]: [d_date_sk#10]
+Join type: Inner
+Join condition: None
+
+(13) Project [codegen id : 5]
 Output [4]: [ss_customer_sk#2, ss_store_sk#3, ss_promo_sk#4, ss_ext_sales_price#5]
-Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_promo_sk#4, ss_ext_sales_price#5, i_item_sk#9]
+Input [6]: [ss_customer_sk#2, ss_store_sk#3, ss_promo_sk#4, ss_ext_sales_price#5, ss_sold_date_sk#6, d_date_sk#10]
 
 (14) Scan parquet spark_catalog.default.promotion
 Output [4]: [p_promo_sk#11, p_channel_dmail#12, p_channel_email#13, p_channel_tv#14]
@@ -147,13 +153,13 @@ Input [4]: [p_promo_sk#11, p_channel_dmail#12, p_channel_email#13, p_channel_tv#
 Input [1]: [p_promo_sk#11]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
-(19) BroadcastHashJoin [codegen id : 7]
+(19) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_promo_sk#4]
 Right keys [1]: [p_promo_sk#11]
 Join type: Inner
 Join condition: None
 
-(20) Project [codegen id : 7]
+(20) Project [codegen id : 5]
 Output [3]: [ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#5]
 Input [5]: [ss_customer_sk#2, ss_store_sk#3, ss_promo_sk#4, ss_ext_sales_price#5, p_promo_sk#11]
 
@@ -179,95 +185,107 @@ Input [2]: [s_store_sk#15, s_gmt_offset#16]
 Input [1]: [s_store_sk#15]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
 
-(26) BroadcastHashJoin [codegen id : 7]
+(26) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_store_sk#3]
 Right keys [1]: [s_store_sk#15]
 Join type: Inner
 Join condition: None
 
-(27) Project [codegen id : 7]
+(27) Project [codegen id : 5]
 Output [2]: [ss_customer_sk#2, ss_ext_sales_price#5]
 Input [4]: [ss_customer_sk#2, ss_store_sk#3, ss_ext_sales_price#5, s_store_sk#15]
 
-(28) Scan parquet spark_catalog.default.customer
+(28) Exchange
+Input [2]: [ss_customer_sk#2, ss_ext_sales_price#5]
+Arguments: hashpartitioning(ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(29) Sort [codegen id : 6]
+Input [2]: [ss_customer_sk#2, ss_ext_sales_price#5]
+Arguments: [ss_customer_sk#2 ASC NULLS FIRST], false, 0
+
+(30) Scan parquet spark_catalog.default.customer
 Output [2]: [c_customer_sk#17, c_current_addr_sk#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
 
-(29) ColumnarToRow [codegen id : 6]
+(31) ColumnarToRow [codegen id : 8]
 Input [2]: [c_customer_sk#17, c_current_addr_sk#18]
 
-(30) Filter [codegen id : 6]
+(32) Filter [codegen id : 8]
 Input [2]: [c_customer_sk#17, c_current_addr_sk#18]
 Condition : (isnotnull(c_customer_sk#17) AND isnotnull(c_current_addr_sk#18))
 
-(31) Scan parquet spark_catalog.default.customer_address
+(33) Scan parquet spark_catalog.default.customer_address
 Output [2]: [ca_address_sk#19, ca_gmt_offset#20]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_gmt_offset), EqualTo(ca_gmt_offset,-5.00), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_gmt_offset:decimal(5,2)>
 
-(32) ColumnarToRow [codegen id : 5]
+(34) ColumnarToRow [codegen id : 7]
 Input [2]: [ca_address_sk#19, ca_gmt_offset#20]
 
-(33) Filter [codegen id : 5]
+(35) Filter [codegen id : 7]
 Input [2]: [ca_address_sk#19, ca_gmt_offset#20]
 Condition : ((isnotnull(ca_gmt_offset#20) AND (ca_gmt_offset#20 = -5.00)) AND isnotnull(ca_address_sk#19))
 
-(34) Project [codegen id : 5]
+(36) Project [codegen id : 7]
 Output [1]: [ca_address_sk#19]
 Input [2]: [ca_address_sk#19, ca_gmt_offset#20]
 
-(35) BroadcastExchange
+(37) BroadcastExchange
 Input [1]: [ca_address_sk#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
-(36) BroadcastHashJoin [codegen id : 6]
+(38) BroadcastHashJoin [codegen id : 8]
 Left keys [1]: [c_current_addr_sk#18]
 Right keys [1]: [ca_address_sk#19]
 Join type: Inner
 Join condition: None
 
-(37) Project [codegen id : 6]
+(39) Project [codegen id : 8]
 Output [1]: [c_customer_sk#17]
 Input [3]: [c_customer_sk#17, c_current_addr_sk#18, ca_address_sk#19]
 
-(38) BroadcastExchange
+(40) Exchange
 Input [1]: [c_customer_sk#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+Arguments: hashpartitioning(c_customer_sk#17, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(39) BroadcastHashJoin [codegen id : 7]
+(41) Sort [codegen id : 9]
+Input [1]: [c_customer_sk#17]
+Arguments: [c_customer_sk#17 ASC NULLS FIRST], false, 0
+
+(42) SortMergeJoin [codegen id : 10]
 Left keys [1]: [ss_customer_sk#2]
 Right keys [1]: [c_customer_sk#17]
 Join type: Inner
 Join condition: None
 
-(40) Project [codegen id : 7]
+(43) Project [codegen id : 10]
 Output [1]: [ss_ext_sales_price#5]
 Input [3]: [ss_customer_sk#2, ss_ext_sales_price#5, c_customer_sk#17]
 
-(41) HashAggregate [codegen id : 7]
+(44) HashAggregate [codegen id : 10]
 Input [1]: [ss_ext_sales_price#5]
 Keys: []
 Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#5))]
 Aggregate Attributes [1]: [sum#21]
 Results [1]: [sum#22]
 
-(42) Exchange
+(45) Exchange
 Input [1]: [sum#22]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
 
-(43) HashAggregate [codegen id : 15]
+(46) HashAggregate [codegen id : 21]
 Input [1]: [sum#22]
 Keys: []
 Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#5))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#5))#23]
 Results [1]: [MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#5))#23,17,2) AS promotions#24]
 
-(44) Scan parquet spark_catalog.default.store_sales
+(47) Scan parquet spark_catalog.default.store_sales
 Output [5]: [ss_item_sk#25, ss_customer_sk#26, ss_store_sk#27, ss_ext_sales_price#28, ss_sold_date_sk#29]
 Batched: true
 Location: InMemoryFileIndex []
@@ -275,127 +293,139 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#29), dynamicpruningexpression(ss_so
 PushedFilters: [IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk), IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ext_sales_price:decimal(7,2)>
 
-(45) ColumnarToRow [codegen id : 13]
+(48) ColumnarToRow [codegen id : 14]
 Input [5]: [ss_item_sk#25, ss_customer_sk#26, ss_store_sk#27, ss_ext_sales_price#28, ss_sold_date_sk#29]
 
-(46) Filter [codegen id : 13]
+(49) Filter [codegen id : 14]
 Input [5]: [ss_item_sk#25, ss_customer_sk#26, ss_store_sk#27, ss_ext_sales_price#28, ss_sold_date_sk#29]
 Condition : ((isnotnull(ss_store_sk#27) AND isnotnull(ss_customer_sk#26)) AND isnotnull(ss_item_sk#25))
 
-(47) ReusedExchange [Reuses operator id: 69]
-Output [1]: [d_date_sk#30]
+(50) ReusedExchange [Reuses operator id: 8]
+Output [1]: [i_item_sk#30]
 
-(48) BroadcastHashJoin [codegen id : 13]
-Left keys [1]: [ss_sold_date_sk#29]
-Right keys [1]: [d_date_sk#30]
-Join type: Inner
-Join condition: None
-
-(49) Project [codegen id : 13]
-Output [4]: [ss_item_sk#25, ss_customer_sk#26, ss_store_sk#27, ss_ext_sales_price#28]
-Input [6]: [ss_item_sk#25, ss_customer_sk#26, ss_store_sk#27, ss_ext_sales_price#28, ss_sold_date_sk#29, d_date_sk#30]
-
-(50) ReusedExchange [Reuses operator id: 11]
-Output [1]: [i_item_sk#31]
-
-(51) BroadcastHashJoin [codegen id : 13]
+(51) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [ss_item_sk#25]
-Right keys [1]: [i_item_sk#31]
+Right keys [1]: [i_item_sk#30]
 Join type: Inner
 Join condition: None
 
-(52) Project [codegen id : 13]
-Output [3]: [ss_customer_sk#26, ss_store_sk#27, ss_ext_sales_price#28]
-Input [5]: [ss_item_sk#25, ss_customer_sk#26, ss_store_sk#27, ss_ext_sales_price#28, i_item_sk#31]
+(52) Project [codegen id : 14]
+Output [4]: [ss_customer_sk#26, ss_store_sk#27, ss_ext_sales_price#28, ss_sold_date_sk#29]
+Input [6]: [ss_item_sk#25, ss_customer_sk#26, ss_store_sk#27, ss_ext_sales_price#28, ss_sold_date_sk#29, i_item_sk#30]
 
-(53) ReusedExchange [Reuses operator id: 25]
+(53) ReusedExchange [Reuses operator id: 75]
+Output [1]: [d_date_sk#31]
+
+(54) BroadcastHashJoin [codegen id : 14]
+Left keys [1]: [ss_sold_date_sk#29]
+Right keys [1]: [d_date_sk#31]
+Join type: Inner
+Join condition: None
+
+(55) Project [codegen id : 14]
+Output [3]: [ss_customer_sk#26, ss_store_sk#27, ss_ext_sales_price#28]
+Input [5]: [ss_customer_sk#26, ss_store_sk#27, ss_ext_sales_price#28, ss_sold_date_sk#29, d_date_sk#31]
+
+(56) ReusedExchange [Reuses operator id: 25]
 Output [1]: [s_store_sk#32]
 
-(54) BroadcastHashJoin [codegen id : 13]
+(57) BroadcastHashJoin [codegen id : 14]
 Left keys [1]: [ss_store_sk#27]
 Right keys [1]: [s_store_sk#32]
 Join type: Inner
 Join condition: None
 
-(55) Project [codegen id : 13]
+(58) Project [codegen id : 14]
 Output [2]: [ss_customer_sk#26, ss_ext_sales_price#28]
 Input [4]: [ss_customer_sk#26, ss_store_sk#27, ss_ext_sales_price#28, s_store_sk#32]
 
-(56) ReusedExchange [Reuses operator id: 38]
+(59) Exchange
+Input [2]: [ss_customer_sk#26, ss_ext_sales_price#28]
+Arguments: hashpartitioning(ss_customer_sk#26, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(60) Sort [codegen id : 15]
+Input [2]: [ss_customer_sk#26, ss_ext_sales_price#28]
+Arguments: [ss_customer_sk#26 ASC NULLS FIRST], false, 0
+
+(61) ReusedExchange [Reuses operator id: 40]
 Output [1]: [c_customer_sk#33]
 
-(57) BroadcastHashJoin [codegen id : 13]
+(62) Sort [codegen id : 18]
+Input [1]: [c_customer_sk#33]
+Arguments: [c_customer_sk#33 ASC NULLS FIRST], false, 0
+
+(63) SortMergeJoin [codegen id : 19]
 Left keys [1]: [ss_customer_sk#26]
 Right keys [1]: [c_customer_sk#33]
 Join type: Inner
 Join condition: None
 
-(58) Project [codegen id : 13]
+(64) Project [codegen id : 19]
 Output [1]: [ss_ext_sales_price#28]
 Input [3]: [ss_customer_sk#26, ss_ext_sales_price#28, c_customer_sk#33]
 
-(59) HashAggregate [codegen id : 13]
+(65) HashAggregate [codegen id : 19]
 Input [1]: [ss_ext_sales_price#28]
 Keys: []
 Functions [1]: [partial_sum(UnscaledValue(ss_ext_sales_price#28))]
 Aggregate Attributes [1]: [sum#34]
 Results [1]: [sum#35]
 
-(60) Exchange
+(66) Exchange
 Input [1]: [sum#35]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
 
-(61) HashAggregate [codegen id : 14]
+(67) HashAggregate [codegen id : 20]
 Input [1]: [sum#35]
 Keys: []
 Functions [1]: [sum(UnscaledValue(ss_ext_sales_price#28))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_ext_sales_price#28))#36]
 Results [1]: [MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#28))#36,17,2) AS total#37]
 
-(62) BroadcastExchange
+(68) BroadcastExchange
 Input [1]: [total#37]
-Arguments: IdentityBroadcastMode, [plan_id=8]
+Arguments: IdentityBroadcastMode, [plan_id=10]
 
-(63) BroadcastNestedLoopJoin [codegen id : 15]
+(69) BroadcastNestedLoopJoin [codegen id : 21]
 Join type: Inner
 Join condition: None
 
-(64) Project [codegen id : 15]
+(70) Project [codegen id : 21]
 Output [3]: [promotions#24, total#37, ((cast(promotions#24 as decimal(15,4)) / cast(total#37 as decimal(15,4))) * 100) AS ((CAST(promotions AS DECIMAL(15,4)) / CAST(total AS DECIMAL(15,4))) * 100)#38]
 Input [2]: [promotions#24, total#37]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#6 IN dynamicpruning#7
-BroadcastExchange (69)
-+- * Project (68)
-   +- * Filter (67)
-      +- * ColumnarToRow (66)
-         +- Scan parquet spark_catalog.default.date_dim (65)
+BroadcastExchange (75)
++- * Project (74)
+   +- * Filter (73)
+      +- * ColumnarToRow (72)
+         +- Scan parquet spark_catalog.default.date_dim (71)
 
 
-(65) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#8, d_year#39, d_moy#40]
+(71) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#10, d_year#39, d_moy#40]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,1998), EqualTo(d_moy,11), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(66) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#8, d_year#39, d_moy#40]
+(72) ColumnarToRow [codegen id : 1]
+Input [3]: [d_date_sk#10, d_year#39, d_moy#40]
 
-(67) Filter [codegen id : 1]
-Input [3]: [d_date_sk#8, d_year#39, d_moy#40]
-Condition : ((((isnotnull(d_year#39) AND isnotnull(d_moy#40)) AND (d_year#39 = 1998)) AND (d_moy#40 = 11)) AND isnotnull(d_date_sk#8))
+(73) Filter [codegen id : 1]
+Input [3]: [d_date_sk#10, d_year#39, d_moy#40]
+Condition : ((((isnotnull(d_year#39) AND isnotnull(d_moy#40)) AND (d_year#39 = 1998)) AND (d_moy#40 = 11)) AND isnotnull(d_date_sk#10))
 
-(68) Project [codegen id : 1]
-Output [1]: [d_date_sk#8]
-Input [3]: [d_date_sk#8, d_year#39, d_moy#40]
+(74) Project [codegen id : 1]
+Output [1]: [d_date_sk#10]
+Input [3]: [d_date_sk#10, d_year#39, d_moy#40]
 
-(69) BroadcastExchange
-Input [1]: [d_date_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
+(75) BroadcastExchange
+Input [1]: [d_date_sk#10]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
-Subquery:2 Hosting operator id = 44 Hosting Expression = ss_sold_date_sk#29 IN dynamicpruning#7
+Subquery:2 Hosting operator id = 47 Hosting Expression = ss_sold_date_sk#29 IN dynamicpruning#7
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q61.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q61.sf100/simplified.txt
@@ -1,102 +1,120 @@
-WholeStageCodegen (15)
+WholeStageCodegen (21)
   Project [promotions,total]
     BroadcastNestedLoopJoin
       HashAggregate [sum] [sum(UnscaledValue(ss_ext_sales_price)),promotions,sum]
         InputAdapter
           Exchange #1
-            WholeStageCodegen (7)
+            WholeStageCodegen (10)
               HashAggregate [ss_ext_sales_price] [sum,sum]
                 Project [ss_ext_sales_price]
-                  BroadcastHashJoin [ss_customer_sk,c_customer_sk]
-                    Project [ss_customer_sk,ss_ext_sales_price]
-                      BroadcastHashJoin [ss_store_sk,s_store_sk]
-                        Project [ss_customer_sk,ss_store_sk,ss_ext_sales_price]
-                          BroadcastHashJoin [ss_promo_sk,p_promo_sk]
-                            Project [ss_customer_sk,ss_store_sk,ss_promo_sk,ss_ext_sales_price]
-                              BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_promo_sk,ss_ext_sales_price]
-                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                    Filter [ss_store_sk,ss_promo_sk,ss_customer_sk,ss_item_sk]
-                                      ColumnarToRow
-                                        InputAdapter
-                                          Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_promo_sk,ss_ext_sales_price,ss_sold_date_sk]
-                                            SubqueryBroadcast [d_date_sk] #1
-                                              BroadcastExchange #2
-                                                WholeStageCodegen (1)
-                                                  Project [d_date_sk]
-                                                    Filter [d_year,d_moy,d_date_sk]
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
-                                    InputAdapter
-                                      ReusedExchange [d_date_sk] #2
-                                InputAdapter
-                                  BroadcastExchange #3
-                                    WholeStageCodegen (2)
-                                      Project [i_item_sk]
-                                        Filter [i_category,i_item_sk]
-                                          ColumnarToRow
-                                            InputAdapter
-                                              Scan parquet spark_catalog.default.item [i_item_sk,i_category]
-                            InputAdapter
-                              BroadcastExchange #4
-                                WholeStageCodegen (3)
-                                  Project [p_promo_sk]
-                                    Filter [p_channel_dmail,p_channel_email,p_channel_tv,p_promo_sk]
-                                      ColumnarToRow
-                                        InputAdapter
-                                          Scan parquet spark_catalog.default.promotion [p_promo_sk,p_channel_dmail,p_channel_email,p_channel_tv]
-                        InputAdapter
-                          BroadcastExchange #5
-                            WholeStageCodegen (4)
-                              Project [s_store_sk]
-                                Filter [s_gmt_offset,s_store_sk]
-                                  ColumnarToRow
-                                    InputAdapter
-                                      Scan parquet spark_catalog.default.store [s_store_sk,s_gmt_offset]
+                  SortMergeJoin [ss_customer_sk,c_customer_sk]
                     InputAdapter
-                      BroadcastExchange #6
-                        WholeStageCodegen (6)
-                          Project [c_customer_sk]
-                            BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
-                              Filter [c_customer_sk,c_current_addr_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
-                              InputAdapter
-                                BroadcastExchange #7
-                                  WholeStageCodegen (5)
-                                    Project [ca_address_sk]
-                                      Filter [ca_gmt_offset,ca_address_sk]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_gmt_offset]
+                      WholeStageCodegen (6)
+                        Sort [ss_customer_sk]
+                          InputAdapter
+                            Exchange [ss_customer_sk] #2
+                              WholeStageCodegen (5)
+                                Project [ss_customer_sk,ss_ext_sales_price]
+                                  BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                    Project [ss_customer_sk,ss_store_sk,ss_ext_sales_price]
+                                      BroadcastHashJoin [ss_promo_sk,p_promo_sk]
+                                        Project [ss_customer_sk,ss_store_sk,ss_promo_sk,ss_ext_sales_price]
+                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                            Project [ss_customer_sk,ss_store_sk,ss_promo_sk,ss_ext_sales_price,ss_sold_date_sk]
+                                              BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                Filter [ss_store_sk,ss_promo_sk,ss_customer_sk,ss_item_sk]
+                                                  ColumnarToRow
+                                                    InputAdapter
+                                                      Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_promo_sk,ss_ext_sales_price,ss_sold_date_sk]
+                                                        SubqueryBroadcast [d_date_sk] #1
+                                                          BroadcastExchange #3
+                                                            WholeStageCodegen (1)
+                                                              Project [d_date_sk]
+                                                                Filter [d_year,d_moy,d_date_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                                                InputAdapter
+                                                  BroadcastExchange #4
+                                                    WholeStageCodegen (1)
+                                                      Project [i_item_sk]
+                                                        Filter [i_category,i_item_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet spark_catalog.default.item [i_item_sk,i_category]
+                                            InputAdapter
+                                              ReusedExchange [d_date_sk] #3
+                                        InputAdapter
+                                          BroadcastExchange #5
+                                            WholeStageCodegen (3)
+                                              Project [p_promo_sk]
+                                                Filter [p_channel_dmail,p_channel_email,p_channel_tv,p_promo_sk]
+                                                  ColumnarToRow
+                                                    InputAdapter
+                                                      Scan parquet spark_catalog.default.promotion [p_promo_sk,p_channel_dmail,p_channel_email,p_channel_tv]
+                                    InputAdapter
+                                      BroadcastExchange #6
+                                        WholeStageCodegen (4)
+                                          Project [s_store_sk]
+                                            Filter [s_gmt_offset,s_store_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.store [s_store_sk,s_gmt_offset]
+                    InputAdapter
+                      WholeStageCodegen (9)
+                        Sort [c_customer_sk]
+                          InputAdapter
+                            Exchange [c_customer_sk] #7
+                              WholeStageCodegen (8)
+                                Project [c_customer_sk]
+                                  BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
+                                    Filter [c_customer_sk,c_current_addr_sk]
+                                      ColumnarToRow
+                                        InputAdapter
+                                          Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
+                                    InputAdapter
+                                      BroadcastExchange #8
+                                        WholeStageCodegen (7)
+                                          Project [ca_address_sk]
+                                            Filter [ca_gmt_offset,ca_address_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_gmt_offset]
       InputAdapter
-        BroadcastExchange #8
-          WholeStageCodegen (14)
+        BroadcastExchange #9
+          WholeStageCodegen (20)
             HashAggregate [sum] [sum(UnscaledValue(ss_ext_sales_price)),total,sum]
               InputAdapter
-                Exchange #9
-                  WholeStageCodegen (13)
+                Exchange #10
+                  WholeStageCodegen (19)
                     HashAggregate [ss_ext_sales_price] [sum,sum]
                       Project [ss_ext_sales_price]
-                        BroadcastHashJoin [ss_customer_sk,c_customer_sk]
-                          Project [ss_customer_sk,ss_ext_sales_price]
-                            BroadcastHashJoin [ss_store_sk,s_store_sk]
-                              Project [ss_customer_sk,ss_store_sk,ss_ext_sales_price]
-                                BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                  Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ext_sales_price]
-                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                      Filter [ss_store_sk,ss_customer_sk,ss_item_sk]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ext_sales_price,ss_sold_date_sk]
-                                              ReusedSubquery [d_date_sk] #1
-                                      InputAdapter
-                                        ReusedExchange [d_date_sk] #2
-                                  InputAdapter
-                                    ReusedExchange [i_item_sk] #3
-                              InputAdapter
-                                ReusedExchange [s_store_sk] #5
+                        SortMergeJoin [ss_customer_sk,c_customer_sk]
                           InputAdapter
-                            ReusedExchange [c_customer_sk] #6
+                            WholeStageCodegen (15)
+                              Sort [ss_customer_sk]
+                                InputAdapter
+                                  Exchange [ss_customer_sk] #11
+                                    WholeStageCodegen (14)
+                                      Project [ss_customer_sk,ss_ext_sales_price]
+                                        BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                          Project [ss_customer_sk,ss_store_sk,ss_ext_sales_price]
+                                            BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                              Project [ss_customer_sk,ss_store_sk,ss_ext_sales_price,ss_sold_date_sk]
+                                                BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                  Filter [ss_store_sk,ss_customer_sk,ss_item_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ext_sales_price,ss_sold_date_sk]
+                                                          ReusedSubquery [d_date_sk] #1
+                                                  InputAdapter
+                                                    ReusedExchange [i_item_sk] #4
+                                              InputAdapter
+                                                ReusedExchange [d_date_sk] #3
+                                          InputAdapter
+                                            ReusedExchange [s_store_sk] #6
+                          InputAdapter
+                            WholeStageCodegen (18)
+                              Sort [c_customer_sk]
+                                InputAdapter
+                                  ReusedExchange [c_customer_sk] #7

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q63.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q63.sf100/explain.txt
@@ -10,158 +10,158 @@ TakeOrderedAndProject (28)
                      +- * HashAggregate (20)
                         +- * Project (19)
                            +- * BroadcastHashJoin Inner BuildRight (18)
-                              :- * Project (16)
-                              :  +- * BroadcastHashJoin Inner BuildRight (15)
-                              :     :- * Project (10)
-                              :     :  +- * BroadcastHashJoin Inner BuildLeft (9)
-                              :     :     :- BroadcastExchange (5)
-                              :     :     :  +- * Project (4)
-                              :     :     :     +- * Filter (3)
-                              :     :     :        +- * ColumnarToRow (2)
-                              :     :     :           +- Scan parquet spark_catalog.default.item (1)
-                              :     :     +- * Filter (8)
-                              :     :        +- * ColumnarToRow (7)
-                              :     :           +- Scan parquet spark_catalog.default.store_sales (6)
-                              :     +- BroadcastExchange (14)
-                              :        +- * Filter (13)
-                              :           +- * ColumnarToRow (12)
-                              :              +- Scan parquet spark_catalog.default.store (11)
-                              +- ReusedExchange (17)
+                              :- * Project (13)
+                              :  +- * BroadcastHashJoin Inner BuildRight (12)
+                              :     :- * Project (6)
+                              :     :  +- * BroadcastHashJoin Inner BuildRight (5)
+                              :     :     :- * Filter (3)
+                              :     :     :  +- * ColumnarToRow (2)
+                              :     :     :     +- Scan parquet spark_catalog.default.store_sales (1)
+                              :     :     +- ReusedExchange (4)
+                              :     +- BroadcastExchange (11)
+                              :        +- * Project (10)
+                              :           +- * Filter (9)
+                              :              +- * ColumnarToRow (8)
+                              :                 +- Scan parquet spark_catalog.default.item (7)
+                              +- BroadcastExchange (17)
+                                 +- * Filter (16)
+                                    +- * ColumnarToRow (15)
+                                       +- Scan parquet spark_catalog.default.store (14)
 
 
-(1) Scan parquet spark_catalog.default.item
-Output [5]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4, i_manager_id#5]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [Or(And(And(In(i_category, [Books                                             ,Children                                          ,Electronics                                       ]),In(i_class, [personal                                          ,portable                                          ,refernece                                         ,self-help                                         ])),In(i_brand, [exportiunivamalg #6                               ,scholaramalgamalg #7                             ,scholaramalgamalg #8                              ,scholaramalgamalg #6                              ])),And(And(In(i_category, [Men                                               ,Music                                             ,Women                                             ]),In(i_class, [accessories                                       ,classical                                         ,fragrances                                        ,pants                                             ])),In(i_brand, [amalgimporto #9                                   ,edu packscholar #9                                ,exportiimporto #9                                 ,importoamalg #9                                   ]))), IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_brand:string,i_class:string,i_category:string,i_manager_id:int>
-
-(2) ColumnarToRow [codegen id : 1]
-Input [5]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4, i_manager_id#5]
-
-(3) Filter [codegen id : 1]
-Input [5]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4, i_manager_id#5]
-Condition : ((((i_category#4 IN (Books                                             ,Children                                          ,Electronics                                       ) AND i_class#3 IN (personal                                          ,portable                                          ,refernece                                         ,self-help                                         )) AND i_brand#2 IN (scholaramalgamalg #7                             ,scholaramalgamalg #8                              ,exportiunivamalg #6                               ,scholaramalgamalg #6                              )) OR ((i_category#4 IN (Women                                             ,Music                                             ,Men                                               ) AND i_class#3 IN (accessories                                       ,classical                                         ,fragrances                                        ,pants                                             )) AND i_brand#2 IN (amalgimporto #9                                   ,edu packscholar #9                                ,exportiimporto #9                                 ,importoamalg #9                                   ))) AND isnotnull(i_item_sk#1))
-
-(4) Project [codegen id : 1]
-Output [2]: [i_item_sk#1, i_manager_id#5]
-Input [5]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4, i_manager_id#5]
-
-(5) BroadcastExchange
-Input [2]: [i_item_sk#1, i_manager_id#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
-
-(6) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_item_sk#10, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
+(1) Scan parquet spark_catalog.default.store_sales
+Output [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#13), dynamicpruningexpression(ss_sold_date_sk#13 IN dynamicpruning#14)]
+PartitionFilters: [isnotnull(ss_sold_date_sk#4), dynamicpruningexpression(ss_sold_date_sk#4 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_store_sk:int,ss_sales_price:decimal(7,2)>
 
-(7) ColumnarToRow
-Input [4]: [ss_item_sk#10, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
+(2) ColumnarToRow [codegen id : 4]
+Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
 
-(8) Filter
-Input [4]: [ss_item_sk#10, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
-Condition : (isnotnull(ss_item_sk#10) AND isnotnull(ss_store_sk#11))
+(3) Filter [codegen id : 4]
+Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
+Condition : (isnotnull(ss_item_sk#1) AND isnotnull(ss_store_sk#2))
 
-(9) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [i_item_sk#1]
-Right keys [1]: [ss_item_sk#10]
+(4) ReusedExchange [Reuses operator id: 33]
+Output [2]: [d_date_sk#6, d_moy#7]
+
+(5) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_sold_date_sk#4]
+Right keys [1]: [d_date_sk#6]
 Join type: Inner
 Join condition: None
 
-(10) Project [codegen id : 4]
-Output [4]: [i_manager_id#5, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
-Input [6]: [i_item_sk#1, i_manager_id#5, ss_item_sk#10, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13]
+(6) Project [codegen id : 4]
+Output [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_moy#7]
+Input [6]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4, d_date_sk#6, d_moy#7]
 
-(11) Scan parquet spark_catalog.default.store
-Output [1]: [s_store_sk#15]
+(7) Scan parquet spark_catalog.default.item
+Output [5]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11, i_manager_id#12]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/item]
+PushedFilters: [Or(And(And(In(i_category, [Books                                             ,Children                                          ,Electronics                                       ]),In(i_class, [personal                                          ,portable                                          ,refernece                                         ,self-help                                         ])),In(i_brand, [exportiunivamalg #13                               ,scholaramalgamalg #14                             ,scholaramalgamalg #15                              ,scholaramalgamalg #13                              ])),And(And(In(i_category, [Men                                               ,Music                                             ,Women                                             ]),In(i_class, [accessories                                       ,classical                                         ,fragrances                                        ,pants                                             ])),In(i_brand, [amalgimporto #16                                   ,edu packscholar #16                                ,exportiimporto #16                                 ,importoamalg #16                                   ]))), IsNotNull(i_item_sk)]
+ReadSchema: struct<i_item_sk:int,i_brand:string,i_class:string,i_category:string,i_manager_id:int>
+
+(8) ColumnarToRow [codegen id : 2]
+Input [5]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11, i_manager_id#12]
+
+(9) Filter [codegen id : 2]
+Input [5]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11, i_manager_id#12]
+Condition : ((((i_category#11 IN (Books                                             ,Children                                          ,Electronics                                       ) AND i_class#10 IN (personal                                          ,portable                                          ,refernece                                         ,self-help                                         )) AND i_brand#9 IN (scholaramalgamalg #14                             ,scholaramalgamalg #15                              ,exportiunivamalg #13                               ,scholaramalgamalg #13                              )) OR ((i_category#11 IN (Women                                             ,Music                                             ,Men                                               ) AND i_class#10 IN (accessories                                       ,classical                                         ,fragrances                                        ,pants                                             )) AND i_brand#9 IN (amalgimporto #16                                   ,edu packscholar #16                                ,exportiimporto #16                                 ,importoamalg #16                                   ))) AND isnotnull(i_item_sk#8))
+
+(10) Project [codegen id : 2]
+Output [2]: [i_item_sk#8, i_manager_id#12]
+Input [5]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11, i_manager_id#12]
+
+(11) BroadcastExchange
+Input [2]: [i_item_sk#8, i_manager_id#12]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
+
+(12) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_item_sk#1]
+Right keys [1]: [i_item_sk#8]
+Join type: Inner
+Join condition: None
+
+(13) Project [codegen id : 4]
+Output [4]: [ss_store_sk#2, ss_sales_price#3, d_moy#7, i_manager_id#12]
+Input [6]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_moy#7, i_item_sk#8, i_manager_id#12]
+
+(14) Scan parquet spark_catalog.default.store
+Output [1]: [s_store_sk#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int>
 
-(12) ColumnarToRow [codegen id : 2]
-Input [1]: [s_store_sk#15]
+(15) ColumnarToRow [codegen id : 3]
+Input [1]: [s_store_sk#17]
 
-(13) Filter [codegen id : 2]
-Input [1]: [s_store_sk#15]
-Condition : isnotnull(s_store_sk#15)
+(16) Filter [codegen id : 3]
+Input [1]: [s_store_sk#17]
+Condition : isnotnull(s_store_sk#17)
 
-(14) BroadcastExchange
-Input [1]: [s_store_sk#15]
+(17) BroadcastExchange
+Input [1]: [s_store_sk#17]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
 
-(15) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_store_sk#11]
-Right keys [1]: [s_store_sk#15]
-Join type: Inner
-Join condition: None
-
-(16) Project [codegen id : 4]
-Output [3]: [i_manager_id#5, ss_sales_price#12, ss_sold_date_sk#13]
-Input [5]: [i_manager_id#5, ss_store_sk#11, ss_sales_price#12, ss_sold_date_sk#13, s_store_sk#15]
-
-(17) ReusedExchange [Reuses operator id: 33]
-Output [2]: [d_date_sk#16, d_moy#17]
-
 (18) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#13]
-Right keys [1]: [d_date_sk#16]
+Left keys [1]: [ss_store_sk#2]
+Right keys [1]: [s_store_sk#17]
 Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]
-Output [3]: [i_manager_id#5, ss_sales_price#12, d_moy#17]
-Input [5]: [i_manager_id#5, ss_sales_price#12, ss_sold_date_sk#13, d_date_sk#16, d_moy#17]
+Output [3]: [i_manager_id#12, ss_sales_price#3, d_moy#7]
+Input [5]: [ss_store_sk#2, ss_sales_price#3, d_moy#7, i_manager_id#12, s_store_sk#17]
 
 (20) HashAggregate [codegen id : 4]
-Input [3]: [i_manager_id#5, ss_sales_price#12, d_moy#17]
-Keys [2]: [i_manager_id#5, d_moy#17]
-Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#12))]
+Input [3]: [i_manager_id#12, ss_sales_price#3, d_moy#7]
+Keys [2]: [i_manager_id#12, d_moy#7]
+Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#3))]
 Aggregate Attributes [1]: [sum#18]
-Results [3]: [i_manager_id#5, d_moy#17, sum#19]
+Results [3]: [i_manager_id#12, d_moy#7, sum#19]
 
 (21) Exchange
-Input [3]: [i_manager_id#5, d_moy#17, sum#19]
-Arguments: hashpartitioning(i_manager_id#5, d_moy#17, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [3]: [i_manager_id#12, d_moy#7, sum#19]
+Arguments: hashpartitioning(i_manager_id#12, d_moy#7, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (22) HashAggregate [codegen id : 5]
-Input [3]: [i_manager_id#5, d_moy#17, sum#19]
-Keys [2]: [i_manager_id#5, d_moy#17]
-Functions [1]: [sum(UnscaledValue(ss_sales_price#12))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#12))#20]
-Results [3]: [i_manager_id#5, MakeDecimal(sum(UnscaledValue(ss_sales_price#12))#20,17,2) AS sum_sales#21, MakeDecimal(sum(UnscaledValue(ss_sales_price#12))#20,17,2) AS _w0#22]
+Input [3]: [i_manager_id#12, d_moy#7, sum#19]
+Keys [2]: [i_manager_id#12, d_moy#7]
+Functions [1]: [sum(UnscaledValue(ss_sales_price#3))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#3))#20]
+Results [3]: [i_manager_id#12, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#20,17,2) AS sum_sales#21, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#20,17,2) AS _w0#22]
 
 (23) Exchange
-Input [3]: [i_manager_id#5, sum_sales#21, _w0#22]
-Arguments: hashpartitioning(i_manager_id#5, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [3]: [i_manager_id#12, sum_sales#21, _w0#22]
+Arguments: hashpartitioning(i_manager_id#12, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (24) Sort [codegen id : 6]
-Input [3]: [i_manager_id#5, sum_sales#21, _w0#22]
-Arguments: [i_manager_id#5 ASC NULLS FIRST], false, 0
+Input [3]: [i_manager_id#12, sum_sales#21, _w0#22]
+Arguments: [i_manager_id#12 ASC NULLS FIRST], false, 0
 
 (25) Window
-Input [3]: [i_manager_id#5, sum_sales#21, _w0#22]
-Arguments: [avg(_w0#22) windowspecdefinition(i_manager_id#5, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_monthly_sales#23], [i_manager_id#5]
+Input [3]: [i_manager_id#12, sum_sales#21, _w0#22]
+Arguments: [avg(_w0#22) windowspecdefinition(i_manager_id#12, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_monthly_sales#23], [i_manager_id#12]
 
 (26) Filter [codegen id : 7]
-Input [4]: [i_manager_id#5, sum_sales#21, _w0#22, avg_monthly_sales#23]
+Input [4]: [i_manager_id#12, sum_sales#21, _w0#22, avg_monthly_sales#23]
 Condition : CASE WHEN (avg_monthly_sales#23 > 0.000000) THEN ((abs((sum_sales#21 - avg_monthly_sales#23)) / avg_monthly_sales#23) > 0.1000000000000000) ELSE false END
 
 (27) Project [codegen id : 7]
-Output [3]: [i_manager_id#5, sum_sales#21, avg_monthly_sales#23]
-Input [4]: [i_manager_id#5, sum_sales#21, _w0#22, avg_monthly_sales#23]
+Output [3]: [i_manager_id#12, sum_sales#21, avg_monthly_sales#23]
+Input [4]: [i_manager_id#12, sum_sales#21, _w0#22, avg_monthly_sales#23]
 
 (28) TakeOrderedAndProject
-Input [3]: [i_manager_id#5, sum_sales#21, avg_monthly_sales#23]
-Arguments: 100, [i_manager_id#5 ASC NULLS FIRST, avg_monthly_sales#23 ASC NULLS FIRST, sum_sales#21 ASC NULLS FIRST], [i_manager_id#5, sum_sales#21, avg_monthly_sales#23]
+Input [3]: [i_manager_id#12, sum_sales#21, avg_monthly_sales#23]
+Arguments: 100, [i_manager_id#12 ASC NULLS FIRST, avg_monthly_sales#23 ASC NULLS FIRST, sum_sales#21 ASC NULLS FIRST], [i_manager_id#12, sum_sales#21, avg_monthly_sales#23]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#13 IN dynamicpruning#14
+Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
 BroadcastExchange (33)
 +- * Project (32)
    +- * Filter (31)
@@ -170,25 +170,25 @@ BroadcastExchange (33)
 
 
 (29) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#16, d_month_seq#24, d_moy#17]
+Output [3]: [d_date_sk#6, d_month_seq#24, d_moy#7]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [In(d_month_seq, [1200,1201,1202,1203,1204,1205,1206,1207,1208,1209,1210,1211]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int,d_moy:int>
 
 (30) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#16, d_month_seq#24, d_moy#17]
+Input [3]: [d_date_sk#6, d_month_seq#24, d_moy#7]
 
 (31) Filter [codegen id : 1]
-Input [3]: [d_date_sk#16, d_month_seq#24, d_moy#17]
-Condition : (d_month_seq#24 INSET 1200, 1201, 1202, 1203, 1204, 1205, 1206, 1207, 1208, 1209, 1210, 1211 AND isnotnull(d_date_sk#16))
+Input [3]: [d_date_sk#6, d_month_seq#24, d_moy#7]
+Condition : (d_month_seq#24 INSET 1200, 1201, 1202, 1203, 1204, 1205, 1206, 1207, 1208, 1209, 1210, 1211 AND isnotnull(d_date_sk#6))
 
 (32) Project [codegen id : 1]
-Output [2]: [d_date_sk#16, d_moy#17]
-Input [3]: [d_date_sk#16, d_month_seq#24, d_moy#17]
+Output [2]: [d_date_sk#6, d_moy#7]
+Input [3]: [d_date_sk#6, d_month_seq#24, d_moy#7]
 
 (33) BroadcastExchange
-Input [2]: [d_date_sk#16, d_moy#17]
+Input [2]: [d_date_sk#6, d_moy#7]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q63.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q63.sf100/simplified.txt
@@ -15,37 +15,37 @@ TakeOrderedAndProject [i_manager_id,avg_monthly_sales,sum_sales]
                             WholeStageCodegen (4)
                               HashAggregate [i_manager_id,d_moy,ss_sales_price] [sum,sum]
                                 Project [i_manager_id,ss_sales_price,d_moy]
-                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                    Project [i_manager_id,ss_sales_price,ss_sold_date_sk]
-                                      BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                        Project [i_manager_id,ss_store_sk,ss_sales_price,ss_sold_date_sk]
-                                          BroadcastHashJoin [i_item_sk,ss_item_sk]
-                                            InputAdapter
-                                              BroadcastExchange #3
-                                                WholeStageCodegen (1)
-                                                  Project [i_item_sk,i_manager_id]
-                                                    Filter [i_category,i_class,i_brand,i_item_sk]
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_class,i_category,i_manager_id]
+                                  BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                    Project [ss_store_sk,ss_sales_price,d_moy,i_manager_id]
+                                      BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                        Project [ss_item_sk,ss_store_sk,ss_sales_price,d_moy]
+                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                             Filter [ss_item_sk,ss_store_sk]
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_sales_price,ss_sold_date_sk]
                                                     SubqueryBroadcast [d_date_sk] #1
-                                                      BroadcastExchange #4
+                                                      BroadcastExchange #3
                                                         WholeStageCodegen (1)
                                                           Project [d_date_sk,d_moy]
                                                             Filter [d_month_seq,d_date_sk]
                                                               ColumnarToRow
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.date_dim [d_date_sk,d_month_seq,d_moy]
+                                            InputAdapter
+                                              ReusedExchange [d_date_sk,d_moy] #3
                                         InputAdapter
-                                          BroadcastExchange #5
+                                          BroadcastExchange #4
                                             WholeStageCodegen (2)
-                                              Filter [s_store_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.store [s_store_sk]
+                                              Project [i_item_sk,i_manager_id]
+                                                Filter [i_category,i_class,i_brand,i_item_sk]
+                                                  ColumnarToRow
+                                                    InputAdapter
+                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_class,i_category,i_manager_id]
                                     InputAdapter
-                                      ReusedExchange [d_date_sk,d_moy] #4
+                                      BroadcastExchange #5
+                                        WholeStageCodegen (3)
+                                          Filter [s_store_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet spark_catalog.default.store [s_store_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q65.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q65.sf100/explain.txt
@@ -1,46 +1,46 @@
 == Physical Plan ==
 TakeOrderedAndProject (42)
 +- * Project (41)
-   +- * SortMergeJoin Inner (40)
-      :- * Sort (34)
-      :  +- Exchange (33)
-      :     +- * Project (32)
-      :        +- * BroadcastHashJoin Inner BuildRight (31)
-      :           :- * Project (26)
-      :           :  +- * BroadcastHashJoin Inner BuildRight (25)
-      :           :     :- * Filter (10)
-      :           :     :  +- * HashAggregate (9)
-      :           :     :     +- Exchange (8)
-      :           :     :        +- * HashAggregate (7)
-      :           :     :           +- * Project (6)
-      :           :     :              +- * BroadcastHashJoin Inner BuildRight (5)
-      :           :     :                 :- * Filter (3)
-      :           :     :                 :  +- * ColumnarToRow (2)
-      :           :     :                 :     +- Scan parquet spark_catalog.default.store_sales (1)
-      :           :     :                 +- ReusedExchange (4)
-      :           :     +- BroadcastExchange (24)
-      :           :        +- * Filter (23)
-      :           :           +- * HashAggregate (22)
-      :           :              +- Exchange (21)
-      :           :                 +- * HashAggregate (20)
-      :           :                    +- * HashAggregate (19)
-      :           :                       +- Exchange (18)
-      :           :                          +- * HashAggregate (17)
-      :           :                             +- * Project (16)
-      :           :                                +- * BroadcastHashJoin Inner BuildRight (15)
-      :           :                                   :- * Filter (13)
-      :           :                                   :  +- * ColumnarToRow (12)
-      :           :                                   :     +- Scan parquet spark_catalog.default.store_sales (11)
-      :           :                                   +- ReusedExchange (14)
-      :           +- BroadcastExchange (30)
-      :              +- * Filter (29)
-      :                 +- * ColumnarToRow (28)
-      :                    +- Scan parquet spark_catalog.default.store (27)
-      +- * Sort (39)
-         +- Exchange (38)
-            +- * Filter (37)
-               +- * ColumnarToRow (36)
-                  +- Scan parquet spark_catalog.default.item (35)
+   +- * BroadcastHashJoin Inner BuildRight (40)
+      :- * Project (35)
+      :  +- * SortMergeJoin Inner (34)
+      :     :- * Sort (28)
+      :     :  +- Exchange (27)
+      :     :     +- * Project (26)
+      :     :        +- * BroadcastHashJoin Inner BuildRight (25)
+      :     :           :- * Filter (10)
+      :     :           :  +- * HashAggregate (9)
+      :     :           :     +- Exchange (8)
+      :     :           :        +- * HashAggregate (7)
+      :     :           :           +- * Project (6)
+      :     :           :              +- * BroadcastHashJoin Inner BuildRight (5)
+      :     :           :                 :- * Filter (3)
+      :     :           :                 :  +- * ColumnarToRow (2)
+      :     :           :                 :     +- Scan parquet spark_catalog.default.store_sales (1)
+      :     :           :                 +- ReusedExchange (4)
+      :     :           +- BroadcastExchange (24)
+      :     :              +- * Filter (23)
+      :     :                 +- * HashAggregate (22)
+      :     :                    +- Exchange (21)
+      :     :                       +- * HashAggregate (20)
+      :     :                          +- * HashAggregate (19)
+      :     :                             +- Exchange (18)
+      :     :                                +- * HashAggregate (17)
+      :     :                                   +- * Project (16)
+      :     :                                      +- * BroadcastHashJoin Inner BuildRight (15)
+      :     :                                         :- * Filter (13)
+      :     :                                         :  +- * ColumnarToRow (12)
+      :     :                                         :     +- Scan parquet spark_catalog.default.store_sales (11)
+      :     :                                         +- ReusedExchange (14)
+      :     +- * Sort (33)
+      :        +- Exchange (32)
+      :           +- * Filter (31)
+      :              +- * ColumnarToRow (30)
+      :                 +- Scan parquet spark_catalog.default.item (29)
+      +- BroadcastExchange (39)
+         +- * Filter (38)
+            +- * ColumnarToRow (37)
+               +- Scan parquet spark_catalog.default.store (36)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -82,14 +82,14 @@ Results [3]: [ss_store_sk#2, ss_item_sk#1, sum#8]
 Input [3]: [ss_store_sk#2, ss_item_sk#1, sum#8]
 Arguments: hashpartitioning(ss_store_sk#2, ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 
-(9) HashAggregate [codegen id : 8]
+(9) HashAggregate [codegen id : 7]
 Input [3]: [ss_store_sk#2, ss_item_sk#1, sum#8]
 Keys [2]: [ss_store_sk#2, ss_item_sk#1]
 Functions [1]: [sum(UnscaledValue(ss_sales_price#3))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#3))#9]
 Results [3]: [ss_store_sk#2, ss_item_sk#1, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#9,17,2) AS revenue#10]
 
-(10) Filter [codegen id : 8]
+(10) Filter [codegen id : 7]
 Input [3]: [ss_store_sk#2, ss_item_sk#1, revenue#10]
 Condition : isnotnull(revenue#10)
 
@@ -165,87 +165,87 @@ Condition : isnotnull(ave#25)
 Input [2]: [ss_store_sk#12, ave#25]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
-(25) BroadcastHashJoin [codegen id : 8]
+(25) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [ss_store_sk#2]
 Right keys [1]: [ss_store_sk#12]
 Join type: Inner
 Join condition: (cast(revenue#10 as decimal(23,7)) <= (0.1 * ave#25))
 
-(26) Project [codegen id : 8]
+(26) Project [codegen id : 7]
 Output [3]: [ss_store_sk#2, ss_item_sk#1, revenue#10]
 Input [5]: [ss_store_sk#2, ss_item_sk#1, revenue#10, ss_store_sk#12, ave#25]
 
-(27) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#26, s_store_name#27]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_store_sk)]
-ReadSchema: struct<s_store_sk:int,s_store_name:string>
+(27) Exchange
+Input [3]: [ss_store_sk#2, ss_item_sk#1, revenue#10]
+Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(28) ColumnarToRow [codegen id : 7]
-Input [2]: [s_store_sk#26, s_store_name#27]
-
-(29) Filter [codegen id : 7]
-Input [2]: [s_store_sk#26, s_store_name#27]
-Condition : isnotnull(s_store_sk#26)
-
-(30) BroadcastExchange
-Input [2]: [s_store_sk#26, s_store_name#27]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
-
-(31) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ss_store_sk#2]
-Right keys [1]: [s_store_sk#26]
-Join type: Inner
-Join condition: None
-
-(32) Project [codegen id : 8]
-Output [3]: [ss_item_sk#1, revenue#10, s_store_name#27]
-Input [5]: [ss_store_sk#2, ss_item_sk#1, revenue#10, s_store_sk#26, s_store_name#27]
-
-(33) Exchange
-Input [3]: [ss_item_sk#1, revenue#10, s_store_name#27]
-Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(34) Sort [codegen id : 9]
-Input [3]: [ss_item_sk#1, revenue#10, s_store_name#27]
+(28) Sort [codegen id : 8]
+Input [3]: [ss_store_sk#2, ss_item_sk#1, revenue#10]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(35) Scan parquet spark_catalog.default.item
-Output [5]: [i_item_sk#28, i_item_desc#29, i_current_price#30, i_wholesale_cost#31, i_brand#32]
+(29) Scan parquet spark_catalog.default.item
+Output [5]: [i_item_sk#26, i_item_desc#27, i_current_price#28, i_wholesale_cost#29, i_brand#30]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_desc:string,i_current_price:decimal(7,2),i_wholesale_cost:decimal(7,2),i_brand:string>
 
-(36) ColumnarToRow [codegen id : 10]
-Input [5]: [i_item_sk#28, i_item_desc#29, i_current_price#30, i_wholesale_cost#31, i_brand#32]
+(30) ColumnarToRow [codegen id : 9]
+Input [5]: [i_item_sk#26, i_item_desc#27, i_current_price#28, i_wholesale_cost#29, i_brand#30]
 
-(37) Filter [codegen id : 10]
-Input [5]: [i_item_sk#28, i_item_desc#29, i_current_price#30, i_wholesale_cost#31, i_brand#32]
-Condition : isnotnull(i_item_sk#28)
+(31) Filter [codegen id : 9]
+Input [5]: [i_item_sk#26, i_item_desc#27, i_current_price#28, i_wholesale_cost#29, i_brand#30]
+Condition : isnotnull(i_item_sk#26)
 
-(38) Exchange
-Input [5]: [i_item_sk#28, i_item_desc#29, i_current_price#30, i_wholesale_cost#31, i_brand#32]
-Arguments: hashpartitioning(i_item_sk#28, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(32) Exchange
+Input [5]: [i_item_sk#26, i_item_desc#27, i_current_price#28, i_wholesale_cost#29, i_brand#30]
+Arguments: hashpartitioning(i_item_sk#26, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(39) Sort [codegen id : 11]
-Input [5]: [i_item_sk#28, i_item_desc#29, i_current_price#30, i_wholesale_cost#31, i_brand#32]
-Arguments: [i_item_sk#28 ASC NULLS FIRST], false, 0
+(33) Sort [codegen id : 10]
+Input [5]: [i_item_sk#26, i_item_desc#27, i_current_price#28, i_wholesale_cost#29, i_brand#30]
+Arguments: [i_item_sk#26 ASC NULLS FIRST], false, 0
 
-(40) SortMergeJoin [codegen id : 12]
+(34) SortMergeJoin [codegen id : 12]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#28]
+Right keys [1]: [i_item_sk#26]
+Join type: Inner
+Join condition: None
+
+(35) Project [codegen id : 12]
+Output [6]: [ss_store_sk#2, revenue#10, i_item_desc#27, i_current_price#28, i_wholesale_cost#29, i_brand#30]
+Input [8]: [ss_store_sk#2, ss_item_sk#1, revenue#10, i_item_sk#26, i_item_desc#27, i_current_price#28, i_wholesale_cost#29, i_brand#30]
+
+(36) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#31, s_store_name#32]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [IsNotNull(s_store_sk)]
+ReadSchema: struct<s_store_sk:int,s_store_name:string>
+
+(37) ColumnarToRow [codegen id : 11]
+Input [2]: [s_store_sk#31, s_store_name#32]
+
+(38) Filter [codegen id : 11]
+Input [2]: [s_store_sk#31, s_store_name#32]
+Condition : isnotnull(s_store_sk#31)
+
+(39) BroadcastExchange
+Input [2]: [s_store_sk#31, s_store_name#32]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
+
+(40) BroadcastHashJoin [codegen id : 12]
+Left keys [1]: [ss_store_sk#2]
+Right keys [1]: [s_store_sk#31]
 Join type: Inner
 Join condition: None
 
 (41) Project [codegen id : 12]
-Output [6]: [s_store_name#27, i_item_desc#29, revenue#10, i_current_price#30, i_wholesale_cost#31, i_brand#32]
-Input [8]: [ss_item_sk#1, revenue#10, s_store_name#27, i_item_sk#28, i_item_desc#29, i_current_price#30, i_wholesale_cost#31, i_brand#32]
+Output [6]: [s_store_name#32, i_item_desc#27, revenue#10, i_current_price#28, i_wholesale_cost#29, i_brand#30]
+Input [8]: [ss_store_sk#2, revenue#10, i_item_desc#27, i_current_price#28, i_wholesale_cost#29, i_brand#30, s_store_sk#31, s_store_name#32]
 
 (42) TakeOrderedAndProject
-Input [6]: [s_store_name#27, i_item_desc#29, revenue#10, i_current_price#30, i_wholesale_cost#31, i_brand#32]
-Arguments: 100, [s_store_name#27 ASC NULLS FIRST, i_item_desc#29 ASC NULLS FIRST], [s_store_name#27, i_item_desc#29, revenue#10, i_current_price#30, i_wholesale_cost#31, i_brand#32]
+Input [6]: [s_store_name#32, i_item_desc#27, revenue#10, i_current_price#28, i_wholesale_cost#29, i_brand#30]
+Arguments: 100, [s_store_name#32 ASC NULLS FIRST, i_item_desc#27 ASC NULLS FIRST], [s_store_name#32, i_item_desc#27, revenue#10, i_current_price#28, i_wholesale_cost#29, i_brand#30]
 
 ===== Subqueries =====
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q65.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q65.sf100/simplified.txt
@@ -1,15 +1,15 @@
 TakeOrderedAndProject [s_store_name,i_item_desc,revenue,i_current_price,i_wholesale_cost,i_brand]
   WholeStageCodegen (12)
     Project [s_store_name,i_item_desc,revenue,i_current_price,i_wholesale_cost,i_brand]
-      SortMergeJoin [ss_item_sk,i_item_sk]
-        InputAdapter
-          WholeStageCodegen (9)
-            Sort [ss_item_sk]
-              InputAdapter
-                Exchange [ss_item_sk] #1
-                  WholeStageCodegen (8)
-                    Project [ss_item_sk,revenue,s_store_name]
-                      BroadcastHashJoin [ss_store_sk,s_store_sk]
+      BroadcastHashJoin [ss_store_sk,s_store_sk]
+        Project [ss_store_sk,revenue,i_item_desc,i_current_price,i_wholesale_cost,i_brand]
+          SortMergeJoin [ss_item_sk,i_item_sk]
+            InputAdapter
+              WholeStageCodegen (8)
+                Sort [ss_item_sk]
+                  InputAdapter
+                    Exchange [ss_item_sk] #1
+                      WholeStageCodegen (7)
                         Project [ss_store_sk,ss_item_sk,revenue]
                           BroadcastHashJoin [ss_store_sk,ss_store_sk,revenue,ave]
                             Filter [revenue]
@@ -57,20 +57,20 @@ TakeOrderedAndProject [s_store_name,i_item_desc,revenue,i_current_price,i_wholes
                                                                     ReusedSubquery [d_date_sk] #1
                                                             InputAdapter
                                                               ReusedExchange [d_date_sk] #3
-                        InputAdapter
-                          BroadcastExchange #7
-                            WholeStageCodegen (7)
-                              Filter [s_store_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.store [s_store_sk,s_store_name]
+            InputAdapter
+              WholeStageCodegen (10)
+                Sort [i_item_sk]
+                  InputAdapter
+                    Exchange [i_item_sk] #7
+                      WholeStageCodegen (9)
+                        Filter [i_item_sk]
+                          ColumnarToRow
+                            InputAdapter
+                              Scan parquet spark_catalog.default.item [i_item_sk,i_item_desc,i_current_price,i_wholesale_cost,i_brand]
         InputAdapter
-          WholeStageCodegen (11)
-            Sort [i_item_sk]
-              InputAdapter
-                Exchange [i_item_sk] #8
-                  WholeStageCodegen (10)
-                    Filter [i_item_sk]
-                      ColumnarToRow
-                        InputAdapter
-                          Scan parquet spark_catalog.default.item [i_item_sk,i_item_desc,i_current_price,i_wholesale_cost,i_brand]
+          BroadcastExchange #8
+            WholeStageCodegen (11)
+              Filter [s_store_sk]
+                ColumnarToRow
+                  InputAdapter
+                    Scan parquet spark_catalog.default.store [s_store_sk,s_store_name]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q67.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q67.sf100/explain.txt
@@ -12,26 +12,26 @@ TakeOrderedAndProject (33)
                            +- * HashAggregate (23)
                               +- * Expand (22)
                                  +- * Project (21)
-                                    +- * SortMergeJoin Inner (20)
-                                       :- * Sort (14)
-                                       :  +- Exchange (13)
-                                       :     +- * Project (12)
-                                       :        +- * BroadcastHashJoin Inner BuildRight (11)
-                                       :           :- * Project (6)
-                                       :           :  +- * BroadcastHashJoin Inner BuildRight (5)
-                                       :           :     :- * Filter (3)
-                                       :           :     :  +- * ColumnarToRow (2)
-                                       :           :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-                                       :           :     +- ReusedExchange (4)
-                                       :           +- BroadcastExchange (10)
-                                       :              +- * Filter (9)
-                                       :                 +- * ColumnarToRow (8)
-                                       :                    +- Scan parquet spark_catalog.default.store (7)
-                                       +- * Sort (19)
-                                          +- Exchange (18)
-                                             +- * Filter (17)
-                                                +- * ColumnarToRow (16)
-                                                   +- Scan parquet spark_catalog.default.item (15)
+                                    +- * BroadcastHashJoin Inner BuildRight (20)
+                                       :- * Project (15)
+                                       :  +- * SortMergeJoin Inner (14)
+                                       :     :- * Sort (8)
+                                       :     :  +- Exchange (7)
+                                       :     :     +- * Project (6)
+                                       :     :        +- * BroadcastHashJoin Inner BuildRight (5)
+                                       :     :           :- * Filter (3)
+                                       :     :           :  +- * ColumnarToRow (2)
+                                       :     :           :     +- Scan parquet spark_catalog.default.store_sales (1)
+                                       :     :           +- ReusedExchange (4)
+                                       :     +- * Sort (13)
+                                       :        +- Exchange (12)
+                                       :           +- * Filter (11)
+                                       :              +- * ColumnarToRow (10)
+                                       :                 +- Scan parquet spark_catalog.default.item (9)
+                                       +- BroadcastExchange (19)
+                                          +- * Filter (18)
+                                             +- * ColumnarToRow (17)
+                                                +- Scan parquet spark_catalog.default.store (16)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -42,97 +42,97 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#5), dynamicpruningexpression(ss_sol
 PushedFilters: [IsNotNull(ss_store_sk), IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_store_sk:int,ss_quantity:int,ss_sales_price:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 3]
+(2) ColumnarToRow [codegen id : 2]
 Input [5]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, ss_sold_date_sk#5]
 
-(3) Filter [codegen id : 3]
+(3) Filter [codegen id : 2]
 Input [5]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, ss_sold_date_sk#5]
 Condition : (isnotnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1))
 
 (4) ReusedExchange [Reuses operator id: 38]
 Output [4]: [d_date_sk#7, d_year#8, d_moy#9, d_qoy#10]
 
-(5) BroadcastHashJoin [codegen id : 3]
+(5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
 Join type: Inner
 Join condition: None
 
-(6) Project [codegen id : 3]
+(6) Project [codegen id : 2]
 Output [7]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10]
 Input [9]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, ss_sold_date_sk#5, d_date_sk#7, d_year#8, d_moy#9, d_qoy#10]
 
-(7) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#11, s_store_id#12]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_store_sk)]
-ReadSchema: struct<s_store_sk:int,s_store_id:string>
+(7) Exchange
+Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10]
+Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 
-(8) ColumnarToRow [codegen id : 2]
-Input [2]: [s_store_sk#11, s_store_id#12]
-
-(9) Filter [codegen id : 2]
-Input [2]: [s_store_sk#11, s_store_id#12]
-Condition : isnotnull(s_store_sk#11)
-
-(10) BroadcastExchange
-Input [2]: [s_store_sk#11, s_store_id#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
-
-(11) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_store_sk#2]
-Right keys [1]: [s_store_sk#11]
-Join type: Inner
-Join condition: None
-
-(12) Project [codegen id : 3]
-Output [7]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_id#12]
-Input [9]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_sk#11, s_store_id#12]
-
-(13) Exchange
-Input [7]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_id#12]
-Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
-
-(14) Sort [codegen id : 4]
-Input [7]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_id#12]
+(8) Sort [codegen id : 3]
+Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(15) Scan parquet spark_catalog.default.item
-Output [5]: [i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
+(9) Scan parquet spark_catalog.default.item
+Output [5]: [i_item_sk#11, i_brand#12, i_class#13, i_category#14, i_product_name#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand:string,i_class:string,i_category:string,i_product_name:string>
 
-(16) ColumnarToRow [codegen id : 5]
-Input [5]: [i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
+(10) ColumnarToRow [codegen id : 4]
+Input [5]: [i_item_sk#11, i_brand#12, i_class#13, i_category#14, i_product_name#15]
 
-(17) Filter [codegen id : 5]
-Input [5]: [i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
-Condition : isnotnull(i_item_sk#13)
+(11) Filter [codegen id : 4]
+Input [5]: [i_item_sk#11, i_brand#12, i_class#13, i_category#14, i_product_name#15]
+Condition : isnotnull(i_item_sk#11)
 
-(18) Exchange
-Input [5]: [i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
-Arguments: hashpartitioning(i_item_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+(12) Exchange
+Input [5]: [i_item_sk#11, i_brand#12, i_class#13, i_category#14, i_product_name#15]
+Arguments: hashpartitioning(i_item_sk#11, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(19) Sort [codegen id : 6]
-Input [5]: [i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
-Arguments: [i_item_sk#13 ASC NULLS FIRST], false, 0
+(13) Sort [codegen id : 5]
+Input [5]: [i_item_sk#11, i_brand#12, i_class#13, i_category#14, i_product_name#15]
+Arguments: [i_item_sk#11 ASC NULLS FIRST], false, 0
 
-(20) SortMergeJoin [codegen id : 7]
+(14) SortMergeJoin [codegen id : 7]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#13]
+Right keys [1]: [i_item_sk#11]
+Join type: Inner
+Join condition: None
+
+(15) Project [codegen id : 7]
+Output [10]: [ss_store_sk#2, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, i_brand#12, i_class#13, i_category#14, i_product_name#15]
+Input [12]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, i_item_sk#11, i_brand#12, i_class#13, i_category#14, i_product_name#15]
+
+(16) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#16, s_store_id#17]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [IsNotNull(s_store_sk)]
+ReadSchema: struct<s_store_sk:int,s_store_id:string>
+
+(17) ColumnarToRow [codegen id : 6]
+Input [2]: [s_store_sk#16, s_store_id#17]
+
+(18) Filter [codegen id : 6]
+Input [2]: [s_store_sk#16, s_store_id#17]
+Condition : isnotnull(s_store_sk#16)
+
+(19) BroadcastExchange
+Input [2]: [s_store_sk#16, s_store_id#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
+
+(20) BroadcastHashJoin [codegen id : 7]
+Left keys [1]: [ss_store_sk#2]
+Right keys [1]: [s_store_sk#16]
 Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 7]
-Output [10]: [ss_quantity#3, ss_sales_price#4, i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12]
-Input [12]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_id#12, i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
+Output [10]: [ss_quantity#3, ss_sales_price#4, i_category#14, i_class#13, i_brand#12, i_product_name#15, d_year#8, d_qoy#10, d_moy#9, s_store_id#17]
+Input [12]: [ss_store_sk#2, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, i_brand#12, i_class#13, i_category#14, i_product_name#15, s_store_sk#16, s_store_id#17]
 
 (22) Expand [codegen id : 7]
-Input [10]: [ss_quantity#3, ss_sales_price#4, i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12]
-Arguments: [[ss_quantity#3, ss_sales_price#4, i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, 0], [ss_quantity#3, ss_sales_price#4, i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, null, 1], [ss_quantity#3, ss_sales_price#4, i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, null, null, 3], [ss_quantity#3, ss_sales_price#4, i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, null, null, null, 7], [ss_quantity#3, ss_sales_price#4, i_category#16, i_class#15, i_brand#14, i_product_name#17, null, null, null, null, 15], [ss_quantity#3, ss_sales_price#4, i_category#16, i_class#15, i_brand#14, null, null, null, null, null, 31], [ss_quantity#3, ss_sales_price#4, i_category#16, i_class#15, null, null, null, null, null, null, 63], [ss_quantity#3, ss_sales_price#4, i_category#16, null, null, null, null, null, null, null, 127], [ss_quantity#3, ss_sales_price#4, null, null, null, null, null, null, null, null, 255]], [ss_quantity#3, ss_sales_price#4, i_category#18, i_class#19, i_brand#20, i_product_name#21, d_year#22, d_qoy#23, d_moy#24, s_store_id#25, spark_grouping_id#26]
+Input [10]: [ss_quantity#3, ss_sales_price#4, i_category#14, i_class#13, i_brand#12, i_product_name#15, d_year#8, d_qoy#10, d_moy#9, s_store_id#17]
+Arguments: [[ss_quantity#3, ss_sales_price#4, i_category#14, i_class#13, i_brand#12, i_product_name#15, d_year#8, d_qoy#10, d_moy#9, s_store_id#17, 0], [ss_quantity#3, ss_sales_price#4, i_category#14, i_class#13, i_brand#12, i_product_name#15, d_year#8, d_qoy#10, d_moy#9, null, 1], [ss_quantity#3, ss_sales_price#4, i_category#14, i_class#13, i_brand#12, i_product_name#15, d_year#8, d_qoy#10, null, null, 3], [ss_quantity#3, ss_sales_price#4, i_category#14, i_class#13, i_brand#12, i_product_name#15, d_year#8, null, null, null, 7], [ss_quantity#3, ss_sales_price#4, i_category#14, i_class#13, i_brand#12, i_product_name#15, null, null, null, null, 15], [ss_quantity#3, ss_sales_price#4, i_category#14, i_class#13, i_brand#12, null, null, null, null, null, 31], [ss_quantity#3, ss_sales_price#4, i_category#14, i_class#13, null, null, null, null, null, null, 63], [ss_quantity#3, ss_sales_price#4, i_category#14, null, null, null, null, null, null, null, 127], [ss_quantity#3, ss_sales_price#4, null, null, null, null, null, null, null, null, 255]], [ss_quantity#3, ss_sales_price#4, i_category#18, i_class#19, i_brand#20, i_product_name#21, d_year#22, d_qoy#23, d_moy#24, s_store_id#25, spark_grouping_id#26]
 
 (23) HashAggregate [codegen id : 7]
 Input [11]: [ss_quantity#3, ss_sales_price#4, i_category#18, i_class#19, i_brand#20, i_product_name#21, d_year#22, d_qoy#23, d_moy#24, s_store_id#25, spark_grouping_id#26]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q67.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q67.sf100/simplified.txt
@@ -18,15 +18,15 @@ TakeOrderedAndProject [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_
                                   HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,spark_grouping_id,ss_sales_price,ss_quantity] [sum,isEmpty,sum,isEmpty]
                                     Expand [ss_quantity,ss_sales_price,i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id]
                                       Project [ss_quantity,ss_sales_price,i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id]
-                                        SortMergeJoin [ss_item_sk,i_item_sk]
-                                          InputAdapter
-                                            WholeStageCodegen (4)
-                                              Sort [ss_item_sk]
-                                                InputAdapter
-                                                  Exchange [ss_item_sk] #3
-                                                    WholeStageCodegen (3)
-                                                      Project [ss_item_sk,ss_quantity,ss_sales_price,d_year,d_moy,d_qoy,s_store_id]
-                                                        BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                        BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                          Project [ss_store_sk,ss_quantity,ss_sales_price,d_year,d_moy,d_qoy,i_brand,i_class,i_category,i_product_name]
+                                            SortMergeJoin [ss_item_sk,i_item_sk]
+                                              InputAdapter
+                                                WholeStageCodegen (3)
+                                                  Sort [ss_item_sk]
+                                                    InputAdapter
+                                                      Exchange [ss_item_sk] #3
+                                                        WholeStageCodegen (2)
                                                           Project [ss_item_sk,ss_store_sk,ss_quantity,ss_sales_price,d_year,d_moy,d_qoy]
                                                             BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                               Filter [ss_store_sk,ss_item_sk]
@@ -43,20 +43,20 @@ TakeOrderedAndProject [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_
                                                                                     Scan parquet spark_catalog.default.date_dim [d_date_sk,d_month_seq,d_year,d_moy,d_qoy]
                                                               InputAdapter
                                                                 ReusedExchange [d_date_sk,d_year,d_moy,d_qoy] #4
-                                                          InputAdapter
-                                                            BroadcastExchange #5
-                                                              WholeStageCodegen (2)
-                                                                Filter [s_store_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
+                                              InputAdapter
+                                                WholeStageCodegen (5)
+                                                  Sort [i_item_sk]
+                                                    InputAdapter
+                                                      Exchange [i_item_sk] #5
+                                                        WholeStageCodegen (4)
+                                                          Filter [i_item_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_class,i_category,i_product_name]
                                           InputAdapter
-                                            WholeStageCodegen (6)
-                                              Sort [i_item_sk]
-                                                InputAdapter
-                                                  Exchange [i_item_sk] #6
-                                                    WholeStageCodegen (5)
-                                                      Filter [i_item_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_class,i_category,i_product_name]
+                                            BroadcastExchange #6
+                                              WholeStageCodegen (6)
+                                                Filter [s_store_sk]
+                                                  ColumnarToRow
+                                                    InputAdapter
+                                                      Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q68.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q68.sf100/explain.txt
@@ -28,17 +28,17 @@ TakeOrderedAndProject (47)
                         :        +- * BroadcastHashJoin Inner BuildRight (33)
                         :           :- * Project (27)
                         :           :  +- * BroadcastHashJoin Inner BuildRight (26)
-                        :           :     :- * Project (20)
-                        :           :     :  +- * BroadcastHashJoin Inner BuildRight (19)
+                        :           :     :- * Project (24)
+                        :           :     :  +- * BroadcastHashJoin Inner BuildRight (23)
                         :           :     :     :- * Filter (17)
                         :           :     :     :  +- * ColumnarToRow (16)
                         :           :     :     :     +- Scan parquet spark_catalog.default.store_sales (15)
-                        :           :     :     +- ReusedExchange (18)
-                        :           :     +- BroadcastExchange (25)
-                        :           :        +- * Project (24)
-                        :           :           +- * Filter (23)
-                        :           :              +- * ColumnarToRow (22)
-                        :           :                 +- Scan parquet spark_catalog.default.store (21)
+                        :           :     :     +- BroadcastExchange (22)
+                        :           :     :        +- * Project (21)
+                        :           :     :           +- * Filter (20)
+                        :           :     :              +- * ColumnarToRow (19)
+                        :           :     :                 +- Scan parquet spark_catalog.default.store (18)
+                        :           :     +- ReusedExchange (25)
                         :           +- BroadcastExchange (32)
                         :              +- * Project (31)
                         :                 +- * Filter (30)
@@ -125,50 +125,50 @@ Input [9]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ti
 Input [9]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, ss_sold_date_sk#15]
 Condition : (((isnotnull(ss_store_sk#10) AND isnotnull(ss_hdemo_sk#8)) AND isnotnull(ss_addr_sk#9)) AND isnotnull(ss_customer_sk#7))
 
-(18) ReusedExchange [Reuses operator id: 52]
-Output [1]: [d_date_sk#17]
-
-(19) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [ss_sold_date_sk#15]
-Right keys [1]: [d_date_sk#17]
-Join type: Inner
-Join condition: None
-
-(20) Project [codegen id : 10]
-Output [8]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14]
-Input [10]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, ss_sold_date_sk#15, d_date_sk#17]
-
-(21) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#18, s_city#19]
+(18) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#17, s_city#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [In(s_city, [Fairview,Midway]), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_city:string>
 
-(22) ColumnarToRow [codegen id : 8]
-Input [2]: [s_store_sk#18, s_city#19]
+(19) ColumnarToRow [codegen id : 7]
+Input [2]: [s_store_sk#17, s_city#18]
 
-(23) Filter [codegen id : 8]
-Input [2]: [s_store_sk#18, s_city#19]
-Condition : (s_city#19 IN (Midway,Fairview) AND isnotnull(s_store_sk#18))
+(20) Filter [codegen id : 7]
+Input [2]: [s_store_sk#17, s_city#18]
+Condition : (s_city#18 IN (Midway,Fairview) AND isnotnull(s_store_sk#17))
 
-(24) Project [codegen id : 8]
-Output [1]: [s_store_sk#18]
-Input [2]: [s_store_sk#18, s_city#19]
+(21) Project [codegen id : 7]
+Output [1]: [s_store_sk#17]
+Input [2]: [s_store_sk#17, s_city#18]
 
-(25) BroadcastExchange
-Input [1]: [s_store_sk#18]
+(22) BroadcastExchange
+Input [1]: [s_store_sk#17]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
-(26) BroadcastHashJoin [codegen id : 10]
+(23) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [ss_store_sk#10]
-Right keys [1]: [s_store_sk#18]
+Right keys [1]: [s_store_sk#17]
+Join type: Inner
+Join condition: None
+
+(24) Project [codegen id : 10]
+Output [8]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, ss_sold_date_sk#15]
+Input [10]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, ss_sold_date_sk#15, s_store_sk#17]
+
+(25) ReusedExchange [Reuses operator id: 52]
+Output [1]: [d_date_sk#19]
+
+(26) BroadcastHashJoin [codegen id : 10]
+Left keys [1]: [ss_sold_date_sk#15]
+Right keys [1]: [d_date_sk#19]
 Join type: Inner
 Join condition: None
 
 (27) Project [codegen id : 10]
 Output [7]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14]
-Input [9]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_store_sk#10, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, s_store_sk#18]
+Input [9]: [ss_customer_sk#7, ss_hdemo_sk#8, ss_addr_sk#9, ss_ticket_number#11, ss_ext_sales_price#12, ss_ext_list_price#13, ss_ext_tax#14, ss_sold_date_sk#15, d_date_sk#19]
 
 (28) Scan parquet spark_catalog.default.household_demographics
 Output [3]: [hd_demo_sk#20, hd_dep_count#21, hd_vehicle_count#22]
@@ -274,25 +274,25 @@ BroadcastExchange (52)
 
 
 (48) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#17, d_year#38, d_dom#39]
+Output [3]: [d_date_sk#19, d_year#38, d_dom#39]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_dom), GreaterThanOrEqual(d_dom,1), LessThanOrEqual(d_dom,2), In(d_year, [1999,2000,2001]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_dom:int>
 
 (49) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#17, d_year#38, d_dom#39]
+Input [3]: [d_date_sk#19, d_year#38, d_dom#39]
 
 (50) Filter [codegen id : 1]
-Input [3]: [d_date_sk#17, d_year#38, d_dom#39]
-Condition : ((((isnotnull(d_dom#39) AND (d_dom#39 >= 1)) AND (d_dom#39 <= 2)) AND d_year#38 IN (1999,2000,2001)) AND isnotnull(d_date_sk#17))
+Input [3]: [d_date_sk#19, d_year#38, d_dom#39]
+Condition : ((((isnotnull(d_dom#39) AND (d_dom#39 >= 1)) AND (d_dom#39 <= 2)) AND d_year#38 IN (1999,2000,2001)) AND isnotnull(d_date_sk#19))
 
 (51) Project [codegen id : 1]
-Output [1]: [d_date_sk#17]
-Input [3]: [d_date_sk#17, d_year#38, d_dom#39]
+Output [1]: [d_date_sk#19]
+Input [3]: [d_date_sk#19, d_year#38, d_dom#39]
 
 (52) BroadcastExchange
-Input [1]: [d_date_sk#17]
+Input [1]: [d_date_sk#19]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q68.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q68.sf100/simplified.txt
@@ -49,9 +49,9 @@ TakeOrderedAndProject [c_last_name,ss_ticket_number,c_first_name,ca_city,bought_
                                         Project [ss_customer_sk,ss_addr_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax]
                                           BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
                                             Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax]
-                                              BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_store_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax]
-                                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                Project [ss_customer_sk,ss_hdemo_sk,ss_addr_sk,ss_ticket_number,ss_ext_sales_price,ss_ext_list_price,ss_ext_tax,ss_sold_date_sk]
+                                                  BroadcastHashJoin [ss_store_sk,s_store_sk]
                                                     Filter [ss_store_sk,ss_hdemo_sk,ss_addr_sk,ss_customer_sk]
                                                       ColumnarToRow
                                                         InputAdapter
@@ -65,15 +65,15 @@ TakeOrderedAndProject [c_last_name,ss_ticket_number,c_first_name,ca_city,bought_
                                                                         InputAdapter
                                                                           Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_dom]
                                                     InputAdapter
-                                                      ReusedExchange [d_date_sk] #6
+                                                      BroadcastExchange #7
+                                                        WholeStageCodegen (7)
+                                                          Project [s_store_sk]
+                                                            Filter [s_city,s_store_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet spark_catalog.default.store [s_store_sk,s_city]
                                                 InputAdapter
-                                                  BroadcastExchange #7
-                                                    WholeStageCodegen (8)
-                                                      Project [s_store_sk]
-                                                        Filter [s_city,s_store_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.store [s_store_sk,s_city]
+                                                  ReusedExchange [d_date_sk] #6
                                             InputAdapter
                                               BroadcastExchange #8
                                                 WholeStageCodegen (9)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69.sf100/explain.txt
@@ -1,51 +1,54 @@
 == Physical Plan ==
-TakeOrderedAndProject (47)
-+- * HashAggregate (46)
-   +- Exchange (45)
-      +- * HashAggregate (44)
-         +- * Project (43)
-            +- * BroadcastHashJoin Inner BuildLeft (42)
-               :- BroadcastExchange (38)
-               :  +- * Project (37)
-               :     +- * BroadcastHashJoin Inner BuildRight (36)
-               :        :- * Project (30)
-               :        :  +- * SortMergeJoin LeftAnti (29)
-               :        :     :- * SortMergeJoin LeftAnti (21)
-               :        :     :  :- * SortMergeJoin LeftSemi (13)
-               :        :     :  :  :- * Sort (5)
-               :        :     :  :  :  +- Exchange (4)
-               :        :     :  :  :     +- * Filter (3)
-               :        :     :  :  :        +- * ColumnarToRow (2)
-               :        :     :  :  :           +- Scan parquet spark_catalog.default.customer (1)
-               :        :     :  :  +- * Sort (12)
-               :        :     :  :     +- Exchange (11)
-               :        :     :  :        +- * Project (10)
-               :        :     :  :           +- * BroadcastHashJoin Inner BuildRight (9)
-               :        :     :  :              :- * ColumnarToRow (7)
-               :        :     :  :              :  +- Scan parquet spark_catalog.default.store_sales (6)
-               :        :     :  :              +- ReusedExchange (8)
-               :        :     :  +- * Sort (20)
-               :        :     :     +- Exchange (19)
-               :        :     :        +- * Project (18)
-               :        :     :           +- * BroadcastHashJoin Inner BuildRight (17)
-               :        :     :              :- * ColumnarToRow (15)
-               :        :     :              :  +- Scan parquet spark_catalog.default.web_sales (14)
-               :        :     :              +- ReusedExchange (16)
-               :        :     +- * Sort (28)
-               :        :        +- Exchange (27)
-               :        :           +- * Project (26)
-               :        :              +- * BroadcastHashJoin Inner BuildRight (25)
-               :        :                 :- * ColumnarToRow (23)
-               :        :                 :  +- Scan parquet spark_catalog.default.catalog_sales (22)
-               :        :                 +- ReusedExchange (24)
-               :        +- BroadcastExchange (35)
-               :           +- * Project (34)
-               :              +- * Filter (33)
-               :                 +- * ColumnarToRow (32)
-               :                    +- Scan parquet spark_catalog.default.customer_address (31)
-               +- * Filter (41)
-                  +- * ColumnarToRow (40)
-                     +- Scan parquet spark_catalog.default.customer_demographics (39)
+TakeOrderedAndProject (50)
++- * HashAggregate (49)
+   +- Exchange (48)
+      +- * HashAggregate (47)
+         +- * Project (46)
+            +- * SortMergeJoin Inner (45)
+               :- * Sort (39)
+               :  +- Exchange (38)
+               :     +- * Project (37)
+               :        +- * BroadcastHashJoin Inner BuildRight (36)
+               :           :- * Project (30)
+               :           :  +- * SortMergeJoin LeftAnti (29)
+               :           :     :- * SortMergeJoin LeftAnti (21)
+               :           :     :  :- * SortMergeJoin LeftSemi (13)
+               :           :     :  :  :- * Sort (5)
+               :           :     :  :  :  +- Exchange (4)
+               :           :     :  :  :     +- * Filter (3)
+               :           :     :  :  :        +- * ColumnarToRow (2)
+               :           :     :  :  :           +- Scan parquet spark_catalog.default.customer (1)
+               :           :     :  :  +- * Sort (12)
+               :           :     :  :     +- Exchange (11)
+               :           :     :  :        +- * Project (10)
+               :           :     :  :           +- * BroadcastHashJoin Inner BuildRight (9)
+               :           :     :  :              :- * ColumnarToRow (7)
+               :           :     :  :              :  +- Scan parquet spark_catalog.default.store_sales (6)
+               :           :     :  :              +- ReusedExchange (8)
+               :           :     :  +- * Sort (20)
+               :           :     :     +- Exchange (19)
+               :           :     :        +- * Project (18)
+               :           :     :           +- * BroadcastHashJoin Inner BuildRight (17)
+               :           :     :              :- * ColumnarToRow (15)
+               :           :     :              :  +- Scan parquet spark_catalog.default.web_sales (14)
+               :           :     :              +- ReusedExchange (16)
+               :           :     +- * Sort (28)
+               :           :        +- Exchange (27)
+               :           :           +- * Project (26)
+               :           :              +- * BroadcastHashJoin Inner BuildRight (25)
+               :           :                 :- * ColumnarToRow (23)
+               :           :                 :  +- Scan parquet spark_catalog.default.catalog_sales (22)
+               :           :                 +- ReusedExchange (24)
+               :           +- BroadcastExchange (35)
+               :              +- * Project (34)
+               :                 +- * Filter (33)
+               :                    +- * ColumnarToRow (32)
+               :                       +- Scan parquet spark_catalog.default.customer_address (31)
+               +- * Sort (44)
+                  +- Exchange (43)
+                     +- * Filter (42)
+                        +- * ColumnarToRow (41)
+                           +- Scan parquet spark_catalog.default.customer_demographics (40)
 
 
 (1) Scan parquet spark_catalog.default.customer
@@ -80,7 +83,7 @@ ReadSchema: struct<ss_customer_sk:int>
 (7) ColumnarToRow [codegen id : 4]
 Input [2]: [ss_customer_sk#6, ss_sold_date_sk#7]
 
-(8) ReusedExchange [Reuses operator id: 59]
+(8) ReusedExchange [Reuses operator id: 62]
 Output [1]: [d_date_sk#9]
 
 (9) BroadcastHashJoin [codegen id : 4]
@@ -117,7 +120,7 @@ ReadSchema: struct<ws_bill_customer_sk:int>
 (15) ColumnarToRow [codegen id : 8]
 Input [2]: [ws_bill_customer_sk#10, ws_sold_date_sk#11]
 
-(16) ReusedExchange [Reuses operator id: 59]
+(16) ReusedExchange [Reuses operator id: 62]
 Output [1]: [d_date_sk#12]
 
 (17) BroadcastHashJoin [codegen id : 8]
@@ -154,7 +157,7 @@ ReadSchema: struct<cs_ship_customer_sk:int>
 (23) ColumnarToRow [codegen id : 12]
 Input [2]: [cs_ship_customer_sk#13, cs_sold_date_sk#14]
 
-(24) ReusedExchange [Reuses operator id: 59]
+(24) ReusedExchange [Reuses operator id: 62]
 Output [1]: [d_date_sk#15]
 
 (25) BroadcastHashJoin [codegen id : 12]
@@ -217,98 +220,110 @@ Join condition: None
 Output [1]: [c_current_cdemo_sk#2]
 Input [3]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#16]
 
-(38) BroadcastExchange
+(38) Exchange
 Input [1]: [c_current_cdemo_sk#2]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=6]
+Arguments: hashpartitioning(c_current_cdemo_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(39) Scan parquet spark_catalog.default.customer_demographics
+(39) Sort [codegen id : 16]
+Input [1]: [c_current_cdemo_sk#2]
+Arguments: [c_current_cdemo_sk#2 ASC NULLS FIRST], false, 0
+
+(40) Scan parquet spark_catalog.default.customer_demographics
 Output [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_education_status:string,cd_purchase_estimate:int,cd_credit_rating:string>
 
-(40) ColumnarToRow
+(41) ColumnarToRow [codegen id : 17]
 Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
 
-(41) Filter
+(42) Filter [codegen id : 17]
 Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
 Condition : isnotnull(cd_demo_sk#18)
 
-(42) BroadcastHashJoin [codegen id : 16]
+(43) Exchange
+Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
+Arguments: hashpartitioning(cd_demo_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(44) Sort [codegen id : 18]
+Input [6]: [cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
+Arguments: [cd_demo_sk#18 ASC NULLS FIRST], false, 0
+
+(45) SortMergeJoin [codegen id : 19]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#18]
 Join type: Inner
 Join condition: None
 
-(43) Project [codegen id : 16]
+(46) Project [codegen id : 19]
 Output [5]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
 Input [7]: [c_current_cdemo_sk#2, cd_demo_sk#18, cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
 
-(44) HashAggregate [codegen id : 16]
+(47) HashAggregate [codegen id : 19]
 Input [5]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
 Keys [5]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
 Functions [1]: [partial_count(1)]
 Aggregate Attributes [1]: [count#24]
 Results [6]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, count#25]
 
-(45) Exchange
+(48) Exchange
 Input [6]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, count#25]
-Arguments: hashpartitioning(cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Arguments: hashpartitioning(cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(46) HashAggregate [codegen id : 17]
+(49) HashAggregate [codegen id : 20]
 Input [6]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23, count#25]
 Keys [5]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cd_purchase_estimate#22, cd_credit_rating#23]
 Functions [1]: [count(1)]
 Aggregate Attributes [1]: [count(1)#26]
 Results [8]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, count(1)#26 AS cnt1#27, cd_purchase_estimate#22, count(1)#26 AS cnt2#28, cd_credit_rating#23, count(1)#26 AS cnt3#29]
 
-(47) TakeOrderedAndProject
+(50) TakeOrderedAndProject
 Input [8]: [cd_gender#19, cd_marital_status#20, cd_education_status#21, cnt1#27, cd_purchase_estimate#22, cnt2#28, cd_credit_rating#23, cnt3#29]
 Arguments: 100, [cd_gender#19 ASC NULLS FIRST, cd_marital_status#20 ASC NULLS FIRST, cd_education_status#21 ASC NULLS FIRST, cd_purchase_estimate#22 ASC NULLS FIRST, cd_credit_rating#23 ASC NULLS FIRST], [cd_gender#19, cd_marital_status#20, cd_education_status#21, cnt1#27, cd_purchase_estimate#22, cnt2#28, cd_credit_rating#23, cnt3#29]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#4, [id=#5]
-ObjectHashAggregate (54)
-+- Exchange (53)
-   +- ObjectHashAggregate (52)
-      +- * Project (51)
-         +- * Filter (50)
-            +- * ColumnarToRow (49)
-               +- Scan parquet spark_catalog.default.customer_address (48)
+ObjectHashAggregate (57)
++- Exchange (56)
+   +- ObjectHashAggregate (55)
+      +- * Project (54)
+         +- * Filter (53)
+            +- * ColumnarToRow (52)
+               +- Scan parquet spark_catalog.default.customer_address (51)
 
 
-(48) Scan parquet spark_catalog.default.customer_address
+(51) Scan parquet spark_catalog.default.customer_address
 Output [2]: [ca_address_sk#16, ca_state#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_state, [GA,KY,NM]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(49) ColumnarToRow [codegen id : 1]
+(52) ColumnarToRow [codegen id : 1]
 Input [2]: [ca_address_sk#16, ca_state#17]
 
-(50) Filter [codegen id : 1]
+(53) Filter [codegen id : 1]
 Input [2]: [ca_address_sk#16, ca_state#17]
 Condition : (ca_state#17 IN (KY,GA,NM) AND isnotnull(ca_address_sk#16))
 
-(51) Project [codegen id : 1]
+(54) Project [codegen id : 1]
 Output [1]: [ca_address_sk#16]
 Input [2]: [ca_address_sk#16, ca_state#17]
 
-(52) ObjectHashAggregate
+(55) ObjectHashAggregate
 Input [1]: [ca_address_sk#16]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#16, 42), 55556, 899992, 0, 0)]
 Aggregate Attributes [1]: [buf#30]
 Results [1]: [buf#31]
 
-(53) Exchange
+(56) Exchange
 Input [1]: [buf#31]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
 
-(54) ObjectHashAggregate
+(57) ObjectHashAggregate
 Input [1]: [buf#31]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#16, 42), 55556, 899992, 0, 0)]
@@ -316,34 +331,34 @@ Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#16, 42), 5555
 Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#16, 42), 55556, 899992, 0, 0)#32 AS bloomFilter#33]
 
 Subquery:2 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#7 IN dynamicpruning#8
-BroadcastExchange (59)
-+- * Project (58)
-   +- * Filter (57)
-      +- * ColumnarToRow (56)
-         +- Scan parquet spark_catalog.default.date_dim (55)
+BroadcastExchange (62)
++- * Project (61)
+   +- * Filter (60)
+      +- * ColumnarToRow (59)
+         +- Scan parquet spark_catalog.default.date_dim (58)
 
 
-(55) Scan parquet spark_catalog.default.date_dim
+(58) Scan parquet spark_catalog.default.date_dim
 Output [3]: [d_date_sk#9, d_year#34, d_moy#35]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2001), GreaterThanOrEqual(d_moy,4), LessThanOrEqual(d_moy,6), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(56) ColumnarToRow [codegen id : 1]
+(59) ColumnarToRow [codegen id : 1]
 Input [3]: [d_date_sk#9, d_year#34, d_moy#35]
 
-(57) Filter [codegen id : 1]
+(60) Filter [codegen id : 1]
 Input [3]: [d_date_sk#9, d_year#34, d_moy#35]
 Condition : (((((isnotnull(d_year#34) AND isnotnull(d_moy#35)) AND (d_year#34 = 2001)) AND (d_moy#35 >= 4)) AND (d_moy#35 <= 6)) AND isnotnull(d_date_sk#9))
 
-(58) Project [codegen id : 1]
+(61) Project [codegen id : 1]
 Output [1]: [d_date_sk#9]
 Input [3]: [d_date_sk#9, d_year#34, d_moy#35]
 
-(59) BroadcastExchange
+(62) BroadcastExchange
 Input [1]: [d_date_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
 Subquery:3 Hosting operator id = 14 Hosting Expression = ws_sold_date_sk#11 IN dynamicpruning#8
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q69.sf100/simplified.txt
@@ -1,103 +1,112 @@
 TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cnt1,cnt2,cnt3]
-  WholeStageCodegen (17)
+  WholeStageCodegen (20)
     HashAggregate [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,count] [count(1),cnt1,cnt2,cnt3,count]
       InputAdapter
         Exchange [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating] #1
-          WholeStageCodegen (16)
+          WholeStageCodegen (19)
             HashAggregate [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating] [count,count]
               Project [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating]
-                BroadcastHashJoin [c_current_cdemo_sk,cd_demo_sk]
+                SortMergeJoin [c_current_cdemo_sk,cd_demo_sk]
                   InputAdapter
-                    BroadcastExchange #2
-                      WholeStageCodegen (15)
-                        Project [c_current_cdemo_sk]
-                          BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
-                            Project [c_current_cdemo_sk,c_current_addr_sk]
-                              SortMergeJoin [c_customer_sk,cs_ship_customer_sk]
-                                InputAdapter
-                                  WholeStageCodegen (10)
-                                    SortMergeJoin [c_customer_sk,ws_bill_customer_sk]
+                    WholeStageCodegen (16)
+                      Sort [c_current_cdemo_sk]
+                        InputAdapter
+                          Exchange [c_current_cdemo_sk] #2
+                            WholeStageCodegen (15)
+                              Project [c_current_cdemo_sk]
+                                BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
+                                  Project [c_current_cdemo_sk,c_current_addr_sk]
+                                    SortMergeJoin [c_customer_sk,cs_ship_customer_sk]
                                       InputAdapter
-                                        WholeStageCodegen (6)
-                                          SortMergeJoin [c_customer_sk,ss_customer_sk]
+                                        WholeStageCodegen (10)
+                                          SortMergeJoin [c_customer_sk,ws_bill_customer_sk]
                                             InputAdapter
-                                              WholeStageCodegen (2)
-                                                Sort [c_customer_sk]
+                                              WholeStageCodegen (6)
+                                                SortMergeJoin [c_customer_sk,ss_customer_sk]
                                                   InputAdapter
-                                                    Exchange [c_customer_sk] #3
-                                                      WholeStageCodegen (1)
-                                                        Filter [c_current_addr_sk,c_current_cdemo_sk]
-                                                          Subquery #1
-                                                            ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 55556, 899992, 0, 0),bloomFilter,buf]
-                                                              Exchange #4
-                                                                ObjectHashAggregate [ca_address_sk] [buf,buf]
-                                                                  WholeStageCodegen (1)
-                                                                    Project [ca_address_sk]
-                                                                      Filter [ca_state,ca_address_sk]
-                                                                        ColumnarToRow
-                                                                          InputAdapter
-                                                                            Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
+                                                    WholeStageCodegen (2)
+                                                      Sort [c_customer_sk]
+                                                        InputAdapter
+                                                          Exchange [c_customer_sk] #3
+                                                            WholeStageCodegen (1)
+                                                              Filter [c_current_addr_sk,c_current_cdemo_sk]
+                                                                Subquery #1
+                                                                  ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 55556, 899992, 0, 0),bloomFilter,buf]
+                                                                    Exchange #4
+                                                                      ObjectHashAggregate [ca_address_sk] [buf,buf]
+                                                                        WholeStageCodegen (1)
+                                                                          Project [ca_address_sk]
+                                                                            Filter [ca_state,ca_address_sk]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
+                                                  InputAdapter
+                                                    WholeStageCodegen (5)
+                                                      Sort [ss_customer_sk]
+                                                        InputAdapter
+                                                          Exchange [ss_customer_sk] #5
+                                                            WholeStageCodegen (4)
+                                                              Project [ss_customer_sk]
+                                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
+                                                                        SubqueryBroadcast [d_date_sk] #2
+                                                                          BroadcastExchange #6
+                                                                            WholeStageCodegen (1)
+                                                                              Project [d_date_sk]
+                                                                                Filter [d_year,d_moy,d_date_sk]
+                                                                                  ColumnarToRow
+                                                                                    InputAdapter
+                                                                                      Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                                                                  InputAdapter
+                                                                    ReusedExchange [d_date_sk] #6
                                             InputAdapter
-                                              WholeStageCodegen (5)
-                                                Sort [ss_customer_sk]
+                                              WholeStageCodegen (9)
+                                                Sort [ws_bill_customer_sk]
                                                   InputAdapter
-                                                    Exchange [ss_customer_sk] #5
-                                                      WholeStageCodegen (4)
-                                                        Project [ss_customer_sk]
-                                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                    Exchange [ws_bill_customer_sk] #7
+                                                      WholeStageCodegen (8)
+                                                        Project [ws_bill_customer_sk]
+                                                          BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                             ColumnarToRow
                                                               InputAdapter
-                                                                Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
-                                                                  SubqueryBroadcast [d_date_sk] #2
-                                                                    BroadcastExchange #6
-                                                                      WholeStageCodegen (1)
-                                                                        Project [d_date_sk]
-                                                                          Filter [d_year,d_moy,d_date_sk]
-                                                                            ColumnarToRow
-                                                                              InputAdapter
-                                                                                Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                                                                Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
+                                                                  ReusedSubquery [d_date_sk] #2
                                                             InputAdapter
                                                               ReusedExchange [d_date_sk] #6
                                       InputAdapter
-                                        WholeStageCodegen (9)
-                                          Sort [ws_bill_customer_sk]
+                                        WholeStageCodegen (13)
+                                          Sort [cs_ship_customer_sk]
                                             InputAdapter
-                                              Exchange [ws_bill_customer_sk] #7
-                                                WholeStageCodegen (8)
-                                                  Project [ws_bill_customer_sk]
-                                                    BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                              Exchange [cs_ship_customer_sk] #8
+                                                WholeStageCodegen (12)
+                                                  Project [cs_ship_customer_sk]
+                                                    BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                       ColumnarToRow
                                                         InputAdapter
-                                                          Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
+                                                          Scan parquet spark_catalog.default.catalog_sales [cs_ship_customer_sk,cs_sold_date_sk]
                                                             ReusedSubquery [d_date_sk] #2
                                                       InputAdapter
                                                         ReusedExchange [d_date_sk] #6
-                                InputAdapter
-                                  WholeStageCodegen (13)
-                                    Sort [cs_ship_customer_sk]
-                                      InputAdapter
-                                        Exchange [cs_ship_customer_sk] #8
-                                          WholeStageCodegen (12)
-                                            Project [cs_ship_customer_sk]
-                                              BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.catalog_sales [cs_ship_customer_sk,cs_sold_date_sk]
-                                                      ReusedSubquery [d_date_sk] #2
-                                                InputAdapter
-                                                  ReusedExchange [d_date_sk] #6
-                            InputAdapter
-                              BroadcastExchange #9
-                                WholeStageCodegen (14)
-                                  Project [ca_address_sk]
-                                    Filter [ca_state,ca_address_sk]
-                                      ColumnarToRow
-                                        InputAdapter
-                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
-                  Filter [cd_demo_sk]
-                    ColumnarToRow
-                      InputAdapter
-                        Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating]
+                                  InputAdapter
+                                    BroadcastExchange #9
+                                      WholeStageCodegen (14)
+                                        Project [ca_address_sk]
+                                          Filter [ca_state,ca_address_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+                  InputAdapter
+                    WholeStageCodegen (18)
+                      Sort [cd_demo_sk]
+                        InputAdapter
+                          Exchange [cd_demo_sk] #10
+                            WholeStageCodegen (17)
+                              Filter [cd_demo_sk]
+                                ColumnarToRow
+                                  InputAdapter
+                                    Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q7.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q7.sf100/explain.txt
@@ -7,24 +7,24 @@ TakeOrderedAndProject (30)
             +- * BroadcastHashJoin Inner BuildRight (25)
                :- * Project (20)
                :  +- * BroadcastHashJoin Inner BuildRight (19)
-               :     :- * Project (17)
-               :     :  +- * BroadcastHashJoin Inner BuildRight (16)
-               :     :     :- * Project (10)
-               :     :     :  +- * BroadcastHashJoin Inner BuildRight (9)
+               :     :- * Project (13)
+               :     :  +- * BroadcastHashJoin Inner BuildRight (12)
+               :     :     :- * Project (6)
+               :     :     :  +- * BroadcastHashJoin Inner BuildRight (5)
                :     :     :     :- * Filter (3)
                :     :     :     :  +- * ColumnarToRow (2)
                :     :     :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-               :     :     :     +- BroadcastExchange (8)
-               :     :     :        +- * Project (7)
-               :     :     :           +- * Filter (6)
-               :     :     :              +- * ColumnarToRow (5)
-               :     :     :                 +- Scan parquet spark_catalog.default.customer_demographics (4)
-               :     :     +- BroadcastExchange (15)
-               :     :        +- * Project (14)
-               :     :           +- * Filter (13)
-               :     :              +- * ColumnarToRow (12)
-               :     :                 +- Scan parquet spark_catalog.default.promotion (11)
-               :     +- ReusedExchange (18)
+               :     :     :     +- ReusedExchange (4)
+               :     :     +- BroadcastExchange (11)
+               :     :        +- * Project (10)
+               :     :           +- * Filter (9)
+               :     :              +- * ColumnarToRow (8)
+               :     :                 +- Scan parquet spark_catalog.default.customer_demographics (7)
+               :     +- BroadcastExchange (18)
+               :        +- * Project (17)
+               :           +- * Filter (16)
+               :              +- * ColumnarToRow (15)
+               :                 +- Scan parquet spark_catalog.default.promotion (14)
                +- BroadcastExchange (24)
                   +- * Filter (23)
                      +- * ColumnarToRow (22)
@@ -46,82 +46,82 @@ Input [8]: [ss_item_sk#1, ss_cdemo_sk#2, ss_promo_sk#3, ss_quantity#4, ss_list_p
 Input [8]: [ss_item_sk#1, ss_cdemo_sk#2, ss_promo_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, ss_sold_date_sk#8]
 Condition : ((isnotnull(ss_cdemo_sk#2) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_promo_sk#3))
 
-(4) Scan parquet spark_catalog.default.customer_demographics
-Output [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_status#13]
+(4) ReusedExchange [Reuses operator id: 35]
+Output [1]: [d_date_sk#10]
+
+(5) BroadcastHashJoin [codegen id : 5]
+Left keys [1]: [ss_sold_date_sk#8]
+Right keys [1]: [d_date_sk#10]
+Join type: Inner
+Join condition: None
+
+(6) Project [codegen id : 5]
+Output [7]: [ss_item_sk#1, ss_cdemo_sk#2, ss_promo_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7]
+Input [9]: [ss_item_sk#1, ss_cdemo_sk#2, ss_promo_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, ss_sold_date_sk#8, d_date_sk#10]
+
+(7) Scan parquet spark_catalog.default.customer_demographics
+Output [4]: [cd_demo_sk#11, cd_gender#12, cd_marital_status#13, cd_education_status#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_gender), IsNotNull(cd_marital_status), IsNotNull(cd_education_status), EqualTo(cd_gender,M), EqualTo(cd_marital_status,S), EqualTo(cd_education_status,College             ), IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_education_status:string>
 
-(5) ColumnarToRow [codegen id : 1]
-Input [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_status#13]
+(8) ColumnarToRow [codegen id : 2]
+Input [4]: [cd_demo_sk#11, cd_gender#12, cd_marital_status#13, cd_education_status#14]
 
-(6) Filter [codegen id : 1]
-Input [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_status#13]
-Condition : ((((((isnotnull(cd_gender#11) AND isnotnull(cd_marital_status#12)) AND isnotnull(cd_education_status#13)) AND (cd_gender#11 = M)) AND (cd_marital_status#12 = S)) AND (cd_education_status#13 = College             )) AND isnotnull(cd_demo_sk#10))
+(9) Filter [codegen id : 2]
+Input [4]: [cd_demo_sk#11, cd_gender#12, cd_marital_status#13, cd_education_status#14]
+Condition : ((((((isnotnull(cd_gender#12) AND isnotnull(cd_marital_status#13)) AND isnotnull(cd_education_status#14)) AND (cd_gender#12 = M)) AND (cd_marital_status#13 = S)) AND (cd_education_status#14 = College             )) AND isnotnull(cd_demo_sk#11))
 
-(7) Project [codegen id : 1]
-Output [1]: [cd_demo_sk#10]
-Input [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_status#13]
+(10) Project [codegen id : 2]
+Output [1]: [cd_demo_sk#11]
+Input [4]: [cd_demo_sk#11, cd_gender#12, cd_marital_status#13, cd_education_status#14]
 
-(8) BroadcastExchange
-Input [1]: [cd_demo_sk#10]
+(11) BroadcastExchange
+Input [1]: [cd_demo_sk#11]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(9) BroadcastHashJoin [codegen id : 5]
+(12) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [ss_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#10]
+Right keys [1]: [cd_demo_sk#11]
 Join type: Inner
 Join condition: None
 
-(10) Project [codegen id : 5]
-Output [7]: [ss_item_sk#1, ss_promo_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, ss_sold_date_sk#8]
-Input [9]: [ss_item_sk#1, ss_cdemo_sk#2, ss_promo_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, ss_sold_date_sk#8, cd_demo_sk#10]
+(13) Project [codegen id : 5]
+Output [6]: [ss_item_sk#1, ss_promo_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7]
+Input [8]: [ss_item_sk#1, ss_cdemo_sk#2, ss_promo_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, cd_demo_sk#11]
 
-(11) Scan parquet spark_catalog.default.promotion
-Output [3]: [p_promo_sk#14, p_channel_email#15, p_channel_event#16]
+(14) Scan parquet spark_catalog.default.promotion
+Output [3]: [p_promo_sk#15, p_channel_email#16, p_channel_event#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/promotion]
 PushedFilters: [Or(EqualTo(p_channel_email,N),EqualTo(p_channel_event,N)), IsNotNull(p_promo_sk)]
 ReadSchema: struct<p_promo_sk:int,p_channel_email:string,p_channel_event:string>
 
-(12) ColumnarToRow [codegen id : 2]
-Input [3]: [p_promo_sk#14, p_channel_email#15, p_channel_event#16]
+(15) ColumnarToRow [codegen id : 3]
+Input [3]: [p_promo_sk#15, p_channel_email#16, p_channel_event#17]
 
-(13) Filter [codegen id : 2]
-Input [3]: [p_promo_sk#14, p_channel_email#15, p_channel_event#16]
-Condition : (((p_channel_email#15 = N) OR (p_channel_event#16 = N)) AND isnotnull(p_promo_sk#14))
+(16) Filter [codegen id : 3]
+Input [3]: [p_promo_sk#15, p_channel_email#16, p_channel_event#17]
+Condition : (((p_channel_email#16 = N) OR (p_channel_event#17 = N)) AND isnotnull(p_promo_sk#15))
 
-(14) Project [codegen id : 2]
-Output [1]: [p_promo_sk#14]
-Input [3]: [p_promo_sk#14, p_channel_email#15, p_channel_event#16]
+(17) Project [codegen id : 3]
+Output [1]: [p_promo_sk#15]
+Input [3]: [p_promo_sk#15, p_channel_email#16, p_channel_event#17]
 
-(15) BroadcastExchange
-Input [1]: [p_promo_sk#14]
+(18) BroadcastExchange
+Input [1]: [p_promo_sk#15]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
-(16) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [ss_promo_sk#3]
-Right keys [1]: [p_promo_sk#14]
-Join type: Inner
-Join condition: None
-
-(17) Project [codegen id : 5]
-Output [6]: [ss_item_sk#1, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, ss_sold_date_sk#8]
-Input [8]: [ss_item_sk#1, ss_promo_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, ss_sold_date_sk#8, p_promo_sk#14]
-
-(18) ReusedExchange [Reuses operator id: 35]
-Output [1]: [d_date_sk#17]
-
 (19) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [ss_sold_date_sk#8]
-Right keys [1]: [d_date_sk#17]
+Left keys [1]: [ss_promo_sk#3]
+Right keys [1]: [p_promo_sk#15]
 Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 5]
 Output [5]: [ss_item_sk#1, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7]
-Input [7]: [ss_item_sk#1, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, ss_sold_date_sk#8, d_date_sk#17]
+Input [7]: [ss_item_sk#1, ss_promo_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, p_promo_sk#15]
 
 (21) Scan parquet spark_catalog.default.item
 Output [2]: [i_item_sk#18, i_item_id#19]
@@ -184,25 +184,25 @@ BroadcastExchange (35)
 
 
 (31) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#17, d_year#44]
+Output [2]: [d_date_sk#10, d_year#44]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (32) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#17, d_year#44]
+Input [2]: [d_date_sk#10, d_year#44]
 
 (33) Filter [codegen id : 1]
-Input [2]: [d_date_sk#17, d_year#44]
-Condition : ((isnotnull(d_year#44) AND (d_year#44 = 2000)) AND isnotnull(d_date_sk#17))
+Input [2]: [d_date_sk#10, d_year#44]
+Condition : ((isnotnull(d_year#44) AND (d_year#44 = 2000)) AND isnotnull(d_date_sk#10))
 
 (34) Project [codegen id : 1]
-Output [1]: [d_date_sk#17]
-Input [2]: [d_date_sk#17, d_year#44]
+Output [1]: [d_date_sk#10]
+Input [2]: [d_date_sk#10, d_year#44]
 
 (35) BroadcastExchange
-Input [1]: [d_date_sk#17]
+Input [1]: [d_date_sk#10]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q7.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q7.sf100/simplified.txt
@@ -8,11 +8,11 @@ TakeOrderedAndProject [i_item_id,agg1,agg2,agg3,agg4]
               Project [ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt,i_item_id]
                 BroadcastHashJoin [ss_item_sk,i_item_sk]
                   Project [ss_item_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
-                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                      Project [ss_item_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt,ss_sold_date_sk]
-                        BroadcastHashJoin [ss_promo_sk,p_promo_sk]
-                          Project [ss_item_sk,ss_promo_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt,ss_sold_date_sk]
-                            BroadcastHashJoin [ss_cdemo_sk,cd_demo_sk]
+                    BroadcastHashJoin [ss_promo_sk,p_promo_sk]
+                      Project [ss_item_sk,ss_promo_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
+                        BroadcastHashJoin [ss_cdemo_sk,cd_demo_sk]
+                          Project [ss_item_sk,ss_cdemo_sk,ss_promo_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
+                            BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                               Filter [ss_cdemo_sk,ss_item_sk,ss_promo_sk]
                                 ColumnarToRow
                                   InputAdapter
@@ -26,23 +26,23 @@ TakeOrderedAndProject [i_item_id,agg1,agg2,agg3,agg4]
                                                   InputAdapter
                                                     Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                               InputAdapter
-                                BroadcastExchange #3
-                                  WholeStageCodegen (1)
-                                    Project [cd_demo_sk]
-                                      Filter [cd_gender,cd_marital_status,cd_education_status,cd_demo_sk]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_education_status]
+                                ReusedExchange [d_date_sk] #2
                           InputAdapter
-                            BroadcastExchange #4
+                            BroadcastExchange #3
                               WholeStageCodegen (2)
-                                Project [p_promo_sk]
-                                  Filter [p_channel_email,p_channel_event,p_promo_sk]
+                                Project [cd_demo_sk]
+                                  Filter [cd_gender,cd_marital_status,cd_education_status,cd_demo_sk]
                                     ColumnarToRow
                                       InputAdapter
-                                        Scan parquet spark_catalog.default.promotion [p_promo_sk,p_channel_email,p_channel_event]
+                                        Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_education_status]
                       InputAdapter
-                        ReusedExchange [d_date_sk] #2
+                        BroadcastExchange #4
+                          WholeStageCodegen (3)
+                            Project [p_promo_sk]
+                              Filter [p_channel_email,p_channel_event,p_promo_sk]
+                                ColumnarToRow
+                                  InputAdapter
+                                    Scan parquet spark_catalog.default.promotion [p_promo_sk,p_channel_email,p_channel_event]
                   InputAdapter
                     BroadcastExchange #5
                       WholeStageCodegen (4)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72.sf100/explain.txt
@@ -1,463 +1,456 @@
 == Physical Plan ==
-TakeOrderedAndProject (70)
-+- * HashAggregate (69)
-   +- Exchange (68)
-      +- * HashAggregate (67)
-         +- * Project (66)
-            +- * SortMergeJoin LeftOuter (65)
-               :- * Sort (58)
-               :  +- Exchange (57)
-               :     +- * Project (56)
-               :        +- * BroadcastHashJoin LeftOuter BuildRight (55)
-               :           :- * Project (50)
-               :           :  +- * SortMergeJoin Inner (49)
-               :           :     :- * Sort (37)
-               :           :     :  +- Exchange (36)
-               :           :     :     +- * Project (35)
-               :           :     :        +- * BroadcastHashJoin Inner BuildRight (34)
-               :           :     :           :- * Project (32)
-               :           :     :           :  +- * SortMergeJoin Inner (31)
-               :           :     :           :     :- * Sort (25)
-               :           :     :           :     :  +- Exchange (24)
-               :           :     :           :     :     +- * Project (23)
-               :           :     :           :     :        +- * BroadcastHashJoin Inner BuildRight (22)
-               :           :     :           :     :           :- * Project (17)
-               :           :     :           :     :           :  +- * BroadcastHashJoin Inner BuildRight (16)
-               :           :     :           :     :           :     :- * Project (10)
-               :           :     :           :     :           :     :  +- * BroadcastHashJoin Inner BuildRight (9)
-               :           :     :           :     :           :     :     :- * Filter (3)
-               :           :     :           :     :           :     :     :  +- * ColumnarToRow (2)
-               :           :     :           :     :           :     :     :     +- Scan parquet spark_catalog.default.catalog_sales (1)
-               :           :     :           :     :           :     :     +- BroadcastExchange (8)
-               :           :     :           :     :           :     :        +- * Project (7)
-               :           :     :           :     :           :     :           +- * Filter (6)
-               :           :     :           :     :           :     :              +- * ColumnarToRow (5)
-               :           :     :           :     :           :     :                 +- Scan parquet spark_catalog.default.household_demographics (4)
-               :           :     :           :     :           :     +- BroadcastExchange (15)
-               :           :     :           :     :           :        +- * Project (14)
-               :           :     :           :     :           :           +- * Filter (13)
-               :           :     :           :     :           :              +- * ColumnarToRow (12)
-               :           :     :           :     :           :                 +- Scan parquet spark_catalog.default.customer_demographics (11)
-               :           :     :           :     :           +- BroadcastExchange (21)
-               :           :     :           :     :              +- * Filter (20)
-               :           :     :           :     :                 +- * ColumnarToRow (19)
-               :           :     :           :     :                    +- Scan parquet spark_catalog.default.date_dim (18)
-               :           :     :           :     +- * Sort (30)
-               :           :     :           :        +- Exchange (29)
-               :           :     :           :           +- * Filter (28)
-               :           :     :           :              +- * ColumnarToRow (27)
-               :           :     :           :                 +- Scan parquet spark_catalog.default.item (26)
-               :           :     :           +- ReusedExchange (33)
-               :           :     +- * Sort (48)
-               :           :        +- Exchange (47)
-               :           :           +- * Project (46)
-               :           :              +- * BroadcastHashJoin Inner BuildRight (45)
-               :           :                 :- * Filter (40)
-               :           :                 :  +- * ColumnarToRow (39)
-               :           :                 :     +- Scan parquet spark_catalog.default.inventory (38)
-               :           :                 +- BroadcastExchange (44)
-               :           :                    +- * Filter (43)
-               :           :                       +- * ColumnarToRow (42)
-               :           :                          +- Scan parquet spark_catalog.default.warehouse (41)
-               :           +- BroadcastExchange (54)
-               :              +- * Filter (53)
-               :                 +- * ColumnarToRow (52)
-               :                    +- Scan parquet spark_catalog.default.promotion (51)
-               +- * Sort (64)
-                  +- Exchange (63)
-                     +- * Project (62)
-                        +- * Filter (61)
-                           +- * ColumnarToRow (60)
-                              +- Scan parquet spark_catalog.default.catalog_returns (59)
+TakeOrderedAndProject (81)
++- * HashAggregate (80)
+   +- Exchange (79)
+      +- * HashAggregate (78)
+         +- * Project (77)
+            +- * SortMergeJoin LeftOuter (76)
+               :- * Sort (69)
+               :  +- Exchange (68)
+               :     +- * Project (67)
+               :        +- * BroadcastHashJoin LeftOuter BuildRight (66)
+               :           :- * Project (61)
+               :           :  +- * SortMergeJoin Inner (60)
+               :           :     :- * Sort (41)
+               :           :     :  +- Exchange (40)
+               :           :     :     +- * Project (39)
+               :           :     :        +- * SortMergeJoin Inner (38)
+               :           :     :           :- * Project (26)
+               :           :     :           :  +- * SortMergeJoin Inner (25)
+               :           :     :           :     :- * Sort (19)
+               :           :     :           :     :  +- Exchange (18)
+               :           :     :           :     :     +- * Project (17)
+               :           :     :           :     :        +- * BroadcastHashJoin Inner BuildRight (16)
+               :           :     :           :     :           :- * Project (10)
+               :           :     :           :     :           :  +- * BroadcastHashJoin Inner BuildRight (9)
+               :           :     :           :     :           :     :- * Filter (3)
+               :           :     :           :     :           :     :  +- * ColumnarToRow (2)
+               :           :     :           :     :           :     :     +- Scan parquet spark_catalog.default.catalog_sales (1)
+               :           :     :           :     :           :     +- BroadcastExchange (8)
+               :           :     :           :     :           :        +- * Project (7)
+               :           :     :           :     :           :           +- * Filter (6)
+               :           :     :           :     :           :              +- * ColumnarToRow (5)
+               :           :     :           :     :           :                 +- Scan parquet spark_catalog.default.household_demographics (4)
+               :           :     :           :     :           +- BroadcastExchange (15)
+               :           :     :           :     :              +- * Project (14)
+               :           :     :           :     :                 +- * Filter (13)
+               :           :     :           :     :                    +- * ColumnarToRow (12)
+               :           :     :           :     :                       +- Scan parquet spark_catalog.default.customer_demographics (11)
+               :           :     :           :     +- * Sort (24)
+               :           :     :           :        +- Exchange (23)
+               :           :     :           :           +- * Filter (22)
+               :           :     :           :              +- * ColumnarToRow (21)
+               :           :     :           :                 +- Scan parquet spark_catalog.default.item (20)
+               :           :     :           +- * Sort (37)
+               :           :     :              +- Exchange (36)
+               :           :     :                 +- * Project (35)
+               :           :     :                    +- * BroadcastHashJoin Inner BuildRight (34)
+               :           :     :                       :- * Filter (29)
+               :           :     :                       :  +- * ColumnarToRow (28)
+               :           :     :                       :     +- Scan parquet spark_catalog.default.inventory (27)
+               :           :     :                       +- BroadcastExchange (33)
+               :           :     :                          +- * Filter (32)
+               :           :     :                             +- * ColumnarToRow (31)
+               :           :     :                                +- Scan parquet spark_catalog.default.warehouse (30)
+               :           :     +- * Sort (59)
+               :           :        +- Exchange (58)
+               :           :           +- * Project (57)
+               :           :              +- * BroadcastNestedLoopJoin Inner BuildRight (56)
+               :           :                 :- * Project (51)
+               :           :                 :  +- * BroadcastHashJoin Inner BuildLeft (50)
+               :           :                 :     :- BroadcastExchange (46)
+               :           :                 :     :  +- * Project (45)
+               :           :                 :     :     +- * Filter (44)
+               :           :                 :     :        +- * ColumnarToRow (43)
+               :           :                 :     :           +- Scan parquet spark_catalog.default.date_dim (42)
+               :           :                 :     +- * Filter (49)
+               :           :                 :        +- * ColumnarToRow (48)
+               :           :                 :           +- Scan parquet spark_catalog.default.date_dim (47)
+               :           :                 +- BroadcastExchange (55)
+               :           :                    +- * Filter (54)
+               :           :                       +- * ColumnarToRow (53)
+               :           :                          +- Scan parquet spark_catalog.default.date_dim (52)
+               :           +- BroadcastExchange (65)
+               :              +- * Filter (64)
+               :                 +- * ColumnarToRow (63)
+               :                    +- Scan parquet spark_catalog.default.promotion (62)
+               +- * Sort (75)
+                  +- Exchange (74)
+                     +- * Project (73)
+                        +- * Filter (72)
+                           +- * ColumnarToRow (71)
+                              +- Scan parquet spark_catalog.default.catalog_returns (70)
 
 
 (1) Scan parquet spark_catalog.default.catalog_sales
 Output [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#8), dynamicpruningexpression(cs_sold_date_sk#8 IN dynamicpruning#9)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#8), dynamicpruningexpression(true)]
 PushedFilters: [IsNotNull(cs_quantity), IsNotNull(cs_item_sk), IsNotNull(cs_bill_cdemo_sk), IsNotNull(cs_bill_hdemo_sk), IsNotNull(cs_ship_date_sk)]
 ReadSchema: struct<cs_ship_date_sk:int,cs_bill_cdemo_sk:int,cs_bill_hdemo_sk:int,cs_item_sk:int,cs_promo_sk:int,cs_order_number:int,cs_quantity:int>
 
-(2) ColumnarToRow [codegen id : 4]
+(2) ColumnarToRow [codegen id : 3]
 Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
 
-(3) Filter [codegen id : 4]
+(3) Filter [codegen id : 3]
 Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
 Condition : ((((isnotnull(cs_quantity#7) AND isnotnull(cs_item_sk#4)) AND isnotnull(cs_bill_cdemo_sk#2)) AND isnotnull(cs_bill_hdemo_sk#3)) AND isnotnull(cs_ship_date_sk#1))
 
 (4) Scan parquet spark_catalog.default.household_demographics
-Output [2]: [hd_demo_sk#10, hd_buy_potential#11]
+Output [2]: [hd_demo_sk#9, hd_buy_potential#10]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [IsNotNull(hd_buy_potential), EqualTo(hd_buy_potential,>10000         ), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string>
 
 (5) ColumnarToRow [codegen id : 1]
-Input [2]: [hd_demo_sk#10, hd_buy_potential#11]
+Input [2]: [hd_demo_sk#9, hd_buy_potential#10]
 
 (6) Filter [codegen id : 1]
-Input [2]: [hd_demo_sk#10, hd_buy_potential#11]
-Condition : ((isnotnull(hd_buy_potential#11) AND (hd_buy_potential#11 = >10000         )) AND isnotnull(hd_demo_sk#10))
+Input [2]: [hd_demo_sk#9, hd_buy_potential#10]
+Condition : ((isnotnull(hd_buy_potential#10) AND (hd_buy_potential#10 = >10000         )) AND isnotnull(hd_demo_sk#9))
 
 (7) Project [codegen id : 1]
-Output [1]: [hd_demo_sk#10]
-Input [2]: [hd_demo_sk#10, hd_buy_potential#11]
+Output [1]: [hd_demo_sk#9]
+Input [2]: [hd_demo_sk#9, hd_buy_potential#10]
 
 (8) BroadcastExchange
-Input [1]: [hd_demo_sk#10]
+Input [1]: [hd_demo_sk#9]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(9) BroadcastHashJoin [codegen id : 4]
+(9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_bill_hdemo_sk#3]
-Right keys [1]: [hd_demo_sk#10]
+Right keys [1]: [hd_demo_sk#9]
 Join type: Inner
 Join condition: None
 
-(10) Project [codegen id : 4]
+(10) Project [codegen id : 3]
 Output [7]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
-Input [9]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, hd_demo_sk#10]
+Input [9]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, hd_demo_sk#9]
 
 (11) Scan parquet spark_catalog.default.customer_demographics
-Output [2]: [cd_demo_sk#12, cd_marital_status#13]
+Output [2]: [cd_demo_sk#11, cd_marital_status#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_marital_status), EqualTo(cd_marital_status,D), IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string>
 
 (12) ColumnarToRow [codegen id : 2]
-Input [2]: [cd_demo_sk#12, cd_marital_status#13]
+Input [2]: [cd_demo_sk#11, cd_marital_status#12]
 
 (13) Filter [codegen id : 2]
-Input [2]: [cd_demo_sk#12, cd_marital_status#13]
-Condition : ((isnotnull(cd_marital_status#13) AND (cd_marital_status#13 = D)) AND isnotnull(cd_demo_sk#12))
+Input [2]: [cd_demo_sk#11, cd_marital_status#12]
+Condition : ((isnotnull(cd_marital_status#12) AND (cd_marital_status#12 = D)) AND isnotnull(cd_demo_sk#11))
 
 (14) Project [codegen id : 2]
-Output [1]: [cd_demo_sk#12]
-Input [2]: [cd_demo_sk#12, cd_marital_status#13]
+Output [1]: [cd_demo_sk#11]
+Input [2]: [cd_demo_sk#11, cd_marital_status#12]
 
 (15) BroadcastExchange
-Input [1]: [cd_demo_sk#12]
+Input [1]: [cd_demo_sk#11]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
-(16) BroadcastHashJoin [codegen id : 4]
+(16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_bill_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#12]
+Right keys [1]: [cd_demo_sk#11]
 Join type: Inner
 Join condition: None
 
-(17) Project [codegen id : 4]
+(17) Project [codegen id : 3]
 Output [6]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
-Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, cd_demo_sk#12]
+Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, cd_demo_sk#11]
 
-(18) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#14, d_date#15]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_date), IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int,d_date:date>
+(18) Exchange
+Input [6]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
+Arguments: hashpartitioning(cs_item_sk#4, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(19) ColumnarToRow [codegen id : 3]
-Input [2]: [d_date_sk#14, d_date#15]
-
-(20) Filter [codegen id : 3]
-Input [2]: [d_date_sk#14, d_date#15]
-Condition : (isnotnull(d_date#15) AND isnotnull(d_date_sk#14))
-
-(21) BroadcastExchange
-Input [2]: [d_date_sk#14, d_date#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
-
-(22) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [cs_ship_date_sk#1]
-Right keys [1]: [d_date_sk#14]
-Join type: Inner
-Join condition: None
-
-(23) Project [codegen id : 4]
-Output [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15]
-Input [8]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date_sk#14, d_date#15]
-
-(24) Exchange
-Input [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15]
-Arguments: hashpartitioning(cs_item_sk#4, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(25) Sort [codegen id : 5]
-Input [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15]
+(19) Sort [codegen id : 4]
+Input [6]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
 Arguments: [cs_item_sk#4 ASC NULLS FIRST], false, 0
 
-(26) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#16, i_item_desc#17]
+(20) Scan parquet spark_catalog.default.item
+Output [2]: [i_item_sk#13, i_item_desc#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_desc:string>
 
-(27) ColumnarToRow [codegen id : 6]
-Input [2]: [i_item_sk#16, i_item_desc#17]
+(21) ColumnarToRow [codegen id : 5]
+Input [2]: [i_item_sk#13, i_item_desc#14]
 
-(28) Filter [codegen id : 6]
-Input [2]: [i_item_sk#16, i_item_desc#17]
-Condition : isnotnull(i_item_sk#16)
+(22) Filter [codegen id : 5]
+Input [2]: [i_item_sk#13, i_item_desc#14]
+Condition : isnotnull(i_item_sk#13)
 
-(29) Exchange
-Input [2]: [i_item_sk#16, i_item_desc#17]
-Arguments: hashpartitioning(i_item_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(23) Exchange
+Input [2]: [i_item_sk#13, i_item_desc#14]
+Arguments: hashpartitioning(i_item_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(30) Sort [codegen id : 7]
-Input [2]: [i_item_sk#16, i_item_desc#17]
-Arguments: [i_item_sk#16 ASC NULLS FIRST], false, 0
+(24) Sort [codegen id : 6]
+Input [2]: [i_item_sk#13, i_item_desc#14]
+Arguments: [i_item_sk#13 ASC NULLS FIRST], false, 0
 
-(31) SortMergeJoin [codegen id : 10]
+(25) SortMergeJoin [codegen id : 7]
 Left keys [1]: [cs_item_sk#4]
-Right keys [1]: [i_item_sk#16]
+Right keys [1]: [i_item_sk#13]
 Join type: Inner
 Join condition: None
 
-(32) Project [codegen id : 10]
-Output [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15, i_item_desc#17]
-Input [8]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15, i_item_sk#16, i_item_desc#17]
+(26) Project [codegen id : 7]
+Output [7]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, i_item_desc#14]
+Input [8]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, i_item_sk#13, i_item_desc#14]
 
-(33) ReusedExchange [Reuses operator id: 81]
-Output [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_date_sk#21]
-
-(34) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [cs_sold_date_sk#8]
-Right keys [1]: [d_date_sk#18]
-Join type: Inner
-Join condition: (d_date#15 > date_add(d_date#19, 5))
-
-(35) Project [codegen id : 10]
-Output [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#17, d_week_seq#20, d_date_sk#21]
-Input [11]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15, i_item_desc#17, d_date_sk#18, d_date#19, d_week_seq#20, d_date_sk#21]
-
-(36) Exchange
-Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#17, d_week_seq#20, d_date_sk#21]
-Arguments: hashpartitioning(cs_item_sk#4, d_date_sk#21, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(37) Sort [codegen id : 11]
-Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#17, d_week_seq#20, d_date_sk#21]
-Arguments: [cs_item_sk#4 ASC NULLS FIRST, d_date_sk#21 ASC NULLS FIRST], false, 0
-
-(38) Scan parquet spark_catalog.default.inventory
-Output [4]: [inv_item_sk#22, inv_warehouse_sk#23, inv_quantity_on_hand#24, inv_date_sk#25]
+(27) Scan parquet spark_catalog.default.inventory
+Output [4]: [inv_item_sk#15, inv_warehouse_sk#16, inv_quantity_on_hand#17, inv_date_sk#18]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(inv_date_sk#25), dynamicpruningexpression(true)]
+PartitionFilters: [isnotnull(inv_date_sk#18), dynamicpruningexpression(true)]
 PushedFilters: [IsNotNull(inv_quantity_on_hand), IsNotNull(inv_item_sk), IsNotNull(inv_warehouse_sk)]
 ReadSchema: struct<inv_item_sk:int,inv_warehouse_sk:int,inv_quantity_on_hand:int>
 
-(39) ColumnarToRow [codegen id : 13]
-Input [4]: [inv_item_sk#22, inv_warehouse_sk#23, inv_quantity_on_hand#24, inv_date_sk#25]
+(28) ColumnarToRow [codegen id : 9]
+Input [4]: [inv_item_sk#15, inv_warehouse_sk#16, inv_quantity_on_hand#17, inv_date_sk#18]
 
-(40) Filter [codegen id : 13]
-Input [4]: [inv_item_sk#22, inv_warehouse_sk#23, inv_quantity_on_hand#24, inv_date_sk#25]
-Condition : ((isnotnull(inv_quantity_on_hand#24) AND isnotnull(inv_item_sk#22)) AND isnotnull(inv_warehouse_sk#23))
+(29) Filter [codegen id : 9]
+Input [4]: [inv_item_sk#15, inv_warehouse_sk#16, inv_quantity_on_hand#17, inv_date_sk#18]
+Condition : ((isnotnull(inv_quantity_on_hand#17) AND isnotnull(inv_item_sk#15)) AND isnotnull(inv_warehouse_sk#16))
 
-(41) Scan parquet spark_catalog.default.warehouse
-Output [2]: [w_warehouse_sk#26, w_warehouse_name#27]
+(30) Scan parquet spark_catalog.default.warehouse
+Output [2]: [w_warehouse_sk#19, w_warehouse_name#20]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/warehouse]
 PushedFilters: [IsNotNull(w_warehouse_sk)]
 ReadSchema: struct<w_warehouse_sk:int,w_warehouse_name:string>
 
-(42) ColumnarToRow [codegen id : 12]
-Input [2]: [w_warehouse_sk#26, w_warehouse_name#27]
+(31) ColumnarToRow [codegen id : 8]
+Input [2]: [w_warehouse_sk#19, w_warehouse_name#20]
 
-(43) Filter [codegen id : 12]
-Input [2]: [w_warehouse_sk#26, w_warehouse_name#27]
-Condition : isnotnull(w_warehouse_sk#26)
+(32) Filter [codegen id : 8]
+Input [2]: [w_warehouse_sk#19, w_warehouse_name#20]
+Condition : isnotnull(w_warehouse_sk#19)
 
-(44) BroadcastExchange
-Input [2]: [w_warehouse_sk#26, w_warehouse_name#27]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
+(33) BroadcastExchange
+Input [2]: [w_warehouse_sk#19, w_warehouse_name#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
 
-(45) BroadcastHashJoin [codegen id : 13]
-Left keys [1]: [inv_warehouse_sk#23]
-Right keys [1]: [w_warehouse_sk#26]
+(34) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [inv_warehouse_sk#16]
+Right keys [1]: [w_warehouse_sk#19]
 Join type: Inner
 Join condition: None
 
-(46) Project [codegen id : 13]
-Output [4]: [inv_item_sk#22, inv_quantity_on_hand#24, inv_date_sk#25, w_warehouse_name#27]
-Input [6]: [inv_item_sk#22, inv_warehouse_sk#23, inv_quantity_on_hand#24, inv_date_sk#25, w_warehouse_sk#26, w_warehouse_name#27]
+(35) Project [codegen id : 9]
+Output [4]: [inv_item_sk#15, inv_quantity_on_hand#17, inv_date_sk#18, w_warehouse_name#20]
+Input [6]: [inv_item_sk#15, inv_warehouse_sk#16, inv_quantity_on_hand#17, inv_date_sk#18, w_warehouse_sk#19, w_warehouse_name#20]
 
-(47) Exchange
-Input [4]: [inv_item_sk#22, inv_quantity_on_hand#24, inv_date_sk#25, w_warehouse_name#27]
-Arguments: hashpartitioning(inv_item_sk#22, inv_date_sk#25, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+(36) Exchange
+Input [4]: [inv_item_sk#15, inv_quantity_on_hand#17, inv_date_sk#18, w_warehouse_name#20]
+Arguments: hashpartitioning(inv_item_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(48) Sort [codegen id : 14]
-Input [4]: [inv_item_sk#22, inv_quantity_on_hand#24, inv_date_sk#25, w_warehouse_name#27]
-Arguments: [inv_item_sk#22 ASC NULLS FIRST, inv_date_sk#25 ASC NULLS FIRST], false, 0
+(37) Sort [codegen id : 10]
+Input [4]: [inv_item_sk#15, inv_quantity_on_hand#17, inv_date_sk#18, w_warehouse_name#20]
+Arguments: [inv_item_sk#15 ASC NULLS FIRST], false, 0
 
-(49) SortMergeJoin [codegen id : 16]
-Left keys [2]: [cs_item_sk#4, d_date_sk#21]
-Right keys [2]: [inv_item_sk#22, inv_date_sk#25]
+(38) SortMergeJoin [codegen id : 11]
+Left keys [1]: [cs_item_sk#4]
+Right keys [1]: [inv_item_sk#15]
 Join type: Inner
-Join condition: (inv_quantity_on_hand#24 < cs_quantity#7)
+Join condition: (inv_quantity_on_hand#17 < cs_quantity#7)
 
-(50) Project [codegen id : 16]
-Output [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
-Input [11]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#17, d_week_seq#20, d_date_sk#21, inv_item_sk#22, inv_quantity_on_hand#24, inv_date_sk#25, w_warehouse_name#27]
+(39) Project [codegen id : 11]
+Output [8]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, i_item_desc#14, inv_date_sk#18, w_warehouse_name#20]
+Input [11]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, i_item_desc#14, inv_item_sk#15, inv_quantity_on_hand#17, inv_date_sk#18, w_warehouse_name#20]
 
-(51) Scan parquet spark_catalog.default.promotion
-Output [1]: [p_promo_sk#28]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/promotion]
-PushedFilters: [IsNotNull(p_promo_sk)]
-ReadSchema: struct<p_promo_sk:int>
+(40) Exchange
+Input [8]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, i_item_desc#14, inv_date_sk#18, w_warehouse_name#20]
+Arguments: hashpartitioning(cs_sold_date_sk#8, inv_date_sk#18, cs_ship_date_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(52) ColumnarToRow [codegen id : 15]
-Input [1]: [p_promo_sk#28]
+(41) Sort [codegen id : 12]
+Input [8]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, i_item_desc#14, inv_date_sk#18, w_warehouse_name#20]
+Arguments: [cs_sold_date_sk#8 ASC NULLS FIRST, inv_date_sk#18 ASC NULLS FIRST, cs_ship_date_sk#1 ASC NULLS FIRST], false, 0
 
-(53) Filter [codegen id : 15]
-Input [1]: [p_promo_sk#28]
-Condition : isnotnull(p_promo_sk#28)
-
-(54) BroadcastExchange
-Input [1]: [p_promo_sk#28]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=9]
-
-(55) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [cs_promo_sk#5]
-Right keys [1]: [p_promo_sk#28]
-Join type: LeftOuter
-Join condition: None
-
-(56) Project [codegen id : 16]
-Output [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
-Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20, p_promo_sk#28]
-
-(57) Exchange
-Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
-Arguments: hashpartitioning(cs_item_sk#4, cs_order_number#6, 5), ENSURE_REQUIREMENTS, [plan_id=10]
-
-(58) Sort [codegen id : 17]
-Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
-Arguments: [cs_item_sk#4 ASC NULLS FIRST, cs_order_number#6 ASC NULLS FIRST], false, 0
-
-(59) Scan parquet spark_catalog.default.catalog_returns
-Output [3]: [cr_item_sk#29, cr_order_number#30, cr_returned_date_sk#31]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/catalog_returns]
-PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
-ReadSchema: struct<cr_item_sk:int,cr_order_number:int>
-
-(60) ColumnarToRow [codegen id : 18]
-Input [3]: [cr_item_sk#29, cr_order_number#30, cr_returned_date_sk#31]
-
-(61) Filter [codegen id : 18]
-Input [3]: [cr_item_sk#29, cr_order_number#30, cr_returned_date_sk#31]
-Condition : (isnotnull(cr_item_sk#29) AND isnotnull(cr_order_number#30))
-
-(62) Project [codegen id : 18]
-Output [2]: [cr_item_sk#29, cr_order_number#30]
-Input [3]: [cr_item_sk#29, cr_order_number#30, cr_returned_date_sk#31]
-
-(63) Exchange
-Input [2]: [cr_item_sk#29, cr_order_number#30]
-Arguments: hashpartitioning(cr_item_sk#29, cr_order_number#30, 5), ENSURE_REQUIREMENTS, [plan_id=11]
-
-(64) Sort [codegen id : 19]
-Input [2]: [cr_item_sk#29, cr_order_number#30]
-Arguments: [cr_item_sk#29 ASC NULLS FIRST, cr_order_number#30 ASC NULLS FIRST], false, 0
-
-(65) SortMergeJoin [codegen id : 20]
-Left keys [2]: [cs_item_sk#4, cs_order_number#6]
-Right keys [2]: [cr_item_sk#29, cr_order_number#30]
-Join type: LeftOuter
-Join condition: None
-
-(66) Project [codegen id : 20]
-Output [3]: [w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
-Input [7]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20, cr_item_sk#29, cr_order_number#30]
-
-(67) HashAggregate [codegen id : 20]
-Input [3]: [w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
-Keys [3]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20]
-Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#32]
-Results [4]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, count#33]
-
-(68) Exchange
-Input [4]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, count#33]
-Arguments: hashpartitioning(i_item_desc#17, w_warehouse_name#27, d_week_seq#20, 5), ENSURE_REQUIREMENTS, [plan_id=12]
-
-(69) HashAggregate [codegen id : 21]
-Input [4]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, count#33]
-Keys [3]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20]
-Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#34]
-Results [6]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, count(1)#34 AS no_promo#35, count(1)#34 AS promo#36, count(1)#34 AS total_cnt#37]
-
-(70) TakeOrderedAndProject
-Input [6]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, no_promo#35, promo#36, total_cnt#37]
-Arguments: 100, [total_cnt#37 DESC NULLS LAST, i_item_desc#17 ASC NULLS FIRST, w_warehouse_name#27 ASC NULLS FIRST, d_week_seq#20 ASC NULLS FIRST], [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, no_promo#35, promo#36, total_cnt#37]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#8 IN dynamicpruning#9
-BroadcastExchange (81)
-+- * Project (80)
-   +- * BroadcastHashJoin Inner BuildLeft (79)
-      :- BroadcastExchange (75)
-      :  +- * Project (74)
-      :     +- * Filter (73)
-      :        +- * ColumnarToRow (72)
-      :           +- Scan parquet spark_catalog.default.date_dim (71)
-      +- * Filter (78)
-         +- * ColumnarToRow (77)
-            +- Scan parquet spark_catalog.default.date_dim (76)
-
-
-(71) Scan parquet spark_catalog.default.date_dim
-Output [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_year#38]
+(42) Scan parquet spark_catalog.default.date_dim
+Output [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_year#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,1999), IsNotNull(d_date_sk), IsNotNull(d_week_seq), IsNotNull(d_date)]
 ReadSchema: struct<d_date_sk:int,d_date:date,d_week_seq:int,d_year:int>
 
-(72) ColumnarToRow [codegen id : 1]
-Input [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_year#38]
+(43) ColumnarToRow [codegen id : 13]
+Input [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_year#24]
 
-(73) Filter [codegen id : 1]
-Input [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_year#38]
-Condition : ((((isnotnull(d_year#38) AND (d_year#38 = 1999)) AND isnotnull(d_date_sk#18)) AND isnotnull(d_week_seq#20)) AND isnotnull(d_date#19))
+(44) Filter [codegen id : 13]
+Input [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_year#24]
+Condition : ((((isnotnull(d_year#24) AND (d_year#24 = 1999)) AND isnotnull(d_date_sk#21)) AND isnotnull(d_week_seq#23)) AND isnotnull(d_date#22))
 
-(74) Project [codegen id : 1]
-Output [3]: [d_date_sk#18, d_date#19, d_week_seq#20]
-Input [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_year#38]
+(45) Project [codegen id : 13]
+Output [3]: [d_date_sk#21, d_date#22, d_week_seq#23]
+Input [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_year#24]
 
-(75) BroadcastExchange
-Input [3]: [d_date_sk#18, d_date#19, d_week_seq#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [plan_id=13]
+(46) BroadcastExchange
+Input [3]: [d_date_sk#21, d_date#22, d_week_seq#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [plan_id=8]
 
-(76) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#21, d_week_seq#39]
+(47) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#25, d_week_seq#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_week_seq), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
-(77) ColumnarToRow
-Input [2]: [d_date_sk#21, d_week_seq#39]
+(48) ColumnarToRow
+Input [2]: [d_date_sk#25, d_week_seq#26]
 
-(78) Filter
-Input [2]: [d_date_sk#21, d_week_seq#39]
-Condition : (isnotnull(d_week_seq#39) AND isnotnull(d_date_sk#21))
+(49) Filter
+Input [2]: [d_date_sk#25, d_week_seq#26]
+Condition : (isnotnull(d_week_seq#26) AND isnotnull(d_date_sk#25))
 
-(79) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [d_week_seq#20]
-Right keys [1]: [d_week_seq#39]
+(50) BroadcastHashJoin [codegen id : 15]
+Left keys [1]: [d_week_seq#23]
+Right keys [1]: [d_week_seq#26]
 Join type: Inner
 Join condition: None
 
-(80) Project [codegen id : 2]
-Output [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_date_sk#21]
-Input [5]: [d_date_sk#18, d_date#19, d_week_seq#20, d_date_sk#21, d_week_seq#39]
+(51) Project [codegen id : 15]
+Output [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_date_sk#25]
+Input [5]: [d_date_sk#21, d_date#22, d_week_seq#23, d_date_sk#25, d_week_seq#26]
 
-(81) BroadcastExchange
-Input [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_date_sk#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=14]
+(52) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#27, d_date#28]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/date_dim]
+PushedFilters: [IsNotNull(d_date), IsNotNull(d_date_sk)]
+ReadSchema: struct<d_date_sk:int,d_date:date>
 
+(53) ColumnarToRow [codegen id : 14]
+Input [2]: [d_date_sk#27, d_date#28]
+
+(54) Filter [codegen id : 14]
+Input [2]: [d_date_sk#27, d_date#28]
+Condition : (isnotnull(d_date#28) AND isnotnull(d_date_sk#27))
+
+(55) BroadcastExchange
+Input [2]: [d_date_sk#27, d_date#28]
+Arguments: IdentityBroadcastMode, [plan_id=9]
+
+(56) BroadcastNestedLoopJoin [codegen id : 15]
+Join type: Inner
+Join condition: (d_date#28 > date_add(d_date#22, 5))
+
+(57) Project [codegen id : 15]
+Output [4]: [d_date_sk#21, d_week_seq#23, d_date_sk#25, d_date_sk#27]
+Input [6]: [d_date_sk#21, d_date#22, d_week_seq#23, d_date_sk#25, d_date_sk#27, d_date#28]
+
+(58) Exchange
+Input [4]: [d_date_sk#21, d_week_seq#23, d_date_sk#25, d_date_sk#27]
+Arguments: hashpartitioning(d_date_sk#21, d_date_sk#25, d_date_sk#27, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+
+(59) Sort [codegen id : 16]
+Input [4]: [d_date_sk#21, d_week_seq#23, d_date_sk#25, d_date_sk#27]
+Arguments: [d_date_sk#21 ASC NULLS FIRST, d_date_sk#25 ASC NULLS FIRST, d_date_sk#27 ASC NULLS FIRST], false, 0
+
+(60) SortMergeJoin [codegen id : 18]
+Left keys [3]: [cs_sold_date_sk#8, inv_date_sk#18, cs_ship_date_sk#1]
+Right keys [3]: [d_date_sk#21, d_date_sk#25, d_date_sk#27]
+Join type: Inner
+Join condition: None
+
+(61) Project [codegen id : 18]
+Output [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#20, i_item_desc#14, d_week_seq#23]
+Input [12]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, i_item_desc#14, inv_date_sk#18, w_warehouse_name#20, d_date_sk#21, d_week_seq#23, d_date_sk#25, d_date_sk#27]
+
+(62) Scan parquet spark_catalog.default.promotion
+Output [1]: [p_promo_sk#29]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/promotion]
+PushedFilters: [IsNotNull(p_promo_sk)]
+ReadSchema: struct<p_promo_sk:int>
+
+(63) ColumnarToRow [codegen id : 17]
+Input [1]: [p_promo_sk#29]
+
+(64) Filter [codegen id : 17]
+Input [1]: [p_promo_sk#29]
+Condition : isnotnull(p_promo_sk#29)
+
+(65) BroadcastExchange
+Input [1]: [p_promo_sk#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=11]
+
+(66) BroadcastHashJoin [codegen id : 18]
+Left keys [1]: [cs_promo_sk#5]
+Right keys [1]: [p_promo_sk#29]
+Join type: LeftOuter
+Join condition: None
+
+(67) Project [codegen id : 18]
+Output [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#20, i_item_desc#14, d_week_seq#23]
+Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#20, i_item_desc#14, d_week_seq#23, p_promo_sk#29]
+
+(68) Exchange
+Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#20, i_item_desc#14, d_week_seq#23]
+Arguments: hashpartitioning(cs_item_sk#4, cs_order_number#6, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+
+(69) Sort [codegen id : 19]
+Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#20, i_item_desc#14, d_week_seq#23]
+Arguments: [cs_item_sk#4 ASC NULLS FIRST, cs_order_number#6 ASC NULLS FIRST], false, 0
+
+(70) Scan parquet spark_catalog.default.catalog_returns
+Output [3]: [cr_item_sk#30, cr_order_number#31, cr_returned_date_sk#32]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/catalog_returns]
+PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
+ReadSchema: struct<cr_item_sk:int,cr_order_number:int>
+
+(71) ColumnarToRow [codegen id : 20]
+Input [3]: [cr_item_sk#30, cr_order_number#31, cr_returned_date_sk#32]
+
+(72) Filter [codegen id : 20]
+Input [3]: [cr_item_sk#30, cr_order_number#31, cr_returned_date_sk#32]
+Condition : (isnotnull(cr_item_sk#30) AND isnotnull(cr_order_number#31))
+
+(73) Project [codegen id : 20]
+Output [2]: [cr_item_sk#30, cr_order_number#31]
+Input [3]: [cr_item_sk#30, cr_order_number#31, cr_returned_date_sk#32]
+
+(74) Exchange
+Input [2]: [cr_item_sk#30, cr_order_number#31]
+Arguments: hashpartitioning(cr_item_sk#30, cr_order_number#31, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+
+(75) Sort [codegen id : 21]
+Input [2]: [cr_item_sk#30, cr_order_number#31]
+Arguments: [cr_item_sk#30 ASC NULLS FIRST, cr_order_number#31 ASC NULLS FIRST], false, 0
+
+(76) SortMergeJoin [codegen id : 22]
+Left keys [2]: [cs_item_sk#4, cs_order_number#6]
+Right keys [2]: [cr_item_sk#30, cr_order_number#31]
+Join type: LeftOuter
+Join condition: None
+
+(77) Project [codegen id : 22]
+Output [3]: [w_warehouse_name#20, i_item_desc#14, d_week_seq#23]
+Input [7]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#20, i_item_desc#14, d_week_seq#23, cr_item_sk#30, cr_order_number#31]
+
+(78) HashAggregate [codegen id : 22]
+Input [3]: [w_warehouse_name#20, i_item_desc#14, d_week_seq#23]
+Keys [3]: [i_item_desc#14, w_warehouse_name#20, d_week_seq#23]
+Functions [1]: [partial_count(1)]
+Aggregate Attributes [1]: [count#33]
+Results [4]: [i_item_desc#14, w_warehouse_name#20, d_week_seq#23, count#34]
+
+(79) Exchange
+Input [4]: [i_item_desc#14, w_warehouse_name#20, d_week_seq#23, count#34]
+Arguments: hashpartitioning(i_item_desc#14, w_warehouse_name#20, d_week_seq#23, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+
+(80) HashAggregate [codegen id : 23]
+Input [4]: [i_item_desc#14, w_warehouse_name#20, d_week_seq#23, count#34]
+Keys [3]: [i_item_desc#14, w_warehouse_name#20, d_week_seq#23]
+Functions [1]: [count(1)]
+Aggregate Attributes [1]: [count(1)#35]
+Results [6]: [i_item_desc#14, w_warehouse_name#20, d_week_seq#23, count(1)#35 AS no_promo#36, count(1)#35 AS promo#37, count(1)#35 AS total_cnt#38]
+
+(81) TakeOrderedAndProject
+Input [6]: [i_item_desc#14, w_warehouse_name#20, d_week_seq#23, no_promo#36, promo#37, total_cnt#38]
+Arguments: 100, [total_cnt#38 DESC NULLS LAST, i_item_desc#14 ASC NULLS FIRST, w_warehouse_name#20 ASC NULLS FIRST, d_week_seq#23 ASC NULLS FIRST], [i_item_desc#14, w_warehouse_name#20, d_week_seq#23, no_promo#36, promo#37, total_cnt#38]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q72.sf100/simplified.txt
@@ -1,40 +1,40 @@
 TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_promo,promo]
-  WholeStageCodegen (21)
+  WholeStageCodegen (23)
     HashAggregate [i_item_desc,w_warehouse_name,d_week_seq,count] [count(1),no_promo,promo,total_cnt,count]
       InputAdapter
         Exchange [i_item_desc,w_warehouse_name,d_week_seq] #1
-          WholeStageCodegen (20)
+          WholeStageCodegen (22)
             HashAggregate [i_item_desc,w_warehouse_name,d_week_seq] [count,count]
               Project [w_warehouse_name,i_item_desc,d_week_seq]
                 SortMergeJoin [cs_item_sk,cs_order_number,cr_item_sk,cr_order_number]
                   InputAdapter
-                    WholeStageCodegen (17)
+                    WholeStageCodegen (19)
                       Sort [cs_item_sk,cs_order_number]
                         InputAdapter
                           Exchange [cs_item_sk,cs_order_number] #2
-                            WholeStageCodegen (16)
+                            WholeStageCodegen (18)
                               Project [cs_item_sk,cs_order_number,w_warehouse_name,i_item_desc,d_week_seq]
                                 BroadcastHashJoin [cs_promo_sk,p_promo_sk]
                                   Project [cs_item_sk,cs_promo_sk,cs_order_number,w_warehouse_name,i_item_desc,d_week_seq]
-                                    SortMergeJoin [cs_item_sk,d_date_sk,inv_item_sk,inv_date_sk,inv_quantity_on_hand,cs_quantity]
+                                    SortMergeJoin [cs_sold_date_sk,inv_date_sk,cs_ship_date_sk,d_date_sk,d_date_sk,d_date_sk]
                                       InputAdapter
-                                        WholeStageCodegen (11)
-                                          Sort [cs_item_sk,d_date_sk]
+                                        WholeStageCodegen (12)
+                                          Sort [cs_sold_date_sk,inv_date_sk,cs_ship_date_sk]
                                             InputAdapter
-                                              Exchange [cs_item_sk,d_date_sk] #3
-                                                WholeStageCodegen (10)
-                                                  Project [cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,i_item_desc,d_week_seq,d_date_sk]
-                                                    BroadcastHashJoin [cs_sold_date_sk,d_date_sk,d_date,d_date]
-                                                      Project [cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk,d_date,i_item_desc]
-                                                        SortMergeJoin [cs_item_sk,i_item_sk]
-                                                          InputAdapter
-                                                            WholeStageCodegen (5)
-                                                              Sort [cs_item_sk]
-                                                                InputAdapter
-                                                                  Exchange [cs_item_sk] #4
-                                                                    WholeStageCodegen (4)
-                                                                      Project [cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk,d_date]
-                                                                        BroadcastHashJoin [cs_ship_date_sk,d_date_sk]
+                                              Exchange [cs_sold_date_sk,inv_date_sk,cs_ship_date_sk] #3
+                                                WholeStageCodegen (11)
+                                                  Project [cs_ship_date_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_sold_date_sk,i_item_desc,inv_date_sk,w_warehouse_name]
+                                                    SortMergeJoin [cs_item_sk,inv_item_sk,inv_quantity_on_hand,cs_quantity]
+                                                      InputAdapter
+                                                        WholeStageCodegen (7)
+                                                          Project [cs_ship_date_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk,i_item_desc]
+                                                            SortMergeJoin [cs_item_sk,i_item_sk]
+                                                              InputAdapter
+                                                                WholeStageCodegen (4)
+                                                                  Sort [cs_item_sk]
+                                                                    InputAdapter
+                                                                      Exchange [cs_item_sk] #4
+                                                                        WholeStageCodegen (3)
                                                                           Project [cs_ship_date_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk]
                                                                             BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
                                                                               Project [cs_ship_date_sk,cs_bill_cdemo_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk]
@@ -43,25 +43,8 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                                                                     ColumnarToRow
                                                                                       InputAdapter
                                                                                         Scan parquet spark_catalog.default.catalog_sales [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk]
-                                                                                          SubqueryBroadcast [d_date_sk] #1
-                                                                                            BroadcastExchange #5
-                                                                                              WholeStageCodegen (2)
-                                                                                                Project [d_date_sk,d_date,d_week_seq,d_date_sk]
-                                                                                                  BroadcastHashJoin [d_week_seq,d_week_seq]
-                                                                                                    InputAdapter
-                                                                                                      BroadcastExchange #6
-                                                                                                        WholeStageCodegen (1)
-                                                                                                          Project [d_date_sk,d_date,d_week_seq]
-                                                                                                            Filter [d_year,d_date_sk,d_week_seq,d_date]
-                                                                                                              ColumnarToRow
-                                                                                                                InputAdapter
-                                                                                                                  Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date,d_week_seq,d_year]
-                                                                                                    Filter [d_week_seq,d_date_sk]
-                                                                                                      ColumnarToRow
-                                                                                                        InputAdapter
-                                                                                                          Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq]
                                                                                   InputAdapter
-                                                                                    BroadcastExchange #7
+                                                                                    BroadcastExchange #5
                                                                                       WholeStageCodegen (1)
                                                                                         Project [hd_demo_sk]
                                                                                           Filter [hd_buy_potential,hd_demo_sk]
@@ -69,64 +52,84 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                                                                               InputAdapter
                                                                                                 Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_buy_potential]
                                                                               InputAdapter
-                                                                                BroadcastExchange #8
+                                                                                BroadcastExchange #6
                                                                                   WholeStageCodegen (2)
                                                                                     Project [cd_demo_sk]
                                                                                       Filter [cd_marital_status,cd_demo_sk]
                                                                                         ColumnarToRow
                                                                                           InputAdapter
                                                                                             Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status]
-                                                                          InputAdapter
-                                                                            BroadcastExchange #9
-                                                                              WholeStageCodegen (3)
-                                                                                Filter [d_date,d_date_sk]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
-                                                          InputAdapter
-                                                            WholeStageCodegen (7)
-                                                              Sort [i_item_sk]
-                                                                InputAdapter
-                                                                  Exchange [i_item_sk] #10
-                                                                    WholeStageCodegen (6)
-                                                                      Filter [i_item_sk]
+                                                              InputAdapter
+                                                                WholeStageCodegen (6)
+                                                                  Sort [i_item_sk]
+                                                                    InputAdapter
+                                                                      Exchange [i_item_sk] #7
+                                                                        WholeStageCodegen (5)
+                                                                          Filter [i_item_sk]
+                                                                            ColumnarToRow
+                                                                              InputAdapter
+                                                                                Scan parquet spark_catalog.default.item [i_item_sk,i_item_desc]
+                                                      InputAdapter
+                                                        WholeStageCodegen (10)
+                                                          Sort [inv_item_sk]
+                                                            InputAdapter
+                                                              Exchange [inv_item_sk] #8
+                                                                WholeStageCodegen (9)
+                                                                  Project [inv_item_sk,inv_quantity_on_hand,inv_date_sk,w_warehouse_name]
+                                                                    BroadcastHashJoin [inv_warehouse_sk,w_warehouse_sk]
+                                                                      Filter [inv_quantity_on_hand,inv_item_sk,inv_warehouse_sk]
                                                                         ColumnarToRow
                                                                           InputAdapter
-                                                                            Scan parquet spark_catalog.default.item [i_item_sk,i_item_desc]
-                                                      InputAdapter
-                                                        ReusedExchange [d_date_sk,d_date,d_week_seq,d_date_sk] #5
+                                                                            Scan parquet spark_catalog.default.inventory [inv_item_sk,inv_warehouse_sk,inv_quantity_on_hand,inv_date_sk]
+                                                                      InputAdapter
+                                                                        BroadcastExchange #9
+                                                                          WholeStageCodegen (8)
+                                                                            Filter [w_warehouse_sk]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet spark_catalog.default.warehouse [w_warehouse_sk,w_warehouse_name]
                                       InputAdapter
-                                        WholeStageCodegen (14)
-                                          Sort [inv_item_sk,inv_date_sk]
+                                        WholeStageCodegen (16)
+                                          Sort [d_date_sk,d_date_sk,d_date_sk]
                                             InputAdapter
-                                              Exchange [inv_item_sk,inv_date_sk] #11
-                                                WholeStageCodegen (13)
-                                                  Project [inv_item_sk,inv_quantity_on_hand,inv_date_sk,w_warehouse_name]
-                                                    BroadcastHashJoin [inv_warehouse_sk,w_warehouse_sk]
-                                                      Filter [inv_quantity_on_hand,inv_item_sk,inv_warehouse_sk]
-                                                        ColumnarToRow
+                                              Exchange [d_date_sk,d_date_sk,d_date_sk] #10
+                                                WholeStageCodegen (15)
+                                                  Project [d_date_sk,d_week_seq,d_date_sk,d_date_sk]
+                                                    BroadcastNestedLoopJoin [d_date,d_date]
+                                                      Project [d_date_sk,d_date,d_week_seq,d_date_sk]
+                                                        BroadcastHashJoin [d_week_seq,d_week_seq]
                                                           InputAdapter
-                                                            Scan parquet spark_catalog.default.inventory [inv_item_sk,inv_warehouse_sk,inv_quantity_on_hand,inv_date_sk]
+                                                            BroadcastExchange #11
+                                                              WholeStageCodegen (13)
+                                                                Project [d_date_sk,d_date,d_week_seq]
+                                                                  Filter [d_year,d_date_sk,d_week_seq,d_date]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date,d_week_seq,d_year]
+                                                          Filter [d_week_seq,d_date_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq]
                                                       InputAdapter
                                                         BroadcastExchange #12
-                                                          WholeStageCodegen (12)
-                                                            Filter [w_warehouse_sk]
+                                                          WholeStageCodegen (14)
+                                                            Filter [d_date,d_date_sk]
                                                               ColumnarToRow
                                                                 InputAdapter
-                                                                  Scan parquet spark_catalog.default.warehouse [w_warehouse_sk,w_warehouse_name]
+                                                                  Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
                                   InputAdapter
                                     BroadcastExchange #13
-                                      WholeStageCodegen (15)
+                                      WholeStageCodegen (17)
                                         Filter [p_promo_sk]
                                           ColumnarToRow
                                             InputAdapter
                                               Scan parquet spark_catalog.default.promotion [p_promo_sk]
                   InputAdapter
-                    WholeStageCodegen (19)
+                    WholeStageCodegen (21)
                       Sort [cr_item_sk,cr_order_number]
                         InputAdapter
                           Exchange [cr_item_sk,cr_order_number] #14
-                            WholeStageCodegen (18)
+                            WholeStageCodegen (20)
                               Project [cr_item_sk,cr_order_number]
                                 Filter [cr_item_sk,cr_order_number]
                                   ColumnarToRow

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q73.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q73.sf100/explain.txt
@@ -23,12 +23,12 @@
          :                       :        +- * Project (10)
          :                       :           +- * Filter (9)
          :                       :              +- * ColumnarToRow (8)
-         :                       :                 +- Scan parquet spark_catalog.default.store (7)
+         :                       :                 +- Scan parquet spark_catalog.default.household_demographics (7)
          :                       +- BroadcastExchange (18)
          :                          +- * Project (17)
          :                             +- * Filter (16)
          :                                +- * ColumnarToRow (15)
-         :                                   +- Scan parquet spark_catalog.default.household_demographics (14)
+         :                                   +- Scan parquet spark_catalog.default.store (14)
          +- * Sort (31)
             +- Exchange (30)
                +- * Filter (29)
@@ -64,69 +64,69 @@ Join condition: None
 Output [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4]
 Input [6]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5, d_date_sk#7]
 
-(7) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#8, s_county#9]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [In(s_county, [Bronx County,Franklin Parish,Orange County,Williamson County]), IsNotNull(s_store_sk)]
-ReadSchema: struct<s_store_sk:int,s_county:string>
-
-(8) ColumnarToRow [codegen id : 2]
-Input [2]: [s_store_sk#8, s_county#9]
-
-(9) Filter [codegen id : 2]
-Input [2]: [s_store_sk#8, s_county#9]
-Condition : (s_county#9 IN (Williamson County,Franklin Parish,Bronx County,Orange County) AND isnotnull(s_store_sk#8))
-
-(10) Project [codegen id : 2]
-Output [1]: [s_store_sk#8]
-Input [2]: [s_store_sk#8, s_county#9]
-
-(11) BroadcastExchange
-Input [1]: [s_store_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
-
-(12) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#8]
-Join type: Inner
-Join condition: None
-
-(13) Project [codegen id : 4]
-Output [3]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4]
-Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, s_store_sk#8]
-
-(14) Scan parquet spark_catalog.default.household_demographics
-Output [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
+(7) Scan parquet spark_catalog.default.household_demographics
+Output [4]: [hd_demo_sk#8, hd_buy_potential#9, hd_dep_count#10, hd_vehicle_count#11]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [IsNotNull(hd_vehicle_count), Or(EqualTo(hd_buy_potential,>10000         ),EqualTo(hd_buy_potential,unknown        )), GreaterThan(hd_vehicle_count,0), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string,hd_dep_count:int,hd_vehicle_count:int>
 
+(8) ColumnarToRow [codegen id : 2]
+Input [4]: [hd_demo_sk#8, hd_buy_potential#9, hd_dep_count#10, hd_vehicle_count#11]
+
+(9) Filter [codegen id : 2]
+Input [4]: [hd_demo_sk#8, hd_buy_potential#9, hd_dep_count#10, hd_vehicle_count#11]
+Condition : ((((isnotnull(hd_vehicle_count#11) AND ((hd_buy_potential#9 = >10000         ) OR (hd_buy_potential#9 = unknown        ))) AND (hd_vehicle_count#11 > 0)) AND CASE WHEN (hd_vehicle_count#11 > 0) THEN ((cast(hd_dep_count#10 as double) / cast(hd_vehicle_count#11 as double)) > 1.0) END) AND isnotnull(hd_demo_sk#8))
+
+(10) Project [codegen id : 2]
+Output [1]: [hd_demo_sk#8]
+Input [4]: [hd_demo_sk#8, hd_buy_potential#9, hd_dep_count#10, hd_vehicle_count#11]
+
+(11) BroadcastExchange
+Input [1]: [hd_demo_sk#8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
+
+(12) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_hdemo_sk#2]
+Right keys [1]: [hd_demo_sk#8]
+Join type: Inner
+Join condition: None
+
+(13) Project [codegen id : 4]
+Output [3]: [ss_customer_sk#1, ss_store_sk#3, ss_ticket_number#4]
+Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, hd_demo_sk#8]
+
+(14) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#12, s_county#13]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [In(s_county, [Bronx County,Franklin Parish,Orange County,Williamson County]), IsNotNull(s_store_sk)]
+ReadSchema: struct<s_store_sk:int,s_county:string>
+
 (15) ColumnarToRow [codegen id : 3]
-Input [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
+Input [2]: [s_store_sk#12, s_county#13]
 
 (16) Filter [codegen id : 3]
-Input [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
-Condition : ((((isnotnull(hd_vehicle_count#13) AND ((hd_buy_potential#11 = >10000         ) OR (hd_buy_potential#11 = unknown        ))) AND (hd_vehicle_count#13 > 0)) AND CASE WHEN (hd_vehicle_count#13 > 0) THEN ((cast(hd_dep_count#12 as double) / cast(hd_vehicle_count#13 as double)) > 1.0) END) AND isnotnull(hd_demo_sk#10))
+Input [2]: [s_store_sk#12, s_county#13]
+Condition : (s_county#13 IN (Williamson County,Franklin Parish,Bronx County,Orange County) AND isnotnull(s_store_sk#12))
 
 (17) Project [codegen id : 3]
-Output [1]: [hd_demo_sk#10]
-Input [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
+Output [1]: [s_store_sk#12]
+Input [2]: [s_store_sk#12, s_county#13]
 
 (18) BroadcastExchange
-Input [1]: [hd_demo_sk#10]
+Input [1]: [s_store_sk#12]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
 (19) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_hdemo_sk#2]
-Right keys [1]: [hd_demo_sk#10]
+Left keys [1]: [ss_store_sk#3]
+Right keys [1]: [s_store_sk#12]
 Join type: Inner
 Join condition: None
 
 (20) Project [codegen id : 4]
 Output [2]: [ss_customer_sk#1, ss_ticket_number#4]
-Input [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4, hd_demo_sk#10]
+Input [4]: [ss_customer_sk#1, ss_store_sk#3, ss_ticket_number#4, s_store_sk#12]
 
 (21) HashAggregate [codegen id : 4]
 Input [2]: [ss_customer_sk#1, ss_ticket_number#4]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q73.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q73.sf100/simplified.txt
@@ -18,9 +18,9 @@ WholeStageCodegen (10)
                                   WholeStageCodegen (4)
                                     HashAggregate [ss_ticket_number,ss_customer_sk] [count,count]
                                       Project [ss_customer_sk,ss_ticket_number]
-                                        BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
-                                          Project [ss_customer_sk,ss_hdemo_sk,ss_ticket_number]
-                                            BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                        BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                          Project [ss_customer_sk,ss_store_sk,ss_ticket_number]
+                                            BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
                                               Project [ss_customer_sk,ss_hdemo_sk,ss_store_sk,ss_ticket_number]
                                                 BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                   Filter [ss_store_sk,ss_hdemo_sk,ss_customer_sk]
@@ -40,19 +40,19 @@ WholeStageCodegen (10)
                                               InputAdapter
                                                 BroadcastExchange #5
                                                   WholeStageCodegen (2)
-                                                    Project [s_store_sk]
-                                                      Filter [s_county,s_store_sk]
+                                                    Project [hd_demo_sk]
+                                                      Filter [hd_vehicle_count,hd_buy_potential,hd_dep_count,hd_demo_sk]
                                                         ColumnarToRow
                                                           InputAdapter
-                                                            Scan parquet spark_catalog.default.store [s_store_sk,s_county]
+                                                            Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_buy_potential,hd_dep_count,hd_vehicle_count]
                                           InputAdapter
                                             BroadcastExchange #6
                                               WholeStageCodegen (3)
-                                                Project [hd_demo_sk]
-                                                  Filter [hd_vehicle_count,hd_buy_potential,hd_dep_count,hd_demo_sk]
+                                                Project [s_store_sk]
+                                                  Filter [s_county,s_store_sk]
                                                     ColumnarToRow
                                                       InputAdapter
-                                                        Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_buy_potential,hd_dep_count,hd_vehicle_count]
+                                                        Scan parquet spark_catalog.default.store [s_store_sk,s_county]
               InputAdapter
                 WholeStageCodegen (8)
                   Sort [c_customer_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q75.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q75.sf100/explain.txt
@@ -18,17 +18,17 @@ TakeOrderedAndProject (129)
       :                             :     :  +- Exchange (14)
       :                             :     :     +- * Project (13)
       :                             :     :        +- * BroadcastHashJoin Inner BuildRight (12)
-      :                             :     :           :- * Project (10)
-      :                             :     :           :  +- * BroadcastHashJoin Inner BuildRight (9)
+      :                             :     :           :- * Project (6)
+      :                             :     :           :  +- * BroadcastHashJoin Inner BuildRight (5)
       :                             :     :           :     :- * Filter (3)
       :                             :     :           :     :  +- * ColumnarToRow (2)
       :                             :     :           :     :     +- Scan parquet spark_catalog.default.catalog_sales (1)
-      :                             :     :           :     +- BroadcastExchange (8)
-      :                             :     :           :        +- * Project (7)
-      :                             :     :           :           +- * Filter (6)
-      :                             :     :           :              +- * ColumnarToRow (5)
-      :                             :     :           :                 +- Scan parquet spark_catalog.default.item (4)
-      :                             :     :           +- ReusedExchange (11)
+      :                             :     :           :     +- ReusedExchange (4)
+      :                             :     :           +- BroadcastExchange (11)
+      :                             :     :              +- * Project (10)
+      :                             :     :                 +- * Filter (9)
+      :                             :     :                    +- * ColumnarToRow (8)
+      :                             :     :                       +- Scan parquet spark_catalog.default.item (7)
       :                             :     +- * Sort (21)
       :                             :        +- Exchange (20)
       :                             :           +- * Project (19)
@@ -145,57 +145,57 @@ Input [5]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4
 Input [5]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, cs_sold_date_sk#5]
 Condition : isnotnull(cs_item_sk#1)
 
-(4) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_category#11, i_manufact_id#12]
+(4) ReusedExchange [Reuses operator id: 133]
+Output [2]: [d_date_sk#7, d_year#8]
+
+(5) BroadcastHashJoin [codegen id : 3]
+Left keys [1]: [cs_sold_date_sk#5]
+Right keys [1]: [d_date_sk#7]
+Join type: Inner
+Join condition: None
+
+(6) Project [codegen id : 3]
+Output [5]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, d_year#8]
+Input [7]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, cs_sold_date_sk#5, d_date_sk#7, d_year#8]
+
+(7) Scan parquet spark_catalog.default.item
+Output [6]: [i_item_sk#9, i_brand_id#10, i_class_id#11, i_category_id#12, i_category#13, i_manufact_id#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_category), EqualTo(i_category,Books                                             ), IsNotNull(i_item_sk), IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id), IsNotNull(i_manufact_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int,i_category:string,i_manufact_id:int>
 
-(5) ColumnarToRow [codegen id : 1]
-Input [6]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_category#11, i_manufact_id#12]
+(8) ColumnarToRow [codegen id : 2]
+Input [6]: [i_item_sk#9, i_brand_id#10, i_class_id#11, i_category_id#12, i_category#13, i_manufact_id#14]
 
-(6) Filter [codegen id : 1]
-Input [6]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_category#11, i_manufact_id#12]
-Condition : ((((((isnotnull(i_category#11) AND (i_category#11 = Books                                             )) AND isnotnull(i_item_sk#7)) AND isnotnull(i_brand_id#8)) AND isnotnull(i_class_id#9)) AND isnotnull(i_category_id#10)) AND isnotnull(i_manufact_id#12))
+(9) Filter [codegen id : 2]
+Input [6]: [i_item_sk#9, i_brand_id#10, i_class_id#11, i_category_id#12, i_category#13, i_manufact_id#14]
+Condition : ((((((isnotnull(i_category#13) AND (i_category#13 = Books                                             )) AND isnotnull(i_item_sk#9)) AND isnotnull(i_brand_id#10)) AND isnotnull(i_class_id#11)) AND isnotnull(i_category_id#12)) AND isnotnull(i_manufact_id#14))
 
-(7) Project [codegen id : 1]
-Output [5]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
-Input [6]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_category#11, i_manufact_id#12]
+(10) Project [codegen id : 2]
+Output [5]: [i_item_sk#9, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14]
+Input [6]: [i_item_sk#9, i_brand_id#10, i_class_id#11, i_category_id#12, i_category#13, i_manufact_id#14]
 
-(8) BroadcastExchange
-Input [5]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
+(11) BroadcastExchange
+Input [5]: [i_item_sk#9, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(9) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [cs_item_sk#1]
-Right keys [1]: [i_item_sk#7]
-Join type: Inner
-Join condition: None
-
-(10) Project [codegen id : 3]
-Output [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, cs_sold_date_sk#5, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
-Input [10]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, cs_sold_date_sk#5, i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
-
-(11) ReusedExchange [Reuses operator id: 133]
-Output [2]: [d_date_sk#13, d_year#14]
-
 (12) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [cs_sold_date_sk#5]
-Right keys [1]: [d_date_sk#13]
+Left keys [1]: [cs_item_sk#1]
+Right keys [1]: [i_item_sk#9]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 3]
-Output [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#14]
-Input [11]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, cs_sold_date_sk#5, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_date_sk#13, d_year#14]
+Output [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, d_year#8]
+Input [10]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, d_year#8, i_item_sk#9, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14]
 
 (14) Exchange
-Input [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#14]
+Input [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, d_year#8]
 Arguments: hashpartitioning(cs_order_number#2, cs_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (15) Sort [codegen id : 4]
-Input [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#14]
+Input [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, d_year#8]
 Arguments: [cs_order_number#2 ASC NULLS FIRST, cs_item_sk#1 ASC NULLS FIRST], false, 0
 
 (16) Scan parquet spark_catalog.default.catalog_returns
@@ -231,8 +231,8 @@ Join type: LeftOuter
 Join condition: None
 
 (23) Project [codegen id : 7]
-Output [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, (cs_quantity#3 - coalesce(cr_return_quantity#17, 0)) AS sales_cnt#20, (cs_ext_sales_price#4 - coalesce(cr_return_amount#18, 0.00)) AS sales_amt#21]
-Input [13]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#14, cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18]
+Output [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, (cs_quantity#3 - coalesce(cr_return_quantity#17, 0)) AS sales_cnt#20, (cs_ext_sales_price#4 - coalesce(cr_return_amount#18, 0.00)) AS sales_amt#21]
+Input [13]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, d_year#8, cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18]
 
 (24) Scan parquet spark_catalog.default.store_sales
 Output [5]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26]
@@ -249,38 +249,38 @@ Input [5]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_pri
 Input [5]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26]
 Condition : isnotnull(ss_item_sk#22)
 
-(27) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#27, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31]
+(27) ReusedExchange [Reuses operator id: 133]
+Output [2]: [d_date_sk#27, d_year#28]
 
 (28) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [ss_item_sk#22]
-Right keys [1]: [i_item_sk#27]
+Left keys [1]: [ss_sold_date_sk#26]
+Right keys [1]: [d_date_sk#27]
 Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 10]
-Output [9]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31]
-Input [10]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26, i_item_sk#27, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31]
+Output [5]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, d_year#28]
+Input [7]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26, d_date_sk#27, d_year#28]
 
-(30) ReusedExchange [Reuses operator id: 133]
-Output [2]: [d_date_sk#32, d_year#33]
+(30) ReusedExchange [Reuses operator id: 11]
+Output [5]: [i_item_sk#29, i_brand_id#30, i_class_id#31, i_category_id#32, i_manufact_id#33]
 
 (31) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [ss_sold_date_sk#26]
-Right keys [1]: [d_date_sk#32]
+Left keys [1]: [ss_item_sk#22]
+Right keys [1]: [i_item_sk#29]
 Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 10]
-Output [9]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, d_year#33]
-Input [11]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, d_date_sk#32, d_year#33]
+Output [9]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#30, i_class_id#31, i_category_id#32, i_manufact_id#33, d_year#28]
+Input [10]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, d_year#28, i_item_sk#29, i_brand_id#30, i_class_id#31, i_category_id#32, i_manufact_id#33]
 
 (33) Exchange
-Input [9]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, d_year#33]
+Input [9]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#30, i_class_id#31, i_category_id#32, i_manufact_id#33, d_year#28]
 Arguments: hashpartitioning(ss_ticket_number#23, ss_item_sk#22, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (34) Sort [codegen id : 11]
-Input [9]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, d_year#33]
+Input [9]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#30, i_class_id#31, i_category_id#32, i_manufact_id#33, d_year#28]
 Arguments: [ss_ticket_number#23 ASC NULLS FIRST, ss_item_sk#22 ASC NULLS FIRST], false, 0
 
 (35) Scan parquet spark_catalog.default.store_returns
@@ -316,8 +316,8 @@ Join type: LeftOuter
 Join condition: None
 
 (42) Project [codegen id : 14]
-Output [7]: [d_year#33, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, (ss_quantity#24 - coalesce(sr_return_quantity#36, 0)) AS sales_cnt#39, (ss_ext_sales_price#25 - coalesce(sr_return_amt#37, 0.00)) AS sales_amt#40]
-Input [13]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, d_year#33, sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37]
+Output [7]: [d_year#28, i_brand_id#30, i_class_id#31, i_category_id#32, i_manufact_id#33, (ss_quantity#24 - coalesce(sr_return_quantity#36, 0)) AS sales_cnt#39, (ss_ext_sales_price#25 - coalesce(sr_return_amt#37, 0.00)) AS sales_amt#40]
+Input [13]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#30, i_class_id#31, i_category_id#32, i_manufact_id#33, d_year#28, sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37]
 
 (43) Scan parquet spark_catalog.default.web_sales
 Output [5]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45]
@@ -334,38 +334,38 @@ Input [5]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_pric
 Input [5]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45]
 Condition : isnotnull(ws_item_sk#41)
 
-(46) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#46, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50]
+(46) ReusedExchange [Reuses operator id: 133]
+Output [2]: [d_date_sk#46, d_year#47]
 
 (47) BroadcastHashJoin [codegen id : 17]
-Left keys [1]: [ws_item_sk#41]
-Right keys [1]: [i_item_sk#46]
+Left keys [1]: [ws_sold_date_sk#45]
+Right keys [1]: [d_date_sk#46]
 Join type: Inner
 Join condition: None
 
 (48) Project [codegen id : 17]
-Output [9]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50]
-Input [10]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45, i_item_sk#46, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50]
+Output [5]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, d_year#47]
+Input [7]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45, d_date_sk#46, d_year#47]
 
-(49) ReusedExchange [Reuses operator id: 133]
-Output [2]: [d_date_sk#51, d_year#52]
+(49) ReusedExchange [Reuses operator id: 11]
+Output [5]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51, i_manufact_id#52]
 
 (50) BroadcastHashJoin [codegen id : 17]
-Left keys [1]: [ws_sold_date_sk#45]
-Right keys [1]: [d_date_sk#51]
+Left keys [1]: [ws_item_sk#41]
+Right keys [1]: [i_item_sk#48]
 Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 17]
-Output [9]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, d_year#52]
-Input [11]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, d_date_sk#51, d_year#52]
+Output [9]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#49, i_class_id#50, i_category_id#51, i_manufact_id#52, d_year#47]
+Input [10]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, d_year#47, i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51, i_manufact_id#52]
 
 (52) Exchange
-Input [9]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, d_year#52]
+Input [9]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#49, i_class_id#50, i_category_id#51, i_manufact_id#52, d_year#47]
 Arguments: hashpartitioning(ws_order_number#42, ws_item_sk#41, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (53) Sort [codegen id : 18]
-Input [9]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, d_year#52]
+Input [9]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#49, i_class_id#50, i_category_id#51, i_manufact_id#52, d_year#47]
 Arguments: [ws_order_number#42 ASC NULLS FIRST, ws_item_sk#41 ASC NULLS FIRST], false, 0
 
 (54) Scan parquet spark_catalog.default.web_returns
@@ -401,58 +401,58 @@ Join type: LeftOuter
 Join condition: None
 
 (61) Project [codegen id : 21]
-Output [7]: [d_year#52, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, (ws_quantity#43 - coalesce(wr_return_quantity#55, 0)) AS sales_cnt#58, (ws_ext_sales_price#44 - coalesce(wr_return_amt#56, 0.00)) AS sales_amt#59]
-Input [13]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, d_year#52, wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56]
+Output [7]: [d_year#47, i_brand_id#49, i_class_id#50, i_category_id#51, i_manufact_id#52, (ws_quantity#43 - coalesce(wr_return_quantity#55, 0)) AS sales_cnt#58, (ws_ext_sales_price#44 - coalesce(wr_return_amt#56, 0.00)) AS sales_amt#59]
+Input [13]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#49, i_class_id#50, i_category_id#51, i_manufact_id#52, d_year#47, wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56]
 
 (62) Union
 
 (63) HashAggregate [codegen id : 22]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-Keys [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
+Input [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#20, sales_amt#21]
+Keys [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#20, sales_amt#21]
 Functions: []
 Aggregate Attributes: []
-Results [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
+Results [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#20, sales_amt#21]
 
 (64) Exchange
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-Arguments: hashpartitioning(d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#20, sales_amt#21]
+Arguments: hashpartitioning(d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#20, sales_amt#21, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (65) HashAggregate [codegen id : 23]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-Keys [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
+Input [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#20, sales_amt#21]
+Keys [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#20, sales_amt#21]
 Functions: []
 Aggregate Attributes: []
-Results [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
+Results [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#20, sales_amt#21]
 
 (66) HashAggregate [codegen id : 23]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-Keys [5]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
+Input [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#20, sales_amt#21]
+Keys [5]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14]
 Functions [2]: [partial_sum(sales_cnt#20), partial_sum(UnscaledValue(sales_amt#21))]
 Aggregate Attributes [2]: [sum#60, sum#61]
-Results [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum#62, sum#63]
+Results [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sum#62, sum#63]
 
 (67) Exchange
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum#62, sum#63]
-Arguments: hashpartitioning(d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Input [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sum#62, sum#63]
+Arguments: hashpartitioning(d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (68) HashAggregate [codegen id : 24]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum#62, sum#63]
-Keys [5]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
+Input [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sum#62, sum#63]
+Keys [5]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14]
 Functions [2]: [sum(sales_cnt#20), sum(UnscaledValue(sales_amt#21))]
 Aggregate Attributes [2]: [sum(sales_cnt#20)#64, sum(UnscaledValue(sales_amt#21))#65]
-Results [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum(sales_cnt#20)#64 AS sales_cnt#66, MakeDecimal(sum(UnscaledValue(sales_amt#21))#65,18,2) AS sales_amt#67]
+Results [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sum(sales_cnt#20)#64 AS sales_cnt#66, MakeDecimal(sum(UnscaledValue(sales_amt#21))#65,18,2) AS sales_amt#67]
 
 (69) Filter [codegen id : 24]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#66, sales_amt#67]
+Input [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#66, sales_amt#67]
 Condition : isnotnull(sales_cnt#66)
 
 (70) Exchange
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#66, sales_amt#67]
-Arguments: hashpartitioning(i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#66, sales_amt#67]
+Arguments: hashpartitioning(i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (71) Sort [codegen id : 25]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#66, sales_amt#67]
-Arguments: [i_brand_id#8 ASC NULLS FIRST, i_class_id#9 ASC NULLS FIRST, i_category_id#10 ASC NULLS FIRST, i_manufact_id#12 ASC NULLS FIRST], false, 0
+Input [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#66, sales_amt#67]
+Arguments: [i_brand_id#10 ASC NULLS FIRST, i_class_id#11 ASC NULLS FIRST, i_category_id#12 ASC NULLS FIRST, i_manufact_id#14 ASC NULLS FIRST], false, 0
 
 (72) Scan parquet spark_catalog.default.catalog_sales
 Output [5]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72]
@@ -469,38 +469,38 @@ Input [5]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_pric
 Input [5]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72]
 Condition : isnotnull(cs_item_sk#68)
 
-(75) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#74, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
+(75) ReusedExchange [Reuses operator id: 137]
+Output [2]: [d_date_sk#74, d_year#75]
 
 (76) BroadcastHashJoin [codegen id : 28]
-Left keys [1]: [cs_item_sk#68]
-Right keys [1]: [i_item_sk#74]
+Left keys [1]: [cs_sold_date_sk#72]
+Right keys [1]: [d_date_sk#74]
 Join type: Inner
 Join condition: None
 
 (77) Project [codegen id : 28]
-Output [9]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
-Input [10]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72, i_item_sk#74, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
+Output [5]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, d_year#75]
+Input [7]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72, d_date_sk#74, d_year#75]
 
-(78) ReusedExchange [Reuses operator id: 137]
-Output [2]: [d_date_sk#79, d_year#80]
+(78) ReusedExchange [Reuses operator id: 11]
+Output [5]: [i_item_sk#76, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80]
 
 (79) BroadcastHashJoin [codegen id : 28]
-Left keys [1]: [cs_sold_date_sk#72]
-Right keys [1]: [d_date_sk#79]
+Left keys [1]: [cs_item_sk#68]
+Right keys [1]: [i_item_sk#76]
 Join type: Inner
 Join condition: None
 
 (80) Project [codegen id : 28]
-Output [9]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, d_year#80]
-Input [11]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, d_date_sk#79, d_year#80]
+Output [9]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, d_year#75]
+Input [10]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, d_year#75, i_item_sk#76, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80]
 
 (81) Exchange
-Input [9]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, d_year#80]
+Input [9]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, d_year#75]
 Arguments: hashpartitioning(cs_order_number#69, cs_item_sk#68, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (82) Sort [codegen id : 29]
-Input [9]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, d_year#80]
+Input [9]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, d_year#75]
 Arguments: [cs_order_number#69 ASC NULLS FIRST, cs_item_sk#68 ASC NULLS FIRST], false, 0
 
 (83) ReusedExchange [Reuses operator id: 20]
@@ -517,8 +517,8 @@ Join type: LeftOuter
 Join condition: None
 
 (86) Project [codegen id : 32]
-Output [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, (cs_quantity#70 - coalesce(cr_return_quantity#83, 0)) AS sales_cnt#85, (cs_ext_sales_price#71 - coalesce(cr_return_amount#84, 0.00)) AS sales_amt#86]
-Input [13]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, d_year#80, cr_item_sk#81, cr_order_number#82, cr_return_quantity#83, cr_return_amount#84]
+Output [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, (cs_quantity#70 - coalesce(cr_return_quantity#83, 0)) AS sales_cnt#85, (cs_ext_sales_price#71 - coalesce(cr_return_amount#84, 0.00)) AS sales_amt#86]
+Input [13]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, d_year#75, cr_item_sk#81, cr_order_number#82, cr_return_quantity#83, cr_return_amount#84]
 
 (87) Scan parquet spark_catalog.default.store_sales
 Output [5]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, ss_sold_date_sk#91]
@@ -535,38 +535,38 @@ Input [5]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_pri
 Input [5]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, ss_sold_date_sk#91]
 Condition : isnotnull(ss_item_sk#87)
 
-(90) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#92, i_brand_id#93, i_class_id#94, i_category_id#95, i_manufact_id#96]
+(90) ReusedExchange [Reuses operator id: 137]
+Output [2]: [d_date_sk#92, d_year#93]
 
 (91) BroadcastHashJoin [codegen id : 35]
-Left keys [1]: [ss_item_sk#87]
-Right keys [1]: [i_item_sk#92]
+Left keys [1]: [ss_sold_date_sk#91]
+Right keys [1]: [d_date_sk#92]
 Join type: Inner
 Join condition: None
 
 (92) Project [codegen id : 35]
-Output [9]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, ss_sold_date_sk#91, i_brand_id#93, i_class_id#94, i_category_id#95, i_manufact_id#96]
-Input [10]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, ss_sold_date_sk#91, i_item_sk#92, i_brand_id#93, i_class_id#94, i_category_id#95, i_manufact_id#96]
+Output [5]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, d_year#93]
+Input [7]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, ss_sold_date_sk#91, d_date_sk#92, d_year#93]
 
-(93) ReusedExchange [Reuses operator id: 137]
-Output [2]: [d_date_sk#97, d_year#98]
+(93) ReusedExchange [Reuses operator id: 11]
+Output [5]: [i_item_sk#94, i_brand_id#95, i_class_id#96, i_category_id#97, i_manufact_id#98]
 
 (94) BroadcastHashJoin [codegen id : 35]
-Left keys [1]: [ss_sold_date_sk#91]
-Right keys [1]: [d_date_sk#97]
+Left keys [1]: [ss_item_sk#87]
+Right keys [1]: [i_item_sk#94]
 Join type: Inner
 Join condition: None
 
 (95) Project [codegen id : 35]
-Output [9]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, i_brand_id#93, i_class_id#94, i_category_id#95, i_manufact_id#96, d_year#98]
-Input [11]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, ss_sold_date_sk#91, i_brand_id#93, i_class_id#94, i_category_id#95, i_manufact_id#96, d_date_sk#97, d_year#98]
+Output [9]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, i_brand_id#95, i_class_id#96, i_category_id#97, i_manufact_id#98, d_year#93]
+Input [10]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, d_year#93, i_item_sk#94, i_brand_id#95, i_class_id#96, i_category_id#97, i_manufact_id#98]
 
 (96) Exchange
-Input [9]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, i_brand_id#93, i_class_id#94, i_category_id#95, i_manufact_id#96, d_year#98]
+Input [9]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, i_brand_id#95, i_class_id#96, i_category_id#97, i_manufact_id#98, d_year#93]
 Arguments: hashpartitioning(ss_ticket_number#88, ss_item_sk#87, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
 (97) Sort [codegen id : 36]
-Input [9]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, i_brand_id#93, i_class_id#94, i_category_id#95, i_manufact_id#96, d_year#98]
+Input [9]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, i_brand_id#95, i_class_id#96, i_category_id#97, i_manufact_id#98, d_year#93]
 Arguments: [ss_ticket_number#88 ASC NULLS FIRST, ss_item_sk#87 ASC NULLS FIRST], false, 0
 
 (98) ReusedExchange [Reuses operator id: 39]
@@ -583,8 +583,8 @@ Join type: LeftOuter
 Join condition: None
 
 (101) Project [codegen id : 39]
-Output [7]: [d_year#98, i_brand_id#93, i_class_id#94, i_category_id#95, i_manufact_id#96, (ss_quantity#89 - coalesce(sr_return_quantity#101, 0)) AS sales_cnt#103, (ss_ext_sales_price#90 - coalesce(sr_return_amt#102, 0.00)) AS sales_amt#104]
-Input [13]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, i_brand_id#93, i_class_id#94, i_category_id#95, i_manufact_id#96, d_year#98, sr_item_sk#99, sr_ticket_number#100, sr_return_quantity#101, sr_return_amt#102]
+Output [7]: [d_year#93, i_brand_id#95, i_class_id#96, i_category_id#97, i_manufact_id#98, (ss_quantity#89 - coalesce(sr_return_quantity#101, 0)) AS sales_cnt#103, (ss_ext_sales_price#90 - coalesce(sr_return_amt#102, 0.00)) AS sales_amt#104]
+Input [13]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, i_brand_id#95, i_class_id#96, i_category_id#97, i_manufact_id#98, d_year#93, sr_item_sk#99, sr_ticket_number#100, sr_return_quantity#101, sr_return_amt#102]
 
 (102) Scan parquet spark_catalog.default.web_sales
 Output [5]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, ws_sold_date_sk#109]
@@ -601,38 +601,38 @@ Input [5]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_p
 Input [5]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, ws_sold_date_sk#109]
 Condition : isnotnull(ws_item_sk#105)
 
-(105) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#110, i_brand_id#111, i_class_id#112, i_category_id#113, i_manufact_id#114]
+(105) ReusedExchange [Reuses operator id: 137]
+Output [2]: [d_date_sk#110, d_year#111]
 
 (106) BroadcastHashJoin [codegen id : 42]
-Left keys [1]: [ws_item_sk#105]
-Right keys [1]: [i_item_sk#110]
+Left keys [1]: [ws_sold_date_sk#109]
+Right keys [1]: [d_date_sk#110]
 Join type: Inner
 Join condition: None
 
 (107) Project [codegen id : 42]
-Output [9]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, ws_sold_date_sk#109, i_brand_id#111, i_class_id#112, i_category_id#113, i_manufact_id#114]
-Input [10]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, ws_sold_date_sk#109, i_item_sk#110, i_brand_id#111, i_class_id#112, i_category_id#113, i_manufact_id#114]
+Output [5]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, d_year#111]
+Input [7]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, ws_sold_date_sk#109, d_date_sk#110, d_year#111]
 
-(108) ReusedExchange [Reuses operator id: 137]
-Output [2]: [d_date_sk#115, d_year#116]
+(108) ReusedExchange [Reuses operator id: 11]
+Output [5]: [i_item_sk#112, i_brand_id#113, i_class_id#114, i_category_id#115, i_manufact_id#116]
 
 (109) BroadcastHashJoin [codegen id : 42]
-Left keys [1]: [ws_sold_date_sk#109]
-Right keys [1]: [d_date_sk#115]
+Left keys [1]: [ws_item_sk#105]
+Right keys [1]: [i_item_sk#112]
 Join type: Inner
 Join condition: None
 
 (110) Project [codegen id : 42]
-Output [9]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, i_brand_id#111, i_class_id#112, i_category_id#113, i_manufact_id#114, d_year#116]
-Input [11]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, ws_sold_date_sk#109, i_brand_id#111, i_class_id#112, i_category_id#113, i_manufact_id#114, d_date_sk#115, d_year#116]
+Output [9]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, i_brand_id#113, i_class_id#114, i_category_id#115, i_manufact_id#116, d_year#111]
+Input [10]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, d_year#111, i_item_sk#112, i_brand_id#113, i_class_id#114, i_category_id#115, i_manufact_id#116]
 
 (111) Exchange
-Input [9]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, i_brand_id#111, i_class_id#112, i_category_id#113, i_manufact_id#114, d_year#116]
+Input [9]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, i_brand_id#113, i_class_id#114, i_category_id#115, i_manufact_id#116, d_year#111]
 Arguments: hashpartitioning(ws_order_number#106, ws_item_sk#105, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (112) Sort [codegen id : 43]
-Input [9]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, i_brand_id#111, i_class_id#112, i_category_id#113, i_manufact_id#114, d_year#116]
+Input [9]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, i_brand_id#113, i_class_id#114, i_category_id#115, i_manufact_id#116, d_year#111]
 Arguments: [ws_order_number#106 ASC NULLS FIRST, ws_item_sk#105 ASC NULLS FIRST], false, 0
 
 (113) ReusedExchange [Reuses operator id: 58]
@@ -649,72 +649,72 @@ Join type: LeftOuter
 Join condition: None
 
 (116) Project [codegen id : 46]
-Output [7]: [d_year#116, i_brand_id#111, i_class_id#112, i_category_id#113, i_manufact_id#114, (ws_quantity#107 - coalesce(wr_return_quantity#119, 0)) AS sales_cnt#121, (ws_ext_sales_price#108 - coalesce(wr_return_amt#120, 0.00)) AS sales_amt#122]
-Input [13]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, i_brand_id#111, i_class_id#112, i_category_id#113, i_manufact_id#114, d_year#116, wr_item_sk#117, wr_order_number#118, wr_return_quantity#119, wr_return_amt#120]
+Output [7]: [d_year#111, i_brand_id#113, i_class_id#114, i_category_id#115, i_manufact_id#116, (ws_quantity#107 - coalesce(wr_return_quantity#119, 0)) AS sales_cnt#121, (ws_ext_sales_price#108 - coalesce(wr_return_amt#120, 0.00)) AS sales_amt#122]
+Input [13]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, i_brand_id#113, i_class_id#114, i_category_id#115, i_manufact_id#116, d_year#111, wr_item_sk#117, wr_order_number#118, wr_return_quantity#119, wr_return_amt#120]
 
 (117) Union
 
 (118) HashAggregate [codegen id : 47]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#85, sales_amt#86]
-Keys [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#85, sales_amt#86]
+Input [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#85, sales_amt#86]
+Keys [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#85, sales_amt#86]
 Functions: []
 Aggregate Attributes: []
-Results [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#85, sales_amt#86]
+Results [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#85, sales_amt#86]
 
 (119) Exchange
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#85, sales_amt#86]
-Arguments: hashpartitioning(d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#85, sales_amt#86, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+Input [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#85, sales_amt#86]
+Arguments: hashpartitioning(d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#85, sales_amt#86, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
 (120) HashAggregate [codegen id : 48]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#85, sales_amt#86]
-Keys [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#85, sales_amt#86]
+Input [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#85, sales_amt#86]
+Keys [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#85, sales_amt#86]
 Functions: []
 Aggregate Attributes: []
-Results [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#85, sales_amt#86]
+Results [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#85, sales_amt#86]
 
 (121) HashAggregate [codegen id : 48]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#85, sales_amt#86]
-Keys [5]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
+Input [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#85, sales_amt#86]
+Keys [5]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80]
 Functions [2]: [partial_sum(sales_cnt#85), partial_sum(UnscaledValue(sales_amt#86))]
 Aggregate Attributes [2]: [sum#123, sum#124]
-Results [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sum#125, sum#126]
+Results [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sum#125, sum#126]
 
 (122) Exchange
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sum#125, sum#126]
-Arguments: hashpartitioning(d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+Input [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sum#125, sum#126]
+Arguments: hashpartitioning(d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
 (123) HashAggregate [codegen id : 49]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sum#125, sum#126]
-Keys [5]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
+Input [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sum#125, sum#126]
+Keys [5]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80]
 Functions [2]: [sum(sales_cnt#85), sum(UnscaledValue(sales_amt#86))]
 Aggregate Attributes [2]: [sum(sales_cnt#85)#64, sum(UnscaledValue(sales_amt#86))#65]
-Results [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sum(sales_cnt#85)#64 AS sales_cnt#127, MakeDecimal(sum(UnscaledValue(sales_amt#86))#65,18,2) AS sales_amt#128]
+Results [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sum(sales_cnt#85)#64 AS sales_cnt#127, MakeDecimal(sum(UnscaledValue(sales_amt#86))#65,18,2) AS sales_amt#128]
 
 (124) Filter [codegen id : 49]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#127, sales_amt#128]
+Input [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#127, sales_amt#128]
 Condition : isnotnull(sales_cnt#127)
 
 (125) Exchange
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#127, sales_amt#128]
-Arguments: hashpartitioning(i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+Input [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#127, sales_amt#128]
+Arguments: hashpartitioning(i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, 5), ENSURE_REQUIREMENTS, [plan_id=16]
 
 (126) Sort [codegen id : 50]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#127, sales_amt#128]
-Arguments: [i_brand_id#75 ASC NULLS FIRST, i_class_id#76 ASC NULLS FIRST, i_category_id#77 ASC NULLS FIRST, i_manufact_id#78 ASC NULLS FIRST], false, 0
+Input [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#127, sales_amt#128]
+Arguments: [i_brand_id#77 ASC NULLS FIRST, i_class_id#78 ASC NULLS FIRST, i_category_id#79 ASC NULLS FIRST, i_manufact_id#80 ASC NULLS FIRST], false, 0
 
 (127) SortMergeJoin [codegen id : 51]
-Left keys [4]: [i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
-Right keys [4]: [i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
+Left keys [4]: [i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14]
+Right keys [4]: [i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80]
 Join type: Inner
 Join condition: ((cast(sales_cnt#66 as decimal(17,2)) / cast(sales_cnt#127 as decimal(17,2))) < 0.90000000000000000000)
 
 (128) Project [codegen id : 51]
-Output [10]: [d_year#80 AS prev_year#129, d_year#14 AS year#130, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#127 AS prev_yr_cnt#131, sales_cnt#66 AS curr_yr_cnt#132, (sales_cnt#66 - sales_cnt#127) AS sales_cnt_diff#133, (sales_amt#67 - sales_amt#128) AS sales_amt_diff#134]
-Input [14]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#66, sales_amt#67, d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#127, sales_amt#128]
+Output [10]: [d_year#75 AS prev_year#129, d_year#8 AS year#130, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#127 AS prev_yr_cnt#131, sales_cnt#66 AS curr_yr_cnt#132, (sales_cnt#66 - sales_cnt#127) AS sales_cnt_diff#133, (sales_amt#67 - sales_amt#128) AS sales_amt_diff#134]
+Input [14]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#66, sales_amt#67, d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#127, sales_amt#128]
 
 (129) TakeOrderedAndProject
-Input [10]: [prev_year#129, year#130, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, prev_yr_cnt#131, curr_yr_cnt#132, sales_cnt_diff#133, sales_amt_diff#134]
-Arguments: 100, [sales_cnt_diff#133 ASC NULLS FIRST], [prev_year#129, year#130, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, prev_yr_cnt#131, curr_yr_cnt#132, sales_cnt_diff#133, sales_amt_diff#134]
+Input [10]: [prev_year#129, year#130, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, prev_yr_cnt#131, curr_yr_cnt#132, sales_cnt_diff#133, sales_amt_diff#134]
+Arguments: 100, [sales_cnt_diff#133 ASC NULLS FIRST], [prev_year#129, year#130, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, prev_yr_cnt#131, curr_yr_cnt#132, sales_cnt_diff#133, sales_amt_diff#134]
 
 ===== Subqueries =====
 
@@ -726,21 +726,21 @@ BroadcastExchange (133)
 
 
 (130) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#13, d_year#14]
+Output [2]: [d_date_sk#7, d_year#8]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2002), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (131) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#13, d_year#14]
+Input [2]: [d_date_sk#7, d_year#8]
 
 (132) Filter [codegen id : 1]
-Input [2]: [d_date_sk#13, d_year#14]
-Condition : ((isnotnull(d_year#14) AND (d_year#14 = 2002)) AND isnotnull(d_date_sk#13))
+Input [2]: [d_date_sk#7, d_year#8]
+Condition : ((isnotnull(d_year#8) AND (d_year#8 = 2002)) AND isnotnull(d_date_sk#7))
 
 (133) BroadcastExchange
-Input [2]: [d_date_sk#13, d_year#14]
+Input [2]: [d_date_sk#7, d_year#8]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=17]
 
 Subquery:2 Hosting operator id = 24 Hosting Expression = ss_sold_date_sk#26 IN dynamicpruning#6
@@ -755,21 +755,21 @@ BroadcastExchange (137)
 
 
 (134) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#79, d_year#80]
+Output [2]: [d_date_sk#74, d_year#75]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (135) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#79, d_year#80]
+Input [2]: [d_date_sk#74, d_year#75]
 
 (136) Filter [codegen id : 1]
-Input [2]: [d_date_sk#79, d_year#80]
-Condition : ((isnotnull(d_year#80) AND (d_year#80 = 2001)) AND isnotnull(d_date_sk#79))
+Input [2]: [d_date_sk#74, d_year#75]
+Condition : ((isnotnull(d_year#75) AND (d_year#75 = 2001)) AND isnotnull(d_date_sk#74))
 
 (137) BroadcastExchange
-Input [2]: [d_date_sk#79, d_year#80]
+Input [2]: [d_date_sk#74, d_year#75]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=18]
 
 Subquery:5 Hosting operator id = 87 Hosting Expression = ss_sold_date_sk#91 IN dynamicpruning#73

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q75.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q75.sf100/simplified.txt
@@ -31,9 +31,9 @@ TakeOrderedAndProject [sales_cnt_diff,prev_year,year,i_brand_id,i_class_id,i_cat
                                                             Exchange [cs_order_number,cs_item_sk] #4
                                                               WholeStageCodegen (3)
                                                                 Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                  BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                    Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,cs_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                      BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                  BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                    Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,d_year]
+                                                                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                                         Filter [cs_item_sk]
                                                                           ColumnarToRow
                                                                             InputAdapter
@@ -46,15 +46,15 @@ TakeOrderedAndProject [sales_cnt_diff,prev_year,year,i_brand_id,i_class_id,i_cat
                                                                                           InputAdapter
                                                                                             Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                                                         InputAdapter
-                                                                          BroadcastExchange #6
-                                                                            WholeStageCodegen (1)
-                                                                              Project [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                                Filter [i_category,i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_class_id,i_category_id,i_category,i_manufact_id]
+                                                                          ReusedExchange [d_date_sk,d_year] #5
                                                                     InputAdapter
-                                                                      ReusedExchange [d_date_sk,d_year] #5
+                                                                      BroadcastExchange #6
+                                                                        WholeStageCodegen (2)
+                                                                          Project [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                            Filter [i_category,i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_class_id,i_category_id,i_category,i_manufact_id]
                                                     InputAdapter
                                                       WholeStageCodegen (6)
                                                         Sort [cr_order_number,cr_item_sk]
@@ -76,18 +76,18 @@ TakeOrderedAndProject [sales_cnt_diff,prev_year,year,i_brand_id,i_class_id,i_cat
                                                             Exchange [ss_ticket_number,ss_item_sk] #8
                                                               WholeStageCodegen (10)
                                                                 Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                    Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,ss_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                      BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                  BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                    Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,d_year]
+                                                                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                         Filter [ss_item_sk]
                                                                           ColumnarToRow
                                                                             InputAdapter
                                                                               Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,ss_sold_date_sk]
                                                                                 ReusedSubquery [d_date_sk] #1
                                                                         InputAdapter
-                                                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
+                                                                          ReusedExchange [d_date_sk,d_year] #5
                                                                     InputAdapter
-                                                                      ReusedExchange [d_date_sk,d_year] #5
+                                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
                                                     InputAdapter
                                                       WholeStageCodegen (13)
                                                         Sort [sr_ticket_number,sr_item_sk]
@@ -109,18 +109,18 @@ TakeOrderedAndProject [sales_cnt_diff,prev_year,year,i_brand_id,i_class_id,i_cat
                                                             Exchange [ws_order_number,ws_item_sk] #10
                                                               WholeStageCodegen (17)
                                                                 Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                  BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                    Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,ws_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                      BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                  BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                    Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,d_year]
+                                                                      BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                                         Filter [ws_item_sk]
                                                                           ColumnarToRow
                                                                             InputAdapter
                                                                               Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,ws_sold_date_sk]
                                                                                 ReusedSubquery [d_date_sk] #1
                                                                         InputAdapter
-                                                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
+                                                                          ReusedExchange [d_date_sk,d_year] #5
                                                                     InputAdapter
-                                                                      ReusedExchange [d_date_sk,d_year] #5
+                                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
                                                     InputAdapter
                                                       WholeStageCodegen (20)
                                                         Sort [wr_order_number,wr_item_sk]
@@ -161,9 +161,9 @@ TakeOrderedAndProject [sales_cnt_diff,prev_year,year,i_brand_id,i_class_id,i_cat
                                                             Exchange [cs_order_number,cs_item_sk] #15
                                                               WholeStageCodegen (28)
                                                                 Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                  BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                    Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,cs_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                      BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                  BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                    Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,d_year]
+                                                                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                                         Filter [cs_item_sk]
                                                                           ColumnarToRow
                                                                             InputAdapter
@@ -176,9 +176,9 @@ TakeOrderedAndProject [sales_cnt_diff,prev_year,year,i_brand_id,i_class_id,i_cat
                                                                                           InputAdapter
                                                                                             Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                                                         InputAdapter
-                                                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
+                                                                          ReusedExchange [d_date_sk,d_year] #16
                                                                     InputAdapter
-                                                                      ReusedExchange [d_date_sk,d_year] #16
+                                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
                                                     InputAdapter
                                                       WholeStageCodegen (31)
                                                         Sort [cr_order_number,cr_item_sk]
@@ -194,18 +194,18 @@ TakeOrderedAndProject [sales_cnt_diff,prev_year,year,i_brand_id,i_class_id,i_cat
                                                             Exchange [ss_ticket_number,ss_item_sk] #17
                                                               WholeStageCodegen (35)
                                                                 Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                    Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,ss_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                      BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                  BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                    Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,d_year]
+                                                                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                         Filter [ss_item_sk]
                                                                           ColumnarToRow
                                                                             InputAdapter
                                                                               Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,ss_sold_date_sk]
                                                                                 ReusedSubquery [d_date_sk] #2
                                                                         InputAdapter
-                                                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
+                                                                          ReusedExchange [d_date_sk,d_year] #16
                                                                     InputAdapter
-                                                                      ReusedExchange [d_date_sk,d_year] #16
+                                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
                                                     InputAdapter
                                                       WholeStageCodegen (38)
                                                         Sort [sr_ticket_number,sr_item_sk]
@@ -221,18 +221,18 @@ TakeOrderedAndProject [sales_cnt_diff,prev_year,year,i_brand_id,i_class_id,i_cat
                                                             Exchange [ws_order_number,ws_item_sk] #18
                                                               WholeStageCodegen (42)
                                                                 Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                  BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                    Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,ws_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                      BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                  BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                    Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,d_year]
+                                                                      BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                                         Filter [ws_item_sk]
                                                                           ColumnarToRow
                                                                             InputAdapter
                                                                               Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,ws_sold_date_sk]
                                                                                 ReusedSubquery [d_date_sk] #2
                                                                         InputAdapter
-                                                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
+                                                                          ReusedExchange [d_date_sk,d_year] #16
                                                                     InputAdapter
-                                                                      ReusedExchange [d_date_sk,d_year] #16
+                                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
                                                     InputAdapter
                                                       WholeStageCodegen (45)
                                                         Sort [wr_order_number,wr_item_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q76.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q76.sf100/explain.txt
@@ -1,9 +1,9 @@
 == Physical Plan ==
-TakeOrderedAndProject (44)
-+- * HashAggregate (43)
-   +- Exchange (42)
-      +- * HashAggregate (41)
-         +- Union (40)
+TakeOrderedAndProject (41)
++- * HashAggregate (40)
+   +- Exchange (39)
+      +- * HashAggregate (38)
+         +- Union (37)
             :- * Project (15)
             :  +- * BroadcastHashJoin Inner BuildRight (14)
             :     :- * Project (9)
@@ -14,35 +14,32 @@ TakeOrderedAndProject (44)
             :     :     +- BroadcastExchange (7)
             :     :        +- * Filter (6)
             :     :           +- * ColumnarToRow (5)
-            :     :              +- Scan parquet spark_catalog.default.date_dim (4)
+            :     :              +- Scan parquet spark_catalog.default.item (4)
             :     +- BroadcastExchange (13)
             :        +- * Filter (12)
             :           +- * ColumnarToRow (11)
-            :              +- Scan parquet spark_catalog.default.item (10)
-            :- * Project (30)
-            :  +- * BroadcastHashJoin Inner BuildLeft (29)
-            :     :- BroadcastExchange (25)
-            :     :  +- * Project (24)
-            :     :     +- * BroadcastHashJoin Inner BuildLeft (23)
-            :     :        :- BroadcastExchange (19)
-            :     :        :  +- * Filter (18)
-            :     :        :     +- * ColumnarToRow (17)
-            :     :        :        +- Scan parquet spark_catalog.default.web_sales (16)
-            :     :        +- * Filter (22)
-            :     :           +- * ColumnarToRow (21)
-            :     :              +- Scan parquet spark_catalog.default.date_dim (20)
-            :     +- * Filter (28)
-            :        +- * ColumnarToRow (27)
-            :           +- Scan parquet spark_catalog.default.item (26)
-            +- * Project (39)
-               +- * BroadcastHashJoin Inner BuildRight (38)
-                  :- * Project (36)
-                  :  +- * BroadcastHashJoin Inner BuildRight (35)
-                  :     :- * Filter (33)
-                  :     :  +- * ColumnarToRow (32)
-                  :     :     +- Scan parquet spark_catalog.default.catalog_sales (31)
-                  :     +- ReusedExchange (34)
-                  +- ReusedExchange (37)
+            :              +- Scan parquet spark_catalog.default.date_dim (10)
+            :- * Project (27)
+            :  +- * BroadcastHashJoin Inner BuildRight (26)
+            :     :- * Project (24)
+            :     :  +- * BroadcastHashJoin Inner BuildLeft (23)
+            :     :     :- BroadcastExchange (19)
+            :     :     :  +- * Filter (18)
+            :     :     :     +- * ColumnarToRow (17)
+            :     :     :        +- Scan parquet spark_catalog.default.web_sales (16)
+            :     :     +- * Filter (22)
+            :     :        +- * ColumnarToRow (21)
+            :     :           +- Scan parquet spark_catalog.default.item (20)
+            :     +- ReusedExchange (25)
+            +- * Project (36)
+               +- * BroadcastHashJoin Inner BuildRight (35)
+                  :- * Project (33)
+                  :  +- * BroadcastHashJoin Inner BuildRight (32)
+                  :     :- * Filter (30)
+                  :     :  +- * ColumnarToRow (29)
+                  :     :     +- Scan parquet spark_catalog.default.catalog_sales (28)
+                  :     +- ReusedExchange (31)
+                  +- ReusedExchange (34)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -60,61 +57,61 @@ Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, ss_sold_date_sk#4
 Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, ss_sold_date_sk#4]
 Condition : (isnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1))
 
-(4) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#5, d_year#6, d_qoy#7]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int,d_year:int,d_qoy:int>
-
-(5) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#5, d_year#6, d_qoy#7]
-
-(6) Filter [codegen id : 1]
-Input [3]: [d_date_sk#5, d_year#6, d_qoy#7]
-Condition : isnotnull(d_date_sk#5)
-
-(7) BroadcastExchange
-Input [3]: [d_date_sk#5, d_year#6, d_qoy#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
-
-(8) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_sold_date_sk#4]
-Right keys [1]: [d_date_sk#5]
-Join type: Inner
-Join condition: None
-
-(9) Project [codegen id : 3]
-Output [5]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, d_year#6, d_qoy#7]
-Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, ss_sold_date_sk#4, d_date_sk#5, d_year#6, d_qoy#7]
-
-(10) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#8, i_category#9]
+(4) Scan parquet spark_catalog.default.item
+Output [2]: [i_item_sk#5, i_category#6]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_category:string>
 
+(5) ColumnarToRow [codegen id : 1]
+Input [2]: [i_item_sk#5, i_category#6]
+
+(6) Filter [codegen id : 1]
+Input [2]: [i_item_sk#5, i_category#6]
+Condition : isnotnull(i_item_sk#5)
+
+(7) BroadcastExchange
+Input [2]: [i_item_sk#5, i_category#6]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
+
+(8) BroadcastHashJoin [codegen id : 3]
+Left keys [1]: [ss_item_sk#1]
+Right keys [1]: [i_item_sk#5]
+Join type: Inner
+Join condition: None
+
+(9) Project [codegen id : 3]
+Output [4]: [ss_store_sk#2, ss_ext_sales_price#3, ss_sold_date_sk#4, i_category#6]
+Input [6]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, ss_sold_date_sk#4, i_item_sk#5, i_category#6]
+
+(10) Scan parquet spark_catalog.default.date_dim
+Output [3]: [d_date_sk#7, d_year#8, d_qoy#9]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/date_dim]
+PushedFilters: [IsNotNull(d_date_sk)]
+ReadSchema: struct<d_date_sk:int,d_year:int,d_qoy:int>
+
 (11) ColumnarToRow [codegen id : 2]
-Input [2]: [i_item_sk#8, i_category#9]
+Input [3]: [d_date_sk#7, d_year#8, d_qoy#9]
 
 (12) Filter [codegen id : 2]
-Input [2]: [i_item_sk#8, i_category#9]
-Condition : isnotnull(i_item_sk#8)
+Input [3]: [d_date_sk#7, d_year#8, d_qoy#9]
+Condition : isnotnull(d_date_sk#7)
 
 (13) BroadcastExchange
-Input [2]: [i_item_sk#8, i_category#9]
+Input [3]: [d_date_sk#7, d_year#8, d_qoy#9]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
 
 (14) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#8]
+Left keys [1]: [ss_sold_date_sk#4]
+Right keys [1]: [d_date_sk#7]
 Join type: Inner
 Join condition: None
 
 (15) Project [codegen id : 3]
-Output [6]: [store AS channel#10, ss_store_sk#2 AS col_name#11, d_year#6, d_qoy#7, i_category#9, ss_ext_sales_price#3 AS ext_sales_price#12]
-Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, d_year#6, d_qoy#7, i_item_sk#8, i_category#9]
+Output [6]: [store AS channel#10, ss_store_sk#2 AS col_name#11, d_year#8, d_qoy#9, i_category#6, ss_ext_sales_price#3 AS ext_sales_price#12]
+Input [7]: [ss_store_sk#2, ss_ext_sales_price#3, ss_sold_date_sk#4, i_category#6, d_date_sk#7, d_year#8, d_qoy#9]
 
 (16) Scan parquet spark_catalog.default.web_sales
 Output [4]: [ws_item_sk#13, ws_ship_customer_sk#14, ws_ext_sales_price#15, ws_sold_date_sk#16]
@@ -133,61 +130,46 @@ Condition : (isnull(ws_ship_customer_sk#14) AND isnotnull(ws_item_sk#13))
 
 (19) BroadcastExchange
 Input [4]: [ws_item_sk#13, ws_ship_customer_sk#14, ws_ext_sales_price#15, ws_sold_date_sk#16]
-Arguments: HashedRelationBroadcastMode(List(cast(input[3, int, true] as bigint)),false), [plan_id=3]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
 
-(20) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#17, d_year#18, d_qoy#19]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int,d_year:int,d_qoy:int>
-
-(21) ColumnarToRow
-Input [3]: [d_date_sk#17, d_year#18, d_qoy#19]
-
-(22) Filter
-Input [3]: [d_date_sk#17, d_year#18, d_qoy#19]
-Condition : isnotnull(d_date_sk#17)
-
-(23) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [ws_sold_date_sk#16]
-Right keys [1]: [d_date_sk#17]
-Join type: Inner
-Join condition: None
-
-(24) Project [codegen id : 5]
-Output [5]: [ws_item_sk#13, ws_ship_customer_sk#14, ws_ext_sales_price#15, d_year#18, d_qoy#19]
-Input [7]: [ws_item_sk#13, ws_ship_customer_sk#14, ws_ext_sales_price#15, ws_sold_date_sk#16, d_date_sk#17, d_year#18, d_qoy#19]
-
-(25) BroadcastExchange
-Input [5]: [ws_item_sk#13, ws_ship_customer_sk#14, ws_ext_sales_price#15, d_year#18, d_qoy#19]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
-
-(26) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#20, i_category#21]
+(20) Scan parquet spark_catalog.default.item
+Output [2]: [i_item_sk#17, i_category#18]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_category:string>
 
-(27) ColumnarToRow
-Input [2]: [i_item_sk#20, i_category#21]
+(21) ColumnarToRow
+Input [2]: [i_item_sk#17, i_category#18]
 
-(28) Filter
-Input [2]: [i_item_sk#20, i_category#21]
-Condition : isnotnull(i_item_sk#20)
+(22) Filter
+Input [2]: [i_item_sk#17, i_category#18]
+Condition : isnotnull(i_item_sk#17)
 
-(29) BroadcastHashJoin [codegen id : 6]
+(23) BroadcastHashJoin [codegen id : 6]
 Left keys [1]: [ws_item_sk#13]
-Right keys [1]: [i_item_sk#20]
+Right keys [1]: [i_item_sk#17]
 Join type: Inner
 Join condition: None
 
-(30) Project [codegen id : 6]
-Output [6]: [web AS channel#22, ws_ship_customer_sk#14 AS col_name#23, d_year#18, d_qoy#19, i_category#21, ws_ext_sales_price#15 AS ext_sales_price#24]
-Input [7]: [ws_item_sk#13, ws_ship_customer_sk#14, ws_ext_sales_price#15, d_year#18, d_qoy#19, i_item_sk#20, i_category#21]
+(24) Project [codegen id : 6]
+Output [4]: [ws_ship_customer_sk#14, ws_ext_sales_price#15, ws_sold_date_sk#16, i_category#18]
+Input [6]: [ws_item_sk#13, ws_ship_customer_sk#14, ws_ext_sales_price#15, ws_sold_date_sk#16, i_item_sk#17, i_category#18]
 
-(31) Scan parquet spark_catalog.default.catalog_sales
+(25) ReusedExchange [Reuses operator id: 13]
+Output [3]: [d_date_sk#19, d_year#20, d_qoy#21]
+
+(26) BroadcastHashJoin [codegen id : 6]
+Left keys [1]: [ws_sold_date_sk#16]
+Right keys [1]: [d_date_sk#19]
+Join type: Inner
+Join condition: None
+
+(27) Project [codegen id : 6]
+Output [6]: [web AS channel#22, ws_ship_customer_sk#14 AS col_name#23, d_year#20, d_qoy#21, i_category#18, ws_ext_sales_price#15 AS ext_sales_price#24]
+Input [7]: [ws_ship_customer_sk#14, ws_ext_sales_price#15, ws_sold_date_sk#16, i_category#18, d_date_sk#19, d_year#20, d_qoy#21]
+
+(28) Scan parquet spark_catalog.default.catalog_sales
 Output [4]: [cs_ship_addr_sk#25, cs_item_sk#26, cs_ext_sales_price#27, cs_sold_date_sk#28]
 Batched: true
 Location: InMemoryFileIndex []
@@ -195,60 +177,60 @@ PartitionFilters: [isnotnull(cs_sold_date_sk#28)]
 PushedFilters: [IsNull(cs_ship_addr_sk), IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_ship_addr_sk:int,cs_item_sk:int,cs_ext_sales_price:decimal(7,2)>
 
-(32) ColumnarToRow [codegen id : 9]
+(29) ColumnarToRow [codegen id : 9]
 Input [4]: [cs_ship_addr_sk#25, cs_item_sk#26, cs_ext_sales_price#27, cs_sold_date_sk#28]
 
-(33) Filter [codegen id : 9]
+(30) Filter [codegen id : 9]
 Input [4]: [cs_ship_addr_sk#25, cs_item_sk#26, cs_ext_sales_price#27, cs_sold_date_sk#28]
 Condition : (isnull(cs_ship_addr_sk#25) AND isnotnull(cs_item_sk#26))
 
-(34) ReusedExchange [Reuses operator id: 7]
-Output [3]: [d_date_sk#29, d_year#30, d_qoy#31]
+(31) ReusedExchange [Reuses operator id: 7]
+Output [2]: [i_item_sk#29, i_category#30]
+
+(32) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [cs_item_sk#26]
+Right keys [1]: [i_item_sk#29]
+Join type: Inner
+Join condition: None
+
+(33) Project [codegen id : 9]
+Output [4]: [cs_ship_addr_sk#25, cs_ext_sales_price#27, cs_sold_date_sk#28, i_category#30]
+Input [6]: [cs_ship_addr_sk#25, cs_item_sk#26, cs_ext_sales_price#27, cs_sold_date_sk#28, i_item_sk#29, i_category#30]
+
+(34) ReusedExchange [Reuses operator id: 13]
+Output [3]: [d_date_sk#31, d_year#32, d_qoy#33]
 
 (35) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [cs_sold_date_sk#28]
-Right keys [1]: [d_date_sk#29]
+Right keys [1]: [d_date_sk#31]
 Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 9]
-Output [5]: [cs_ship_addr_sk#25, cs_item_sk#26, cs_ext_sales_price#27, d_year#30, d_qoy#31]
-Input [7]: [cs_ship_addr_sk#25, cs_item_sk#26, cs_ext_sales_price#27, cs_sold_date_sk#28, d_date_sk#29, d_year#30, d_qoy#31]
+Output [6]: [catalog AS channel#34, cs_ship_addr_sk#25 AS col_name#35, d_year#32, d_qoy#33, i_category#30, cs_ext_sales_price#27 AS ext_sales_price#36]
+Input [7]: [cs_ship_addr_sk#25, cs_ext_sales_price#27, cs_sold_date_sk#28, i_category#30, d_date_sk#31, d_year#32, d_qoy#33]
 
-(37) ReusedExchange [Reuses operator id: 13]
-Output [2]: [i_item_sk#32, i_category#33]
+(37) Union
 
-(38) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [cs_item_sk#26]
-Right keys [1]: [i_item_sk#32]
-Join type: Inner
-Join condition: None
-
-(39) Project [codegen id : 9]
-Output [6]: [catalog AS channel#34, cs_ship_addr_sk#25 AS col_name#35, d_year#30, d_qoy#31, i_category#33, cs_ext_sales_price#27 AS ext_sales_price#36]
-Input [7]: [cs_ship_addr_sk#25, cs_item_sk#26, cs_ext_sales_price#27, d_year#30, d_qoy#31, i_item_sk#32, i_category#33]
-
-(40) Union
-
-(41) HashAggregate [codegen id : 10]
-Input [6]: [channel#10, col_name#11, d_year#6, d_qoy#7, i_category#9, ext_sales_price#12]
-Keys [5]: [channel#10, col_name#11, d_year#6, d_qoy#7, i_category#9]
+(38) HashAggregate [codegen id : 10]
+Input [6]: [channel#10, col_name#11, d_year#8, d_qoy#9, i_category#6, ext_sales_price#12]
+Keys [5]: [channel#10, col_name#11, d_year#8, d_qoy#9, i_category#6]
 Functions [2]: [partial_count(1), partial_sum(UnscaledValue(ext_sales_price#12))]
 Aggregate Attributes [2]: [count#37, sum#38]
-Results [7]: [channel#10, col_name#11, d_year#6, d_qoy#7, i_category#9, count#39, sum#40]
+Results [7]: [channel#10, col_name#11, d_year#8, d_qoy#9, i_category#6, count#39, sum#40]
 
-(42) Exchange
-Input [7]: [channel#10, col_name#11, d_year#6, d_qoy#7, i_category#9, count#39, sum#40]
-Arguments: hashpartitioning(channel#10, col_name#11, d_year#6, d_qoy#7, i_category#9, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(39) Exchange
+Input [7]: [channel#10, col_name#11, d_year#8, d_qoy#9, i_category#6, count#39, sum#40]
+Arguments: hashpartitioning(channel#10, col_name#11, d_year#8, d_qoy#9, i_category#6, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(43) HashAggregate [codegen id : 11]
-Input [7]: [channel#10, col_name#11, d_year#6, d_qoy#7, i_category#9, count#39, sum#40]
-Keys [5]: [channel#10, col_name#11, d_year#6, d_qoy#7, i_category#9]
+(40) HashAggregate [codegen id : 11]
+Input [7]: [channel#10, col_name#11, d_year#8, d_qoy#9, i_category#6, count#39, sum#40]
+Keys [5]: [channel#10, col_name#11, d_year#8, d_qoy#9, i_category#6]
 Functions [2]: [count(1), sum(UnscaledValue(ext_sales_price#12))]
 Aggregate Attributes [2]: [count(1)#41, sum(UnscaledValue(ext_sales_price#12))#42]
-Results [7]: [channel#10, col_name#11, d_year#6, d_qoy#7, i_category#9, count(1)#41 AS sales_cnt#43, MakeDecimal(sum(UnscaledValue(ext_sales_price#12))#42,17,2) AS sales_amt#44]
+Results [7]: [channel#10, col_name#11, d_year#8, d_qoy#9, i_category#6, count(1)#41 AS sales_cnt#43, MakeDecimal(sum(UnscaledValue(ext_sales_price#12))#42,17,2) AS sales_amt#44]
 
-(44) TakeOrderedAndProject
-Input [7]: [channel#10, col_name#11, d_year#6, d_qoy#7, i_category#9, sales_cnt#43, sales_amt#44]
-Arguments: 100, [channel#10 ASC NULLS FIRST, col_name#11 ASC NULLS FIRST, d_year#6 ASC NULLS FIRST, d_qoy#7 ASC NULLS FIRST, i_category#9 ASC NULLS FIRST], [channel#10, col_name#11, d_year#6, d_qoy#7, i_category#9, sales_cnt#43, sales_amt#44]
+(41) TakeOrderedAndProject
+Input [7]: [channel#10, col_name#11, d_year#8, d_qoy#9, i_category#6, sales_cnt#43, sales_amt#44]
+Arguments: 100, [channel#10 ASC NULLS FIRST, col_name#11 ASC NULLS FIRST, d_year#8 ASC NULLS FIRST, d_qoy#9 ASC NULLS FIRST, i_category#6 ASC NULLS FIRST], [channel#10, col_name#11, d_year#8, d_qoy#9, i_category#6, sales_cnt#43, sales_amt#44]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q76.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q76.sf100/simplified.txt
@@ -9,9 +9,9 @@ TakeOrderedAndProject [channel,col_name,d_year,d_qoy,i_category,sales_cnt,sales_
                 Union
                   WholeStageCodegen (3)
                     Project [ss_store_sk,d_year,d_qoy,i_category,ss_ext_sales_price]
-                      BroadcastHashJoin [ss_item_sk,i_item_sk]
-                        Project [ss_item_sk,ss_store_sk,ss_ext_sales_price,d_year,d_qoy]
-                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                        Project [ss_store_sk,ss_ext_sales_price,ss_sold_date_sk,i_category]
+                          BroadcastHashJoin [ss_item_sk,i_item_sk]
                             Filter [ss_store_sk,ss_item_sk]
                               ColumnarToRow
                                 InputAdapter
@@ -19,50 +19,45 @@ TakeOrderedAndProject [channel,col_name,d_year,d_qoy,i_category,sales_cnt,sales_
                             InputAdapter
                               BroadcastExchange #2
                                 WholeStageCodegen (1)
-                                  Filter [d_date_sk]
+                                  Filter [i_item_sk]
                                     ColumnarToRow
                                       InputAdapter
-                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_qoy]
+                                        Scan parquet spark_catalog.default.item [i_item_sk,i_category]
                         InputAdapter
                           BroadcastExchange #3
                             WholeStageCodegen (2)
-                              Filter [i_item_sk]
+                              Filter [d_date_sk]
                                 ColumnarToRow
                                   InputAdapter
-                                    Scan parquet spark_catalog.default.item [i_item_sk,i_category]
+                                    Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_qoy]
                   WholeStageCodegen (6)
                     Project [ws_ship_customer_sk,d_year,d_qoy,i_category,ws_ext_sales_price]
-                      BroadcastHashJoin [ws_item_sk,i_item_sk]
-                        InputAdapter
-                          BroadcastExchange #4
-                            WholeStageCodegen (5)
-                              Project [ws_item_sk,ws_ship_customer_sk,ws_ext_sales_price,d_year,d_qoy]
-                                BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                  InputAdapter
-                                    BroadcastExchange #5
-                                      WholeStageCodegen (4)
-                                        Filter [ws_ship_customer_sk,ws_item_sk]
-                                          ColumnarToRow
-                                            InputAdapter
-                                              Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_ship_customer_sk,ws_ext_sales_price,ws_sold_date_sk]
-                                  Filter [d_date_sk]
+                      BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                        Project [ws_ship_customer_sk,ws_ext_sales_price,ws_sold_date_sk,i_category]
+                          BroadcastHashJoin [ws_item_sk,i_item_sk]
+                            InputAdapter
+                              BroadcastExchange #4
+                                WholeStageCodegen (4)
+                                  Filter [ws_ship_customer_sk,ws_item_sk]
                                     ColumnarToRow
                                       InputAdapter
-                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_qoy]
-                        Filter [i_item_sk]
-                          ColumnarToRow
-                            InputAdapter
-                              Scan parquet spark_catalog.default.item [i_item_sk,i_category]
+                                        Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_ship_customer_sk,ws_ext_sales_price,ws_sold_date_sk]
+                            Filter [i_item_sk]
+                              ColumnarToRow
+                                InputAdapter
+                                  Scan parquet spark_catalog.default.item [i_item_sk,i_category]
+                        InputAdapter
+                          ReusedExchange [d_date_sk,d_year,d_qoy] #3
                   WholeStageCodegen (9)
                     Project [cs_ship_addr_sk,d_year,d_qoy,i_category,cs_ext_sales_price]
-                      BroadcastHashJoin [cs_item_sk,i_item_sk]
-                        Project [cs_ship_addr_sk,cs_item_sk,cs_ext_sales_price,d_year,d_qoy]
-                          BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                        Project [cs_ship_addr_sk,cs_ext_sales_price,cs_sold_date_sk,i_category]
+                          BroadcastHashJoin [cs_item_sk,i_item_sk]
                             Filter [cs_ship_addr_sk,cs_item_sk]
                               ColumnarToRow
                                 InputAdapter
                                   Scan parquet spark_catalog.default.catalog_sales [cs_ship_addr_sk,cs_item_sk,cs_ext_sales_price,cs_sold_date_sk]
                             InputAdapter
-                              ReusedExchange [d_date_sk,d_year,d_qoy] #2
+                              ReusedExchange [i_item_sk,i_category] #2
                         InputAdapter
-                          ReusedExchange [i_item_sk,i_category] #3
+                          ReusedExchange [d_date_sk,d_year,d_qoy] #3

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q77.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q77.sf100/explain.txt
@@ -12,16 +12,16 @@ TakeOrderedAndProject (85)
                :     :     +- * HashAggregate (13)
                :     :        +- * Project (12)
                :     :           +- * BroadcastHashJoin Inner BuildRight (11)
-               :     :              :- * Project (6)
-               :     :              :  +- * BroadcastHashJoin Inner BuildRight (5)
+               :     :              :- * Project (9)
+               :     :              :  +- * BroadcastHashJoin Inner BuildRight (8)
                :     :              :     :- * Filter (3)
                :     :              :     :  +- * ColumnarToRow (2)
                :     :              :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-               :     :              :     +- ReusedExchange (4)
-               :     :              +- BroadcastExchange (10)
-               :     :                 +- * Filter (9)
-               :     :                    +- * ColumnarToRow (8)
-               :     :                       +- Scan parquet spark_catalog.default.store (7)
+               :     :              :     +- BroadcastExchange (7)
+               :     :              :        +- * Filter (6)
+               :     :              :           +- * ColumnarToRow (5)
+               :     :              :              +- Scan parquet spark_catalog.default.store (4)
+               :     :              +- ReusedExchange (10)
                :     +- BroadcastExchange (28)
                :        +- * HashAggregate (27)
                :           +- Exchange (26)
@@ -61,16 +61,16 @@ TakeOrderedAndProject (85)
                      :     +- * HashAggregate (62)
                      :        +- * Project (61)
                      :           +- * BroadcastHashJoin Inner BuildRight (60)
-                     :              :- * Project (55)
-                     :              :  +- * BroadcastHashJoin Inner BuildRight (54)
+                     :              :- * Project (58)
+                     :              :  +- * BroadcastHashJoin Inner BuildRight (57)
                      :              :     :- * Filter (52)
                      :              :     :  +- * ColumnarToRow (51)
                      :              :     :     +- Scan parquet spark_catalog.default.web_sales (50)
-                     :              :     +- ReusedExchange (53)
-                     :              +- BroadcastExchange (59)
-                     :                 +- * Filter (58)
-                     :                    +- * ColumnarToRow (57)
-                     :                       +- Scan parquet spark_catalog.default.web_page (56)
+                     :              :     +- BroadcastExchange (56)
+                     :              :        +- * Filter (55)
+                     :              :           +- * ColumnarToRow (54)
+                     :              :              +- Scan parquet spark_catalog.default.web_page (53)
+                     :              +- ReusedExchange (59)
                      +- BroadcastExchange (77)
                         +- * HashAggregate (76)
                            +- Exchange (75)
@@ -101,64 +101,64 @@ Input [4]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_s
 Input [4]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4]
 Condition : isnotnull(ss_store_sk#1)
 
-(4) ReusedExchange [Reuses operator id: 90]
-Output [1]: [d_date_sk#6]
-
-(5) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_sold_date_sk#4]
-Right keys [1]: [d_date_sk#6]
-Join type: Inner
-Join condition: None
-
-(6) Project [codegen id : 3]
-Output [3]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3]
-Input [5]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4, d_date_sk#6]
-
-(7) Scan parquet spark_catalog.default.store
-Output [1]: [s_store_sk#7]
+(4) Scan parquet spark_catalog.default.store
+Output [1]: [s_store_sk#6]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int>
 
-(8) ColumnarToRow [codegen id : 2]
-Input [1]: [s_store_sk#7]
+(5) ColumnarToRow [codegen id : 1]
+Input [1]: [s_store_sk#6]
 
-(9) Filter [codegen id : 2]
-Input [1]: [s_store_sk#7]
-Condition : isnotnull(s_store_sk#7)
+(6) Filter [codegen id : 1]
+Input [1]: [s_store_sk#6]
+Condition : isnotnull(s_store_sk#6)
 
-(10) BroadcastExchange
-Input [1]: [s_store_sk#7]
+(7) BroadcastExchange
+Input [1]: [s_store_sk#6]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
-(11) BroadcastHashJoin [codegen id : 3]
+(8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#1]
-Right keys [1]: [s_store_sk#7]
+Right keys [1]: [s_store_sk#6]
+Join type: Inner
+Join condition: None
+
+(9) Project [codegen id : 3]
+Output [4]: [ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4, s_store_sk#6]
+Input [5]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4, s_store_sk#6]
+
+(10) ReusedExchange [Reuses operator id: 90]
+Output [1]: [d_date_sk#7]
+
+(11) BroadcastHashJoin [codegen id : 3]
+Left keys [1]: [ss_sold_date_sk#4]
+Right keys [1]: [d_date_sk#7]
 Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
-Output [3]: [ss_ext_sales_price#2, ss_net_profit#3, s_store_sk#7]
-Input [4]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, s_store_sk#7]
+Output [3]: [ss_ext_sales_price#2, ss_net_profit#3, s_store_sk#6]
+Input [5]: [ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4, s_store_sk#6, d_date_sk#7]
 
 (13) HashAggregate [codegen id : 3]
-Input [3]: [ss_ext_sales_price#2, ss_net_profit#3, s_store_sk#7]
-Keys [1]: [s_store_sk#7]
+Input [3]: [ss_ext_sales_price#2, ss_net_profit#3, s_store_sk#6]
+Keys [1]: [s_store_sk#6]
 Functions [2]: [partial_sum(UnscaledValue(ss_ext_sales_price#2)), partial_sum(UnscaledValue(ss_net_profit#3))]
 Aggregate Attributes [2]: [sum#8, sum#9]
-Results [3]: [s_store_sk#7, sum#10, sum#11]
+Results [3]: [s_store_sk#6, sum#10, sum#11]
 
 (14) Exchange
-Input [3]: [s_store_sk#7, sum#10, sum#11]
-Arguments: hashpartitioning(s_store_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [3]: [s_store_sk#6, sum#10, sum#11]
+Arguments: hashpartitioning(s_store_sk#6, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (15) HashAggregate [codegen id : 8]
-Input [3]: [s_store_sk#7, sum#10, sum#11]
-Keys [1]: [s_store_sk#7]
+Input [3]: [s_store_sk#6, sum#10, sum#11]
+Keys [1]: [s_store_sk#6]
 Functions [2]: [sum(UnscaledValue(ss_ext_sales_price#2)), sum(UnscaledValue(ss_net_profit#3))]
 Aggregate Attributes [2]: [sum(UnscaledValue(ss_ext_sales_price#2))#12, sum(UnscaledValue(ss_net_profit#3))#13]
-Results [3]: [s_store_sk#7, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#12,17,2) AS sales#14, MakeDecimal(sum(UnscaledValue(ss_net_profit#3))#13,17,2) AS profit#15]
+Results [3]: [s_store_sk#6, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#12,17,2) AS sales#14, MakeDecimal(sum(UnscaledValue(ss_net_profit#3))#13,17,2) AS profit#15]
 
 (16) Scan parquet spark_catalog.default.store_returns
 Output [4]: [sr_store_sk#16, sr_return_amt#17, sr_net_loss#18, sr_returned_date_sk#19]
@@ -175,63 +175,63 @@ Input [4]: [sr_store_sk#16, sr_return_amt#17, sr_net_loss#18, sr_returned_date_s
 Input [4]: [sr_store_sk#16, sr_return_amt#17, sr_net_loss#18, sr_returned_date_sk#19]
 Condition : isnotnull(sr_store_sk#16)
 
-(19) ReusedExchange [Reuses operator id: 90]
-Output [1]: [d_date_sk#20]
+(19) ReusedExchange [Reuses operator id: 7]
+Output [1]: [s_store_sk#20]
 
 (20) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [sr_returned_date_sk#19]
-Right keys [1]: [d_date_sk#20]
+Left keys [1]: [sr_store_sk#16]
+Right keys [1]: [s_store_sk#20]
 Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 6]
-Output [3]: [sr_store_sk#16, sr_return_amt#17, sr_net_loss#18]
-Input [5]: [sr_store_sk#16, sr_return_amt#17, sr_net_loss#18, sr_returned_date_sk#19, d_date_sk#20]
+Output [4]: [sr_return_amt#17, sr_net_loss#18, sr_returned_date_sk#19, s_store_sk#20]
+Input [5]: [sr_store_sk#16, sr_return_amt#17, sr_net_loss#18, sr_returned_date_sk#19, s_store_sk#20]
 
-(22) ReusedExchange [Reuses operator id: 10]
-Output [1]: [s_store_sk#21]
+(22) ReusedExchange [Reuses operator id: 90]
+Output [1]: [d_date_sk#21]
 
 (23) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [sr_store_sk#16]
-Right keys [1]: [s_store_sk#21]
+Left keys [1]: [sr_returned_date_sk#19]
+Right keys [1]: [d_date_sk#21]
 Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 6]
-Output [3]: [sr_return_amt#17, sr_net_loss#18, s_store_sk#21]
-Input [4]: [sr_store_sk#16, sr_return_amt#17, sr_net_loss#18, s_store_sk#21]
+Output [3]: [sr_return_amt#17, sr_net_loss#18, s_store_sk#20]
+Input [5]: [sr_return_amt#17, sr_net_loss#18, sr_returned_date_sk#19, s_store_sk#20, d_date_sk#21]
 
 (25) HashAggregate [codegen id : 6]
-Input [3]: [sr_return_amt#17, sr_net_loss#18, s_store_sk#21]
-Keys [1]: [s_store_sk#21]
+Input [3]: [sr_return_amt#17, sr_net_loss#18, s_store_sk#20]
+Keys [1]: [s_store_sk#20]
 Functions [2]: [partial_sum(UnscaledValue(sr_return_amt#17)), partial_sum(UnscaledValue(sr_net_loss#18))]
 Aggregate Attributes [2]: [sum#22, sum#23]
-Results [3]: [s_store_sk#21, sum#24, sum#25]
+Results [3]: [s_store_sk#20, sum#24, sum#25]
 
 (26) Exchange
-Input [3]: [s_store_sk#21, sum#24, sum#25]
-Arguments: hashpartitioning(s_store_sk#21, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [3]: [s_store_sk#20, sum#24, sum#25]
+Arguments: hashpartitioning(s_store_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (27) HashAggregate [codegen id : 7]
-Input [3]: [s_store_sk#21, sum#24, sum#25]
-Keys [1]: [s_store_sk#21]
+Input [3]: [s_store_sk#20, sum#24, sum#25]
+Keys [1]: [s_store_sk#20]
 Functions [2]: [sum(UnscaledValue(sr_return_amt#17)), sum(UnscaledValue(sr_net_loss#18))]
 Aggregate Attributes [2]: [sum(UnscaledValue(sr_return_amt#17))#26, sum(UnscaledValue(sr_net_loss#18))#27]
-Results [3]: [s_store_sk#21, MakeDecimal(sum(UnscaledValue(sr_return_amt#17))#26,17,2) AS returns#28, MakeDecimal(sum(UnscaledValue(sr_net_loss#18))#27,17,2) AS profit_loss#29]
+Results [3]: [s_store_sk#20, MakeDecimal(sum(UnscaledValue(sr_return_amt#17))#26,17,2) AS returns#28, MakeDecimal(sum(UnscaledValue(sr_net_loss#18))#27,17,2) AS profit_loss#29]
 
 (28) BroadcastExchange
-Input [3]: [s_store_sk#21, returns#28, profit_loss#29]
+Input [3]: [s_store_sk#20, returns#28, profit_loss#29]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
 (29) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [s_store_sk#7]
-Right keys [1]: [s_store_sk#21]
+Left keys [1]: [s_store_sk#6]
+Right keys [1]: [s_store_sk#20]
 Join type: LeftOuter
 Join condition: None
 
 (30) Project [codegen id : 8]
-Output [5]: [sales#14, coalesce(returns#28, 0.00) AS returns#30, (profit#15 - coalesce(profit_loss#29, 0.00)) AS profit#31, store channel AS channel#32, s_store_sk#7 AS id#33]
-Input [6]: [s_store_sk#7, sales#14, profit#15, s_store_sk#21, returns#28, profit_loss#29]
+Output [5]: [sales#14, coalesce(returns#28, 0.00) AS returns#30, (profit#15 - coalesce(profit_loss#29, 0.00)) AS profit#31, store channel AS channel#32, s_store_sk#6 AS id#33]
+Input [6]: [s_store_sk#6, sales#14, profit#15, s_store_sk#20, returns#28, profit_loss#29]
 
 (31) Scan parquet spark_catalog.default.catalog_sales
 Output [4]: [cs_call_center_sk#34, cs_ext_sales_price#35, cs_net_profit#36, cs_sold_date_sk#37]
@@ -342,64 +342,64 @@ Input [4]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, ws_sold_
 Input [4]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, ws_sold_date_sk#65]
 Condition : isnotnull(ws_web_page_sk#62)
 
-(53) ReusedExchange [Reuses operator id: 90]
-Output [1]: [d_date_sk#66]
-
-(54) BroadcastHashJoin [codegen id : 17]
-Left keys [1]: [ws_sold_date_sk#65]
-Right keys [1]: [d_date_sk#66]
-Join type: Inner
-Join condition: None
-
-(55) Project [codegen id : 17]
-Output [3]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64]
-Input [5]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, ws_sold_date_sk#65, d_date_sk#66]
-
-(56) Scan parquet spark_catalog.default.web_page
-Output [1]: [wp_web_page_sk#67]
+(53) Scan parquet spark_catalog.default.web_page
+Output [1]: [wp_web_page_sk#66]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_page]
 PushedFilters: [IsNotNull(wp_web_page_sk)]
 ReadSchema: struct<wp_web_page_sk:int>
 
-(57) ColumnarToRow [codegen id : 16]
-Input [1]: [wp_web_page_sk#67]
+(54) ColumnarToRow [codegen id : 15]
+Input [1]: [wp_web_page_sk#66]
 
-(58) Filter [codegen id : 16]
-Input [1]: [wp_web_page_sk#67]
-Condition : isnotnull(wp_web_page_sk#67)
+(55) Filter [codegen id : 15]
+Input [1]: [wp_web_page_sk#66]
+Condition : isnotnull(wp_web_page_sk#66)
 
-(59) BroadcastExchange
-Input [1]: [wp_web_page_sk#67]
+(56) BroadcastExchange
+Input [1]: [wp_web_page_sk#66]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=8]
 
-(60) BroadcastHashJoin [codegen id : 17]
+(57) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_web_page_sk#62]
-Right keys [1]: [wp_web_page_sk#67]
+Right keys [1]: [wp_web_page_sk#66]
+Join type: Inner
+Join condition: None
+
+(58) Project [codegen id : 17]
+Output [4]: [ws_ext_sales_price#63, ws_net_profit#64, ws_sold_date_sk#65, wp_web_page_sk#66]
+Input [5]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, ws_sold_date_sk#65, wp_web_page_sk#66]
+
+(59) ReusedExchange [Reuses operator id: 90]
+Output [1]: [d_date_sk#67]
+
+(60) BroadcastHashJoin [codegen id : 17]
+Left keys [1]: [ws_sold_date_sk#65]
+Right keys [1]: [d_date_sk#67]
 Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 17]
-Output [3]: [ws_ext_sales_price#63, ws_net_profit#64, wp_web_page_sk#67]
-Input [4]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, wp_web_page_sk#67]
+Output [3]: [ws_ext_sales_price#63, ws_net_profit#64, wp_web_page_sk#66]
+Input [5]: [ws_ext_sales_price#63, ws_net_profit#64, ws_sold_date_sk#65, wp_web_page_sk#66, d_date_sk#67]
 
 (62) HashAggregate [codegen id : 17]
-Input [3]: [ws_ext_sales_price#63, ws_net_profit#64, wp_web_page_sk#67]
-Keys [1]: [wp_web_page_sk#67]
+Input [3]: [ws_ext_sales_price#63, ws_net_profit#64, wp_web_page_sk#66]
+Keys [1]: [wp_web_page_sk#66]
 Functions [2]: [partial_sum(UnscaledValue(ws_ext_sales_price#63)), partial_sum(UnscaledValue(ws_net_profit#64))]
 Aggregate Attributes [2]: [sum#68, sum#69]
-Results [3]: [wp_web_page_sk#67, sum#70, sum#71]
+Results [3]: [wp_web_page_sk#66, sum#70, sum#71]
 
 (63) Exchange
-Input [3]: [wp_web_page_sk#67, sum#70, sum#71]
-Arguments: hashpartitioning(wp_web_page_sk#67, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Input [3]: [wp_web_page_sk#66, sum#70, sum#71]
+Arguments: hashpartitioning(wp_web_page_sk#66, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (64) HashAggregate [codegen id : 22]
-Input [3]: [wp_web_page_sk#67, sum#70, sum#71]
-Keys [1]: [wp_web_page_sk#67]
+Input [3]: [wp_web_page_sk#66, sum#70, sum#71]
+Keys [1]: [wp_web_page_sk#66]
 Functions [2]: [sum(UnscaledValue(ws_ext_sales_price#63)), sum(UnscaledValue(ws_net_profit#64))]
 Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_sales_price#63))#72, sum(UnscaledValue(ws_net_profit#64))#73]
-Results [3]: [wp_web_page_sk#67, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#63))#72,17,2) AS sales#74, MakeDecimal(sum(UnscaledValue(ws_net_profit#64))#73,17,2) AS profit#75]
+Results [3]: [wp_web_page_sk#66, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#63))#72,17,2) AS sales#74, MakeDecimal(sum(UnscaledValue(ws_net_profit#64))#73,17,2) AS profit#75]
 
 (65) Scan parquet spark_catalog.default.web_returns
 Output [4]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79]
@@ -416,63 +416,63 @@ Input [4]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wr_returned_dat
 Input [4]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79]
 Condition : isnotnull(wr_web_page_sk#76)
 
-(68) ReusedExchange [Reuses operator id: 90]
-Output [1]: [d_date_sk#80]
+(68) ReusedExchange [Reuses operator id: 56]
+Output [1]: [wp_web_page_sk#80]
 
 (69) BroadcastHashJoin [codegen id : 20]
-Left keys [1]: [wr_returned_date_sk#79]
-Right keys [1]: [d_date_sk#80]
+Left keys [1]: [wr_web_page_sk#76]
+Right keys [1]: [wp_web_page_sk#80]
 Join type: Inner
 Join condition: None
 
 (70) Project [codegen id : 20]
-Output [3]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78]
-Input [5]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79, d_date_sk#80]
+Output [4]: [wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79, wp_web_page_sk#80]
+Input [5]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79, wp_web_page_sk#80]
 
-(71) ReusedExchange [Reuses operator id: 59]
-Output [1]: [wp_web_page_sk#81]
+(71) ReusedExchange [Reuses operator id: 90]
+Output [1]: [d_date_sk#81]
 
 (72) BroadcastHashJoin [codegen id : 20]
-Left keys [1]: [wr_web_page_sk#76]
-Right keys [1]: [wp_web_page_sk#81]
+Left keys [1]: [wr_returned_date_sk#79]
+Right keys [1]: [d_date_sk#81]
 Join type: Inner
 Join condition: None
 
 (73) Project [codegen id : 20]
-Output [3]: [wr_return_amt#77, wr_net_loss#78, wp_web_page_sk#81]
-Input [4]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wp_web_page_sk#81]
+Output [3]: [wr_return_amt#77, wr_net_loss#78, wp_web_page_sk#80]
+Input [5]: [wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79, wp_web_page_sk#80, d_date_sk#81]
 
 (74) HashAggregate [codegen id : 20]
-Input [3]: [wr_return_amt#77, wr_net_loss#78, wp_web_page_sk#81]
-Keys [1]: [wp_web_page_sk#81]
+Input [3]: [wr_return_amt#77, wr_net_loss#78, wp_web_page_sk#80]
+Keys [1]: [wp_web_page_sk#80]
 Functions [2]: [partial_sum(UnscaledValue(wr_return_amt#77)), partial_sum(UnscaledValue(wr_net_loss#78))]
 Aggregate Attributes [2]: [sum#82, sum#83]
-Results [3]: [wp_web_page_sk#81, sum#84, sum#85]
+Results [3]: [wp_web_page_sk#80, sum#84, sum#85]
 
 (75) Exchange
-Input [3]: [wp_web_page_sk#81, sum#84, sum#85]
-Arguments: hashpartitioning(wp_web_page_sk#81, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [3]: [wp_web_page_sk#80, sum#84, sum#85]
+Arguments: hashpartitioning(wp_web_page_sk#80, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (76) HashAggregate [codegen id : 21]
-Input [3]: [wp_web_page_sk#81, sum#84, sum#85]
-Keys [1]: [wp_web_page_sk#81]
+Input [3]: [wp_web_page_sk#80, sum#84, sum#85]
+Keys [1]: [wp_web_page_sk#80]
 Functions [2]: [sum(UnscaledValue(wr_return_amt#77)), sum(UnscaledValue(wr_net_loss#78))]
 Aggregate Attributes [2]: [sum(UnscaledValue(wr_return_amt#77))#86, sum(UnscaledValue(wr_net_loss#78))#87]
-Results [3]: [wp_web_page_sk#81, MakeDecimal(sum(UnscaledValue(wr_return_amt#77))#86,17,2) AS returns#88, MakeDecimal(sum(UnscaledValue(wr_net_loss#78))#87,17,2) AS profit_loss#89]
+Results [3]: [wp_web_page_sk#80, MakeDecimal(sum(UnscaledValue(wr_return_amt#77))#86,17,2) AS returns#88, MakeDecimal(sum(UnscaledValue(wr_net_loss#78))#87,17,2) AS profit_loss#89]
 
 (77) BroadcastExchange
-Input [3]: [wp_web_page_sk#81, returns#88, profit_loss#89]
+Input [3]: [wp_web_page_sk#80, returns#88, profit_loss#89]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
 (78) BroadcastHashJoin [codegen id : 22]
-Left keys [1]: [wp_web_page_sk#67]
-Right keys [1]: [wp_web_page_sk#81]
+Left keys [1]: [wp_web_page_sk#66]
+Right keys [1]: [wp_web_page_sk#80]
 Join type: LeftOuter
 Join condition: None
 
 (79) Project [codegen id : 22]
-Output [5]: [sales#74, coalesce(returns#88, 0.00) AS returns#90, (profit#75 - coalesce(profit_loss#89, 0.00)) AS profit#91, web channel AS channel#92, wp_web_page_sk#67 AS id#93]
-Input [6]: [wp_web_page_sk#67, sales#74, profit#75, wp_web_page_sk#81, returns#88, profit_loss#89]
+Output [5]: [sales#74, coalesce(returns#88, 0.00) AS returns#90, (profit#75 - coalesce(profit_loss#89, 0.00)) AS profit#91, web channel AS channel#92, wp_web_page_sk#66 AS id#93]
+Input [6]: [wp_web_page_sk#66, sales#74, profit#75, wp_web_page_sk#80, returns#88, profit_loss#89]
 
 (80) Union
 
@@ -513,25 +513,25 @@ BroadcastExchange (90)
 
 
 (86) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#6, d_date#115]
+Output [2]: [d_date_sk#7, d_date#115]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-08-03), LessThanOrEqual(d_date,2000-09-02), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (87) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#6, d_date#115]
+Input [2]: [d_date_sk#7, d_date#115]
 
 (88) Filter [codegen id : 1]
-Input [2]: [d_date_sk#6, d_date#115]
-Condition : (((isnotnull(d_date#115) AND (d_date#115 >= 2000-08-03)) AND (d_date#115 <= 2000-09-02)) AND isnotnull(d_date_sk#6))
+Input [2]: [d_date_sk#7, d_date#115]
+Condition : (((isnotnull(d_date#115) AND (d_date#115 >= 2000-08-03)) AND (d_date#115 <= 2000-09-02)) AND isnotnull(d_date_sk#7))
 
 (89) Project [codegen id : 1]
-Output [1]: [d_date_sk#6]
-Input [2]: [d_date_sk#6, d_date#115]
+Output [1]: [d_date_sk#7]
+Input [2]: [d_date_sk#7, d_date#115]
 
 (90) BroadcastExchange
-Input [1]: [d_date_sk#6]
+Input [1]: [d_date_sk#7]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=13]
 
 Subquery:2 Hosting operator id = 16 Hosting Expression = sr_returned_date_sk#19 IN dynamicpruning#5

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q77.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q77.sf100/simplified.txt
@@ -17,9 +17,9 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                 WholeStageCodegen (3)
                                   HashAggregate [s_store_sk,ss_ext_sales_price,ss_net_profit] [sum,sum,sum,sum]
                                     Project [ss_ext_sales_price,ss_net_profit,s_store_sk]
-                                      BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                        Project [ss_store_sk,ss_ext_sales_price,ss_net_profit]
-                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                        Project [ss_ext_sales_price,ss_net_profit,ss_sold_date_sk,s_store_sk]
+                                          BroadcastHashJoin [ss_store_sk,s_store_sk]
                                             Filter [ss_store_sk]
                                               ColumnarToRow
                                                 InputAdapter
@@ -33,14 +33,14 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
                                             InputAdapter
-                                              ReusedExchange [d_date_sk] #3
+                                              BroadcastExchange #4
+                                                WholeStageCodegen (1)
+                                                  Filter [s_store_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.store [s_store_sk]
                                         InputAdapter
-                                          BroadcastExchange #4
-                                            WholeStageCodegen (2)
-                                              Filter [s_store_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.store [s_store_sk]
+                                          ReusedExchange [d_date_sk] #3
                           InputAdapter
                             BroadcastExchange #5
                               WholeStageCodegen (7)
@@ -50,18 +50,18 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                       WholeStageCodegen (6)
                                         HashAggregate [s_store_sk,sr_return_amt,sr_net_loss] [sum,sum,sum,sum]
                                           Project [sr_return_amt,sr_net_loss,s_store_sk]
-                                            BroadcastHashJoin [sr_store_sk,s_store_sk]
-                                              Project [sr_store_sk,sr_return_amt,sr_net_loss]
-                                                BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
+                                            BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
+                                              Project [sr_return_amt,sr_net_loss,sr_returned_date_sk,s_store_sk]
+                                                BroadcastHashJoin [sr_store_sk,s_store_sk]
                                                   Filter [sr_store_sk]
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.store_returns [sr_store_sk,sr_return_amt,sr_net_loss,sr_returned_date_sk]
                                                           ReusedSubquery [d_date_sk] #1
                                                   InputAdapter
-                                                    ReusedExchange [d_date_sk] #3
+                                                    ReusedExchange [s_store_sk] #4
                                               InputAdapter
-                                                ReusedExchange [s_store_sk] #4
+                                                ReusedExchange [d_date_sk] #3
                     WholeStageCodegen (14)
                       Project [sales,returns,profit,profit_loss,cs_call_center_sk]
                         BroadcastNestedLoopJoin
@@ -103,23 +103,23 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                 WholeStageCodegen (17)
                                   HashAggregate [wp_web_page_sk,ws_ext_sales_price,ws_net_profit] [sum,sum,sum,sum]
                                     Project [ws_ext_sales_price,ws_net_profit,wp_web_page_sk]
-                                      BroadcastHashJoin [ws_web_page_sk,wp_web_page_sk]
-                                        Project [ws_web_page_sk,ws_ext_sales_price,ws_net_profit]
-                                          BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                      BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                        Project [ws_ext_sales_price,ws_net_profit,ws_sold_date_sk,wp_web_page_sk]
+                                          BroadcastHashJoin [ws_web_page_sk,wp_web_page_sk]
                                             Filter [ws_web_page_sk]
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet spark_catalog.default.web_sales [ws_web_page_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk]
                                                     ReusedSubquery [d_date_sk] #1
                                             InputAdapter
-                                              ReusedExchange [d_date_sk] #3
+                                              BroadcastExchange #11
+                                                WholeStageCodegen (15)
+                                                  Filter [wp_web_page_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.web_page [wp_web_page_sk]
                                         InputAdapter
-                                          BroadcastExchange #11
-                                            WholeStageCodegen (16)
-                                              Filter [wp_web_page_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.web_page [wp_web_page_sk]
+                                          ReusedExchange [d_date_sk] #3
                           InputAdapter
                             BroadcastExchange #12
                               WholeStageCodegen (21)
@@ -129,15 +129,15 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                       WholeStageCodegen (20)
                                         HashAggregate [wp_web_page_sk,wr_return_amt,wr_net_loss] [sum,sum,sum,sum]
                                           Project [wr_return_amt,wr_net_loss,wp_web_page_sk]
-                                            BroadcastHashJoin [wr_web_page_sk,wp_web_page_sk]
-                                              Project [wr_web_page_sk,wr_return_amt,wr_net_loss]
-                                                BroadcastHashJoin [wr_returned_date_sk,d_date_sk]
+                                            BroadcastHashJoin [wr_returned_date_sk,d_date_sk]
+                                              Project [wr_return_amt,wr_net_loss,wr_returned_date_sk,wp_web_page_sk]
+                                                BroadcastHashJoin [wr_web_page_sk,wp_web_page_sk]
                                                   Filter [wr_web_page_sk]
                                                     ColumnarToRow
                                                       InputAdapter
                                                         Scan parquet spark_catalog.default.web_returns [wr_web_page_sk,wr_return_amt,wr_net_loss,wr_returned_date_sk]
                                                           ReusedSubquery [d_date_sk] #1
                                                   InputAdapter
-                                                    ReusedExchange [d_date_sk] #3
+                                                    ReusedExchange [wp_web_page_sk] #11
                                               InputAdapter
-                                                ReusedExchange [wp_web_page_sk] #11
+                                                ReusedExchange [d_date_sk] #3

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q80.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q80.sf100/explain.txt
@@ -10,8 +10,8 @@ TakeOrderedAndProject (107)
                :     +- * HashAggregate (37)
                :        +- * Project (36)
                :           +- * BroadcastHashJoin Inner BuildRight (35)
-               :              :- * Project (30)
-               :              :  +- * BroadcastHashJoin Inner BuildRight (29)
+               :              :- * Project (33)
+               :              :  +- * BroadcastHashJoin Inner BuildRight (32)
                :              :     :- * Project (27)
                :              :     :  +- * BroadcastHashJoin Inner BuildRight (26)
                :              :     :     :- * Project (20)
@@ -39,18 +39,18 @@ TakeOrderedAndProject (107)
                :              :     :           +- * Filter (23)
                :              :     :              +- * ColumnarToRow (22)
                :              :     :                 +- Scan parquet spark_catalog.default.promotion (21)
-               :              :     +- ReusedExchange (28)
-               :              +- BroadcastExchange (34)
-               :                 +- * Filter (33)
-               :                    +- * ColumnarToRow (32)
-               :                       +- Scan parquet spark_catalog.default.store (31)
+               :              :     +- BroadcastExchange (31)
+               :              :        +- * Filter (30)
+               :              :           +- * ColumnarToRow (29)
+               :              :              +- Scan parquet spark_catalog.default.store (28)
+               :              +- ReusedExchange (34)
                :- * HashAggregate (70)
                :  +- Exchange (69)
                :     +- * HashAggregate (68)
                :        +- * Project (67)
                :           +- * BroadcastHashJoin Inner BuildRight (66)
-               :              :- * Project (61)
-               :              :  +- * BroadcastHashJoin Inner BuildRight (60)
+               :              :- * Project (64)
+               :              :  +- * BroadcastHashJoin Inner BuildRight (63)
                :              :     :- * Project (58)
                :              :     :  +- * BroadcastHashJoin Inner BuildRight (57)
                :              :     :     :- * Project (55)
@@ -70,18 +70,18 @@ TakeOrderedAndProject (107)
                :              :     :     :     :                    +- Scan parquet spark_catalog.default.catalog_returns (45)
                :              :     :     :     +- ReusedExchange (53)
                :              :     :     +- ReusedExchange (56)
-               :              :     +- ReusedExchange (59)
-               :              +- BroadcastExchange (65)
-               :                 +- * Filter (64)
-               :                    +- * ColumnarToRow (63)
-               :                       +- Scan parquet spark_catalog.default.catalog_page (62)
+               :              :     +- BroadcastExchange (62)
+               :              :        +- * Filter (61)
+               :              :           +- * ColumnarToRow (60)
+               :              :              +- Scan parquet spark_catalog.default.catalog_page (59)
+               :              +- ReusedExchange (65)
                +- * HashAggregate (101)
                   +- Exchange (100)
                      +- * HashAggregate (99)
                         +- * Project (98)
                            +- * BroadcastHashJoin Inner BuildRight (97)
-                              :- * Project (92)
-                              :  +- * BroadcastHashJoin Inner BuildRight (91)
+                              :- * Project (95)
+                              :  +- * BroadcastHashJoin Inner BuildRight (94)
                               :     :- * Project (89)
                               :     :  +- * BroadcastHashJoin Inner BuildRight (88)
                               :     :     :- * Project (86)
@@ -101,11 +101,11 @@ TakeOrderedAndProject (107)
                               :     :     :     :                    +- Scan parquet spark_catalog.default.web_returns (76)
                               :     :     :     +- ReusedExchange (84)
                               :     :     +- ReusedExchange (87)
-                              :     +- ReusedExchange (90)
-                              +- BroadcastExchange (96)
-                                 +- * Filter (95)
-                                    +- * ColumnarToRow (94)
-                                       +- Scan parquet spark_catalog.default.web_site (93)
+                              :     +- BroadcastExchange (93)
+                              :        +- * Filter (92)
+                              :           +- * ColumnarToRow (91)
+                              :              +- Scan parquet spark_catalog.default.web_site (90)
+                              +- ReusedExchange (96)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -231,64 +231,64 @@ Join condition: None
 Output [6]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16]
 Input [8]: [ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, p_promo_sk#20]
 
-(28) ReusedExchange [Reuses operator id: 126]
-Output [1]: [d_date_sk#22]
-
-(29) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [ss_sold_date_sk#7]
-Right keys [1]: [d_date_sk#22]
-Join type: Inner
-Join condition: None
-
-(30) Project [codegen id : 9]
-Output [5]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16]
-Input [7]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, d_date_sk#22]
-
-(31) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#23, s_store_id#24]
+(28) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#22, s_store_id#23]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string>
 
-(32) ColumnarToRow [codegen id : 8]
-Input [2]: [s_store_sk#23, s_store_id#24]
+(29) ColumnarToRow [codegen id : 7]
+Input [2]: [s_store_sk#22, s_store_id#23]
 
-(33) Filter [codegen id : 8]
-Input [2]: [s_store_sk#23, s_store_id#24]
-Condition : isnotnull(s_store_sk#23)
+(30) Filter [codegen id : 7]
+Input [2]: [s_store_sk#22, s_store_id#23]
+Condition : isnotnull(s_store_sk#22)
 
-(34) BroadcastExchange
-Input [2]: [s_store_sk#23, s_store_id#24]
+(31) BroadcastExchange
+Input [2]: [s_store_sk#22, s_store_id#23]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
 
-(35) BroadcastHashJoin [codegen id : 9]
+(32) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#2]
-Right keys [1]: [s_store_sk#23]
+Right keys [1]: [s_store_sk#22]
+Join type: Inner
+Join condition: None
+
+(33) Project [codegen id : 9]
+Output [6]: [ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, s_store_id#23]
+Input [8]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, s_store_sk#22, s_store_id#23]
+
+(34) ReusedExchange [Reuses operator id: 126]
+Output [1]: [d_date_sk#24]
+
+(35) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [ss_sold_date_sk#7]
+Right keys [1]: [d_date_sk#24]
 Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 9]
-Output [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_id#24]
-Input [7]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_sk#23, s_store_id#24]
+Output [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_id#23]
+Input [7]: [ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, s_store_id#23, d_date_sk#24]
 
 (37) HashAggregate [codegen id : 9]
-Input [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_id#24]
-Keys [1]: [s_store_id#24]
+Input [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_id#23]
+Keys [1]: [s_store_id#23]
 Functions [3]: [partial_sum(UnscaledValue(ss_ext_sales_price#5)), partial_sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00)), partial_sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))]
 Aggregate Attributes [5]: [sum#25, sum#26, isEmpty#27, sum#28, isEmpty#29]
-Results [6]: [s_store_id#24, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
+Results [6]: [s_store_id#23, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
 
 (38) Exchange
-Input [6]: [s_store_id#24, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
-Arguments: hashpartitioning(s_store_id#24, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [6]: [s_store_id#23, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
+Arguments: hashpartitioning(s_store_id#23, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (39) HashAggregate [codegen id : 10]
-Input [6]: [s_store_id#24, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
-Keys [1]: [s_store_id#24]
+Input [6]: [s_store_id#23, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
+Keys [1]: [s_store_id#23]
 Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#5)), sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00)), sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))]
 Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#5))#35, sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00))#36, sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))#37]
-Results [5]: [MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#5))#35,17,2) AS sales#38, sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00))#36 AS returns#39, sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))#37 AS profit#40, store channel AS channel#41, concat(store, s_store_id#24) AS id#42]
+Results [5]: [MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#5))#35,17,2) AS sales#38, sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00))#36 AS returns#39, sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))#37 AS profit#40, store channel AS channel#41, concat(store, s_store_id#23) AS id#42]
 
 (40) Scan parquet spark_catalog.default.catalog_sales
 Output [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
@@ -303,7 +303,7 @@ Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_numbe
 
 (42) Filter [codegen id : 11]
 Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
-Condition : ((((isnotnull(cs_catalog_page_sk#43) AND isnotnull(cs_item_sk#44)) AND isnotnull(cs_promo_sk#45)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(cs_item_sk#44, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(cs_promo_sk#45, 42)))
+Condition : ((((isnotnull(cs_catalog_page_sk#43) AND isnotnull(cs_item_sk#44)) AND isnotnull(cs_promo_sk#45)) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(cs_promo_sk#45, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(cs_item_sk#44, 42)))
 
 (43) Exchange
 Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
@@ -349,90 +349,90 @@ Join condition: None
 Output [8]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53]
 Input [11]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53]
 
-(53) ReusedExchange [Reuses operator id: 18]
-Output [1]: [i_item_sk#55]
+(53) ReusedExchange [Reuses operator id: 25]
+Output [1]: [p_promo_sk#55]
 
 (54) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_item_sk#44]
-Right keys [1]: [i_item_sk#55]
+Left keys [1]: [cs_promo_sk#45]
+Right keys [1]: [p_promo_sk#55]
 Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 19]
-Output [7]: [cs_catalog_page_sk#43, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53]
-Input [9]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, i_item_sk#55]
+Output [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53]
+Input [9]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, p_promo_sk#55]
 
-(56) ReusedExchange [Reuses operator id: 25]
-Output [1]: [p_promo_sk#56]
+(56) ReusedExchange [Reuses operator id: 18]
+Output [1]: [i_item_sk#56]
 
 (57) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_promo_sk#45]
-Right keys [1]: [p_promo_sk#56]
+Left keys [1]: [cs_item_sk#44]
+Right keys [1]: [i_item_sk#56]
 Join type: Inner
 Join condition: None
 
 (58) Project [codegen id : 19]
 Output [6]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53]
-Input [8]: [cs_catalog_page_sk#43, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, p_promo_sk#56]
+Input [8]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, i_item_sk#56]
 
-(59) ReusedExchange [Reuses operator id: 126]
-Output [1]: [d_date_sk#57]
-
-(60) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_sold_date_sk#49]
-Right keys [1]: [d_date_sk#57]
-Join type: Inner
-Join condition: None
-
-(61) Project [codegen id : 19]
-Output [5]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53]
-Input [7]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, d_date_sk#57]
-
-(62) Scan parquet spark_catalog.default.catalog_page
-Output [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
+(59) Scan parquet spark_catalog.default.catalog_page
+Output [2]: [cp_catalog_page_sk#57, cp_catalog_page_id#58]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_page]
 PushedFilters: [IsNotNull(cp_catalog_page_sk)]
 ReadSchema: struct<cp_catalog_page_sk:int,cp_catalog_page_id:string>
 
-(63) ColumnarToRow [codegen id : 18]
-Input [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
+(60) ColumnarToRow [codegen id : 17]
+Input [2]: [cp_catalog_page_sk#57, cp_catalog_page_id#58]
 
-(64) Filter [codegen id : 18]
-Input [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
-Condition : isnotnull(cp_catalog_page_sk#58)
+(61) Filter [codegen id : 17]
+Input [2]: [cp_catalog_page_sk#57, cp_catalog_page_id#58]
+Condition : isnotnull(cp_catalog_page_sk#57)
 
-(65) BroadcastExchange
-Input [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
+(62) BroadcastExchange
+Input [2]: [cp_catalog_page_sk#57, cp_catalog_page_id#58]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=9]
 
-(66) BroadcastHashJoin [codegen id : 19]
+(63) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_catalog_page_sk#43]
-Right keys [1]: [cp_catalog_page_sk#58]
+Right keys [1]: [cp_catalog_page_sk#57]
+Join type: Inner
+Join condition: None
+
+(64) Project [codegen id : 19]
+Output [6]: [cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_id#58]
+Input [8]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_sk#57, cp_catalog_page_id#58]
+
+(65) ReusedExchange [Reuses operator id: 126]
+Output [1]: [d_date_sk#59]
+
+(66) BroadcastHashJoin [codegen id : 19]
+Left keys [1]: [cs_sold_date_sk#49]
+Right keys [1]: [d_date_sk#59]
 Join type: Inner
 Join condition: None
 
 (67) Project [codegen id : 19]
-Output [5]: [cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_id#59]
-Input [7]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_sk#58, cp_catalog_page_id#59]
+Output [5]: [cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_id#58]
+Input [7]: [cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_id#58, d_date_sk#59]
 
 (68) HashAggregate [codegen id : 19]
-Input [5]: [cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_id#59]
-Keys [1]: [cp_catalog_page_id#59]
+Input [5]: [cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_id#58]
+Keys [1]: [cp_catalog_page_id#58]
 Functions [3]: [partial_sum(UnscaledValue(cs_ext_sales_price#47)), partial_sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00)), partial_sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))]
 Aggregate Attributes [5]: [sum#60, sum#61, isEmpty#62, sum#63, isEmpty#64]
-Results [6]: [cp_catalog_page_id#59, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
+Results [6]: [cp_catalog_page_id#58, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
 
 (69) Exchange
-Input [6]: [cp_catalog_page_id#59, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
-Arguments: hashpartitioning(cp_catalog_page_id#59, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [6]: [cp_catalog_page_id#58, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
+Arguments: hashpartitioning(cp_catalog_page_id#58, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (70) HashAggregate [codegen id : 20]
-Input [6]: [cp_catalog_page_id#59, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
-Keys [1]: [cp_catalog_page_id#59]
+Input [6]: [cp_catalog_page_id#58, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
+Keys [1]: [cp_catalog_page_id#58]
 Functions [3]: [sum(UnscaledValue(cs_ext_sales_price#47)), sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00)), sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))]
 Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_sales_price#47))#70, sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00))#71, sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))#72]
-Results [5]: [MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#47))#70,17,2) AS sales#73, sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00))#71 AS returns#74, sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))#72 AS profit#75, catalog channel AS channel#76, concat(catalog_page, cp_catalog_page_id#59) AS id#77]
+Results [5]: [MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#47))#70,17,2) AS sales#73, sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00))#71 AS returns#74, sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))#72 AS profit#75, catalog channel AS channel#76, concat(catalog_page, cp_catalog_page_id#58) AS id#77]
 
 (71) Scan parquet spark_catalog.default.web_sales
 Output [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
@@ -447,7 +447,7 @@ Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81
 
 (73) Filter [codegen id : 21]
 Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
-Condition : ((((isnotnull(ws_web_site_sk#79) AND isnotnull(ws_item_sk#78)) AND isnotnull(ws_promo_sk#80)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(ws_item_sk#78, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(ws_promo_sk#80, 42)))
+Condition : ((((isnotnull(ws_web_site_sk#79) AND isnotnull(ws_item_sk#78)) AND isnotnull(ws_promo_sk#80)) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(ws_promo_sk#80, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(ws_item_sk#78, 42)))
 
 (74) Exchange
 Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
@@ -493,90 +493,90 @@ Join condition: None
 Output [8]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88]
 Input [11]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88]
 
-(84) ReusedExchange [Reuses operator id: 18]
-Output [1]: [i_item_sk#90]
+(84) ReusedExchange [Reuses operator id: 25]
+Output [1]: [p_promo_sk#90]
 
 (85) BroadcastHashJoin [codegen id : 29]
-Left keys [1]: [ws_item_sk#78]
-Right keys [1]: [i_item_sk#90]
+Left keys [1]: [ws_promo_sk#80]
+Right keys [1]: [p_promo_sk#90]
 Join type: Inner
 Join condition: None
 
 (86) Project [codegen id : 29]
-Output [7]: [ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88]
-Input [9]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, i_item_sk#90]
+Output [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88]
+Input [9]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, p_promo_sk#90]
 
-(87) ReusedExchange [Reuses operator id: 25]
-Output [1]: [p_promo_sk#91]
+(87) ReusedExchange [Reuses operator id: 18]
+Output [1]: [i_item_sk#91]
 
 (88) BroadcastHashJoin [codegen id : 29]
-Left keys [1]: [ws_promo_sk#80]
-Right keys [1]: [p_promo_sk#91]
+Left keys [1]: [ws_item_sk#78]
+Right keys [1]: [i_item_sk#91]
 Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 29]
 Output [6]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88]
-Input [8]: [ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, p_promo_sk#91]
+Input [8]: [ws_item_sk#78, ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, i_item_sk#91]
 
-(90) ReusedExchange [Reuses operator id: 126]
-Output [1]: [d_date_sk#92]
-
-(91) BroadcastHashJoin [codegen id : 29]
-Left keys [1]: [ws_sold_date_sk#84]
-Right keys [1]: [d_date_sk#92]
-Join type: Inner
-Join condition: None
-
-(92) Project [codegen id : 29]
-Output [5]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88]
-Input [7]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, d_date_sk#92]
-
-(93) Scan parquet spark_catalog.default.web_site
-Output [2]: [web_site_sk#93, web_site_id#94]
+(90) Scan parquet spark_catalog.default.web_site
+Output [2]: [web_site_sk#92, web_site_id#93]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_site]
 PushedFilters: [IsNotNull(web_site_sk)]
 ReadSchema: struct<web_site_sk:int,web_site_id:string>
 
-(94) ColumnarToRow [codegen id : 28]
-Input [2]: [web_site_sk#93, web_site_id#94]
+(91) ColumnarToRow [codegen id : 27]
+Input [2]: [web_site_sk#92, web_site_id#93]
 
-(95) Filter [codegen id : 28]
-Input [2]: [web_site_sk#93, web_site_id#94]
-Condition : isnotnull(web_site_sk#93)
+(92) Filter [codegen id : 27]
+Input [2]: [web_site_sk#92, web_site_id#93]
+Condition : isnotnull(web_site_sk#92)
 
-(96) BroadcastExchange
-Input [2]: [web_site_sk#93, web_site_id#94]
+(93) BroadcastExchange
+Input [2]: [web_site_sk#92, web_site_id#93]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=13]
 
-(97) BroadcastHashJoin [codegen id : 29]
+(94) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ws_web_site_sk#79]
-Right keys [1]: [web_site_sk#93]
+Right keys [1]: [web_site_sk#92]
+Join type: Inner
+Join condition: None
+
+(95) Project [codegen id : 29]
+Output [6]: [ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, web_site_id#93]
+Input [8]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, web_site_sk#92, web_site_id#93]
+
+(96) ReusedExchange [Reuses operator id: 126]
+Output [1]: [d_date_sk#94]
+
+(97) BroadcastHashJoin [codegen id : 29]
+Left keys [1]: [ws_sold_date_sk#84]
+Right keys [1]: [d_date_sk#94]
 Join type: Inner
 Join condition: None
 
 (98) Project [codegen id : 29]
-Output [5]: [ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88, web_site_id#94]
-Input [7]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88, web_site_sk#93, web_site_id#94]
+Output [5]: [ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88, web_site_id#93]
+Input [7]: [ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, web_site_id#93, d_date_sk#94]
 
 (99) HashAggregate [codegen id : 29]
-Input [5]: [ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88, web_site_id#94]
-Keys [1]: [web_site_id#94]
+Input [5]: [ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88, web_site_id#93]
+Keys [1]: [web_site_id#93]
 Functions [3]: [partial_sum(UnscaledValue(ws_ext_sales_price#82)), partial_sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00)), partial_sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))]
 Aggregate Attributes [5]: [sum#95, sum#96, isEmpty#97, sum#98, isEmpty#99]
-Results [6]: [web_site_id#94, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
+Results [6]: [web_site_id#93, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
 
 (100) Exchange
-Input [6]: [web_site_id#94, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
-Arguments: hashpartitioning(web_site_id#94, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+Input [6]: [web_site_id#93, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
+Arguments: hashpartitioning(web_site_id#93, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
 (101) HashAggregate [codegen id : 30]
-Input [6]: [web_site_id#94, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
-Keys [1]: [web_site_id#94]
+Input [6]: [web_site_id#93, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
+Keys [1]: [web_site_id#93]
 Functions [3]: [sum(UnscaledValue(ws_ext_sales_price#82)), sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00)), sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))]
 Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_sales_price#82))#105, sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00))#106, sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))#107]
-Results [5]: [MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#82))#105,17,2) AS sales#108, sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00))#106 AS returns#109, sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))#107 AS profit#110, web channel AS channel#111, concat(web_site, web_site_id#94) AS id#112]
+Results [5]: [MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#82))#105,17,2) AS sales#108, sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00))#106 AS returns#109, sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))#107 AS profit#110, web channel AS channel#111, concat(web_site, web_site_id#93) AS id#112]
 
 (102) Union
 
@@ -709,36 +709,36 @@ BroadcastExchange (126)
 
 
 (122) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#22, d_date#142]
+Output [2]: [d_date_sk#24, d_date#142]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-08-23), LessThanOrEqual(d_date,2000-09-22), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (123) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#22, d_date#142]
+Input [2]: [d_date_sk#24, d_date#142]
 
 (124) Filter [codegen id : 1]
-Input [2]: [d_date_sk#22, d_date#142]
-Condition : (((isnotnull(d_date#142) AND (d_date#142 >= 2000-08-23)) AND (d_date#142 <= 2000-09-22)) AND isnotnull(d_date_sk#22))
+Input [2]: [d_date_sk#24, d_date#142]
+Condition : (((isnotnull(d_date#142) AND (d_date#142 >= 2000-08-23)) AND (d_date#142 <= 2000-09-22)) AND isnotnull(d_date_sk#24))
 
 (125) Project [codegen id : 1]
-Output [1]: [d_date_sk#22]
-Input [2]: [d_date_sk#22, d_date#142]
+Output [1]: [d_date_sk#24]
+Input [2]: [d_date_sk#24, d_date#142]
 
 (126) BroadcastExchange
-Input [1]: [d_date_sk#22]
+Input [1]: [d_date_sk#24]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=18]
 
-Subquery:4 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#10]
+Subquery:4 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
 
-Subquery:5 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
+Subquery:5 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#10]
 
 Subquery:6 Hosting operator id = 40 Hosting Expression = cs_sold_date_sk#49 IN dynamicpruning#8
 
-Subquery:7 Hosting operator id = 73 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#10]
+Subquery:7 Hosting operator id = 73 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
 
-Subquery:8 Hosting operator id = 73 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
+Subquery:8 Hosting operator id = 73 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#10]
 
 Subquery:9 Hosting operator id = 71 Hosting Expression = ws_sold_date_sk#84 IN dynamicpruning#8
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q80.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q80.sf100/simplified.txt
@@ -15,9 +15,9 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                             WholeStageCodegen (9)
                               HashAggregate [s_store_id,ss_ext_sales_price,sr_return_amt,ss_net_profit,sr_net_loss] [sum,sum,isEmpty,sum,isEmpty,sum,sum,isEmpty,sum,isEmpty]
                                 Project [ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss,s_store_id]
-                                  BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                    Project [ss_store_sk,ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss]
-                                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                    Project [ss_ext_sales_price,ss_net_profit,ss_sold_date_sk,sr_return_amt,sr_net_loss,s_store_id]
+                                      BroadcastHashJoin [ss_store_sk,s_store_sk]
                                         Project [ss_store_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk,sr_return_amt,sr_net_loss]
                                           BroadcastHashJoin [ss_promo_sk,p_promo_sk]
                                             Project [ss_store_sk,ss_promo_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk,sr_return_amt,sr_net_loss]
@@ -90,14 +90,14 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                         InputAdapter
                                                           Scan parquet spark_catalog.default.promotion [p_promo_sk,p_channel_tv]
                                         InputAdapter
-                                          ReusedExchange [d_date_sk] #4
+                                          BroadcastExchange #10
+                                            WholeStageCodegen (7)
+                                              Filter [s_store_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
                                     InputAdapter
-                                      BroadcastExchange #10
-                                        WholeStageCodegen (8)
-                                          Filter [s_store_sk]
-                                            ColumnarToRow
-                                              InputAdapter
-                                                Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
+                                      ReusedExchange [d_date_sk] #4
                     WholeStageCodegen (20)
                       HashAggregate [cp_catalog_page_id,sum,sum,isEmpty,sum,isEmpty] [sum(UnscaledValue(cs_ext_sales_price)),sum(coalesce(cast(cr_return_amount as decimal(12,2)), 0.00)),sum((cs_net_profit - coalesce(cast(cr_net_loss as decimal(12,2)), 0.00))),sales,returns,profit,channel,id,sum,sum,isEmpty,sum,isEmpty]
                         InputAdapter
@@ -105,13 +105,13 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                             WholeStageCodegen (19)
                               HashAggregate [cp_catalog_page_id,cs_ext_sales_price,cr_return_amount,cs_net_profit,cr_net_loss] [sum,sum,isEmpty,sum,isEmpty,sum,sum,isEmpty,sum,isEmpty]
                                 Project [cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss,cp_catalog_page_id]
-                                  BroadcastHashJoin [cs_catalog_page_sk,cp_catalog_page_sk]
-                                    Project [cs_catalog_page_sk,cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss]
-                                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                  BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                    Project [cs_ext_sales_price,cs_net_profit,cs_sold_date_sk,cr_return_amount,cr_net_loss,cp_catalog_page_id]
+                                      BroadcastHashJoin [cs_catalog_page_sk,cp_catalog_page_sk]
                                         Project [cs_catalog_page_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk,cr_return_amount,cr_net_loss]
-                                          BroadcastHashJoin [cs_promo_sk,p_promo_sk]
-                                            Project [cs_catalog_page_sk,cs_promo_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk,cr_return_amount,cr_net_loss]
-                                              BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                          BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                            Project [cs_catalog_page_sk,cs_item_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk,cr_return_amount,cr_net_loss]
+                                              BroadcastHashJoin [cs_promo_sk,p_promo_sk]
                                                 Project [cs_catalog_page_sk,cs_item_sk,cs_promo_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk,cr_return_amount,cr_net_loss]
                                                   SortMergeJoin [cs_item_sk,cs_order_number,cr_item_sk,cr_order_number]
                                                     InputAdapter
@@ -121,8 +121,8 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                             Exchange [cs_item_sk,cs_order_number] #12
                                                               WholeStageCodegen (11)
                                                                 Filter [cs_catalog_page_sk,cs_item_sk,cs_promo_sk]
-                                                                  ReusedSubquery [bloomFilter] #2
                                                                   ReusedSubquery [bloomFilter] #3
+                                                                  ReusedSubquery [bloomFilter] #2
                                                                   ColumnarToRow
                                                                     InputAdapter
                                                                       Scan parquet spark_catalog.default.catalog_sales [cs_catalog_page_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk]
@@ -139,18 +139,18 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.catalog_returns [cr_item_sk,cr_order_number,cr_return_amount,cr_net_loss,cr_returned_date_sk]
                                                 InputAdapter
-                                                  ReusedExchange [i_item_sk] #8
+                                                  ReusedExchange [p_promo_sk] #9
                                             InputAdapter
-                                              ReusedExchange [p_promo_sk] #9
+                                              ReusedExchange [i_item_sk] #8
                                         InputAdapter
-                                          ReusedExchange [d_date_sk] #4
+                                          BroadcastExchange #14
+                                            WholeStageCodegen (17)
+                                              Filter [cp_catalog_page_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet spark_catalog.default.catalog_page [cp_catalog_page_sk,cp_catalog_page_id]
                                     InputAdapter
-                                      BroadcastExchange #14
-                                        WholeStageCodegen (18)
-                                          Filter [cp_catalog_page_sk]
-                                            ColumnarToRow
-                                              InputAdapter
-                                                Scan parquet spark_catalog.default.catalog_page [cp_catalog_page_sk,cp_catalog_page_id]
+                                      ReusedExchange [d_date_sk] #4
                     WholeStageCodegen (30)
                       HashAggregate [web_site_id,sum,sum,isEmpty,sum,isEmpty] [sum(UnscaledValue(ws_ext_sales_price)),sum(coalesce(cast(wr_return_amt as decimal(12,2)), 0.00)),sum((ws_net_profit - coalesce(cast(wr_net_loss as decimal(12,2)), 0.00))),sales,returns,profit,channel,id,sum,sum,isEmpty,sum,isEmpty]
                         InputAdapter
@@ -158,13 +158,13 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                             WholeStageCodegen (29)
                               HashAggregate [web_site_id,ws_ext_sales_price,wr_return_amt,ws_net_profit,wr_net_loss] [sum,sum,isEmpty,sum,isEmpty,sum,sum,isEmpty,sum,isEmpty]
                                 Project [ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss,web_site_id]
-                                  BroadcastHashJoin [ws_web_site_sk,web_site_sk]
-                                    Project [ws_web_site_sk,ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss]
-                                      BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                  BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                    Project [ws_ext_sales_price,ws_net_profit,ws_sold_date_sk,wr_return_amt,wr_net_loss,web_site_id]
+                                      BroadcastHashJoin [ws_web_site_sk,web_site_sk]
                                         Project [ws_web_site_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk,wr_return_amt,wr_net_loss]
-                                          BroadcastHashJoin [ws_promo_sk,p_promo_sk]
-                                            Project [ws_web_site_sk,ws_promo_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk,wr_return_amt,wr_net_loss]
-                                              BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                          BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                            Project [ws_item_sk,ws_web_site_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk,wr_return_amt,wr_net_loss]
+                                              BroadcastHashJoin [ws_promo_sk,p_promo_sk]
                                                 Project [ws_item_sk,ws_web_site_sk,ws_promo_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk,wr_return_amt,wr_net_loss]
                                                   SortMergeJoin [ws_item_sk,ws_order_number,wr_item_sk,wr_order_number]
                                                     InputAdapter
@@ -174,8 +174,8 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                             Exchange [ws_item_sk,ws_order_number] #16
                                                               WholeStageCodegen (21)
                                                                 Filter [ws_web_site_sk,ws_item_sk,ws_promo_sk]
-                                                                  ReusedSubquery [bloomFilter] #2
                                                                   ReusedSubquery [bloomFilter] #3
+                                                                  ReusedSubquery [bloomFilter] #2
                                                                   ColumnarToRow
                                                                     InputAdapter
                                                                       Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_web_site_sk,ws_promo_sk,ws_order_number,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk]
@@ -192,15 +192,15 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_order_number,wr_return_amt,wr_net_loss,wr_returned_date_sk]
                                                 InputAdapter
-                                                  ReusedExchange [i_item_sk] #8
+                                                  ReusedExchange [p_promo_sk] #9
                                             InputAdapter
-                                              ReusedExchange [p_promo_sk] #9
+                                              ReusedExchange [i_item_sk] #8
                                         InputAdapter
-                                          ReusedExchange [d_date_sk] #4
+                                          BroadcastExchange #18
+                                            WholeStageCodegen (27)
+                                              Filter [web_site_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet spark_catalog.default.web_site [web_site_sk,web_site_id]
                                     InputAdapter
-                                      BroadcastExchange #18
-                                        WholeStageCodegen (28)
-                                          Filter [web_site_sk]
-                                            ColumnarToRow
-                                              InputAdapter
-                                                Scan parquet spark_catalog.default.web_site [web_site_sk,web_site_id]
+                                      ReusedExchange [d_date_sk] #4

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q81.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q81.sf100/explain.txt
@@ -1,335 +1,335 @@
 == Physical Plan ==
 TakeOrderedAndProject (57)
 +- * Project (56)
-   +- * BroadcastHashJoin Inner BuildRight (55)
-      :- * Project (34)
-      :  +- * SortMergeJoin Inner (33)
-      :     :- * Sort (11)
-      :     :  +- Exchange (10)
-      :     :     +- * Project (9)
-      :     :        +- * BroadcastHashJoin Inner BuildRight (8)
-      :     :           :- * Filter (3)
-      :     :           :  +- * ColumnarToRow (2)
-      :     :           :     +- Scan parquet spark_catalog.default.customer (1)
-      :     :           +- BroadcastExchange (7)
-      :     :              +- * Filter (6)
-      :     :                 +- * ColumnarToRow (5)
-      :     :                    +- Scan parquet spark_catalog.default.customer_address (4)
-      :     +- * Sort (32)
-      :        +- Exchange (31)
-      :           +- * Filter (30)
-      :              +- * HashAggregate (29)
-      :                 +- Exchange (28)
-      :                    +- * HashAggregate (27)
-      :                       +- * Project (26)
-      :                          +- * SortMergeJoin Inner (25)
-      :                             :- * Sort (19)
-      :                             :  +- Exchange (18)
-      :                             :     +- * Project (17)
-      :                             :        +- * BroadcastHashJoin Inner BuildRight (16)
-      :                             :           :- * Filter (14)
-      :                             :           :  +- * ColumnarToRow (13)
-      :                             :           :     +- Scan parquet spark_catalog.default.catalog_returns (12)
-      :                             :           +- ReusedExchange (15)
-      :                             +- * Sort (24)
-      :                                +- Exchange (23)
-      :                                   +- * Filter (22)
-      :                                      +- * ColumnarToRow (21)
-      :                                         +- Scan parquet spark_catalog.default.customer_address (20)
-      +- BroadcastExchange (54)
-         +- * Filter (53)
-            +- * HashAggregate (52)
-               +- Exchange (51)
-                  +- * HashAggregate (50)
-                     +- * HashAggregate (49)
-                        +- Exchange (48)
-                           +- * HashAggregate (47)
-                              +- * Project (46)
-                                 +- * SortMergeJoin Inner (45)
-                                    :- * Sort (42)
-                                    :  +- Exchange (41)
-                                    :     +- * Project (40)
-                                    :        +- * BroadcastHashJoin Inner BuildRight (39)
-                                    :           :- * Filter (37)
-                                    :           :  +- * ColumnarToRow (36)
-                                    :           :     +- Scan parquet spark_catalog.default.catalog_returns (35)
-                                    :           +- ReusedExchange (38)
-                                    +- * Sort (44)
-                                       +- ReusedExchange (43)
+   +- * SortMergeJoin Inner (55)
+      :- * Sort (43)
+      :  +- Exchange (42)
+      :     +- * Project (41)
+      :        +- * BroadcastHashJoin Inner BuildRight (40)
+      :           :- * Filter (19)
+      :           :  +- * HashAggregate (18)
+      :           :     +- Exchange (17)
+      :           :        +- * HashAggregate (16)
+      :           :           +- * Project (15)
+      :           :              +- * SortMergeJoin Inner (14)
+      :           :                 :- * Sort (8)
+      :           :                 :  +- Exchange (7)
+      :           :                 :     +- * Project (6)
+      :           :                 :        +- * BroadcastHashJoin Inner BuildRight (5)
+      :           :                 :           :- * Filter (3)
+      :           :                 :           :  +- * ColumnarToRow (2)
+      :           :                 :           :     +- Scan parquet spark_catalog.default.catalog_returns (1)
+      :           :                 :           +- ReusedExchange (4)
+      :           :                 +- * Sort (13)
+      :           :                    +- Exchange (12)
+      :           :                       +- * Filter (11)
+      :           :                          +- * ColumnarToRow (10)
+      :           :                             +- Scan parquet spark_catalog.default.customer_address (9)
+      :           +- BroadcastExchange (39)
+      :              +- * Filter (38)
+      :                 +- * HashAggregate (37)
+      :                    +- Exchange (36)
+      :                       +- * HashAggregate (35)
+      :                          +- * HashAggregate (34)
+      :                             +- Exchange (33)
+      :                                +- * HashAggregate (32)
+      :                                   +- * Project (31)
+      :                                      +- * SortMergeJoin Inner (30)
+      :                                         :- * Sort (27)
+      :                                         :  +- Exchange (26)
+      :                                         :     +- * Project (25)
+      :                                         :        +- * BroadcastHashJoin Inner BuildRight (24)
+      :                                         :           :- * Filter (22)
+      :                                         :           :  +- * ColumnarToRow (21)
+      :                                         :           :     +- Scan parquet spark_catalog.default.catalog_returns (20)
+      :                                         :           +- ReusedExchange (23)
+      :                                         +- * Sort (29)
+      :                                            +- ReusedExchange (28)
+      +- * Sort (54)
+         +- Exchange (53)
+            +- * Project (52)
+               +- * BroadcastHashJoin Inner BuildRight (51)
+                  :- * Filter (46)
+                  :  +- * ColumnarToRow (45)
+                  :     +- Scan parquet spark_catalog.default.customer (44)
+                  +- BroadcastExchange (50)
+                     +- * Filter (49)
+                        +- * ColumnarToRow (48)
+                           +- Scan parquet spark_catalog.default.customer_address (47)
 
 
-(1) Scan parquet spark_catalog.default.customer
-Output [6]: [c_customer_sk#1, c_customer_id#2, c_current_addr_sk#3, c_salutation#4, c_first_name#5, c_last_name#6]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer]
-PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
-ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_current_addr_sk:int,c_salutation:string,c_first_name:string,c_last_name:string>
-
-(2) ColumnarToRow [codegen id : 2]
-Input [6]: [c_customer_sk#1, c_customer_id#2, c_current_addr_sk#3, c_salutation#4, c_first_name#5, c_last_name#6]
-
-(3) Filter [codegen id : 2]
-Input [6]: [c_customer_sk#1, c_customer_id#2, c_current_addr_sk#3, c_salutation#4, c_first_name#5, c_last_name#6]
-Condition : (isnotnull(c_customer_sk#1) AND isnotnull(c_current_addr_sk#3))
-
-(4) Scan parquet spark_catalog.default.customer_address
-Output [12]: [ca_address_sk#7, ca_street_number#8, ca_street_name#9, ca_street_type#10, ca_suite_number#11, ca_city#12, ca_county#13, ca_state#14, ca_zip#15, ca_country#16, ca_gmt_offset#17, ca_location_type#18]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,GA), IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_street_number:string,ca_street_name:string,ca_street_type:string,ca_suite_number:string,ca_city:string,ca_county:string,ca_state:string,ca_zip:string,ca_country:string,ca_gmt_offset:decimal(5,2),ca_location_type:string>
-
-(5) ColumnarToRow [codegen id : 1]
-Input [12]: [ca_address_sk#7, ca_street_number#8, ca_street_name#9, ca_street_type#10, ca_suite_number#11, ca_city#12, ca_county#13, ca_state#14, ca_zip#15, ca_country#16, ca_gmt_offset#17, ca_location_type#18]
-
-(6) Filter [codegen id : 1]
-Input [12]: [ca_address_sk#7, ca_street_number#8, ca_street_name#9, ca_street_type#10, ca_suite_number#11, ca_city#12, ca_county#13, ca_state#14, ca_zip#15, ca_country#16, ca_gmt_offset#17, ca_location_type#18]
-Condition : ((isnotnull(ca_state#14) AND (ca_state#14 = GA)) AND isnotnull(ca_address_sk#7))
-
-(7) BroadcastExchange
-Input [12]: [ca_address_sk#7, ca_street_number#8, ca_street_name#9, ca_street_type#10, ca_suite_number#11, ca_city#12, ca_county#13, ca_state#14, ca_zip#15, ca_country#16, ca_gmt_offset#17, ca_location_type#18]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
-
-(8) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [c_current_addr_sk#3]
-Right keys [1]: [ca_address_sk#7]
-Join type: Inner
-Join condition: None
-
-(9) Project [codegen id : 2]
-Output [16]: [c_customer_sk#1, c_customer_id#2, c_salutation#4, c_first_name#5, c_last_name#6, ca_street_number#8, ca_street_name#9, ca_street_type#10, ca_suite_number#11, ca_city#12, ca_county#13, ca_state#14, ca_zip#15, ca_country#16, ca_gmt_offset#17, ca_location_type#18]
-Input [18]: [c_customer_sk#1, c_customer_id#2, c_current_addr_sk#3, c_salutation#4, c_first_name#5, c_last_name#6, ca_address_sk#7, ca_street_number#8, ca_street_name#9, ca_street_type#10, ca_suite_number#11, ca_city#12, ca_county#13, ca_state#14, ca_zip#15, ca_country#16, ca_gmt_offset#17, ca_location_type#18]
-
-(10) Exchange
-Input [16]: [c_customer_sk#1, c_customer_id#2, c_salutation#4, c_first_name#5, c_last_name#6, ca_street_number#8, ca_street_name#9, ca_street_type#10, ca_suite_number#11, ca_city#12, ca_county#13, ca_state#14, ca_zip#15, ca_country#16, ca_gmt_offset#17, ca_location_type#18]
-Arguments: hashpartitioning(c_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
-
-(11) Sort [codegen id : 3]
-Input [16]: [c_customer_sk#1, c_customer_id#2, c_salutation#4, c_first_name#5, c_last_name#6, ca_street_number#8, ca_street_name#9, ca_street_type#10, ca_suite_number#11, ca_city#12, ca_county#13, ca_state#14, ca_zip#15, ca_country#16, ca_gmt_offset#17, ca_location_type#18]
-Arguments: [c_customer_sk#1 ASC NULLS FIRST], false, 0
-
-(12) Scan parquet spark_catalog.default.catalog_returns
-Output [4]: [cr_returning_customer_sk#19, cr_returning_addr_sk#20, cr_return_amt_inc_tax#21, cr_returned_date_sk#22]
+(1) Scan parquet spark_catalog.default.catalog_returns
+Output [4]: [cr_returning_customer_sk#1, cr_returning_addr_sk#2, cr_return_amt_inc_tax#3, cr_returned_date_sk#4]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cr_returned_date_sk#22), dynamicpruningexpression(cr_returned_date_sk#22 IN dynamicpruning#23)]
+PartitionFilters: [isnotnull(cr_returned_date_sk#4), dynamicpruningexpression(cr_returned_date_sk#4 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(cr_returning_addr_sk), IsNotNull(cr_returning_customer_sk)]
 ReadSchema: struct<cr_returning_customer_sk:int,cr_returning_addr_sk:int,cr_return_amt_inc_tax:decimal(7,2)>
 
-(13) ColumnarToRow [codegen id : 5]
-Input [4]: [cr_returning_customer_sk#19, cr_returning_addr_sk#20, cr_return_amt_inc_tax#21, cr_returned_date_sk#22]
+(2) ColumnarToRow [codegen id : 2]
+Input [4]: [cr_returning_customer_sk#1, cr_returning_addr_sk#2, cr_return_amt_inc_tax#3, cr_returned_date_sk#4]
 
-(14) Filter [codegen id : 5]
-Input [4]: [cr_returning_customer_sk#19, cr_returning_addr_sk#20, cr_return_amt_inc_tax#21, cr_returned_date_sk#22]
-Condition : (isnotnull(cr_returning_addr_sk#20) AND isnotnull(cr_returning_customer_sk#19))
+(3) Filter [codegen id : 2]
+Input [4]: [cr_returning_customer_sk#1, cr_returning_addr_sk#2, cr_return_amt_inc_tax#3, cr_returned_date_sk#4]
+Condition : (isnotnull(cr_returning_addr_sk#2) AND isnotnull(cr_returning_customer_sk#1))
 
-(15) ReusedExchange [Reuses operator id: 62]
-Output [1]: [d_date_sk#24]
+(4) ReusedExchange [Reuses operator id: 62]
+Output [1]: [d_date_sk#6]
 
-(16) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [cr_returned_date_sk#22]
-Right keys [1]: [d_date_sk#24]
+(5) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [cr_returned_date_sk#4]
+Right keys [1]: [d_date_sk#6]
 Join type: Inner
 Join condition: None
 
-(17) Project [codegen id : 5]
-Output [3]: [cr_returning_customer_sk#19, cr_returning_addr_sk#20, cr_return_amt_inc_tax#21]
-Input [5]: [cr_returning_customer_sk#19, cr_returning_addr_sk#20, cr_return_amt_inc_tax#21, cr_returned_date_sk#22, d_date_sk#24]
+(6) Project [codegen id : 2]
+Output [3]: [cr_returning_customer_sk#1, cr_returning_addr_sk#2, cr_return_amt_inc_tax#3]
+Input [5]: [cr_returning_customer_sk#1, cr_returning_addr_sk#2, cr_return_amt_inc_tax#3, cr_returned_date_sk#4, d_date_sk#6]
 
-(18) Exchange
-Input [3]: [cr_returning_customer_sk#19, cr_returning_addr_sk#20, cr_return_amt_inc_tax#21]
-Arguments: hashpartitioning(cr_returning_addr_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+(7) Exchange
+Input [3]: [cr_returning_customer_sk#1, cr_returning_addr_sk#2, cr_return_amt_inc_tax#3]
+Arguments: hashpartitioning(cr_returning_addr_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 
-(19) Sort [codegen id : 6]
-Input [3]: [cr_returning_customer_sk#19, cr_returning_addr_sk#20, cr_return_amt_inc_tax#21]
-Arguments: [cr_returning_addr_sk#20 ASC NULLS FIRST], false, 0
+(8) Sort [codegen id : 3]
+Input [3]: [cr_returning_customer_sk#1, cr_returning_addr_sk#2, cr_return_amt_inc_tax#3]
+Arguments: [cr_returning_addr_sk#2 ASC NULLS FIRST], false, 0
 
-(20) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#25, ca_state#26]
+(9) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#7, ca_state#8]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_state)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(21) ColumnarToRow [codegen id : 7]
-Input [2]: [ca_address_sk#25, ca_state#26]
+(10) ColumnarToRow [codegen id : 4]
+Input [2]: [ca_address_sk#7, ca_state#8]
 
-(22) Filter [codegen id : 7]
-Input [2]: [ca_address_sk#25, ca_state#26]
-Condition : (isnotnull(ca_address_sk#25) AND isnotnull(ca_state#26))
+(11) Filter [codegen id : 4]
+Input [2]: [ca_address_sk#7, ca_state#8]
+Condition : (isnotnull(ca_address_sk#7) AND isnotnull(ca_state#8))
 
-(23) Exchange
-Input [2]: [ca_address_sk#25, ca_state#26]
-Arguments: hashpartitioning(ca_address_sk#25, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+(12) Exchange
+Input [2]: [ca_address_sk#7, ca_state#8]
+Arguments: hashpartitioning(ca_address_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(24) Sort [codegen id : 8]
-Input [2]: [ca_address_sk#25, ca_state#26]
-Arguments: [ca_address_sk#25 ASC NULLS FIRST], false, 0
+(13) Sort [codegen id : 5]
+Input [2]: [ca_address_sk#7, ca_state#8]
+Arguments: [ca_address_sk#7 ASC NULLS FIRST], false, 0
 
-(25) SortMergeJoin [codegen id : 9]
-Left keys [1]: [cr_returning_addr_sk#20]
-Right keys [1]: [ca_address_sk#25]
+(14) SortMergeJoin [codegen id : 6]
+Left keys [1]: [cr_returning_addr_sk#2]
+Right keys [1]: [ca_address_sk#7]
 Join type: Inner
 Join condition: None
 
-(26) Project [codegen id : 9]
-Output [3]: [cr_returning_customer_sk#19, cr_return_amt_inc_tax#21, ca_state#26]
-Input [5]: [cr_returning_customer_sk#19, cr_returning_addr_sk#20, cr_return_amt_inc_tax#21, ca_address_sk#25, ca_state#26]
+(15) Project [codegen id : 6]
+Output [3]: [cr_returning_customer_sk#1, cr_return_amt_inc_tax#3, ca_state#8]
+Input [5]: [cr_returning_customer_sk#1, cr_returning_addr_sk#2, cr_return_amt_inc_tax#3, ca_address_sk#7, ca_state#8]
 
-(27) HashAggregate [codegen id : 9]
-Input [3]: [cr_returning_customer_sk#19, cr_return_amt_inc_tax#21, ca_state#26]
-Keys [2]: [cr_returning_customer_sk#19, ca_state#26]
-Functions [1]: [partial_sum(UnscaledValue(cr_return_amt_inc_tax#21))]
-Aggregate Attributes [1]: [sum#27]
-Results [3]: [cr_returning_customer_sk#19, ca_state#26, sum#28]
+(16) HashAggregate [codegen id : 6]
+Input [3]: [cr_returning_customer_sk#1, cr_return_amt_inc_tax#3, ca_state#8]
+Keys [2]: [cr_returning_customer_sk#1, ca_state#8]
+Functions [1]: [partial_sum(UnscaledValue(cr_return_amt_inc_tax#3))]
+Aggregate Attributes [1]: [sum#9]
+Results [3]: [cr_returning_customer_sk#1, ca_state#8, sum#10]
 
-(28) Exchange
-Input [3]: [cr_returning_customer_sk#19, ca_state#26, sum#28]
-Arguments: hashpartitioning(cr_returning_customer_sk#19, ca_state#26, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(17) Exchange
+Input [3]: [cr_returning_customer_sk#1, ca_state#8, sum#10]
+Arguments: hashpartitioning(cr_returning_customer_sk#1, ca_state#8, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(29) HashAggregate [codegen id : 10]
-Input [3]: [cr_returning_customer_sk#19, ca_state#26, sum#28]
-Keys [2]: [cr_returning_customer_sk#19, ca_state#26]
-Functions [1]: [sum(UnscaledValue(cr_return_amt_inc_tax#21))]
-Aggregate Attributes [1]: [sum(UnscaledValue(cr_return_amt_inc_tax#21))#29]
-Results [3]: [cr_returning_customer_sk#19 AS ctr_customer_sk#30, ca_state#26 AS ctr_state#31, MakeDecimal(sum(UnscaledValue(cr_return_amt_inc_tax#21))#29,17,2) AS ctr_total_return#32]
+(18) HashAggregate [codegen id : 15]
+Input [3]: [cr_returning_customer_sk#1, ca_state#8, sum#10]
+Keys [2]: [cr_returning_customer_sk#1, ca_state#8]
+Functions [1]: [sum(UnscaledValue(cr_return_amt_inc_tax#3))]
+Aggregate Attributes [1]: [sum(UnscaledValue(cr_return_amt_inc_tax#3))#11]
+Results [3]: [cr_returning_customer_sk#1 AS ctr_customer_sk#12, ca_state#8 AS ctr_state#13, MakeDecimal(sum(UnscaledValue(cr_return_amt_inc_tax#3))#11,17,2) AS ctr_total_return#14]
 
-(30) Filter [codegen id : 10]
-Input [3]: [ctr_customer_sk#30, ctr_state#31, ctr_total_return#32]
-Condition : isnotnull(ctr_total_return#32)
+(19) Filter [codegen id : 15]
+Input [3]: [ctr_customer_sk#12, ctr_state#13, ctr_total_return#14]
+Condition : isnotnull(ctr_total_return#14)
 
-(31) Exchange
-Input [3]: [ctr_customer_sk#30, ctr_state#31, ctr_total_return#32]
-Arguments: hashpartitioning(ctr_customer_sk#30, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(32) Sort [codegen id : 11]
-Input [3]: [ctr_customer_sk#30, ctr_state#31, ctr_total_return#32]
-Arguments: [ctr_customer_sk#30 ASC NULLS FIRST], false, 0
-
-(33) SortMergeJoin [codegen id : 20]
-Left keys [1]: [c_customer_sk#1]
-Right keys [1]: [ctr_customer_sk#30]
-Join type: Inner
-Join condition: None
-
-(34) Project [codegen id : 20]
-Output [17]: [c_customer_id#2, c_salutation#4, c_first_name#5, c_last_name#6, ca_street_number#8, ca_street_name#9, ca_street_type#10, ca_suite_number#11, ca_city#12, ca_county#13, ca_state#14, ca_zip#15, ca_country#16, ca_gmt_offset#17, ca_location_type#18, ctr_state#31, ctr_total_return#32]
-Input [19]: [c_customer_sk#1, c_customer_id#2, c_salutation#4, c_first_name#5, c_last_name#6, ca_street_number#8, ca_street_name#9, ca_street_type#10, ca_suite_number#11, ca_city#12, ca_county#13, ca_state#14, ca_zip#15, ca_country#16, ca_gmt_offset#17, ca_location_type#18, ctr_customer_sk#30, ctr_state#31, ctr_total_return#32]
-
-(35) Scan parquet spark_catalog.default.catalog_returns
-Output [4]: [cr_returning_customer_sk#33, cr_returning_addr_sk#34, cr_return_amt_inc_tax#35, cr_returned_date_sk#36]
+(20) Scan parquet spark_catalog.default.catalog_returns
+Output [4]: [cr_returning_customer_sk#15, cr_returning_addr_sk#16, cr_return_amt_inc_tax#17, cr_returned_date_sk#18]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cr_returned_date_sk#36), dynamicpruningexpression(cr_returned_date_sk#36 IN dynamicpruning#23)]
+PartitionFilters: [isnotnull(cr_returned_date_sk#18), dynamicpruningexpression(cr_returned_date_sk#18 IN dynamicpruning#5)]
 PushedFilters: [IsNotNull(cr_returning_addr_sk)]
 ReadSchema: struct<cr_returning_customer_sk:int,cr_returning_addr_sk:int,cr_return_amt_inc_tax:decimal(7,2)>
 
-(36) ColumnarToRow [codegen id : 13]
-Input [4]: [cr_returning_customer_sk#33, cr_returning_addr_sk#34, cr_return_amt_inc_tax#35, cr_returned_date_sk#36]
+(21) ColumnarToRow [codegen id : 8]
+Input [4]: [cr_returning_customer_sk#15, cr_returning_addr_sk#16, cr_return_amt_inc_tax#17, cr_returned_date_sk#18]
 
-(37) Filter [codegen id : 13]
-Input [4]: [cr_returning_customer_sk#33, cr_returning_addr_sk#34, cr_return_amt_inc_tax#35, cr_returned_date_sk#36]
-Condition : isnotnull(cr_returning_addr_sk#34)
+(22) Filter [codegen id : 8]
+Input [4]: [cr_returning_customer_sk#15, cr_returning_addr_sk#16, cr_return_amt_inc_tax#17, cr_returned_date_sk#18]
+Condition : isnotnull(cr_returning_addr_sk#16)
 
-(38) ReusedExchange [Reuses operator id: 62]
-Output [1]: [d_date_sk#37]
+(23) ReusedExchange [Reuses operator id: 62]
+Output [1]: [d_date_sk#19]
 
-(39) BroadcastHashJoin [codegen id : 13]
-Left keys [1]: [cr_returned_date_sk#36]
-Right keys [1]: [d_date_sk#37]
+(24) BroadcastHashJoin [codegen id : 8]
+Left keys [1]: [cr_returned_date_sk#18]
+Right keys [1]: [d_date_sk#19]
 Join type: Inner
 Join condition: None
 
-(40) Project [codegen id : 13]
-Output [3]: [cr_returning_customer_sk#33, cr_returning_addr_sk#34, cr_return_amt_inc_tax#35]
-Input [5]: [cr_returning_customer_sk#33, cr_returning_addr_sk#34, cr_return_amt_inc_tax#35, cr_returned_date_sk#36, d_date_sk#37]
+(25) Project [codegen id : 8]
+Output [3]: [cr_returning_customer_sk#15, cr_returning_addr_sk#16, cr_return_amt_inc_tax#17]
+Input [5]: [cr_returning_customer_sk#15, cr_returning_addr_sk#16, cr_return_amt_inc_tax#17, cr_returned_date_sk#18, d_date_sk#19]
 
-(41) Exchange
-Input [3]: [cr_returning_customer_sk#33, cr_returning_addr_sk#34, cr_return_amt_inc_tax#35]
-Arguments: hashpartitioning(cr_returning_addr_sk#34, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(26) Exchange
+Input [3]: [cr_returning_customer_sk#15, cr_returning_addr_sk#16, cr_return_amt_inc_tax#17]
+Arguments: hashpartitioning(cr_returning_addr_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(42) Sort [codegen id : 14]
-Input [3]: [cr_returning_customer_sk#33, cr_returning_addr_sk#34, cr_return_amt_inc_tax#35]
-Arguments: [cr_returning_addr_sk#34 ASC NULLS FIRST], false, 0
+(27) Sort [codegen id : 9]
+Input [3]: [cr_returning_customer_sk#15, cr_returning_addr_sk#16, cr_return_amt_inc_tax#17]
+Arguments: [cr_returning_addr_sk#16 ASC NULLS FIRST], false, 0
 
-(43) ReusedExchange [Reuses operator id: 23]
-Output [2]: [ca_address_sk#38, ca_state#39]
+(28) ReusedExchange [Reuses operator id: 12]
+Output [2]: [ca_address_sk#20, ca_state#21]
 
-(44) Sort [codegen id : 16]
-Input [2]: [ca_address_sk#38, ca_state#39]
-Arguments: [ca_address_sk#38 ASC NULLS FIRST], false, 0
+(29) Sort [codegen id : 11]
+Input [2]: [ca_address_sk#20, ca_state#21]
+Arguments: [ca_address_sk#20 ASC NULLS FIRST], false, 0
 
-(45) SortMergeJoin [codegen id : 17]
-Left keys [1]: [cr_returning_addr_sk#34]
+(30) SortMergeJoin [codegen id : 12]
+Left keys [1]: [cr_returning_addr_sk#16]
+Right keys [1]: [ca_address_sk#20]
+Join type: Inner
+Join condition: None
+
+(31) Project [codegen id : 12]
+Output [3]: [cr_returning_customer_sk#15, cr_return_amt_inc_tax#17, ca_state#21]
+Input [5]: [cr_returning_customer_sk#15, cr_returning_addr_sk#16, cr_return_amt_inc_tax#17, ca_address_sk#20, ca_state#21]
+
+(32) HashAggregate [codegen id : 12]
+Input [3]: [cr_returning_customer_sk#15, cr_return_amt_inc_tax#17, ca_state#21]
+Keys [2]: [cr_returning_customer_sk#15, ca_state#21]
+Functions [1]: [partial_sum(UnscaledValue(cr_return_amt_inc_tax#17))]
+Aggregate Attributes [1]: [sum#22]
+Results [3]: [cr_returning_customer_sk#15, ca_state#21, sum#23]
+
+(33) Exchange
+Input [3]: [cr_returning_customer_sk#15, ca_state#21, sum#23]
+Arguments: hashpartitioning(cr_returning_customer_sk#15, ca_state#21, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(34) HashAggregate [codegen id : 13]
+Input [3]: [cr_returning_customer_sk#15, ca_state#21, sum#23]
+Keys [2]: [cr_returning_customer_sk#15, ca_state#21]
+Functions [1]: [sum(UnscaledValue(cr_return_amt_inc_tax#17))]
+Aggregate Attributes [1]: [sum(UnscaledValue(cr_return_amt_inc_tax#17))#11]
+Results [2]: [ca_state#21 AS ctr_state#24, MakeDecimal(sum(UnscaledValue(cr_return_amt_inc_tax#17))#11,17,2) AS ctr_total_return#25]
+
+(35) HashAggregate [codegen id : 13]
+Input [2]: [ctr_state#24, ctr_total_return#25]
+Keys [1]: [ctr_state#24]
+Functions [1]: [partial_avg(ctr_total_return#25)]
+Aggregate Attributes [2]: [sum#26, count#27]
+Results [3]: [ctr_state#24, sum#28, count#29]
+
+(36) Exchange
+Input [3]: [ctr_state#24, sum#28, count#29]
+Arguments: hashpartitioning(ctr_state#24, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(37) HashAggregate [codegen id : 14]
+Input [3]: [ctr_state#24, sum#28, count#29]
+Keys [1]: [ctr_state#24]
+Functions [1]: [avg(ctr_total_return#25)]
+Aggregate Attributes [1]: [avg(ctr_total_return#25)#30]
+Results [2]: [(avg(ctr_total_return#25)#30 * 1.2) AS (avg(ctr_total_return) * 1.2)#31, ctr_state#24]
+
+(38) Filter [codegen id : 14]
+Input [2]: [(avg(ctr_total_return) * 1.2)#31, ctr_state#24]
+Condition : isnotnull((avg(ctr_total_return) * 1.2)#31)
+
+(39) BroadcastExchange
+Input [2]: [(avg(ctr_total_return) * 1.2)#31, ctr_state#24]
+Arguments: HashedRelationBroadcastMode(List(input[1, string, true]),false), [plan_id=7]
+
+(40) BroadcastHashJoin [codegen id : 15]
+Left keys [1]: [ctr_state#13]
+Right keys [1]: [ctr_state#24]
+Join type: Inner
+Join condition: (cast(ctr_total_return#14 as decimal(24,7)) > (avg(ctr_total_return) * 1.2)#31)
+
+(41) Project [codegen id : 15]
+Output [2]: [ctr_customer_sk#12, ctr_total_return#14]
+Input [5]: [ctr_customer_sk#12, ctr_state#13, ctr_total_return#14, (avg(ctr_total_return) * 1.2)#31, ctr_state#24]
+
+(42) Exchange
+Input [2]: [ctr_customer_sk#12, ctr_total_return#14]
+Arguments: hashpartitioning(ctr_customer_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(43) Sort [codegen id : 16]
+Input [2]: [ctr_customer_sk#12, ctr_total_return#14]
+Arguments: [ctr_customer_sk#12 ASC NULLS FIRST], false, 0
+
+(44) Scan parquet spark_catalog.default.customer
+Output [6]: [c_customer_sk#32, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk)]
+ReadSchema: struct<c_customer_sk:int,c_customer_id:string,c_current_addr_sk:int,c_salutation:string,c_first_name:string,c_last_name:string>
+
+(45) ColumnarToRow [codegen id : 18]
+Input [6]: [c_customer_sk#32, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37]
+
+(46) Filter [codegen id : 18]
+Input [6]: [c_customer_sk#32, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37]
+Condition : (isnotnull(c_customer_sk#32) AND isnotnull(c_current_addr_sk#34))
+
+(47) Scan parquet spark_catalog.default.customer_address
+Output [12]: [ca_address_sk#38, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,GA), IsNotNull(ca_address_sk)]
+ReadSchema: struct<ca_address_sk:int,ca_street_number:string,ca_street_name:string,ca_street_type:string,ca_suite_number:string,ca_city:string,ca_county:string,ca_state:string,ca_zip:string,ca_country:string,ca_gmt_offset:decimal(5,2),ca_location_type:string>
+
+(48) ColumnarToRow [codegen id : 17]
+Input [12]: [ca_address_sk#38, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49]
+
+(49) Filter [codegen id : 17]
+Input [12]: [ca_address_sk#38, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49]
+Condition : ((isnotnull(ca_state#45) AND (ca_state#45 = GA)) AND isnotnull(ca_address_sk#38))
+
+(50) BroadcastExchange
+Input [12]: [ca_address_sk#38, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=9]
+
+(51) BroadcastHashJoin [codegen id : 18]
+Left keys [1]: [c_current_addr_sk#34]
 Right keys [1]: [ca_address_sk#38]
 Join type: Inner
 Join condition: None
 
-(46) Project [codegen id : 17]
-Output [3]: [cr_returning_customer_sk#33, cr_return_amt_inc_tax#35, ca_state#39]
-Input [5]: [cr_returning_customer_sk#33, cr_returning_addr_sk#34, cr_return_amt_inc_tax#35, ca_address_sk#38, ca_state#39]
+(52) Project [codegen id : 18]
+Output [16]: [c_customer_sk#32, c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49]
+Input [18]: [c_customer_sk#32, c_customer_id#33, c_current_addr_sk#34, c_salutation#35, c_first_name#36, c_last_name#37, ca_address_sk#38, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49]
 
-(47) HashAggregate [codegen id : 17]
-Input [3]: [cr_returning_customer_sk#33, cr_return_amt_inc_tax#35, ca_state#39]
-Keys [2]: [cr_returning_customer_sk#33, ca_state#39]
-Functions [1]: [partial_sum(UnscaledValue(cr_return_amt_inc_tax#35))]
-Aggregate Attributes [1]: [sum#40]
-Results [3]: [cr_returning_customer_sk#33, ca_state#39, sum#41]
+(53) Exchange
+Input [16]: [c_customer_sk#32, c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49]
+Arguments: hashpartitioning(c_customer_sk#32, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
-(48) Exchange
-Input [3]: [cr_returning_customer_sk#33, ca_state#39, sum#41]
-Arguments: hashpartitioning(cr_returning_customer_sk#33, ca_state#39, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+(54) Sort [codegen id : 19]
+Input [16]: [c_customer_sk#32, c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49]
+Arguments: [c_customer_sk#32 ASC NULLS FIRST], false, 0
 
-(49) HashAggregate [codegen id : 18]
-Input [3]: [cr_returning_customer_sk#33, ca_state#39, sum#41]
-Keys [2]: [cr_returning_customer_sk#33, ca_state#39]
-Functions [1]: [sum(UnscaledValue(cr_return_amt_inc_tax#35))]
-Aggregate Attributes [1]: [sum(UnscaledValue(cr_return_amt_inc_tax#35))#29]
-Results [2]: [ca_state#39 AS ctr_state#42, MakeDecimal(sum(UnscaledValue(cr_return_amt_inc_tax#35))#29,17,2) AS ctr_total_return#43]
-
-(50) HashAggregate [codegen id : 18]
-Input [2]: [ctr_state#42, ctr_total_return#43]
-Keys [1]: [ctr_state#42]
-Functions [1]: [partial_avg(ctr_total_return#43)]
-Aggregate Attributes [2]: [sum#44, count#45]
-Results [3]: [ctr_state#42, sum#46, count#47]
-
-(51) Exchange
-Input [3]: [ctr_state#42, sum#46, count#47]
-Arguments: hashpartitioning(ctr_state#42, 5), ENSURE_REQUIREMENTS, [plan_id=9]
-
-(52) HashAggregate [codegen id : 19]
-Input [3]: [ctr_state#42, sum#46, count#47]
-Keys [1]: [ctr_state#42]
-Functions [1]: [avg(ctr_total_return#43)]
-Aggregate Attributes [1]: [avg(ctr_total_return#43)#48]
-Results [2]: [(avg(ctr_total_return#43)#48 * 1.2) AS (avg(ctr_total_return) * 1.2)#49, ctr_state#42]
-
-(53) Filter [codegen id : 19]
-Input [2]: [(avg(ctr_total_return) * 1.2)#49, ctr_state#42]
-Condition : isnotnull((avg(ctr_total_return) * 1.2)#49)
-
-(54) BroadcastExchange
-Input [2]: [(avg(ctr_total_return) * 1.2)#49, ctr_state#42]
-Arguments: HashedRelationBroadcastMode(List(input[1, string, true]),false), [plan_id=10]
-
-(55) BroadcastHashJoin [codegen id : 20]
-Left keys [1]: [ctr_state#31]
-Right keys [1]: [ctr_state#42]
+(55) SortMergeJoin [codegen id : 20]
+Left keys [1]: [ctr_customer_sk#12]
+Right keys [1]: [c_customer_sk#32]
 Join type: Inner
-Join condition: (cast(ctr_total_return#32 as decimal(24,7)) > (avg(ctr_total_return) * 1.2)#49)
+Join condition: None
 
 (56) Project [codegen id : 20]
-Output [16]: [c_customer_id#2, c_salutation#4, c_first_name#5, c_last_name#6, ca_street_number#8, ca_street_name#9, ca_street_type#10, ca_suite_number#11, ca_city#12, ca_county#13, ca_state#14, ca_zip#15, ca_country#16, ca_gmt_offset#17, ca_location_type#18, ctr_total_return#32]
-Input [19]: [c_customer_id#2, c_salutation#4, c_first_name#5, c_last_name#6, ca_street_number#8, ca_street_name#9, ca_street_type#10, ca_suite_number#11, ca_city#12, ca_county#13, ca_state#14, ca_zip#15, ca_country#16, ca_gmt_offset#17, ca_location_type#18, ctr_state#31, ctr_total_return#32, (avg(ctr_total_return) * 1.2)#49, ctr_state#42]
+Output [16]: [c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49, ctr_total_return#14]
+Input [18]: [ctr_customer_sk#12, ctr_total_return#14, c_customer_sk#32, c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49]
 
 (57) TakeOrderedAndProject
-Input [16]: [c_customer_id#2, c_salutation#4, c_first_name#5, c_last_name#6, ca_street_number#8, ca_street_name#9, ca_street_type#10, ca_suite_number#11, ca_city#12, ca_county#13, ca_state#14, ca_zip#15, ca_country#16, ca_gmt_offset#17, ca_location_type#18, ctr_total_return#32]
-Arguments: 100, [c_customer_id#2 ASC NULLS FIRST, c_salutation#4 ASC NULLS FIRST, c_first_name#5 ASC NULLS FIRST, c_last_name#6 ASC NULLS FIRST, ca_street_number#8 ASC NULLS FIRST, ca_street_name#9 ASC NULLS FIRST, ca_street_type#10 ASC NULLS FIRST, ca_suite_number#11 ASC NULLS FIRST, ca_city#12 ASC NULLS FIRST, ca_county#13 ASC NULLS FIRST, ca_state#14 ASC NULLS FIRST, ca_zip#15 ASC NULLS FIRST, ca_country#16 ASC NULLS FIRST, ca_gmt_offset#17 ASC NULLS FIRST, ca_location_type#18 ASC NULLS FIRST, ctr_total_return#32 ASC NULLS FIRST], [c_customer_id#2, c_salutation#4, c_first_name#5, c_last_name#6, ca_street_number#8, ca_street_name#9, ca_street_type#10, ca_suite_number#11, ca_city#12, ca_county#13, ca_state#14, ca_zip#15, ca_country#16, ca_gmt_offset#17, ca_location_type#18, ctr_total_return#32]
+Input [16]: [c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49, ctr_total_return#14]
+Arguments: 100, [c_customer_id#33 ASC NULLS FIRST, c_salutation#35 ASC NULLS FIRST, c_first_name#36 ASC NULLS FIRST, c_last_name#37 ASC NULLS FIRST, ca_street_number#39 ASC NULLS FIRST, ca_street_name#40 ASC NULLS FIRST, ca_street_type#41 ASC NULLS FIRST, ca_suite_number#42 ASC NULLS FIRST, ca_city#43 ASC NULLS FIRST, ca_county#44 ASC NULLS FIRST, ca_state#45 ASC NULLS FIRST, ca_zip#46 ASC NULLS FIRST, ca_country#47 ASC NULLS FIRST, ca_gmt_offset#48 ASC NULLS FIRST, ca_location_type#49 ASC NULLS FIRST, ctr_total_return#14 ASC NULLS FIRST], [c_customer_id#33, c_salutation#35, c_first_name#36, c_last_name#37, ca_street_number#39, ca_street_name#40, ca_street_type#41, ca_suite_number#42, ca_city#43, ca_county#44, ca_state#45, ca_zip#46, ca_country#47, ca_gmt_offset#48, ca_location_type#49, ctr_total_return#14]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 12 Hosting Expression = cr_returned_date_sk#22 IN dynamicpruning#23
+Subquery:1 Hosting operator id = 1 Hosting Expression = cr_returned_date_sk#4 IN dynamicpruning#5
 BroadcastExchange (62)
 +- * Project (61)
    +- * Filter (60)
@@ -338,27 +338,27 @@ BroadcastExchange (62)
 
 
 (58) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#24, d_year#50]
+Output [2]: [d_date_sk#6, d_year#50]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (59) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#24, d_year#50]
+Input [2]: [d_date_sk#6, d_year#50]
 
 (60) Filter [codegen id : 1]
-Input [2]: [d_date_sk#24, d_year#50]
-Condition : ((isnotnull(d_year#50) AND (d_year#50 = 2000)) AND isnotnull(d_date_sk#24))
+Input [2]: [d_date_sk#6, d_year#50]
+Condition : ((isnotnull(d_year#50) AND (d_year#50 = 2000)) AND isnotnull(d_date_sk#6))
 
 (61) Project [codegen id : 1]
-Output [1]: [d_date_sk#24]
-Input [2]: [d_date_sk#24, d_year#50]
+Output [1]: [d_date_sk#6]
+Input [2]: [d_date_sk#6, d_year#50]
 
 (62) BroadcastExchange
-Input [1]: [d_date_sk#24]
+Input [1]: [d_date_sk#6]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
-Subquery:2 Hosting operator id = 35 Hosting Expression = cr_returned_date_sk#36 IN dynamicpruning#23
+Subquery:2 Hosting operator id = 20 Hosting Expression = cr_returned_date_sk#18 IN dynamicpruning#5
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q81.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q81.sf100/simplified.txt
@@ -1,48 +1,29 @@
 TakeOrderedAndProject [c_customer_id,c_salutation,c_first_name,c_last_name,ca_street_number,ca_street_name,ca_street_type,ca_suite_number,ca_city,ca_county,ca_state,ca_zip,ca_country,ca_gmt_offset,ca_location_type,ctr_total_return]
   WholeStageCodegen (20)
     Project [c_customer_id,c_salutation,c_first_name,c_last_name,ca_street_number,ca_street_name,ca_street_type,ca_suite_number,ca_city,ca_county,ca_state,ca_zip,ca_country,ca_gmt_offset,ca_location_type,ctr_total_return]
-      BroadcastHashJoin [ctr_state,ctr_state,ctr_total_return,(avg(ctr_total_return) * 1.2)]
-        Project [c_customer_id,c_salutation,c_first_name,c_last_name,ca_street_number,ca_street_name,ca_street_type,ca_suite_number,ca_city,ca_county,ca_state,ca_zip,ca_country,ca_gmt_offset,ca_location_type,ctr_state,ctr_total_return]
-          SortMergeJoin [c_customer_sk,ctr_customer_sk]
-            InputAdapter
-              WholeStageCodegen (3)
-                Sort [c_customer_sk]
-                  InputAdapter
-                    Exchange [c_customer_sk] #1
-                      WholeStageCodegen (2)
-                        Project [c_customer_sk,c_customer_id,c_salutation,c_first_name,c_last_name,ca_street_number,ca_street_name,ca_street_type,ca_suite_number,ca_city,ca_county,ca_state,ca_zip,ca_country,ca_gmt_offset,ca_location_type]
-                          BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
-                            Filter [c_customer_sk,c_current_addr_sk]
-                              ColumnarToRow
-                                InputAdapter
-                                  Scan parquet spark_catalog.default.customer [c_customer_sk,c_customer_id,c_current_addr_sk,c_salutation,c_first_name,c_last_name]
-                            InputAdapter
-                              BroadcastExchange #2
-                                WholeStageCodegen (1)
-                                  Filter [ca_state,ca_address_sk]
-                                    ColumnarToRow
-                                      InputAdapter
-                                        Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_street_number,ca_street_name,ca_street_type,ca_suite_number,ca_city,ca_county,ca_state,ca_zip,ca_country,ca_gmt_offset,ca_location_type]
-            InputAdapter
-              WholeStageCodegen (11)
-                Sort [ctr_customer_sk]
-                  InputAdapter
-                    Exchange [ctr_customer_sk] #3
-                      WholeStageCodegen (10)
+      SortMergeJoin [ctr_customer_sk,c_customer_sk]
+        InputAdapter
+          WholeStageCodegen (16)
+            Sort [ctr_customer_sk]
+              InputAdapter
+                Exchange [ctr_customer_sk] #1
+                  WholeStageCodegen (15)
+                    Project [ctr_customer_sk,ctr_total_return]
+                      BroadcastHashJoin [ctr_state,ctr_state,ctr_total_return,(avg(ctr_total_return) * 1.2)]
                         Filter [ctr_total_return]
                           HashAggregate [cr_returning_customer_sk,ca_state,sum] [sum(UnscaledValue(cr_return_amt_inc_tax)),ctr_customer_sk,ctr_state,ctr_total_return,sum]
                             InputAdapter
-                              Exchange [cr_returning_customer_sk,ca_state] #4
-                                WholeStageCodegen (9)
+                              Exchange [cr_returning_customer_sk,ca_state] #2
+                                WholeStageCodegen (6)
                                   HashAggregate [cr_returning_customer_sk,ca_state,cr_return_amt_inc_tax] [sum,sum]
                                     Project [cr_returning_customer_sk,cr_return_amt_inc_tax,ca_state]
                                       SortMergeJoin [cr_returning_addr_sk,ca_address_sk]
                                         InputAdapter
-                                          WholeStageCodegen (6)
+                                          WholeStageCodegen (3)
                                             Sort [cr_returning_addr_sk]
                                               InputAdapter
-                                                Exchange [cr_returning_addr_sk] #5
-                                                  WholeStageCodegen (5)
+                                                Exchange [cr_returning_addr_sk] #3
+                                                  WholeStageCodegen (2)
                                                     Project [cr_returning_customer_sk,cr_returning_addr_sk,cr_return_amt_inc_tax]
                                                       BroadcastHashJoin [cr_returned_date_sk,d_date_sk]
                                                         Filter [cr_returning_addr_sk,cr_returning_customer_sk]
@@ -50,7 +31,7 @@ TakeOrderedAndProject [c_customer_id,c_salutation,c_first_name,c_last_name,ca_st
                                                             InputAdapter
                                                               Scan parquet spark_catalog.default.catalog_returns [cr_returning_customer_sk,cr_returning_addr_sk,cr_return_amt_inc_tax,cr_returned_date_sk]
                                                                 SubqueryBroadcast [d_date_sk] #1
-                                                                  BroadcastExchange #6
+                                                                  BroadcastExchange #4
                                                                     WholeStageCodegen (1)
                                                                       Project [d_date_sk]
                                                                         Filter [d_year,d_date_sk]
@@ -58,50 +39,69 @@ TakeOrderedAndProject [c_customer_id,c_salutation,c_first_name,c_last_name,ca_st
                                                                             InputAdapter
                                                                               Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                                         InputAdapter
-                                                          ReusedExchange [d_date_sk] #6
+                                                          ReusedExchange [d_date_sk] #4
                                         InputAdapter
-                                          WholeStageCodegen (8)
+                                          WholeStageCodegen (5)
                                             Sort [ca_address_sk]
                                               InputAdapter
-                                                Exchange [ca_address_sk] #7
-                                                  WholeStageCodegen (7)
+                                                Exchange [ca_address_sk] #5
+                                                  WholeStageCodegen (4)
                                                     Filter [ca_address_sk,ca_state]
                                                       ColumnarToRow
                                                         InputAdapter
                                                           Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
-        InputAdapter
-          BroadcastExchange #8
-            WholeStageCodegen (19)
-              Filter [(avg(ctr_total_return) * 1.2)]
-                HashAggregate [ctr_state,sum,count] [avg(ctr_total_return),(avg(ctr_total_return) * 1.2),sum,count]
-                  InputAdapter
-                    Exchange [ctr_state] #9
-                      WholeStageCodegen (18)
-                        HashAggregate [ctr_state,ctr_total_return] [sum,count,sum,count]
-                          HashAggregate [cr_returning_customer_sk,ca_state,sum] [sum(UnscaledValue(cr_return_amt_inc_tax)),ctr_state,ctr_total_return,sum]
-                            InputAdapter
-                              Exchange [cr_returning_customer_sk,ca_state] #10
-                                WholeStageCodegen (17)
-                                  HashAggregate [cr_returning_customer_sk,ca_state,cr_return_amt_inc_tax] [sum,sum]
-                                    Project [cr_returning_customer_sk,cr_return_amt_inc_tax,ca_state]
-                                      SortMergeJoin [cr_returning_addr_sk,ca_address_sk]
-                                        InputAdapter
-                                          WholeStageCodegen (14)
-                                            Sort [cr_returning_addr_sk]
-                                              InputAdapter
-                                                Exchange [cr_returning_addr_sk] #11
-                                                  WholeStageCodegen (13)
-                                                    Project [cr_returning_customer_sk,cr_returning_addr_sk,cr_return_amt_inc_tax]
-                                                      BroadcastHashJoin [cr_returned_date_sk,d_date_sk]
-                                                        Filter [cr_returning_addr_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.catalog_returns [cr_returning_customer_sk,cr_returning_addr_sk,cr_return_amt_inc_tax,cr_returned_date_sk]
-                                                                ReusedSubquery [d_date_sk] #1
+                        InputAdapter
+                          BroadcastExchange #6
+                            WholeStageCodegen (14)
+                              Filter [(avg(ctr_total_return) * 1.2)]
+                                HashAggregate [ctr_state,sum,count] [avg(ctr_total_return),(avg(ctr_total_return) * 1.2),sum,count]
+                                  InputAdapter
+                                    Exchange [ctr_state] #7
+                                      WholeStageCodegen (13)
+                                        HashAggregate [ctr_state,ctr_total_return] [sum,count,sum,count]
+                                          HashAggregate [cr_returning_customer_sk,ca_state,sum] [sum(UnscaledValue(cr_return_amt_inc_tax)),ctr_state,ctr_total_return,sum]
+                                            InputAdapter
+                                              Exchange [cr_returning_customer_sk,ca_state] #8
+                                                WholeStageCodegen (12)
+                                                  HashAggregate [cr_returning_customer_sk,ca_state,cr_return_amt_inc_tax] [sum,sum]
+                                                    Project [cr_returning_customer_sk,cr_return_amt_inc_tax,ca_state]
+                                                      SortMergeJoin [cr_returning_addr_sk,ca_address_sk]
                                                         InputAdapter
-                                                          ReusedExchange [d_date_sk] #6
-                                        InputAdapter
-                                          WholeStageCodegen (16)
-                                            Sort [ca_address_sk]
-                                              InputAdapter
-                                                ReusedExchange [ca_address_sk,ca_state] #7
+                                                          WholeStageCodegen (9)
+                                                            Sort [cr_returning_addr_sk]
+                                                              InputAdapter
+                                                                Exchange [cr_returning_addr_sk] #9
+                                                                  WholeStageCodegen (8)
+                                                                    Project [cr_returning_customer_sk,cr_returning_addr_sk,cr_return_amt_inc_tax]
+                                                                      BroadcastHashJoin [cr_returned_date_sk,d_date_sk]
+                                                                        Filter [cr_returning_addr_sk]
+                                                                          ColumnarToRow
+                                                                            InputAdapter
+                                                                              Scan parquet spark_catalog.default.catalog_returns [cr_returning_customer_sk,cr_returning_addr_sk,cr_return_amt_inc_tax,cr_returned_date_sk]
+                                                                                ReusedSubquery [d_date_sk] #1
+                                                                        InputAdapter
+                                                                          ReusedExchange [d_date_sk] #4
+                                                        InputAdapter
+                                                          WholeStageCodegen (11)
+                                                            Sort [ca_address_sk]
+                                                              InputAdapter
+                                                                ReusedExchange [ca_address_sk,ca_state] #5
+        InputAdapter
+          WholeStageCodegen (19)
+            Sort [c_customer_sk]
+              InputAdapter
+                Exchange [c_customer_sk] #10
+                  WholeStageCodegen (18)
+                    Project [c_customer_sk,c_customer_id,c_salutation,c_first_name,c_last_name,ca_street_number,ca_street_name,ca_street_type,ca_suite_number,ca_city,ca_county,ca_state,ca_zip,ca_country,ca_gmt_offset,ca_location_type]
+                      BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
+                        Filter [c_customer_sk,c_current_addr_sk]
+                          ColumnarToRow
+                            InputAdapter
+                              Scan parquet spark_catalog.default.customer [c_customer_sk,c_customer_id,c_current_addr_sk,c_salutation,c_first_name,c_last_name]
+                        InputAdapter
+                          BroadcastExchange #11
+                            WholeStageCodegen (17)
+                              Filter [ca_state,ca_address_sk]
+                                ColumnarToRow
+                                  InputAdapter
+                                    Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_street_number,ca_street_name,ca_street_type,ca_suite_number,ca_city,ca_county,ca_state,ca_zip,ca_country,ca_gmt_offset,ca_location_type]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/explain.txt
@@ -5,28 +5,28 @@ TakeOrderedAndProject (28)
       +- * HashAggregate (25)
          +- * Project (24)
             +- * SortMergeJoin Inner (23)
-               :- * Sort (16)
-               :  +- Exchange (15)
-               :     +- * Project (14)
-               :        +- * BroadcastHashJoin Inner BuildRight (13)
-               :           :- * Project (11)
-               :           :  +- * BroadcastHashJoin Inner BuildLeft (10)
-               :           :     :- BroadcastExchange (5)
-               :           :     :  +- * Project (4)
-               :           :     :     +- * Filter (3)
-               :           :     :        +- * ColumnarToRow (2)
-               :           :     :           +- Scan parquet spark_catalog.default.item (1)
-               :           :     +- * Project (9)
-               :           :        +- * Filter (8)
-               :           :           +- * ColumnarToRow (7)
-               :           :              +- Scan parquet spark_catalog.default.inventory (6)
-               :           +- ReusedExchange (12)
+               :- * Sort (13)
+               :  +- Exchange (12)
+               :     +- * Project (11)
+               :        +- * BroadcastHashJoin Inner BuildLeft (10)
+               :           :- BroadcastExchange (5)
+               :           :  +- * Project (4)
+               :           :     +- * Filter (3)
+               :           :        +- * ColumnarToRow (2)
+               :           :           +- Scan parquet spark_catalog.default.item (1)
+               :           +- * Project (9)
+               :              +- * Filter (8)
+               :                 +- * ColumnarToRow (7)
+               :                    +- Scan parquet spark_catalog.default.store_sales (6)
                +- * Sort (22)
                   +- Exchange (21)
                      +- * Project (20)
-                        +- * Filter (19)
-                           +- * ColumnarToRow (18)
-                              +- Scan parquet spark_catalog.default.store_sales (17)
+                        +- * BroadcastHashJoin Inner BuildRight (19)
+                           :- * Project (17)
+                           :  +- * Filter (16)
+                           :     +- * ColumnarToRow (15)
+                           :        +- Scan parquet spark_catalog.default.inventory (14)
+                           +- ReusedExchange (18)
 
 
 (1) Scan parquet spark_catalog.default.item
@@ -51,91 +51,91 @@ Input [5]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, i_manufa
 Input [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(6) Scan parquet spark_catalog.default.inventory
-Output [3]: [inv_item_sk#6, inv_quantity_on_hand#7, inv_date_sk#8]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(inv_date_sk#8), dynamicpruningexpression(inv_date_sk#8 IN dynamicpruning#9)]
-PushedFilters: [IsNotNull(inv_quantity_on_hand), GreaterThanOrEqual(inv_quantity_on_hand,100), LessThanOrEqual(inv_quantity_on_hand,500), IsNotNull(inv_item_sk)]
-ReadSchema: struct<inv_item_sk:int,inv_quantity_on_hand:int>
-
-(7) ColumnarToRow
-Input [3]: [inv_item_sk#6, inv_quantity_on_hand#7, inv_date_sk#8]
-
-(8) Filter
-Input [3]: [inv_item_sk#6, inv_quantity_on_hand#7, inv_date_sk#8]
-Condition : (((isnotnull(inv_quantity_on_hand#7) AND (inv_quantity_on_hand#7 >= 100)) AND (inv_quantity_on_hand#7 <= 500)) AND isnotnull(inv_item_sk#6))
-
-(9) Project
-Output [2]: [inv_item_sk#6, inv_date_sk#8]
-Input [3]: [inv_item_sk#6, inv_quantity_on_hand#7, inv_date_sk#8]
-
-(10) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [i_item_sk#1]
-Right keys [1]: [inv_item_sk#6]
-Join type: Inner
-Join condition: None
-
-(11) Project [codegen id : 3]
-Output [5]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, inv_date_sk#8]
-Input [6]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, inv_item_sk#6, inv_date_sk#8]
-
-(12) ReusedExchange [Reuses operator id: 33]
-Output [1]: [d_date_sk#10]
-
-(13) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [inv_date_sk#8]
-Right keys [1]: [d_date_sk#10]
-Join type: Inner
-Join condition: None
-
-(14) Project [codegen id : 3]
-Output [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
-Input [6]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, inv_date_sk#8, d_date_sk#10]
-
-(15) Exchange
-Input [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
-Arguments: hashpartitioning(i_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
-
-(16) Sort [codegen id : 4]
-Input [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
-Arguments: [i_item_sk#1 ASC NULLS FIRST], false, 0
-
-(17) Scan parquet spark_catalog.default.store_sales
-Output [2]: [ss_item_sk#11, ss_sold_date_sk#12]
+(6) Scan parquet spark_catalog.default.store_sales
+Output [2]: [ss_item_sk#6, ss_sold_date_sk#7]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int>
 
-(18) ColumnarToRow [codegen id : 5]
-Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
+(7) ColumnarToRow
+Input [2]: [ss_item_sk#6, ss_sold_date_sk#7]
 
-(19) Filter [codegen id : 5]
-Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
-Condition : (isnotnull(ss_item_sk#11) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(ss_item_sk#11, 42)))
+(8) Filter
+Input [2]: [ss_item_sk#6, ss_sold_date_sk#7]
+Condition : isnotnull(ss_item_sk#6)
+
+(9) Project
+Output [1]: [ss_item_sk#6]
+Input [2]: [ss_item_sk#6, ss_sold_date_sk#7]
+
+(10) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [i_item_sk#1]
+Right keys [1]: [ss_item_sk#6]
+Join type: Inner
+Join condition: None
+
+(11) Project [codegen id : 2]
+Output [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
+Input [5]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, ss_item_sk#6]
+
+(12) Exchange
+Input [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
+Arguments: hashpartitioning(i_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+
+(13) Sort [codegen id : 3]
+Input [4]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4]
+Arguments: [i_item_sk#1 ASC NULLS FIRST], false, 0
+
+(14) Scan parquet spark_catalog.default.inventory
+Output [3]: [inv_item_sk#8, inv_quantity_on_hand#9, inv_date_sk#10]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(inv_date_sk#10), dynamicpruningexpression(inv_date_sk#10 IN dynamicpruning#11)]
+PushedFilters: [IsNotNull(inv_quantity_on_hand), GreaterThanOrEqual(inv_quantity_on_hand,100), LessThanOrEqual(inv_quantity_on_hand,500), IsNotNull(inv_item_sk)]
+ReadSchema: struct<inv_item_sk:int,inv_quantity_on_hand:int>
+
+(15) ColumnarToRow [codegen id : 5]
+Input [3]: [inv_item_sk#8, inv_quantity_on_hand#9, inv_date_sk#10]
+
+(16) Filter [codegen id : 5]
+Input [3]: [inv_item_sk#8, inv_quantity_on_hand#9, inv_date_sk#10]
+Condition : (((isnotnull(inv_quantity_on_hand#9) AND (inv_quantity_on_hand#9 >= 100)) AND (inv_quantity_on_hand#9 <= 500)) AND isnotnull(inv_item_sk#8))
+
+(17) Project [codegen id : 5]
+Output [2]: [inv_item_sk#8, inv_date_sk#10]
+Input [3]: [inv_item_sk#8, inv_quantity_on_hand#9, inv_date_sk#10]
+
+(18) ReusedExchange [Reuses operator id: 33]
+Output [1]: [d_date_sk#12]
+
+(19) BroadcastHashJoin [codegen id : 5]
+Left keys [1]: [inv_date_sk#10]
+Right keys [1]: [d_date_sk#12]
+Join type: Inner
+Join condition: None
 
 (20) Project [codegen id : 5]
-Output [1]: [ss_item_sk#11]
-Input [2]: [ss_item_sk#11, ss_sold_date_sk#12]
+Output [1]: [inv_item_sk#8]
+Input [3]: [inv_item_sk#8, inv_date_sk#10, d_date_sk#12]
 
 (21) Exchange
-Input [1]: [ss_item_sk#11]
-Arguments: hashpartitioning(ss_item_sk#11, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [1]: [inv_item_sk#8]
+Arguments: hashpartitioning(inv_item_sk#8, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (22) Sort [codegen id : 6]
-Input [1]: [ss_item_sk#11]
-Arguments: [ss_item_sk#11 ASC NULLS FIRST], false, 0
+Input [1]: [inv_item_sk#8]
+Arguments: [inv_item_sk#8 ASC NULLS FIRST], false, 0
 
 (23) SortMergeJoin [codegen id : 7]
 Left keys [1]: [i_item_sk#1]
-Right keys [1]: [ss_item_sk#11]
+Right keys [1]: [inv_item_sk#8]
 Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 7]
 Output [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
-Input [5]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, ss_item_sk#11]
+Input [5]: [i_item_sk#1, i_item_id#2, i_item_desc#3, i_current_price#4, inv_item_sk#8]
 
 (25) HashAggregate [codegen id : 7]
 Input [3]: [i_item_id#2, i_item_desc#3, i_current_price#4]
@@ -161,7 +161,7 @@ Arguments: 100, [i_item_id#2 ASC NULLS FIRST], [i_item_id#2, i_item_desc#3, i_cu
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 6 Hosting Expression = inv_date_sk#8 IN dynamicpruning#9
+Subquery:1 Hosting operator id = 14 Hosting Expression = inv_date_sk#10 IN dynamicpruning#11
 BroadcastExchange (33)
 +- * Project (32)
    +- * Filter (31)
@@ -170,71 +170,25 @@ BroadcastExchange (33)
 
 
 (29) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#10, d_date#15]
+Output [2]: [d_date_sk#12, d_date#13]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,2000-05-25), LessThanOrEqual(d_date,2000-07-24), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (30) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#10, d_date#15]
+Input [2]: [d_date_sk#12, d_date#13]
 
 (31) Filter [codegen id : 1]
-Input [2]: [d_date_sk#10, d_date#15]
-Condition : (((isnotnull(d_date#15) AND (d_date#15 >= 2000-05-25)) AND (d_date#15 <= 2000-07-24)) AND isnotnull(d_date_sk#10))
+Input [2]: [d_date_sk#12, d_date#13]
+Condition : (((isnotnull(d_date#13) AND (d_date#13 >= 2000-05-25)) AND (d_date#13 <= 2000-07-24)) AND isnotnull(d_date_sk#12))
 
 (32) Project [codegen id : 1]
-Output [1]: [d_date_sk#10]
-Input [2]: [d_date_sk#10, d_date#15]
+Output [1]: [d_date_sk#12]
+Input [2]: [d_date_sk#12, d_date#13]
 
 (33) BroadcastExchange
-Input [1]: [d_date_sk#10]
+Input [1]: [d_date_sk#12]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
-
-Subquery:2 Hosting operator id = 19 Hosting Expression = Subquery scalar-subquery#13, [id=#14]
-ObjectHashAggregate (40)
-+- Exchange (39)
-   +- ObjectHashAggregate (38)
-      +- * Project (37)
-         +- * Filter (36)
-            +- * ColumnarToRow (35)
-               +- Scan parquet spark_catalog.default.item (34)
-
-
-(34) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/item]
-PushedFilters: [IsNotNull(i_current_price), GreaterThanOrEqual(i_current_price,62.00), LessThanOrEqual(i_current_price,92.00), In(i_manufact_id, [129,270,423,821]), IsNotNull(i_item_sk)]
-ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_manufact_id:int>
-
-(35) ColumnarToRow [codegen id : 1]
-Input [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
-
-(36) Filter [codegen id : 1]
-Input [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
-Condition : ((((isnotnull(i_current_price#4) AND (i_current_price#4 >= 62.00)) AND (i_current_price#4 <= 92.00)) AND i_manufact_id#5 IN (129,270,821,423)) AND isnotnull(i_item_sk#1))
-
-(37) Project [codegen id : 1]
-Output [1]: [i_item_sk#1]
-Input [3]: [i_item_sk#1, i_current_price#4, i_manufact_id#5]
-
-(38) ObjectHashAggregate
-Input [1]: [i_item_sk#1]
-Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)]
-Aggregate Attributes [1]: [buf#16]
-Results [1]: [buf#17]
-
-(39) Exchange
-Input [1]: [buf#17]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=6]
-
-(40) ObjectHashAggregate
-Input [1]: [buf#17]
-Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)#18]
-Results [1]: [bloom_filter_agg(xxhash64(i_item_sk#1, 42), 239, 6582, 0, 0)#18 AS bloomFilter#19]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q82.sf100/simplified.txt
@@ -6,58 +6,48 @@ TakeOrderedAndProject [i_item_id,i_item_desc,i_current_price]
           WholeStageCodegen (7)
             HashAggregate [i_item_id,i_item_desc,i_current_price]
               Project [i_item_id,i_item_desc,i_current_price]
-                SortMergeJoin [i_item_sk,ss_item_sk]
+                SortMergeJoin [i_item_sk,inv_item_sk]
                   InputAdapter
-                    WholeStageCodegen (4)
+                    WholeStageCodegen (3)
                       Sort [i_item_sk]
                         InputAdapter
                           Exchange [i_item_sk] #2
-                            WholeStageCodegen (3)
+                            WholeStageCodegen (2)
                               Project [i_item_sk,i_item_id,i_item_desc,i_current_price]
-                                BroadcastHashJoin [inv_date_sk,d_date_sk]
-                                  Project [i_item_sk,i_item_id,i_item_desc,i_current_price,inv_date_sk]
-                                    BroadcastHashJoin [i_item_sk,inv_item_sk]
-                                      InputAdapter
-                                        BroadcastExchange #3
-                                          WholeStageCodegen (1)
-                                            Project [i_item_sk,i_item_id,i_item_desc,i_current_price]
-                                              Filter [i_current_price,i_manufact_id,i_item_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_manufact_id]
-                                      Project [inv_item_sk,inv_date_sk]
-                                        Filter [inv_quantity_on_hand,inv_item_sk]
-                                          ColumnarToRow
-                                            InputAdapter
-                                              Scan parquet spark_catalog.default.inventory [inv_item_sk,inv_quantity_on_hand,inv_date_sk]
-                                                SubqueryBroadcast [d_date_sk] #1
-                                                  BroadcastExchange #4
-                                                    WholeStageCodegen (1)
-                                                      Project [d_date_sk]
-                                                        Filter [d_date,d_date_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
+                                BroadcastHashJoin [i_item_sk,ss_item_sk]
                                   InputAdapter
-                                    ReusedExchange [d_date_sk] #4
+                                    BroadcastExchange #3
+                                      WholeStageCodegen (1)
+                                        Project [i_item_sk,i_item_id,i_item_desc,i_current_price]
+                                          Filter [i_current_price,i_manufact_id,i_item_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet spark_catalog.default.item [i_item_sk,i_item_id,i_item_desc,i_current_price,i_manufact_id]
+                                  Project [ss_item_sk]
+                                    Filter [ss_item_sk]
+                                      ColumnarToRow
+                                        InputAdapter
+                                          Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_sold_date_sk]
                   InputAdapter
                     WholeStageCodegen (6)
-                      Sort [ss_item_sk]
+                      Sort [inv_item_sk]
                         InputAdapter
-                          Exchange [ss_item_sk] #5
+                          Exchange [inv_item_sk] #4
                             WholeStageCodegen (5)
-                              Project [ss_item_sk]
-                                Filter [ss_item_sk]
-                                  Subquery #2
-                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(i_item_sk, 42), 239, 6582, 0, 0),bloomFilter,buf]
-                                      Exchange #6
-                                        ObjectHashAggregate [i_item_sk] [buf,buf]
-                                          WholeStageCodegen (1)
-                                            Project [i_item_sk]
-                                              Filter [i_current_price,i_manufact_id,i_item_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_manufact_id]
-                                  ColumnarToRow
-                                    InputAdapter
-                                      Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_sold_date_sk]
+                              Project [inv_item_sk]
+                                BroadcastHashJoin [inv_date_sk,d_date_sk]
+                                  Project [inv_item_sk,inv_date_sk]
+                                    Filter [inv_quantity_on_hand,inv_item_sk]
+                                      ColumnarToRow
+                                        InputAdapter
+                                          Scan parquet spark_catalog.default.inventory [inv_item_sk,inv_quantity_on_hand,inv_date_sk]
+                                            SubqueryBroadcast [d_date_sk] #1
+                                              BroadcastExchange #5
+                                                WholeStageCodegen (1)
+                                                  Project [d_date_sk]
+                                                    Filter [d_date,d_date_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
+                                  InputAdapter
+                                    ReusedExchange [d_date_sk] #5

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q83.sf100.ansi/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q83.sf100.ansi/explain.txt
@@ -9,16 +9,16 @@ TakeOrderedAndProject (46)
       :     :     +- * HashAggregate (13)
       :     :        +- * Project (12)
       :     :           +- * BroadcastHashJoin Inner BuildRight (11)
-      :     :              :- * Project (6)
-      :     :              :  +- * BroadcastHashJoin Inner BuildRight (5)
+      :     :              :- * Project (9)
+      :     :              :  +- * BroadcastHashJoin Inner BuildRight (8)
       :     :              :     :- * Filter (3)
       :     :              :     :  +- * ColumnarToRow (2)
       :     :              :     :     +- Scan parquet spark_catalog.default.store_returns (1)
-      :     :              :     +- ReusedExchange (4)
-      :     :              +- BroadcastExchange (10)
-      :     :                 +- * Filter (9)
-      :     :                    +- * ColumnarToRow (8)
-      :     :                       +- Scan parquet spark_catalog.default.item (7)
+      :     :              :     +- BroadcastExchange (7)
+      :     :              :        +- * Filter (6)
+      :     :              :           +- * ColumnarToRow (5)
+      :     :              :              +- Scan parquet spark_catalog.default.item (4)
+      :     :              +- ReusedExchange (10)
       :     +- BroadcastExchange (28)
       :        +- * HashAggregate (27)
       :           +- Exchange (26)
@@ -62,64 +62,64 @@ Input [3]: [sr_item_sk#1, sr_return_quantity#2, sr_returned_date_sk#3]
 Input [3]: [sr_item_sk#1, sr_return_quantity#2, sr_returned_date_sk#3]
 Condition : isnotnull(sr_item_sk#1)
 
-(4) ReusedExchange [Reuses operator id: 62]
-Output [1]: [d_date_sk#5]
-
-(5) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [sr_returned_date_sk#3]
-Right keys [1]: [d_date_sk#5]
-Join type: Inner
-Join condition: None
-
-(6) Project [codegen id : 5]
-Output [2]: [sr_item_sk#1, sr_return_quantity#2]
-Input [4]: [sr_item_sk#1, sr_return_quantity#2, sr_returned_date_sk#3, d_date_sk#5]
-
-(7) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#6, i_item_id#7]
+(4) Scan parquet spark_catalog.default.item
+Output [2]: [i_item_sk#5, i_item_id#6]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_item_id)]
 ReadSchema: struct<i_item_sk:int,i_item_id:string>
 
-(8) ColumnarToRow [codegen id : 4]
-Input [2]: [i_item_sk#6, i_item_id#7]
+(5) ColumnarToRow [codegen id : 1]
+Input [2]: [i_item_sk#5, i_item_id#6]
 
-(9) Filter [codegen id : 4]
-Input [2]: [i_item_sk#6, i_item_id#7]
-Condition : (isnotnull(i_item_sk#6) AND isnotnull(i_item_id#7))
+(6) Filter [codegen id : 1]
+Input [2]: [i_item_sk#5, i_item_id#6]
+Condition : (isnotnull(i_item_sk#5) AND isnotnull(i_item_id#6))
 
-(10) BroadcastExchange
-Input [2]: [i_item_sk#6, i_item_id#7]
+(7) BroadcastExchange
+Input [2]: [i_item_sk#5, i_item_id#6]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
-(11) BroadcastHashJoin [codegen id : 5]
+(8) BroadcastHashJoin [codegen id : 5]
 Left keys [1]: [sr_item_sk#1]
-Right keys [1]: [i_item_sk#6]
+Right keys [1]: [i_item_sk#5]
+Join type: Inner
+Join condition: None
+
+(9) Project [codegen id : 5]
+Output [3]: [sr_return_quantity#2, sr_returned_date_sk#3, i_item_id#6]
+Input [5]: [sr_item_sk#1, sr_return_quantity#2, sr_returned_date_sk#3, i_item_sk#5, i_item_id#6]
+
+(10) ReusedExchange [Reuses operator id: 62]
+Output [1]: [d_date_sk#7]
+
+(11) BroadcastHashJoin [codegen id : 5]
+Left keys [1]: [sr_returned_date_sk#3]
+Right keys [1]: [d_date_sk#7]
 Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 5]
-Output [2]: [sr_return_quantity#2, i_item_id#7]
-Input [4]: [sr_item_sk#1, sr_return_quantity#2, i_item_sk#6, i_item_id#7]
+Output [2]: [sr_return_quantity#2, i_item_id#6]
+Input [4]: [sr_return_quantity#2, sr_returned_date_sk#3, i_item_id#6, d_date_sk#7]
 
 (13) HashAggregate [codegen id : 5]
-Input [2]: [sr_return_quantity#2, i_item_id#7]
-Keys [1]: [i_item_id#7]
+Input [2]: [sr_return_quantity#2, i_item_id#6]
+Keys [1]: [i_item_id#6]
 Functions [1]: [partial_sum(sr_return_quantity#2)]
 Aggregate Attributes [1]: [sum#8]
-Results [2]: [i_item_id#7, sum#9]
+Results [2]: [i_item_id#6, sum#9]
 
 (14) Exchange
-Input [2]: [i_item_id#7, sum#9]
-Arguments: hashpartitioning(i_item_id#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [2]: [i_item_id#6, sum#9]
+Arguments: hashpartitioning(i_item_id#6, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (15) HashAggregate [codegen id : 18]
-Input [2]: [i_item_id#7, sum#9]
-Keys [1]: [i_item_id#7]
+Input [2]: [i_item_id#6, sum#9]
+Keys [1]: [i_item_id#6]
 Functions [1]: [sum(sr_return_quantity#2)]
 Aggregate Attributes [1]: [sum(sr_return_quantity#2)#10]
-Results [2]: [i_item_id#7 AS item_id#11, sum(sr_return_quantity#2)#10 AS sr_item_qty#12]
+Results [2]: [i_item_id#6 AS item_id#11, sum(sr_return_quantity#2)#10 AS sr_item_qty#12]
 
 (16) Scan parquet spark_catalog.default.catalog_returns
 Output [3]: [cr_item_sk#13, cr_return_quantity#14, cr_returned_date_sk#15]
@@ -136,49 +136,49 @@ Input [3]: [cr_item_sk#13, cr_return_quantity#14, cr_returned_date_sk#15]
 Input [3]: [cr_item_sk#13, cr_return_quantity#14, cr_returned_date_sk#15]
 Condition : isnotnull(cr_item_sk#13)
 
-(19) ReusedExchange [Reuses operator id: 62]
-Output [1]: [d_date_sk#16]
+(19) ReusedExchange [Reuses operator id: 7]
+Output [2]: [i_item_sk#16, i_item_id#17]
 
 (20) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [cr_returned_date_sk#15]
-Right keys [1]: [d_date_sk#16]
+Left keys [1]: [cr_item_sk#13]
+Right keys [1]: [i_item_sk#16]
 Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 10]
-Output [2]: [cr_item_sk#13, cr_return_quantity#14]
-Input [4]: [cr_item_sk#13, cr_return_quantity#14, cr_returned_date_sk#15, d_date_sk#16]
+Output [3]: [cr_return_quantity#14, cr_returned_date_sk#15, i_item_id#17]
+Input [5]: [cr_item_sk#13, cr_return_quantity#14, cr_returned_date_sk#15, i_item_sk#16, i_item_id#17]
 
-(22) ReusedExchange [Reuses operator id: 10]
-Output [2]: [i_item_sk#17, i_item_id#18]
+(22) ReusedExchange [Reuses operator id: 62]
+Output [1]: [d_date_sk#18]
 
 (23) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [cr_item_sk#13]
-Right keys [1]: [i_item_sk#17]
+Left keys [1]: [cr_returned_date_sk#15]
+Right keys [1]: [d_date_sk#18]
 Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 10]
-Output [2]: [cr_return_quantity#14, i_item_id#18]
-Input [4]: [cr_item_sk#13, cr_return_quantity#14, i_item_sk#17, i_item_id#18]
+Output [2]: [cr_return_quantity#14, i_item_id#17]
+Input [4]: [cr_return_quantity#14, cr_returned_date_sk#15, i_item_id#17, d_date_sk#18]
 
 (25) HashAggregate [codegen id : 10]
-Input [2]: [cr_return_quantity#14, i_item_id#18]
-Keys [1]: [i_item_id#18]
+Input [2]: [cr_return_quantity#14, i_item_id#17]
+Keys [1]: [i_item_id#17]
 Functions [1]: [partial_sum(cr_return_quantity#14)]
 Aggregate Attributes [1]: [sum#19]
-Results [2]: [i_item_id#18, sum#20]
+Results [2]: [i_item_id#17, sum#20]
 
 (26) Exchange
-Input [2]: [i_item_id#18, sum#20]
-Arguments: hashpartitioning(i_item_id#18, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [2]: [i_item_id#17, sum#20]
+Arguments: hashpartitioning(i_item_id#17, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (27) HashAggregate [codegen id : 11]
-Input [2]: [i_item_id#18, sum#20]
-Keys [1]: [i_item_id#18]
+Input [2]: [i_item_id#17, sum#20]
+Keys [1]: [i_item_id#17]
 Functions [1]: [sum(cr_return_quantity#14)]
 Aggregate Attributes [1]: [sum(cr_return_quantity#14)#21]
-Results [2]: [i_item_id#18 AS item_id#22, sum(cr_return_quantity#14)#21 AS cr_item_qty#23]
+Results [2]: [i_item_id#17 AS item_id#22, sum(cr_return_quantity#14)#21 AS cr_item_qty#23]
 
 (28) BroadcastExchange
 Input [2]: [item_id#22, cr_item_qty#23]
@@ -209,49 +209,49 @@ Input [3]: [wr_item_sk#24, wr_return_quantity#25, wr_returned_date_sk#26]
 Input [3]: [wr_item_sk#24, wr_return_quantity#25, wr_returned_date_sk#26]
 Condition : isnotnull(wr_item_sk#24)
 
-(34) ReusedExchange [Reuses operator id: 62]
-Output [1]: [d_date_sk#27]
+(34) ReusedExchange [Reuses operator id: 7]
+Output [2]: [i_item_sk#27, i_item_id#28]
 
 (35) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [wr_returned_date_sk#26]
-Right keys [1]: [d_date_sk#27]
+Left keys [1]: [wr_item_sk#24]
+Right keys [1]: [i_item_sk#27]
 Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 16]
-Output [2]: [wr_item_sk#24, wr_return_quantity#25]
-Input [4]: [wr_item_sk#24, wr_return_quantity#25, wr_returned_date_sk#26, d_date_sk#27]
+Output [3]: [wr_return_quantity#25, wr_returned_date_sk#26, i_item_id#28]
+Input [5]: [wr_item_sk#24, wr_return_quantity#25, wr_returned_date_sk#26, i_item_sk#27, i_item_id#28]
 
-(37) ReusedExchange [Reuses operator id: 10]
-Output [2]: [i_item_sk#28, i_item_id#29]
+(37) ReusedExchange [Reuses operator id: 62]
+Output [1]: [d_date_sk#29]
 
 (38) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [wr_item_sk#24]
-Right keys [1]: [i_item_sk#28]
+Left keys [1]: [wr_returned_date_sk#26]
+Right keys [1]: [d_date_sk#29]
 Join type: Inner
 Join condition: None
 
 (39) Project [codegen id : 16]
-Output [2]: [wr_return_quantity#25, i_item_id#29]
-Input [4]: [wr_item_sk#24, wr_return_quantity#25, i_item_sk#28, i_item_id#29]
+Output [2]: [wr_return_quantity#25, i_item_id#28]
+Input [4]: [wr_return_quantity#25, wr_returned_date_sk#26, i_item_id#28, d_date_sk#29]
 
 (40) HashAggregate [codegen id : 16]
-Input [2]: [wr_return_quantity#25, i_item_id#29]
-Keys [1]: [i_item_id#29]
+Input [2]: [wr_return_quantity#25, i_item_id#28]
+Keys [1]: [i_item_id#28]
 Functions [1]: [partial_sum(wr_return_quantity#25)]
 Aggregate Attributes [1]: [sum#30]
-Results [2]: [i_item_id#29, sum#31]
+Results [2]: [i_item_id#28, sum#31]
 
 (41) Exchange
-Input [2]: [i_item_id#29, sum#31]
-Arguments: hashpartitioning(i_item_id#29, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [2]: [i_item_id#28, sum#31]
+Arguments: hashpartitioning(i_item_id#28, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (42) HashAggregate [codegen id : 17]
-Input [2]: [i_item_id#29, sum#31]
-Keys [1]: [i_item_id#29]
+Input [2]: [i_item_id#28, sum#31]
+Keys [1]: [i_item_id#28]
 Functions [1]: [sum(wr_return_quantity#25)]
 Aggregate Attributes [1]: [sum(wr_return_quantity#25)#32]
-Results [2]: [i_item_id#29 AS item_id#33, sum(wr_return_quantity#25)#32 AS wr_item_qty#34]
+Results [2]: [i_item_id#28 AS item_id#33, sum(wr_return_quantity#25)#32 AS wr_item_qty#34]
 
 (43) BroadcastExchange
 Input [2]: [item_id#33, wr_item_qty#34]
@@ -293,18 +293,18 @@ BroadcastExchange (62)
 
 
 (47) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#5, d_date#39]
+Output [2]: [d_date_sk#7, d_date#39]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (48) ColumnarToRow [codegen id : 3]
-Input [2]: [d_date_sk#5, d_date#39]
+Input [2]: [d_date_sk#7, d_date#39]
 
 (49) Filter [codegen id : 3]
-Input [2]: [d_date_sk#5, d_date#39]
-Condition : isnotnull(d_date_sk#5)
+Input [2]: [d_date_sk#7, d_date#39]
+Condition : isnotnull(d_date_sk#7)
 
 (50) Scan parquet spark_catalog.default.date_dim
 Output [2]: [d_date#40, d_week_seq#41]
@@ -358,11 +358,11 @@ Join type: LeftSemi
 Join condition: None
 
 (61) Project [codegen id : 3]
-Output [1]: [d_date_sk#5]
-Input [2]: [d_date_sk#5, d_date#39]
+Output [1]: [d_date_sk#7]
+Input [2]: [d_date_sk#7, d_date#39]
 
 (62) BroadcastExchange
-Input [1]: [d_date_sk#5]
+Input [1]: [d_date_sk#7]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
 Subquery:2 Hosting operator id = 16 Hosting Expression = cr_returned_date_sk#15 IN dynamicpruning#4

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q83.sf100.ansi/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q83.sf100.ansi/simplified.txt
@@ -10,9 +10,9 @@ TakeOrderedAndProject [item_id,sr_item_qty,sr_dev,cr_item_qty,cr_dev,wr_item_qty
                   WholeStageCodegen (5)
                     HashAggregate [i_item_id,sr_return_quantity] [sum,sum]
                       Project [sr_return_quantity,i_item_id]
-                        BroadcastHashJoin [sr_item_sk,i_item_sk]
-                          Project [sr_item_sk,sr_return_quantity]
-                            BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
+                        BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
+                          Project [sr_return_quantity,sr_returned_date_sk,i_item_id]
+                            BroadcastHashJoin [sr_item_sk,i_item_sk]
                               Filter [sr_item_sk]
                                 ColumnarToRow
                                   InputAdapter
@@ -43,14 +43,14 @@ TakeOrderedAndProject [item_id,sr_item_qty,sr_dev,cr_item_qty,cr_dev,wr_item_qty
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.date_dim [d_date,d_week_seq]
                               InputAdapter
-                                ReusedExchange [d_date_sk] #2
+                                BroadcastExchange #5
+                                  WholeStageCodegen (1)
+                                    Filter [i_item_sk,i_item_id]
+                                      ColumnarToRow
+                                        InputAdapter
+                                          Scan parquet spark_catalog.default.item [i_item_sk,i_item_id]
                           InputAdapter
-                            BroadcastExchange #5
-                              WholeStageCodegen (4)
-                                Filter [i_item_sk,i_item_id]
-                                  ColumnarToRow
-                                    InputAdapter
-                                      Scan parquet spark_catalog.default.item [i_item_sk,i_item_id]
+                            ReusedExchange [d_date_sk] #2
             InputAdapter
               BroadcastExchange #6
                 WholeStageCodegen (11)
@@ -60,18 +60,18 @@ TakeOrderedAndProject [item_id,sr_item_qty,sr_dev,cr_item_qty,cr_dev,wr_item_qty
                         WholeStageCodegen (10)
                           HashAggregate [i_item_id,cr_return_quantity] [sum,sum]
                             Project [cr_return_quantity,i_item_id]
-                              BroadcastHashJoin [cr_item_sk,i_item_sk]
-                                Project [cr_item_sk,cr_return_quantity]
-                                  BroadcastHashJoin [cr_returned_date_sk,d_date_sk]
+                              BroadcastHashJoin [cr_returned_date_sk,d_date_sk]
+                                Project [cr_return_quantity,cr_returned_date_sk,i_item_id]
+                                  BroadcastHashJoin [cr_item_sk,i_item_sk]
                                     Filter [cr_item_sk]
                                       ColumnarToRow
                                         InputAdapter
                                           Scan parquet spark_catalog.default.catalog_returns [cr_item_sk,cr_return_quantity,cr_returned_date_sk]
                                             ReusedSubquery [d_date_sk] #1
                                     InputAdapter
-                                      ReusedExchange [d_date_sk] #2
+                                      ReusedExchange [i_item_sk,i_item_id] #5
                                 InputAdapter
-                                  ReusedExchange [i_item_sk,i_item_id] #5
+                                  ReusedExchange [d_date_sk] #2
         InputAdapter
           BroadcastExchange #8
             WholeStageCodegen (17)
@@ -81,15 +81,15 @@ TakeOrderedAndProject [item_id,sr_item_qty,sr_dev,cr_item_qty,cr_dev,wr_item_qty
                     WholeStageCodegen (16)
                       HashAggregate [i_item_id,wr_return_quantity] [sum,sum]
                         Project [wr_return_quantity,i_item_id]
-                          BroadcastHashJoin [wr_item_sk,i_item_sk]
-                            Project [wr_item_sk,wr_return_quantity]
-                              BroadcastHashJoin [wr_returned_date_sk,d_date_sk]
+                          BroadcastHashJoin [wr_returned_date_sk,d_date_sk]
+                            Project [wr_return_quantity,wr_returned_date_sk,i_item_id]
+                              BroadcastHashJoin [wr_item_sk,i_item_sk]
                                 Filter [wr_item_sk]
                                   ColumnarToRow
                                     InputAdapter
                                       Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_return_quantity,wr_returned_date_sk]
                                         ReusedSubquery [d_date_sk] #1
                                 InputAdapter
-                                  ReusedExchange [d_date_sk] #2
+                                  ReusedExchange [i_item_sk,i_item_id] #5
                             InputAdapter
-                              ReusedExchange [i_item_sk,i_item_id] #5
+                              ReusedExchange [d_date_sk] #2

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q84.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q84.sf100/explain.txt
@@ -1,41 +1,45 @@
 == Physical Plan ==
-TakeOrderedAndProject (37)
-+- * Project (36)
-   +- * BroadcastHashJoin Inner BuildLeft (35)
-      :- BroadcastExchange (30)
-      :  +- * Project (29)
-      :     +- * BroadcastHashJoin Inner BuildLeft (28)
-      :        :- BroadcastExchange (24)
-      :        :  +- * Project (23)
-      :        :     +- * BroadcastHashJoin Inner BuildRight (22)
-      :        :        :- * Project (10)
-      :        :        :  +- * BroadcastHashJoin Inner BuildRight (9)
-      :        :        :     :- * Filter (3)
-      :        :        :     :  +- * ColumnarToRow (2)
-      :        :        :     :     +- Scan parquet spark_catalog.default.customer (1)
-      :        :        :     +- BroadcastExchange (8)
-      :        :        :        +- * Project (7)
-      :        :        :           +- * Filter (6)
-      :        :        :              +- * ColumnarToRow (5)
-      :        :        :                 +- Scan parquet spark_catalog.default.customer_address (4)
-      :        :        +- BroadcastExchange (21)
-      :        :           +- * Project (20)
-      :        :              +- * BroadcastHashJoin Inner BuildRight (19)
-      :        :                 :- * Filter (13)
-      :        :                 :  +- * ColumnarToRow (12)
-      :        :                 :     +- Scan parquet spark_catalog.default.household_demographics (11)
-      :        :                 +- BroadcastExchange (18)
-      :        :                    +- * Project (17)
-      :        :                       +- * Filter (16)
-      :        :                          +- * ColumnarToRow (15)
-      :        :                             +- Scan parquet spark_catalog.default.income_band (14)
-      :        +- * Filter (27)
-      :           +- * ColumnarToRow (26)
-      :              +- Scan parquet spark_catalog.default.customer_demographics (25)
-      +- * Project (34)
-         +- * Filter (33)
-            +- * ColumnarToRow (32)
-               +- Scan parquet spark_catalog.default.store_returns (31)
+TakeOrderedAndProject (41)
++- * Project (40)
+   +- * SortMergeJoin Inner (39)
+      :- * Project (32)
+      :  +- * SortMergeJoin Inner (31)
+      :     :- * Sort (25)
+      :     :  +- Exchange (24)
+      :     :     +- * Project (23)
+      :     :        +- * BroadcastHashJoin Inner BuildRight (22)
+      :     :           :- * Project (10)
+      :     :           :  +- * BroadcastHashJoin Inner BuildRight (9)
+      :     :           :     :- * Filter (3)
+      :     :           :     :  +- * ColumnarToRow (2)
+      :     :           :     :     +- Scan parquet spark_catalog.default.customer (1)
+      :     :           :     +- BroadcastExchange (8)
+      :     :           :        +- * Project (7)
+      :     :           :           +- * Filter (6)
+      :     :           :              +- * ColumnarToRow (5)
+      :     :           :                 +- Scan parquet spark_catalog.default.customer_address (4)
+      :     :           +- BroadcastExchange (21)
+      :     :              +- * Project (20)
+      :     :                 +- * BroadcastHashJoin Inner BuildRight (19)
+      :     :                    :- * Filter (13)
+      :     :                    :  +- * ColumnarToRow (12)
+      :     :                    :     +- Scan parquet spark_catalog.default.household_demographics (11)
+      :     :                    +- BroadcastExchange (18)
+      :     :                       +- * Project (17)
+      :     :                          +- * Filter (16)
+      :     :                             +- * ColumnarToRow (15)
+      :     :                                +- Scan parquet spark_catalog.default.income_band (14)
+      :     +- * Sort (30)
+      :        +- Exchange (29)
+      :           +- * Filter (28)
+      :              +- * ColumnarToRow (27)
+      :                 +- Scan parquet spark_catalog.default.customer_demographics (26)
+      +- * Sort (38)
+         +- Exchange (37)
+            +- * Project (36)
+               +- * Filter (35)
+                  +- * ColumnarToRow (34)
+                     +- Scan parquet spark_catalog.default.store_returns (33)
 
 
 (1) Scan parquet spark_catalog.default.customer
@@ -144,67 +148,83 @@ Join condition: None
 Output [4]: [c_customer_id#1, c_current_cdemo_sk#2, c_first_name#5, c_last_name#6]
 Input [6]: [c_customer_id#1, c_current_cdemo_sk#2, c_current_hdemo_sk#3, c_first_name#5, c_last_name#6, hd_demo_sk#9]
 
-(24) BroadcastExchange
+(24) Exchange
 Input [4]: [c_customer_id#1, c_current_cdemo_sk#2, c_first_name#5, c_last_name#6]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [plan_id=4]
+Arguments: hashpartitioning(c_current_cdemo_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(25) Scan parquet spark_catalog.default.customer_demographics
+(25) Sort [codegen id : 5]
+Input [4]: [c_customer_id#1, c_current_cdemo_sk#2, c_first_name#5, c_last_name#6]
+Arguments: [c_current_cdemo_sk#2 ASC NULLS FIRST], false, 0
+
+(26) Scan parquet spark_catalog.default.customer_demographics
 Output [1]: [cd_demo_sk#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int>
 
-(26) ColumnarToRow
+(27) ColumnarToRow [codegen id : 6]
 Input [1]: [cd_demo_sk#14]
 
-(27) Filter
+(28) Filter [codegen id : 6]
 Input [1]: [cd_demo_sk#14]
 Condition : isnotnull(cd_demo_sk#14)
 
-(28) BroadcastHashJoin [codegen id : 5]
+(29) Exchange
+Input [1]: [cd_demo_sk#14]
+Arguments: hashpartitioning(cd_demo_sk#14, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+
+(30) Sort [codegen id : 7]
+Input [1]: [cd_demo_sk#14]
+Arguments: [cd_demo_sk#14 ASC NULLS FIRST], false, 0
+
+(31) SortMergeJoin [codegen id : 8]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#14]
 Join type: Inner
 Join condition: None
 
-(29) Project [codegen id : 5]
+(32) Project [codegen id : 8]
 Output [4]: [c_customer_id#1, c_first_name#5, c_last_name#6, cd_demo_sk#14]
 Input [5]: [c_customer_id#1, c_current_cdemo_sk#2, c_first_name#5, c_last_name#6, cd_demo_sk#14]
 
-(30) BroadcastExchange
-Input [4]: [c_customer_id#1, c_first_name#5, c_last_name#6, cd_demo_sk#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[3, int, true] as bigint)),false), [plan_id=5]
-
-(31) Scan parquet spark_catalog.default.store_returns
+(33) Scan parquet spark_catalog.default.store_returns
 Output [2]: [sr_cdemo_sk#15, sr_returned_date_sk#16]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_returns]
 PushedFilters: [IsNotNull(sr_cdemo_sk)]
 ReadSchema: struct<sr_cdemo_sk:int>
 
-(32) ColumnarToRow
+(34) ColumnarToRow [codegen id : 9]
 Input [2]: [sr_cdemo_sk#15, sr_returned_date_sk#16]
 
-(33) Filter
+(35) Filter [codegen id : 9]
 Input [2]: [sr_cdemo_sk#15, sr_returned_date_sk#16]
 Condition : isnotnull(sr_cdemo_sk#15)
 
-(34) Project
+(36) Project [codegen id : 9]
 Output [1]: [sr_cdemo_sk#15]
 Input [2]: [sr_cdemo_sk#15, sr_returned_date_sk#16]
 
-(35) BroadcastHashJoin [codegen id : 6]
+(37) Exchange
+Input [1]: [sr_cdemo_sk#15]
+Arguments: hashpartitioning(sr_cdemo_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(38) Sort [codegen id : 10]
+Input [1]: [sr_cdemo_sk#15]
+Arguments: [sr_cdemo_sk#15 ASC NULLS FIRST], false, 0
+
+(39) SortMergeJoin [codegen id : 11]
 Left keys [1]: [cd_demo_sk#14]
 Right keys [1]: [sr_cdemo_sk#15]
 Join type: Inner
 Join condition: None
 
-(36) Project [codegen id : 6]
+(40) Project [codegen id : 11]
 Output [3]: [c_customer_id#1 AS customer_id#17, concat(c_last_name#6, , , c_first_name#5) AS customername#18, c_customer_id#1]
 Input [5]: [c_customer_id#1, c_first_name#5, c_last_name#6, cd_demo_sk#14, sr_cdemo_sk#15]
 
-(37) TakeOrderedAndProject
+(41) TakeOrderedAndProject
 Input [3]: [customer_id#17, customername#18, c_customer_id#1]
 Arguments: 100, [c_customer_id#1 ASC NULLS FIRST], [customer_id#17, customername#18]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q84.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q84.sf100/simplified.txt
@@ -1,54 +1,68 @@
 TakeOrderedAndProject [c_customer_id,customer_id,customername]
-  WholeStageCodegen (6)
+  WholeStageCodegen (11)
     Project [c_customer_id,c_last_name,c_first_name]
-      BroadcastHashJoin [cd_demo_sk,sr_cdemo_sk]
+      SortMergeJoin [cd_demo_sk,sr_cdemo_sk]
         InputAdapter
-          BroadcastExchange #1
-            WholeStageCodegen (5)
-              Project [c_customer_id,c_first_name,c_last_name,cd_demo_sk]
-                BroadcastHashJoin [c_current_cdemo_sk,cd_demo_sk]
-                  InputAdapter
-                    BroadcastExchange #2
-                      WholeStageCodegen (4)
-                        Project [c_customer_id,c_current_cdemo_sk,c_first_name,c_last_name]
-                          BroadcastHashJoin [c_current_hdemo_sk,hd_demo_sk]
-                            Project [c_customer_id,c_current_cdemo_sk,c_current_hdemo_sk,c_first_name,c_last_name]
-                              BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
-                                Filter [c_current_addr_sk,c_current_cdemo_sk,c_current_hdemo_sk]
-                                  ColumnarToRow
+          WholeStageCodegen (8)
+            Project [c_customer_id,c_first_name,c_last_name,cd_demo_sk]
+              SortMergeJoin [c_current_cdemo_sk,cd_demo_sk]
+                InputAdapter
+                  WholeStageCodegen (5)
+                    Sort [c_current_cdemo_sk]
+                      InputAdapter
+                        Exchange [c_current_cdemo_sk] #1
+                          WholeStageCodegen (4)
+                            Project [c_customer_id,c_current_cdemo_sk,c_first_name,c_last_name]
+                              BroadcastHashJoin [c_current_hdemo_sk,hd_demo_sk]
+                                Project [c_customer_id,c_current_cdemo_sk,c_current_hdemo_sk,c_first_name,c_last_name]
+                                  BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
+                                    Filter [c_current_addr_sk,c_current_cdemo_sk,c_current_hdemo_sk]
+                                      ColumnarToRow
+                                        InputAdapter
+                                          Scan parquet spark_catalog.default.customer [c_customer_id,c_current_cdemo_sk,c_current_hdemo_sk,c_current_addr_sk,c_first_name,c_last_name]
                                     InputAdapter
-                                      Scan parquet spark_catalog.default.customer [c_customer_id,c_current_cdemo_sk,c_current_hdemo_sk,c_current_addr_sk,c_first_name,c_last_name]
+                                      BroadcastExchange #2
+                                        WholeStageCodegen (1)
+                                          Project [ca_address_sk]
+                                            Filter [ca_city,ca_address_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_city]
                                 InputAdapter
                                   BroadcastExchange #3
-                                    WholeStageCodegen (1)
-                                      Project [ca_address_sk]
-                                        Filter [ca_city,ca_address_sk]
-                                          ColumnarToRow
-                                            InputAdapter
-                                              Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_city]
-                            InputAdapter
-                              BroadcastExchange #4
-                                WholeStageCodegen (3)
-                                  Project [hd_demo_sk]
-                                    BroadcastHashJoin [hd_income_band_sk,ib_income_band_sk]
-                                      Filter [hd_demo_sk,hd_income_band_sk]
-                                        ColumnarToRow
+                                    WholeStageCodegen (3)
+                                      Project [hd_demo_sk]
+                                        BroadcastHashJoin [hd_income_band_sk,ib_income_band_sk]
+                                          Filter [hd_demo_sk,hd_income_band_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_income_band_sk]
                                           InputAdapter
-                                            Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_income_band_sk]
-                                      InputAdapter
-                                        BroadcastExchange #5
-                                          WholeStageCodegen (2)
-                                            Project [ib_income_band_sk]
-                                              Filter [ib_lower_bound,ib_upper_bound,ib_income_band_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.income_band [ib_income_band_sk,ib_lower_bound,ib_upper_bound]
-                  Filter [cd_demo_sk]
-                    ColumnarToRow
+                                            BroadcastExchange #4
+                                              WholeStageCodegen (2)
+                                                Project [ib_income_band_sk]
+                                                  Filter [ib_lower_bound,ib_upper_bound,ib_income_band_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.income_band [ib_income_band_sk,ib_lower_bound,ib_upper_bound]
+                InputAdapter
+                  WholeStageCodegen (7)
+                    Sort [cd_demo_sk]
                       InputAdapter
-                        Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk]
-        Project [sr_cdemo_sk]
-          Filter [sr_cdemo_sk]
-            ColumnarToRow
+                        Exchange [cd_demo_sk] #5
+                          WholeStageCodegen (6)
+                            Filter [cd_demo_sk]
+                              ColumnarToRow
+                                InputAdapter
+                                  Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk]
+        InputAdapter
+          WholeStageCodegen (10)
+            Sort [sr_cdemo_sk]
               InputAdapter
-                Scan parquet spark_catalog.default.store_returns [sr_cdemo_sk,sr_returned_date_sk]
+                Exchange [sr_cdemo_sk] #6
+                  WholeStageCodegen (9)
+                    Project [sr_cdemo_sk]
+                      Filter [sr_cdemo_sk]
+                        ColumnarToRow
+                          InputAdapter
+                            Scan parquet spark_catalog.default.store_returns [sr_cdemo_sk,sr_returned_date_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85.sf100/explain.txt
@@ -6,49 +6,49 @@ TakeOrderedAndProject (54)
          +- * Project (50)
             +- * BroadcastHashJoin Inner BuildRight (49)
                :- * Project (44)
-               :  +- * BroadcastHashJoin Inner BuildRight (43)
-               :     :- * Project (41)
-               :     :  +- * BroadcastHashJoin Inner BuildRight (40)
-               :     :     :- * Project (34)
-               :     :     :  +- * SortMergeJoin Inner (33)
-               :     :     :     :- * Sort (27)
-               :     :     :     :  +- Exchange (26)
-               :     :     :     :     +- * Project (25)
-               :     :     :     :        +- * BroadcastHashJoin Inner BuildRight (24)
-               :     :     :     :           :- * Project (19)
-               :     :     :     :           :  +- * SortMergeJoin Inner (18)
-               :     :     :     :           :     :- * Sort (11)
-               :     :     :     :           :     :  +- Exchange (10)
-               :     :     :     :           :     :     +- * Project (9)
-               :     :     :     :           :     :        +- * BroadcastHashJoin Inner BuildRight (8)
-               :     :     :     :           :     :           :- * Filter (3)
-               :     :     :     :           :     :           :  +- * ColumnarToRow (2)
-               :     :     :     :           :     :           :     +- Scan parquet spark_catalog.default.web_sales (1)
-               :     :     :     :           :     :           +- BroadcastExchange (7)
-               :     :     :     :           :     :              +- * Filter (6)
-               :     :     :     :           :     :                 +- * ColumnarToRow (5)
-               :     :     :     :           :     :                    +- Scan parquet spark_catalog.default.web_page (4)
-               :     :     :     :           :     +- * Sort (17)
-               :     :     :     :           :        +- Exchange (16)
-               :     :     :     :           :           +- * Project (15)
-               :     :     :     :           :              +- * Filter (14)
-               :     :     :     :           :                 +- * ColumnarToRow (13)
-               :     :     :     :           :                    +- Scan parquet spark_catalog.default.web_returns (12)
-               :     :     :     :           +- BroadcastExchange (23)
-               :     :     :     :              +- * Filter (22)
-               :     :     :     :                 +- * ColumnarToRow (21)
-               :     :     :     :                    +- Scan parquet spark_catalog.default.customer_demographics (20)
-               :     :     :     +- * Sort (32)
-               :     :     :        +- Exchange (31)
-               :     :     :           +- * Filter (30)
-               :     :     :              +- * ColumnarToRow (29)
-               :     :     :                 +- Scan parquet spark_catalog.default.customer_demographics (28)
-               :     :     +- BroadcastExchange (39)
-               :     :        +- * Project (38)
-               :     :           +- * Filter (37)
-               :     :              +- * ColumnarToRow (36)
-               :     :                 +- Scan parquet spark_catalog.default.customer_address (35)
-               :     +- ReusedExchange (42)
+               :  +- * SortMergeJoin Inner (43)
+               :     :- * Sort (37)
+               :     :  +- Exchange (36)
+               :     :     +- * Project (35)
+               :     :        +- * BroadcastHashJoin Inner BuildRight (34)
+               :     :           :- * Project (29)
+               :     :           :  +- * BroadcastHashJoin Inner BuildRight (28)
+               :     :           :     :- * Project (22)
+               :     :           :     :  +- * BroadcastHashJoin Inner BuildRight (21)
+               :     :           :     :     :- * Project (19)
+               :     :           :     :     :  +- * SortMergeJoin Inner (18)
+               :     :           :     :     :     :- * Sort (11)
+               :     :           :     :     :     :  +- Exchange (10)
+               :     :           :     :     :     :     +- * Project (9)
+               :     :           :     :     :     :        +- * BroadcastHashJoin Inner BuildRight (8)
+               :     :           :     :     :     :           :- * Filter (3)
+               :     :           :     :     :     :           :  +- * ColumnarToRow (2)
+               :     :           :     :     :     :           :     +- Scan parquet spark_catalog.default.web_sales (1)
+               :     :           :     :     :     :           +- BroadcastExchange (7)
+               :     :           :     :     :     :              +- * Filter (6)
+               :     :           :     :     :     :                 +- * ColumnarToRow (5)
+               :     :           :     :     :     :                    +- Scan parquet spark_catalog.default.web_page (4)
+               :     :           :     :     :     +- * Sort (17)
+               :     :           :     :     :        +- Exchange (16)
+               :     :           :     :     :           +- * Project (15)
+               :     :           :     :     :              +- * Filter (14)
+               :     :           :     :     :                 +- * ColumnarToRow (13)
+               :     :           :     :     :                    +- Scan parquet spark_catalog.default.web_returns (12)
+               :     :           :     :     +- ReusedExchange (20)
+               :     :           :     +- BroadcastExchange (27)
+               :     :           :        +- * Project (26)
+               :     :           :           +- * Filter (25)
+               :     :           :              +- * ColumnarToRow (24)
+               :     :           :                 +- Scan parquet spark_catalog.default.customer_address (23)
+               :     :           +- BroadcastExchange (33)
+               :     :              +- * Filter (32)
+               :     :                 +- * ColumnarToRow (31)
+               :     :                    +- Scan parquet spark_catalog.default.customer_demographics (30)
+               :     +- * Sort (42)
+               :        +- Exchange (41)
+               :           +- * Filter (40)
+               :              +- * ColumnarToRow (39)
+               :                 +- Scan parquet spark_catalog.default.customer_demographics (38)
                +- BroadcastExchange (48)
                   +- * Filter (47)
                      +- * ColumnarToRow (46)
@@ -118,7 +118,7 @@ Input [9]: [wr_item_sk#10, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_r
 
 (14) Filter [codegen id : 4]
 Input [9]: [wr_item_sk#10, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_order_number#15, wr_fee#16, wr_refunded_cash#17, wr_returned_date_sk#18]
-Condition : (((((((isnotnull(wr_item_sk#10) AND isnotnull(wr_order_number#15)) AND isnotnull(wr_refunded_cdemo_sk#11)) AND isnotnull(wr_returning_cdemo_sk#13)) AND isnotnull(wr_refunded_addr_sk#12)) AND isnotnull(wr_reason_sk#14)) AND might_contain(Subquery scalar-subquery#19, [id=#20], xxhash64(wr_refunded_cdemo_sk#11, 42))) AND might_contain(Subquery scalar-subquery#21, [id=#22], xxhash64(wr_refunded_addr_sk#12, 42)))
+Condition : (((((((isnotnull(wr_item_sk#10) AND isnotnull(wr_order_number#15)) AND isnotnull(wr_refunded_cdemo_sk#11)) AND isnotnull(wr_returning_cdemo_sk#13)) AND isnotnull(wr_refunded_addr_sk#12)) AND isnotnull(wr_reason_sk#14)) AND might_contain(Subquery scalar-subquery#19, [id=#20], xxhash64(wr_refunded_addr_sk#12, 42))) AND might_contain(Subquery scalar-subquery#21, [id=#22], xxhash64(wr_refunded_cdemo_sk#11, 42)))
 
 (15) Project [codegen id : 4]
 Output [8]: [wr_item_sk#10, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_order_number#15, wr_fee#16, wr_refunded_cash#17]
@@ -132,128 +132,128 @@ Arguments: hashpartitioning(wr_item_sk#10, wr_order_number#15, 5), ENSURE_REQUIR
 Input [8]: [wr_item_sk#10, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_order_number#15, wr_fee#16, wr_refunded_cash#17]
 Arguments: [wr_item_sk#10 ASC NULLS FIRST, wr_order_number#15 ASC NULLS FIRST], false, 0
 
-(18) SortMergeJoin [codegen id : 7]
+(18) SortMergeJoin [codegen id : 9]
 Left keys [2]: [ws_item_sk#1, ws_order_number#3]
 Right keys [2]: [wr_item_sk#10, wr_order_number#15]
 Join type: Inner
 Join condition: None
 
-(19) Project [codegen id : 7]
+(19) Project [codegen id : 9]
 Output [10]: [ws_quantity#4, ws_sales_price#5, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17]
 Input [14]: [ws_item_sk#1, ws_order_number#3, ws_quantity#4, ws_sales_price#5, ws_net_profit#6, ws_sold_date_sk#7, wr_item_sk#10, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_order_number#15, wr_fee#16, wr_refunded_cash#17]
 
-(20) Scan parquet spark_catalog.default.customer_demographics
-Output [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_demographics]
-PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status), IsNotNull(cd_education_status), Or(Or(And(EqualTo(cd_marital_status,M),EqualTo(cd_education_status,Advanced Degree     )),And(EqualTo(cd_marital_status,S),EqualTo(cd_education_status,College             ))),And(EqualTo(cd_marital_status,W),EqualTo(cd_education_status,2 yr Degree         )))]
-ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string,cd_education_status:string>
+(20) ReusedExchange [Reuses operator id: 59]
+Output [1]: [d_date_sk#23]
 
-(21) ColumnarToRow [codegen id : 6]
-Input [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
-
-(22) Filter [codegen id : 6]
-Input [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
-Condition : (((isnotnull(cd_demo_sk#23) AND isnotnull(cd_marital_status#24)) AND isnotnull(cd_education_status#25)) AND ((((cd_marital_status#24 = M) AND (cd_education_status#25 = Advanced Degree     )) OR ((cd_marital_status#24 = S) AND (cd_education_status#25 = College             ))) OR ((cd_marital_status#24 = W) AND (cd_education_status#25 = 2 yr Degree         ))))
-
-(23) BroadcastExchange
-Input [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
-
-(24) BroadcastHashJoin [codegen id : 7]
-Left keys [1]: [wr_refunded_cdemo_sk#11]
-Right keys [1]: [cd_demo_sk#23]
-Join type: Inner
-Join condition: ((((((cd_marital_status#24 = M) AND (cd_education_status#25 = Advanced Degree     )) AND (ws_sales_price#5 >= 100.00)) AND (ws_sales_price#5 <= 150.00)) OR ((((cd_marital_status#24 = S) AND (cd_education_status#25 = College             )) AND (ws_sales_price#5 >= 50.00)) AND (ws_sales_price#5 <= 100.00))) OR ((((cd_marital_status#24 = W) AND (cd_education_status#25 = 2 yr Degree         )) AND (ws_sales_price#5 >= 150.00)) AND (ws_sales_price#5 <= 200.00)))
-
-(25) Project [codegen id : 7]
-Output [10]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#24, cd_education_status#25]
-Input [13]: [ws_quantity#4, ws_sales_price#5, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
-
-(26) Exchange
-Input [10]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#24, cd_education_status#25]
-Arguments: hashpartitioning(wr_returning_cdemo_sk#13, cd_marital_status#24, cd_education_status#25, 5), ENSURE_REQUIREMENTS, [plan_id=5]
-
-(27) Sort [codegen id : 8]
-Input [10]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#24, cd_education_status#25]
-Arguments: [wr_returning_cdemo_sk#13 ASC NULLS FIRST, cd_marital_status#24 ASC NULLS FIRST, cd_education_status#25 ASC NULLS FIRST], false, 0
-
-(28) Scan parquet spark_catalog.default.customer_demographics
-Output [3]: [cd_demo_sk#26, cd_marital_status#27, cd_education_status#28]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_demographics]
-PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status), IsNotNull(cd_education_status)]
-ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string,cd_education_status:string>
-
-(29) ColumnarToRow [codegen id : 9]
-Input [3]: [cd_demo_sk#26, cd_marital_status#27, cd_education_status#28]
-
-(30) Filter [codegen id : 9]
-Input [3]: [cd_demo_sk#26, cd_marital_status#27, cd_education_status#28]
-Condition : ((isnotnull(cd_demo_sk#26) AND isnotnull(cd_marital_status#27)) AND isnotnull(cd_education_status#28))
-
-(31) Exchange
-Input [3]: [cd_demo_sk#26, cd_marital_status#27, cd_education_status#28]
-Arguments: hashpartitioning(cd_demo_sk#26, cd_marital_status#27, cd_education_status#28, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(32) Sort [codegen id : 10]
-Input [3]: [cd_demo_sk#26, cd_marital_status#27, cd_education_status#28]
-Arguments: [cd_demo_sk#26 ASC NULLS FIRST, cd_marital_status#27 ASC NULLS FIRST, cd_education_status#28 ASC NULLS FIRST], false, 0
-
-(33) SortMergeJoin [codegen id : 14]
-Left keys [3]: [wr_returning_cdemo_sk#13, cd_marital_status#24, cd_education_status#25]
-Right keys [3]: [cd_demo_sk#26, cd_marital_status#27, cd_education_status#28]
+(21) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [ws_sold_date_sk#7]
+Right keys [1]: [d_date_sk#23]
 Join type: Inner
 Join condition: None
 
-(34) Project [codegen id : 14]
-Output [7]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17]
-Input [13]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#24, cd_education_status#25, cd_demo_sk#26, cd_marital_status#27, cd_education_status#28]
+(22) Project [codegen id : 9]
+Output [9]: [ws_quantity#4, ws_sales_price#5, ws_net_profit#6, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17]
+Input [11]: [ws_quantity#4, ws_sales_price#5, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, d_date_sk#23]
 
-(35) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
+(23) Scan parquet spark_catalog.default.customer_address
+Output [3]: [ca_address_sk#24, ca_state#25, ca_country#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_country), EqualTo(ca_country,United States), IsNotNull(ca_address_sk), Or(Or(In(ca_state, [IN,NJ,OH]),In(ca_state, [CT,KY,WI])),In(ca_state, [AR,IA,LA]))]
 ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_country:string>
 
-(36) ColumnarToRow [codegen id : 11]
-Input [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
+(24) ColumnarToRow [codegen id : 7]
+Input [3]: [ca_address_sk#24, ca_state#25, ca_country#26]
 
-(37) Filter [codegen id : 11]
-Input [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
-Condition : (((isnotnull(ca_country#31) AND (ca_country#31 = United States)) AND isnotnull(ca_address_sk#29)) AND ((ca_state#30 IN (IN,OH,NJ) OR ca_state#30 IN (WI,CT,KY)) OR ca_state#30 IN (LA,IA,AR)))
+(25) Filter [codegen id : 7]
+Input [3]: [ca_address_sk#24, ca_state#25, ca_country#26]
+Condition : (((isnotnull(ca_country#26) AND (ca_country#26 = United States)) AND isnotnull(ca_address_sk#24)) AND ((ca_state#25 IN (IN,OH,NJ) OR ca_state#25 IN (WI,CT,KY)) OR ca_state#25 IN (LA,IA,AR)))
 
-(38) Project [codegen id : 11]
-Output [2]: [ca_address_sk#29, ca_state#30]
-Input [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
+(26) Project [codegen id : 7]
+Output [2]: [ca_address_sk#24, ca_state#25]
+Input [3]: [ca_address_sk#24, ca_state#25, ca_country#26]
 
-(39) BroadcastExchange
-Input [2]: [ca_address_sk#29, ca_state#30]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
+(27) BroadcastExchange
+Input [2]: [ca_address_sk#24, ca_state#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
-(40) BroadcastHashJoin [codegen id : 14]
+(28) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [wr_refunded_addr_sk#12]
-Right keys [1]: [ca_address_sk#29]
+Right keys [1]: [ca_address_sk#24]
 Join type: Inner
-Join condition: ((((ca_state#30 IN (IN,OH,NJ) AND (ws_net_profit#6 >= 100.00)) AND (ws_net_profit#6 <= 200.00)) OR ((ca_state#30 IN (WI,CT,KY) AND (ws_net_profit#6 >= 150.00)) AND (ws_net_profit#6 <= 300.00))) OR ((ca_state#30 IN (LA,IA,AR) AND (ws_net_profit#6 >= 50.00)) AND (ws_net_profit#6 <= 250.00)))
+Join condition: ((((ca_state#25 IN (IN,OH,NJ) AND (ws_net_profit#6 >= 100.00)) AND (ws_net_profit#6 <= 200.00)) OR ((ca_state#25 IN (WI,CT,KY) AND (ws_net_profit#6 >= 150.00)) AND (ws_net_profit#6 <= 300.00))) OR ((ca_state#25 IN (LA,IA,AR) AND (ws_net_profit#6 >= 50.00)) AND (ws_net_profit#6 <= 250.00)))
 
-(41) Project [codegen id : 14]
-Output [5]: [ws_quantity#4, ws_sold_date_sk#7, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17]
-Input [9]: [ws_quantity#4, ws_net_profit#6, ws_sold_date_sk#7, wr_refunded_addr_sk#12, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, ca_address_sk#29, ca_state#30]
+(29) Project [codegen id : 9]
+Output [7]: [ws_quantity#4, ws_sales_price#5, wr_refunded_cdemo_sk#11, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17]
+Input [11]: [ws_quantity#4, ws_sales_price#5, ws_net_profit#6, wr_refunded_cdemo_sk#11, wr_refunded_addr_sk#12, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, ca_address_sk#24, ca_state#25]
 
-(42) ReusedExchange [Reuses operator id: 59]
-Output [1]: [d_date_sk#32]
+(30) Scan parquet spark_catalog.default.customer_demographics
+Output [3]: [cd_demo_sk#27, cd_marital_status#28, cd_education_status#29]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_demographics]
+PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status), IsNotNull(cd_education_status), Or(Or(And(EqualTo(cd_marital_status,M),EqualTo(cd_education_status,Advanced Degree     )),And(EqualTo(cd_marital_status,S),EqualTo(cd_education_status,College             ))),And(EqualTo(cd_marital_status,W),EqualTo(cd_education_status,2 yr Degree         )))]
+ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string,cd_education_status:string>
 
-(43) BroadcastHashJoin [codegen id : 14]
-Left keys [1]: [ws_sold_date_sk#7]
-Right keys [1]: [d_date_sk#32]
+(31) ColumnarToRow [codegen id : 8]
+Input [3]: [cd_demo_sk#27, cd_marital_status#28, cd_education_status#29]
+
+(32) Filter [codegen id : 8]
+Input [3]: [cd_demo_sk#27, cd_marital_status#28, cd_education_status#29]
+Condition : (((isnotnull(cd_demo_sk#27) AND isnotnull(cd_marital_status#28)) AND isnotnull(cd_education_status#29)) AND ((((cd_marital_status#28 = M) AND (cd_education_status#29 = Advanced Degree     )) OR ((cd_marital_status#28 = S) AND (cd_education_status#29 = College             ))) OR ((cd_marital_status#28 = W) AND (cd_education_status#29 = 2 yr Degree         ))))
+
+(33) BroadcastExchange
+Input [3]: [cd_demo_sk#27, cd_marital_status#28, cd_education_status#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
+
+(34) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [wr_refunded_cdemo_sk#11]
+Right keys [1]: [cd_demo_sk#27]
+Join type: Inner
+Join condition: ((((((cd_marital_status#28 = M) AND (cd_education_status#29 = Advanced Degree     )) AND (ws_sales_price#5 >= 100.00)) AND (ws_sales_price#5 <= 150.00)) OR ((((cd_marital_status#28 = S) AND (cd_education_status#29 = College             )) AND (ws_sales_price#5 >= 50.00)) AND (ws_sales_price#5 <= 100.00))) OR ((((cd_marital_status#28 = W) AND (cd_education_status#29 = 2 yr Degree         )) AND (ws_sales_price#5 >= 150.00)) AND (ws_sales_price#5 <= 200.00)))
+
+(35) Project [codegen id : 9]
+Output [7]: [ws_quantity#4, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#28, cd_education_status#29]
+Input [10]: [ws_quantity#4, ws_sales_price#5, wr_refunded_cdemo_sk#11, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_demo_sk#27, cd_marital_status#28, cd_education_status#29]
+
+(36) Exchange
+Input [7]: [ws_quantity#4, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#28, cd_education_status#29]
+Arguments: hashpartitioning(wr_returning_cdemo_sk#13, cd_marital_status#28, cd_education_status#29, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(37) Sort [codegen id : 10]
+Input [7]: [ws_quantity#4, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#28, cd_education_status#29]
+Arguments: [wr_returning_cdemo_sk#13 ASC NULLS FIRST, cd_marital_status#28 ASC NULLS FIRST, cd_education_status#29 ASC NULLS FIRST], false, 0
+
+(38) Scan parquet spark_catalog.default.customer_demographics
+Output [3]: [cd_demo_sk#30, cd_marital_status#31, cd_education_status#32]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_demographics]
+PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status), IsNotNull(cd_education_status)]
+ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string,cd_education_status:string>
+
+(39) ColumnarToRow [codegen id : 11]
+Input [3]: [cd_demo_sk#30, cd_marital_status#31, cd_education_status#32]
+
+(40) Filter [codegen id : 11]
+Input [3]: [cd_demo_sk#30, cd_marital_status#31, cd_education_status#32]
+Condition : ((isnotnull(cd_demo_sk#30) AND isnotnull(cd_marital_status#31)) AND isnotnull(cd_education_status#32))
+
+(41) Exchange
+Input [3]: [cd_demo_sk#30, cd_marital_status#31, cd_education_status#32]
+Arguments: hashpartitioning(cd_demo_sk#30, cd_marital_status#31, cd_education_status#32, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+
+(42) Sort [codegen id : 12]
+Input [3]: [cd_demo_sk#30, cd_marital_status#31, cd_education_status#32]
+Arguments: [cd_demo_sk#30 ASC NULLS FIRST, cd_marital_status#31 ASC NULLS FIRST, cd_education_status#32 ASC NULLS FIRST], false, 0
+
+(43) SortMergeJoin [codegen id : 14]
+Left keys [3]: [wr_returning_cdemo_sk#13, cd_marital_status#28, cd_education_status#29]
+Right keys [3]: [cd_demo_sk#30, cd_marital_status#31, cd_education_status#32]
 Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 14]
 Output [4]: [ws_quantity#4, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17]
-Input [6]: [ws_quantity#4, ws_sold_date_sk#7, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, d_date_sk#32]
+Input [10]: [ws_quantity#4, wr_returning_cdemo_sk#13, wr_reason_sk#14, wr_fee#16, wr_refunded_cash#17, cd_marital_status#28, cd_education_status#29, cd_demo_sk#30, cd_marital_status#31, cd_education_status#32]
 
 (45) Scan parquet spark_catalog.default.reason
 Output [2]: [r_reason_sk#33, r_reason_desc#34]
@@ -316,25 +316,25 @@ BroadcastExchange (59)
 
 
 (55) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#32, d_year#54]
+Output [2]: [d_date_sk#23, d_year#54]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2000), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (56) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#32, d_year#54]
+Input [2]: [d_date_sk#23, d_year#54]
 
 (57) Filter [codegen id : 1]
-Input [2]: [d_date_sk#32, d_year#54]
-Condition : ((isnotnull(d_year#54) AND (d_year#54 = 2000)) AND isnotnull(d_date_sk#32))
+Input [2]: [d_date_sk#23, d_year#54]
+Condition : ((isnotnull(d_year#54) AND (d_year#54 = 2000)) AND isnotnull(d_date_sk#23))
 
 (58) Project [codegen id : 1]
-Output [1]: [d_date_sk#32]
-Input [2]: [d_date_sk#32, d_year#54]
+Output [1]: [d_date_sk#23]
+Input [2]: [d_date_sk#23, d_year#54]
 
 (59) BroadcastExchange
-Input [1]: [d_date_sk#32]
+Input [1]: [d_date_sk#23]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=10]
 
 Subquery:2 Hosting operator id = 14 Hosting Expression = Subquery scalar-subquery#19, [id=#20]
@@ -344,31 +344,31 @@ ObjectHashAggregate (66)
       +- * Project (63)
          +- * Filter (62)
             +- * ColumnarToRow (61)
-               +- Scan parquet spark_catalog.default.customer_demographics (60)
+               +- Scan parquet spark_catalog.default.customer_address (60)
 
 
-(60) Scan parquet spark_catalog.default.customer_demographics
-Output [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
+(60) Scan parquet spark_catalog.default.customer_address
+Output [3]: [ca_address_sk#24, ca_state#25, ca_country#26]
 Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_demographics]
-PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status), IsNotNull(cd_education_status), Or(Or(And(EqualTo(cd_marital_status,M),EqualTo(cd_education_status,Advanced Degree     )),And(EqualTo(cd_marital_status,S),EqualTo(cd_education_status,College             ))),And(EqualTo(cd_marital_status,W),EqualTo(cd_education_status,2 yr Degree         )))]
-ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string,cd_education_status:string>
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_country), EqualTo(ca_country,United States), IsNotNull(ca_address_sk), Or(Or(In(ca_state, [IN,NJ,OH]),In(ca_state, [CT,KY,WI])),In(ca_state, [AR,IA,LA]))]
+ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_country:string>
 
 (61) ColumnarToRow [codegen id : 1]
-Input [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
+Input [3]: [ca_address_sk#24, ca_state#25, ca_country#26]
 
 (62) Filter [codegen id : 1]
-Input [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
-Condition : (((isnotnull(cd_demo_sk#23) AND isnotnull(cd_marital_status#24)) AND isnotnull(cd_education_status#25)) AND ((((cd_marital_status#24 = M) AND (cd_education_status#25 = Advanced Degree     )) OR ((cd_marital_status#24 = S) AND (cd_education_status#25 = College             ))) OR ((cd_marital_status#24 = W) AND (cd_education_status#25 = 2 yr Degree         ))))
+Input [3]: [ca_address_sk#24, ca_state#25, ca_country#26]
+Condition : (((isnotnull(ca_country#26) AND (ca_country#26 = United States)) AND isnotnull(ca_address_sk#24)) AND ((ca_state#25 IN (IN,OH,NJ) OR ca_state#25 IN (WI,CT,KY)) OR ca_state#25 IN (LA,IA,AR)))
 
 (63) Project [codegen id : 1]
-Output [1]: [cd_demo_sk#23]
-Input [3]: [cd_demo_sk#23, cd_marital_status#24, cd_education_status#25]
+Output [1]: [ca_address_sk#24]
+Input [3]: [ca_address_sk#24, ca_state#25, ca_country#26]
 
 (64) ObjectHashAggregate
-Input [1]: [cd_demo_sk#23]
+Input [1]: [ca_address_sk#24]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(cd_demo_sk#23, 42), 159981, 2239471, 0, 0)]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#24, 42), 152837, 2153999, 0, 0)]
 Aggregate Attributes [1]: [buf#55]
 Results [1]: [buf#56]
 
@@ -379,9 +379,9 @@ Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=11]
 (66) ObjectHashAggregate
 Input [1]: [buf#56]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#23, 42), 159981, 2239471, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#23, 42), 159981, 2239471, 0, 0)#57]
-Results [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#23, 42), 159981, 2239471, 0, 0)#57 AS bloomFilter#58]
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#24, 42), 152837, 2153999, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#24, 42), 152837, 2153999, 0, 0)#57]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#24, 42), 152837, 2153999, 0, 0)#57 AS bloomFilter#58]
 
 Subquery:3 Hosting operator id = 14 Hosting Expression = Subquery scalar-subquery#21, [id=#22]
 ObjectHashAggregate (73)
@@ -390,31 +390,31 @@ ObjectHashAggregate (73)
       +- * Project (70)
          +- * Filter (69)
             +- * ColumnarToRow (68)
-               +- Scan parquet spark_catalog.default.customer_address (67)
+               +- Scan parquet spark_catalog.default.customer_demographics (67)
 
 
-(67) Scan parquet spark_catalog.default.customer_address
-Output [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
+(67) Scan parquet spark_catalog.default.customer_demographics
+Output [3]: [cd_demo_sk#27, cd_marital_status#28, cd_education_status#29]
 Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_country), EqualTo(ca_country,United States), IsNotNull(ca_address_sk), Or(Or(In(ca_state, [IN,NJ,OH]),In(ca_state, [CT,KY,WI])),In(ca_state, [AR,IA,LA]))]
-ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_country:string>
+Location [not included in comparison]/{warehouse_dir}/customer_demographics]
+PushedFilters: [IsNotNull(cd_demo_sk), IsNotNull(cd_marital_status), IsNotNull(cd_education_status), Or(Or(And(EqualTo(cd_marital_status,M),EqualTo(cd_education_status,Advanced Degree     )),And(EqualTo(cd_marital_status,S),EqualTo(cd_education_status,College             ))),And(EqualTo(cd_marital_status,W),EqualTo(cd_education_status,2 yr Degree         )))]
+ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string,cd_education_status:string>
 
 (68) ColumnarToRow [codegen id : 1]
-Input [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
+Input [3]: [cd_demo_sk#27, cd_marital_status#28, cd_education_status#29]
 
 (69) Filter [codegen id : 1]
-Input [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
-Condition : (((isnotnull(ca_country#31) AND (ca_country#31 = United States)) AND isnotnull(ca_address_sk#29)) AND ((ca_state#30 IN (IN,OH,NJ) OR ca_state#30 IN (WI,CT,KY)) OR ca_state#30 IN (LA,IA,AR)))
+Input [3]: [cd_demo_sk#27, cd_marital_status#28, cd_education_status#29]
+Condition : (((isnotnull(cd_demo_sk#27) AND isnotnull(cd_marital_status#28)) AND isnotnull(cd_education_status#29)) AND ((((cd_marital_status#28 = M) AND (cd_education_status#29 = Advanced Degree     )) OR ((cd_marital_status#28 = S) AND (cd_education_status#29 = College             ))) OR ((cd_marital_status#28 = W) AND (cd_education_status#29 = 2 yr Degree         ))))
 
 (70) Project [codegen id : 1]
-Output [1]: [ca_address_sk#29]
-Input [3]: [ca_address_sk#29, ca_state#30, ca_country#31]
+Output [1]: [cd_demo_sk#27]
+Input [3]: [cd_demo_sk#27, cd_marital_status#28, cd_education_status#29]
 
 (71) ObjectHashAggregate
-Input [1]: [ca_address_sk#29]
+Input [1]: [cd_demo_sk#27]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#29, 42), 152837, 2153999, 0, 0)]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(cd_demo_sk#27, 42), 159981, 2239471, 0, 0)]
 Aggregate Attributes [1]: [buf#59]
 Results [1]: [buf#60]
 
@@ -425,8 +425,8 @@ Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=12]
 (73) ObjectHashAggregate
 Input [1]: [buf#60]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#29, 42), 152837, 2153999, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#29, 42), 152837, 2153999, 0, 0)#61]
-Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#29, 42), 152837, 2153999, 0, 0)#61 AS bloomFilter#62]
+Functions [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#27, 42), 159981, 2239471, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#27, 42), 159981, 2239471, 0, 0)#61]
+Results [1]: [bloom_filter_agg(xxhash64(cd_demo_sk#27, 42), 159981, 2239471, 0, 0)#61 AS bloomFilter#62]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q85.sf100/simplified.txt
@@ -8,19 +8,19 @@ TakeOrderedAndProject [substr(r_reason_desc, 1, 20),avg(ws_quantity),avg(wr_refu
               Project [ws_quantity,wr_fee,wr_refunded_cash,r_reason_desc]
                 BroadcastHashJoin [wr_reason_sk,r_reason_sk]
                   Project [ws_quantity,wr_reason_sk,wr_fee,wr_refunded_cash]
-                    BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                      Project [ws_quantity,ws_sold_date_sk,wr_reason_sk,wr_fee,wr_refunded_cash]
-                        BroadcastHashJoin [wr_refunded_addr_sk,ca_address_sk,ca_state,ws_net_profit]
-                          Project [ws_quantity,ws_net_profit,ws_sold_date_sk,wr_refunded_addr_sk,wr_reason_sk,wr_fee,wr_refunded_cash]
-                            SortMergeJoin [wr_returning_cdemo_sk,cd_marital_status,cd_education_status,cd_demo_sk,cd_marital_status,cd_education_status]
-                              InputAdapter
-                                WholeStageCodegen (8)
-                                  Sort [wr_returning_cdemo_sk,cd_marital_status,cd_education_status]
-                                    InputAdapter
-                                      Exchange [wr_returning_cdemo_sk,cd_marital_status,cd_education_status] #2
-                                        WholeStageCodegen (7)
-                                          Project [ws_quantity,ws_net_profit,ws_sold_date_sk,wr_refunded_addr_sk,wr_returning_cdemo_sk,wr_reason_sk,wr_fee,wr_refunded_cash,cd_marital_status,cd_education_status]
-                                            BroadcastHashJoin [wr_refunded_cdemo_sk,cd_demo_sk,cd_marital_status,cd_education_status,ws_sales_price]
+                    SortMergeJoin [wr_returning_cdemo_sk,cd_marital_status,cd_education_status,cd_demo_sk,cd_marital_status,cd_education_status]
+                      InputAdapter
+                        WholeStageCodegen (10)
+                          Sort [wr_returning_cdemo_sk,cd_marital_status,cd_education_status]
+                            InputAdapter
+                              Exchange [wr_returning_cdemo_sk,cd_marital_status,cd_education_status] #2
+                                WholeStageCodegen (9)
+                                  Project [ws_quantity,wr_returning_cdemo_sk,wr_reason_sk,wr_fee,wr_refunded_cash,cd_marital_status,cd_education_status]
+                                    BroadcastHashJoin [wr_refunded_cdemo_sk,cd_demo_sk,cd_marital_status,cd_education_status,ws_sales_price]
+                                      Project [ws_quantity,ws_sales_price,wr_refunded_cdemo_sk,wr_returning_cdemo_sk,wr_reason_sk,wr_fee,wr_refunded_cash]
+                                        BroadcastHashJoin [wr_refunded_addr_sk,ca_address_sk,ca_state,ws_net_profit]
+                                          Project [ws_quantity,ws_sales_price,ws_net_profit,wr_refunded_cdemo_sk,wr_refunded_addr_sk,wr_returning_cdemo_sk,wr_reason_sk,wr_fee,wr_refunded_cash]
+                                            BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                               Project [ws_quantity,ws_sales_price,ws_net_profit,ws_sold_date_sk,wr_refunded_cdemo_sk,wr_refunded_addr_sk,wr_returning_cdemo_sk,wr_reason_sk,wr_fee,wr_refunded_cash]
                                                 SortMergeJoin [ws_item_sk,ws_order_number,wr_item_sk,wr_order_number]
                                                   InputAdapter
@@ -59,18 +59,8 @@ TakeOrderedAndProject [substr(r_reason_desc, 1, 20),avg(ws_quantity),avg(wr_refu
                                                               Project [wr_item_sk,wr_refunded_cdemo_sk,wr_refunded_addr_sk,wr_returning_cdemo_sk,wr_reason_sk,wr_order_number,wr_fee,wr_refunded_cash]
                                                                 Filter [wr_item_sk,wr_order_number,wr_refunded_cdemo_sk,wr_returning_cdemo_sk,wr_refunded_addr_sk,wr_reason_sk]
                                                                   Subquery #2
-                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(cd_demo_sk, 42), 159981, 2239471, 0, 0),bloomFilter,buf]
-                                                                      Exchange #7
-                                                                        ObjectHashAggregate [cd_demo_sk] [buf,buf]
-                                                                          WholeStageCodegen (1)
-                                                                            Project [cd_demo_sk]
-                                                                              Filter [cd_demo_sk,cd_marital_status,cd_education_status]
-                                                                                ColumnarToRow
-                                                                                  InputAdapter
-                                                                                    Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status,cd_education_status]
-                                                                  Subquery #3
                                                                     ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 152837, 2153999, 0, 0),bloomFilter,buf]
-                                                                      Exchange #8
+                                                                      Exchange #7
                                                                         ObjectHashAggregate [ca_address_sk] [buf,buf]
                                                                           WholeStageCodegen (1)
                                                                             Project [ca_address_sk]
@@ -78,36 +68,46 @@ TakeOrderedAndProject [substr(r_reason_desc, 1, 20),avg(ws_quantity),avg(wr_refu
                                                                                 ColumnarToRow
                                                                                   InputAdapter
                                                                                     Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state,ca_country]
+                                                                  Subquery #3
+                                                                    ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(cd_demo_sk, 42), 159981, 2239471, 0, 0),bloomFilter,buf]
+                                                                      Exchange #8
+                                                                        ObjectHashAggregate [cd_demo_sk] [buf,buf]
+                                                                          WholeStageCodegen (1)
+                                                                            Project [cd_demo_sk]
+                                                                              Filter [cd_demo_sk,cd_marital_status,cd_education_status]
+                                                                                ColumnarToRow
+                                                                                  InputAdapter
+                                                                                    Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status,cd_education_status]
                                                                   ColumnarToRow
                                                                     InputAdapter
                                                                       Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_refunded_cdemo_sk,wr_refunded_addr_sk,wr_returning_cdemo_sk,wr_reason_sk,wr_order_number,wr_fee,wr_refunded_cash,wr_returned_date_sk]
                                               InputAdapter
-                                                BroadcastExchange #9
-                                                  WholeStageCodegen (6)
-                                                    Filter [cd_demo_sk,cd_marital_status,cd_education_status]
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status,cd_education_status]
-                              InputAdapter
-                                WholeStageCodegen (10)
-                                  Sort [cd_demo_sk,cd_marital_status,cd_education_status]
-                                    InputAdapter
-                                      Exchange [cd_demo_sk,cd_marital_status,cd_education_status] #10
-                                        WholeStageCodegen (9)
-                                          Filter [cd_demo_sk,cd_marital_status,cd_education_status]
-                                            ColumnarToRow
-                                              InputAdapter
-                                                Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status,cd_education_status]
-                          InputAdapter
-                            BroadcastExchange #11
-                              WholeStageCodegen (11)
-                                Project [ca_address_sk,ca_state]
-                                  Filter [ca_country,ca_address_sk,ca_state]
+                                                ReusedExchange [d_date_sk] #4
+                                          InputAdapter
+                                            BroadcastExchange #9
+                                              WholeStageCodegen (7)
+                                                Project [ca_address_sk,ca_state]
+                                                  Filter [ca_country,ca_address_sk,ca_state]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state,ca_country]
+                                      InputAdapter
+                                        BroadcastExchange #10
+                                          WholeStageCodegen (8)
+                                            Filter [cd_demo_sk,cd_marital_status,cd_education_status]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status,cd_education_status]
+                      InputAdapter
+                        WholeStageCodegen (12)
+                          Sort [cd_demo_sk,cd_marital_status,cd_education_status]
+                            InputAdapter
+                              Exchange [cd_demo_sk,cd_marital_status,cd_education_status] #11
+                                WholeStageCodegen (11)
+                                  Filter [cd_demo_sk,cd_marital_status,cd_education_status]
                                     ColumnarToRow
                                       InputAdapter
-                                        Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state,ca_country]
-                      InputAdapter
-                        ReusedExchange [d_date_sk] #4
+                                        Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status,cd_education_status]
                   InputAdapter
                     BroadcastExchange #12
                       WholeStageCodegen (13)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q88.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q88.sf100/explain.txt
@@ -23,164 +23,164 @@
 :  :  :  :  :  :  :              :     :        +- * Project (8)
 :  :  :  :  :  :  :              :     :           +- * Filter (7)
 :  :  :  :  :  :  :              :     :              +- * ColumnarToRow (6)
-:  :  :  :  :  :  :              :     :                 +- Scan parquet spark_catalog.default.time_dim (5)
+:  :  :  :  :  :  :              :     :                 +- Scan parquet spark_catalog.default.store (5)
 :  :  :  :  :  :  :              :     +- BroadcastExchange (16)
 :  :  :  :  :  :  :              :        +- * Project (15)
 :  :  :  :  :  :  :              :           +- * Filter (14)
 :  :  :  :  :  :  :              :              +- * ColumnarToRow (13)
-:  :  :  :  :  :  :              :                 +- Scan parquet spark_catalog.default.store (12)
+:  :  :  :  :  :  :              :                 +- Scan parquet spark_catalog.default.household_demographics (12)
 :  :  :  :  :  :  :              +- BroadcastExchange (23)
 :  :  :  :  :  :  :                 +- * Project (22)
 :  :  :  :  :  :  :                    +- * Filter (21)
 :  :  :  :  :  :  :                       +- * ColumnarToRow (20)
-:  :  :  :  :  :  :                          +- Scan parquet spark_catalog.default.household_demographics (19)
+:  :  :  :  :  :  :                          +- Scan parquet spark_catalog.default.time_dim (19)
 :  :  :  :  :  :  +- BroadcastExchange (49)
 :  :  :  :  :  :     +- * HashAggregate (48)
 :  :  :  :  :  :        +- Exchange (47)
 :  :  :  :  :  :           +- * HashAggregate (46)
 :  :  :  :  :  :              +- * Project (45)
 :  :  :  :  :  :                 +- * BroadcastHashJoin Inner BuildRight (44)
-:  :  :  :  :  :                    :- * Project (42)
-:  :  :  :  :  :                    :  +- * BroadcastHashJoin Inner BuildRight (41)
-:  :  :  :  :  :                    :     :- * Project (39)
-:  :  :  :  :  :                    :     :  +- * BroadcastHashJoin Inner BuildRight (38)
+:  :  :  :  :  :                    :- * Project (38)
+:  :  :  :  :  :                    :  +- * BroadcastHashJoin Inner BuildRight (37)
+:  :  :  :  :  :                    :     :- * Project (35)
+:  :  :  :  :  :                    :     :  +- * BroadcastHashJoin Inner BuildRight (34)
 :  :  :  :  :  :                    :     :     :- * Project (32)
 :  :  :  :  :  :                    :     :     :  +- * Filter (31)
 :  :  :  :  :  :                    :     :     :     +- * ColumnarToRow (30)
 :  :  :  :  :  :                    :     :     :        +- Scan parquet spark_catalog.default.store_sales (29)
-:  :  :  :  :  :                    :     :     +- BroadcastExchange (37)
-:  :  :  :  :  :                    :     :        +- * Project (36)
-:  :  :  :  :  :                    :     :           +- * Filter (35)
-:  :  :  :  :  :                    :     :              +- * ColumnarToRow (34)
-:  :  :  :  :  :                    :     :                 +- Scan parquet spark_catalog.default.time_dim (33)
-:  :  :  :  :  :                    :     +- ReusedExchange (40)
-:  :  :  :  :  :                    +- ReusedExchange (43)
+:  :  :  :  :  :                    :     :     +- ReusedExchange (33)
+:  :  :  :  :  :                    :     +- ReusedExchange (36)
+:  :  :  :  :  :                    +- BroadcastExchange (43)
+:  :  :  :  :  :                       +- * Project (42)
+:  :  :  :  :  :                          +- * Filter (41)
+:  :  :  :  :  :                             +- * ColumnarToRow (40)
+:  :  :  :  :  :                                +- Scan parquet spark_catalog.default.time_dim (39)
 :  :  :  :  :  +- BroadcastExchange (71)
 :  :  :  :  :     +- * HashAggregate (70)
 :  :  :  :  :        +- Exchange (69)
 :  :  :  :  :           +- * HashAggregate (68)
 :  :  :  :  :              +- * Project (67)
 :  :  :  :  :                 +- * BroadcastHashJoin Inner BuildRight (66)
-:  :  :  :  :                    :- * Project (64)
-:  :  :  :  :                    :  +- * BroadcastHashJoin Inner BuildRight (63)
-:  :  :  :  :                    :     :- * Project (61)
-:  :  :  :  :                    :     :  +- * BroadcastHashJoin Inner BuildRight (60)
+:  :  :  :  :                    :- * Project (60)
+:  :  :  :  :                    :  +- * BroadcastHashJoin Inner BuildRight (59)
+:  :  :  :  :                    :     :- * Project (57)
+:  :  :  :  :                    :     :  +- * BroadcastHashJoin Inner BuildRight (56)
 :  :  :  :  :                    :     :     :- * Project (54)
 :  :  :  :  :                    :     :     :  +- * Filter (53)
 :  :  :  :  :                    :     :     :     +- * ColumnarToRow (52)
 :  :  :  :  :                    :     :     :        +- Scan parquet spark_catalog.default.store_sales (51)
-:  :  :  :  :                    :     :     +- BroadcastExchange (59)
-:  :  :  :  :                    :     :        +- * Project (58)
-:  :  :  :  :                    :     :           +- * Filter (57)
-:  :  :  :  :                    :     :              +- * ColumnarToRow (56)
-:  :  :  :  :                    :     :                 +- Scan parquet spark_catalog.default.time_dim (55)
-:  :  :  :  :                    :     +- ReusedExchange (62)
-:  :  :  :  :                    +- ReusedExchange (65)
+:  :  :  :  :                    :     :     +- ReusedExchange (55)
+:  :  :  :  :                    :     +- ReusedExchange (58)
+:  :  :  :  :                    +- BroadcastExchange (65)
+:  :  :  :  :                       +- * Project (64)
+:  :  :  :  :                          +- * Filter (63)
+:  :  :  :  :                             +- * ColumnarToRow (62)
+:  :  :  :  :                                +- Scan parquet spark_catalog.default.time_dim (61)
 :  :  :  :  +- BroadcastExchange (93)
 :  :  :  :     +- * HashAggregate (92)
 :  :  :  :        +- Exchange (91)
 :  :  :  :           +- * HashAggregate (90)
 :  :  :  :              +- * Project (89)
 :  :  :  :                 +- * BroadcastHashJoin Inner BuildRight (88)
-:  :  :  :                    :- * Project (86)
-:  :  :  :                    :  +- * BroadcastHashJoin Inner BuildRight (85)
-:  :  :  :                    :     :- * Project (83)
-:  :  :  :                    :     :  +- * BroadcastHashJoin Inner BuildRight (82)
+:  :  :  :                    :- * Project (82)
+:  :  :  :                    :  +- * BroadcastHashJoin Inner BuildRight (81)
+:  :  :  :                    :     :- * Project (79)
+:  :  :  :                    :     :  +- * BroadcastHashJoin Inner BuildRight (78)
 :  :  :  :                    :     :     :- * Project (76)
 :  :  :  :                    :     :     :  +- * Filter (75)
 :  :  :  :                    :     :     :     +- * ColumnarToRow (74)
 :  :  :  :                    :     :     :        +- Scan parquet spark_catalog.default.store_sales (73)
-:  :  :  :                    :     :     +- BroadcastExchange (81)
-:  :  :  :                    :     :        +- * Project (80)
-:  :  :  :                    :     :           +- * Filter (79)
-:  :  :  :                    :     :              +- * ColumnarToRow (78)
-:  :  :  :                    :     :                 +- Scan parquet spark_catalog.default.time_dim (77)
-:  :  :  :                    :     +- ReusedExchange (84)
-:  :  :  :                    +- ReusedExchange (87)
+:  :  :  :                    :     :     +- ReusedExchange (77)
+:  :  :  :                    :     +- ReusedExchange (80)
+:  :  :  :                    +- BroadcastExchange (87)
+:  :  :  :                       +- * Project (86)
+:  :  :  :                          +- * Filter (85)
+:  :  :  :                             +- * ColumnarToRow (84)
+:  :  :  :                                +- Scan parquet spark_catalog.default.time_dim (83)
 :  :  :  +- BroadcastExchange (115)
 :  :  :     +- * HashAggregate (114)
 :  :  :        +- Exchange (113)
 :  :  :           +- * HashAggregate (112)
 :  :  :              +- * Project (111)
 :  :  :                 +- * BroadcastHashJoin Inner BuildRight (110)
-:  :  :                    :- * Project (108)
-:  :  :                    :  +- * BroadcastHashJoin Inner BuildRight (107)
-:  :  :                    :     :- * Project (105)
-:  :  :                    :     :  +- * BroadcastHashJoin Inner BuildRight (104)
+:  :  :                    :- * Project (104)
+:  :  :                    :  +- * BroadcastHashJoin Inner BuildRight (103)
+:  :  :                    :     :- * Project (101)
+:  :  :                    :     :  +- * BroadcastHashJoin Inner BuildRight (100)
 :  :  :                    :     :     :- * Project (98)
 :  :  :                    :     :     :  +- * Filter (97)
 :  :  :                    :     :     :     +- * ColumnarToRow (96)
 :  :  :                    :     :     :        +- Scan parquet spark_catalog.default.store_sales (95)
-:  :  :                    :     :     +- BroadcastExchange (103)
-:  :  :                    :     :        +- * Project (102)
-:  :  :                    :     :           +- * Filter (101)
-:  :  :                    :     :              +- * ColumnarToRow (100)
-:  :  :                    :     :                 +- Scan parquet spark_catalog.default.time_dim (99)
-:  :  :                    :     +- ReusedExchange (106)
-:  :  :                    +- ReusedExchange (109)
+:  :  :                    :     :     +- ReusedExchange (99)
+:  :  :                    :     +- ReusedExchange (102)
+:  :  :                    +- BroadcastExchange (109)
+:  :  :                       +- * Project (108)
+:  :  :                          +- * Filter (107)
+:  :  :                             +- * ColumnarToRow (106)
+:  :  :                                +- Scan parquet spark_catalog.default.time_dim (105)
 :  :  +- BroadcastExchange (137)
 :  :     +- * HashAggregate (136)
 :  :        +- Exchange (135)
 :  :           +- * HashAggregate (134)
 :  :              +- * Project (133)
 :  :                 +- * BroadcastHashJoin Inner BuildRight (132)
-:  :                    :- * Project (130)
-:  :                    :  +- * BroadcastHashJoin Inner BuildRight (129)
-:  :                    :     :- * Project (127)
-:  :                    :     :  +- * BroadcastHashJoin Inner BuildRight (126)
+:  :                    :- * Project (126)
+:  :                    :  +- * BroadcastHashJoin Inner BuildRight (125)
+:  :                    :     :- * Project (123)
+:  :                    :     :  +- * BroadcastHashJoin Inner BuildRight (122)
 :  :                    :     :     :- * Project (120)
 :  :                    :     :     :  +- * Filter (119)
 :  :                    :     :     :     +- * ColumnarToRow (118)
 :  :                    :     :     :        +- Scan parquet spark_catalog.default.store_sales (117)
-:  :                    :     :     +- BroadcastExchange (125)
-:  :                    :     :        +- * Project (124)
-:  :                    :     :           +- * Filter (123)
-:  :                    :     :              +- * ColumnarToRow (122)
-:  :                    :     :                 +- Scan parquet spark_catalog.default.time_dim (121)
-:  :                    :     +- ReusedExchange (128)
-:  :                    +- ReusedExchange (131)
+:  :                    :     :     +- ReusedExchange (121)
+:  :                    :     +- ReusedExchange (124)
+:  :                    +- BroadcastExchange (131)
+:  :                       +- * Project (130)
+:  :                          +- * Filter (129)
+:  :                             +- * ColumnarToRow (128)
+:  :                                +- Scan parquet spark_catalog.default.time_dim (127)
 :  +- BroadcastExchange (159)
 :     +- * HashAggregate (158)
 :        +- Exchange (157)
 :           +- * HashAggregate (156)
 :              +- * Project (155)
 :                 +- * BroadcastHashJoin Inner BuildRight (154)
-:                    :- * Project (152)
-:                    :  +- * BroadcastHashJoin Inner BuildRight (151)
-:                    :     :- * Project (149)
-:                    :     :  +- * BroadcastHashJoin Inner BuildRight (148)
+:                    :- * Project (148)
+:                    :  +- * BroadcastHashJoin Inner BuildRight (147)
+:                    :     :- * Project (145)
+:                    :     :  +- * BroadcastHashJoin Inner BuildRight (144)
 :                    :     :     :- * Project (142)
 :                    :     :     :  +- * Filter (141)
 :                    :     :     :     +- * ColumnarToRow (140)
 :                    :     :     :        +- Scan parquet spark_catalog.default.store_sales (139)
-:                    :     :     +- BroadcastExchange (147)
-:                    :     :        +- * Project (146)
-:                    :     :           +- * Filter (145)
-:                    :     :              +- * ColumnarToRow (144)
-:                    :     :                 +- Scan parquet spark_catalog.default.time_dim (143)
-:                    :     +- ReusedExchange (150)
-:                    +- ReusedExchange (153)
+:                    :     :     +- ReusedExchange (143)
+:                    :     +- ReusedExchange (146)
+:                    +- BroadcastExchange (153)
+:                       +- * Project (152)
+:                          +- * Filter (151)
+:                             +- * ColumnarToRow (150)
+:                                +- Scan parquet spark_catalog.default.time_dim (149)
 +- BroadcastExchange (181)
    +- * HashAggregate (180)
       +- Exchange (179)
          +- * HashAggregate (178)
             +- * Project (177)
                +- * BroadcastHashJoin Inner BuildRight (176)
-                  :- * Project (174)
-                  :  +- * BroadcastHashJoin Inner BuildRight (173)
-                  :     :- * Project (171)
-                  :     :  +- * BroadcastHashJoin Inner BuildRight (170)
+                  :- * Project (170)
+                  :  +- * BroadcastHashJoin Inner BuildRight (169)
+                  :     :- * Project (167)
+                  :     :  +- * BroadcastHashJoin Inner BuildRight (166)
                   :     :     :- * Project (164)
                   :     :     :  +- * Filter (163)
                   :     :     :     +- * ColumnarToRow (162)
                   :     :     :        +- Scan parquet spark_catalog.default.store_sales (161)
-                  :     :     +- BroadcastExchange (169)
-                  :     :        +- * Project (168)
-                  :     :           +- * Filter (167)
-                  :     :              +- * ColumnarToRow (166)
-                  :     :                 +- Scan parquet spark_catalog.default.time_dim (165)
-                  :     +- ReusedExchange (172)
-                  +- ReusedExchange (175)
+                  :     :     +- ReusedExchange (165)
+                  :     +- ReusedExchange (168)
+                  +- BroadcastExchange (175)
+                     +- * Project (174)
+                        +- * Filter (173)
+                           +- * ColumnarToRow (172)
+                              +- Scan parquet spark_catalog.default.time_dim (171)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -201,101 +201,101 @@ Condition : ((isnotnull(ss_hdemo_sk#2) AND isnotnull(ss_sold_time_sk#1)) AND isn
 Output [3]: [ss_sold_time_sk#1, ss_hdemo_sk#2, ss_store_sk#3]
 Input [4]: [ss_sold_time_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_sold_date_sk#4]
 
-(5) Scan parquet spark_catalog.default.time_dim
-Output [3]: [t_time_sk#5, t_hour#6, t_minute#7]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/time_dim]
-PushedFilters: [IsNotNull(t_hour), IsNotNull(t_minute), EqualTo(t_hour,8), GreaterThanOrEqual(t_minute,30), IsNotNull(t_time_sk)]
-ReadSchema: struct<t_time_sk:int,t_hour:int,t_minute:int>
-
-(6) ColumnarToRow [codegen id : 1]
-Input [3]: [t_time_sk#5, t_hour#6, t_minute#7]
-
-(7) Filter [codegen id : 1]
-Input [3]: [t_time_sk#5, t_hour#6, t_minute#7]
-Condition : ((((isnotnull(t_hour#6) AND isnotnull(t_minute#7)) AND (t_hour#6 = 8)) AND (t_minute#7 >= 30)) AND isnotnull(t_time_sk#5))
-
-(8) Project [codegen id : 1]
-Output [1]: [t_time_sk#5]
-Input [3]: [t_time_sk#5, t_hour#6, t_minute#7]
-
-(9) BroadcastExchange
-Input [1]: [t_time_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
-
-(10) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_time_sk#1]
-Right keys [1]: [t_time_sk#5]
-Join type: Inner
-Join condition: None
-
-(11) Project [codegen id : 4]
-Output [2]: [ss_hdemo_sk#2, ss_store_sk#3]
-Input [4]: [ss_sold_time_sk#1, ss_hdemo_sk#2, ss_store_sk#3, t_time_sk#5]
-
-(12) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#8, s_store_name#9]
+(5) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#5, s_store_name#6]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_name), EqualTo(s_store_name,ese), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string>
 
-(13) ColumnarToRow [codegen id : 2]
-Input [2]: [s_store_sk#8, s_store_name#9]
+(6) ColumnarToRow [codegen id : 1]
+Input [2]: [s_store_sk#5, s_store_name#6]
 
-(14) Filter [codegen id : 2]
-Input [2]: [s_store_sk#8, s_store_name#9]
-Condition : ((isnotnull(s_store_name#9) AND (s_store_name#9 = ese)) AND isnotnull(s_store_sk#8))
+(7) Filter [codegen id : 1]
+Input [2]: [s_store_sk#5, s_store_name#6]
+Condition : ((isnotnull(s_store_name#6) AND (s_store_name#6 = ese)) AND isnotnull(s_store_sk#5))
 
-(15) Project [codegen id : 2]
-Output [1]: [s_store_sk#8]
-Input [2]: [s_store_sk#8, s_store_name#9]
+(8) Project [codegen id : 1]
+Output [1]: [s_store_sk#5]
+Input [2]: [s_store_sk#5, s_store_name#6]
 
-(16) BroadcastExchange
-Input [1]: [s_store_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
+(9) BroadcastExchange
+Input [1]: [s_store_sk#5]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(17) BroadcastHashJoin [codegen id : 4]
+(10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#8]
+Right keys [1]: [s_store_sk#5]
 Join type: Inner
 Join condition: None
 
-(18) Project [codegen id : 4]
-Output [1]: [ss_hdemo_sk#2]
-Input [3]: [ss_hdemo_sk#2, ss_store_sk#3, s_store_sk#8]
+(11) Project [codegen id : 4]
+Output [2]: [ss_sold_time_sk#1, ss_hdemo_sk#2]
+Input [4]: [ss_sold_time_sk#1, ss_hdemo_sk#2, ss_store_sk#3, s_store_sk#5]
 
-(19) Scan parquet spark_catalog.default.household_demographics
-Output [3]: [hd_demo_sk#10, hd_dep_count#11, hd_vehicle_count#12]
+(12) Scan parquet spark_catalog.default.household_demographics
+Output [3]: [hd_demo_sk#7, hd_dep_count#8, hd_vehicle_count#9]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [Or(Or(And(EqualTo(hd_dep_count,4),LessThanOrEqual(hd_vehicle_count,6)),And(EqualTo(hd_dep_count,2),LessThanOrEqual(hd_vehicle_count,4))),And(EqualTo(hd_dep_count,0),LessThanOrEqual(hd_vehicle_count,2))), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_dep_count:int,hd_vehicle_count:int>
 
+(13) ColumnarToRow [codegen id : 2]
+Input [3]: [hd_demo_sk#7, hd_dep_count#8, hd_vehicle_count#9]
+
+(14) Filter [codegen id : 2]
+Input [3]: [hd_demo_sk#7, hd_dep_count#8, hd_vehicle_count#9]
+Condition : (((((hd_dep_count#8 = 4) AND (hd_vehicle_count#9 <= 6)) OR ((hd_dep_count#8 = 2) AND (hd_vehicle_count#9 <= 4))) OR ((hd_dep_count#8 = 0) AND (hd_vehicle_count#9 <= 2))) AND isnotnull(hd_demo_sk#7))
+
+(15) Project [codegen id : 2]
+Output [1]: [hd_demo_sk#7]
+Input [3]: [hd_demo_sk#7, hd_dep_count#8, hd_vehicle_count#9]
+
+(16) BroadcastExchange
+Input [1]: [hd_demo_sk#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
+
+(17) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_hdemo_sk#2]
+Right keys [1]: [hd_demo_sk#7]
+Join type: Inner
+Join condition: None
+
+(18) Project [codegen id : 4]
+Output [1]: [ss_sold_time_sk#1]
+Input [3]: [ss_sold_time_sk#1, ss_hdemo_sk#2, hd_demo_sk#7]
+
+(19) Scan parquet spark_catalog.default.time_dim
+Output [3]: [t_time_sk#10, t_hour#11, t_minute#12]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/time_dim]
+PushedFilters: [IsNotNull(t_hour), IsNotNull(t_minute), EqualTo(t_hour,8), GreaterThanOrEqual(t_minute,30), IsNotNull(t_time_sk)]
+ReadSchema: struct<t_time_sk:int,t_hour:int,t_minute:int>
+
 (20) ColumnarToRow [codegen id : 3]
-Input [3]: [hd_demo_sk#10, hd_dep_count#11, hd_vehicle_count#12]
+Input [3]: [t_time_sk#10, t_hour#11, t_minute#12]
 
 (21) Filter [codegen id : 3]
-Input [3]: [hd_demo_sk#10, hd_dep_count#11, hd_vehicle_count#12]
-Condition : (((((hd_dep_count#11 = 4) AND (hd_vehicle_count#12 <= 6)) OR ((hd_dep_count#11 = 2) AND (hd_vehicle_count#12 <= 4))) OR ((hd_dep_count#11 = 0) AND (hd_vehicle_count#12 <= 2))) AND isnotnull(hd_demo_sk#10))
+Input [3]: [t_time_sk#10, t_hour#11, t_minute#12]
+Condition : ((((isnotnull(t_hour#11) AND isnotnull(t_minute#12)) AND (t_hour#11 = 8)) AND (t_minute#12 >= 30)) AND isnotnull(t_time_sk#10))
 
 (22) Project [codegen id : 3]
-Output [1]: [hd_demo_sk#10]
-Input [3]: [hd_demo_sk#10, hd_dep_count#11, hd_vehicle_count#12]
+Output [1]: [t_time_sk#10]
+Input [3]: [t_time_sk#10, t_hour#11, t_minute#12]
 
 (23) BroadcastExchange
-Input [1]: [hd_demo_sk#10]
+Input [1]: [t_time_sk#10]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
 
 (24) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_hdemo_sk#2]
-Right keys [1]: [hd_demo_sk#10]
+Left keys [1]: [ss_sold_time_sk#1]
+Right keys [1]: [t_time_sk#10]
 Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 4]
 Output: []
-Input [2]: [ss_hdemo_sk#2, hd_demo_sk#10]
+Input [2]: [ss_sold_time_sk#1, t_time_sk#10]
 
 (26) HashAggregate [codegen id : 4]
 Input: []
@@ -333,63 +333,63 @@ Condition : ((isnotnull(ss_hdemo_sk#18) AND isnotnull(ss_sold_time_sk#17)) AND i
 Output [3]: [ss_sold_time_sk#17, ss_hdemo_sk#18, ss_store_sk#19]
 Input [4]: [ss_sold_time_sk#17, ss_hdemo_sk#18, ss_store_sk#19, ss_sold_date_sk#20]
 
-(33) Scan parquet spark_catalog.default.time_dim
-Output [3]: [t_time_sk#21, t_hour#22, t_minute#23]
+(33) ReusedExchange [Reuses operator id: 9]
+Output [1]: [s_store_sk#21]
+
+(34) BroadcastHashJoin [codegen id : 8]
+Left keys [1]: [ss_store_sk#19]
+Right keys [1]: [s_store_sk#21]
+Join type: Inner
+Join condition: None
+
+(35) Project [codegen id : 8]
+Output [2]: [ss_sold_time_sk#17, ss_hdemo_sk#18]
+Input [4]: [ss_sold_time_sk#17, ss_hdemo_sk#18, ss_store_sk#19, s_store_sk#21]
+
+(36) ReusedExchange [Reuses operator id: 16]
+Output [1]: [hd_demo_sk#22]
+
+(37) BroadcastHashJoin [codegen id : 8]
+Left keys [1]: [ss_hdemo_sk#18]
+Right keys [1]: [hd_demo_sk#22]
+Join type: Inner
+Join condition: None
+
+(38) Project [codegen id : 8]
+Output [1]: [ss_sold_time_sk#17]
+Input [3]: [ss_sold_time_sk#17, ss_hdemo_sk#18, hd_demo_sk#22]
+
+(39) Scan parquet spark_catalog.default.time_dim
+Output [3]: [t_time_sk#23, t_hour#24, t_minute#25]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/time_dim]
 PushedFilters: [IsNotNull(t_hour), IsNotNull(t_minute), EqualTo(t_hour,9), LessThan(t_minute,30), IsNotNull(t_time_sk)]
 ReadSchema: struct<t_time_sk:int,t_hour:int,t_minute:int>
 
-(34) ColumnarToRow [codegen id : 5]
-Input [3]: [t_time_sk#21, t_hour#22, t_minute#23]
+(40) ColumnarToRow [codegen id : 7]
+Input [3]: [t_time_sk#23, t_hour#24, t_minute#25]
 
-(35) Filter [codegen id : 5]
-Input [3]: [t_time_sk#21, t_hour#22, t_minute#23]
-Condition : ((((isnotnull(t_hour#22) AND isnotnull(t_minute#23)) AND (t_hour#22 = 9)) AND (t_minute#23 < 30)) AND isnotnull(t_time_sk#21))
+(41) Filter [codegen id : 7]
+Input [3]: [t_time_sk#23, t_hour#24, t_minute#25]
+Condition : ((((isnotnull(t_hour#24) AND isnotnull(t_minute#25)) AND (t_hour#24 = 9)) AND (t_minute#25 < 30)) AND isnotnull(t_time_sk#23))
 
-(36) Project [codegen id : 5]
-Output [1]: [t_time_sk#21]
-Input [3]: [t_time_sk#21, t_hour#22, t_minute#23]
+(42) Project [codegen id : 7]
+Output [1]: [t_time_sk#23]
+Input [3]: [t_time_sk#23, t_hour#24, t_minute#25]
 
-(37) BroadcastExchange
-Input [1]: [t_time_sk#21]
+(43) BroadcastExchange
+Input [1]: [t_time_sk#23]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
-(38) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ss_sold_time_sk#17]
-Right keys [1]: [t_time_sk#21]
-Join type: Inner
-Join condition: None
-
-(39) Project [codegen id : 8]
-Output [2]: [ss_hdemo_sk#18, ss_store_sk#19]
-Input [4]: [ss_sold_time_sk#17, ss_hdemo_sk#18, ss_store_sk#19, t_time_sk#21]
-
-(40) ReusedExchange [Reuses operator id: 16]
-Output [1]: [s_store_sk#24]
-
-(41) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ss_store_sk#19]
-Right keys [1]: [s_store_sk#24]
-Join type: Inner
-Join condition: None
-
-(42) Project [codegen id : 8]
-Output [1]: [ss_hdemo_sk#18]
-Input [3]: [ss_hdemo_sk#18, ss_store_sk#19, s_store_sk#24]
-
-(43) ReusedExchange [Reuses operator id: 23]
-Output [1]: [hd_demo_sk#25]
-
 (44) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [ss_hdemo_sk#18]
-Right keys [1]: [hd_demo_sk#25]
+Left keys [1]: [ss_sold_time_sk#17]
+Right keys [1]: [t_time_sk#23]
 Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 8]
 Output: []
-Input [2]: [ss_hdemo_sk#18, hd_demo_sk#25]
+Input [2]: [ss_sold_time_sk#17, t_time_sk#23]
 
 (46) HashAggregate [codegen id : 8]
 Input: []
@@ -435,63 +435,63 @@ Condition : ((isnotnull(ss_hdemo_sk#31) AND isnotnull(ss_sold_time_sk#30)) AND i
 Output [3]: [ss_sold_time_sk#30, ss_hdemo_sk#31, ss_store_sk#32]
 Input [4]: [ss_sold_time_sk#30, ss_hdemo_sk#31, ss_store_sk#32, ss_sold_date_sk#33]
 
-(55) Scan parquet spark_catalog.default.time_dim
-Output [3]: [t_time_sk#34, t_hour#35, t_minute#36]
+(55) ReusedExchange [Reuses operator id: 9]
+Output [1]: [s_store_sk#34]
+
+(56) BroadcastHashJoin [codegen id : 13]
+Left keys [1]: [ss_store_sk#32]
+Right keys [1]: [s_store_sk#34]
+Join type: Inner
+Join condition: None
+
+(57) Project [codegen id : 13]
+Output [2]: [ss_sold_time_sk#30, ss_hdemo_sk#31]
+Input [4]: [ss_sold_time_sk#30, ss_hdemo_sk#31, ss_store_sk#32, s_store_sk#34]
+
+(58) ReusedExchange [Reuses operator id: 16]
+Output [1]: [hd_demo_sk#35]
+
+(59) BroadcastHashJoin [codegen id : 13]
+Left keys [1]: [ss_hdemo_sk#31]
+Right keys [1]: [hd_demo_sk#35]
+Join type: Inner
+Join condition: None
+
+(60) Project [codegen id : 13]
+Output [1]: [ss_sold_time_sk#30]
+Input [3]: [ss_sold_time_sk#30, ss_hdemo_sk#31, hd_demo_sk#35]
+
+(61) Scan parquet spark_catalog.default.time_dim
+Output [3]: [t_time_sk#36, t_hour#37, t_minute#38]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/time_dim]
 PushedFilters: [IsNotNull(t_hour), IsNotNull(t_minute), EqualTo(t_hour,9), GreaterThanOrEqual(t_minute,30), IsNotNull(t_time_sk)]
 ReadSchema: struct<t_time_sk:int,t_hour:int,t_minute:int>
 
-(56) ColumnarToRow [codegen id : 10]
-Input [3]: [t_time_sk#34, t_hour#35, t_minute#36]
+(62) ColumnarToRow [codegen id : 12]
+Input [3]: [t_time_sk#36, t_hour#37, t_minute#38]
 
-(57) Filter [codegen id : 10]
-Input [3]: [t_time_sk#34, t_hour#35, t_minute#36]
-Condition : ((((isnotnull(t_hour#35) AND isnotnull(t_minute#36)) AND (t_hour#35 = 9)) AND (t_minute#36 >= 30)) AND isnotnull(t_time_sk#34))
+(63) Filter [codegen id : 12]
+Input [3]: [t_time_sk#36, t_hour#37, t_minute#38]
+Condition : ((((isnotnull(t_hour#37) AND isnotnull(t_minute#38)) AND (t_hour#37 = 9)) AND (t_minute#38 >= 30)) AND isnotnull(t_time_sk#36))
 
-(58) Project [codegen id : 10]
-Output [1]: [t_time_sk#34]
-Input [3]: [t_time_sk#34, t_hour#35, t_minute#36]
+(64) Project [codegen id : 12]
+Output [1]: [t_time_sk#36]
+Input [3]: [t_time_sk#36, t_hour#37, t_minute#38]
 
-(59) BroadcastExchange
-Input [1]: [t_time_sk#34]
+(65) BroadcastExchange
+Input [1]: [t_time_sk#36]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 
-(60) BroadcastHashJoin [codegen id : 13]
-Left keys [1]: [ss_sold_time_sk#30]
-Right keys [1]: [t_time_sk#34]
-Join type: Inner
-Join condition: None
-
-(61) Project [codegen id : 13]
-Output [2]: [ss_hdemo_sk#31, ss_store_sk#32]
-Input [4]: [ss_sold_time_sk#30, ss_hdemo_sk#31, ss_store_sk#32, t_time_sk#34]
-
-(62) ReusedExchange [Reuses operator id: 16]
-Output [1]: [s_store_sk#37]
-
-(63) BroadcastHashJoin [codegen id : 13]
-Left keys [1]: [ss_store_sk#32]
-Right keys [1]: [s_store_sk#37]
-Join type: Inner
-Join condition: None
-
-(64) Project [codegen id : 13]
-Output [1]: [ss_hdemo_sk#31]
-Input [3]: [ss_hdemo_sk#31, ss_store_sk#32, s_store_sk#37]
-
-(65) ReusedExchange [Reuses operator id: 23]
-Output [1]: [hd_demo_sk#38]
-
 (66) BroadcastHashJoin [codegen id : 13]
-Left keys [1]: [ss_hdemo_sk#31]
-Right keys [1]: [hd_demo_sk#38]
+Left keys [1]: [ss_sold_time_sk#30]
+Right keys [1]: [t_time_sk#36]
 Join type: Inner
 Join condition: None
 
 (67) Project [codegen id : 13]
 Output: []
-Input [2]: [ss_hdemo_sk#31, hd_demo_sk#38]
+Input [2]: [ss_sold_time_sk#30, t_time_sk#36]
 
 (68) HashAggregate [codegen id : 13]
 Input: []
@@ -537,63 +537,63 @@ Condition : ((isnotnull(ss_hdemo_sk#44) AND isnotnull(ss_sold_time_sk#43)) AND i
 Output [3]: [ss_sold_time_sk#43, ss_hdemo_sk#44, ss_store_sk#45]
 Input [4]: [ss_sold_time_sk#43, ss_hdemo_sk#44, ss_store_sk#45, ss_sold_date_sk#46]
 
-(77) Scan parquet spark_catalog.default.time_dim
-Output [3]: [t_time_sk#47, t_hour#48, t_minute#49]
+(77) ReusedExchange [Reuses operator id: 9]
+Output [1]: [s_store_sk#47]
+
+(78) BroadcastHashJoin [codegen id : 18]
+Left keys [1]: [ss_store_sk#45]
+Right keys [1]: [s_store_sk#47]
+Join type: Inner
+Join condition: None
+
+(79) Project [codegen id : 18]
+Output [2]: [ss_sold_time_sk#43, ss_hdemo_sk#44]
+Input [4]: [ss_sold_time_sk#43, ss_hdemo_sk#44, ss_store_sk#45, s_store_sk#47]
+
+(80) ReusedExchange [Reuses operator id: 16]
+Output [1]: [hd_demo_sk#48]
+
+(81) BroadcastHashJoin [codegen id : 18]
+Left keys [1]: [ss_hdemo_sk#44]
+Right keys [1]: [hd_demo_sk#48]
+Join type: Inner
+Join condition: None
+
+(82) Project [codegen id : 18]
+Output [1]: [ss_sold_time_sk#43]
+Input [3]: [ss_sold_time_sk#43, ss_hdemo_sk#44, hd_demo_sk#48]
+
+(83) Scan parquet spark_catalog.default.time_dim
+Output [3]: [t_time_sk#49, t_hour#50, t_minute#51]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/time_dim]
 PushedFilters: [IsNotNull(t_hour), IsNotNull(t_minute), EqualTo(t_hour,10), LessThan(t_minute,30), IsNotNull(t_time_sk)]
 ReadSchema: struct<t_time_sk:int,t_hour:int,t_minute:int>
 
-(78) ColumnarToRow [codegen id : 15]
-Input [3]: [t_time_sk#47, t_hour#48, t_minute#49]
+(84) ColumnarToRow [codegen id : 17]
+Input [3]: [t_time_sk#49, t_hour#50, t_minute#51]
 
-(79) Filter [codegen id : 15]
-Input [3]: [t_time_sk#47, t_hour#48, t_minute#49]
-Condition : ((((isnotnull(t_hour#48) AND isnotnull(t_minute#49)) AND (t_hour#48 = 10)) AND (t_minute#49 < 30)) AND isnotnull(t_time_sk#47))
+(85) Filter [codegen id : 17]
+Input [3]: [t_time_sk#49, t_hour#50, t_minute#51]
+Condition : ((((isnotnull(t_hour#50) AND isnotnull(t_minute#51)) AND (t_hour#50 = 10)) AND (t_minute#51 < 30)) AND isnotnull(t_time_sk#49))
 
-(80) Project [codegen id : 15]
-Output [1]: [t_time_sk#47]
-Input [3]: [t_time_sk#47, t_hour#48, t_minute#49]
+(86) Project [codegen id : 17]
+Output [1]: [t_time_sk#49]
+Input [3]: [t_time_sk#49, t_hour#50, t_minute#51]
 
-(81) BroadcastExchange
-Input [1]: [t_time_sk#47]
+(87) BroadcastExchange
+Input [1]: [t_time_sk#49]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
-(82) BroadcastHashJoin [codegen id : 18]
-Left keys [1]: [ss_sold_time_sk#43]
-Right keys [1]: [t_time_sk#47]
-Join type: Inner
-Join condition: None
-
-(83) Project [codegen id : 18]
-Output [2]: [ss_hdemo_sk#44, ss_store_sk#45]
-Input [4]: [ss_sold_time_sk#43, ss_hdemo_sk#44, ss_store_sk#45, t_time_sk#47]
-
-(84) ReusedExchange [Reuses operator id: 16]
-Output [1]: [s_store_sk#50]
-
-(85) BroadcastHashJoin [codegen id : 18]
-Left keys [1]: [ss_store_sk#45]
-Right keys [1]: [s_store_sk#50]
-Join type: Inner
-Join condition: None
-
-(86) Project [codegen id : 18]
-Output [1]: [ss_hdemo_sk#44]
-Input [3]: [ss_hdemo_sk#44, ss_store_sk#45, s_store_sk#50]
-
-(87) ReusedExchange [Reuses operator id: 23]
-Output [1]: [hd_demo_sk#51]
-
 (88) BroadcastHashJoin [codegen id : 18]
-Left keys [1]: [ss_hdemo_sk#44]
-Right keys [1]: [hd_demo_sk#51]
+Left keys [1]: [ss_sold_time_sk#43]
+Right keys [1]: [t_time_sk#49]
 Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 18]
 Output: []
-Input [2]: [ss_hdemo_sk#44, hd_demo_sk#51]
+Input [2]: [ss_sold_time_sk#43, t_time_sk#49]
 
 (90) HashAggregate [codegen id : 18]
 Input: []
@@ -639,63 +639,63 @@ Condition : ((isnotnull(ss_hdemo_sk#57) AND isnotnull(ss_sold_time_sk#56)) AND i
 Output [3]: [ss_sold_time_sk#56, ss_hdemo_sk#57, ss_store_sk#58]
 Input [4]: [ss_sold_time_sk#56, ss_hdemo_sk#57, ss_store_sk#58, ss_sold_date_sk#59]
 
-(99) Scan parquet spark_catalog.default.time_dim
-Output [3]: [t_time_sk#60, t_hour#61, t_minute#62]
+(99) ReusedExchange [Reuses operator id: 9]
+Output [1]: [s_store_sk#60]
+
+(100) BroadcastHashJoin [codegen id : 23]
+Left keys [1]: [ss_store_sk#58]
+Right keys [1]: [s_store_sk#60]
+Join type: Inner
+Join condition: None
+
+(101) Project [codegen id : 23]
+Output [2]: [ss_sold_time_sk#56, ss_hdemo_sk#57]
+Input [4]: [ss_sold_time_sk#56, ss_hdemo_sk#57, ss_store_sk#58, s_store_sk#60]
+
+(102) ReusedExchange [Reuses operator id: 16]
+Output [1]: [hd_demo_sk#61]
+
+(103) BroadcastHashJoin [codegen id : 23]
+Left keys [1]: [ss_hdemo_sk#57]
+Right keys [1]: [hd_demo_sk#61]
+Join type: Inner
+Join condition: None
+
+(104) Project [codegen id : 23]
+Output [1]: [ss_sold_time_sk#56]
+Input [3]: [ss_sold_time_sk#56, ss_hdemo_sk#57, hd_demo_sk#61]
+
+(105) Scan parquet spark_catalog.default.time_dim
+Output [3]: [t_time_sk#62, t_hour#63, t_minute#64]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/time_dim]
 PushedFilters: [IsNotNull(t_hour), IsNotNull(t_minute), EqualTo(t_hour,10), GreaterThanOrEqual(t_minute,30), IsNotNull(t_time_sk)]
 ReadSchema: struct<t_time_sk:int,t_hour:int,t_minute:int>
 
-(100) ColumnarToRow [codegen id : 20]
-Input [3]: [t_time_sk#60, t_hour#61, t_minute#62]
+(106) ColumnarToRow [codegen id : 22]
+Input [3]: [t_time_sk#62, t_hour#63, t_minute#64]
 
-(101) Filter [codegen id : 20]
-Input [3]: [t_time_sk#60, t_hour#61, t_minute#62]
-Condition : ((((isnotnull(t_hour#61) AND isnotnull(t_minute#62)) AND (t_hour#61 = 10)) AND (t_minute#62 >= 30)) AND isnotnull(t_time_sk#60))
+(107) Filter [codegen id : 22]
+Input [3]: [t_time_sk#62, t_hour#63, t_minute#64]
+Condition : ((((isnotnull(t_hour#63) AND isnotnull(t_minute#64)) AND (t_hour#63 = 10)) AND (t_minute#64 >= 30)) AND isnotnull(t_time_sk#62))
 
-(102) Project [codegen id : 20]
-Output [1]: [t_time_sk#60]
-Input [3]: [t_time_sk#60, t_hour#61, t_minute#62]
+(108) Project [codegen id : 22]
+Output [1]: [t_time_sk#62]
+Input [3]: [t_time_sk#62, t_hour#63, t_minute#64]
 
-(103) BroadcastExchange
-Input [1]: [t_time_sk#60]
+(109) BroadcastExchange
+Input [1]: [t_time_sk#62]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=14]
 
-(104) BroadcastHashJoin [codegen id : 23]
-Left keys [1]: [ss_sold_time_sk#56]
-Right keys [1]: [t_time_sk#60]
-Join type: Inner
-Join condition: None
-
-(105) Project [codegen id : 23]
-Output [2]: [ss_hdemo_sk#57, ss_store_sk#58]
-Input [4]: [ss_sold_time_sk#56, ss_hdemo_sk#57, ss_store_sk#58, t_time_sk#60]
-
-(106) ReusedExchange [Reuses operator id: 16]
-Output [1]: [s_store_sk#63]
-
-(107) BroadcastHashJoin [codegen id : 23]
-Left keys [1]: [ss_store_sk#58]
-Right keys [1]: [s_store_sk#63]
-Join type: Inner
-Join condition: None
-
-(108) Project [codegen id : 23]
-Output [1]: [ss_hdemo_sk#57]
-Input [3]: [ss_hdemo_sk#57, ss_store_sk#58, s_store_sk#63]
-
-(109) ReusedExchange [Reuses operator id: 23]
-Output [1]: [hd_demo_sk#64]
-
 (110) BroadcastHashJoin [codegen id : 23]
-Left keys [1]: [ss_hdemo_sk#57]
-Right keys [1]: [hd_demo_sk#64]
+Left keys [1]: [ss_sold_time_sk#56]
+Right keys [1]: [t_time_sk#62]
 Join type: Inner
 Join condition: None
 
 (111) Project [codegen id : 23]
 Output: []
-Input [2]: [ss_hdemo_sk#57, hd_demo_sk#64]
+Input [2]: [ss_sold_time_sk#56, t_time_sk#62]
 
 (112) HashAggregate [codegen id : 23]
 Input: []
@@ -741,63 +741,63 @@ Condition : ((isnotnull(ss_hdemo_sk#70) AND isnotnull(ss_sold_time_sk#69)) AND i
 Output [3]: [ss_sold_time_sk#69, ss_hdemo_sk#70, ss_store_sk#71]
 Input [4]: [ss_sold_time_sk#69, ss_hdemo_sk#70, ss_store_sk#71, ss_sold_date_sk#72]
 
-(121) Scan parquet spark_catalog.default.time_dim
-Output [3]: [t_time_sk#73, t_hour#74, t_minute#75]
+(121) ReusedExchange [Reuses operator id: 9]
+Output [1]: [s_store_sk#73]
+
+(122) BroadcastHashJoin [codegen id : 28]
+Left keys [1]: [ss_store_sk#71]
+Right keys [1]: [s_store_sk#73]
+Join type: Inner
+Join condition: None
+
+(123) Project [codegen id : 28]
+Output [2]: [ss_sold_time_sk#69, ss_hdemo_sk#70]
+Input [4]: [ss_sold_time_sk#69, ss_hdemo_sk#70, ss_store_sk#71, s_store_sk#73]
+
+(124) ReusedExchange [Reuses operator id: 16]
+Output [1]: [hd_demo_sk#74]
+
+(125) BroadcastHashJoin [codegen id : 28]
+Left keys [1]: [ss_hdemo_sk#70]
+Right keys [1]: [hd_demo_sk#74]
+Join type: Inner
+Join condition: None
+
+(126) Project [codegen id : 28]
+Output [1]: [ss_sold_time_sk#69]
+Input [3]: [ss_sold_time_sk#69, ss_hdemo_sk#70, hd_demo_sk#74]
+
+(127) Scan parquet spark_catalog.default.time_dim
+Output [3]: [t_time_sk#75, t_hour#76, t_minute#77]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/time_dim]
 PushedFilters: [IsNotNull(t_hour), IsNotNull(t_minute), EqualTo(t_hour,11), LessThan(t_minute,30), IsNotNull(t_time_sk)]
 ReadSchema: struct<t_time_sk:int,t_hour:int,t_minute:int>
 
-(122) ColumnarToRow [codegen id : 25]
-Input [3]: [t_time_sk#73, t_hour#74, t_minute#75]
+(128) ColumnarToRow [codegen id : 27]
+Input [3]: [t_time_sk#75, t_hour#76, t_minute#77]
 
-(123) Filter [codegen id : 25]
-Input [3]: [t_time_sk#73, t_hour#74, t_minute#75]
-Condition : ((((isnotnull(t_hour#74) AND isnotnull(t_minute#75)) AND (t_hour#74 = 11)) AND (t_minute#75 < 30)) AND isnotnull(t_time_sk#73))
+(129) Filter [codegen id : 27]
+Input [3]: [t_time_sk#75, t_hour#76, t_minute#77]
+Condition : ((((isnotnull(t_hour#76) AND isnotnull(t_minute#77)) AND (t_hour#76 = 11)) AND (t_minute#77 < 30)) AND isnotnull(t_time_sk#75))
 
-(124) Project [codegen id : 25]
-Output [1]: [t_time_sk#73]
-Input [3]: [t_time_sk#73, t_hour#74, t_minute#75]
+(130) Project [codegen id : 27]
+Output [1]: [t_time_sk#75]
+Input [3]: [t_time_sk#75, t_hour#76, t_minute#77]
 
-(125) BroadcastExchange
-Input [1]: [t_time_sk#73]
+(131) BroadcastExchange
+Input [1]: [t_time_sk#75]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=17]
 
-(126) BroadcastHashJoin [codegen id : 28]
-Left keys [1]: [ss_sold_time_sk#69]
-Right keys [1]: [t_time_sk#73]
-Join type: Inner
-Join condition: None
-
-(127) Project [codegen id : 28]
-Output [2]: [ss_hdemo_sk#70, ss_store_sk#71]
-Input [4]: [ss_sold_time_sk#69, ss_hdemo_sk#70, ss_store_sk#71, t_time_sk#73]
-
-(128) ReusedExchange [Reuses operator id: 16]
-Output [1]: [s_store_sk#76]
-
-(129) BroadcastHashJoin [codegen id : 28]
-Left keys [1]: [ss_store_sk#71]
-Right keys [1]: [s_store_sk#76]
-Join type: Inner
-Join condition: None
-
-(130) Project [codegen id : 28]
-Output [1]: [ss_hdemo_sk#70]
-Input [3]: [ss_hdemo_sk#70, ss_store_sk#71, s_store_sk#76]
-
-(131) ReusedExchange [Reuses operator id: 23]
-Output [1]: [hd_demo_sk#77]
-
 (132) BroadcastHashJoin [codegen id : 28]
-Left keys [1]: [ss_hdemo_sk#70]
-Right keys [1]: [hd_demo_sk#77]
+Left keys [1]: [ss_sold_time_sk#69]
+Right keys [1]: [t_time_sk#75]
 Join type: Inner
 Join condition: None
 
 (133) Project [codegen id : 28]
 Output: []
-Input [2]: [ss_hdemo_sk#70, hd_demo_sk#77]
+Input [2]: [ss_sold_time_sk#69, t_time_sk#75]
 
 (134) HashAggregate [codegen id : 28]
 Input: []
@@ -843,63 +843,63 @@ Condition : ((isnotnull(ss_hdemo_sk#83) AND isnotnull(ss_sold_time_sk#82)) AND i
 Output [3]: [ss_sold_time_sk#82, ss_hdemo_sk#83, ss_store_sk#84]
 Input [4]: [ss_sold_time_sk#82, ss_hdemo_sk#83, ss_store_sk#84, ss_sold_date_sk#85]
 
-(143) Scan parquet spark_catalog.default.time_dim
-Output [3]: [t_time_sk#86, t_hour#87, t_minute#88]
+(143) ReusedExchange [Reuses operator id: 9]
+Output [1]: [s_store_sk#86]
+
+(144) BroadcastHashJoin [codegen id : 33]
+Left keys [1]: [ss_store_sk#84]
+Right keys [1]: [s_store_sk#86]
+Join type: Inner
+Join condition: None
+
+(145) Project [codegen id : 33]
+Output [2]: [ss_sold_time_sk#82, ss_hdemo_sk#83]
+Input [4]: [ss_sold_time_sk#82, ss_hdemo_sk#83, ss_store_sk#84, s_store_sk#86]
+
+(146) ReusedExchange [Reuses operator id: 16]
+Output [1]: [hd_demo_sk#87]
+
+(147) BroadcastHashJoin [codegen id : 33]
+Left keys [1]: [ss_hdemo_sk#83]
+Right keys [1]: [hd_demo_sk#87]
+Join type: Inner
+Join condition: None
+
+(148) Project [codegen id : 33]
+Output [1]: [ss_sold_time_sk#82]
+Input [3]: [ss_sold_time_sk#82, ss_hdemo_sk#83, hd_demo_sk#87]
+
+(149) Scan parquet spark_catalog.default.time_dim
+Output [3]: [t_time_sk#88, t_hour#89, t_minute#90]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/time_dim]
 PushedFilters: [IsNotNull(t_hour), IsNotNull(t_minute), EqualTo(t_hour,11), GreaterThanOrEqual(t_minute,30), IsNotNull(t_time_sk)]
 ReadSchema: struct<t_time_sk:int,t_hour:int,t_minute:int>
 
-(144) ColumnarToRow [codegen id : 30]
-Input [3]: [t_time_sk#86, t_hour#87, t_minute#88]
+(150) ColumnarToRow [codegen id : 32]
+Input [3]: [t_time_sk#88, t_hour#89, t_minute#90]
 
-(145) Filter [codegen id : 30]
-Input [3]: [t_time_sk#86, t_hour#87, t_minute#88]
-Condition : ((((isnotnull(t_hour#87) AND isnotnull(t_minute#88)) AND (t_hour#87 = 11)) AND (t_minute#88 >= 30)) AND isnotnull(t_time_sk#86))
+(151) Filter [codegen id : 32]
+Input [3]: [t_time_sk#88, t_hour#89, t_minute#90]
+Condition : ((((isnotnull(t_hour#89) AND isnotnull(t_minute#90)) AND (t_hour#89 = 11)) AND (t_minute#90 >= 30)) AND isnotnull(t_time_sk#88))
 
-(146) Project [codegen id : 30]
-Output [1]: [t_time_sk#86]
-Input [3]: [t_time_sk#86, t_hour#87, t_minute#88]
+(152) Project [codegen id : 32]
+Output [1]: [t_time_sk#88]
+Input [3]: [t_time_sk#88, t_hour#89, t_minute#90]
 
-(147) BroadcastExchange
-Input [1]: [t_time_sk#86]
+(153) BroadcastExchange
+Input [1]: [t_time_sk#88]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=20]
 
-(148) BroadcastHashJoin [codegen id : 33]
-Left keys [1]: [ss_sold_time_sk#82]
-Right keys [1]: [t_time_sk#86]
-Join type: Inner
-Join condition: None
-
-(149) Project [codegen id : 33]
-Output [2]: [ss_hdemo_sk#83, ss_store_sk#84]
-Input [4]: [ss_sold_time_sk#82, ss_hdemo_sk#83, ss_store_sk#84, t_time_sk#86]
-
-(150) ReusedExchange [Reuses operator id: 16]
-Output [1]: [s_store_sk#89]
-
-(151) BroadcastHashJoin [codegen id : 33]
-Left keys [1]: [ss_store_sk#84]
-Right keys [1]: [s_store_sk#89]
-Join type: Inner
-Join condition: None
-
-(152) Project [codegen id : 33]
-Output [1]: [ss_hdemo_sk#83]
-Input [3]: [ss_hdemo_sk#83, ss_store_sk#84, s_store_sk#89]
-
-(153) ReusedExchange [Reuses operator id: 23]
-Output [1]: [hd_demo_sk#90]
-
 (154) BroadcastHashJoin [codegen id : 33]
-Left keys [1]: [ss_hdemo_sk#83]
-Right keys [1]: [hd_demo_sk#90]
+Left keys [1]: [ss_sold_time_sk#82]
+Right keys [1]: [t_time_sk#88]
 Join type: Inner
 Join condition: None
 
 (155) Project [codegen id : 33]
 Output: []
-Input [2]: [ss_hdemo_sk#83, hd_demo_sk#90]
+Input [2]: [ss_sold_time_sk#82, t_time_sk#88]
 
 (156) HashAggregate [codegen id : 33]
 Input: []
@@ -945,63 +945,63 @@ Condition : ((isnotnull(ss_hdemo_sk#96) AND isnotnull(ss_sold_time_sk#95)) AND i
 Output [3]: [ss_sold_time_sk#95, ss_hdemo_sk#96, ss_store_sk#97]
 Input [4]: [ss_sold_time_sk#95, ss_hdemo_sk#96, ss_store_sk#97, ss_sold_date_sk#98]
 
-(165) Scan parquet spark_catalog.default.time_dim
-Output [3]: [t_time_sk#99, t_hour#100, t_minute#101]
+(165) ReusedExchange [Reuses operator id: 9]
+Output [1]: [s_store_sk#99]
+
+(166) BroadcastHashJoin [codegen id : 38]
+Left keys [1]: [ss_store_sk#97]
+Right keys [1]: [s_store_sk#99]
+Join type: Inner
+Join condition: None
+
+(167) Project [codegen id : 38]
+Output [2]: [ss_sold_time_sk#95, ss_hdemo_sk#96]
+Input [4]: [ss_sold_time_sk#95, ss_hdemo_sk#96, ss_store_sk#97, s_store_sk#99]
+
+(168) ReusedExchange [Reuses operator id: 16]
+Output [1]: [hd_demo_sk#100]
+
+(169) BroadcastHashJoin [codegen id : 38]
+Left keys [1]: [ss_hdemo_sk#96]
+Right keys [1]: [hd_demo_sk#100]
+Join type: Inner
+Join condition: None
+
+(170) Project [codegen id : 38]
+Output [1]: [ss_sold_time_sk#95]
+Input [3]: [ss_sold_time_sk#95, ss_hdemo_sk#96, hd_demo_sk#100]
+
+(171) Scan parquet spark_catalog.default.time_dim
+Output [3]: [t_time_sk#101, t_hour#102, t_minute#103]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/time_dim]
 PushedFilters: [IsNotNull(t_hour), IsNotNull(t_minute), EqualTo(t_hour,12), LessThan(t_minute,30), IsNotNull(t_time_sk)]
 ReadSchema: struct<t_time_sk:int,t_hour:int,t_minute:int>
 
-(166) ColumnarToRow [codegen id : 35]
-Input [3]: [t_time_sk#99, t_hour#100, t_minute#101]
+(172) ColumnarToRow [codegen id : 37]
+Input [3]: [t_time_sk#101, t_hour#102, t_minute#103]
 
-(167) Filter [codegen id : 35]
-Input [3]: [t_time_sk#99, t_hour#100, t_minute#101]
-Condition : ((((isnotnull(t_hour#100) AND isnotnull(t_minute#101)) AND (t_hour#100 = 12)) AND (t_minute#101 < 30)) AND isnotnull(t_time_sk#99))
+(173) Filter [codegen id : 37]
+Input [3]: [t_time_sk#101, t_hour#102, t_minute#103]
+Condition : ((((isnotnull(t_hour#102) AND isnotnull(t_minute#103)) AND (t_hour#102 = 12)) AND (t_minute#103 < 30)) AND isnotnull(t_time_sk#101))
 
-(168) Project [codegen id : 35]
-Output [1]: [t_time_sk#99]
-Input [3]: [t_time_sk#99, t_hour#100, t_minute#101]
+(174) Project [codegen id : 37]
+Output [1]: [t_time_sk#101]
+Input [3]: [t_time_sk#101, t_hour#102, t_minute#103]
 
-(169) BroadcastExchange
-Input [1]: [t_time_sk#99]
+(175) BroadcastExchange
+Input [1]: [t_time_sk#101]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=23]
 
-(170) BroadcastHashJoin [codegen id : 38]
-Left keys [1]: [ss_sold_time_sk#95]
-Right keys [1]: [t_time_sk#99]
-Join type: Inner
-Join condition: None
-
-(171) Project [codegen id : 38]
-Output [2]: [ss_hdemo_sk#96, ss_store_sk#97]
-Input [4]: [ss_sold_time_sk#95, ss_hdemo_sk#96, ss_store_sk#97, t_time_sk#99]
-
-(172) ReusedExchange [Reuses operator id: 16]
-Output [1]: [s_store_sk#102]
-
-(173) BroadcastHashJoin [codegen id : 38]
-Left keys [1]: [ss_store_sk#97]
-Right keys [1]: [s_store_sk#102]
-Join type: Inner
-Join condition: None
-
-(174) Project [codegen id : 38]
-Output [1]: [ss_hdemo_sk#96]
-Input [3]: [ss_hdemo_sk#96, ss_store_sk#97, s_store_sk#102]
-
-(175) ReusedExchange [Reuses operator id: 23]
-Output [1]: [hd_demo_sk#103]
-
 (176) BroadcastHashJoin [codegen id : 38]
-Left keys [1]: [ss_hdemo_sk#96]
-Right keys [1]: [hd_demo_sk#103]
+Left keys [1]: [ss_sold_time_sk#95]
+Right keys [1]: [t_time_sk#101]
 Join type: Inner
 Join condition: None
 
 (177) Project [codegen id : 38]
 Output: []
-Input [2]: [ss_hdemo_sk#96, hd_demo_sk#103]
+Input [2]: [ss_sold_time_sk#95, t_time_sk#101]
 
 (178) HashAggregate [codegen id : 38]
 Input: []

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q88.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q88.sf100/simplified.txt
@@ -12,11 +12,11 @@ WholeStageCodegen (40)
                       WholeStageCodegen (4)
                         HashAggregate [count,count]
                           Project
-                            BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
-                              Project [ss_hdemo_sk]
-                                BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                  Project [ss_hdemo_sk,ss_store_sk]
-                                    BroadcastHashJoin [ss_sold_time_sk,t_time_sk]
+                            BroadcastHashJoin [ss_sold_time_sk,t_time_sk]
+                              Project [ss_sold_time_sk]
+                                BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
+                                  Project [ss_sold_time_sk,ss_hdemo_sk]
+                                    BroadcastHashJoin [ss_store_sk,s_store_sk]
                                       Project [ss_sold_time_sk,ss_hdemo_sk,ss_store_sk]
                                         Filter [ss_hdemo_sk,ss_sold_time_sk,ss_store_sk]
                                           ColumnarToRow
@@ -25,27 +25,27 @@ WholeStageCodegen (40)
                                       InputAdapter
                                         BroadcastExchange #2
                                           WholeStageCodegen (1)
-                                            Project [t_time_sk]
-                                              Filter [t_hour,t_minute,t_time_sk]
+                                            Project [s_store_sk]
+                                              Filter [s_store_name,s_store_sk]
                                                 ColumnarToRow
                                                   InputAdapter
-                                                    Scan parquet spark_catalog.default.time_dim [t_time_sk,t_hour,t_minute]
+                                                    Scan parquet spark_catalog.default.store [s_store_sk,s_store_name]
                                   InputAdapter
                                     BroadcastExchange #3
                                       WholeStageCodegen (2)
-                                        Project [s_store_sk]
-                                          Filter [s_store_name,s_store_sk]
+                                        Project [hd_demo_sk]
+                                          Filter [hd_dep_count,hd_vehicle_count,hd_demo_sk]
                                             ColumnarToRow
                                               InputAdapter
-                                                Scan parquet spark_catalog.default.store [s_store_sk,s_store_name]
+                                                Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_dep_count,hd_vehicle_count]
                               InputAdapter
                                 BroadcastExchange #4
                                   WholeStageCodegen (3)
-                                    Project [hd_demo_sk]
-                                      Filter [hd_dep_count,hd_vehicle_count,hd_demo_sk]
+                                    Project [t_time_sk]
+                                      Filter [t_hour,t_minute,t_time_sk]
                                         ColumnarToRow
                                           InputAdapter
-                                            Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_dep_count,hd_vehicle_count]
+                                            Scan parquet spark_catalog.default.time_dim [t_time_sk,t_hour,t_minute]
                 InputAdapter
                   BroadcastExchange #5
                     WholeStageCodegen (9)
@@ -55,28 +55,28 @@ WholeStageCodegen (40)
                             WholeStageCodegen (8)
                               HashAggregate [count,count]
                                 Project
-                                  BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
-                                    Project [ss_hdemo_sk]
-                                      BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                        Project [ss_hdemo_sk,ss_store_sk]
-                                          BroadcastHashJoin [ss_sold_time_sk,t_time_sk]
+                                  BroadcastHashJoin [ss_sold_time_sk,t_time_sk]
+                                    Project [ss_sold_time_sk]
+                                      BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
+                                        Project [ss_sold_time_sk,ss_hdemo_sk]
+                                          BroadcastHashJoin [ss_store_sk,s_store_sk]
                                             Project [ss_sold_time_sk,ss_hdemo_sk,ss_store_sk]
                                               Filter [ss_hdemo_sk,ss_sold_time_sk,ss_store_sk]
                                                 ColumnarToRow
                                                   InputAdapter
                                                     Scan parquet spark_catalog.default.store_sales [ss_sold_time_sk,ss_hdemo_sk,ss_store_sk,ss_sold_date_sk]
                                             InputAdapter
-                                              BroadcastExchange #7
-                                                WholeStageCodegen (5)
-                                                  Project [t_time_sk]
-                                                    Filter [t_hour,t_minute,t_time_sk]
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet spark_catalog.default.time_dim [t_time_sk,t_hour,t_minute]
+                                              ReusedExchange [s_store_sk] #2
                                         InputAdapter
-                                          ReusedExchange [s_store_sk] #3
+                                          ReusedExchange [hd_demo_sk] #3
                                     InputAdapter
-                                      ReusedExchange [hd_demo_sk] #4
+                                      BroadcastExchange #7
+                                        WholeStageCodegen (7)
+                                          Project [t_time_sk]
+                                            Filter [t_hour,t_minute,t_time_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.time_dim [t_time_sk,t_hour,t_minute]
               InputAdapter
                 BroadcastExchange #8
                   WholeStageCodegen (14)
@@ -86,28 +86,28 @@ WholeStageCodegen (40)
                           WholeStageCodegen (13)
                             HashAggregate [count,count]
                               Project
-                                BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
-                                  Project [ss_hdemo_sk]
-                                    BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                      Project [ss_hdemo_sk,ss_store_sk]
-                                        BroadcastHashJoin [ss_sold_time_sk,t_time_sk]
+                                BroadcastHashJoin [ss_sold_time_sk,t_time_sk]
+                                  Project [ss_sold_time_sk]
+                                    BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
+                                      Project [ss_sold_time_sk,ss_hdemo_sk]
+                                        BroadcastHashJoin [ss_store_sk,s_store_sk]
                                           Project [ss_sold_time_sk,ss_hdemo_sk,ss_store_sk]
                                             Filter [ss_hdemo_sk,ss_sold_time_sk,ss_store_sk]
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet spark_catalog.default.store_sales [ss_sold_time_sk,ss_hdemo_sk,ss_store_sk,ss_sold_date_sk]
                                           InputAdapter
-                                            BroadcastExchange #10
-                                              WholeStageCodegen (10)
-                                                Project [t_time_sk]
-                                                  Filter [t_hour,t_minute,t_time_sk]
-                                                    ColumnarToRow
-                                                      InputAdapter
-                                                        Scan parquet spark_catalog.default.time_dim [t_time_sk,t_hour,t_minute]
+                                            ReusedExchange [s_store_sk] #2
                                       InputAdapter
-                                        ReusedExchange [s_store_sk] #3
+                                        ReusedExchange [hd_demo_sk] #3
                                   InputAdapter
-                                    ReusedExchange [hd_demo_sk] #4
+                                    BroadcastExchange #10
+                                      WholeStageCodegen (12)
+                                        Project [t_time_sk]
+                                          Filter [t_hour,t_minute,t_time_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet spark_catalog.default.time_dim [t_time_sk,t_hour,t_minute]
             InputAdapter
               BroadcastExchange #11
                 WholeStageCodegen (19)
@@ -117,28 +117,28 @@ WholeStageCodegen (40)
                         WholeStageCodegen (18)
                           HashAggregate [count,count]
                             Project
-                              BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
-                                Project [ss_hdemo_sk]
-                                  BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                    Project [ss_hdemo_sk,ss_store_sk]
-                                      BroadcastHashJoin [ss_sold_time_sk,t_time_sk]
+                              BroadcastHashJoin [ss_sold_time_sk,t_time_sk]
+                                Project [ss_sold_time_sk]
+                                  BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
+                                    Project [ss_sold_time_sk,ss_hdemo_sk]
+                                      BroadcastHashJoin [ss_store_sk,s_store_sk]
                                         Project [ss_sold_time_sk,ss_hdemo_sk,ss_store_sk]
                                           Filter [ss_hdemo_sk,ss_sold_time_sk,ss_store_sk]
                                             ColumnarToRow
                                               InputAdapter
                                                 Scan parquet spark_catalog.default.store_sales [ss_sold_time_sk,ss_hdemo_sk,ss_store_sk,ss_sold_date_sk]
                                         InputAdapter
-                                          BroadcastExchange #13
-                                            WholeStageCodegen (15)
-                                              Project [t_time_sk]
-                                                Filter [t_hour,t_minute,t_time_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.time_dim [t_time_sk,t_hour,t_minute]
+                                          ReusedExchange [s_store_sk] #2
                                     InputAdapter
-                                      ReusedExchange [s_store_sk] #3
+                                      ReusedExchange [hd_demo_sk] #3
                                 InputAdapter
-                                  ReusedExchange [hd_demo_sk] #4
+                                  BroadcastExchange #13
+                                    WholeStageCodegen (17)
+                                      Project [t_time_sk]
+                                        Filter [t_hour,t_minute,t_time_sk]
+                                          ColumnarToRow
+                                            InputAdapter
+                                              Scan parquet spark_catalog.default.time_dim [t_time_sk,t_hour,t_minute]
           InputAdapter
             BroadcastExchange #14
               WholeStageCodegen (24)
@@ -148,28 +148,28 @@ WholeStageCodegen (40)
                       WholeStageCodegen (23)
                         HashAggregate [count,count]
                           Project
-                            BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
-                              Project [ss_hdemo_sk]
-                                BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                  Project [ss_hdemo_sk,ss_store_sk]
-                                    BroadcastHashJoin [ss_sold_time_sk,t_time_sk]
+                            BroadcastHashJoin [ss_sold_time_sk,t_time_sk]
+                              Project [ss_sold_time_sk]
+                                BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
+                                  Project [ss_sold_time_sk,ss_hdemo_sk]
+                                    BroadcastHashJoin [ss_store_sk,s_store_sk]
                                       Project [ss_sold_time_sk,ss_hdemo_sk,ss_store_sk]
                                         Filter [ss_hdemo_sk,ss_sold_time_sk,ss_store_sk]
                                           ColumnarToRow
                                             InputAdapter
                                               Scan parquet spark_catalog.default.store_sales [ss_sold_time_sk,ss_hdemo_sk,ss_store_sk,ss_sold_date_sk]
                                       InputAdapter
-                                        BroadcastExchange #16
-                                          WholeStageCodegen (20)
-                                            Project [t_time_sk]
-                                              Filter [t_hour,t_minute,t_time_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.time_dim [t_time_sk,t_hour,t_minute]
+                                        ReusedExchange [s_store_sk] #2
                                   InputAdapter
-                                    ReusedExchange [s_store_sk] #3
+                                    ReusedExchange [hd_demo_sk] #3
                               InputAdapter
-                                ReusedExchange [hd_demo_sk] #4
+                                BroadcastExchange #16
+                                  WholeStageCodegen (22)
+                                    Project [t_time_sk]
+                                      Filter [t_hour,t_minute,t_time_sk]
+                                        ColumnarToRow
+                                          InputAdapter
+                                            Scan parquet spark_catalog.default.time_dim [t_time_sk,t_hour,t_minute]
         InputAdapter
           BroadcastExchange #17
             WholeStageCodegen (29)
@@ -179,28 +179,28 @@ WholeStageCodegen (40)
                     WholeStageCodegen (28)
                       HashAggregate [count,count]
                         Project
-                          BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
-                            Project [ss_hdemo_sk]
-                              BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                Project [ss_hdemo_sk,ss_store_sk]
-                                  BroadcastHashJoin [ss_sold_time_sk,t_time_sk]
+                          BroadcastHashJoin [ss_sold_time_sk,t_time_sk]
+                            Project [ss_sold_time_sk]
+                              BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
+                                Project [ss_sold_time_sk,ss_hdemo_sk]
+                                  BroadcastHashJoin [ss_store_sk,s_store_sk]
                                     Project [ss_sold_time_sk,ss_hdemo_sk,ss_store_sk]
                                       Filter [ss_hdemo_sk,ss_sold_time_sk,ss_store_sk]
                                         ColumnarToRow
                                           InputAdapter
                                             Scan parquet spark_catalog.default.store_sales [ss_sold_time_sk,ss_hdemo_sk,ss_store_sk,ss_sold_date_sk]
                                     InputAdapter
-                                      BroadcastExchange #19
-                                        WholeStageCodegen (25)
-                                          Project [t_time_sk]
-                                            Filter [t_hour,t_minute,t_time_sk]
-                                              ColumnarToRow
-                                                InputAdapter
-                                                  Scan parquet spark_catalog.default.time_dim [t_time_sk,t_hour,t_minute]
+                                      ReusedExchange [s_store_sk] #2
                                 InputAdapter
-                                  ReusedExchange [s_store_sk] #3
+                                  ReusedExchange [hd_demo_sk] #3
                             InputAdapter
-                              ReusedExchange [hd_demo_sk] #4
+                              BroadcastExchange #19
+                                WholeStageCodegen (27)
+                                  Project [t_time_sk]
+                                    Filter [t_hour,t_minute,t_time_sk]
+                                      ColumnarToRow
+                                        InputAdapter
+                                          Scan parquet spark_catalog.default.time_dim [t_time_sk,t_hour,t_minute]
       InputAdapter
         BroadcastExchange #20
           WholeStageCodegen (34)
@@ -210,28 +210,28 @@ WholeStageCodegen (40)
                   WholeStageCodegen (33)
                     HashAggregate [count,count]
                       Project
-                        BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
-                          Project [ss_hdemo_sk]
-                            BroadcastHashJoin [ss_store_sk,s_store_sk]
-                              Project [ss_hdemo_sk,ss_store_sk]
-                                BroadcastHashJoin [ss_sold_time_sk,t_time_sk]
+                        BroadcastHashJoin [ss_sold_time_sk,t_time_sk]
+                          Project [ss_sold_time_sk]
+                            BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
+                              Project [ss_sold_time_sk,ss_hdemo_sk]
+                                BroadcastHashJoin [ss_store_sk,s_store_sk]
                                   Project [ss_sold_time_sk,ss_hdemo_sk,ss_store_sk]
                                     Filter [ss_hdemo_sk,ss_sold_time_sk,ss_store_sk]
                                       ColumnarToRow
                                         InputAdapter
                                           Scan parquet spark_catalog.default.store_sales [ss_sold_time_sk,ss_hdemo_sk,ss_store_sk,ss_sold_date_sk]
                                   InputAdapter
-                                    BroadcastExchange #22
-                                      WholeStageCodegen (30)
-                                        Project [t_time_sk]
-                                          Filter [t_hour,t_minute,t_time_sk]
-                                            ColumnarToRow
-                                              InputAdapter
-                                                Scan parquet spark_catalog.default.time_dim [t_time_sk,t_hour,t_minute]
+                                    ReusedExchange [s_store_sk] #2
                               InputAdapter
-                                ReusedExchange [s_store_sk] #3
+                                ReusedExchange [hd_demo_sk] #3
                           InputAdapter
-                            ReusedExchange [hd_demo_sk] #4
+                            BroadcastExchange #22
+                              WholeStageCodegen (32)
+                                Project [t_time_sk]
+                                  Filter [t_hour,t_minute,t_time_sk]
+                                    ColumnarToRow
+                                      InputAdapter
+                                        Scan parquet spark_catalog.default.time_dim [t_time_sk,t_hour,t_minute]
     InputAdapter
       BroadcastExchange #23
         WholeStageCodegen (39)
@@ -241,25 +241,25 @@ WholeStageCodegen (40)
                 WholeStageCodegen (38)
                   HashAggregate [count,count]
                     Project
-                      BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
-                        Project [ss_hdemo_sk]
-                          BroadcastHashJoin [ss_store_sk,s_store_sk]
-                            Project [ss_hdemo_sk,ss_store_sk]
-                              BroadcastHashJoin [ss_sold_time_sk,t_time_sk]
+                      BroadcastHashJoin [ss_sold_time_sk,t_time_sk]
+                        Project [ss_sold_time_sk]
+                          BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
+                            Project [ss_sold_time_sk,ss_hdemo_sk]
+                              BroadcastHashJoin [ss_store_sk,s_store_sk]
                                 Project [ss_sold_time_sk,ss_hdemo_sk,ss_store_sk]
                                   Filter [ss_hdemo_sk,ss_sold_time_sk,ss_store_sk]
                                     ColumnarToRow
                                       InputAdapter
                                         Scan parquet spark_catalog.default.store_sales [ss_sold_time_sk,ss_hdemo_sk,ss_store_sk,ss_sold_date_sk]
                                 InputAdapter
-                                  BroadcastExchange #25
-                                    WholeStageCodegen (35)
-                                      Project [t_time_sk]
-                                        Filter [t_hour,t_minute,t_time_sk]
-                                          ColumnarToRow
-                                            InputAdapter
-                                              Scan parquet spark_catalog.default.time_dim [t_time_sk,t_hour,t_minute]
+                                  ReusedExchange [s_store_sk] #2
                             InputAdapter
-                              ReusedExchange [s_store_sk] #3
+                              ReusedExchange [hd_demo_sk] #3
                         InputAdapter
-                          ReusedExchange [hd_demo_sk] #4
+                          BroadcastExchange #25
+                            WholeStageCodegen (37)
+                              Project [t_time_sk]
+                                Filter [t_hour,t_minute,t_time_sk]
+                                  ColumnarToRow
+                                    InputAdapter
+                                      Scan parquet spark_catalog.default.time_dim [t_time_sk,t_hour,t_minute]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q89.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q89.sf100/explain.txt
@@ -12,77 +12,77 @@ TakeOrderedAndProject (27)
                            +- * BroadcastHashJoin Inner BuildRight (17)
                               :- * Project (12)
                               :  +- * BroadcastHashJoin Inner BuildRight (11)
-                              :     :- * Project (9)
-                              :     :  +- * BroadcastHashJoin Inner BuildLeft (8)
-                              :     :     :- BroadcastExchange (4)
-                              :     :     :  +- * Filter (3)
-                              :     :     :     +- * ColumnarToRow (2)
-                              :     :     :        +- Scan parquet spark_catalog.default.item (1)
-                              :     :     +- * Filter (7)
-                              :     :        +- * ColumnarToRow (6)
-                              :     :           +- Scan parquet spark_catalog.default.store_sales (5)
-                              :     +- ReusedExchange (10)
+                              :     :- * Project (6)
+                              :     :  +- * BroadcastHashJoin Inner BuildRight (5)
+                              :     :     :- * Filter (3)
+                              :     :     :  +- * ColumnarToRow (2)
+                              :     :     :     +- Scan parquet spark_catalog.default.store_sales (1)
+                              :     :     +- ReusedExchange (4)
+                              :     +- BroadcastExchange (10)
+                              :        +- * Filter (9)
+                              :           +- * ColumnarToRow (8)
+                              :              +- Scan parquet spark_catalog.default.item (7)
                               +- BroadcastExchange (16)
                                  +- * Filter (15)
                                     +- * ColumnarToRow (14)
                                        +- Scan parquet spark_catalog.default.store (13)
 
 
-(1) Scan parquet spark_catalog.default.item
-Output [4]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4]
+(1) Scan parquet spark_catalog.default.store_sales
+Output [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
+Batched: true
+Location: InMemoryFileIndex []
+PartitionFilters: [isnotnull(ss_sold_date_sk#4), dynamicpruningexpression(ss_sold_date_sk#4 IN dynamicpruning#5)]
+PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_store_sk)]
+ReadSchema: struct<ss_item_sk:int,ss_store_sk:int,ss_sales_price:decimal(7,2)>
+
+(2) ColumnarToRow [codegen id : 4]
+Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
+
+(3) Filter [codegen id : 4]
+Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
+Condition : (isnotnull(ss_item_sk#1) AND isnotnull(ss_store_sk#2))
+
+(4) ReusedExchange [Reuses operator id: 32]
+Output [2]: [d_date_sk#6, d_moy#7]
+
+(5) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_sold_date_sk#4]
+Right keys [1]: [d_date_sk#6]
+Join type: Inner
+Join condition: None
+
+(6) Project [codegen id : 4]
+Output [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_moy#7]
+Input [6]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4, d_date_sk#6, d_moy#7]
+
+(7) Scan parquet spark_catalog.default.item
+Output [4]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [Or(And(In(i_category, [Books                                             ,Electronics                                       ,Sports                                            ]),In(i_class, [computers                                         ,football                                          ,stereo                                            ])),And(In(i_category, [Jewelry                                           ,Men                                               ,Women                                             ]),In(i_class, [birdal                                            ,dresses                                           ,shirts                                            ]))), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand:string,i_class:string,i_category:string>
 
-(2) ColumnarToRow [codegen id : 1]
-Input [4]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4]
+(8) ColumnarToRow [codegen id : 2]
+Input [4]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11]
 
-(3) Filter [codegen id : 1]
-Input [4]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4]
-Condition : (((i_category#4 IN (Books                                             ,Electronics                                       ,Sports                                            ) AND i_class#3 IN (computers                                         ,stereo                                            ,football                                          )) OR (i_category#4 IN (Men                                               ,Jewelry                                           ,Women                                             ) AND i_class#3 IN (shirts                                            ,birdal                                            ,dresses                                           ))) AND isnotnull(i_item_sk#1))
+(9) Filter [codegen id : 2]
+Input [4]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11]
+Condition : (((i_category#11 IN (Books                                             ,Electronics                                       ,Sports                                            ) AND i_class#10 IN (computers                                         ,stereo                                            ,football                                          )) OR (i_category#11 IN (Men                                               ,Jewelry                                           ,Women                                             ) AND i_class#10 IN (shirts                                            ,birdal                                            ,dresses                                           ))) AND isnotnull(i_item_sk#8))
 
-(4) BroadcastExchange
-Input [4]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4]
+(10) BroadcastExchange
+Input [4]: [i_item_sk#8, i_brand#9, i_class#10, i_category#11]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
-(5) Scan parquet spark_catalog.default.store_sales
-Output [4]: [ss_item_sk#5, ss_store_sk#6, ss_sales_price#7, ss_sold_date_sk#8]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(ss_sold_date_sk#8), dynamicpruningexpression(ss_sold_date_sk#8 IN dynamicpruning#9)]
-PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_store_sk)]
-ReadSchema: struct<ss_item_sk:int,ss_store_sk:int,ss_sales_price:decimal(7,2)>
-
-(6) ColumnarToRow
-Input [4]: [ss_item_sk#5, ss_store_sk#6, ss_sales_price#7, ss_sold_date_sk#8]
-
-(7) Filter
-Input [4]: [ss_item_sk#5, ss_store_sk#6, ss_sales_price#7, ss_sold_date_sk#8]
-Condition : (isnotnull(ss_item_sk#5) AND isnotnull(ss_store_sk#6))
-
-(8) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [i_item_sk#1]
-Right keys [1]: [ss_item_sk#5]
-Join type: Inner
-Join condition: None
-
-(9) Project [codegen id : 4]
-Output [6]: [i_brand#2, i_class#3, i_category#4, ss_store_sk#6, ss_sales_price#7, ss_sold_date_sk#8]
-Input [8]: [i_item_sk#1, i_brand#2, i_class#3, i_category#4, ss_item_sk#5, ss_store_sk#6, ss_sales_price#7, ss_sold_date_sk#8]
-
-(10) ReusedExchange [Reuses operator id: 32]
-Output [2]: [d_date_sk#10, d_moy#11]
-
 (11) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#8]
-Right keys [1]: [d_date_sk#10]
+Left keys [1]: [ss_item_sk#1]
+Right keys [1]: [i_item_sk#8]
 Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 4]
-Output [6]: [i_brand#2, i_class#3, i_category#4, ss_store_sk#6, ss_sales_price#7, d_moy#11]
-Input [8]: [i_brand#2, i_class#3, i_category#4, ss_store_sk#6, ss_sales_price#7, ss_sold_date_sk#8, d_date_sk#10, d_moy#11]
+Output [6]: [ss_store_sk#2, ss_sales_price#3, d_moy#7, i_brand#9, i_class#10, i_category#11]
+Input [8]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_moy#7, i_item_sk#8, i_brand#9, i_class#10, i_category#11]
 
 (13) Scan parquet spark_catalog.default.store
 Output [3]: [s_store_sk#12, s_store_name#13, s_company_name#14]
@@ -103,60 +103,60 @@ Input [3]: [s_store_sk#12, s_store_name#13, s_company_name#14]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=2]
 
 (17) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_store_sk#6]
+Left keys [1]: [ss_store_sk#2]
 Right keys [1]: [s_store_sk#12]
 Join type: Inner
 Join condition: None
 
 (18) Project [codegen id : 4]
-Output [7]: [i_brand#2, i_class#3, i_category#4, ss_sales_price#7, d_moy#11, s_store_name#13, s_company_name#14]
-Input [9]: [i_brand#2, i_class#3, i_category#4, ss_store_sk#6, ss_sales_price#7, d_moy#11, s_store_sk#12, s_store_name#13, s_company_name#14]
+Output [7]: [i_brand#9, i_class#10, i_category#11, ss_sales_price#3, d_moy#7, s_store_name#13, s_company_name#14]
+Input [9]: [ss_store_sk#2, ss_sales_price#3, d_moy#7, i_brand#9, i_class#10, i_category#11, s_store_sk#12, s_store_name#13, s_company_name#14]
 
 (19) HashAggregate [codegen id : 4]
-Input [7]: [i_brand#2, i_class#3, i_category#4, ss_sales_price#7, d_moy#11, s_store_name#13, s_company_name#14]
-Keys [6]: [i_category#4, i_class#3, i_brand#2, s_store_name#13, s_company_name#14, d_moy#11]
-Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#7))]
+Input [7]: [i_brand#9, i_class#10, i_category#11, ss_sales_price#3, d_moy#7, s_store_name#13, s_company_name#14]
+Keys [6]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7]
+Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#3))]
 Aggregate Attributes [1]: [sum#15]
-Results [7]: [i_category#4, i_class#3, i_brand#2, s_store_name#13, s_company_name#14, d_moy#11, sum#16]
+Results [7]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, sum#16]
 
 (20) Exchange
-Input [7]: [i_category#4, i_class#3, i_brand#2, s_store_name#13, s_company_name#14, d_moy#11, sum#16]
-Arguments: hashpartitioning(i_category#4, i_class#3, i_brand#2, s_store_name#13, s_company_name#14, d_moy#11, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [7]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, sum#16]
+Arguments: hashpartitioning(i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (21) HashAggregate [codegen id : 5]
-Input [7]: [i_category#4, i_class#3, i_brand#2, s_store_name#13, s_company_name#14, d_moy#11, sum#16]
-Keys [6]: [i_category#4, i_class#3, i_brand#2, s_store_name#13, s_company_name#14, d_moy#11]
-Functions [1]: [sum(UnscaledValue(ss_sales_price#7))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#7))#17]
-Results [8]: [i_category#4, i_class#3, i_brand#2, s_store_name#13, s_company_name#14, d_moy#11, MakeDecimal(sum(UnscaledValue(ss_sales_price#7))#17,17,2) AS sum_sales#18, MakeDecimal(sum(UnscaledValue(ss_sales_price#7))#17,17,2) AS _w0#19]
+Input [7]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, sum#16]
+Keys [6]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7]
+Functions [1]: [sum(UnscaledValue(ss_sales_price#3))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#3))#17]
+Results [8]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#17,17,2) AS sum_sales#18, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#17,17,2) AS _w0#19]
 
 (22) Exchange
-Input [8]: [i_category#4, i_class#3, i_brand#2, s_store_name#13, s_company_name#14, d_moy#11, sum_sales#18, _w0#19]
-Arguments: hashpartitioning(i_category#4, i_brand#2, s_store_name#13, s_company_name#14, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [8]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, sum_sales#18, _w0#19]
+Arguments: hashpartitioning(i_category#11, i_brand#9, s_store_name#13, s_company_name#14, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (23) Sort [codegen id : 6]
-Input [8]: [i_category#4, i_class#3, i_brand#2, s_store_name#13, s_company_name#14, d_moy#11, sum_sales#18, _w0#19]
-Arguments: [i_category#4 ASC NULLS FIRST, i_brand#2 ASC NULLS FIRST, s_store_name#13 ASC NULLS FIRST, s_company_name#14 ASC NULLS FIRST], false, 0
+Input [8]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, sum_sales#18, _w0#19]
+Arguments: [i_category#11 ASC NULLS FIRST, i_brand#9 ASC NULLS FIRST, s_store_name#13 ASC NULLS FIRST, s_company_name#14 ASC NULLS FIRST], false, 0
 
 (24) Window
-Input [8]: [i_category#4, i_class#3, i_brand#2, s_store_name#13, s_company_name#14, d_moy#11, sum_sales#18, _w0#19]
-Arguments: [avg(_w0#19) windowspecdefinition(i_category#4, i_brand#2, s_store_name#13, s_company_name#14, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_monthly_sales#20], [i_category#4, i_brand#2, s_store_name#13, s_company_name#14]
+Input [8]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, sum_sales#18, _w0#19]
+Arguments: [avg(_w0#19) windowspecdefinition(i_category#11, i_brand#9, s_store_name#13, s_company_name#14, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_monthly_sales#20], [i_category#11, i_brand#9, s_store_name#13, s_company_name#14]
 
 (25) Filter [codegen id : 7]
-Input [9]: [i_category#4, i_class#3, i_brand#2, s_store_name#13, s_company_name#14, d_moy#11, sum_sales#18, _w0#19, avg_monthly_sales#20]
+Input [9]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, sum_sales#18, _w0#19, avg_monthly_sales#20]
 Condition : CASE WHEN NOT (avg_monthly_sales#20 = 0.000000) THEN ((abs((sum_sales#18 - avg_monthly_sales#20)) / avg_monthly_sales#20) > 0.1000000000000000) END
 
 (26) Project [codegen id : 7]
-Output [8]: [i_category#4, i_class#3, i_brand#2, s_store_name#13, s_company_name#14, d_moy#11, sum_sales#18, avg_monthly_sales#20]
-Input [9]: [i_category#4, i_class#3, i_brand#2, s_store_name#13, s_company_name#14, d_moy#11, sum_sales#18, _w0#19, avg_monthly_sales#20]
+Output [8]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, sum_sales#18, avg_monthly_sales#20]
+Input [9]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, sum_sales#18, _w0#19, avg_monthly_sales#20]
 
 (27) TakeOrderedAndProject
-Input [8]: [i_category#4, i_class#3, i_brand#2, s_store_name#13, s_company_name#14, d_moy#11, sum_sales#18, avg_monthly_sales#20]
-Arguments: 100, [(sum_sales#18 - avg_monthly_sales#20) ASC NULLS FIRST, s_store_name#13 ASC NULLS FIRST], [i_category#4, i_class#3, i_brand#2, s_store_name#13, s_company_name#14, d_moy#11, sum_sales#18, avg_monthly_sales#20]
+Input [8]: [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, sum_sales#18, avg_monthly_sales#20]
+Arguments: 100, [(sum_sales#18 - avg_monthly_sales#20) ASC NULLS FIRST, s_store_name#13 ASC NULLS FIRST], [i_category#11, i_class#10, i_brand#9, s_store_name#13, s_company_name#14, d_moy#7, sum_sales#18, avg_monthly_sales#20]
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 5 Hosting Expression = ss_sold_date_sk#8 IN dynamicpruning#9
+Subquery:1 Hosting operator id = 1 Hosting Expression = ss_sold_date_sk#4 IN dynamicpruning#5
 BroadcastExchange (32)
 +- * Project (31)
    +- * Filter (30)
@@ -165,25 +165,25 @@ BroadcastExchange (32)
 
 
 (28) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#10, d_year#21, d_moy#11]
+Output [3]: [d_date_sk#6, d_year#21, d_moy#7]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,1999), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
 (29) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#10, d_year#21, d_moy#11]
+Input [3]: [d_date_sk#6, d_year#21, d_moy#7]
 
 (30) Filter [codegen id : 1]
-Input [3]: [d_date_sk#10, d_year#21, d_moy#11]
-Condition : ((isnotnull(d_year#21) AND (d_year#21 = 1999)) AND isnotnull(d_date_sk#10))
+Input [3]: [d_date_sk#6, d_year#21, d_moy#7]
+Condition : ((isnotnull(d_year#21) AND (d_year#21 = 1999)) AND isnotnull(d_date_sk#6))
 
 (31) Project [codegen id : 1]
-Output [2]: [d_date_sk#10, d_moy#11]
-Input [3]: [d_date_sk#10, d_year#21, d_moy#11]
+Output [2]: [d_date_sk#6, d_moy#7]
+Input [3]: [d_date_sk#6, d_year#21, d_moy#7]
 
 (32) BroadcastExchange
-Input [2]: [d_date_sk#10, d_moy#11]
+Input [2]: [d_date_sk#6, d_moy#7]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q89.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q89.sf100/simplified.txt
@@ -16,31 +16,31 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,s_store_name,i_category,i_cla
                               HashAggregate [i_category,i_class,i_brand,s_store_name,s_company_name,d_moy,ss_sales_price] [sum,sum]
                                 Project [i_brand,i_class,i_category,ss_sales_price,d_moy,s_store_name,s_company_name]
                                   BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                    Project [i_brand,i_class,i_category,ss_store_sk,ss_sales_price,d_moy]
-                                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                        Project [i_brand,i_class,i_category,ss_store_sk,ss_sales_price,ss_sold_date_sk]
-                                          BroadcastHashJoin [i_item_sk,ss_item_sk]
-                                            InputAdapter
-                                              BroadcastExchange #3
-                                                WholeStageCodegen (1)
-                                                  Filter [i_category,i_class,i_item_sk]
-                                                    ColumnarToRow
-                                                      InputAdapter
-                                                        Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_class,i_category]
+                                    Project [ss_store_sk,ss_sales_price,d_moy,i_brand,i_class,i_category]
+                                      BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                        Project [ss_item_sk,ss_store_sk,ss_sales_price,d_moy]
+                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                             Filter [ss_item_sk,ss_store_sk]
                                               ColumnarToRow
                                                 InputAdapter
                                                   Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_store_sk,ss_sales_price,ss_sold_date_sk]
                                                     SubqueryBroadcast [d_date_sk] #1
-                                                      BroadcastExchange #4
+                                                      BroadcastExchange #3
                                                         WholeStageCodegen (1)
                                                           Project [d_date_sk,d_moy]
                                                             Filter [d_year,d_date_sk]
                                                               ColumnarToRow
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                                            InputAdapter
+                                              ReusedExchange [d_date_sk,d_moy] #3
                                         InputAdapter
-                                          ReusedExchange [d_date_sk,d_moy] #4
+                                          BroadcastExchange #4
+                                            WholeStageCodegen (2)
+                                              Filter [i_category,i_class,i_item_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_class,i_category]
                                     InputAdapter
                                       BroadcastExchange #5
                                         WholeStageCodegen (3)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q91.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q91.sf100/explain.txt
@@ -1,47 +1,50 @@
 == Physical Plan ==
-* Sort (43)
-+- Exchange (42)
-   +- * HashAggregate (41)
-      +- Exchange (40)
-         +- * HashAggregate (39)
-            +- * Project (38)
-               +- * BroadcastHashJoin Inner BuildRight (37)
-                  :- * Project (32)
-                  :  +- * BroadcastHashJoin Inner BuildRight (31)
-                  :     :- * Project (23)
-                  :     :  +- * BroadcastHashJoin Inner BuildRight (22)
-                  :     :     :- * Project (16)
-                  :     :     :  +- * BroadcastHashJoin Inner BuildRight (15)
-                  :     :     :     :- * Project (9)
-                  :     :     :     :  +- * BroadcastHashJoin Inner BuildRight (8)
-                  :     :     :     :     :- * Filter (3)
-                  :     :     :     :     :  +- * ColumnarToRow (2)
-                  :     :     :     :     :     +- Scan parquet spark_catalog.default.customer (1)
-                  :     :     :     :     +- BroadcastExchange (7)
-                  :     :     :     :        +- * Filter (6)
-                  :     :     :     :           +- * ColumnarToRow (5)
-                  :     :     :     :              +- Scan parquet spark_catalog.default.customer_demographics (4)
-                  :     :     :     +- BroadcastExchange (14)
-                  :     :     :        +- * Project (13)
-                  :     :     :           +- * Filter (12)
-                  :     :     :              +- * ColumnarToRow (11)
-                  :     :     :                 +- Scan parquet spark_catalog.default.household_demographics (10)
-                  :     :     +- BroadcastExchange (21)
-                  :     :        +- * Project (20)
-                  :     :           +- * Filter (19)
-                  :     :              +- * ColumnarToRow (18)
-                  :     :                 +- Scan parquet spark_catalog.default.customer_address (17)
-                  :     +- BroadcastExchange (30)
-                  :        +- * Project (29)
-                  :           +- * BroadcastHashJoin Inner BuildRight (28)
-                  :              :- * Filter (26)
-                  :              :  +- * ColumnarToRow (25)
-                  :              :     +- Scan parquet spark_catalog.default.catalog_returns (24)
-                  :              +- ReusedExchange (27)
-                  +- BroadcastExchange (36)
-                     +- * Filter (35)
-                        +- * ColumnarToRow (34)
-                           +- Scan parquet spark_catalog.default.call_center (33)
+* Sort (46)
++- Exchange (45)
+   +- * HashAggregate (44)
+      +- Exchange (43)
+         +- * HashAggregate (42)
+            +- * Project (41)
+               +- * BroadcastHashJoin Inner BuildRight (40)
+                  :- * Project (35)
+                  :  +- * SortMergeJoin Inner (34)
+                  :     :- * Sort (25)
+                  :     :  +- Exchange (24)
+                  :     :     +- * Project (23)
+                  :     :        +- * BroadcastHashJoin Inner BuildRight (22)
+                  :     :           :- * Project (17)
+                  :     :           :  +- * BroadcastHashJoin Inner BuildRight (16)
+                  :     :           :     :- * Project (10)
+                  :     :           :     :  +- * BroadcastHashJoin Inner BuildRight (9)
+                  :     :           :     :     :- * Filter (3)
+                  :     :           :     :     :  +- * ColumnarToRow (2)
+                  :     :           :     :     :     +- Scan parquet spark_catalog.default.customer (1)
+                  :     :           :     :     +- BroadcastExchange (8)
+                  :     :           :     :        +- * Project (7)
+                  :     :           :     :           +- * Filter (6)
+                  :     :           :     :              +- * ColumnarToRow (5)
+                  :     :           :     :                 +- Scan parquet spark_catalog.default.customer_address (4)
+                  :     :           :     +- BroadcastExchange (15)
+                  :     :           :        +- * Project (14)
+                  :     :           :           +- * Filter (13)
+                  :     :           :              +- * ColumnarToRow (12)
+                  :     :           :                 +- Scan parquet spark_catalog.default.household_demographics (11)
+                  :     :           +- BroadcastExchange (21)
+                  :     :              +- * Filter (20)
+                  :     :                 +- * ColumnarToRow (19)
+                  :     :                    +- Scan parquet spark_catalog.default.customer_demographics (18)
+                  :     +- * Sort (33)
+                  :        +- Exchange (32)
+                  :           +- * Project (31)
+                  :              +- * BroadcastHashJoin Inner BuildRight (30)
+                  :                 :- * Filter (28)
+                  :                 :  +- * ColumnarToRow (27)
+                  :                 :     +- Scan parquet spark_catalog.default.catalog_returns (26)
+                  :                 +- ReusedExchange (29)
+                  +- BroadcastExchange (39)
+                     +- * Filter (38)
+                        +- * ColumnarToRow (37)
+                           +- Scan parquet spark_catalog.default.call_center (36)
 
 
 (1) Scan parquet spark_catalog.default.customer
@@ -51,106 +54,114 @@ Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_hdemo_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_hdemo_sk:int,c_current_addr_sk:int>
 
-(2) ColumnarToRow [codegen id : 7]
+(2) ColumnarToRow [codegen id : 4]
 Input [4]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_hdemo_sk#3, c_current_addr_sk#4]
 
-(3) Filter [codegen id : 7]
+(3) Filter [codegen id : 4]
 Input [4]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_hdemo_sk#3, c_current_addr_sk#4]
 Condition : (((isnotnull(c_customer_sk#1) AND isnotnull(c_current_addr_sk#4)) AND isnotnull(c_current_cdemo_sk#2)) AND isnotnull(c_current_hdemo_sk#3))
 
-(4) Scan parquet spark_catalog.default.customer_demographics
-Output [3]: [cd_demo_sk#5, cd_marital_status#6, cd_education_status#7]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_demographics]
-PushedFilters: [Or(And(EqualTo(cd_marital_status,M),EqualTo(cd_education_status,Unknown             )),And(EqualTo(cd_marital_status,W),EqualTo(cd_education_status,Advanced Degree     ))), IsNotNull(cd_demo_sk)]
-ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string,cd_education_status:string>
-
-(5) ColumnarToRow [codegen id : 1]
-Input [3]: [cd_demo_sk#5, cd_marital_status#6, cd_education_status#7]
-
-(6) Filter [codegen id : 1]
-Input [3]: [cd_demo_sk#5, cd_marital_status#6, cd_education_status#7]
-Condition : ((((cd_marital_status#6 = M) AND (cd_education_status#7 = Unknown             )) OR ((cd_marital_status#6 = W) AND (cd_education_status#7 = Advanced Degree     ))) AND isnotnull(cd_demo_sk#5))
-
-(7) BroadcastExchange
-Input [3]: [cd_demo_sk#5, cd_marital_status#6, cd_education_status#7]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
-
-(8) BroadcastHashJoin [codegen id : 7]
-Left keys [1]: [c_current_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#5]
-Join type: Inner
-Join condition: None
-
-(9) Project [codegen id : 7]
-Output [5]: [c_customer_sk#1, c_current_hdemo_sk#3, c_current_addr_sk#4, cd_marital_status#6, cd_education_status#7]
-Input [7]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_hdemo_sk#3, c_current_addr_sk#4, cd_demo_sk#5, cd_marital_status#6, cd_education_status#7]
-
-(10) Scan parquet spark_catalog.default.household_demographics
-Output [2]: [hd_demo_sk#8, hd_buy_potential#9]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/household_demographics]
-PushedFilters: [IsNotNull(hd_buy_potential), StringStartsWith(hd_buy_potential,Unknown), IsNotNull(hd_demo_sk)]
-ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string>
-
-(11) ColumnarToRow [codegen id : 2]
-Input [2]: [hd_demo_sk#8, hd_buy_potential#9]
-
-(12) Filter [codegen id : 2]
-Input [2]: [hd_demo_sk#8, hd_buy_potential#9]
-Condition : ((isnotnull(hd_buy_potential#9) AND StartsWith(hd_buy_potential#9, Unknown)) AND isnotnull(hd_demo_sk#8))
-
-(13) Project [codegen id : 2]
-Output [1]: [hd_demo_sk#8]
-Input [2]: [hd_demo_sk#8, hd_buy_potential#9]
-
-(14) BroadcastExchange
-Input [1]: [hd_demo_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
-
-(15) BroadcastHashJoin [codegen id : 7]
-Left keys [1]: [c_current_hdemo_sk#3]
-Right keys [1]: [hd_demo_sk#8]
-Join type: Inner
-Join condition: None
-
-(16) Project [codegen id : 7]
-Output [4]: [c_customer_sk#1, c_current_addr_sk#4, cd_marital_status#6, cd_education_status#7]
-Input [6]: [c_customer_sk#1, c_current_hdemo_sk#3, c_current_addr_sk#4, cd_marital_status#6, cd_education_status#7, hd_demo_sk#8]
-
-(17) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#10, ca_gmt_offset#11]
+(4) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#5, ca_gmt_offset#6]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_gmt_offset), EqualTo(ca_gmt_offset,-7.00), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_gmt_offset:decimal(5,2)>
 
-(18) ColumnarToRow [codegen id : 3]
-Input [2]: [ca_address_sk#10, ca_gmt_offset#11]
+(5) ColumnarToRow [codegen id : 1]
+Input [2]: [ca_address_sk#5, ca_gmt_offset#6]
 
-(19) Filter [codegen id : 3]
-Input [2]: [ca_address_sk#10, ca_gmt_offset#11]
-Condition : ((isnotnull(ca_gmt_offset#11) AND (ca_gmt_offset#11 = -7.00)) AND isnotnull(ca_address_sk#10))
+(6) Filter [codegen id : 1]
+Input [2]: [ca_address_sk#5, ca_gmt_offset#6]
+Condition : ((isnotnull(ca_gmt_offset#6) AND (ca_gmt_offset#6 = -7.00)) AND isnotnull(ca_address_sk#5))
 
-(20) Project [codegen id : 3]
-Output [1]: [ca_address_sk#10]
-Input [2]: [ca_address_sk#10, ca_gmt_offset#11]
+(7) Project [codegen id : 1]
+Output [1]: [ca_address_sk#5]
+Input [2]: [ca_address_sk#5, ca_gmt_offset#6]
 
-(21) BroadcastExchange
-Input [1]: [ca_address_sk#10]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
+(8) BroadcastExchange
+Input [1]: [ca_address_sk#5]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(22) BroadcastHashJoin [codegen id : 7]
+(9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [c_current_addr_sk#4]
-Right keys [1]: [ca_address_sk#10]
+Right keys [1]: [ca_address_sk#5]
 Join type: Inner
 Join condition: None
 
-(23) Project [codegen id : 7]
-Output [3]: [c_customer_sk#1, cd_marital_status#6, cd_education_status#7]
-Input [5]: [c_customer_sk#1, c_current_addr_sk#4, cd_marital_status#6, cd_education_status#7, ca_address_sk#10]
+(10) Project [codegen id : 4]
+Output [3]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_hdemo_sk#3]
+Input [5]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_hdemo_sk#3, c_current_addr_sk#4, ca_address_sk#5]
 
-(24) Scan parquet spark_catalog.default.catalog_returns
+(11) Scan parquet spark_catalog.default.household_demographics
+Output [2]: [hd_demo_sk#7, hd_buy_potential#8]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/household_demographics]
+PushedFilters: [IsNotNull(hd_buy_potential), StringStartsWith(hd_buy_potential,Unknown), IsNotNull(hd_demo_sk)]
+ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string>
+
+(12) ColumnarToRow [codegen id : 2]
+Input [2]: [hd_demo_sk#7, hd_buy_potential#8]
+
+(13) Filter [codegen id : 2]
+Input [2]: [hd_demo_sk#7, hd_buy_potential#8]
+Condition : ((isnotnull(hd_buy_potential#8) AND StartsWith(hd_buy_potential#8, Unknown)) AND isnotnull(hd_demo_sk#7))
+
+(14) Project [codegen id : 2]
+Output [1]: [hd_demo_sk#7]
+Input [2]: [hd_demo_sk#7, hd_buy_potential#8]
+
+(15) BroadcastExchange
+Input [1]: [hd_demo_sk#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
+
+(16) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [c_current_hdemo_sk#3]
+Right keys [1]: [hd_demo_sk#7]
+Join type: Inner
+Join condition: None
+
+(17) Project [codegen id : 4]
+Output [2]: [c_customer_sk#1, c_current_cdemo_sk#2]
+Input [4]: [c_customer_sk#1, c_current_cdemo_sk#2, c_current_hdemo_sk#3, hd_demo_sk#7]
+
+(18) Scan parquet spark_catalog.default.customer_demographics
+Output [3]: [cd_demo_sk#9, cd_marital_status#10, cd_education_status#11]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_demographics]
+PushedFilters: [Or(And(EqualTo(cd_marital_status,M),EqualTo(cd_education_status,Unknown             )),And(EqualTo(cd_marital_status,W),EqualTo(cd_education_status,Advanced Degree     ))), IsNotNull(cd_demo_sk)]
+ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string,cd_education_status:string>
+
+(19) ColumnarToRow [codegen id : 3]
+Input [3]: [cd_demo_sk#9, cd_marital_status#10, cd_education_status#11]
+
+(20) Filter [codegen id : 3]
+Input [3]: [cd_demo_sk#9, cd_marital_status#10, cd_education_status#11]
+Condition : ((((cd_marital_status#10 = M) AND (cd_education_status#11 = Unknown             )) OR ((cd_marital_status#10 = W) AND (cd_education_status#11 = Advanced Degree     ))) AND isnotnull(cd_demo_sk#9))
+
+(21) BroadcastExchange
+Input [3]: [cd_demo_sk#9, cd_marital_status#10, cd_education_status#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
+
+(22) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [c_current_cdemo_sk#2]
+Right keys [1]: [cd_demo_sk#9]
+Join type: Inner
+Join condition: None
+
+(23) Project [codegen id : 4]
+Output [3]: [c_customer_sk#1, cd_marital_status#10, cd_education_status#11]
+Input [5]: [c_customer_sk#1, c_current_cdemo_sk#2, cd_demo_sk#9, cd_marital_status#10, cd_education_status#11]
+
+(24) Exchange
+Input [3]: [c_customer_sk#1, cd_marital_status#10, cd_education_status#11]
+Arguments: hashpartitioning(c_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+
+(25) Sort [codegen id : 5]
+Input [3]: [c_customer_sk#1, cd_marital_status#10, cd_education_status#11]
+Arguments: [c_customer_sk#1 ASC NULLS FIRST], false, 0
+
+(26) Scan parquet spark_catalog.default.catalog_returns
 Output [4]: [cr_returning_customer_sk#12, cr_call_center_sk#13, cr_net_loss#14, cr_returned_date_sk#15]
 Batched: true
 Location: InMemoryFileIndex []
@@ -158,124 +169,128 @@ PartitionFilters: [isnotnull(cr_returned_date_sk#15), dynamicpruningexpression(c
 PushedFilters: [IsNotNull(cr_call_center_sk), IsNotNull(cr_returning_customer_sk)]
 ReadSchema: struct<cr_returning_customer_sk:int,cr_call_center_sk:int,cr_net_loss:decimal(7,2)>
 
-(25) ColumnarToRow [codegen id : 5]
+(27) ColumnarToRow [codegen id : 7]
 Input [4]: [cr_returning_customer_sk#12, cr_call_center_sk#13, cr_net_loss#14, cr_returned_date_sk#15]
 
-(26) Filter [codegen id : 5]
+(28) Filter [codegen id : 7]
 Input [4]: [cr_returning_customer_sk#12, cr_call_center_sk#13, cr_net_loss#14, cr_returned_date_sk#15]
 Condition : (isnotnull(cr_call_center_sk#13) AND isnotnull(cr_returning_customer_sk#12))
 
-(27) ReusedExchange [Reuses operator id: 48]
+(29) ReusedExchange [Reuses operator id: 51]
 Output [1]: [d_date_sk#17]
 
-(28) BroadcastHashJoin [codegen id : 5]
+(30) BroadcastHashJoin [codegen id : 7]
 Left keys [1]: [cr_returned_date_sk#15]
 Right keys [1]: [d_date_sk#17]
 Join type: Inner
 Join condition: None
 
-(29) Project [codegen id : 5]
+(31) Project [codegen id : 7]
 Output [3]: [cr_returning_customer_sk#12, cr_call_center_sk#13, cr_net_loss#14]
 Input [5]: [cr_returning_customer_sk#12, cr_call_center_sk#13, cr_net_loss#14, cr_returned_date_sk#15, d_date_sk#17]
 
-(30) BroadcastExchange
+(32) Exchange
 Input [3]: [cr_returning_customer_sk#12, cr_call_center_sk#13, cr_net_loss#14]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
+Arguments: hashpartitioning(cr_returning_customer_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(31) BroadcastHashJoin [codegen id : 7]
+(33) Sort [codegen id : 8]
+Input [3]: [cr_returning_customer_sk#12, cr_call_center_sk#13, cr_net_loss#14]
+Arguments: [cr_returning_customer_sk#12 ASC NULLS FIRST], false, 0
+
+(34) SortMergeJoin [codegen id : 10]
 Left keys [1]: [c_customer_sk#1]
 Right keys [1]: [cr_returning_customer_sk#12]
 Join type: Inner
 Join condition: None
 
-(32) Project [codegen id : 7]
-Output [4]: [cd_marital_status#6, cd_education_status#7, cr_call_center_sk#13, cr_net_loss#14]
-Input [6]: [c_customer_sk#1, cd_marital_status#6, cd_education_status#7, cr_returning_customer_sk#12, cr_call_center_sk#13, cr_net_loss#14]
+(35) Project [codegen id : 10]
+Output [4]: [cd_marital_status#10, cd_education_status#11, cr_call_center_sk#13, cr_net_loss#14]
+Input [6]: [c_customer_sk#1, cd_marital_status#10, cd_education_status#11, cr_returning_customer_sk#12, cr_call_center_sk#13, cr_net_loss#14]
 
-(33) Scan parquet spark_catalog.default.call_center
+(36) Scan parquet spark_catalog.default.call_center
 Output [4]: [cc_call_center_sk#18, cc_call_center_id#19, cc_name#20, cc_manager#21]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/call_center]
 PushedFilters: [IsNotNull(cc_call_center_sk)]
 ReadSchema: struct<cc_call_center_sk:int,cc_call_center_id:string,cc_name:string,cc_manager:string>
 
-(34) ColumnarToRow [codegen id : 6]
+(37) ColumnarToRow [codegen id : 9]
 Input [4]: [cc_call_center_sk#18, cc_call_center_id#19, cc_name#20, cc_manager#21]
 
-(35) Filter [codegen id : 6]
+(38) Filter [codegen id : 9]
 Input [4]: [cc_call_center_sk#18, cc_call_center_id#19, cc_name#20, cc_manager#21]
 Condition : isnotnull(cc_call_center_sk#18)
 
-(36) BroadcastExchange
+(39) BroadcastExchange
 Input [4]: [cc_call_center_sk#18, cc_call_center_id#19, cc_name#20, cc_manager#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=6]
 
-(37) BroadcastHashJoin [codegen id : 7]
+(40) BroadcastHashJoin [codegen id : 10]
 Left keys [1]: [cr_call_center_sk#13]
 Right keys [1]: [cc_call_center_sk#18]
 Join type: Inner
 Join condition: None
 
-(38) Project [codegen id : 7]
-Output [6]: [cc_call_center_id#19, cc_name#20, cc_manager#21, cr_net_loss#14, cd_marital_status#6, cd_education_status#7]
-Input [8]: [cd_marital_status#6, cd_education_status#7, cr_call_center_sk#13, cr_net_loss#14, cc_call_center_sk#18, cc_call_center_id#19, cc_name#20, cc_manager#21]
+(41) Project [codegen id : 10]
+Output [6]: [cc_call_center_id#19, cc_name#20, cc_manager#21, cr_net_loss#14, cd_marital_status#10, cd_education_status#11]
+Input [8]: [cd_marital_status#10, cd_education_status#11, cr_call_center_sk#13, cr_net_loss#14, cc_call_center_sk#18, cc_call_center_id#19, cc_name#20, cc_manager#21]
 
-(39) HashAggregate [codegen id : 7]
-Input [6]: [cc_call_center_id#19, cc_name#20, cc_manager#21, cr_net_loss#14, cd_marital_status#6, cd_education_status#7]
-Keys [5]: [cc_call_center_id#19, cc_name#20, cc_manager#21, cd_marital_status#6, cd_education_status#7]
+(42) HashAggregate [codegen id : 10]
+Input [6]: [cc_call_center_id#19, cc_name#20, cc_manager#21, cr_net_loss#14, cd_marital_status#10, cd_education_status#11]
+Keys [5]: [cc_call_center_id#19, cc_name#20, cc_manager#21, cd_marital_status#10, cd_education_status#11]
 Functions [1]: [partial_sum(UnscaledValue(cr_net_loss#14))]
 Aggregate Attributes [1]: [sum#22]
-Results [6]: [cc_call_center_id#19, cc_name#20, cc_manager#21, cd_marital_status#6, cd_education_status#7, sum#23]
+Results [6]: [cc_call_center_id#19, cc_name#20, cc_manager#21, cd_marital_status#10, cd_education_status#11, sum#23]
 
-(40) Exchange
-Input [6]: [cc_call_center_id#19, cc_name#20, cc_manager#21, cd_marital_status#6, cd_education_status#7, sum#23]
-Arguments: hashpartitioning(cc_call_center_id#19, cc_name#20, cc_manager#21, cd_marital_status#6, cd_education_status#7, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+(43) Exchange
+Input [6]: [cc_call_center_id#19, cc_name#20, cc_manager#21, cd_marital_status#10, cd_education_status#11, sum#23]
+Arguments: hashpartitioning(cc_call_center_id#19, cc_name#20, cc_manager#21, cd_marital_status#10, cd_education_status#11, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(41) HashAggregate [codegen id : 8]
-Input [6]: [cc_call_center_id#19, cc_name#20, cc_manager#21, cd_marital_status#6, cd_education_status#7, sum#23]
-Keys [5]: [cc_call_center_id#19, cc_name#20, cc_manager#21, cd_marital_status#6, cd_education_status#7]
+(44) HashAggregate [codegen id : 11]
+Input [6]: [cc_call_center_id#19, cc_name#20, cc_manager#21, cd_marital_status#10, cd_education_status#11, sum#23]
+Keys [5]: [cc_call_center_id#19, cc_name#20, cc_manager#21, cd_marital_status#10, cd_education_status#11]
 Functions [1]: [sum(UnscaledValue(cr_net_loss#14))]
 Aggregate Attributes [1]: [sum(UnscaledValue(cr_net_loss#14))#24]
 Results [4]: [cc_call_center_id#19 AS Call_Center#25, cc_name#20 AS Call_Center_Name#26, cc_manager#21 AS Manager#27, MakeDecimal(sum(UnscaledValue(cr_net_loss#14))#24,17,2) AS Returns_Loss#28]
 
-(42) Exchange
+(45) Exchange
 Input [4]: [Call_Center#25, Call_Center_Name#26, Manager#27, Returns_Loss#28]
-Arguments: rangepartitioning(Returns_Loss#28 DESC NULLS LAST, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+Arguments: rangepartitioning(Returns_Loss#28 DESC NULLS LAST, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
-(43) Sort [codegen id : 9]
+(46) Sort [codegen id : 12]
 Input [4]: [Call_Center#25, Call_Center_Name#26, Manager#27, Returns_Loss#28]
 Arguments: [Returns_Loss#28 DESC NULLS LAST], true, 0
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 24 Hosting Expression = cr_returned_date_sk#15 IN dynamicpruning#16
-BroadcastExchange (48)
-+- * Project (47)
-   +- * Filter (46)
-      +- * ColumnarToRow (45)
-         +- Scan parquet spark_catalog.default.date_dim (44)
+Subquery:1 Hosting operator id = 26 Hosting Expression = cr_returned_date_sk#15 IN dynamicpruning#16
+BroadcastExchange (51)
++- * Project (50)
+   +- * Filter (49)
+      +- * ColumnarToRow (48)
+         +- Scan parquet spark_catalog.default.date_dim (47)
 
 
-(44) Scan parquet spark_catalog.default.date_dim
+(47) Scan parquet spark_catalog.default.date_dim
 Output [3]: [d_date_sk#17, d_year#29, d_moy#30]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,1998), EqualTo(d_moy,11), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(45) ColumnarToRow [codegen id : 1]
+(48) ColumnarToRow [codegen id : 1]
 Input [3]: [d_date_sk#17, d_year#29, d_moy#30]
 
-(46) Filter [codegen id : 1]
+(49) Filter [codegen id : 1]
 Input [3]: [d_date_sk#17, d_year#29, d_moy#30]
 Condition : ((((isnotnull(d_year#29) AND isnotnull(d_moy#30)) AND (d_year#29 = 1998)) AND (d_moy#30 = 11)) AND isnotnull(d_date_sk#17))
 
-(47) Project [codegen id : 1]
+(50) Project [codegen id : 1]
 Output [1]: [d_date_sk#17]
 Input [3]: [d_date_sk#17, d_year#29, d_moy#30]
 
-(48) BroadcastExchange
+(51) BroadcastExchange
 Input [1]: [d_date_sk#17]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q91.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q91.sf100/simplified.txt
@@ -1,72 +1,81 @@
-WholeStageCodegen (9)
+WholeStageCodegen (12)
   Sort [Returns_Loss]
     InputAdapter
       Exchange [Returns_Loss] #1
-        WholeStageCodegen (8)
+        WholeStageCodegen (11)
           HashAggregate [cc_call_center_id,cc_name,cc_manager,cd_marital_status,cd_education_status,sum] [sum(UnscaledValue(cr_net_loss)),Call_Center,Call_Center_Name,Manager,Returns_Loss,sum]
             InputAdapter
               Exchange [cc_call_center_id,cc_name,cc_manager,cd_marital_status,cd_education_status] #2
-                WholeStageCodegen (7)
+                WholeStageCodegen (10)
                   HashAggregate [cc_call_center_id,cc_name,cc_manager,cd_marital_status,cd_education_status,cr_net_loss] [sum,sum]
                     Project [cc_call_center_id,cc_name,cc_manager,cr_net_loss,cd_marital_status,cd_education_status]
                       BroadcastHashJoin [cr_call_center_sk,cc_call_center_sk]
                         Project [cd_marital_status,cd_education_status,cr_call_center_sk,cr_net_loss]
-                          BroadcastHashJoin [c_customer_sk,cr_returning_customer_sk]
-                            Project [c_customer_sk,cd_marital_status,cd_education_status]
-                              BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
-                                Project [c_customer_sk,c_current_addr_sk,cd_marital_status,cd_education_status]
-                                  BroadcastHashJoin [c_current_hdemo_sk,hd_demo_sk]
-                                    Project [c_customer_sk,c_current_hdemo_sk,c_current_addr_sk,cd_marital_status,cd_education_status]
-                                      BroadcastHashJoin [c_current_cdemo_sk,cd_demo_sk]
-                                        Filter [c_customer_sk,c_current_addr_sk,c_current_cdemo_sk,c_current_hdemo_sk]
-                                          ColumnarToRow
+                          SortMergeJoin [c_customer_sk,cr_returning_customer_sk]
+                            InputAdapter
+                              WholeStageCodegen (5)
+                                Sort [c_customer_sk]
+                                  InputAdapter
+                                    Exchange [c_customer_sk] #3
+                                      WholeStageCodegen (4)
+                                        Project [c_customer_sk,cd_marital_status,cd_education_status]
+                                          BroadcastHashJoin [c_current_cdemo_sk,cd_demo_sk]
+                                            Project [c_customer_sk,c_current_cdemo_sk]
+                                              BroadcastHashJoin [c_current_hdemo_sk,hd_demo_sk]
+                                                Project [c_customer_sk,c_current_cdemo_sk,c_current_hdemo_sk]
+                                                  BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
+                                                    Filter [c_customer_sk,c_current_addr_sk,c_current_cdemo_sk,c_current_hdemo_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_hdemo_sk,c_current_addr_sk]
+                                                    InputAdapter
+                                                      BroadcastExchange #4
+                                                        WholeStageCodegen (1)
+                                                          Project [ca_address_sk]
+                                                            Filter [ca_gmt_offset,ca_address_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_gmt_offset]
+                                                InputAdapter
+                                                  BroadcastExchange #5
+                                                    WholeStageCodegen (2)
+                                                      Project [hd_demo_sk]
+                                                        Filter [hd_buy_potential,hd_demo_sk]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_buy_potential]
                                             InputAdapter
-                                              Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_hdemo_sk,c_current_addr_sk]
-                                        InputAdapter
-                                          BroadcastExchange #3
-                                            WholeStageCodegen (1)
-                                              Filter [cd_marital_status,cd_education_status,cd_demo_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status,cd_education_status]
-                                    InputAdapter
-                                      BroadcastExchange #4
-                                        WholeStageCodegen (2)
-                                          Project [hd_demo_sk]
-                                            Filter [hd_buy_potential,hd_demo_sk]
+                                              BroadcastExchange #6
+                                                WholeStageCodegen (3)
+                                                  Filter [cd_marital_status,cd_education_status,cd_demo_sk]
+                                                    ColumnarToRow
+                                                      InputAdapter
+                                                        Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status,cd_education_status]
+                            InputAdapter
+                              WholeStageCodegen (8)
+                                Sort [cr_returning_customer_sk]
+                                  InputAdapter
+                                    Exchange [cr_returning_customer_sk] #7
+                                      WholeStageCodegen (7)
+                                        Project [cr_returning_customer_sk,cr_call_center_sk,cr_net_loss]
+                                          BroadcastHashJoin [cr_returned_date_sk,d_date_sk]
+                                            Filter [cr_call_center_sk,cr_returning_customer_sk]
                                               ColumnarToRow
                                                 InputAdapter
-                                                  Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_buy_potential]
-                                InputAdapter
-                                  BroadcastExchange #5
-                                    WholeStageCodegen (3)
-                                      Project [ca_address_sk]
-                                        Filter [ca_gmt_offset,ca_address_sk]
-                                          ColumnarToRow
+                                                  Scan parquet spark_catalog.default.catalog_returns [cr_returning_customer_sk,cr_call_center_sk,cr_net_loss,cr_returned_date_sk]
+                                                    SubqueryBroadcast [d_date_sk] #1
+                                                      BroadcastExchange #8
+                                                        WholeStageCodegen (1)
+                                                          Project [d_date_sk]
+                                                            Filter [d_year,d_moy,d_date_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
                                             InputAdapter
-                                              Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_gmt_offset]
-                            InputAdapter
-                              BroadcastExchange #6
-                                WholeStageCodegen (5)
-                                  Project [cr_returning_customer_sk,cr_call_center_sk,cr_net_loss]
-                                    BroadcastHashJoin [cr_returned_date_sk,d_date_sk]
-                                      Filter [cr_call_center_sk,cr_returning_customer_sk]
-                                        ColumnarToRow
-                                          InputAdapter
-                                            Scan parquet spark_catalog.default.catalog_returns [cr_returning_customer_sk,cr_call_center_sk,cr_net_loss,cr_returned_date_sk]
-                                              SubqueryBroadcast [d_date_sk] #1
-                                                BroadcastExchange #7
-                                                  WholeStageCodegen (1)
-                                                    Project [d_date_sk]
-                                                      Filter [d_year,d_moy,d_date_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
-                                      InputAdapter
-                                        ReusedExchange [d_date_sk] #7
+                                              ReusedExchange [d_date_sk] #8
                         InputAdapter
-                          BroadcastExchange #8
-                            WholeStageCodegen (6)
+                          BroadcastExchange #9
+                            WholeStageCodegen (9)
                               Filter [cc_call_center_sk]
                                 ColumnarToRow
                                   InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94.sf100/explain.txt
@@ -33,12 +33,12 @@
                   :     :        +- * Project (23)
                   :     :           +- * Filter (22)
                   :     :              +- * ColumnarToRow (21)
-                  :     :                 +- Scan parquet spark_catalog.default.customer_address (20)
+                  :     :                 +- Scan parquet spark_catalog.default.web_site (20)
                   :     +- BroadcastExchange (31)
                   :        +- * Project (30)
                   :           +- * Filter (29)
                   :              +- * ColumnarToRow (28)
-                  :                 +- Scan parquet spark_catalog.default.web_site (27)
+                  :                 +- Scan parquet spark_catalog.default.customer_address (27)
                   +- BroadcastExchange (38)
                      +- * Project (37)
                         +- * Filter (36)
@@ -58,7 +58,7 @@ Input [8]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_warehouse
 
 (3) Filter [codegen id : 1]
 Input [8]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_warehouse_sk#4, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7, ws_sold_date_sk#8]
-Condition : (((((isnotnull(ws_ship_date_sk#1) AND isnotnull(ws_ship_addr_sk#2)) AND isnotnull(ws_web_site_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#10], xxhash64(ws_ship_addr_sk#2, 42))) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(ws_web_site_sk#3, 42))) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(ws_ship_date_sk#1, 42)))
+Condition : (((((isnotnull(ws_ship_date_sk#1) AND isnotnull(ws_ship_addr_sk#2)) AND isnotnull(ws_web_site_sk#3)) AND might_contain(Subquery scalar-subquery#9, [id=#10], xxhash64(ws_web_site_sk#3, 42))) AND might_contain(Subquery scalar-subquery#11, [id=#12], xxhash64(ws_ship_addr_sk#2, 42))) AND might_contain(Subquery scalar-subquery#13, [id=#14], xxhash64(ws_ship_date_sk#1, 42)))
 
 (4) Project [codegen id : 1]
 Output [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_warehouse_sk#4, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7]
@@ -130,69 +130,69 @@ Right keys [1]: [wr_order_number#18]
 Join type: LeftAnti
 Join condition: None
 
-(20) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#20, ca_state#21]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,IL), IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_state:string>
-
-(21) ColumnarToRow [codegen id : 8]
-Input [2]: [ca_address_sk#20, ca_state#21]
-
-(22) Filter [codegen id : 8]
-Input [2]: [ca_address_sk#20, ca_state#21]
-Condition : ((isnotnull(ca_state#21) AND (ca_state#21 = IL)) AND isnotnull(ca_address_sk#20))
-
-(23) Project [codegen id : 8]
-Output [1]: [ca_address_sk#20]
-Input [2]: [ca_address_sk#20, ca_state#21]
-
-(24) BroadcastExchange
-Input [1]: [ca_address_sk#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
-
-(25) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ws_ship_addr_sk#2]
-Right keys [1]: [ca_address_sk#20]
-Join type: Inner
-Join condition: None
-
-(26) Project [codegen id : 11]
-Output [5]: [ws_ship_date_sk#1, ws_web_site_sk#3, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7]
-Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7, ca_address_sk#20]
-
-(27) Scan parquet spark_catalog.default.web_site
-Output [2]: [web_site_sk#22, web_company_name#23]
+(20) Scan parquet spark_catalog.default.web_site
+Output [2]: [web_site_sk#20, web_company_name#21]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_site]
 PushedFilters: [IsNotNull(web_company_name), EqualTo(web_company_name,pri                                               ), IsNotNull(web_site_sk)]
 ReadSchema: struct<web_site_sk:int,web_company_name:string>
 
+(21) ColumnarToRow [codegen id : 8]
+Input [2]: [web_site_sk#20, web_company_name#21]
+
+(22) Filter [codegen id : 8]
+Input [2]: [web_site_sk#20, web_company_name#21]
+Condition : ((isnotnull(web_company_name#21) AND (web_company_name#21 = pri                                               )) AND isnotnull(web_site_sk#20))
+
+(23) Project [codegen id : 8]
+Output [1]: [web_site_sk#20]
+Input [2]: [web_site_sk#20, web_company_name#21]
+
+(24) BroadcastExchange
+Input [1]: [web_site_sk#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
+
+(25) BroadcastHashJoin [codegen id : 11]
+Left keys [1]: [ws_web_site_sk#3]
+Right keys [1]: [web_site_sk#20]
+Join type: Inner
+Join condition: None
+
+(26) Project [codegen id : 11]
+Output [5]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7]
+Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7, web_site_sk#20]
+
+(27) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#22, ca_state#23]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,IL), IsNotNull(ca_address_sk)]
+ReadSchema: struct<ca_address_sk:int,ca_state:string>
+
 (28) ColumnarToRow [codegen id : 9]
-Input [2]: [web_site_sk#22, web_company_name#23]
+Input [2]: [ca_address_sk#22, ca_state#23]
 
 (29) Filter [codegen id : 9]
-Input [2]: [web_site_sk#22, web_company_name#23]
-Condition : ((isnotnull(web_company_name#23) AND (web_company_name#23 = pri                                               )) AND isnotnull(web_site_sk#22))
+Input [2]: [ca_address_sk#22, ca_state#23]
+Condition : ((isnotnull(ca_state#23) AND (ca_state#23 = IL)) AND isnotnull(ca_address_sk#22))
 
 (30) Project [codegen id : 9]
-Output [1]: [web_site_sk#22]
-Input [2]: [web_site_sk#22, web_company_name#23]
+Output [1]: [ca_address_sk#22]
+Input [2]: [ca_address_sk#22, ca_state#23]
 
 (31) BroadcastExchange
-Input [1]: [web_site_sk#22]
+Input [1]: [ca_address_sk#22]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
 (32) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ws_web_site_sk#3]
-Right keys [1]: [web_site_sk#22]
+Left keys [1]: [ws_ship_addr_sk#2]
+Right keys [1]: [ca_address_sk#22]
 Join type: Inner
 Join condition: None
 
 (33) Project [codegen id : 11]
 Output [4]: [ws_ship_date_sk#1, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7]
-Input [6]: [ws_ship_date_sk#1, ws_web_site_sk#3, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7, web_site_sk#22]
+Input [6]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_order_number#5, ws_ext_ship_cost#6, ws_net_profit#7, ca_address_sk#22]
 
 (34) Scan parquet spark_catalog.default.date_dim
 Output [2]: [d_date_sk#24, d_date#25]
@@ -267,31 +267,31 @@ ObjectHashAggregate (52)
       +- * Project (49)
          +- * Filter (48)
             +- * ColumnarToRow (47)
-               +- Scan parquet spark_catalog.default.customer_address (46)
+               +- Scan parquet spark_catalog.default.web_site (46)
 
 
-(46) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#20, ca_state#21]
+(46) Scan parquet spark_catalog.default.web_site
+Output [2]: [web_site_sk#20, web_company_name#21]
 Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,IL), IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_state:string>
+Location [not included in comparison]/{warehouse_dir}/web_site]
+PushedFilters: [IsNotNull(web_company_name), EqualTo(web_company_name,pri                                               ), IsNotNull(web_site_sk)]
+ReadSchema: struct<web_site_sk:int,web_company_name:string>
 
 (47) ColumnarToRow [codegen id : 1]
-Input [2]: [ca_address_sk#20, ca_state#21]
+Input [2]: [web_site_sk#20, web_company_name#21]
 
 (48) Filter [codegen id : 1]
-Input [2]: [ca_address_sk#20, ca_state#21]
-Condition : ((isnotnull(ca_state#21) AND (ca_state#21 = IL)) AND isnotnull(ca_address_sk#20))
+Input [2]: [web_site_sk#20, web_company_name#21]
+Condition : ((isnotnull(web_company_name#21) AND (web_company_name#21 = pri                                               )) AND isnotnull(web_site_sk#20))
 
 (49) Project [codegen id : 1]
-Output [1]: [ca_address_sk#20]
-Input [2]: [ca_address_sk#20, ca_state#21]
+Output [1]: [web_site_sk#20]
+Input [2]: [web_site_sk#20, web_company_name#21]
 
 (50) ObjectHashAggregate
-Input [1]: [ca_address_sk#20]
+Input [1]: [web_site_sk#20]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 17961, 333176, 0, 0)]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(web_site_sk#20, 42), 4, 144, 0, 0)]
 Aggregate Attributes [1]: [buf#35]
 Results [1]: [buf#36]
 
@@ -302,9 +302,9 @@ Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 (52) ObjectHashAggregate
 Input [1]: [buf#36]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 17961, 333176, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 17961, 333176, 0, 0)#37]
-Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#20, 42), 17961, 333176, 0, 0)#37 AS bloomFilter#38]
+Functions [1]: [bloom_filter_agg(xxhash64(web_site_sk#20, 42), 4, 144, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(web_site_sk#20, 42), 4, 144, 0, 0)#37]
+Results [1]: [bloom_filter_agg(xxhash64(web_site_sk#20, 42), 4, 144, 0, 0)#37 AS bloomFilter#38]
 
 Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#11, [id=#12]
 ObjectHashAggregate (59)
@@ -313,31 +313,31 @@ ObjectHashAggregate (59)
       +- * Project (56)
          +- * Filter (55)
             +- * ColumnarToRow (54)
-               +- Scan parquet spark_catalog.default.web_site (53)
+               +- Scan parquet spark_catalog.default.customer_address (53)
 
 
-(53) Scan parquet spark_catalog.default.web_site
-Output [2]: [web_site_sk#22, web_company_name#23]
+(53) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#22, ca_state#23]
 Batched: true
-Location [not included in comparison]/{warehouse_dir}/web_site]
-PushedFilters: [IsNotNull(web_company_name), EqualTo(web_company_name,pri                                               ), IsNotNull(web_site_sk)]
-ReadSchema: struct<web_site_sk:int,web_company_name:string>
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,IL), IsNotNull(ca_address_sk)]
+ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
 (54) ColumnarToRow [codegen id : 1]
-Input [2]: [web_site_sk#22, web_company_name#23]
+Input [2]: [ca_address_sk#22, ca_state#23]
 
 (55) Filter [codegen id : 1]
-Input [2]: [web_site_sk#22, web_company_name#23]
-Condition : ((isnotnull(web_company_name#23) AND (web_company_name#23 = pri                                               )) AND isnotnull(web_site_sk#22))
+Input [2]: [ca_address_sk#22, ca_state#23]
+Condition : ((isnotnull(ca_state#23) AND (ca_state#23 = IL)) AND isnotnull(ca_address_sk#22))
 
 (56) Project [codegen id : 1]
-Output [1]: [web_site_sk#22]
-Input [2]: [web_site_sk#22, web_company_name#23]
+Output [1]: [ca_address_sk#22]
+Input [2]: [ca_address_sk#22, ca_state#23]
 
 (57) ObjectHashAggregate
-Input [1]: [web_site_sk#22]
+Input [1]: [ca_address_sk#22]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(web_site_sk#22, 42), 4, 144, 0, 0)]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#22, 42), 17961, 333176, 0, 0)]
 Aggregate Attributes [1]: [buf#39]
 Results [1]: [buf#40]
 
@@ -348,9 +348,9 @@ Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
 (59) ObjectHashAggregate
 Input [1]: [buf#40]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(web_site_sk#22, 42), 4, 144, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(web_site_sk#22, 42), 4, 144, 0, 0)#41]
-Results [1]: [bloom_filter_agg(xxhash64(web_site_sk#22, 42), 4, 144, 0, 0)#41 AS bloomFilter#42]
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#22, 42), 17961, 333176, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#22, 42), 17961, 333176, 0, 0)#41]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#22, 42), 17961, 333176, 0, 0)#41 AS bloomFilter#42]
 
 Subquery:3 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#13, [id=#14]
 ObjectHashAggregate (66)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q94.sf100/simplified.txt
@@ -9,9 +9,9 @@ WholeStageCodegen (12)
                 Project [ws_order_number,ws_ext_ship_cost,ws_net_profit]
                   BroadcastHashJoin [ws_ship_date_sk,d_date_sk]
                     Project [ws_ship_date_sk,ws_order_number,ws_ext_ship_cost,ws_net_profit]
-                      BroadcastHashJoin [ws_web_site_sk,web_site_sk]
-                        Project [ws_ship_date_sk,ws_web_site_sk,ws_order_number,ws_ext_ship_cost,ws_net_profit]
-                          BroadcastHashJoin [ws_ship_addr_sk,ca_address_sk]
+                      BroadcastHashJoin [ws_ship_addr_sk,ca_address_sk]
+                        Project [ws_ship_date_sk,ws_ship_addr_sk,ws_order_number,ws_ext_ship_cost,ws_net_profit]
+                          BroadcastHashJoin [ws_web_site_sk,web_site_sk]
                             SortMergeJoin [ws_order_number,wr_order_number]
                               InputAdapter
                                 WholeStageCodegen (5)
@@ -26,18 +26,8 @@ WholeStageCodegen (12)
                                                   Project [ws_ship_date_sk,ws_ship_addr_sk,ws_web_site_sk,ws_warehouse_sk,ws_order_number,ws_ext_ship_cost,ws_net_profit]
                                                     Filter [ws_ship_date_sk,ws_ship_addr_sk,ws_web_site_sk]
                                                       Subquery #1
-                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 17961, 333176, 0, 0),bloomFilter,buf]
-                                                          Exchange #3
-                                                            ObjectHashAggregate [ca_address_sk] [buf,buf]
-                                                              WholeStageCodegen (1)
-                                                                Project [ca_address_sk]
-                                                                  Filter [ca_state,ca_address_sk]
-                                                                    ColumnarToRow
-                                                                      InputAdapter
-                                                                        Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
-                                                      Subquery #2
                                                         ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(web_site_sk, 42), 4, 144, 0, 0),bloomFilter,buf]
-                                                          Exchange #4
+                                                          Exchange #3
                                                             ObjectHashAggregate [web_site_sk] [buf,buf]
                                                               WholeStageCodegen (1)
                                                                 Project [web_site_sk]
@@ -45,6 +35,16 @@ WholeStageCodegen (12)
                                                                     ColumnarToRow
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.web_site [web_site_sk,web_company_name]
+                                                      Subquery #2
+                                                        ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 17961, 333176, 0, 0),bloomFilter,buf]
+                                                          Exchange #4
+                                                            ObjectHashAggregate [ca_address_sk] [buf,buf]
+                                                              WholeStageCodegen (1)
+                                                                Project [ca_address_sk]
+                                                                  Filter [ca_state,ca_address_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
                                                       Subquery #3
                                                         ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_date_sk, 42), 73049, 1141755, 0, 0),bloomFilter,buf]
                                                           Exchange #5
@@ -81,19 +81,19 @@ WholeStageCodegen (12)
                             InputAdapter
                               BroadcastExchange #8
                                 WholeStageCodegen (8)
-                                  Project [ca_address_sk]
-                                    Filter [ca_state,ca_address_sk]
+                                  Project [web_site_sk]
+                                    Filter [web_company_name,web_site_sk]
                                       ColumnarToRow
                                         InputAdapter
-                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+                                          Scan parquet spark_catalog.default.web_site [web_site_sk,web_company_name]
                         InputAdapter
                           BroadcastExchange #9
                             WholeStageCodegen (9)
-                              Project [web_site_sk]
-                                Filter [web_company_name,web_site_sk]
+                              Project [ca_address_sk]
+                                Filter [ca_state,ca_address_sk]
                                   ColumnarToRow
                                     InputAdapter
-                                      Scan parquet spark_catalog.default.web_site [web_site_sk,web_company_name]
+                                      Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
                     InputAdapter
                       BroadcastExchange #10
                         WholeStageCodegen (10)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q95.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q95.sf100/explain.txt
@@ -45,12 +45,12 @@
                   :     :        +- * Project (35)
                   :     :           +- * Filter (34)
                   :     :              +- * ColumnarToRow (33)
-                  :     :                 +- Scan parquet spark_catalog.default.customer_address (32)
+                  :     :                 +- Scan parquet spark_catalog.default.web_site (32)
                   :     +- BroadcastExchange (43)
                   :        +- * Project (42)
                   :           +- * Filter (41)
                   :              +- * ColumnarToRow (40)
-                  :                 +- Scan parquet spark_catalog.default.web_site (39)
+                  :                 +- Scan parquet spark_catalog.default.customer_address (39)
                   +- BroadcastExchange (50)
                      +- * Project (49)
                         +- * Filter (48)
@@ -70,7 +70,7 @@ Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_num
 
 (3) Filter [codegen id : 1]
 Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, ws_sold_date_sk#7]
-Condition : (((((isnotnull(ws_ship_date_sk#1) AND isnotnull(ws_ship_addr_sk#2)) AND isnotnull(ws_web_site_sk#3)) AND might_contain(Subquery scalar-subquery#8, [id=#9], xxhash64(ws_ship_addr_sk#2, 42))) AND might_contain(Subquery scalar-subquery#10, [id=#11], xxhash64(ws_web_site_sk#3, 42))) AND might_contain(Subquery scalar-subquery#12, [id=#13], xxhash64(ws_ship_date_sk#1, 42)))
+Condition : (((((isnotnull(ws_ship_date_sk#1) AND isnotnull(ws_ship_addr_sk#2)) AND isnotnull(ws_web_site_sk#3)) AND might_contain(Subquery scalar-subquery#8, [id=#9], xxhash64(ws_web_site_sk#3, 42))) AND might_contain(Subquery scalar-subquery#10, [id=#11], xxhash64(ws_ship_addr_sk#2, 42))) AND might_contain(Subquery scalar-subquery#12, [id=#13], xxhash64(ws_ship_date_sk#1, 42)))
 
 (4) Project [codegen id : 1]
 Output [6]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
@@ -195,69 +195,69 @@ Right keys [1]: [wr_order_number#19]
 Join type: LeftSemi
 Join condition: None
 
-(32) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#25, ca_state#26]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,IL), IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_state:string>
-
-(33) ColumnarToRow [codegen id : 17]
-Input [2]: [ca_address_sk#25, ca_state#26]
-
-(34) Filter [codegen id : 17]
-Input [2]: [ca_address_sk#25, ca_state#26]
-Condition : ((isnotnull(ca_state#26) AND (ca_state#26 = IL)) AND isnotnull(ca_address_sk#25))
-
-(35) Project [codegen id : 17]
-Output [1]: [ca_address_sk#25]
-Input [2]: [ca_address_sk#25, ca_state#26]
-
-(36) BroadcastExchange
-Input [1]: [ca_address_sk#25]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
-
-(37) BroadcastHashJoin [codegen id : 20]
-Left keys [1]: [ws_ship_addr_sk#2]
-Right keys [1]: [ca_address_sk#25]
-Join type: Inner
-Join condition: None
-
-(38) Project [codegen id : 20]
-Output [5]: [ws_ship_date_sk#1, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
-Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, ca_address_sk#25]
-
-(39) Scan parquet spark_catalog.default.web_site
-Output [2]: [web_site_sk#27, web_company_name#28]
+(32) Scan parquet spark_catalog.default.web_site
+Output [2]: [web_site_sk#25, web_company_name#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_site]
 PushedFilters: [IsNotNull(web_company_name), EqualTo(web_company_name,pri                                               ), IsNotNull(web_site_sk)]
 ReadSchema: struct<web_site_sk:int,web_company_name:string>
 
+(33) ColumnarToRow [codegen id : 17]
+Input [2]: [web_site_sk#25, web_company_name#26]
+
+(34) Filter [codegen id : 17]
+Input [2]: [web_site_sk#25, web_company_name#26]
+Condition : ((isnotnull(web_company_name#26) AND (web_company_name#26 = pri                                               )) AND isnotnull(web_site_sk#25))
+
+(35) Project [codegen id : 17]
+Output [1]: [web_site_sk#25]
+Input [2]: [web_site_sk#25, web_company_name#26]
+
+(36) BroadcastExchange
+Input [1]: [web_site_sk#25]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
+
+(37) BroadcastHashJoin [codegen id : 20]
+Left keys [1]: [ws_web_site_sk#3]
+Right keys [1]: [web_site_sk#25]
+Join type: Inner
+Join condition: None
+
+(38) Project [codegen id : 20]
+Output [5]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
+Input [7]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, web_site_sk#25]
+
+(39) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#27, ca_state#28]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,IL), IsNotNull(ca_address_sk)]
+ReadSchema: struct<ca_address_sk:int,ca_state:string>
+
 (40) ColumnarToRow [codegen id : 18]
-Input [2]: [web_site_sk#27, web_company_name#28]
+Input [2]: [ca_address_sk#27, ca_state#28]
 
 (41) Filter [codegen id : 18]
-Input [2]: [web_site_sk#27, web_company_name#28]
-Condition : ((isnotnull(web_company_name#28) AND (web_company_name#28 = pri                                               )) AND isnotnull(web_site_sk#27))
+Input [2]: [ca_address_sk#27, ca_state#28]
+Condition : ((isnotnull(ca_state#28) AND (ca_state#28 = IL)) AND isnotnull(ca_address_sk#27))
 
 (42) Project [codegen id : 18]
-Output [1]: [web_site_sk#27]
-Input [2]: [web_site_sk#27, web_company_name#28]
+Output [1]: [ca_address_sk#27]
+Input [2]: [ca_address_sk#27, ca_state#28]
 
 (43) BroadcastExchange
-Input [1]: [web_site_sk#27]
+Input [1]: [ca_address_sk#27]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
 (44) BroadcastHashJoin [codegen id : 20]
-Left keys [1]: [ws_web_site_sk#3]
-Right keys [1]: [web_site_sk#27]
+Left keys [1]: [ws_ship_addr_sk#2]
+Right keys [1]: [ca_address_sk#27]
 Join type: Inner
 Join condition: None
 
 (45) Project [codegen id : 20]
 Output [4]: [ws_ship_date_sk#1, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6]
-Input [6]: [ws_ship_date_sk#1, ws_web_site_sk#3, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, web_site_sk#27]
+Input [6]: [ws_ship_date_sk#1, ws_ship_addr_sk#2, ws_order_number#4, ws_ext_ship_cost#5, ws_net_profit#6, ca_address_sk#27]
 
 (46) Scan parquet spark_catalog.default.date_dim
 Output [2]: [d_date_sk#29, d_date#30]
@@ -332,31 +332,31 @@ ObjectHashAggregate (64)
       +- * Project (61)
          +- * Filter (60)
             +- * ColumnarToRow (59)
-               +- Scan parquet spark_catalog.default.customer_address (58)
+               +- Scan parquet spark_catalog.default.web_site (58)
 
 
-(58) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#25, ca_state#26]
+(58) Scan parquet spark_catalog.default.web_site
+Output [2]: [web_site_sk#25, web_company_name#26]
 Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,IL), IsNotNull(ca_address_sk)]
-ReadSchema: struct<ca_address_sk:int,ca_state:string>
+Location [not included in comparison]/{warehouse_dir}/web_site]
+PushedFilters: [IsNotNull(web_company_name), EqualTo(web_company_name,pri                                               ), IsNotNull(web_site_sk)]
+ReadSchema: struct<web_site_sk:int,web_company_name:string>
 
 (59) ColumnarToRow [codegen id : 1]
-Input [2]: [ca_address_sk#25, ca_state#26]
+Input [2]: [web_site_sk#25, web_company_name#26]
 
 (60) Filter [codegen id : 1]
-Input [2]: [ca_address_sk#25, ca_state#26]
-Condition : ((isnotnull(ca_state#26) AND (ca_state#26 = IL)) AND isnotnull(ca_address_sk#25))
+Input [2]: [web_site_sk#25, web_company_name#26]
+Condition : ((isnotnull(web_company_name#26) AND (web_company_name#26 = pri                                               )) AND isnotnull(web_site_sk#25))
 
 (61) Project [codegen id : 1]
-Output [1]: [ca_address_sk#25]
-Input [2]: [ca_address_sk#25, ca_state#26]
+Output [1]: [web_site_sk#25]
+Input [2]: [web_site_sk#25, web_company_name#26]
 
 (62) ObjectHashAggregate
-Input [1]: [ca_address_sk#25]
+Input [1]: [web_site_sk#25]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#25, 42), 17961, 333176, 0, 0)]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(web_site_sk#25, 42), 4, 144, 0, 0)]
 Aggregate Attributes [1]: [buf#40]
 Results [1]: [buf#41]
 
@@ -367,9 +367,9 @@ Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 (64) ObjectHashAggregate
 Input [1]: [buf#41]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#25, 42), 17961, 333176, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#25, 42), 17961, 333176, 0, 0)#42]
-Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#25, 42), 17961, 333176, 0, 0)#42 AS bloomFilter#43]
+Functions [1]: [bloom_filter_agg(xxhash64(web_site_sk#25, 42), 4, 144, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(web_site_sk#25, 42), 4, 144, 0, 0)#42]
+Results [1]: [bloom_filter_agg(xxhash64(web_site_sk#25, 42), 4, 144, 0, 0)#42 AS bloomFilter#43]
 
 Subquery:2 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#10, [id=#11]
 ObjectHashAggregate (71)
@@ -378,31 +378,31 @@ ObjectHashAggregate (71)
       +- * Project (68)
          +- * Filter (67)
             +- * ColumnarToRow (66)
-               +- Scan parquet spark_catalog.default.web_site (65)
+               +- Scan parquet spark_catalog.default.customer_address (65)
 
 
-(65) Scan parquet spark_catalog.default.web_site
-Output [2]: [web_site_sk#27, web_company_name#28]
+(65) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#27, ca_state#28]
 Batched: true
-Location [not included in comparison]/{warehouse_dir}/web_site]
-PushedFilters: [IsNotNull(web_company_name), EqualTo(web_company_name,pri                                               ), IsNotNull(web_site_sk)]
-ReadSchema: struct<web_site_sk:int,web_company_name:string>
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_state), EqualTo(ca_state,IL), IsNotNull(ca_address_sk)]
+ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
 (66) ColumnarToRow [codegen id : 1]
-Input [2]: [web_site_sk#27, web_company_name#28]
+Input [2]: [ca_address_sk#27, ca_state#28]
 
 (67) Filter [codegen id : 1]
-Input [2]: [web_site_sk#27, web_company_name#28]
-Condition : ((isnotnull(web_company_name#28) AND (web_company_name#28 = pri                                               )) AND isnotnull(web_site_sk#27))
+Input [2]: [ca_address_sk#27, ca_state#28]
+Condition : ((isnotnull(ca_state#28) AND (ca_state#28 = IL)) AND isnotnull(ca_address_sk#27))
 
 (68) Project [codegen id : 1]
-Output [1]: [web_site_sk#27]
-Input [2]: [web_site_sk#27, web_company_name#28]
+Output [1]: [ca_address_sk#27]
+Input [2]: [ca_address_sk#27, ca_state#28]
 
 (69) ObjectHashAggregate
-Input [1]: [web_site_sk#27]
+Input [1]: [ca_address_sk#27]
 Keys: []
-Functions [1]: [partial_bloom_filter_agg(xxhash64(web_site_sk#27, 42), 4, 144, 0, 0)]
+Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#27, 42), 17961, 333176, 0, 0)]
 Aggregate Attributes [1]: [buf#44]
 Results [1]: [buf#45]
 
@@ -413,9 +413,9 @@ Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=9]
 (71) ObjectHashAggregate
 Input [1]: [buf#45]
 Keys: []
-Functions [1]: [bloom_filter_agg(xxhash64(web_site_sk#27, 42), 4, 144, 0, 0)]
-Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(web_site_sk#27, 42), 4, 144, 0, 0)#46]
-Results [1]: [bloom_filter_agg(xxhash64(web_site_sk#27, 42), 4, 144, 0, 0)#46 AS bloomFilter#47]
+Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#27, 42), 17961, 333176, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#27, 42), 17961, 333176, 0, 0)#46]
+Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#27, 42), 17961, 333176, 0, 0)#46 AS bloomFilter#47]
 
 Subquery:3 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#12, [id=#13]
 ObjectHashAggregate (78)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q95.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q95.sf100/simplified.txt
@@ -9,9 +9,9 @@ WholeStageCodegen (21)
                 Project [ws_order_number,ws_ext_ship_cost,ws_net_profit]
                   BroadcastHashJoin [ws_ship_date_sk,d_date_sk]
                     Project [ws_ship_date_sk,ws_order_number,ws_ext_ship_cost,ws_net_profit]
-                      BroadcastHashJoin [ws_web_site_sk,web_site_sk]
-                        Project [ws_ship_date_sk,ws_web_site_sk,ws_order_number,ws_ext_ship_cost,ws_net_profit]
-                          BroadcastHashJoin [ws_ship_addr_sk,ca_address_sk]
+                      BroadcastHashJoin [ws_ship_addr_sk,ca_address_sk]
+                        Project [ws_ship_date_sk,ws_ship_addr_sk,ws_order_number,ws_ext_ship_cost,ws_net_profit]
+                          BroadcastHashJoin [ws_web_site_sk,web_site_sk]
                             SortMergeJoin [ws_order_number,wr_order_number]
                               InputAdapter
                                 WholeStageCodegen (8)
@@ -25,18 +25,8 @@ WholeStageCodegen (21)
                                                 Project [ws_ship_date_sk,ws_ship_addr_sk,ws_web_site_sk,ws_order_number,ws_ext_ship_cost,ws_net_profit]
                                                   Filter [ws_ship_date_sk,ws_ship_addr_sk,ws_web_site_sk]
                                                     Subquery #1
-                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 17961, 333176, 0, 0),bloomFilter,buf]
-                                                        Exchange #3
-                                                          ObjectHashAggregate [ca_address_sk] [buf,buf]
-                                                            WholeStageCodegen (1)
-                                                              Project [ca_address_sk]
-                                                                Filter [ca_state,ca_address_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
-                                                    Subquery #2
                                                       ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(web_site_sk, 42), 4, 144, 0, 0),bloomFilter,buf]
-                                                        Exchange #4
+                                                        Exchange #3
                                                           ObjectHashAggregate [web_site_sk] [buf,buf]
                                                             WholeStageCodegen (1)
                                                               Project [web_site_sk]
@@ -44,6 +34,16 @@ WholeStageCodegen (21)
                                                                   ColumnarToRow
                                                                     InputAdapter
                                                                       Scan parquet spark_catalog.default.web_site [web_site_sk,web_company_name]
+                                                    Subquery #2
+                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 17961, 333176, 0, 0),bloomFilter,buf]
+                                                        Exchange #4
+                                                          ObjectHashAggregate [ca_address_sk] [buf,buf]
+                                                            WholeStageCodegen (1)
+                                                              Project [ca_address_sk]
+                                                                Filter [ca_state,ca_address_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
                                                     Subquery #3
                                                       ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(d_date_sk, 42), 73049, 1141755, 0, 0),bloomFilter,buf]
                                                         Exchange #5
@@ -108,19 +108,19 @@ WholeStageCodegen (21)
                             InputAdapter
                               BroadcastExchange #8
                                 WholeStageCodegen (17)
-                                  Project [ca_address_sk]
-                                    Filter [ca_state,ca_address_sk]
+                                  Project [web_site_sk]
+                                    Filter [web_company_name,web_site_sk]
                                       ColumnarToRow
                                         InputAdapter
-                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+                                          Scan parquet spark_catalog.default.web_site [web_site_sk,web_company_name]
                         InputAdapter
                           BroadcastExchange #9
                             WholeStageCodegen (18)
-                              Project [web_site_sk]
-                                Filter [web_company_name,web_site_sk]
+                              Project [ca_address_sk]
+                                Filter [ca_state,ca_address_sk]
                                   ColumnarToRow
                                     InputAdapter
-                                      Scan parquet spark_catalog.default.web_site [web_site_sk,web_company_name]
+                                      Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
                     InputAdapter
                       BroadcastExchange #10
                         WholeStageCodegen (19)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q96.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q96.sf100/explain.txt
@@ -16,17 +16,17 @@
             :     :        +- * Project (8)
             :     :           +- * Filter (7)
             :     :              +- * ColumnarToRow (6)
-            :     :                 +- Scan parquet spark_catalog.default.time_dim (5)
+            :     :                 +- Scan parquet spark_catalog.default.store (5)
             :     +- BroadcastExchange (16)
             :        +- * Project (15)
             :           +- * Filter (14)
             :              +- * ColumnarToRow (13)
-            :                 +- Scan parquet spark_catalog.default.store (12)
+            :                 +- Scan parquet spark_catalog.default.household_demographics (12)
             +- BroadcastExchange (23)
                +- * Project (22)
                   +- * Filter (21)
                      +- * ColumnarToRow (20)
-                        +- Scan parquet spark_catalog.default.household_demographics (19)
+                        +- Scan parquet spark_catalog.default.time_dim (19)
 
 
 (1) Scan parquet spark_catalog.default.store_sales
@@ -47,101 +47,101 @@ Condition : ((isnotnull(ss_hdemo_sk#2) AND isnotnull(ss_sold_time_sk#1)) AND isn
 Output [3]: [ss_sold_time_sk#1, ss_hdemo_sk#2, ss_store_sk#3]
 Input [4]: [ss_sold_time_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_sold_date_sk#4]
 
-(5) Scan parquet spark_catalog.default.time_dim
-Output [3]: [t_time_sk#5, t_hour#6, t_minute#7]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/time_dim]
-PushedFilters: [IsNotNull(t_hour), IsNotNull(t_minute), EqualTo(t_hour,20), GreaterThanOrEqual(t_minute,30), IsNotNull(t_time_sk)]
-ReadSchema: struct<t_time_sk:int,t_hour:int,t_minute:int>
-
-(6) ColumnarToRow [codegen id : 1]
-Input [3]: [t_time_sk#5, t_hour#6, t_minute#7]
-
-(7) Filter [codegen id : 1]
-Input [3]: [t_time_sk#5, t_hour#6, t_minute#7]
-Condition : ((((isnotnull(t_hour#6) AND isnotnull(t_minute#7)) AND (t_hour#6 = 20)) AND (t_minute#7 >= 30)) AND isnotnull(t_time_sk#5))
-
-(8) Project [codegen id : 1]
-Output [1]: [t_time_sk#5]
-Input [3]: [t_time_sk#5, t_hour#6, t_minute#7]
-
-(9) BroadcastExchange
-Input [1]: [t_time_sk#5]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
-
-(10) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_time_sk#1]
-Right keys [1]: [t_time_sk#5]
-Join type: Inner
-Join condition: None
-
-(11) Project [codegen id : 4]
-Output [2]: [ss_hdemo_sk#2, ss_store_sk#3]
-Input [4]: [ss_sold_time_sk#1, ss_hdemo_sk#2, ss_store_sk#3, t_time_sk#5]
-
-(12) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#8, s_store_name#9]
+(5) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#5, s_store_name#6]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_name), EqualTo(s_store_name,ese), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_store_name:string>
 
-(13) ColumnarToRow [codegen id : 2]
-Input [2]: [s_store_sk#8, s_store_name#9]
+(6) ColumnarToRow [codegen id : 1]
+Input [2]: [s_store_sk#5, s_store_name#6]
 
-(14) Filter [codegen id : 2]
-Input [2]: [s_store_sk#8, s_store_name#9]
-Condition : ((isnotnull(s_store_name#9) AND (s_store_name#9 = ese)) AND isnotnull(s_store_sk#8))
+(7) Filter [codegen id : 1]
+Input [2]: [s_store_sk#5, s_store_name#6]
+Condition : ((isnotnull(s_store_name#6) AND (s_store_name#6 = ese)) AND isnotnull(s_store_sk#5))
 
-(15) Project [codegen id : 2]
-Output [1]: [s_store_sk#8]
-Input [2]: [s_store_sk#8, s_store_name#9]
+(8) Project [codegen id : 1]
+Output [1]: [s_store_sk#5]
+Input [2]: [s_store_sk#5, s_store_name#6]
 
-(16) BroadcastExchange
-Input [1]: [s_store_sk#8]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
+(9) BroadcastExchange
+Input [1]: [s_store_sk#5]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(17) BroadcastHashJoin [codegen id : 4]
+(10) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#8]
+Right keys [1]: [s_store_sk#5]
 Join type: Inner
 Join condition: None
 
-(18) Project [codegen id : 4]
-Output [1]: [ss_hdemo_sk#2]
-Input [3]: [ss_hdemo_sk#2, ss_store_sk#3, s_store_sk#8]
+(11) Project [codegen id : 4]
+Output [2]: [ss_sold_time_sk#1, ss_hdemo_sk#2]
+Input [4]: [ss_sold_time_sk#1, ss_hdemo_sk#2, ss_store_sk#3, s_store_sk#5]
 
-(19) Scan parquet spark_catalog.default.household_demographics
-Output [2]: [hd_demo_sk#10, hd_dep_count#11]
+(12) Scan parquet spark_catalog.default.household_demographics
+Output [2]: [hd_demo_sk#7, hd_dep_count#8]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [IsNotNull(hd_dep_count), EqualTo(hd_dep_count,7), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_dep_count:int>
 
+(13) ColumnarToRow [codegen id : 2]
+Input [2]: [hd_demo_sk#7, hd_dep_count#8]
+
+(14) Filter [codegen id : 2]
+Input [2]: [hd_demo_sk#7, hd_dep_count#8]
+Condition : ((isnotnull(hd_dep_count#8) AND (hd_dep_count#8 = 7)) AND isnotnull(hd_demo_sk#7))
+
+(15) Project [codegen id : 2]
+Output [1]: [hd_demo_sk#7]
+Input [2]: [hd_demo_sk#7, hd_dep_count#8]
+
+(16) BroadcastExchange
+Input [1]: [hd_demo_sk#7]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
+
+(17) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_hdemo_sk#2]
+Right keys [1]: [hd_demo_sk#7]
+Join type: Inner
+Join condition: None
+
+(18) Project [codegen id : 4]
+Output [1]: [ss_sold_time_sk#1]
+Input [3]: [ss_sold_time_sk#1, ss_hdemo_sk#2, hd_demo_sk#7]
+
+(19) Scan parquet spark_catalog.default.time_dim
+Output [3]: [t_time_sk#9, t_hour#10, t_minute#11]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/time_dim]
+PushedFilters: [IsNotNull(t_hour), IsNotNull(t_minute), EqualTo(t_hour,20), GreaterThanOrEqual(t_minute,30), IsNotNull(t_time_sk)]
+ReadSchema: struct<t_time_sk:int,t_hour:int,t_minute:int>
+
 (20) ColumnarToRow [codegen id : 3]
-Input [2]: [hd_demo_sk#10, hd_dep_count#11]
+Input [3]: [t_time_sk#9, t_hour#10, t_minute#11]
 
 (21) Filter [codegen id : 3]
-Input [2]: [hd_demo_sk#10, hd_dep_count#11]
-Condition : ((isnotnull(hd_dep_count#11) AND (hd_dep_count#11 = 7)) AND isnotnull(hd_demo_sk#10))
+Input [3]: [t_time_sk#9, t_hour#10, t_minute#11]
+Condition : ((((isnotnull(t_hour#10) AND isnotnull(t_minute#11)) AND (t_hour#10 = 20)) AND (t_minute#11 >= 30)) AND isnotnull(t_time_sk#9))
 
 (22) Project [codegen id : 3]
-Output [1]: [hd_demo_sk#10]
-Input [2]: [hd_demo_sk#10, hd_dep_count#11]
+Output [1]: [t_time_sk#9]
+Input [3]: [t_time_sk#9, t_hour#10, t_minute#11]
 
 (23) BroadcastExchange
-Input [1]: [hd_demo_sk#10]
+Input [1]: [t_time_sk#9]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=3]
 
 (24) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_hdemo_sk#2]
-Right keys [1]: [hd_demo_sk#10]
+Left keys [1]: [ss_sold_time_sk#1]
+Right keys [1]: [t_time_sk#9]
 Join type: Inner
 Join condition: None
 
 (25) Project [codegen id : 4]
 Output: []
-Input [2]: [ss_hdemo_sk#2, hd_demo_sk#10]
+Input [2]: [ss_sold_time_sk#1, t_time_sk#9]
 
 (26) HashAggregate [codegen id : 4]
 Input: []

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q96.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v1_4/q96.sf100/simplified.txt
@@ -5,11 +5,11 @@ WholeStageCodegen (5)
         WholeStageCodegen (4)
           HashAggregate [count,count]
             Project
-              BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
-                Project [ss_hdemo_sk]
-                  BroadcastHashJoin [ss_store_sk,s_store_sk]
-                    Project [ss_hdemo_sk,ss_store_sk]
-                      BroadcastHashJoin [ss_sold_time_sk,t_time_sk]
+              BroadcastHashJoin [ss_sold_time_sk,t_time_sk]
+                Project [ss_sold_time_sk]
+                  BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
+                    Project [ss_sold_time_sk,ss_hdemo_sk]
+                      BroadcastHashJoin [ss_store_sk,s_store_sk]
                         Project [ss_sold_time_sk,ss_hdemo_sk,ss_store_sk]
                           Filter [ss_hdemo_sk,ss_sold_time_sk,ss_store_sk]
                             ColumnarToRow
@@ -18,24 +18,24 @@ WholeStageCodegen (5)
                         InputAdapter
                           BroadcastExchange #2
                             WholeStageCodegen (1)
-                              Project [t_time_sk]
-                                Filter [t_hour,t_minute,t_time_sk]
+                              Project [s_store_sk]
+                                Filter [s_store_name,s_store_sk]
                                   ColumnarToRow
                                     InputAdapter
-                                      Scan parquet spark_catalog.default.time_dim [t_time_sk,t_hour,t_minute]
+                                      Scan parquet spark_catalog.default.store [s_store_sk,s_store_name]
                     InputAdapter
                       BroadcastExchange #3
                         WholeStageCodegen (2)
-                          Project [s_store_sk]
-                            Filter [s_store_name,s_store_sk]
+                          Project [hd_demo_sk]
+                            Filter [hd_dep_count,hd_demo_sk]
                               ColumnarToRow
                                 InputAdapter
-                                  Scan parquet spark_catalog.default.store [s_store_sk,s_store_name]
+                                  Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_dep_count]
                 InputAdapter
                   BroadcastExchange #4
                     WholeStageCodegen (3)
-                      Project [hd_demo_sk]
-                        Filter [hd_dep_count,hd_demo_sk]
+                      Project [t_time_sk]
+                        Filter [t_hour,t_minute,t_time_sk]
                           ColumnarToRow
                             InputAdapter
-                              Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_dep_count]
+                              Scan parquet spark_catalog.default.time_dim [t_time_sk,t_hour,t_minute]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.sf100/explain.txt
@@ -1,49 +1,52 @@
 == Physical Plan ==
-TakeOrderedAndProject (45)
-+- * HashAggregate (44)
-   +- Exchange (43)
-      +- * HashAggregate (42)
-         +- * Project (41)
-            +- * BroadcastHashJoin Inner BuildLeft (40)
-               :- BroadcastExchange (36)
-               :  +- * Project (35)
-               :     +- * BroadcastHashJoin Inner BuildRight (34)
-               :        :- * Project (28)
-               :        :  +- * SortMergeJoin LeftSemi (27)
-               :        :     :- * SortMergeJoin LeftSemi (13)
-               :        :     :  :- * Sort (5)
-               :        :     :  :  +- Exchange (4)
-               :        :     :  :     +- * Filter (3)
-               :        :     :  :        +- * ColumnarToRow (2)
-               :        :     :  :           +- Scan parquet spark_catalog.default.customer (1)
-               :        :     :  +- * Sort (12)
-               :        :     :     +- Exchange (11)
-               :        :     :        +- * Project (10)
-               :        :     :           +- * BroadcastHashJoin Inner BuildRight (9)
-               :        :     :              :- * ColumnarToRow (7)
-               :        :     :              :  +- Scan parquet spark_catalog.default.store_sales (6)
-               :        :     :              +- ReusedExchange (8)
-               :        :     +- * Sort (26)
-               :        :        +- Exchange (25)
-               :        :           +- Union (24)
-               :        :              :- * Project (18)
-               :        :              :  +- * BroadcastHashJoin Inner BuildRight (17)
-               :        :              :     :- * ColumnarToRow (15)
-               :        :              :     :  +- Scan parquet spark_catalog.default.web_sales (14)
-               :        :              :     +- ReusedExchange (16)
-               :        :              +- * Project (23)
-               :        :                 +- * BroadcastHashJoin Inner BuildRight (22)
-               :        :                    :- * ColumnarToRow (20)
-               :        :                    :  +- Scan parquet spark_catalog.default.catalog_sales (19)
-               :        :                    +- ReusedExchange (21)
-               :        +- BroadcastExchange (33)
-               :           +- * Project (32)
-               :              +- * Filter (31)
-               :                 +- * ColumnarToRow (30)
-               :                    +- Scan parquet spark_catalog.default.customer_address (29)
-               +- * Filter (39)
-                  +- * ColumnarToRow (38)
-                     +- Scan parquet spark_catalog.default.customer_demographics (37)
+TakeOrderedAndProject (48)
++- * HashAggregate (47)
+   +- Exchange (46)
+      +- * HashAggregate (45)
+         +- * Project (44)
+            +- * SortMergeJoin Inner (43)
+               :- * Sort (37)
+               :  +- Exchange (36)
+               :     +- * Project (35)
+               :        +- * BroadcastHashJoin Inner BuildRight (34)
+               :           :- * Project (28)
+               :           :  +- * SortMergeJoin LeftSemi (27)
+               :           :     :- * SortMergeJoin LeftSemi (13)
+               :           :     :  :- * Sort (5)
+               :           :     :  :  +- Exchange (4)
+               :           :     :  :     +- * Filter (3)
+               :           :     :  :        +- * ColumnarToRow (2)
+               :           :     :  :           +- Scan parquet spark_catalog.default.customer (1)
+               :           :     :  +- * Sort (12)
+               :           :     :     +- Exchange (11)
+               :           :     :        +- * Project (10)
+               :           :     :           +- * BroadcastHashJoin Inner BuildRight (9)
+               :           :     :              :- * ColumnarToRow (7)
+               :           :     :              :  +- Scan parquet spark_catalog.default.store_sales (6)
+               :           :     :              +- ReusedExchange (8)
+               :           :     +- * Sort (26)
+               :           :        +- Exchange (25)
+               :           :           +- Union (24)
+               :           :              :- * Project (18)
+               :           :              :  +- * BroadcastHashJoin Inner BuildRight (17)
+               :           :              :     :- * ColumnarToRow (15)
+               :           :              :     :  +- Scan parquet spark_catalog.default.web_sales (14)
+               :           :              :     +- ReusedExchange (16)
+               :           :              +- * Project (23)
+               :           :                 +- * BroadcastHashJoin Inner BuildRight (22)
+               :           :                    :- * ColumnarToRow (20)
+               :           :                    :  +- Scan parquet spark_catalog.default.catalog_sales (19)
+               :           :                    +- ReusedExchange (21)
+               :           +- BroadcastExchange (33)
+               :              +- * Project (32)
+               :                 +- * Filter (31)
+               :                    +- * ColumnarToRow (30)
+               :                       +- Scan parquet spark_catalog.default.customer_address (29)
+               +- * Sort (42)
+                  +- Exchange (41)
+                     +- * Filter (40)
+                        +- * ColumnarToRow (39)
+                           +- Scan parquet spark_catalog.default.customer_demographics (38)
 
 
 (1) Scan parquet spark_catalog.default.customer
@@ -78,7 +81,7 @@ ReadSchema: struct<ss_customer_sk:int>
 (7) ColumnarToRow [codegen id : 4]
 Input [2]: [ss_customer_sk#6, ss_sold_date_sk#7]
 
-(8) ReusedExchange [Reuses operator id: 57]
+(8) ReusedExchange [Reuses operator id: 60]
 Output [1]: [d_date_sk#9]
 
 (9) BroadcastHashJoin [codegen id : 4]
@@ -115,7 +118,7 @@ ReadSchema: struct<ws_bill_customer_sk:int>
 (15) ColumnarToRow [codegen id : 8]
 Input [2]: [ws_bill_customer_sk#10, ws_sold_date_sk#11]
 
-(16) ReusedExchange [Reuses operator id: 57]
+(16) ReusedExchange [Reuses operator id: 60]
 Output [1]: [d_date_sk#12]
 
 (17) BroadcastHashJoin [codegen id : 8]
@@ -138,7 +141,7 @@ ReadSchema: struct<cs_ship_customer_sk:int>
 (20) ColumnarToRow [codegen id : 10]
 Input [2]: [cs_ship_customer_sk#14, cs_sold_date_sk#15]
 
-(21) ReusedExchange [Reuses operator id: 57]
+(21) ReusedExchange [Reuses operator id: 60]
 Output [1]: [d_date_sk#16]
 
 (22) BroadcastHashJoin [codegen id : 10]
@@ -203,98 +206,110 @@ Join condition: None
 Output [1]: [c_current_cdemo_sk#2]
 Input [3]: [c_current_cdemo_sk#2, c_current_addr_sk#3, ca_address_sk#18]
 
-(36) BroadcastExchange
+(36) Exchange
 Input [1]: [c_current_cdemo_sk#2]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
+Arguments: hashpartitioning(c_current_cdemo_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(37) Scan parquet spark_catalog.default.customer_demographics
+(37) Sort [codegen id : 14]
+Input [1]: [c_current_cdemo_sk#2]
+Arguments: [c_current_cdemo_sk#2 ASC NULLS FIRST], false, 0
+
+(38) Scan parquet spark_catalog.default.customer_demographics
 Output [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_education_status:string,cd_purchase_estimate:int,cd_credit_rating:string,cd_dep_count:int,cd_dep_employed_count:int,cd_dep_college_count:int>
 
-(38) ColumnarToRow
+(39) ColumnarToRow [codegen id : 15]
 Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 
-(39) Filter
+(40) Filter [codegen id : 15]
 Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Condition : isnotnull(cd_demo_sk#20)
 
-(40) BroadcastHashJoin [codegen id : 14]
+(41) Exchange
+Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+Arguments: hashpartitioning(cd_demo_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(42) Sort [codegen id : 16]
+Input [9]: [cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
+Arguments: [cd_demo_sk#20 ASC NULLS FIRST], false, 0
+
+(43) SortMergeJoin [codegen id : 17]
 Left keys [1]: [c_current_cdemo_sk#2]
 Right keys [1]: [cd_demo_sk#20]
 Join type: Inner
 Join condition: None
 
-(41) Project [codegen id : 14]
+(44) Project [codegen id : 17]
 Output [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Input [10]: [c_current_cdemo_sk#2, cd_demo_sk#20, cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 
-(42) HashAggregate [codegen id : 14]
+(45) HashAggregate [codegen id : 17]
 Input [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Keys [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Functions [1]: [partial_count(1)]
 Aggregate Attributes [1]: [count#29]
 Results [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
 
-(43) Exchange
+(46) Exchange
 Input [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
-Arguments: hashpartitioning(cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Arguments: hashpartitioning(cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(44) HashAggregate [codegen id : 15]
+(47) HashAggregate [codegen id : 18]
 Input [9]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28, count#30]
 Keys [8]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cd_purchase_estimate#24, cd_credit_rating#25, cd_dep_count#26, cd_dep_employed_count#27, cd_dep_college_count#28]
 Functions [1]: [count(1)]
 Aggregate Attributes [1]: [count(1)#31]
 Results [14]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, count(1)#31 AS cnt1#32, cd_purchase_estimate#24, count(1)#31 AS cnt2#33, cd_credit_rating#25, count(1)#31 AS cnt3#34, cd_dep_count#26, count(1)#31 AS cnt4#35, cd_dep_employed_count#27, count(1)#31 AS cnt5#36, cd_dep_college_count#28, count(1)#31 AS cnt6#37]
 
-(45) TakeOrderedAndProject
+(48) TakeOrderedAndProject
 Input [14]: [cd_gender#21, cd_marital_status#22, cd_education_status#23, cnt1#32, cd_purchase_estimate#24, cnt2#33, cd_credit_rating#25, cnt3#34, cd_dep_count#26, cnt4#35, cd_dep_employed_count#27, cnt5#36, cd_dep_college_count#28, cnt6#37]
 Arguments: 100, [cd_gender#21 ASC NULLS FIRST, cd_marital_status#22 ASC NULLS FIRST, cd_education_status#23 ASC NULLS FIRST, cd_purchase_estimate#24 ASC NULLS FIRST, cd_credit_rating#25 ASC NULLS FIRST, cd_dep_count#26 ASC NULLS FIRST, cd_dep_employed_count#27 ASC NULLS FIRST, cd_dep_college_count#28 ASC NULLS FIRST], [cd_gender#21, cd_marital_status#22, cd_education_status#23, cnt1#32, cd_purchase_estimate#24, cnt2#33, cd_credit_rating#25, cnt3#34, cd_dep_count#26, cnt4#35, cd_dep_employed_count#27, cnt5#36, cd_dep_college_count#28, cnt6#37]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#4, [id=#5]
-ObjectHashAggregate (52)
-+- Exchange (51)
-   +- ObjectHashAggregate (50)
-      +- * Project (49)
-         +- * Filter (48)
-            +- * ColumnarToRow (47)
-               +- Scan parquet spark_catalog.default.customer_address (46)
+ObjectHashAggregate (55)
++- Exchange (54)
+   +- ObjectHashAggregate (53)
+      +- * Project (52)
+         +- * Filter (51)
+            +- * ColumnarToRow (50)
+               +- Scan parquet spark_catalog.default.customer_address (49)
 
 
-(46) Scan parquet spark_catalog.default.customer_address
+(49) Scan parquet spark_catalog.default.customer_address
 Output [2]: [ca_address_sk#18, ca_county#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_county, [Dona Ana County,Douglas County,Gaines County,Richland County,Walker County]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_county:string>
 
-(47) ColumnarToRow [codegen id : 1]
+(50) ColumnarToRow [codegen id : 1]
 Input [2]: [ca_address_sk#18, ca_county#19]
 
-(48) Filter [codegen id : 1]
+(51) Filter [codegen id : 1]
 Input [2]: [ca_address_sk#18, ca_county#19]
 Condition : (ca_county#19 IN (Walker County,Richland County,Gaines County,Douglas County,Dona Ana County) AND isnotnull(ca_address_sk#18))
 
-(49) Project [codegen id : 1]
+(52) Project [codegen id : 1]
 Output [1]: [ca_address_sk#18]
 Input [2]: [ca_address_sk#18, ca_county#19]
 
-(50) ObjectHashAggregate
+(53) ObjectHashAggregate
 Input [1]: [ca_address_sk#18]
 Keys: []
 Functions [1]: [partial_bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)]
 Aggregate Attributes [1]: [buf#38]
 Results [1]: [buf#39]
 
-(51) Exchange
+(54) Exchange
 Input [1]: [buf#39]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=7]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=8]
 
-(52) ObjectHashAggregate
+(55) ObjectHashAggregate
 Input [1]: [buf#39]
 Keys: []
 Functions [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)]
@@ -302,34 +317,34 @@ Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555
 Results [1]: [bloom_filter_agg(xxhash64(ca_address_sk#18, 42), 2555, 57765, 0, 0)#40 AS bloomFilter#41]
 
 Subquery:2 Hosting operator id = 6 Hosting Expression = ss_sold_date_sk#7 IN dynamicpruning#8
-BroadcastExchange (57)
-+- * Project (56)
-   +- * Filter (55)
-      +- * ColumnarToRow (54)
-         +- Scan parquet spark_catalog.default.date_dim (53)
+BroadcastExchange (60)
++- * Project (59)
+   +- * Filter (58)
+      +- * ColumnarToRow (57)
+         +- Scan parquet spark_catalog.default.date_dim (56)
 
 
-(53) Scan parquet spark_catalog.default.date_dim
+(56) Scan parquet spark_catalog.default.date_dim
 Output [3]: [d_date_sk#9, d_year#42, d_moy#43]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), IsNotNull(d_moy), EqualTo(d_year,2002), GreaterThanOrEqual(d_moy,4), LessThanOrEqual(d_moy,7), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_moy:int>
 
-(54) ColumnarToRow [codegen id : 1]
+(57) ColumnarToRow [codegen id : 1]
 Input [3]: [d_date_sk#9, d_year#42, d_moy#43]
 
-(55) Filter [codegen id : 1]
+(58) Filter [codegen id : 1]
 Input [3]: [d_date_sk#9, d_year#42, d_moy#43]
 Condition : (((((isnotnull(d_year#42) AND isnotnull(d_moy#43)) AND (d_year#42 = 2002)) AND (d_moy#43 >= 4)) AND (d_moy#43 <= 7)) AND isnotnull(d_date_sk#9))
 
-(56) Project [codegen id : 1]
+(59) Project [codegen id : 1]
 Output [1]: [d_date_sk#9]
 Input [3]: [d_date_sk#9, d_year#42, d_moy#43]
 
-(57) BroadcastExchange
+(60) BroadcastExchange
 Input [1]: [d_date_sk#9]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
 Subquery:3 Hosting operator id = 14 Hosting Expression = ws_sold_date_sk#11 IN dynamicpruning#8
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q10a.sf100/simplified.txt
@@ -1,96 +1,105 @@
 TakeOrderedAndProject [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count,cnt1,cnt2,cnt3,cnt4,cnt5,cnt6]
-  WholeStageCodegen (15)
+  WholeStageCodegen (18)
     HashAggregate [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count,count] [count(1),cnt1,cnt2,cnt3,cnt4,cnt5,cnt6,count]
       InputAdapter
         Exchange [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count] #1
-          WholeStageCodegen (14)
+          WholeStageCodegen (17)
             HashAggregate [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count] [count,count]
               Project [cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count]
-                BroadcastHashJoin [c_current_cdemo_sk,cd_demo_sk]
+                SortMergeJoin [c_current_cdemo_sk,cd_demo_sk]
                   InputAdapter
-                    BroadcastExchange #2
-                      WholeStageCodegen (13)
-                        Project [c_current_cdemo_sk]
-                          BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
-                            Project [c_current_cdemo_sk,c_current_addr_sk]
-                              SortMergeJoin [c_customer_sk,customer_sk]
-                                InputAdapter
-                                  WholeStageCodegen (6)
-                                    SortMergeJoin [c_customer_sk,ss_customer_sk]
+                    WholeStageCodegen (14)
+                      Sort [c_current_cdemo_sk]
+                        InputAdapter
+                          Exchange [c_current_cdemo_sk] #2
+                            WholeStageCodegen (13)
+                              Project [c_current_cdemo_sk]
+                                BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
+                                  Project [c_current_cdemo_sk,c_current_addr_sk]
+                                    SortMergeJoin [c_customer_sk,customer_sk]
                                       InputAdapter
-                                        WholeStageCodegen (2)
-                                          Sort [c_customer_sk]
+                                        WholeStageCodegen (6)
+                                          SortMergeJoin [c_customer_sk,ss_customer_sk]
                                             InputAdapter
-                                              Exchange [c_customer_sk] #3
-                                                WholeStageCodegen (1)
-                                                  Filter [c_current_addr_sk,c_current_cdemo_sk]
-                                                    Subquery #1
-                                                      ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 2555, 57765, 0, 0),bloomFilter,buf]
-                                                        Exchange #4
-                                                          ObjectHashAggregate [ca_address_sk] [buf,buf]
-                                                            WholeStageCodegen (1)
-                                                              Project [ca_address_sk]
-                                                                Filter [ca_county,ca_address_sk]
-                                                                  ColumnarToRow
-                                                                    InputAdapter
-                                                                      Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
-                                                    ColumnarToRow
-                                                      InputAdapter
-                                                        Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
+                                              WholeStageCodegen (2)
+                                                Sort [c_customer_sk]
+                                                  InputAdapter
+                                                    Exchange [c_customer_sk] #3
+                                                      WholeStageCodegen (1)
+                                                        Filter [c_current_addr_sk,c_current_cdemo_sk]
+                                                          Subquery #1
+                                                            ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(ca_address_sk, 42), 2555, 57765, 0, 0),bloomFilter,buf]
+                                                              Exchange #4
+                                                                ObjectHashAggregate [ca_address_sk] [buf,buf]
+                                                                  WholeStageCodegen (1)
+                                                                    Project [ca_address_sk]
+                                                                      Filter [ca_county,ca_address_sk]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
+                                                          ColumnarToRow
+                                                            InputAdapter
+                                                              Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
+                                            InputAdapter
+                                              WholeStageCodegen (5)
+                                                Sort [ss_customer_sk]
+                                                  InputAdapter
+                                                    Exchange [ss_customer_sk] #5
+                                                      WholeStageCodegen (4)
+                                                        Project [ss_customer_sk]
+                                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
+                                                                  SubqueryBroadcast [d_date_sk] #2
+                                                                    BroadcastExchange #6
+                                                                      WholeStageCodegen (1)
+                                                                        Project [d_date_sk]
+                                                                          Filter [d_year,d_moy,d_date_sk]
+                                                                            ColumnarToRow
+                                                                              InputAdapter
+                                                                                Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
+                                                            InputAdapter
+                                                              ReusedExchange [d_date_sk] #6
                                       InputAdapter
-                                        WholeStageCodegen (5)
-                                          Sort [ss_customer_sk]
+                                        WholeStageCodegen (11)
+                                          Sort [customer_sk]
                                             InputAdapter
-                                              Exchange [ss_customer_sk] #5
-                                                WholeStageCodegen (4)
-                                                  Project [ss_customer_sk]
-                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                      ColumnarToRow
+                                              Exchange [customer_sk] #7
+                                                Union
+                                                  WholeStageCodegen (8)
+                                                    Project [ws_bill_customer_sk]
+                                                      BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                        ColumnarToRow
+                                                          InputAdapter
+                                                            Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
+                                                              ReusedSubquery [d_date_sk] #2
                                                         InputAdapter
-                                                          Scan parquet spark_catalog.default.store_sales [ss_customer_sk,ss_sold_date_sk]
-                                                            SubqueryBroadcast [d_date_sk] #2
-                                                              BroadcastExchange #6
-                                                                WholeStageCodegen (1)
-                                                                  Project [d_date_sk]
-                                                                    Filter [d_year,d_moy,d_date_sk]
-                                                                      ColumnarToRow
-                                                                        InputAdapter
-                                                                          Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
-                                                      InputAdapter
-                                                        ReusedExchange [d_date_sk] #6
-                                InputAdapter
-                                  WholeStageCodegen (11)
-                                    Sort [customer_sk]
-                                      InputAdapter
-                                        Exchange [customer_sk] #7
-                                          Union
-                                            WholeStageCodegen (8)
-                                              Project [ws_bill_customer_sk]
-                                                BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.web_sales [ws_bill_customer_sk,ws_sold_date_sk]
-                                                        ReusedSubquery [d_date_sk] #2
-                                                  InputAdapter
-                                                    ReusedExchange [d_date_sk] #6
-                                            WholeStageCodegen (10)
-                                              Project [cs_ship_customer_sk]
-                                                BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.catalog_sales [cs_ship_customer_sk,cs_sold_date_sk]
-                                                        ReusedSubquery [d_date_sk] #2
-                                                  InputAdapter
-                                                    ReusedExchange [d_date_sk] #6
-                            InputAdapter
-                              BroadcastExchange #8
-                                WholeStageCodegen (12)
-                                  Project [ca_address_sk]
-                                    Filter [ca_county,ca_address_sk]
-                                      ColumnarToRow
-                                        InputAdapter
-                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
-                  Filter [cd_demo_sk]
-                    ColumnarToRow
-                      InputAdapter
-                        Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count]
+                                                          ReusedExchange [d_date_sk] #6
+                                                  WholeStageCodegen (10)
+                                                    Project [cs_ship_customer_sk]
+                                                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                        ColumnarToRow
+                                                          InputAdapter
+                                                            Scan parquet spark_catalog.default.catalog_sales [cs_ship_customer_sk,cs_sold_date_sk]
+                                                              ReusedSubquery [d_date_sk] #2
+                                                        InputAdapter
+                                                          ReusedExchange [d_date_sk] #6
+                                  InputAdapter
+                                    BroadcastExchange #8
+                                      WholeStageCodegen (12)
+                                        Project [ca_address_sk]
+                                          Filter [ca_county,ca_address_sk]
+                                            ColumnarToRow
+                                              InputAdapter
+                                                Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_county]
+                  InputAdapter
+                    WholeStageCodegen (16)
+                      Sort [cd_demo_sk]
+                        InputAdapter
+                          Exchange [cd_demo_sk] #9
+                            WholeStageCodegen (15)
+                              Filter [cd_demo_sk]
+                                ColumnarToRow
+                                  InputAdapter
+                                    Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_education_status,cd_purchase_estimate,cd_credit_rating,cd_dep_count,cd_dep_employed_count,cd_dep_college_count]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14.sf100/explain.txt
@@ -7,8 +7,8 @@ TakeOrderedAndProject (90)
    :        +- * HashAggregate (69)
    :           +- * Project (68)
    :              +- * BroadcastHashJoin Inner BuildRight (67)
-   :                 :- * Project (60)
-   :                 :  +- * BroadcastHashJoin Inner BuildRight (59)
+   :                 :- * Project (65)
+   :                 :  +- * BroadcastHashJoin Inner BuildRight (64)
    :                 :     :- * BroadcastHashJoin LeftSemi BuildRight (57)
    :                 :     :  :- * Filter (3)
    :                 :     :  :  +- * ColumnarToRow (2)
@@ -66,13 +66,13 @@ TakeOrderedAndProject (90)
    :                 :     :                             :     :     +- Scan parquet spark_catalog.default.web_sales (41)
    :                 :     :                             :     +- ReusedExchange (44)
    :                 :     :                             +- ReusedExchange (47)
-   :                 :     +- ReusedExchange (58)
-   :                 +- BroadcastExchange (66)
-   :                    +- * BroadcastHashJoin LeftSemi BuildRight (65)
-   :                       :- * Filter (63)
-   :                       :  +- * ColumnarToRow (62)
-   :                       :     +- Scan parquet spark_catalog.default.item (61)
-   :                       +- ReusedExchange (64)
+   :                 :     +- BroadcastExchange (63)
+   :                 :        +- * BroadcastHashJoin LeftSemi BuildRight (62)
+   :                 :           :- * Filter (60)
+   :                 :           :  +- * ColumnarToRow (59)
+   :                 :           :     +- Scan parquet spark_catalog.default.item (58)
+   :                 :           +- ReusedExchange (61)
+   :                 +- ReusedExchange (66)
    +- BroadcastExchange (88)
       +- * Filter (87)
          +- * HashAggregate (86)
@@ -359,76 +359,76 @@ Right keys [1]: [ss_item_sk#35]
 Join type: LeftSemi
 Join condition: None
 
-(58) ReusedExchange [Reuses operator id: 114]
-Output [1]: [d_date_sk#36]
-
-(59) BroadcastHashJoin [codegen id : 37]
-Left keys [1]: [ss_sold_date_sk#4]
-Right keys [1]: [d_date_sk#36]
-Join type: Inner
-Join condition: None
-
-(60) Project [codegen id : 37]
-Output [3]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3]
-Input [5]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4, d_date_sk#36]
-
-(61) Scan parquet spark_catalog.default.item
-Output [4]: [i_item_sk#37, i_brand_id#38, i_class_id#39, i_category_id#40]
+(58) Scan parquet spark_catalog.default.item
+Output [4]: [i_item_sk#36, i_brand_id#37, i_class_id#38, i_category_id#39]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int>
 
-(62) ColumnarToRow [codegen id : 36]
-Input [4]: [i_item_sk#37, i_brand_id#38, i_class_id#39, i_category_id#40]
+(59) ColumnarToRow [codegen id : 35]
+Input [4]: [i_item_sk#36, i_brand_id#37, i_class_id#38, i_category_id#39]
 
-(63) Filter [codegen id : 36]
-Input [4]: [i_item_sk#37, i_brand_id#38, i_class_id#39, i_category_id#40]
-Condition : (((isnotnull(i_item_sk#37) AND isnotnull(i_brand_id#38)) AND isnotnull(i_class_id#39)) AND isnotnull(i_category_id#40))
+(60) Filter [codegen id : 35]
+Input [4]: [i_item_sk#36, i_brand_id#37, i_class_id#38, i_category_id#39]
+Condition : (((isnotnull(i_item_sk#36) AND isnotnull(i_brand_id#37)) AND isnotnull(i_class_id#38)) AND isnotnull(i_category_id#39))
 
-(64) ReusedExchange [Reuses operator id: 56]
+(61) ReusedExchange [Reuses operator id: 56]
 Output [1]: [ss_item_sk#35]
 
-(65) BroadcastHashJoin [codegen id : 36]
-Left keys [1]: [i_item_sk#37]
+(62) BroadcastHashJoin [codegen id : 35]
+Left keys [1]: [i_item_sk#36]
 Right keys [1]: [ss_item_sk#35]
 Join type: LeftSemi
 Join condition: None
 
-(66) BroadcastExchange
-Input [4]: [i_item_sk#37, i_brand_id#38, i_class_id#39, i_category_id#40]
+(63) BroadcastExchange
+Input [4]: [i_item_sk#36, i_brand_id#37, i_class_id#38, i_category_id#39]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=10]
 
-(67) BroadcastHashJoin [codegen id : 37]
+(64) BroadcastHashJoin [codegen id : 37]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#37]
+Right keys [1]: [i_item_sk#36]
+Join type: Inner
+Join condition: None
+
+(65) Project [codegen id : 37]
+Output [6]: [ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4, i_brand_id#37, i_class_id#38, i_category_id#39]
+Input [8]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4, i_item_sk#36, i_brand_id#37, i_class_id#38, i_category_id#39]
+
+(66) ReusedExchange [Reuses operator id: 114]
+Output [1]: [d_date_sk#40]
+
+(67) BroadcastHashJoin [codegen id : 37]
+Left keys [1]: [ss_sold_date_sk#4]
+Right keys [1]: [d_date_sk#40]
 Join type: Inner
 Join condition: None
 
 (68) Project [codegen id : 37]
-Output [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#38, i_class_id#39, i_category_id#40]
-Input [7]: [ss_item_sk#1, ss_quantity#2, ss_list_price#3, i_item_sk#37, i_brand_id#38, i_class_id#39, i_category_id#40]
+Output [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#37, i_class_id#38, i_category_id#39]
+Input [7]: [ss_quantity#2, ss_list_price#3, ss_sold_date_sk#4, i_brand_id#37, i_class_id#38, i_category_id#39, d_date_sk#40]
 
 (69) HashAggregate [codegen id : 37]
-Input [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#38, i_class_id#39, i_category_id#40]
-Keys [3]: [i_brand_id#38, i_class_id#39, i_category_id#40]
+Input [5]: [ss_quantity#2, ss_list_price#3, i_brand_id#37, i_class_id#38, i_category_id#39]
+Keys [3]: [i_brand_id#37, i_class_id#38, i_category_id#39]
 Functions [2]: [partial_sum((cast(ss_quantity#2 as decimal(10,0)) * ss_list_price#3)), partial_count(1)]
 Aggregate Attributes [3]: [sum#41, isEmpty#42, count#43]
-Results [6]: [i_brand_id#38, i_class_id#39, i_category_id#40, sum#44, isEmpty#45, count#46]
+Results [6]: [i_brand_id#37, i_class_id#38, i_category_id#39, sum#44, isEmpty#45, count#46]
 
 (70) Exchange
-Input [6]: [i_brand_id#38, i_class_id#39, i_category_id#40, sum#44, isEmpty#45, count#46]
-Arguments: hashpartitioning(i_brand_id#38, i_class_id#39, i_category_id#40, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+Input [6]: [i_brand_id#37, i_class_id#38, i_category_id#39, sum#44, isEmpty#45, count#46]
+Arguments: hashpartitioning(i_brand_id#37, i_class_id#38, i_category_id#39, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (71) HashAggregate [codegen id : 76]
-Input [6]: [i_brand_id#38, i_class_id#39, i_category_id#40, sum#44, isEmpty#45, count#46]
-Keys [3]: [i_brand_id#38, i_class_id#39, i_category_id#40]
+Input [6]: [i_brand_id#37, i_class_id#38, i_category_id#39, sum#44, isEmpty#45, count#46]
+Keys [3]: [i_brand_id#37, i_class_id#38, i_category_id#39]
 Functions [2]: [sum((cast(ss_quantity#2 as decimal(10,0)) * ss_list_price#3)), count(1)]
 Aggregate Attributes [2]: [sum((cast(ss_quantity#2 as decimal(10,0)) * ss_list_price#3))#47, count(1)#48]
-Results [6]: [store AS channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sum((cast(ss_quantity#2 as decimal(10,0)) * ss_list_price#3))#47 AS sales#50, count(1)#48 AS number_sales#51]
+Results [6]: [store AS channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sum((cast(ss_quantity#2 as decimal(10,0)) * ss_list_price#3))#47 AS sales#50, count(1)#48 AS number_sales#51]
 
 (72) Filter [codegen id : 76]
-Input [6]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sales#50, number_sales#51]
+Input [6]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sales#50, number_sales#51]
 Condition : (isnotnull(sales#50) AND (cast(sales#50 as decimal(32,6)) > cast(Subquery scalar-subquery#52, [id=#53] as decimal(32,6))))
 
 (73) Scan parquet spark_catalog.default.store_sales
@@ -455,67 +455,67 @@ Right keys [1]: [ss_item_sk#59]
 Join type: LeftSemi
 Join condition: None
 
-(78) ReusedExchange [Reuses operator id: 128]
-Output [1]: [d_date_sk#60]
+(78) ReusedExchange [Reuses operator id: 63]
+Output [4]: [i_item_sk#60, i_brand_id#61, i_class_id#62, i_category_id#63]
 
 (79) BroadcastHashJoin [codegen id : 74]
-Left keys [1]: [ss_sold_date_sk#57]
-Right keys [1]: [d_date_sk#60]
+Left keys [1]: [ss_item_sk#54]
+Right keys [1]: [i_item_sk#60]
 Join type: Inner
 Join condition: None
 
 (80) Project [codegen id : 74]
-Output [3]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56]
-Input [5]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57, d_date_sk#60]
+Output [6]: [ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57, i_brand_id#61, i_class_id#62, i_category_id#63]
+Input [8]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57, i_item_sk#60, i_brand_id#61, i_class_id#62, i_category_id#63]
 
-(81) ReusedExchange [Reuses operator id: 66]
-Output [4]: [i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64]
+(81) ReusedExchange [Reuses operator id: 128]
+Output [1]: [d_date_sk#64]
 
 (82) BroadcastHashJoin [codegen id : 74]
-Left keys [1]: [ss_item_sk#54]
-Right keys [1]: [i_item_sk#61]
+Left keys [1]: [ss_sold_date_sk#57]
+Right keys [1]: [d_date_sk#64]
 Join type: Inner
 Join condition: None
 
 (83) Project [codegen id : 74]
-Output [5]: [ss_quantity#55, ss_list_price#56, i_brand_id#62, i_class_id#63, i_category_id#64]
-Input [7]: [ss_item_sk#54, ss_quantity#55, ss_list_price#56, i_item_sk#61, i_brand_id#62, i_class_id#63, i_category_id#64]
+Output [5]: [ss_quantity#55, ss_list_price#56, i_brand_id#61, i_class_id#62, i_category_id#63]
+Input [7]: [ss_quantity#55, ss_list_price#56, ss_sold_date_sk#57, i_brand_id#61, i_class_id#62, i_category_id#63, d_date_sk#64]
 
 (84) HashAggregate [codegen id : 74]
-Input [5]: [ss_quantity#55, ss_list_price#56, i_brand_id#62, i_class_id#63, i_category_id#64]
-Keys [3]: [i_brand_id#62, i_class_id#63, i_category_id#64]
+Input [5]: [ss_quantity#55, ss_list_price#56, i_brand_id#61, i_class_id#62, i_category_id#63]
+Keys [3]: [i_brand_id#61, i_class_id#62, i_category_id#63]
 Functions [2]: [partial_sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56)), partial_count(1)]
 Aggregate Attributes [3]: [sum#65, isEmpty#66, count#67]
-Results [6]: [i_brand_id#62, i_class_id#63, i_category_id#64, sum#68, isEmpty#69, count#70]
+Results [6]: [i_brand_id#61, i_class_id#62, i_category_id#63, sum#68, isEmpty#69, count#70]
 
 (85) Exchange
-Input [6]: [i_brand_id#62, i_class_id#63, i_category_id#64, sum#68, isEmpty#69, count#70]
-Arguments: hashpartitioning(i_brand_id#62, i_class_id#63, i_category_id#64, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+Input [6]: [i_brand_id#61, i_class_id#62, i_category_id#63, sum#68, isEmpty#69, count#70]
+Arguments: hashpartitioning(i_brand_id#61, i_class_id#62, i_category_id#63, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
 (86) HashAggregate [codegen id : 75]
-Input [6]: [i_brand_id#62, i_class_id#63, i_category_id#64, sum#68, isEmpty#69, count#70]
-Keys [3]: [i_brand_id#62, i_class_id#63, i_category_id#64]
+Input [6]: [i_brand_id#61, i_class_id#62, i_category_id#63, sum#68, isEmpty#69, count#70]
+Keys [3]: [i_brand_id#61, i_class_id#62, i_category_id#63]
 Functions [2]: [sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56)), count(1)]
 Aggregate Attributes [2]: [sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56))#71, count(1)#72]
-Results [6]: [store AS channel#73, i_brand_id#62, i_class_id#63, i_category_id#64, sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56))#71 AS sales#74, count(1)#72 AS number_sales#75]
+Results [6]: [store AS channel#73, i_brand_id#61, i_class_id#62, i_category_id#63, sum((cast(ss_quantity#55 as decimal(10,0)) * ss_list_price#56))#71 AS sales#74, count(1)#72 AS number_sales#75]
 
 (87) Filter [codegen id : 75]
-Input [6]: [channel#73, i_brand_id#62, i_class_id#63, i_category_id#64, sales#74, number_sales#75]
+Input [6]: [channel#73, i_brand_id#61, i_class_id#62, i_category_id#63, sales#74, number_sales#75]
 Condition : (isnotnull(sales#74) AND (cast(sales#74 as decimal(32,6)) > cast(ReusedSubquery Subquery scalar-subquery#52, [id=#53] as decimal(32,6))))
 
 (88) BroadcastExchange
-Input [6]: [channel#73, i_brand_id#62, i_class_id#63, i_category_id#64, sales#74, number_sales#75]
+Input [6]: [channel#73, i_brand_id#61, i_class_id#62, i_category_id#63, sales#74, number_sales#75]
 Arguments: HashedRelationBroadcastMode(List(input[1, int, true], input[2, int, true], input[3, int, true]),false), [plan_id=13]
 
 (89) BroadcastHashJoin [codegen id : 76]
-Left keys [3]: [i_brand_id#38, i_class_id#39, i_category_id#40]
-Right keys [3]: [i_brand_id#62, i_class_id#63, i_category_id#64]
+Left keys [3]: [i_brand_id#37, i_class_id#38, i_category_id#39]
+Right keys [3]: [i_brand_id#61, i_class_id#62, i_category_id#63]
 Join type: Inner
 Join condition: None
 
 (90) TakeOrderedAndProject
-Input [12]: [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sales#50, number_sales#51, channel#73, i_brand_id#62, i_class_id#63, i_category_id#64, sales#74, number_sales#75]
-Arguments: 100, [i_brand_id#38 ASC NULLS FIRST, i_class_id#39 ASC NULLS FIRST, i_category_id#40 ASC NULLS FIRST], [channel#49, i_brand_id#38, i_class_id#39, i_category_id#40, sales#50, number_sales#51, channel#73, i_brand_id#62, i_class_id#63, i_category_id#64, sales#74, number_sales#75]
+Input [12]: [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sales#50, number_sales#51, channel#73, i_brand_id#61, i_class_id#62, i_category_id#63, sales#74, number_sales#75]
+Arguments: 100, [i_brand_id#37 ASC NULLS FIRST, i_class_id#38 ASC NULLS FIRST, i_category_id#39 ASC NULLS FIRST], [channel#49, i_brand_id#37, i_class_id#38, i_category_id#39, sales#50, number_sales#51, channel#73, i_brand_id#61, i_class_id#62, i_category_id#63, sales#74, number_sales#75]
 
 ===== Subqueries =====
 
@@ -645,25 +645,25 @@ BroadcastExchange (114)
 
 
 (110) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#36, d_week_seq#100]
+Output [2]: [d_date_sk#40, d_week_seq#100]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_week_seq), EqualTo(d_week_seq,ScalarSubquery#101), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
 (111) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#36, d_week_seq#100]
+Input [2]: [d_date_sk#40, d_week_seq#100]
 
 (112) Filter [codegen id : 1]
-Input [2]: [d_date_sk#36, d_week_seq#100]
-Condition : ((isnotnull(d_week_seq#100) AND (d_week_seq#100 = ReusedSubquery Subquery scalar-subquery#101, [id=#102])) AND isnotnull(d_date_sk#36))
+Input [2]: [d_date_sk#40, d_week_seq#100]
+Condition : ((isnotnull(d_week_seq#100) AND (d_week_seq#100 = ReusedSubquery Subquery scalar-subquery#101, [id=#102])) AND isnotnull(d_date_sk#40))
 
 (113) Project [codegen id : 1]
-Output [1]: [d_date_sk#36]
-Input [2]: [d_date_sk#36, d_week_seq#100]
+Output [1]: [d_date_sk#40]
+Input [2]: [d_date_sk#40, d_week_seq#100]
 
 (114) BroadcastExchange
-Input [1]: [d_date_sk#36]
+Input [1]: [d_date_sk#40]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=15]
 
 Subquery:6 Hosting operator id = 112 Hosting Expression = ReusedSubquery Subquery scalar-subquery#101, [id=#102]
@@ -738,25 +738,25 @@ BroadcastExchange (128)
 
 
 (124) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#60, d_week_seq#108]
+Output [2]: [d_date_sk#64, d_week_seq#108]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_week_seq), EqualTo(d_week_seq,ScalarSubquery#109), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
 (125) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#60, d_week_seq#108]
+Input [2]: [d_date_sk#64, d_week_seq#108]
 
 (126) Filter [codegen id : 1]
-Input [2]: [d_date_sk#60, d_week_seq#108]
-Condition : ((isnotnull(d_week_seq#108) AND (d_week_seq#108 = ReusedSubquery Subquery scalar-subquery#109, [id=#110])) AND isnotnull(d_date_sk#60))
+Input [2]: [d_date_sk#64, d_week_seq#108]
+Condition : ((isnotnull(d_week_seq#108) AND (d_week_seq#108 = ReusedSubquery Subquery scalar-subquery#109, [id=#110])) AND isnotnull(d_date_sk#64))
 
 (127) Project [codegen id : 1]
-Output [1]: [d_date_sk#60]
-Input [2]: [d_date_sk#60, d_week_seq#108]
+Output [1]: [d_date_sk#64]
+Input [2]: [d_date_sk#64, d_week_seq#108]
 
 (128) BroadcastExchange
-Input [1]: [d_date_sk#60]
+Input [1]: [d_date_sk#64]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=17]
 
 Subquery:13 Hosting operator id = 126 Hosting Expression = ReusedSubquery Subquery scalar-subquery#109, [id=#110]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q14.sf100/simplified.txt
@@ -44,9 +44,9 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
               WholeStageCodegen (37)
                 HashAggregate [i_brand_id,i_class_id,i_category_id,ss_quantity,ss_list_price] [sum,isEmpty,count,sum,isEmpty,count]
                   Project [ss_quantity,ss_list_price,i_brand_id,i_class_id,i_category_id]
-                    BroadcastHashJoin [ss_item_sk,i_item_sk]
-                      Project [ss_item_sk,ss_quantity,ss_list_price]
-                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                      Project [ss_quantity,ss_list_price,ss_sold_date_sk,i_brand_id,i_class_id,i_category_id]
+                        BroadcastHashJoin [ss_item_sk,i_item_sk]
                           BroadcastHashJoin [ss_item_sk,ss_item_sk]
                             Filter [ss_item_sk]
                               ColumnarToRow
@@ -168,17 +168,17 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                                               InputAdapter
                                                                 ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #11
                           InputAdapter
-                            ReusedExchange [d_date_sk] #2
-                      InputAdapter
-                        BroadcastExchange #13
-                          WholeStageCodegen (36)
-                            BroadcastHashJoin [i_item_sk,ss_item_sk]
-                              Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                                ColumnarToRow
+                            BroadcastExchange #13
+                              WholeStageCodegen (35)
+                                BroadcastHashJoin [i_item_sk,ss_item_sk]
+                                  Filter [i_item_sk,i_brand_id,i_class_id,i_category_id]
+                                    ColumnarToRow
+                                      InputAdapter
+                                        Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
                                   InputAdapter
-                                    Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_class_id,i_category_id]
-                              InputAdapter
-                                ReusedExchange [ss_item_sk] #3
+                                    ReusedExchange [ss_item_sk] #3
+                      InputAdapter
+                        ReusedExchange [d_date_sk] #2
       InputAdapter
         BroadcastExchange #15
           WholeStageCodegen (75)
@@ -190,9 +190,9 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                     WholeStageCodegen (74)
                       HashAggregate [i_brand_id,i_class_id,i_category_id,ss_quantity,ss_list_price] [sum,isEmpty,count,sum,isEmpty,count]
                         Project [ss_quantity,ss_list_price,i_brand_id,i_class_id,i_category_id]
-                          BroadcastHashJoin [ss_item_sk,i_item_sk]
-                            Project [ss_item_sk,ss_quantity,ss_list_price]
-                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                            Project [ss_quantity,ss_list_price,ss_sold_date_sk,i_brand_id,i_class_id,i_category_id]
+                              BroadcastHashJoin [ss_item_sk,i_item_sk]
                                 BroadcastHashJoin [ss_item_sk,ss_item_sk]
                                   Filter [ss_item_sk]
                                     ColumnarToRow
@@ -217,6 +217,6 @@ TakeOrderedAndProject [i_brand_id,i_class_id,i_category_id,channel,sales,number_
                                   InputAdapter
                                     ReusedExchange [ss_item_sk] #3
                                 InputAdapter
-                                  ReusedExchange [d_date_sk] #17
+                                  ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #13
                             InputAdapter
-                              ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id] #13
+                              ReusedExchange [d_date_sk] #17

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a.sf100/explain.txt
@@ -1,6 +1,6 @@
 == Physical Plan ==
-TakeOrderedAndProject (156)
-+- Union (155)
+TakeOrderedAndProject (150)
++- Union (149)
    :- * HashAggregate (47)
    :  +- Exchange (46)
    :     +- * HashAggregate (45)
@@ -12,17 +12,17 @@ TakeOrderedAndProject (156)
    :              :        +- * BroadcastHashJoin Inner BuildRight (18)
    :              :           :- * Project (13)
    :              :           :  +- * BroadcastHashJoin Inner BuildRight (12)
-   :              :           :     :- * Project (10)
-   :              :           :     :  +- * BroadcastHashJoin Inner BuildRight (9)
+   :              :           :     :- * Project (6)
+   :              :           :     :  +- * BroadcastHashJoin Inner BuildRight (5)
    :              :           :     :     :- * Filter (3)
    :              :           :     :     :  +- * ColumnarToRow (2)
    :              :           :     :     :     +- Scan parquet spark_catalog.default.catalog_sales (1)
-   :              :           :     :     +- BroadcastExchange (8)
-   :              :           :     :        +- * Project (7)
-   :              :           :     :           +- * Filter (6)
-   :              :           :     :              +- * ColumnarToRow (5)
-   :              :           :     :                 +- Scan parquet spark_catalog.default.customer_demographics (4)
-   :              :           :     +- ReusedExchange (11)
+   :              :           :     :     +- ReusedExchange (4)
+   :              :           :     +- BroadcastExchange (11)
+   :              :           :        +- * Project (10)
+   :              :           :           +- * Filter (9)
+   :              :           :              +- * ColumnarToRow (8)
+   :              :           :                 +- Scan parquet spark_catalog.default.customer_demographics (7)
    :              :           +- BroadcastExchange (17)
    :              :              +- * Filter (16)
    :              :                 +- * ColumnarToRow (15)
@@ -99,62 +99,56 @@ TakeOrderedAndProject (156)
    :                          :                       +- Scan parquet spark_catalog.default.customer_address (79)
    :                          +- * Sort (89)
    :                             +- ReusedExchange (88)
-   :- * HashAggregate (133)
-   :  +- Exchange (132)
-   :     +- * HashAggregate (131)
-   :        +- * Project (130)
-   :           +- * BroadcastHashJoin Inner BuildRight (129)
-   :              :- * Project (127)
-   :              :  +- * BroadcastHashJoin Inner BuildRight (126)
-   :              :     :- * Project (107)
-   :              :     :  +- * BroadcastHashJoin Inner BuildRight (106)
-   :              :     :     :- * Project (104)
-   :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (103)
-   :              :     :     :     :- * Filter (101)
-   :              :     :     :     :  +- * ColumnarToRow (100)
-   :              :     :     :     :     +- Scan parquet spark_catalog.default.catalog_sales (99)
-   :              :     :     :     +- ReusedExchange (102)
-   :              :     :     +- ReusedExchange (105)
-   :              :     +- BroadcastExchange (125)
-   :              :        +- * Project (124)
-   :              :           +- * BroadcastHashJoin Inner BuildLeft (123)
-   :              :              :- BroadcastExchange (119)
-   :              :              :  +- * Project (118)
-   :              :              :     +- * BroadcastHashJoin Inner BuildRight (117)
-   :              :              :        :- * Project (111)
-   :              :              :        :  +- * Filter (110)
-   :              :              :        :     +- * ColumnarToRow (109)
-   :              :              :        :        +- Scan parquet spark_catalog.default.customer (108)
-   :              :              :        +- BroadcastExchange (116)
-   :              :              :           +- * Project (115)
-   :              :              :              +- * Filter (114)
-   :              :              :                 +- * ColumnarToRow (113)
-   :              :              :                    +- Scan parquet spark_catalog.default.customer_address (112)
-   :              :              +- * Filter (122)
-   :              :                 +- * ColumnarToRow (121)
-   :              :                    +- Scan parquet spark_catalog.default.customer_demographics (120)
-   :              +- ReusedExchange (128)
-   +- * HashAggregate (154)
-      +- Exchange (153)
-         +- * HashAggregate (152)
-            +- * Project (151)
-               +- * BroadcastHashJoin Inner BuildRight (150)
-                  :- * Project (148)
-                  :  +- * BroadcastHashJoin Inner BuildRight (147)
-                  :     :- * Project (142)
-                  :     :  +- * BroadcastHashJoin Inner BuildRight (141)
-                  :     :     :- * Project (139)
-                  :     :     :  +- * BroadcastHashJoin Inner BuildRight (138)
-                  :     :     :     :- * Filter (136)
-                  :     :     :     :  +- * ColumnarToRow (135)
-                  :     :     :     :     +- Scan parquet spark_catalog.default.catalog_sales (134)
-                  :     :     :     +- ReusedExchange (137)
-                  :     :     +- ReusedExchange (140)
-                  :     +- BroadcastExchange (146)
-                  :        +- * Filter (145)
-                  :           +- * ColumnarToRow (144)
-                  :              +- Scan parquet spark_catalog.default.item (143)
-                  +- ReusedExchange (149)
+   :- * HashAggregate (124)
+   :  +- Exchange (123)
+   :     +- * HashAggregate (122)
+   :        +- * Project (121)
+   :           +- * SortMergeJoin Inner (120)
+   :              :- * Sort (100)
+   :              :  +- ReusedExchange (99)
+   :              +- * Sort (119)
+   :                 +- Exchange (118)
+   :                    +- * Project (117)
+   :                       +- * SortMergeJoin Inner (116)
+   :                          :- * Sort (113)
+   :                          :  +- Exchange (112)
+   :                          :     +- * Project (111)
+   :                          :        +- * BroadcastHashJoin Inner BuildRight (110)
+   :                          :           :- * Project (104)
+   :                          :           :  +- * Filter (103)
+   :                          :           :     +- * ColumnarToRow (102)
+   :                          :           :        +- Scan parquet spark_catalog.default.customer (101)
+   :                          :           +- BroadcastExchange (109)
+   :                          :              +- * Project (108)
+   :                          :                 +- * Filter (107)
+   :                          :                    +- * ColumnarToRow (106)
+   :                          :                       +- Scan parquet spark_catalog.default.customer_address (105)
+   :                          +- * Sort (115)
+   :                             +- ReusedExchange (114)
+   +- * HashAggregate (148)
+      +- Exchange (147)
+         +- * HashAggregate (146)
+            +- * Project (145)
+               +- * SortMergeJoin Inner (144)
+                  :- * Sort (141)
+                  :  +- Exchange (140)
+                  :     +- * Project (139)
+                  :        +- * BroadcastHashJoin Inner BuildRight (138)
+                  :           :- * Project (136)
+                  :           :  +- * BroadcastHashJoin Inner BuildRight (135)
+                  :           :     :- * Project (130)
+                  :           :     :  +- * BroadcastHashJoin Inner BuildRight (129)
+                  :           :     :     :- * Filter (127)
+                  :           :     :     :  +- * ColumnarToRow (126)
+                  :           :     :     :     +- Scan parquet spark_catalog.default.catalog_sales (125)
+                  :           :     :     +- ReusedExchange (128)
+                  :           :     +- BroadcastExchange (134)
+                  :           :        +- * Filter (133)
+                  :           :           +- * ColumnarToRow (132)
+                  :           :              +- Scan parquet spark_catalog.default.item (131)
+                  :           +- ReusedExchange (137)
+                  +- * Sort (143)
+                     +- ReusedExchange (142)
 
 
 (1) Scan parquet spark_catalog.default.catalog_sales
@@ -172,50 +166,50 @@ Input [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity
 Input [9]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9]
 Condition : ((isnotnull(cs_bill_cdemo_sk#2) AND isnotnull(cs_bill_customer_sk#1)) AND isnotnull(cs_item_sk#3))
 
-(4) Scan parquet spark_catalog.default.customer_demographics
-Output [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
+(4) ReusedExchange [Reuses operator id: 155]
+Output [1]: [d_date_sk#11]
+
+(5) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [cs_sold_date_sk#9]
+Right keys [1]: [d_date_sk#11]
+Join type: Inner
+Join condition: None
+
+(6) Project [codegen id : 4]
+Output [8]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8]
+Input [10]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, d_date_sk#11]
+
+(7) Scan parquet spark_catalog.default.customer_demographics
+Output [4]: [cd_demo_sk#12, cd_gender#13, cd_education_status#14, cd_dep_count#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_gender), IsNotNull(cd_education_status), EqualTo(cd_gender,M), EqualTo(cd_education_status,College             ), IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_education_status:string,cd_dep_count:int>
 
-(5) ColumnarToRow [codegen id : 1]
-Input [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
+(8) ColumnarToRow [codegen id : 2]
+Input [4]: [cd_demo_sk#12, cd_gender#13, cd_education_status#14, cd_dep_count#15]
 
-(6) Filter [codegen id : 1]
-Input [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
-Condition : ((((isnotnull(cd_gender#12) AND isnotnull(cd_education_status#13)) AND (cd_gender#12 = M)) AND (cd_education_status#13 = College             )) AND isnotnull(cd_demo_sk#11))
+(9) Filter [codegen id : 2]
+Input [4]: [cd_demo_sk#12, cd_gender#13, cd_education_status#14, cd_dep_count#15]
+Condition : ((((isnotnull(cd_gender#13) AND isnotnull(cd_education_status#14)) AND (cd_gender#13 = M)) AND (cd_education_status#14 = College             )) AND isnotnull(cd_demo_sk#12))
 
-(7) Project [codegen id : 1]
-Output [2]: [cd_demo_sk#11, cd_dep_count#14]
-Input [4]: [cd_demo_sk#11, cd_gender#12, cd_education_status#13, cd_dep_count#14]
+(10) Project [codegen id : 2]
+Output [2]: [cd_demo_sk#12, cd_dep_count#15]
+Input [4]: [cd_demo_sk#12, cd_gender#13, cd_education_status#14, cd_dep_count#15]
 
-(8) BroadcastExchange
-Input [2]: [cd_demo_sk#11, cd_dep_count#14]
+(11) BroadcastExchange
+Input [2]: [cd_demo_sk#12, cd_dep_count#15]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(9) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [cs_bill_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#11]
-Join type: Inner
-Join condition: None
-
-(10) Project [codegen id : 4]
-Output [9]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#14]
-Input [11]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_demo_sk#11, cd_dep_count#14]
-
-(11) ReusedExchange [Reuses operator id: 161]
-Output [1]: [d_date_sk#15]
-
 (12) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [cs_sold_date_sk#9]
-Right keys [1]: [d_date_sk#15]
+Left keys [1]: [cs_bill_cdemo_sk#2]
+Right keys [1]: [cd_demo_sk#12]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
-Output [8]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14]
-Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cs_sold_date_sk#9, cd_dep_count#14, d_date_sk#15]
+Output [8]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#15]
+Input [10]: [cs_bill_customer_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_demo_sk#12, cd_dep_count#15]
 
 (14) Scan parquet spark_catalog.default.item
 Output [2]: [i_item_sk#16, i_item_id#17]
@@ -242,15 +236,15 @@ Join type: Inner
 Join condition: None
 
 (19) Project [codegen id : 4]
-Output [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17]
-Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_sk#16, i_item_id#17]
+Output [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#15, i_item_id#17]
+Input [10]: [cs_bill_customer_sk#1, cs_item_sk#3, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#15, i_item_sk#16, i_item_id#17]
 
 (20) Exchange
-Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17]
+Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#15, i_item_id#17]
 Arguments: hashpartitioning(cs_bill_customer_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (21) Sort [codegen id : 5]
-Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17]
+Input [8]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#15, i_item_id#17]
 Arguments: [cs_bill_customer_sk#1 ASC NULLS FIRST], false, 0
 
 (22) Scan parquet spark_catalog.default.customer
@@ -354,8 +348,8 @@ Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 13]
-Output [11]: [i_item_id#17, ca_country#26, ca_state#25, ca_county#24, cast(cs_quantity#4 as decimal(12,2)) AS agg1#28, cast(cs_list_price#5 as decimal(12,2)) AS agg2#29, cast(cs_coupon_amt#7 as decimal(12,2)) AS agg3#30, cast(cs_sales_price#6 as decimal(12,2)) AS agg4#31, cast(cs_net_profit#8 as decimal(12,2)) AS agg5#32, cast(c_birth_year#22 as decimal(12,2)) AS agg6#33, cast(cd_dep_count#14 as decimal(12,2)) AS agg7#34]
-Input [13]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#14, i_item_id#17, c_customer_sk#18, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
+Output [11]: [i_item_id#17, ca_country#26, ca_state#25, ca_county#24, cast(cs_quantity#4 as decimal(12,2)) AS agg1#28, cast(cs_list_price#5 as decimal(12,2)) AS agg2#29, cast(cs_coupon_amt#7 as decimal(12,2)) AS agg3#30, cast(cs_sales_price#6 as decimal(12,2)) AS agg4#31, cast(cs_net_profit#8 as decimal(12,2)) AS agg5#32, cast(c_birth_year#22 as decimal(12,2)) AS agg6#33, cast(cd_dep_count#15 as decimal(12,2)) AS agg7#34]
+Input [13]: [cs_bill_customer_sk#1, cs_quantity#4, cs_list_price#5, cs_sales_price#6, cs_coupon_amt#7, cs_net_profit#8, cd_dep_count#15, i_item_id#17, c_customer_sk#18, c_birth_year#22, ca_county#24, ca_state#25, ca_country#26]
 
 (45) HashAggregate [codegen id : 13]
 Input [11]: [i_item_id#17, ca_country#26, ca_state#25, ca_county#24, agg1#28, agg2#29, agg3#30, agg4#31, agg5#32, agg6#33, agg7#34]
@@ -607,310 +601,274 @@ Functions [7]: [avg(agg1#161), avg(agg2#162), avg(agg3#163), avg(agg4#164), avg(
 Aggregate Attributes [7]: [avg(agg1#161)#196, avg(agg2#162)#197, avg(agg3#163)#198, avg(agg4#164)#199, avg(agg5#165)#200, avg(agg6#166)#201, avg(agg7#167)#202]
 Results [11]: [i_item_id#151, ca_country#159, null AS ca_state#203, null AS county#204, avg(agg1#161)#196 AS agg1#205, avg(agg2#162)#197 AS agg2#206, avg(agg3#163)#198 AS agg3#207, avg(agg4#164)#199 AS agg4#208, avg(agg5#165)#200 AS agg5#209, avg(agg6#166)#201 AS agg6#210, avg(agg7#167)#202 AS agg7#211]
 
-(99) Scan parquet spark_catalog.default.catalog_sales
-Output [9]: [cs_bill_customer_sk#212, cs_bill_cdemo_sk#213, cs_item_sk#214, cs_quantity#215, cs_list_price#216, cs_sales_price#217, cs_coupon_amt#218, cs_net_profit#219, cs_sold_date_sk#220]
-Batched: true
-Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#220), dynamicpruningexpression(cs_sold_date_sk#220 IN dynamicpruning#10)]
-PushedFilters: [IsNotNull(cs_bill_cdemo_sk), IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
-ReadSchema: struct<cs_bill_customer_sk:int,cs_bill_cdemo_sk:int,cs_item_sk:int,cs_quantity:int,cs_list_price:decimal(7,2),cs_sales_price:decimal(7,2),cs_coupon_amt:decimal(7,2),cs_net_profit:decimal(7,2)>
+(99) ReusedExchange [Reuses operator id: 20]
+Output [8]: [cs_bill_customer_sk#212, cs_quantity#213, cs_list_price#214, cs_sales_price#215, cs_coupon_amt#216, cs_net_profit#217, cd_dep_count#218, i_item_id#219]
 
-(100) ColumnarToRow [codegen id : 49]
-Input [9]: [cs_bill_customer_sk#212, cs_bill_cdemo_sk#213, cs_item_sk#214, cs_quantity#215, cs_list_price#216, cs_sales_price#217, cs_coupon_amt#218, cs_net_profit#219, cs_sold_date_sk#220]
+(100) Sort [codegen id : 47]
+Input [8]: [cs_bill_customer_sk#212, cs_quantity#213, cs_list_price#214, cs_sales_price#215, cs_coupon_amt#216, cs_net_profit#217, cd_dep_count#218, i_item_id#219]
+Arguments: [cs_bill_customer_sk#212 ASC NULLS FIRST], false, 0
 
-(101) Filter [codegen id : 49]
-Input [9]: [cs_bill_customer_sk#212, cs_bill_cdemo_sk#213, cs_item_sk#214, cs_quantity#215, cs_list_price#216, cs_sales_price#217, cs_coupon_amt#218, cs_net_profit#219, cs_sold_date_sk#220]
-Condition : ((isnotnull(cs_bill_cdemo_sk#213) AND isnotnull(cs_bill_customer_sk#212)) AND isnotnull(cs_item_sk#214))
-
-(102) ReusedExchange [Reuses operator id: 8]
-Output [2]: [cd_demo_sk#221, cd_dep_count#222]
-
-(103) BroadcastHashJoin [codegen id : 49]
-Left keys [1]: [cs_bill_cdemo_sk#213]
-Right keys [1]: [cd_demo_sk#221]
-Join type: Inner
-Join condition: None
-
-(104) Project [codegen id : 49]
-Output [9]: [cs_bill_customer_sk#212, cs_item_sk#214, cs_quantity#215, cs_list_price#216, cs_sales_price#217, cs_coupon_amt#218, cs_net_profit#219, cs_sold_date_sk#220, cd_dep_count#222]
-Input [11]: [cs_bill_customer_sk#212, cs_bill_cdemo_sk#213, cs_item_sk#214, cs_quantity#215, cs_list_price#216, cs_sales_price#217, cs_coupon_amt#218, cs_net_profit#219, cs_sold_date_sk#220, cd_demo_sk#221, cd_dep_count#222]
-
-(105) ReusedExchange [Reuses operator id: 161]
-Output [1]: [d_date_sk#223]
-
-(106) BroadcastHashJoin [codegen id : 49]
-Left keys [1]: [cs_sold_date_sk#220]
-Right keys [1]: [d_date_sk#223]
-Join type: Inner
-Join condition: None
-
-(107) Project [codegen id : 49]
-Output [8]: [cs_bill_customer_sk#212, cs_item_sk#214, cs_quantity#215, cs_list_price#216, cs_sales_price#217, cs_coupon_amt#218, cs_net_profit#219, cd_dep_count#222]
-Input [10]: [cs_bill_customer_sk#212, cs_item_sk#214, cs_quantity#215, cs_list_price#216, cs_sales_price#217, cs_coupon_amt#218, cs_net_profit#219, cs_sold_date_sk#220, cd_dep_count#222, d_date_sk#223]
-
-(108) Scan parquet spark_catalog.default.customer
-Output [5]: [c_customer_sk#224, c_current_cdemo_sk#225, c_current_addr_sk#226, c_birth_month#227, c_birth_year#228]
+(101) Scan parquet spark_catalog.default.customer
+Output [5]: [c_customer_sk#220, c_current_cdemo_sk#221, c_current_addr_sk#222, c_birth_month#223, c_birth_year#224]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [In(c_birth_month, [1,10,12,4,5,9]), IsNotNull(c_customer_sk), IsNotNull(c_current_cdemo_sk), IsNotNull(c_current_addr_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_cdemo_sk:int,c_current_addr_sk:int,c_birth_month:int,c_birth_year:int>
 
-(109) ColumnarToRow [codegen id : 46]
-Input [5]: [c_customer_sk#224, c_current_cdemo_sk#225, c_current_addr_sk#226, c_birth_month#227, c_birth_year#228]
+(102) ColumnarToRow [codegen id : 49]
+Input [5]: [c_customer_sk#220, c_current_cdemo_sk#221, c_current_addr_sk#222, c_birth_month#223, c_birth_year#224]
 
-(110) Filter [codegen id : 46]
-Input [5]: [c_customer_sk#224, c_current_cdemo_sk#225, c_current_addr_sk#226, c_birth_month#227, c_birth_year#228]
-Condition : (((c_birth_month#227 IN (9,5,12,4,1,10) AND isnotnull(c_customer_sk#224)) AND isnotnull(c_current_cdemo_sk#225)) AND isnotnull(c_current_addr_sk#226))
+(103) Filter [codegen id : 49]
+Input [5]: [c_customer_sk#220, c_current_cdemo_sk#221, c_current_addr_sk#222, c_birth_month#223, c_birth_year#224]
+Condition : (((c_birth_month#223 IN (9,5,12,4,1,10) AND isnotnull(c_customer_sk#220)) AND isnotnull(c_current_cdemo_sk#221)) AND isnotnull(c_current_addr_sk#222))
 
-(111) Project [codegen id : 46]
-Output [4]: [c_customer_sk#224, c_current_cdemo_sk#225, c_current_addr_sk#226, c_birth_year#228]
-Input [5]: [c_customer_sk#224, c_current_cdemo_sk#225, c_current_addr_sk#226, c_birth_month#227, c_birth_year#228]
+(104) Project [codegen id : 49]
+Output [4]: [c_customer_sk#220, c_current_cdemo_sk#221, c_current_addr_sk#222, c_birth_year#224]
+Input [5]: [c_customer_sk#220, c_current_cdemo_sk#221, c_current_addr_sk#222, c_birth_month#223, c_birth_year#224]
 
-(112) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#229, ca_state#230]
+(105) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#225, ca_state#226]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [In(ca_state, [AL,MS,NC,ND,OK,TN,WI]), IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(113) ColumnarToRow [codegen id : 45]
-Input [2]: [ca_address_sk#229, ca_state#230]
+(106) ColumnarToRow [codegen id : 48]
+Input [2]: [ca_address_sk#225, ca_state#226]
 
-(114) Filter [codegen id : 45]
-Input [2]: [ca_address_sk#229, ca_state#230]
-Condition : (ca_state#230 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#229))
+(107) Filter [codegen id : 48]
+Input [2]: [ca_address_sk#225, ca_state#226]
+Condition : (ca_state#226 IN (ND,WI,AL,NC,OK,MS,TN) AND isnotnull(ca_address_sk#225))
 
-(115) Project [codegen id : 45]
-Output [1]: [ca_address_sk#229]
-Input [2]: [ca_address_sk#229, ca_state#230]
+(108) Project [codegen id : 48]
+Output [1]: [ca_address_sk#225]
+Input [2]: [ca_address_sk#225, ca_state#226]
 
-(116) BroadcastExchange
-Input [1]: [ca_address_sk#229]
+(109) BroadcastExchange
+Input [1]: [ca_address_sk#225]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=17]
 
-(117) BroadcastHashJoin [codegen id : 46]
-Left keys [1]: [c_current_addr_sk#226]
-Right keys [1]: [ca_address_sk#229]
+(110) BroadcastHashJoin [codegen id : 49]
+Left keys [1]: [c_current_addr_sk#222]
+Right keys [1]: [ca_address_sk#225]
 Join type: Inner
 Join condition: None
 
-(118) Project [codegen id : 46]
-Output [3]: [c_customer_sk#224, c_current_cdemo_sk#225, c_birth_year#228]
-Input [5]: [c_customer_sk#224, c_current_cdemo_sk#225, c_current_addr_sk#226, c_birth_year#228, ca_address_sk#229]
+(111) Project [codegen id : 49]
+Output [3]: [c_customer_sk#220, c_current_cdemo_sk#221, c_birth_year#224]
+Input [5]: [c_customer_sk#220, c_current_cdemo_sk#221, c_current_addr_sk#222, c_birth_year#224, ca_address_sk#225]
 
-(119) BroadcastExchange
-Input [3]: [c_customer_sk#224, c_current_cdemo_sk#225, c_birth_year#228]
-Arguments: HashedRelationBroadcastMode(List(cast(input[1, int, true] as bigint)),false), [plan_id=18]
+(112) Exchange
+Input [3]: [c_customer_sk#220, c_current_cdemo_sk#221, c_birth_year#224]
+Arguments: hashpartitioning(c_current_cdemo_sk#221, 5), ENSURE_REQUIREMENTS, [plan_id=18]
 
-(120) Scan parquet spark_catalog.default.customer_demographics
-Output [1]: [cd_demo_sk#231]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_demographics]
-PushedFilters: [IsNotNull(cd_demo_sk)]
-ReadSchema: struct<cd_demo_sk:int>
+(113) Sort [codegen id : 50]
+Input [3]: [c_customer_sk#220, c_current_cdemo_sk#221, c_birth_year#224]
+Arguments: [c_current_cdemo_sk#221 ASC NULLS FIRST], false, 0
 
-(121) ColumnarToRow
-Input [1]: [cd_demo_sk#231]
+(114) ReusedExchange [Reuses operator id: 37]
+Output [1]: [cd_demo_sk#227]
 
-(122) Filter
-Input [1]: [cd_demo_sk#231]
-Condition : isnotnull(cd_demo_sk#231)
+(115) Sort [codegen id : 52]
+Input [1]: [cd_demo_sk#227]
+Arguments: [cd_demo_sk#227 ASC NULLS FIRST], false, 0
 
-(123) BroadcastHashJoin [codegen id : 47]
-Left keys [1]: [c_current_cdemo_sk#225]
-Right keys [1]: [cd_demo_sk#231]
+(116) SortMergeJoin [codegen id : 53]
+Left keys [1]: [c_current_cdemo_sk#221]
+Right keys [1]: [cd_demo_sk#227]
 Join type: Inner
 Join condition: None
 
-(124) Project [codegen id : 47]
-Output [2]: [c_customer_sk#224, c_birth_year#228]
-Input [4]: [c_customer_sk#224, c_current_cdemo_sk#225, c_birth_year#228, cd_demo_sk#231]
+(117) Project [codegen id : 53]
+Output [2]: [c_customer_sk#220, c_birth_year#224]
+Input [4]: [c_customer_sk#220, c_current_cdemo_sk#221, c_birth_year#224, cd_demo_sk#227]
 
-(125) BroadcastExchange
-Input [2]: [c_customer_sk#224, c_birth_year#228]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=19]
+(118) Exchange
+Input [2]: [c_customer_sk#220, c_birth_year#224]
+Arguments: hashpartitioning(c_customer_sk#220, 5), ENSURE_REQUIREMENTS, [plan_id=19]
 
-(126) BroadcastHashJoin [codegen id : 49]
+(119) Sort [codegen id : 54]
+Input [2]: [c_customer_sk#220, c_birth_year#224]
+Arguments: [c_customer_sk#220 ASC NULLS FIRST], false, 0
+
+(120) SortMergeJoin [codegen id : 55]
 Left keys [1]: [cs_bill_customer_sk#212]
-Right keys [1]: [c_customer_sk#224]
+Right keys [1]: [c_customer_sk#220]
 Join type: Inner
 Join condition: None
 
-(127) Project [codegen id : 49]
-Output [8]: [cs_item_sk#214, cs_quantity#215, cs_list_price#216, cs_sales_price#217, cs_coupon_amt#218, cs_net_profit#219, cd_dep_count#222, c_birth_year#228]
-Input [10]: [cs_bill_customer_sk#212, cs_item_sk#214, cs_quantity#215, cs_list_price#216, cs_sales_price#217, cs_coupon_amt#218, cs_net_profit#219, cd_dep_count#222, c_customer_sk#224, c_birth_year#228]
+(121) Project [codegen id : 55]
+Output [8]: [i_item_id#219, cast(cs_quantity#213 as decimal(12,2)) AS agg1#228, cast(cs_list_price#214 as decimal(12,2)) AS agg2#229, cast(cs_coupon_amt#216 as decimal(12,2)) AS agg3#230, cast(cs_sales_price#215 as decimal(12,2)) AS agg4#231, cast(cs_net_profit#217 as decimal(12,2)) AS agg5#232, cast(c_birth_year#224 as decimal(12,2)) AS agg6#233, cast(cd_dep_count#218 as decimal(12,2)) AS agg7#234]
+Input [10]: [cs_bill_customer_sk#212, cs_quantity#213, cs_list_price#214, cs_sales_price#215, cs_coupon_amt#216, cs_net_profit#217, cd_dep_count#218, i_item_id#219, c_customer_sk#220, c_birth_year#224]
 
-(128) ReusedExchange [Reuses operator id: 17]
-Output [2]: [i_item_sk#232, i_item_id#233]
+(122) HashAggregate [codegen id : 55]
+Input [8]: [i_item_id#219, agg1#228, agg2#229, agg3#230, agg4#231, agg5#232, agg6#233, agg7#234]
+Keys [1]: [i_item_id#219]
+Functions [7]: [partial_avg(agg1#228), partial_avg(agg2#229), partial_avg(agg3#230), partial_avg(agg4#231), partial_avg(agg5#232), partial_avg(agg6#233), partial_avg(agg7#234)]
+Aggregate Attributes [14]: [sum#235, count#236, sum#237, count#238, sum#239, count#240, sum#241, count#242, sum#243, count#244, sum#245, count#246, sum#247, count#248]
+Results [15]: [i_item_id#219, sum#249, count#250, sum#251, count#252, sum#253, count#254, sum#255, count#256, sum#257, count#258, sum#259, count#260, sum#261, count#262]
 
-(129) BroadcastHashJoin [codegen id : 49]
-Left keys [1]: [cs_item_sk#214]
-Right keys [1]: [i_item_sk#232]
-Join type: Inner
-Join condition: None
+(123) Exchange
+Input [15]: [i_item_id#219, sum#249, count#250, sum#251, count#252, sum#253, count#254, sum#255, count#256, sum#257, count#258, sum#259, count#260, sum#261, count#262]
+Arguments: hashpartitioning(i_item_id#219, 5), ENSURE_REQUIREMENTS, [plan_id=20]
 
-(130) Project [codegen id : 49]
-Output [8]: [i_item_id#233, cast(cs_quantity#215 as decimal(12,2)) AS agg1#234, cast(cs_list_price#216 as decimal(12,2)) AS agg2#235, cast(cs_coupon_amt#218 as decimal(12,2)) AS agg3#236, cast(cs_sales_price#217 as decimal(12,2)) AS agg4#237, cast(cs_net_profit#219 as decimal(12,2)) AS agg5#238, cast(c_birth_year#228 as decimal(12,2)) AS agg6#239, cast(cd_dep_count#222 as decimal(12,2)) AS agg7#240]
-Input [10]: [cs_item_sk#214, cs_quantity#215, cs_list_price#216, cs_sales_price#217, cs_coupon_amt#218, cs_net_profit#219, cd_dep_count#222, c_birth_year#228, i_item_sk#232, i_item_id#233]
+(124) HashAggregate [codegen id : 56]
+Input [15]: [i_item_id#219, sum#249, count#250, sum#251, count#252, sum#253, count#254, sum#255, count#256, sum#257, count#258, sum#259, count#260, sum#261, count#262]
+Keys [1]: [i_item_id#219]
+Functions [7]: [avg(agg1#228), avg(agg2#229), avg(agg3#230), avg(agg4#231), avg(agg5#232), avg(agg6#233), avg(agg7#234)]
+Aggregate Attributes [7]: [avg(agg1#228)#263, avg(agg2#229)#264, avg(agg3#230)#265, avg(agg4#231)#266, avg(agg5#232)#267, avg(agg6#233)#268, avg(agg7#234)#269]
+Results [11]: [i_item_id#219, null AS ca_country#270, null AS ca_state#271, null AS county#272, avg(agg1#228)#263 AS agg1#273, avg(agg2#229)#264 AS agg2#274, avg(agg3#230)#265 AS agg3#275, avg(agg4#231)#266 AS agg4#276, avg(agg5#232)#267 AS agg5#277, avg(agg6#233)#268 AS agg6#278, avg(agg7#234)#269 AS agg7#279]
 
-(131) HashAggregate [codegen id : 49]
-Input [8]: [i_item_id#233, agg1#234, agg2#235, agg3#236, agg4#237, agg5#238, agg6#239, agg7#240]
-Keys [1]: [i_item_id#233]
-Functions [7]: [partial_avg(agg1#234), partial_avg(agg2#235), partial_avg(agg3#236), partial_avg(agg4#237), partial_avg(agg5#238), partial_avg(agg6#239), partial_avg(agg7#240)]
-Aggregate Attributes [14]: [sum#241, count#242, sum#243, count#244, sum#245, count#246, sum#247, count#248, sum#249, count#250, sum#251, count#252, sum#253, count#254]
-Results [15]: [i_item_id#233, sum#255, count#256, sum#257, count#258, sum#259, count#260, sum#261, count#262, sum#263, count#264, sum#265, count#266, sum#267, count#268]
-
-(132) Exchange
-Input [15]: [i_item_id#233, sum#255, count#256, sum#257, count#258, sum#259, count#260, sum#261, count#262, sum#263, count#264, sum#265, count#266, sum#267, count#268]
-Arguments: hashpartitioning(i_item_id#233, 5), ENSURE_REQUIREMENTS, [plan_id=20]
-
-(133) HashAggregate [codegen id : 50]
-Input [15]: [i_item_id#233, sum#255, count#256, sum#257, count#258, sum#259, count#260, sum#261, count#262, sum#263, count#264, sum#265, count#266, sum#267, count#268]
-Keys [1]: [i_item_id#233]
-Functions [7]: [avg(agg1#234), avg(agg2#235), avg(agg3#236), avg(agg4#237), avg(agg5#238), avg(agg6#239), avg(agg7#240)]
-Aggregate Attributes [7]: [avg(agg1#234)#269, avg(agg2#235)#270, avg(agg3#236)#271, avg(agg4#237)#272, avg(agg5#238)#273, avg(agg6#239)#274, avg(agg7#240)#275]
-Results [11]: [i_item_id#233, null AS ca_country#276, null AS ca_state#277, null AS county#278, avg(agg1#234)#269 AS agg1#279, avg(agg2#235)#270 AS agg2#280, avg(agg3#236)#271 AS agg3#281, avg(agg4#237)#272 AS agg4#282, avg(agg5#238)#273 AS agg5#283, avg(agg6#239)#274 AS agg6#284, avg(agg7#240)#275 AS agg7#285]
-
-(134) Scan parquet spark_catalog.default.catalog_sales
-Output [9]: [cs_bill_customer_sk#286, cs_bill_cdemo_sk#287, cs_item_sk#288, cs_quantity#289, cs_list_price#290, cs_sales_price#291, cs_coupon_amt#292, cs_net_profit#293, cs_sold_date_sk#294]
+(125) Scan parquet spark_catalog.default.catalog_sales
+Output [9]: [cs_bill_customer_sk#280, cs_bill_cdemo_sk#281, cs_item_sk#282, cs_quantity#283, cs_list_price#284, cs_sales_price#285, cs_coupon_amt#286, cs_net_profit#287, cs_sold_date_sk#288]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#294), dynamicpruningexpression(cs_sold_date_sk#294 IN dynamicpruning#10)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#288), dynamicpruningexpression(cs_sold_date_sk#288 IN dynamicpruning#10)]
 PushedFilters: [IsNotNull(cs_bill_cdemo_sk), IsNotNull(cs_bill_customer_sk), IsNotNull(cs_item_sk)]
 ReadSchema: struct<cs_bill_customer_sk:int,cs_bill_cdemo_sk:int,cs_item_sk:int,cs_quantity:int,cs_list_price:decimal(7,2),cs_sales_price:decimal(7,2),cs_coupon_amt:decimal(7,2),cs_net_profit:decimal(7,2)>
 
-(135) ColumnarToRow [codegen id : 57]
-Input [9]: [cs_bill_customer_sk#286, cs_bill_cdemo_sk#287, cs_item_sk#288, cs_quantity#289, cs_list_price#290, cs_sales_price#291, cs_coupon_amt#292, cs_net_profit#293, cs_sold_date_sk#294]
+(126) ColumnarToRow [codegen id : 60]
+Input [9]: [cs_bill_customer_sk#280, cs_bill_cdemo_sk#281, cs_item_sk#282, cs_quantity#283, cs_list_price#284, cs_sales_price#285, cs_coupon_amt#286, cs_net_profit#287, cs_sold_date_sk#288]
 
-(136) Filter [codegen id : 57]
-Input [9]: [cs_bill_customer_sk#286, cs_bill_cdemo_sk#287, cs_item_sk#288, cs_quantity#289, cs_list_price#290, cs_sales_price#291, cs_coupon_amt#292, cs_net_profit#293, cs_sold_date_sk#294]
-Condition : ((isnotnull(cs_bill_cdemo_sk#287) AND isnotnull(cs_bill_customer_sk#286)) AND isnotnull(cs_item_sk#288))
+(127) Filter [codegen id : 60]
+Input [9]: [cs_bill_customer_sk#280, cs_bill_cdemo_sk#281, cs_item_sk#282, cs_quantity#283, cs_list_price#284, cs_sales_price#285, cs_coupon_amt#286, cs_net_profit#287, cs_sold_date_sk#288]
+Condition : ((isnotnull(cs_bill_cdemo_sk#281) AND isnotnull(cs_bill_customer_sk#280)) AND isnotnull(cs_item_sk#282))
 
-(137) ReusedExchange [Reuses operator id: 8]
-Output [2]: [cd_demo_sk#295, cd_dep_count#296]
+(128) ReusedExchange [Reuses operator id: 155]
+Output [1]: [d_date_sk#289]
 
-(138) BroadcastHashJoin [codegen id : 57]
-Left keys [1]: [cs_bill_cdemo_sk#287]
-Right keys [1]: [cd_demo_sk#295]
+(129) BroadcastHashJoin [codegen id : 60]
+Left keys [1]: [cs_sold_date_sk#288]
+Right keys [1]: [d_date_sk#289]
 Join type: Inner
 Join condition: None
 
-(139) Project [codegen id : 57]
-Output [9]: [cs_bill_customer_sk#286, cs_item_sk#288, cs_quantity#289, cs_list_price#290, cs_sales_price#291, cs_coupon_amt#292, cs_net_profit#293, cs_sold_date_sk#294, cd_dep_count#296]
-Input [11]: [cs_bill_customer_sk#286, cs_bill_cdemo_sk#287, cs_item_sk#288, cs_quantity#289, cs_list_price#290, cs_sales_price#291, cs_coupon_amt#292, cs_net_profit#293, cs_sold_date_sk#294, cd_demo_sk#295, cd_dep_count#296]
+(130) Project [codegen id : 60]
+Output [8]: [cs_bill_customer_sk#280, cs_bill_cdemo_sk#281, cs_item_sk#282, cs_quantity#283, cs_list_price#284, cs_sales_price#285, cs_coupon_amt#286, cs_net_profit#287]
+Input [10]: [cs_bill_customer_sk#280, cs_bill_cdemo_sk#281, cs_item_sk#282, cs_quantity#283, cs_list_price#284, cs_sales_price#285, cs_coupon_amt#286, cs_net_profit#287, cs_sold_date_sk#288, d_date_sk#289]
 
-(140) ReusedExchange [Reuses operator id: 161]
-Output [1]: [d_date_sk#297]
-
-(141) BroadcastHashJoin [codegen id : 57]
-Left keys [1]: [cs_sold_date_sk#294]
-Right keys [1]: [d_date_sk#297]
-Join type: Inner
-Join condition: None
-
-(142) Project [codegen id : 57]
-Output [8]: [cs_bill_customer_sk#286, cs_item_sk#288, cs_quantity#289, cs_list_price#290, cs_sales_price#291, cs_coupon_amt#292, cs_net_profit#293, cd_dep_count#296]
-Input [10]: [cs_bill_customer_sk#286, cs_item_sk#288, cs_quantity#289, cs_list_price#290, cs_sales_price#291, cs_coupon_amt#292, cs_net_profit#293, cs_sold_date_sk#294, cd_dep_count#296, d_date_sk#297]
-
-(143) Scan parquet spark_catalog.default.item
-Output [1]: [i_item_sk#298]
+(131) Scan parquet spark_catalog.default.item
+Output [1]: [i_item_sk#290]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int>
 
-(144) ColumnarToRow [codegen id : 53]
-Input [1]: [i_item_sk#298]
+(132) ColumnarToRow [codegen id : 58]
+Input [1]: [i_item_sk#290]
 
-(145) Filter [codegen id : 53]
-Input [1]: [i_item_sk#298]
-Condition : isnotnull(i_item_sk#298)
+(133) Filter [codegen id : 58]
+Input [1]: [i_item_sk#290]
+Condition : isnotnull(i_item_sk#290)
 
-(146) BroadcastExchange
-Input [1]: [i_item_sk#298]
+(134) BroadcastExchange
+Input [1]: [i_item_sk#290]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=21]
 
-(147) BroadcastHashJoin [codegen id : 57]
-Left keys [1]: [cs_item_sk#288]
-Right keys [1]: [i_item_sk#298]
+(135) BroadcastHashJoin [codegen id : 60]
+Left keys [1]: [cs_item_sk#282]
+Right keys [1]: [i_item_sk#290]
 Join type: Inner
 Join condition: None
 
-(148) Project [codegen id : 57]
-Output [7]: [cs_bill_customer_sk#286, cs_quantity#289, cs_list_price#290, cs_sales_price#291, cs_coupon_amt#292, cs_net_profit#293, cd_dep_count#296]
-Input [9]: [cs_bill_customer_sk#286, cs_item_sk#288, cs_quantity#289, cs_list_price#290, cs_sales_price#291, cs_coupon_amt#292, cs_net_profit#293, cd_dep_count#296, i_item_sk#298]
+(136) Project [codegen id : 60]
+Output [7]: [cs_bill_customer_sk#280, cs_bill_cdemo_sk#281, cs_quantity#283, cs_list_price#284, cs_sales_price#285, cs_coupon_amt#286, cs_net_profit#287]
+Input [9]: [cs_bill_customer_sk#280, cs_bill_cdemo_sk#281, cs_item_sk#282, cs_quantity#283, cs_list_price#284, cs_sales_price#285, cs_coupon_amt#286, cs_net_profit#287, i_item_sk#290]
 
-(149) ReusedExchange [Reuses operator id: 125]
-Output [2]: [c_customer_sk#299, c_birth_year#300]
+(137) ReusedExchange [Reuses operator id: 11]
+Output [2]: [cd_demo_sk#291, cd_dep_count#292]
 
-(150) BroadcastHashJoin [codegen id : 57]
-Left keys [1]: [cs_bill_customer_sk#286]
-Right keys [1]: [c_customer_sk#299]
+(138) BroadcastHashJoin [codegen id : 60]
+Left keys [1]: [cs_bill_cdemo_sk#281]
+Right keys [1]: [cd_demo_sk#291]
 Join type: Inner
 Join condition: None
 
-(151) Project [codegen id : 57]
-Output [7]: [cast(cs_quantity#289 as decimal(12,2)) AS agg1#301, cast(cs_list_price#290 as decimal(12,2)) AS agg2#302, cast(cs_coupon_amt#292 as decimal(12,2)) AS agg3#303, cast(cs_sales_price#291 as decimal(12,2)) AS agg4#304, cast(cs_net_profit#293 as decimal(12,2)) AS agg5#305, cast(c_birth_year#300 as decimal(12,2)) AS agg6#306, cast(cd_dep_count#296 as decimal(12,2)) AS agg7#307]
-Input [9]: [cs_bill_customer_sk#286, cs_quantity#289, cs_list_price#290, cs_sales_price#291, cs_coupon_amt#292, cs_net_profit#293, cd_dep_count#296, c_customer_sk#299, c_birth_year#300]
+(139) Project [codegen id : 60]
+Output [7]: [cs_bill_customer_sk#280, cs_quantity#283, cs_list_price#284, cs_sales_price#285, cs_coupon_amt#286, cs_net_profit#287, cd_dep_count#292]
+Input [9]: [cs_bill_customer_sk#280, cs_bill_cdemo_sk#281, cs_quantity#283, cs_list_price#284, cs_sales_price#285, cs_coupon_amt#286, cs_net_profit#287, cd_demo_sk#291, cd_dep_count#292]
 
-(152) HashAggregate [codegen id : 57]
-Input [7]: [agg1#301, agg2#302, agg3#303, agg4#304, agg5#305, agg6#306, agg7#307]
+(140) Exchange
+Input [7]: [cs_bill_customer_sk#280, cs_quantity#283, cs_list_price#284, cs_sales_price#285, cs_coupon_amt#286, cs_net_profit#287, cd_dep_count#292]
+Arguments: hashpartitioning(cs_bill_customer_sk#280, 5), ENSURE_REQUIREMENTS, [plan_id=22]
+
+(141) Sort [codegen id : 61]
+Input [7]: [cs_bill_customer_sk#280, cs_quantity#283, cs_list_price#284, cs_sales_price#285, cs_coupon_amt#286, cs_net_profit#287, cd_dep_count#292]
+Arguments: [cs_bill_customer_sk#280 ASC NULLS FIRST], false, 0
+
+(142) ReusedExchange [Reuses operator id: 118]
+Output [2]: [c_customer_sk#293, c_birth_year#294]
+
+(143) Sort [codegen id : 68]
+Input [2]: [c_customer_sk#293, c_birth_year#294]
+Arguments: [c_customer_sk#293 ASC NULLS FIRST], false, 0
+
+(144) SortMergeJoin [codegen id : 69]
+Left keys [1]: [cs_bill_customer_sk#280]
+Right keys [1]: [c_customer_sk#293]
+Join type: Inner
+Join condition: None
+
+(145) Project [codegen id : 69]
+Output [7]: [cast(cs_quantity#283 as decimal(12,2)) AS agg1#295, cast(cs_list_price#284 as decimal(12,2)) AS agg2#296, cast(cs_coupon_amt#286 as decimal(12,2)) AS agg3#297, cast(cs_sales_price#285 as decimal(12,2)) AS agg4#298, cast(cs_net_profit#287 as decimal(12,2)) AS agg5#299, cast(c_birth_year#294 as decimal(12,2)) AS agg6#300, cast(cd_dep_count#292 as decimal(12,2)) AS agg7#301]
+Input [9]: [cs_bill_customer_sk#280, cs_quantity#283, cs_list_price#284, cs_sales_price#285, cs_coupon_amt#286, cs_net_profit#287, cd_dep_count#292, c_customer_sk#293, c_birth_year#294]
+
+(146) HashAggregate [codegen id : 69]
+Input [7]: [agg1#295, agg2#296, agg3#297, agg4#298, agg5#299, agg6#300, agg7#301]
 Keys: []
-Functions [7]: [partial_avg(agg1#301), partial_avg(agg2#302), partial_avg(agg3#303), partial_avg(agg4#304), partial_avg(agg5#305), partial_avg(agg6#306), partial_avg(agg7#307)]
-Aggregate Attributes [14]: [sum#308, count#309, sum#310, count#311, sum#312, count#313, sum#314, count#315, sum#316, count#317, sum#318, count#319, sum#320, count#321]
-Results [14]: [sum#322, count#323, sum#324, count#325, sum#326, count#327, sum#328, count#329, sum#330, count#331, sum#332, count#333, sum#334, count#335]
+Functions [7]: [partial_avg(agg1#295), partial_avg(agg2#296), partial_avg(agg3#297), partial_avg(agg4#298), partial_avg(agg5#299), partial_avg(agg6#300), partial_avg(agg7#301)]
+Aggregate Attributes [14]: [sum#302, count#303, sum#304, count#305, sum#306, count#307, sum#308, count#309, sum#310, count#311, sum#312, count#313, sum#314, count#315]
+Results [14]: [sum#316, count#317, sum#318, count#319, sum#320, count#321, sum#322, count#323, sum#324, count#325, sum#326, count#327, sum#328, count#329]
 
-(153) Exchange
-Input [14]: [sum#322, count#323, sum#324, count#325, sum#326, count#327, sum#328, count#329, sum#330, count#331, sum#332, count#333, sum#334, count#335]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=22]
+(147) Exchange
+Input [14]: [sum#316, count#317, sum#318, count#319, sum#320, count#321, sum#322, count#323, sum#324, count#325, sum#326, count#327, sum#328, count#329]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=23]
 
-(154) HashAggregate [codegen id : 58]
-Input [14]: [sum#322, count#323, sum#324, count#325, sum#326, count#327, sum#328, count#329, sum#330, count#331, sum#332, count#333, sum#334, count#335]
+(148) HashAggregate [codegen id : 70]
+Input [14]: [sum#316, count#317, sum#318, count#319, sum#320, count#321, sum#322, count#323, sum#324, count#325, sum#326, count#327, sum#328, count#329]
 Keys: []
-Functions [7]: [avg(agg1#301), avg(agg2#302), avg(agg3#303), avg(agg4#304), avg(agg5#305), avg(agg6#306), avg(agg7#307)]
-Aggregate Attributes [7]: [avg(agg1#301)#336, avg(agg2#302)#337, avg(agg3#303)#338, avg(agg4#304)#339, avg(agg5#305)#340, avg(agg6#306)#341, avg(agg7#307)#342]
-Results [11]: [null AS i_item_id#343, null AS ca_country#344, null AS ca_state#345, null AS county#346, avg(agg1#301)#336 AS agg1#347, avg(agg2#302)#337 AS agg2#348, avg(agg3#303)#338 AS agg3#349, avg(agg4#304)#339 AS agg4#350, avg(agg5#305)#340 AS agg5#351, avg(agg6#306)#341 AS agg6#352, avg(agg7#307)#342 AS agg7#353]
+Functions [7]: [avg(agg1#295), avg(agg2#296), avg(agg3#297), avg(agg4#298), avg(agg5#299), avg(agg6#300), avg(agg7#301)]
+Aggregate Attributes [7]: [avg(agg1#295)#330, avg(agg2#296)#331, avg(agg3#297)#332, avg(agg4#298)#333, avg(agg5#299)#334, avg(agg6#300)#335, avg(agg7#301)#336]
+Results [11]: [null AS i_item_id#337, null AS ca_country#338, null AS ca_state#339, null AS county#340, avg(agg1#295)#330 AS agg1#341, avg(agg2#296)#331 AS agg2#342, avg(agg3#297)#332 AS agg3#343, avg(agg4#298)#333 AS agg4#344, avg(agg5#299)#334 AS agg5#345, avg(agg6#300)#335 AS agg6#346, avg(agg7#301)#336 AS agg7#347]
 
-(155) Union
+(149) Union
 
-(156) TakeOrderedAndProject
+(150) TakeOrderedAndProject
 Input [11]: [i_item_id#17, ca_country#26, ca_state#25, ca_county#24, agg1#70, agg2#71, agg3#72, agg4#73, agg5#74, agg6#75, agg7#76]
 Arguments: 100, [ca_country#26 ASC NULLS FIRST, ca_state#25 ASC NULLS FIRST, ca_county#24 ASC NULLS FIRST, i_item_id#17 ASC NULLS FIRST], [i_item_id#17, ca_country#26, ca_state#25, ca_county#24, agg1#70, agg2#71, agg3#72, agg4#73, agg5#74, agg6#75, agg7#76]
 
 ===== Subqueries =====
 
 Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#9 IN dynamicpruning#10
-BroadcastExchange (161)
-+- * Project (160)
-   +- * Filter (159)
-      +- * ColumnarToRow (158)
-         +- Scan parquet spark_catalog.default.date_dim (157)
+BroadcastExchange (155)
++- * Project (154)
+   +- * Filter (153)
+      +- * ColumnarToRow (152)
+         +- Scan parquet spark_catalog.default.date_dim (151)
 
 
-(157) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#15, d_year#354]
+(151) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#11, d_year#348]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
-(158) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#15, d_year#354]
+(152) ColumnarToRow [codegen id : 1]
+Input [2]: [d_date_sk#11, d_year#348]
 
-(159) Filter [codegen id : 1]
-Input [2]: [d_date_sk#15, d_year#354]
-Condition : ((isnotnull(d_year#354) AND (d_year#354 = 2001)) AND isnotnull(d_date_sk#15))
+(153) Filter [codegen id : 1]
+Input [2]: [d_date_sk#11, d_year#348]
+Condition : ((isnotnull(d_year#348) AND (d_year#348 = 2001)) AND isnotnull(d_date_sk#11))
 
-(160) Project [codegen id : 1]
-Output [1]: [d_date_sk#15]
-Input [2]: [d_date_sk#15, d_year#354]
+(154) Project [codegen id : 1]
+Output [1]: [d_date_sk#11]
+Input [2]: [d_date_sk#11, d_year#348]
 
-(161) BroadcastExchange
-Input [1]: [d_date_sk#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=23]
+(155) BroadcastExchange
+Input [1]: [d_date_sk#11]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=24]
 
-Subquery:2 Hosting operator id = 99 Hosting Expression = cs_sold_date_sk#220 IN dynamicpruning#10
-
-Subquery:3 Hosting operator id = 134 Hosting Expression = cs_sold_date_sk#294 IN dynamicpruning#10
+Subquery:2 Hosting operator id = 125 Hosting Expression = cs_sold_date_sk#288 IN dynamicpruning#10
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q18a.sf100/simplified.txt
@@ -17,9 +17,9 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                 Project [cs_bill_customer_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cd_dep_count,i_item_id]
                                   BroadcastHashJoin [cs_item_sk,i_item_sk]
                                     Project [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cd_dep_count]
-                                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                        Project [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk,cd_dep_count]
-                                          BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
+                                      BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
+                                        Project [cs_bill_customer_sk,cs_bill_cdemo_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit]
+                                          BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                             Filter [cs_bill_cdemo_sk,cs_bill_customer_sk,cs_item_sk]
                                               ColumnarToRow
                                                 InputAdapter
@@ -33,15 +33,15 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                                                 InputAdapter
                                                                   Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                             InputAdapter
-                                              BroadcastExchange #4
-                                                WholeStageCodegen (1)
-                                                  Project [cd_demo_sk,cd_dep_count]
-                                                    Filter [cd_gender,cd_education_status,cd_demo_sk]
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_education_status,cd_dep_count]
+                                              ReusedExchange [d_date_sk] #3
                                         InputAdapter
-                                          ReusedExchange [d_date_sk] #3
+                                          BroadcastExchange #4
+                                            WholeStageCodegen (2)
+                                              Project [cd_demo_sk,cd_dep_count]
+                                                Filter [cd_gender,cd_education_status,cd_demo_sk]
+                                                  ColumnarToRow
+                                                    InputAdapter
+                                                      Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_education_status,cd_dep_count]
                                     InputAdapter
                                       BroadcastExchange #5
                                         WholeStageCodegen (3)
@@ -180,87 +180,91 @@ TakeOrderedAndProject [ca_country,ca_state,ca_county,i_item_id,agg1,agg2,agg3,ag
                                         Sort [cd_demo_sk]
                                           InputAdapter
                                             ReusedExchange [cd_demo_sk] #9
-    WholeStageCodegen (50)
+    WholeStageCodegen (56)
       HashAggregate [i_item_id,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(agg2),avg(agg3),avg(agg4),avg(agg5),avg(agg6),avg(agg7),ca_country,ca_state,county,agg1,agg2,agg3,agg4,agg5,agg6,agg7,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
           Exchange [i_item_id] #18
-            WholeStageCodegen (49)
+            WholeStageCodegen (55)
               HashAggregate [i_item_id,agg1,agg2,agg3,agg4,agg5,agg6,agg7] [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
                 Project [i_item_id,cs_quantity,cs_list_price,cs_coupon_amt,cs_sales_price,cs_net_profit,c_birth_year,cd_dep_count]
-                  BroadcastHashJoin [cs_item_sk,i_item_sk]
-                    Project [cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cd_dep_count,c_birth_year]
-                      BroadcastHashJoin [cs_bill_customer_sk,c_customer_sk]
-                        Project [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cd_dep_count]
-                          BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                            Project [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk,cd_dep_count]
-                              BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
-                                Filter [cs_bill_cdemo_sk,cs_bill_customer_sk,cs_item_sk]
-                                  ColumnarToRow
-                                    InputAdapter
-                                      Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_bill_cdemo_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk]
-                                        ReusedSubquery [d_date_sk] #1
-                                InputAdapter
-                                  ReusedExchange [cd_demo_sk,cd_dep_count] #4
-                            InputAdapter
-                              ReusedExchange [d_date_sk] #3
-                        InputAdapter
-                          BroadcastExchange #19
-                            WholeStageCodegen (47)
-                              Project [c_customer_sk,c_birth_year]
-                                BroadcastHashJoin [c_current_cdemo_sk,cd_demo_sk]
-                                  InputAdapter
-                                    BroadcastExchange #20
-                                      WholeStageCodegen (46)
-                                        Project [c_customer_sk,c_current_cdemo_sk,c_birth_year]
-                                          BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
-                                            Project [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_year]
-                                              Filter [c_birth_month,c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
-                                                ColumnarToRow
-                                                  InputAdapter
-                                                    Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_month,c_birth_year]
-                                            InputAdapter
-                                              BroadcastExchange #21
-                                                WholeStageCodegen (45)
-                                                  Project [ca_address_sk]
-                                                    Filter [ca_state,ca_address_sk]
-                                                      ColumnarToRow
-                                                        InputAdapter
-                                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
-                                  Filter [cd_demo_sk]
-                                    ColumnarToRow
-                                      InputAdapter
-                                        Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk]
+                  SortMergeJoin [cs_bill_customer_sk,c_customer_sk]
                     InputAdapter
-                      ReusedExchange [i_item_sk,i_item_id] #5
-    WholeStageCodegen (58)
+                      WholeStageCodegen (47)
+                        Sort [cs_bill_customer_sk]
+                          InputAdapter
+                            ReusedExchange [cs_bill_customer_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cd_dep_count,i_item_id] #2
+                    InputAdapter
+                      WholeStageCodegen (54)
+                        Sort [c_customer_sk]
+                          InputAdapter
+                            Exchange [c_customer_sk] #19
+                              WholeStageCodegen (53)
+                                Project [c_customer_sk,c_birth_year]
+                                  SortMergeJoin [c_current_cdemo_sk,cd_demo_sk]
+                                    InputAdapter
+                                      WholeStageCodegen (50)
+                                        Sort [c_current_cdemo_sk]
+                                          InputAdapter
+                                            Exchange [c_current_cdemo_sk] #20
+                                              WholeStageCodegen (49)
+                                                Project [c_customer_sk,c_current_cdemo_sk,c_birth_year]
+                                                  BroadcastHashJoin [c_current_addr_sk,ca_address_sk]
+                                                    Project [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_year]
+                                                      Filter [c_birth_month,c_customer_sk,c_current_cdemo_sk,c_current_addr_sk]
+                                                        ColumnarToRow
+                                                          InputAdapter
+                                                            Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_cdemo_sk,c_current_addr_sk,c_birth_month,c_birth_year]
+                                                    InputAdapter
+                                                      BroadcastExchange #21
+                                                        WholeStageCodegen (48)
+                                                          Project [ca_address_sk]
+                                                            Filter [ca_state,ca_address_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+                                    InputAdapter
+                                      WholeStageCodegen (52)
+                                        Sort [cd_demo_sk]
+                                          InputAdapter
+                                            ReusedExchange [cd_demo_sk] #9
+    WholeStageCodegen (70)
       HashAggregate [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count] [avg(agg1),avg(agg2),avg(agg3),avg(agg4),avg(agg5),avg(agg6),avg(agg7),i_item_id,ca_country,ca_state,county,agg1,agg2,agg3,agg4,agg5,agg6,agg7,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
         InputAdapter
           Exchange #22
-            WholeStageCodegen (57)
+            WholeStageCodegen (69)
               HashAggregate [agg1,agg2,agg3,agg4,agg5,agg6,agg7] [sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count,sum,count]
                 Project [cs_quantity,cs_list_price,cs_coupon_amt,cs_sales_price,cs_net_profit,c_birth_year,cd_dep_count]
-                  BroadcastHashJoin [cs_bill_customer_sk,c_customer_sk]
-                    Project [cs_bill_customer_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cd_dep_count]
-                      BroadcastHashJoin [cs_item_sk,i_item_sk]
-                        Project [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cd_dep_count]
-                          BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                            Project [cs_bill_customer_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk,cd_dep_count]
-                              BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
-                                Filter [cs_bill_cdemo_sk,cs_bill_customer_sk,cs_item_sk]
-                                  ColumnarToRow
-                                    InputAdapter
-                                      Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_bill_cdemo_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk]
-                                        ReusedSubquery [d_date_sk] #1
-                                InputAdapter
-                                  ReusedExchange [cd_demo_sk,cd_dep_count] #4
-                            InputAdapter
-                              ReusedExchange [d_date_sk] #3
-                        InputAdapter
-                          BroadcastExchange #23
-                            WholeStageCodegen (53)
-                              Filter [i_item_sk]
-                                ColumnarToRow
-                                  InputAdapter
-                                    Scan parquet spark_catalog.default.item [i_item_sk]
+                  SortMergeJoin [cs_bill_customer_sk,c_customer_sk]
                     InputAdapter
-                      ReusedExchange [c_customer_sk,c_birth_year] #19
+                      WholeStageCodegen (61)
+                        Sort [cs_bill_customer_sk]
+                          InputAdapter
+                            Exchange [cs_bill_customer_sk] #23
+                              WholeStageCodegen (60)
+                                Project [cs_bill_customer_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cd_dep_count]
+                                  BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
+                                    Project [cs_bill_customer_sk,cs_bill_cdemo_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit]
+                                      BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                        Project [cs_bill_customer_sk,cs_bill_cdemo_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit]
+                                          BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                            Filter [cs_bill_cdemo_sk,cs_bill_customer_sk,cs_item_sk]
+                                              ColumnarToRow
+                                                InputAdapter
+                                                  Scan parquet spark_catalog.default.catalog_sales [cs_bill_customer_sk,cs_bill_cdemo_sk,cs_item_sk,cs_quantity,cs_list_price,cs_sales_price,cs_coupon_amt,cs_net_profit,cs_sold_date_sk]
+                                                    ReusedSubquery [d_date_sk] #1
+                                            InputAdapter
+                                              ReusedExchange [d_date_sk] #3
+                                        InputAdapter
+                                          BroadcastExchange #24
+                                            WholeStageCodegen (58)
+                                              Filter [i_item_sk]
+                                                ColumnarToRow
+                                                  InputAdapter
+                                                    Scan parquet spark_catalog.default.item [i_item_sk]
+                                    InputAdapter
+                                      ReusedExchange [cd_demo_sk,cd_dep_count] #4
+                    InputAdapter
+                      WholeStageCodegen (68)
+                        Sort [c_customer_sk]
+                          InputAdapter
+                            ReusedExchange [c_customer_sk,c_birth_year] #19

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24.sf100/explain.txt
@@ -1,443 +1,536 @@
 == Physical Plan ==
-* Sort (48)
-+- Exchange (47)
-   +- * Filter (46)
-      +- * HashAggregate (45)
-         +- Exchange (44)
-            +- * HashAggregate (43)
-               +- * HashAggregate (42)
-                  +- Exchange (41)
-                     +- * HashAggregate (40)
-                        +- * Project (39)
-                           +- * SortMergeJoin Inner (38)
-                              :- * Sort (31)
-                              :  +- Exchange (30)
-                              :     +- * Project (29)
-                              :        +- * BroadcastHashJoin Inner BuildRight (28)
-                              :           :- * Project (23)
-                              :           :  +- * BroadcastHashJoin Inner BuildLeft (22)
-                              :           :     :- BroadcastExchange (17)
-                              :           :     :  +- * Project (16)
-                              :           :     :     +- * BroadcastHashJoin Inner BuildLeft (15)
-                              :           :     :        :- BroadcastExchange (11)
-                              :           :     :        :  +- * Project (10)
-                              :           :     :        :     +- * BroadcastHashJoin Inner BuildLeft (9)
-                              :           :     :        :        :- BroadcastExchange (5)
-                              :           :     :        :        :  +- * Project (4)
-                              :           :     :        :        :     +- * Filter (3)
-                              :           :     :        :        :        +- * ColumnarToRow (2)
-                              :           :     :        :        :           +- Scan parquet spark_catalog.default.store (1)
-                              :           :     :        :        +- * Filter (8)
-                              :           :     :        :           +- * ColumnarToRow (7)
-                              :           :     :        :              +- Scan parquet spark_catalog.default.customer_address (6)
-                              :           :     :        +- * Filter (14)
-                              :           :     :           +- * ColumnarToRow (13)
-                              :           :     :              +- Scan parquet spark_catalog.default.customer (12)
-                              :           :     +- * Project (21)
-                              :           :        +- * Filter (20)
-                              :           :           +- * ColumnarToRow (19)
-                              :           :              +- Scan parquet spark_catalog.default.store_sales (18)
-                              :           +- BroadcastExchange (27)
-                              :              +- * Filter (26)
-                              :                 +- * ColumnarToRow (25)
-                              :                    +- Scan parquet spark_catalog.default.item (24)
-                              +- * Sort (37)
-                                 +- Exchange (36)
-                                    +- * Project (35)
-                                       +- * Filter (34)
-                                          +- * ColumnarToRow (33)
-                                             +- Scan parquet spark_catalog.default.store_returns (32)
+* Sort (54)
++- Exchange (53)
+   +- * Filter (52)
+      +- * HashAggregate (51)
+         +- Exchange (50)
+            +- * HashAggregate (49)
+               +- * HashAggregate (48)
+                  +- Exchange (47)
+                     +- * HashAggregate (46)
+                        +- * Project (45)
+                           +- * SortMergeJoin Inner (44)
+                              :- * Sort (22)
+                              :  +- Exchange (21)
+                              :     +- * Project (20)
+                              :        +- * SortMergeJoin Inner (19)
+                              :           :- * Sort (12)
+                              :           :  +- Exchange (11)
+                              :           :     +- * Project (10)
+                              :           :        +- * BroadcastHashJoin Inner BuildRight (9)
+                              :           :           :- * Project (4)
+                              :           :           :  +- * Filter (3)
+                              :           :           :     +- * ColumnarToRow (2)
+                              :           :           :        +- Scan parquet spark_catalog.default.store_sales (1)
+                              :           :           +- BroadcastExchange (8)
+                              :           :              +- * Filter (7)
+                              :           :                 +- * ColumnarToRow (6)
+                              :           :                    +- Scan parquet spark_catalog.default.item (5)
+                              :           +- * Sort (18)
+                              :              +- Exchange (17)
+                              :                 +- * Project (16)
+                              :                    +- * Filter (15)
+                              :                       +- * ColumnarToRow (14)
+                              :                          +- Scan parquet spark_catalog.default.store_returns (13)
+                              +- * Sort (43)
+                                 +- Exchange (42)
+                                    +- * Project (41)
+                                       +- * BroadcastHashJoin Inner BuildRight (40)
+                                          :- * Project (34)
+                                          :  +- * SortMergeJoin Inner (33)
+                                          :     :- * Sort (27)
+                                          :     :  +- Exchange (26)
+                                          :     :     +- * Filter (25)
+                                          :     :        +- * ColumnarToRow (24)
+                                          :     :           +- Scan parquet spark_catalog.default.customer (23)
+                                          :     +- * Sort (32)
+                                          :        +- Exchange (31)
+                                          :           +- * Filter (30)
+                                          :              +- * ColumnarToRow (29)
+                                          :                 +- Scan parquet spark_catalog.default.customer_address (28)
+                                          +- BroadcastExchange (39)
+                                             +- * Project (38)
+                                                +- * Filter (37)
+                                                   +- * ColumnarToRow (36)
+                                                      +- Scan parquet spark_catalog.default.store (35)
 
 
-(1) Scan parquet spark_catalog.default.store
-Output [5]: [s_store_sk#1, s_store_name#2, s_market_id#3, s_state#4, s_zip#5]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
-ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
-
-(2) ColumnarToRow [codegen id : 1]
-Input [5]: [s_store_sk#1, s_store_name#2, s_market_id#3, s_state#4, s_zip#5]
-
-(3) Filter [codegen id : 1]
-Input [5]: [s_store_sk#1, s_store_name#2, s_market_id#3, s_state#4, s_zip#5]
-Condition : (((isnotnull(s_market_id#3) AND (s_market_id#3 = 8)) AND isnotnull(s_store_sk#1)) AND isnotnull(s_zip#5))
-
-(4) Project [codegen id : 1]
-Output [4]: [s_store_sk#1, s_store_name#2, s_state#4, s_zip#5]
-Input [5]: [s_store_sk#1, s_store_name#2, s_market_id#3, s_state#4, s_zip#5]
-
-(5) BroadcastExchange
-Input [4]: [s_store_sk#1, s_store_name#2, s_state#4, s_zip#5]
-Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [plan_id=1]
-
-(6) Scan parquet spark_catalog.default.customer_address
-Output [4]: [ca_address_sk#6, ca_state#7, ca_zip#8, ca_country#9]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer_address]
-PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_country), IsNotNull(ca_zip)]
-ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_zip:string,ca_country:string>
-
-(7) ColumnarToRow
-Input [4]: [ca_address_sk#6, ca_state#7, ca_zip#8, ca_country#9]
-
-(8) Filter
-Input [4]: [ca_address_sk#6, ca_state#7, ca_zip#8, ca_country#9]
-Condition : ((isnotnull(ca_address_sk#6) AND isnotnull(ca_country#9)) AND isnotnull(ca_zip#8))
-
-(9) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [s_zip#5]
-Right keys [1]: [ca_zip#8]
-Join type: Inner
-Join condition: None
-
-(10) Project [codegen id : 2]
-Output [6]: [s_store_sk#1, s_store_name#2, s_state#4, ca_address_sk#6, ca_state#7, ca_country#9]
-Input [8]: [s_store_sk#1, s_store_name#2, s_state#4, s_zip#5, ca_address_sk#6, ca_state#7, ca_zip#8, ca_country#9]
-
-(11) BroadcastExchange
-Input [6]: [s_store_sk#1, s_store_name#2, s_state#4, ca_address_sk#6, ca_state#7, ca_country#9]
-Arguments: HashedRelationBroadcastMode(List(input[3, int, true], upper(input[5, string, true])),false), [plan_id=2]
-
-(12) Scan parquet spark_catalog.default.customer
-Output [5]: [c_customer_sk#10, c_current_addr_sk#11, c_first_name#12, c_last_name#13, c_birth_country#14]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/customer]
-PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk), IsNotNull(c_birth_country)]
-ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int,c_first_name:string,c_last_name:string,c_birth_country:string>
-
-(13) ColumnarToRow
-Input [5]: [c_customer_sk#10, c_current_addr_sk#11, c_first_name#12, c_last_name#13, c_birth_country#14]
-
-(14) Filter
-Input [5]: [c_customer_sk#10, c_current_addr_sk#11, c_first_name#12, c_last_name#13, c_birth_country#14]
-Condition : ((isnotnull(c_customer_sk#10) AND isnotnull(c_current_addr_sk#11)) AND isnotnull(c_birth_country#14))
-
-(15) BroadcastHashJoin [codegen id : 3]
-Left keys [2]: [ca_address_sk#6, upper(ca_country#9)]
-Right keys [2]: [c_current_addr_sk#11, c_birth_country#14]
-Join type: Inner
-Join condition: None
-
-(16) Project [codegen id : 3]
-Output [7]: [s_store_sk#1, s_store_name#2, s_state#4, ca_state#7, c_customer_sk#10, c_first_name#12, c_last_name#13]
-Input [11]: [s_store_sk#1, s_store_name#2, s_state#4, ca_address_sk#6, ca_state#7, ca_country#9, c_customer_sk#10, c_current_addr_sk#11, c_first_name#12, c_last_name#13, c_birth_country#14]
-
-(17) BroadcastExchange
-Input [7]: [s_store_sk#1, s_store_name#2, s_state#4, ca_state#7, c_customer_sk#10, c_first_name#12, c_last_name#13]
-Arguments: HashedRelationBroadcastMode(List((shiftleft(cast(input[0, int, true] as bigint), 32) | (cast(input[4, int, true] as bigint) & 4294967295))),false), [plan_id=3]
-
-(18) Scan parquet spark_catalog.default.store_sales
-Output [6]: [ss_item_sk#15, ss_customer_sk#16, ss_store_sk#17, ss_ticket_number#18, ss_net_paid#19, ss_sold_date_sk#20]
+(1) Scan parquet spark_catalog.default.store_sales
+Output [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_ticket_number), IsNotNull(ss_item_sk), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_net_paid:decimal(7,2)>
 
-(19) ColumnarToRow
-Input [6]: [ss_item_sk#15, ss_customer_sk#16, ss_store_sk#17, ss_ticket_number#18, ss_net_paid#19, ss_sold_date_sk#20]
+(2) ColumnarToRow [codegen id : 2]
+Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
 
-(20) Filter
-Input [6]: [ss_item_sk#15, ss_customer_sk#16, ss_store_sk#17, ss_ticket_number#18, ss_net_paid#19, ss_sold_date_sk#20]
-Condition : (((isnotnull(ss_ticket_number#18) AND isnotnull(ss_item_sk#15)) AND isnotnull(ss_store_sk#17)) AND isnotnull(ss_customer_sk#16))
+(3) Filter [codegen id : 2]
+Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
+Condition : ((((isnotnull(ss_ticket_number#4) AND isnotnull(ss_item_sk#1)) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_customer_sk#2)) AND might_contain(Subquery scalar-subquery#7, [id=#8], xxhash64(ss_store_sk#3, 42)))
 
-(21) Project
-Output [5]: [ss_item_sk#15, ss_customer_sk#16, ss_store_sk#17, ss_ticket_number#18, ss_net_paid#19]
-Input [6]: [ss_item_sk#15, ss_customer_sk#16, ss_store_sk#17, ss_ticket_number#18, ss_net_paid#19, ss_sold_date_sk#20]
+(4) Project [codegen id : 2]
+Output [5]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5]
+Input [6]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, ss_sold_date_sk#6]
 
-(22) BroadcastHashJoin [codegen id : 5]
-Left keys [2]: [s_store_sk#1, c_customer_sk#10]
-Right keys [2]: [ss_store_sk#17, ss_customer_sk#16]
-Join type: Inner
-Join condition: None
-
-(23) Project [codegen id : 5]
-Output [8]: [s_store_name#2, s_state#4, ca_state#7, c_first_name#12, c_last_name#13, ss_item_sk#15, ss_ticket_number#18, ss_net_paid#19]
-Input [12]: [s_store_sk#1, s_store_name#2, s_state#4, ca_state#7, c_customer_sk#10, c_first_name#12, c_last_name#13, ss_item_sk#15, ss_customer_sk#16, ss_store_sk#17, ss_ticket_number#18, ss_net_paid#19]
-
-(24) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#21, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
+(5) Scan parquet spark_catalog.default.item
+Output [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_color), EqualTo(i_color,pale                ), IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
-(25) ColumnarToRow [codegen id : 4]
-Input [6]: [i_item_sk#21, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
+(6) ColumnarToRow [codegen id : 1]
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 
-(26) Filter [codegen id : 4]
-Input [6]: [i_item_sk#21, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
-Condition : ((isnotnull(i_color#24) AND (i_color#24 = pale                )) AND isnotnull(i_item_sk#21))
+(7) Filter [codegen id : 1]
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Condition : ((isnotnull(i_color#12) AND (i_color#12 = pale                )) AND isnotnull(i_item_sk#9))
 
-(27) BroadcastExchange
-Input [6]: [i_item_sk#21, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=4]
+(8) BroadcastExchange
+Input [6]: [i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
-(28) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [ss_item_sk#15]
-Right keys [1]: [i_item_sk#21]
+(9) BroadcastHashJoin [codegen id : 2]
+Left keys [1]: [ss_item_sk#1]
+Right keys [1]: [i_item_sk#9]
 Join type: Inner
 Join condition: None
 
-(29) Project [codegen id : 5]
-Output [13]: [s_store_name#2, s_state#4, ca_state#7, c_first_name#12, c_last_name#13, ss_item_sk#15, ss_ticket_number#18, ss_net_paid#19, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
-Input [14]: [s_store_name#2, s_state#4, ca_state#7, c_first_name#12, c_last_name#13, ss_item_sk#15, ss_ticket_number#18, ss_net_paid#19, i_item_sk#21, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
+(10) Project [codegen id : 2]
+Output [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Input [11]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_item_sk#9, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
 
-(30) Exchange
-Input [13]: [s_store_name#2, s_state#4, ca_state#7, c_first_name#12, c_last_name#13, ss_item_sk#15, ss_ticket_number#18, ss_net_paid#19, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
-Arguments: hashpartitioning(ss_ticket_number#18, ss_item_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(11) Exchange
+Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Arguments: hashpartitioning(ss_ticket_number#4, ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(31) Sort [codegen id : 6]
-Input [13]: [s_store_name#2, s_state#4, ca_state#7, c_first_name#12, c_last_name#13, ss_item_sk#15, ss_ticket_number#18, ss_net_paid#19, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26]
-Arguments: [ss_ticket_number#18 ASC NULLS FIRST, ss_item_sk#15 ASC NULLS FIRST], false, 0
+(12) Sort [codegen id : 3]
+Input [10]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Arguments: [ss_ticket_number#4 ASC NULLS FIRST, ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(32) Scan parquet spark_catalog.default.store_returns
-Output [3]: [sr_item_sk#27, sr_ticket_number#28, sr_returned_date_sk#29]
+(13) Scan parquet spark_catalog.default.store_returns
+Output [3]: [sr_item_sk#15, sr_ticket_number#16, sr_returned_date_sk#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_returns]
 PushedFilters: [IsNotNull(sr_ticket_number), IsNotNull(sr_item_sk)]
 ReadSchema: struct<sr_item_sk:int,sr_ticket_number:int>
 
-(33) ColumnarToRow [codegen id : 7]
-Input [3]: [sr_item_sk#27, sr_ticket_number#28, sr_returned_date_sk#29]
+(14) ColumnarToRow [codegen id : 4]
+Input [3]: [sr_item_sk#15, sr_ticket_number#16, sr_returned_date_sk#17]
 
-(34) Filter [codegen id : 7]
-Input [3]: [sr_item_sk#27, sr_ticket_number#28, sr_returned_date_sk#29]
-Condition : (isnotnull(sr_ticket_number#28) AND isnotnull(sr_item_sk#27))
+(15) Filter [codegen id : 4]
+Input [3]: [sr_item_sk#15, sr_ticket_number#16, sr_returned_date_sk#17]
+Condition : (isnotnull(sr_ticket_number#16) AND isnotnull(sr_item_sk#15))
 
-(35) Project [codegen id : 7]
-Output [2]: [sr_item_sk#27, sr_ticket_number#28]
-Input [3]: [sr_item_sk#27, sr_ticket_number#28, sr_returned_date_sk#29]
+(16) Project [codegen id : 4]
+Output [2]: [sr_item_sk#15, sr_ticket_number#16]
+Input [3]: [sr_item_sk#15, sr_ticket_number#16, sr_returned_date_sk#17]
 
-(36) Exchange
-Input [2]: [sr_item_sk#27, sr_ticket_number#28]
-Arguments: hashpartitioning(sr_ticket_number#28, sr_item_sk#27, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+(17) Exchange
+Input [2]: [sr_item_sk#15, sr_ticket_number#16]
+Arguments: hashpartitioning(sr_ticket_number#16, sr_item_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(37) Sort [codegen id : 8]
-Input [2]: [sr_item_sk#27, sr_ticket_number#28]
-Arguments: [sr_ticket_number#28 ASC NULLS FIRST, sr_item_sk#27 ASC NULLS FIRST], false, 0
+(18) Sort [codegen id : 5]
+Input [2]: [sr_item_sk#15, sr_ticket_number#16]
+Arguments: [sr_ticket_number#16 ASC NULLS FIRST, sr_item_sk#15 ASC NULLS FIRST], false, 0
 
-(38) SortMergeJoin [codegen id : 9]
-Left keys [2]: [ss_ticket_number#18, ss_item_sk#15]
-Right keys [2]: [sr_ticket_number#28, sr_item_sk#27]
+(19) SortMergeJoin [codegen id : 6]
+Left keys [2]: [ss_ticket_number#4, ss_item_sk#1]
+Right keys [2]: [sr_ticket_number#16, sr_item_sk#15]
 Join type: Inner
 Join condition: None
 
-(39) Project [codegen id : 9]
-Output [11]: [ss_net_paid#19, s_store_name#2, s_state#4, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26, c_first_name#12, c_last_name#13, ca_state#7]
-Input [15]: [s_store_name#2, s_state#4, ca_state#7, c_first_name#12, c_last_name#13, ss_item_sk#15, ss_ticket_number#18, ss_net_paid#19, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26, sr_item_sk#27, sr_ticket_number#28]
+(20) Project [codegen id : 6]
+Output [8]: [ss_customer_sk#2, ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Input [12]: [ss_item_sk#1, ss_customer_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, sr_item_sk#15, sr_ticket_number#16]
 
-(40) HashAggregate [codegen id : 9]
-Input [11]: [ss_net_paid#19, s_store_name#2, s_state#4, i_current_price#22, i_size#23, i_color#24, i_units#25, i_manager_id#26, c_first_name#12, c_last_name#13, ca_state#7]
-Keys [10]: [c_last_name#13, c_first_name#12, s_store_name#2, ca_state#7, s_state#4, i_color#24, i_current_price#22, i_manager_id#26, i_units#25, i_size#23]
-Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#19))]
-Aggregate Attributes [1]: [sum#30]
-Results [11]: [c_last_name#13, c_first_name#12, s_store_name#2, ca_state#7, s_state#4, i_color#24, i_current_price#22, i_manager_id#26, i_units#25, i_size#23, sum#31]
+(21) Exchange
+Input [8]: [ss_customer_sk#2, ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Arguments: hashpartitioning(ss_store_sk#3, ss_customer_sk#2, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(41) Exchange
-Input [11]: [c_last_name#13, c_first_name#12, s_store_name#2, ca_state#7, s_state#4, i_color#24, i_current_price#22, i_manager_id#26, i_units#25, i_size#23, sum#31]
-Arguments: hashpartitioning(c_last_name#13, c_first_name#12, s_store_name#2, ca_state#7, s_state#4, i_color#24, i_current_price#22, i_manager_id#26, i_units#25, i_size#23, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(22) Sort [codegen id : 7]
+Input [8]: [ss_customer_sk#2, ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14]
+Arguments: [ss_store_sk#3 ASC NULLS FIRST, ss_customer_sk#2 ASC NULLS FIRST], false, 0
 
-(42) HashAggregate [codegen id : 10]
-Input [11]: [c_last_name#13, c_first_name#12, s_store_name#2, ca_state#7, s_state#4, i_color#24, i_current_price#22, i_manager_id#26, i_units#25, i_size#23, sum#31]
-Keys [10]: [c_last_name#13, c_first_name#12, s_store_name#2, ca_state#7, s_state#4, i_color#24, i_current_price#22, i_manager_id#26, i_units#25, i_size#23]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#19))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#19))#32]
-Results [4]: [c_last_name#13, c_first_name#12, s_store_name#2, MakeDecimal(sum(UnscaledValue(ss_net_paid#19))#32,17,2) AS netpaid#33]
+(23) Scan parquet spark_catalog.default.customer
+Output [5]: [c_customer_sk#18, c_current_addr_sk#19, c_first_name#20, c_last_name#21, c_birth_country#22]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer]
+PushedFilters: [IsNotNull(c_customer_sk), IsNotNull(c_current_addr_sk), IsNotNull(c_birth_country)]
+ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int,c_first_name:string,c_last_name:string,c_birth_country:string>
 
-(43) HashAggregate [codegen id : 10]
-Input [4]: [c_last_name#13, c_first_name#12, s_store_name#2, netpaid#33]
-Keys [3]: [c_last_name#13, c_first_name#12, s_store_name#2]
-Functions [1]: [partial_sum(netpaid#33)]
-Aggregate Attributes [2]: [sum#34, isEmpty#35]
-Results [5]: [c_last_name#13, c_first_name#12, s_store_name#2, sum#36, isEmpty#37]
+(24) ColumnarToRow [codegen id : 8]
+Input [5]: [c_customer_sk#18, c_current_addr_sk#19, c_first_name#20, c_last_name#21, c_birth_country#22]
 
-(44) Exchange
-Input [5]: [c_last_name#13, c_first_name#12, s_store_name#2, sum#36, isEmpty#37]
-Arguments: hashpartitioning(c_last_name#13, c_first_name#12, s_store_name#2, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+(25) Filter [codegen id : 8]
+Input [5]: [c_customer_sk#18, c_current_addr_sk#19, c_first_name#20, c_last_name#21, c_birth_country#22]
+Condition : ((isnotnull(c_customer_sk#18) AND isnotnull(c_current_addr_sk#19)) AND isnotnull(c_birth_country#22))
 
-(45) HashAggregate [codegen id : 11]
-Input [5]: [c_last_name#13, c_first_name#12, s_store_name#2, sum#36, isEmpty#37]
-Keys [3]: [c_last_name#13, c_first_name#12, s_store_name#2]
-Functions [1]: [sum(netpaid#33)]
-Aggregate Attributes [1]: [sum(netpaid#33)#38]
-Results [4]: [c_last_name#13, c_first_name#12, s_store_name#2, sum(netpaid#33)#38 AS paid#39]
+(26) Exchange
+Input [5]: [c_customer_sk#18, c_current_addr_sk#19, c_first_name#20, c_last_name#21, c_birth_country#22]
+Arguments: hashpartitioning(c_current_addr_sk#19, c_birth_country#22, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(46) Filter [codegen id : 11]
-Input [4]: [c_last_name#13, c_first_name#12, s_store_name#2, paid#39]
-Condition : (isnotnull(paid#39) AND (cast(paid#39 as decimal(33,8)) > cast(Subquery scalar-subquery#40, [id=#41] as decimal(33,8))))
+(27) Sort [codegen id : 9]
+Input [5]: [c_customer_sk#18, c_current_addr_sk#19, c_first_name#20, c_last_name#21, c_birth_country#22]
+Arguments: [c_current_addr_sk#19 ASC NULLS FIRST, c_birth_country#22 ASC NULLS FIRST], false, 0
+
+(28) Scan parquet spark_catalog.default.customer_address
+Output [4]: [ca_address_sk#23, ca_state#24, ca_zip#25, ca_country#26]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/customer_address]
+PushedFilters: [IsNotNull(ca_address_sk), IsNotNull(ca_country), IsNotNull(ca_zip)]
+ReadSchema: struct<ca_address_sk:int,ca_state:string,ca_zip:string,ca_country:string>
+
+(29) ColumnarToRow [codegen id : 10]
+Input [4]: [ca_address_sk#23, ca_state#24, ca_zip#25, ca_country#26]
+
+(30) Filter [codegen id : 10]
+Input [4]: [ca_address_sk#23, ca_state#24, ca_zip#25, ca_country#26]
+Condition : ((isnotnull(ca_address_sk#23) AND isnotnull(ca_country#26)) AND isnotnull(ca_zip#25))
+
+(31) Exchange
+Input [4]: [ca_address_sk#23, ca_state#24, ca_zip#25, ca_country#26]
+Arguments: hashpartitioning(ca_address_sk#23, upper(ca_country#26), 5), ENSURE_REQUIREMENTS, [plan_id=6]
+
+(32) Sort [codegen id : 11]
+Input [4]: [ca_address_sk#23, ca_state#24, ca_zip#25, ca_country#26]
+Arguments: [ca_address_sk#23 ASC NULLS FIRST, upper(ca_country#26) ASC NULLS FIRST], false, 0
+
+(33) SortMergeJoin [codegen id : 13]
+Left keys [2]: [c_current_addr_sk#19, c_birth_country#22]
+Right keys [2]: [ca_address_sk#23, upper(ca_country#26)]
+Join type: Inner
+Join condition: None
+
+(34) Project [codegen id : 13]
+Output [5]: [c_customer_sk#18, c_first_name#20, c_last_name#21, ca_state#24, ca_zip#25]
+Input [9]: [c_customer_sk#18, c_current_addr_sk#19, c_first_name#20, c_last_name#21, c_birth_country#22, ca_address_sk#23, ca_state#24, ca_zip#25, ca_country#26]
+
+(35) Scan parquet spark_catalog.default.store
+Output [5]: [s_store_sk#27, s_store_name#28, s_market_id#29, s_state#30, s_zip#31]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
+ReadSchema: struct<s_store_sk:int,s_store_name:string,s_market_id:int,s_state:string,s_zip:string>
+
+(36) ColumnarToRow [codegen id : 12]
+Input [5]: [s_store_sk#27, s_store_name#28, s_market_id#29, s_state#30, s_zip#31]
+
+(37) Filter [codegen id : 12]
+Input [5]: [s_store_sk#27, s_store_name#28, s_market_id#29, s_state#30, s_zip#31]
+Condition : (((isnotnull(s_market_id#29) AND (s_market_id#29 = 8)) AND isnotnull(s_store_sk#27)) AND isnotnull(s_zip#31))
+
+(38) Project [codegen id : 12]
+Output [4]: [s_store_sk#27, s_store_name#28, s_state#30, s_zip#31]
+Input [5]: [s_store_sk#27, s_store_name#28, s_market_id#29, s_state#30, s_zip#31]
+
+(39) BroadcastExchange
+Input [4]: [s_store_sk#27, s_store_name#28, s_state#30, s_zip#31]
+Arguments: HashedRelationBroadcastMode(List(input[3, string, true]),false), [plan_id=7]
+
+(40) BroadcastHashJoin [codegen id : 13]
+Left keys [1]: [ca_zip#25]
+Right keys [1]: [s_zip#31]
+Join type: Inner
+Join condition: None
+
+(41) Project [codegen id : 13]
+Output [7]: [c_customer_sk#18, c_first_name#20, c_last_name#21, ca_state#24, s_store_sk#27, s_store_name#28, s_state#30]
+Input [9]: [c_customer_sk#18, c_first_name#20, c_last_name#21, ca_state#24, ca_zip#25, s_store_sk#27, s_store_name#28, s_state#30, s_zip#31]
+
+(42) Exchange
+Input [7]: [c_customer_sk#18, c_first_name#20, c_last_name#21, ca_state#24, s_store_sk#27, s_store_name#28, s_state#30]
+Arguments: hashpartitioning(s_store_sk#27, c_customer_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+
+(43) Sort [codegen id : 14]
+Input [7]: [c_customer_sk#18, c_first_name#20, c_last_name#21, ca_state#24, s_store_sk#27, s_store_name#28, s_state#30]
+Arguments: [s_store_sk#27 ASC NULLS FIRST, c_customer_sk#18 ASC NULLS FIRST], false, 0
+
+(44) SortMergeJoin [codegen id : 15]
+Left keys [2]: [ss_store_sk#3, ss_customer_sk#2]
+Right keys [2]: [s_store_sk#27, c_customer_sk#18]
+Join type: Inner
+Join condition: None
+
+(45) Project [codegen id : 15]
+Output [11]: [ss_net_paid#5, s_store_name#28, s_state#30, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#20, c_last_name#21, ca_state#24]
+Input [15]: [ss_customer_sk#2, ss_store_sk#3, ss_net_paid#5, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_customer_sk#18, c_first_name#20, c_last_name#21, ca_state#24, s_store_sk#27, s_store_name#28, s_state#30]
+
+(46) HashAggregate [codegen id : 15]
+Input [11]: [ss_net_paid#5, s_store_name#28, s_state#30, i_current_price#10, i_size#11, i_color#12, i_units#13, i_manager_id#14, c_first_name#20, c_last_name#21, ca_state#24]
+Keys [10]: [c_last_name#21, c_first_name#20, s_store_name#28, ca_state#24, s_state#30, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
+Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#5))]
+Aggregate Attributes [1]: [sum#32]
+Results [11]: [c_last_name#21, c_first_name#20, s_store_name#28, ca_state#24, s_state#30, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#33]
 
 (47) Exchange
-Input [4]: [c_last_name#13, c_first_name#12, s_store_name#2, paid#39]
-Arguments: rangepartitioning(c_last_name#13 ASC NULLS FIRST, c_first_name#12 ASC NULLS FIRST, s_store_name#2 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Input [11]: [c_last_name#21, c_first_name#20, s_store_name#28, ca_state#24, s_state#30, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#33]
+Arguments: hashpartitioning(c_last_name#21, c_first_name#20, s_store_name#28, ca_state#24, s_state#30, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
-(48) Sort [codegen id : 12]
-Input [4]: [c_last_name#13, c_first_name#12, s_store_name#2, paid#39]
-Arguments: [c_last_name#13 ASC NULLS FIRST, c_first_name#12 ASC NULLS FIRST, s_store_name#2 ASC NULLS FIRST], true, 0
+(48) HashAggregate [codegen id : 16]
+Input [11]: [c_last_name#21, c_first_name#20, s_store_name#28, ca_state#24, s_state#30, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11, sum#33]
+Keys [10]: [c_last_name#21, c_first_name#20, s_store_name#28, ca_state#24, s_state#30, i_color#12, i_current_price#10, i_manager_id#14, i_units#13, i_size#11]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#5))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#5))#34]
+Results [4]: [c_last_name#21, c_first_name#20, s_store_name#28, MakeDecimal(sum(UnscaledValue(ss_net_paid#5))#34,17,2) AS netpaid#35]
+
+(49) HashAggregate [codegen id : 16]
+Input [4]: [c_last_name#21, c_first_name#20, s_store_name#28, netpaid#35]
+Keys [3]: [c_last_name#21, c_first_name#20, s_store_name#28]
+Functions [1]: [partial_sum(netpaid#35)]
+Aggregate Attributes [2]: [sum#36, isEmpty#37]
+Results [5]: [c_last_name#21, c_first_name#20, s_store_name#28, sum#38, isEmpty#39]
+
+(50) Exchange
+Input [5]: [c_last_name#21, c_first_name#20, s_store_name#28, sum#38, isEmpty#39]
+Arguments: hashpartitioning(c_last_name#21, c_first_name#20, s_store_name#28, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+
+(51) HashAggregate [codegen id : 17]
+Input [5]: [c_last_name#21, c_first_name#20, s_store_name#28, sum#38, isEmpty#39]
+Keys [3]: [c_last_name#21, c_first_name#20, s_store_name#28]
+Functions [1]: [sum(netpaid#35)]
+Aggregate Attributes [1]: [sum(netpaid#35)#40]
+Results [4]: [c_last_name#21, c_first_name#20, s_store_name#28, sum(netpaid#35)#40 AS paid#41]
+
+(52) Filter [codegen id : 17]
+Input [4]: [c_last_name#21, c_first_name#20, s_store_name#28, paid#41]
+Condition : (isnotnull(paid#41) AND (cast(paid#41 as decimal(33,8)) > cast(Subquery scalar-subquery#42, [id=#43] as decimal(33,8))))
+
+(53) Exchange
+Input [4]: [c_last_name#21, c_first_name#20, s_store_name#28, paid#41]
+Arguments: rangepartitioning(c_last_name#21 ASC NULLS FIRST, c_first_name#20 ASC NULLS FIRST, s_store_name#28 ASC NULLS FIRST, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+
+(54) Sort [codegen id : 18]
+Input [4]: [c_last_name#21, c_first_name#20, s_store_name#28, paid#41]
+Arguments: [c_last_name#21 ASC NULLS FIRST, c_first_name#20 ASC NULLS FIRST, s_store_name#28 ASC NULLS FIRST], true, 0
 
 ===== Subqueries =====
 
-Subquery:1 Hosting operator id = 46 Hosting Expression = Subquery scalar-subquery#40, [id=#41]
-* HashAggregate (76)
-+- Exchange (75)
-   +- * HashAggregate (74)
-      +- * HashAggregate (73)
-         +- Exchange (72)
-            +- * HashAggregate (71)
-               +- * Project (70)
-                  +- * SortMergeJoin Inner (69)
-                     :- * Sort (66)
-                     :  +- Exchange (65)
-                     :     +- * Project (64)
-                     :        +- * SortMergeJoin Inner (63)
-                     :           :- * Sort (57)
-                     :           :  +- Exchange (56)
-                     :           :     +- * Project (55)
-                     :           :        +- * BroadcastHashJoin Inner BuildLeft (54)
-                     :           :           :- ReusedExchange (49)
-                     :           :           +- * Project (53)
-                     :           :              +- * Filter (52)
-                     :           :                 +- * ColumnarToRow (51)
-                     :           :                    +- Scan parquet spark_catalog.default.store_sales (50)
-                     :           +- * Sort (62)
-                     :              +- Exchange (61)
-                     :                 +- * Filter (60)
-                     :                    +- * ColumnarToRow (59)
-                     :                       +- Scan parquet spark_catalog.default.item (58)
-                     +- * Sort (68)
-                        +- ReusedExchange (67)
+Subquery:1 Hosting operator id = 52 Hosting Expression = Subquery scalar-subquery#42, [id=#43]
+* HashAggregate (85)
++- Exchange (84)
+   +- * HashAggregate (83)
+      +- * HashAggregate (82)
+         +- Exchange (81)
+            +- * HashAggregate (80)
+               +- * Project (79)
+                  +- * SortMergeJoin Inner (78)
+                     :- * Sort (75)
+                     :  +- Exchange (74)
+                     :     +- * Project (73)
+                     :        +- * SortMergeJoin Inner (72)
+                     :           :- * Sort (69)
+                     :           :  +- Exchange (68)
+                     :           :     +- * Project (67)
+                     :           :        +- * SortMergeJoin Inner (66)
+                     :           :           :- * Sort (60)
+                     :           :           :  +- Exchange (59)
+                     :           :           :     +- * Project (58)
+                     :           :           :        +- * Filter (57)
+                     :           :           :           +- * ColumnarToRow (56)
+                     :           :           :              +- Scan parquet spark_catalog.default.store_sales (55)
+                     :           :           +- * Sort (65)
+                     :           :              +- Exchange (64)
+                     :           :                 +- * Filter (63)
+                     :           :                    +- * ColumnarToRow (62)
+                     :           :                       +- Scan parquet spark_catalog.default.item (61)
+                     :           +- * Sort (71)
+                     :              +- ReusedExchange (70)
+                     +- * Sort (77)
+                        +- ReusedExchange (76)
 
 
-(49) ReusedExchange [Reuses operator id: 17]
-Output [7]: [s_store_sk#42, s_store_name#43, s_state#44, ca_state#45, c_customer_sk#46, c_first_name#47, c_last_name#48]
-
-(50) Scan parquet spark_catalog.default.store_sales
-Output [6]: [ss_item_sk#49, ss_customer_sk#50, ss_store_sk#51, ss_ticket_number#52, ss_net_paid#53, ss_sold_date_sk#54]
+(55) Scan parquet spark_catalog.default.store_sales
+Output [6]: [ss_item_sk#44, ss_customer_sk#45, ss_store_sk#46, ss_ticket_number#47, ss_net_paid#48, ss_sold_date_sk#49]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store_sales]
 PushedFilters: [IsNotNull(ss_ticket_number), IsNotNull(ss_item_sk), IsNotNull(ss_store_sk), IsNotNull(ss_customer_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_customer_sk:int,ss_store_sk:int,ss_ticket_number:int,ss_net_paid:decimal(7,2)>
 
-(51) ColumnarToRow
-Input [6]: [ss_item_sk#49, ss_customer_sk#50, ss_store_sk#51, ss_ticket_number#52, ss_net_paid#53, ss_sold_date_sk#54]
+(56) ColumnarToRow [codegen id : 1]
+Input [6]: [ss_item_sk#44, ss_customer_sk#45, ss_store_sk#46, ss_ticket_number#47, ss_net_paid#48, ss_sold_date_sk#49]
 
-(52) Filter
-Input [6]: [ss_item_sk#49, ss_customer_sk#50, ss_store_sk#51, ss_ticket_number#52, ss_net_paid#53, ss_sold_date_sk#54]
-Condition : (((isnotnull(ss_ticket_number#52) AND isnotnull(ss_item_sk#49)) AND isnotnull(ss_store_sk#51)) AND isnotnull(ss_customer_sk#50))
+(57) Filter [codegen id : 1]
+Input [6]: [ss_item_sk#44, ss_customer_sk#45, ss_store_sk#46, ss_ticket_number#47, ss_net_paid#48, ss_sold_date_sk#49]
+Condition : ((((isnotnull(ss_ticket_number#47) AND isnotnull(ss_item_sk#44)) AND isnotnull(ss_store_sk#46)) AND isnotnull(ss_customer_sk#45)) AND might_contain(ReusedSubquery Subquery scalar-subquery#7, [id=#8], xxhash64(ss_store_sk#46, 42)))
 
-(53) Project
-Output [5]: [ss_item_sk#49, ss_customer_sk#50, ss_store_sk#51, ss_ticket_number#52, ss_net_paid#53]
-Input [6]: [ss_item_sk#49, ss_customer_sk#50, ss_store_sk#51, ss_ticket_number#52, ss_net_paid#53, ss_sold_date_sk#54]
+(58) Project [codegen id : 1]
+Output [5]: [ss_item_sk#44, ss_customer_sk#45, ss_store_sk#46, ss_ticket_number#47, ss_net_paid#48]
+Input [6]: [ss_item_sk#44, ss_customer_sk#45, ss_store_sk#46, ss_ticket_number#47, ss_net_paid#48, ss_sold_date_sk#49]
 
-(54) BroadcastHashJoin [codegen id : 4]
-Left keys [2]: [s_store_sk#42, c_customer_sk#46]
-Right keys [2]: [ss_store_sk#51, ss_customer_sk#50]
-Join type: Inner
-Join condition: None
+(59) Exchange
+Input [5]: [ss_item_sk#44, ss_customer_sk#45, ss_store_sk#46, ss_ticket_number#47, ss_net_paid#48]
+Arguments: hashpartitioning(ss_item_sk#44, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
-(55) Project [codegen id : 4]
-Output [8]: [s_store_name#43, s_state#44, ca_state#45, c_first_name#47, c_last_name#48, ss_item_sk#49, ss_ticket_number#52, ss_net_paid#53]
-Input [12]: [s_store_sk#42, s_store_name#43, s_state#44, ca_state#45, c_customer_sk#46, c_first_name#47, c_last_name#48, ss_item_sk#49, ss_customer_sk#50, ss_store_sk#51, ss_ticket_number#52, ss_net_paid#53]
+(60) Sort [codegen id : 2]
+Input [5]: [ss_item_sk#44, ss_customer_sk#45, ss_store_sk#46, ss_ticket_number#47, ss_net_paid#48]
+Arguments: [ss_item_sk#44 ASC NULLS FIRST], false, 0
 
-(56) Exchange
-Input [8]: [s_store_name#43, s_state#44, ca_state#45, c_first_name#47, c_last_name#48, ss_item_sk#49, ss_ticket_number#52, ss_net_paid#53]
-Arguments: hashpartitioning(ss_item_sk#49, 5), ENSURE_REQUIREMENTS, [plan_id=10]
-
-(57) Sort [codegen id : 5]
-Input [8]: [s_store_name#43, s_state#44, ca_state#45, c_first_name#47, c_last_name#48, ss_item_sk#49, ss_ticket_number#52, ss_net_paid#53]
-Arguments: [ss_item_sk#49 ASC NULLS FIRST], false, 0
-
-(58) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#55, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60]
+(61) Scan parquet spark_catalog.default.item
+Output [6]: [i_item_sk#50, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_current_price:decimal(7,2),i_size:string,i_color:string,i_units:string,i_manager_id:int>
 
-(59) ColumnarToRow [codegen id : 6]
-Input [6]: [i_item_sk#55, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60]
+(62) ColumnarToRow [codegen id : 3]
+Input [6]: [i_item_sk#50, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
 
-(60) Filter [codegen id : 6]
-Input [6]: [i_item_sk#55, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60]
-Condition : isnotnull(i_item_sk#55)
+(63) Filter [codegen id : 3]
+Input [6]: [i_item_sk#50, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
+Condition : isnotnull(i_item_sk#50)
 
-(61) Exchange
-Input [6]: [i_item_sk#55, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60]
-Arguments: hashpartitioning(i_item_sk#55, 5), ENSURE_REQUIREMENTS, [plan_id=11]
+(64) Exchange
+Input [6]: [i_item_sk#50, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
+Arguments: hashpartitioning(i_item_sk#50, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
-(62) Sort [codegen id : 7]
-Input [6]: [i_item_sk#55, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60]
-Arguments: [i_item_sk#55 ASC NULLS FIRST], false, 0
+(65) Sort [codegen id : 4]
+Input [6]: [i_item_sk#50, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
+Arguments: [i_item_sk#50 ASC NULLS FIRST], false, 0
 
-(63) SortMergeJoin [codegen id : 8]
-Left keys [1]: [ss_item_sk#49]
-Right keys [1]: [i_item_sk#55]
+(66) SortMergeJoin [codegen id : 5]
+Left keys [1]: [ss_item_sk#44]
+Right keys [1]: [i_item_sk#50]
 Join type: Inner
 Join condition: None
 
-(64) Project [codegen id : 8]
-Output [13]: [s_store_name#43, s_state#44, ca_state#45, c_first_name#47, c_last_name#48, ss_item_sk#49, ss_ticket_number#52, ss_net_paid#53, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60]
-Input [14]: [s_store_name#43, s_state#44, ca_state#45, c_first_name#47, c_last_name#48, ss_item_sk#49, ss_ticket_number#52, ss_net_paid#53, i_item_sk#55, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60]
+(67) Project [codegen id : 5]
+Output [10]: [ss_item_sk#44, ss_customer_sk#45, ss_store_sk#46, ss_ticket_number#47, ss_net_paid#48, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
+Input [11]: [ss_item_sk#44, ss_customer_sk#45, ss_store_sk#46, ss_ticket_number#47, ss_net_paid#48, i_item_sk#50, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
 
-(65) Exchange
-Input [13]: [s_store_name#43, s_state#44, ca_state#45, c_first_name#47, c_last_name#48, ss_item_sk#49, ss_ticket_number#52, ss_net_paid#53, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60]
-Arguments: hashpartitioning(ss_ticket_number#52, ss_item_sk#49, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+(68) Exchange
+Input [10]: [ss_item_sk#44, ss_customer_sk#45, ss_store_sk#46, ss_ticket_number#47, ss_net_paid#48, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
+Arguments: hashpartitioning(ss_ticket_number#47, ss_item_sk#44, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
-(66) Sort [codegen id : 9]
-Input [13]: [s_store_name#43, s_state#44, ca_state#45, c_first_name#47, c_last_name#48, ss_item_sk#49, ss_ticket_number#52, ss_net_paid#53, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60]
-Arguments: [ss_ticket_number#52 ASC NULLS FIRST, ss_item_sk#49 ASC NULLS FIRST], false, 0
+(69) Sort [codegen id : 6]
+Input [10]: [ss_item_sk#44, ss_customer_sk#45, ss_store_sk#46, ss_ticket_number#47, ss_net_paid#48, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
+Arguments: [ss_ticket_number#47 ASC NULLS FIRST, ss_item_sk#44 ASC NULLS FIRST], false, 0
 
-(67) ReusedExchange [Reuses operator id: 36]
-Output [2]: [sr_item_sk#61, sr_ticket_number#62]
+(70) ReusedExchange [Reuses operator id: 17]
+Output [2]: [sr_item_sk#56, sr_ticket_number#57]
 
-(68) Sort [codegen id : 11]
-Input [2]: [sr_item_sk#61, sr_ticket_number#62]
-Arguments: [sr_ticket_number#62 ASC NULLS FIRST, sr_item_sk#61 ASC NULLS FIRST], false, 0
+(71) Sort [codegen id : 8]
+Input [2]: [sr_item_sk#56, sr_ticket_number#57]
+Arguments: [sr_ticket_number#57 ASC NULLS FIRST, sr_item_sk#56 ASC NULLS FIRST], false, 0
 
-(69) SortMergeJoin [codegen id : 12]
-Left keys [2]: [ss_ticket_number#52, ss_item_sk#49]
-Right keys [2]: [sr_ticket_number#62, sr_item_sk#61]
+(72) SortMergeJoin [codegen id : 9]
+Left keys [2]: [ss_ticket_number#47, ss_item_sk#44]
+Right keys [2]: [sr_ticket_number#57, sr_item_sk#56]
 Join type: Inner
 Join condition: None
 
-(70) Project [codegen id : 12]
-Output [11]: [ss_net_paid#53, s_store_name#43, s_state#44, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60, c_first_name#47, c_last_name#48, ca_state#45]
-Input [15]: [s_store_name#43, s_state#44, ca_state#45, c_first_name#47, c_last_name#48, ss_item_sk#49, ss_ticket_number#52, ss_net_paid#53, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60, sr_item_sk#61, sr_ticket_number#62]
+(73) Project [codegen id : 9]
+Output [8]: [ss_customer_sk#45, ss_store_sk#46, ss_net_paid#48, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
+Input [12]: [ss_item_sk#44, ss_customer_sk#45, ss_store_sk#46, ss_ticket_number#47, ss_net_paid#48, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55, sr_item_sk#56, sr_ticket_number#57]
 
-(71) HashAggregate [codegen id : 12]
-Input [11]: [ss_net_paid#53, s_store_name#43, s_state#44, i_current_price#56, i_size#57, i_color#58, i_units#59, i_manager_id#60, c_first_name#47, c_last_name#48, ca_state#45]
-Keys [10]: [c_last_name#48, c_first_name#47, s_store_name#43, ca_state#45, s_state#44, i_color#58, i_current_price#56, i_manager_id#60, i_units#59, i_size#57]
-Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#53))]
-Aggregate Attributes [1]: [sum#63]
-Results [11]: [c_last_name#48, c_first_name#47, s_store_name#43, ca_state#45, s_state#44, i_color#58, i_current_price#56, i_manager_id#60, i_units#59, i_size#57, sum#64]
+(74) Exchange
+Input [8]: [ss_customer_sk#45, ss_store_sk#46, ss_net_paid#48, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
+Arguments: hashpartitioning(ss_store_sk#46, ss_customer_sk#45, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
-(72) Exchange
-Input [11]: [c_last_name#48, c_first_name#47, s_store_name#43, ca_state#45, s_state#44, i_color#58, i_current_price#56, i_manager_id#60, i_units#59, i_size#57, sum#64]
-Arguments: hashpartitioning(c_last_name#48, c_first_name#47, s_store_name#43, ca_state#45, s_state#44, i_color#58, i_current_price#56, i_manager_id#60, i_units#59, i_size#57, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+(75) Sort [codegen id : 10]
+Input [8]: [ss_customer_sk#45, ss_store_sk#46, ss_net_paid#48, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55]
+Arguments: [ss_store_sk#46 ASC NULLS FIRST, ss_customer_sk#45 ASC NULLS FIRST], false, 0
 
-(73) HashAggregate [codegen id : 13]
-Input [11]: [c_last_name#48, c_first_name#47, s_store_name#43, ca_state#45, s_state#44, i_color#58, i_current_price#56, i_manager_id#60, i_units#59, i_size#57, sum#64]
-Keys [10]: [c_last_name#48, c_first_name#47, s_store_name#43, ca_state#45, s_state#44, i_color#58, i_current_price#56, i_manager_id#60, i_units#59, i_size#57]
-Functions [1]: [sum(UnscaledValue(ss_net_paid#53))]
-Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#53))#32]
-Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#53))#32,17,2) AS netpaid#65]
+(76) ReusedExchange [Reuses operator id: 42]
+Output [7]: [c_customer_sk#58, c_first_name#59, c_last_name#60, ca_state#61, s_store_sk#62, s_store_name#63, s_state#64]
 
-(74) HashAggregate [codegen id : 13]
-Input [1]: [netpaid#65]
+(77) Sort [codegen id : 17]
+Input [7]: [c_customer_sk#58, c_first_name#59, c_last_name#60, ca_state#61, s_store_sk#62, s_store_name#63, s_state#64]
+Arguments: [s_store_sk#62 ASC NULLS FIRST, c_customer_sk#58 ASC NULLS FIRST], false, 0
+
+(78) SortMergeJoin [codegen id : 18]
+Left keys [2]: [ss_store_sk#46, ss_customer_sk#45]
+Right keys [2]: [s_store_sk#62, c_customer_sk#58]
+Join type: Inner
+Join condition: None
+
+(79) Project [codegen id : 18]
+Output [11]: [ss_net_paid#48, s_store_name#63, s_state#64, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55, c_first_name#59, c_last_name#60, ca_state#61]
+Input [15]: [ss_customer_sk#45, ss_store_sk#46, ss_net_paid#48, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55, c_customer_sk#58, c_first_name#59, c_last_name#60, ca_state#61, s_store_sk#62, s_store_name#63, s_state#64]
+
+(80) HashAggregate [codegen id : 18]
+Input [11]: [ss_net_paid#48, s_store_name#63, s_state#64, i_current_price#51, i_size#52, i_color#53, i_units#54, i_manager_id#55, c_first_name#59, c_last_name#60, ca_state#61]
+Keys [10]: [c_last_name#60, c_first_name#59, s_store_name#63, ca_state#61, s_state#64, i_color#53, i_current_price#51, i_manager_id#55, i_units#54, i_size#52]
+Functions [1]: [partial_sum(UnscaledValue(ss_net_paid#48))]
+Aggregate Attributes [1]: [sum#65]
+Results [11]: [c_last_name#60, c_first_name#59, s_store_name#63, ca_state#61, s_state#64, i_color#53, i_current_price#51, i_manager_id#55, i_units#54, i_size#52, sum#66]
+
+(81) Exchange
+Input [11]: [c_last_name#60, c_first_name#59, s_store_name#63, ca_state#61, s_state#64, i_color#53, i_current_price#51, i_manager_id#55, i_units#54, i_size#52, sum#66]
+Arguments: hashpartitioning(c_last_name#60, c_first_name#59, s_store_name#63, ca_state#61, s_state#64, i_color#53, i_current_price#51, i_manager_id#55, i_units#54, i_size#52, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+
+(82) HashAggregate [codegen id : 19]
+Input [11]: [c_last_name#60, c_first_name#59, s_store_name#63, ca_state#61, s_state#64, i_color#53, i_current_price#51, i_manager_id#55, i_units#54, i_size#52, sum#66]
+Keys [10]: [c_last_name#60, c_first_name#59, s_store_name#63, ca_state#61, s_state#64, i_color#53, i_current_price#51, i_manager_id#55, i_units#54, i_size#52]
+Functions [1]: [sum(UnscaledValue(ss_net_paid#48))]
+Aggregate Attributes [1]: [sum(UnscaledValue(ss_net_paid#48))#34]
+Results [1]: [MakeDecimal(sum(UnscaledValue(ss_net_paid#48))#34,17,2) AS netpaid#67]
+
+(83) HashAggregate [codegen id : 19]
+Input [1]: [netpaid#67]
 Keys: []
-Functions [1]: [partial_avg(netpaid#65)]
-Aggregate Attributes [2]: [sum#66, count#67]
-Results [2]: [sum#68, count#69]
+Functions [1]: [partial_avg(netpaid#67)]
+Aggregate Attributes [2]: [sum#68, count#69]
+Results [2]: [sum#70, count#71]
 
-(75) Exchange
-Input [2]: [sum#68, count#69]
-Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=14]
+(84) Exchange
+Input [2]: [sum#70, count#71]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=17]
 
-(76) HashAggregate [codegen id : 14]
-Input [2]: [sum#68, count#69]
+(85) HashAggregate [codegen id : 20]
+Input [2]: [sum#70, count#71]
 Keys: []
-Functions [1]: [avg(netpaid#65)]
-Aggregate Attributes [1]: [avg(netpaid#65)#70]
-Results [1]: [(0.05 * avg(netpaid#65)#70) AS (0.05 * avg(netpaid))#71]
+Functions [1]: [avg(netpaid#67)]
+Aggregate Attributes [1]: [avg(netpaid#67)#72]
+Results [1]: [(0.05 * avg(netpaid#67)#72) AS (0.05 * avg(netpaid))#73]
+
+Subquery:2 Hosting operator id = 57 Hosting Expression = ReusedSubquery Subquery scalar-subquery#7, [id=#8]
+
+Subquery:3 Hosting operator id = 3 Hosting Expression = Subquery scalar-subquery#7, [id=#8]
+ObjectHashAggregate (92)
++- Exchange (91)
+   +- ObjectHashAggregate (90)
+      +- * Project (89)
+         +- * Filter (88)
+            +- * ColumnarToRow (87)
+               +- Scan parquet spark_catalog.default.store (86)
+
+
+(86) Scan parquet spark_catalog.default.store
+Output [3]: [s_store_sk#27, s_market_id#29, s_zip#31]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [IsNotNull(s_market_id), EqualTo(s_market_id,8), IsNotNull(s_store_sk), IsNotNull(s_zip)]
+ReadSchema: struct<s_store_sk:int,s_market_id:int,s_zip:string>
+
+(87) ColumnarToRow [codegen id : 1]
+Input [3]: [s_store_sk#27, s_market_id#29, s_zip#31]
+
+(88) Filter [codegen id : 1]
+Input [3]: [s_store_sk#27, s_market_id#29, s_zip#31]
+Condition : (((isnotnull(s_market_id#29) AND (s_market_id#29 = 8)) AND isnotnull(s_store_sk#27)) AND isnotnull(s_zip#31))
+
+(89) Project [codegen id : 1]
+Output [1]: [s_store_sk#27]
+Input [3]: [s_store_sk#27, s_market_id#29, s_zip#31]
+
+(90) ObjectHashAggregate
+Input [1]: [s_store_sk#27]
+Keys: []
+Functions [1]: [partial_bloom_filter_agg(xxhash64(s_store_sk#27, 42), 40, 1250, 0, 0)]
+Aggregate Attributes [1]: [buf#74]
+Results [1]: [buf#75]
+
+(91) Exchange
+Input [1]: [buf#75]
+Arguments: SinglePartition, ENSURE_REQUIREMENTS, [plan_id=18]
+
+(92) ObjectHashAggregate
+Input [1]: [buf#75]
+Keys: []
+Functions [1]: [bloom_filter_agg(xxhash64(s_store_sk#27, 42), 40, 1250, 0, 0)]
+Aggregate Attributes [1]: [bloom_filter_agg(xxhash64(s_store_sk#27, 42), 40, 1250, 0, 0)#76]
+Results [1]: [bloom_filter_agg(xxhash64(s_store_sk#27, 42), 40, 1250, 0, 0)#76 AS bloomFilter#77]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q24.sf100/simplified.txt
@@ -1,129 +1,167 @@
-WholeStageCodegen (12)
+WholeStageCodegen (18)
   Sort [c_last_name,c_first_name,s_store_name]
     InputAdapter
       Exchange [c_last_name,c_first_name,s_store_name] #1
-        WholeStageCodegen (11)
+        WholeStageCodegen (17)
           Filter [paid]
-            Subquery #1
-              WholeStageCodegen (14)
+            Subquery #2
+              WholeStageCodegen (20)
                 HashAggregate [sum,count] [avg(netpaid),(0.05 * avg(netpaid)),sum,count]
                   InputAdapter
-                    Exchange #10
-                      WholeStageCodegen (13)
+                    Exchange #13
+                      WholeStageCodegen (19)
                         HashAggregate [netpaid] [sum,count,sum,count]
                           HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,sum] [sum(UnscaledValue(ss_net_paid)),netpaid,sum]
                             InputAdapter
-                              Exchange [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size] #11
-                                WholeStageCodegen (12)
+                              Exchange [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size] #14
+                                WholeStageCodegen (18)
                                   HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,ss_net_paid] [sum,sum]
                                     Project [ss_net_paid,s_store_name,s_state,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,ca_state]
-                                      SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
+                                      SortMergeJoin [ss_store_sk,ss_customer_sk,s_store_sk,c_customer_sk]
                                         InputAdapter
-                                          WholeStageCodegen (9)
-                                            Sort [ss_ticket_number,ss_item_sk]
+                                          WholeStageCodegen (10)
+                                            Sort [ss_store_sk,ss_customer_sk]
                                               InputAdapter
-                                                Exchange [ss_ticket_number,ss_item_sk] #12
-                                                  WholeStageCodegen (8)
-                                                    Project [s_store_name,s_state,ca_state,c_first_name,c_last_name,ss_item_sk,ss_ticket_number,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id]
-                                                      SortMergeJoin [ss_item_sk,i_item_sk]
+                                                Exchange [ss_store_sk,ss_customer_sk] #15
+                                                  WholeStageCodegen (9)
+                                                    Project [ss_customer_sk,ss_store_sk,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                      SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
                                                         InputAdapter
-                                                          WholeStageCodegen (5)
-                                                            Sort [ss_item_sk]
+                                                          WholeStageCodegen (6)
+                                                            Sort [ss_ticket_number,ss_item_sk]
                                                               InputAdapter
-                                                                Exchange [ss_item_sk] #13
-                                                                  WholeStageCodegen (4)
-                                                                    Project [s_store_name,s_state,ca_state,c_first_name,c_last_name,ss_item_sk,ss_ticket_number,ss_net_paid]
-                                                                      BroadcastHashJoin [s_store_sk,c_customer_sk,ss_store_sk,ss_customer_sk]
+                                                                Exchange [ss_ticket_number,ss_item_sk] #16
+                                                                  WholeStageCodegen (5)
+                                                                    Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                                      SortMergeJoin [ss_item_sk,i_item_sk]
                                                                         InputAdapter
-                                                                          ReusedExchange [s_store_sk,s_store_name,s_state,ca_state,c_customer_sk,c_first_name,c_last_name] #5
-                                                                        Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
-                                                                          Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
-                                                                            ColumnarToRow
+                                                                          WholeStageCodegen (2)
+                                                                            Sort [ss_item_sk]
                                                                               InputAdapter
-                                                                                Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
-                                                        InputAdapter
-                                                          WholeStageCodegen (7)
-                                                            Sort [i_item_sk]
-                                                              InputAdapter
-                                                                Exchange [i_item_sk] #14
-                                                                  WholeStageCodegen (6)
-                                                                    Filter [i_item_sk]
-                                                                      ColumnarToRow
+                                                                                Exchange [ss_item_sk] #17
+                                                                                  WholeStageCodegen (1)
+                                                                                    Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
+                                                                                      Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
+                                                                                        ReusedSubquery [bloomFilter] #1
+                                                                                        ColumnarToRow
+                                                                                          InputAdapter
+                                                                                            Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
                                                                         InputAdapter
-                                                                          Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                                          WholeStageCodegen (4)
+                                                                            Sort [i_item_sk]
+                                                                              InputAdapter
+                                                                                Exchange [i_item_sk] #18
+                                                                                  WholeStageCodegen (3)
+                                                                                    Filter [i_item_sk]
+                                                                                      ColumnarToRow
+                                                                                        InputAdapter
+                                                                                          Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                        InputAdapter
+                                                          WholeStageCodegen (8)
+                                                            Sort [sr_ticket_number,sr_item_sk]
+                                                              InputAdapter
+                                                                ReusedExchange [sr_item_sk,sr_ticket_number] #8
                                         InputAdapter
-                                          WholeStageCodegen (11)
-                                            Sort [sr_ticket_number,sr_item_sk]
+                                          WholeStageCodegen (17)
+                                            Sort [s_store_sk,c_customer_sk]
                                               InputAdapter
-                                                ReusedExchange [sr_item_sk,sr_ticket_number] #9
+                                                ReusedExchange [c_customer_sk,c_first_name,c_last_name,ca_state,s_store_sk,s_store_name,s_state] #9
             HashAggregate [c_last_name,c_first_name,s_store_name,sum,isEmpty] [sum(netpaid),paid,sum,isEmpty]
               InputAdapter
                 Exchange [c_last_name,c_first_name,s_store_name] #2
-                  WholeStageCodegen (10)
+                  WholeStageCodegen (16)
                     HashAggregate [c_last_name,c_first_name,s_store_name,netpaid] [sum,isEmpty,sum,isEmpty]
                       HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,sum] [sum(UnscaledValue(ss_net_paid)),netpaid,sum]
                         InputAdapter
                           Exchange [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size] #3
-                            WholeStageCodegen (9)
+                            WholeStageCodegen (15)
                               HashAggregate [c_last_name,c_first_name,s_store_name,ca_state,s_state,i_color,i_current_price,i_manager_id,i_units,i_size,ss_net_paid] [sum,sum]
                                 Project [ss_net_paid,s_store_name,s_state,i_current_price,i_size,i_color,i_units,i_manager_id,c_first_name,c_last_name,ca_state]
-                                  SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
+                                  SortMergeJoin [ss_store_sk,ss_customer_sk,s_store_sk,c_customer_sk]
                                     InputAdapter
-                                      WholeStageCodegen (6)
-                                        Sort [ss_ticket_number,ss_item_sk]
+                                      WholeStageCodegen (7)
+                                        Sort [ss_store_sk,ss_customer_sk]
                                           InputAdapter
-                                            Exchange [ss_ticket_number,ss_item_sk] #4
-                                              WholeStageCodegen (5)
-                                                Project [s_store_name,s_state,ca_state,c_first_name,c_last_name,ss_item_sk,ss_ticket_number,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id]
-                                                  BroadcastHashJoin [ss_item_sk,i_item_sk]
-                                                    Project [s_store_name,s_state,ca_state,c_first_name,c_last_name,ss_item_sk,ss_ticket_number,ss_net_paid]
-                                                      BroadcastHashJoin [s_store_sk,c_customer_sk,ss_store_sk,ss_customer_sk]
-                                                        InputAdapter
-                                                          BroadcastExchange #5
-                                                            WholeStageCodegen (3)
-                                                              Project [s_store_sk,s_store_name,s_state,ca_state,c_customer_sk,c_first_name,c_last_name]
-                                                                BroadcastHashJoin [ca_address_sk,ca_country,c_current_addr_sk,c_birth_country]
-                                                                  InputAdapter
-                                                                    BroadcastExchange #6
-                                                                      WholeStageCodegen (2)
-                                                                        Project [s_store_sk,s_store_name,s_state,ca_address_sk,ca_state,ca_country]
-                                                                          BroadcastHashJoin [s_zip,ca_zip]
-                                                                            InputAdapter
-                                                                              BroadcastExchange #7
+                                            Exchange [ss_store_sk,ss_customer_sk] #4
+                                              WholeStageCodegen (6)
+                                                Project [ss_customer_sk,ss_store_sk,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                  SortMergeJoin [ss_ticket_number,ss_item_sk,sr_ticket_number,sr_item_sk]
+                                                    InputAdapter
+                                                      WholeStageCodegen (3)
+                                                        Sort [ss_ticket_number,ss_item_sk]
+                                                          InputAdapter
+                                                            Exchange [ss_ticket_number,ss_item_sk] #5
+                                                              WholeStageCodegen (2)
+                                                                Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                                  BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                    Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
+                                                                      Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
+                                                                        Subquery #1
+                                                                          ObjectHashAggregate [buf] [bloom_filter_agg(xxhash64(s_store_sk, 42), 40, 1250, 0, 0),bloomFilter,buf]
+                                                                            Exchange #6
+                                                                              ObjectHashAggregate [s_store_sk] [buf,buf]
                                                                                 WholeStageCodegen (1)
-                                                                                  Project [s_store_sk,s_store_name,s_state,s_zip]
+                                                                                  Project [s_store_sk]
                                                                                     Filter [s_market_id,s_store_sk,s_zip]
                                                                                       ColumnarToRow
                                                                                         InputAdapter
-                                                                                          Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_market_id,s_state,s_zip]
-                                                                            Filter [ca_address_sk,ca_country,ca_zip]
-                                                                              ColumnarToRow
-                                                                                InputAdapter
-                                                                                  Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state,ca_zip,ca_country]
-                                                                  Filter [c_customer_sk,c_current_addr_sk,c_birth_country]
+                                                                                          Scan parquet spark_catalog.default.store [s_store_sk,s_market_id,s_zip]
+                                                                        ColumnarToRow
+                                                                          InputAdapter
+                                                                            Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
+                                                                    InputAdapter
+                                                                      BroadcastExchange #7
+                                                                        WholeStageCodegen (1)
+                                                                          Filter [i_color,i_item_sk]
+                                                                            ColumnarToRow
+                                                                              InputAdapter
+                                                                                Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                    InputAdapter
+                                                      WholeStageCodegen (5)
+                                                        Sort [sr_ticket_number,sr_item_sk]
+                                                          InputAdapter
+                                                            Exchange [sr_ticket_number,sr_item_sk] #8
+                                                              WholeStageCodegen (4)
+                                                                Project [sr_item_sk,sr_ticket_number]
+                                                                  Filter [sr_ticket_number,sr_item_sk]
                                                                     ColumnarToRow
                                                                       InputAdapter
-                                                                        Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk,c_first_name,c_last_name,c_birth_country]
-                                                        Project [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid]
-                                                          Filter [ss_ticket_number,ss_item_sk,ss_store_sk,ss_customer_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_customer_sk,ss_store_sk,ss_ticket_number,ss_net_paid,ss_sold_date_sk]
-                                                    InputAdapter
-                                                      BroadcastExchange #8
-                                                        WholeStageCodegen (4)
-                                                          Filter [i_color,i_item_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet spark_catalog.default.item [i_item_sk,i_current_price,i_size,i_color,i_units,i_manager_id]
+                                                                        Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_returned_date_sk]
                                     InputAdapter
-                                      WholeStageCodegen (8)
-                                        Sort [sr_ticket_number,sr_item_sk]
+                                      WholeStageCodegen (14)
+                                        Sort [s_store_sk,c_customer_sk]
                                           InputAdapter
-                                            Exchange [sr_ticket_number,sr_item_sk] #9
-                                              WholeStageCodegen (7)
-                                                Project [sr_item_sk,sr_ticket_number]
-                                                  Filter [sr_ticket_number,sr_item_sk]
-                                                    ColumnarToRow
-                                                      InputAdapter
-                                                        Scan parquet spark_catalog.default.store_returns [sr_item_sk,sr_ticket_number,sr_returned_date_sk]
+                                            Exchange [s_store_sk,c_customer_sk] #9
+                                              WholeStageCodegen (13)
+                                                Project [c_customer_sk,c_first_name,c_last_name,ca_state,s_store_sk,s_store_name,s_state]
+                                                  BroadcastHashJoin [ca_zip,s_zip]
+                                                    Project [c_customer_sk,c_first_name,c_last_name,ca_state,ca_zip]
+                                                      SortMergeJoin [c_current_addr_sk,c_birth_country,ca_address_sk,ca_country]
+                                                        InputAdapter
+                                                          WholeStageCodegen (9)
+                                                            Sort [c_current_addr_sk,c_birth_country]
+                                                              InputAdapter
+                                                                Exchange [c_current_addr_sk,c_birth_country] #10
+                                                                  WholeStageCodegen (8)
+                                                                    Filter [c_customer_sk,c_current_addr_sk,c_birth_country]
+                                                                      ColumnarToRow
+                                                                        InputAdapter
+                                                                          Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk,c_first_name,c_last_name,c_birth_country]
+                                                        InputAdapter
+                                                          WholeStageCodegen (11)
+                                                            Sort [ca_address_sk,ca_country]
+                                                              InputAdapter
+                                                                Exchange [ca_address_sk,ca_country] #11
+                                                                  WholeStageCodegen (10)
+                                                                    Filter [ca_address_sk,ca_country,ca_zip]
+                                                                      ColumnarToRow
+                                                                        InputAdapter
+                                                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state,ca_zip,ca_country]
+                                                    InputAdapter
+                                                      BroadcastExchange #12
+                                                        WholeStageCodegen (12)
+                                                          Project [s_store_sk,s_store_name,s_state,s_zip]
+                                                            Filter [s_market_id,s_store_sk,s_zip]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_market_id,s_state,s_zip]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a.sf100/explain.txt
@@ -10,17 +10,17 @@ TakeOrderedAndProject (73)
    :              :  +- * BroadcastHashJoin Inner BuildRight (18)
    :              :     :- * Project (13)
    :              :     :  +- * BroadcastHashJoin Inner BuildRight (12)
-   :              :     :     :- * Project (10)
-   :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (9)
+   :              :     :     :- * Project (6)
+   :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (5)
    :              :     :     :     :- * Filter (3)
    :              :     :     :     :  +- * ColumnarToRow (2)
    :              :     :     :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-   :              :     :     :     +- BroadcastExchange (8)
-   :              :     :     :        +- * Project (7)
-   :              :     :     :           +- * Filter (6)
-   :              :     :     :              +- * ColumnarToRow (5)
-   :              :     :     :                 +- Scan parquet spark_catalog.default.customer_demographics (4)
-   :              :     :     +- ReusedExchange (11)
+   :              :     :     :     +- ReusedExchange (4)
+   :              :     :     +- BroadcastExchange (11)
+   :              :     :        +- * Project (10)
+   :              :     :           +- * Filter (9)
+   :              :     :              +- * ColumnarToRow (8)
+   :              :     :                 +- Scan parquet spark_catalog.default.customer_demographics (7)
    :              :     +- BroadcastExchange (17)
    :              :        +- * Filter (16)
    :              :           +- * ColumnarToRow (15)
@@ -38,17 +38,17 @@ TakeOrderedAndProject (73)
    :              :  +- * BroadcastHashJoin Inner BuildRight (43)
    :              :     :- * Project (41)
    :              :     :  +- * BroadcastHashJoin Inner BuildRight (40)
-   :              :     :     :- * Project (34)
-   :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (33)
+   :              :     :     :- * Project (38)
+   :              :     :     :  +- * BroadcastHashJoin Inner BuildRight (37)
    :              :     :     :     :- * Filter (31)
    :              :     :     :     :  +- * ColumnarToRow (30)
    :              :     :     :     :     +- Scan parquet spark_catalog.default.store_sales (29)
-   :              :     :     :     +- ReusedExchange (32)
-   :              :     :     +- BroadcastExchange (39)
-   :              :     :        +- * Project (38)
-   :              :     :           +- * Filter (37)
-   :              :     :              +- * ColumnarToRow (36)
-   :              :     :                 +- Scan parquet spark_catalog.default.store (35)
+   :              :     :     :     +- BroadcastExchange (36)
+   :              :     :     :        +- * Project (35)
+   :              :     :     :           +- * Filter (34)
+   :              :     :     :              +- * ColumnarToRow (33)
+   :              :     :     :                 +- Scan parquet spark_catalog.default.store (32)
+   :              :     :     +- ReusedExchange (39)
    :              :     +- ReusedExchange (42)
    :              +- ReusedExchange (45)
    +- * HashAggregate (71)
@@ -89,50 +89,50 @@ Input [8]: [ss_item_sk#1, ss_cdemo_sk#2, ss_store_sk#3, ss_quantity#4, ss_list_p
 Input [8]: [ss_item_sk#1, ss_cdemo_sk#2, ss_store_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, ss_sold_date_sk#8]
 Condition : ((isnotnull(ss_cdemo_sk#2) AND isnotnull(ss_store_sk#3)) AND isnotnull(ss_item_sk#1))
 
-(4) Scan parquet spark_catalog.default.customer_demographics
-Output [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_status#13]
+(4) ReusedExchange [Reuses operator id: 78]
+Output [1]: [d_date_sk#10]
+
+(5) BroadcastHashJoin [codegen id : 5]
+Left keys [1]: [ss_sold_date_sk#8]
+Right keys [1]: [d_date_sk#10]
+Join type: Inner
+Join condition: None
+
+(6) Project [codegen id : 5]
+Output [7]: [ss_item_sk#1, ss_cdemo_sk#2, ss_store_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7]
+Input [9]: [ss_item_sk#1, ss_cdemo_sk#2, ss_store_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, ss_sold_date_sk#8, d_date_sk#10]
+
+(7) Scan parquet spark_catalog.default.customer_demographics
+Output [4]: [cd_demo_sk#11, cd_gender#12, cd_marital_status#13, cd_education_status#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_gender), IsNotNull(cd_marital_status), IsNotNull(cd_education_status), EqualTo(cd_gender,F), EqualTo(cd_marital_status,W), EqualTo(cd_education_status,Primary             ), IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_gender:string,cd_marital_status:string,cd_education_status:string>
 
-(5) ColumnarToRow [codegen id : 1]
-Input [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_status#13]
+(8) ColumnarToRow [codegen id : 2]
+Input [4]: [cd_demo_sk#11, cd_gender#12, cd_marital_status#13, cd_education_status#14]
 
-(6) Filter [codegen id : 1]
-Input [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_status#13]
-Condition : ((((((isnotnull(cd_gender#11) AND isnotnull(cd_marital_status#12)) AND isnotnull(cd_education_status#13)) AND (cd_gender#11 = F)) AND (cd_marital_status#12 = W)) AND (cd_education_status#13 = Primary             )) AND isnotnull(cd_demo_sk#10))
+(9) Filter [codegen id : 2]
+Input [4]: [cd_demo_sk#11, cd_gender#12, cd_marital_status#13, cd_education_status#14]
+Condition : ((((((isnotnull(cd_gender#12) AND isnotnull(cd_marital_status#13)) AND isnotnull(cd_education_status#14)) AND (cd_gender#12 = F)) AND (cd_marital_status#13 = W)) AND (cd_education_status#14 = Primary             )) AND isnotnull(cd_demo_sk#11))
 
-(7) Project [codegen id : 1]
-Output [1]: [cd_demo_sk#10]
-Input [4]: [cd_demo_sk#10, cd_gender#11, cd_marital_status#12, cd_education_status#13]
+(10) Project [codegen id : 2]
+Output [1]: [cd_demo_sk#11]
+Input [4]: [cd_demo_sk#11, cd_gender#12, cd_marital_status#13, cd_education_status#14]
 
-(8) BroadcastExchange
-Input [1]: [cd_demo_sk#10]
+(11) BroadcastExchange
+Input [1]: [cd_demo_sk#11]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(9) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [ss_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#10]
-Join type: Inner
-Join condition: None
-
-(10) Project [codegen id : 5]
-Output [7]: [ss_item_sk#1, ss_store_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, ss_sold_date_sk#8]
-Input [9]: [ss_item_sk#1, ss_cdemo_sk#2, ss_store_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, ss_sold_date_sk#8, cd_demo_sk#10]
-
-(11) ReusedExchange [Reuses operator id: 78]
-Output [1]: [d_date_sk#14]
-
 (12) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [ss_sold_date_sk#8]
-Right keys [1]: [d_date_sk#14]
+Left keys [1]: [ss_cdemo_sk#2]
+Right keys [1]: [cd_demo_sk#11]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 5]
 Output [6]: [ss_item_sk#1, ss_store_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7]
-Input [8]: [ss_item_sk#1, ss_store_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, ss_sold_date_sk#8, d_date_sk#14]
+Input [8]: [ss_item_sk#1, ss_cdemo_sk#2, ss_store_sk#3, ss_quantity#4, ss_list_price#5, ss_sales_price#6, ss_coupon_amt#7, cd_demo_sk#11]
 
 (14) Scan parquet spark_catalog.default.store
 Output [2]: [s_store_sk#15, s_state#16]
@@ -223,63 +223,63 @@ Input [8]: [ss_item_sk#48, ss_cdemo_sk#49, ss_store_sk#50, ss_quantity#51, ss_li
 Input [8]: [ss_item_sk#48, ss_cdemo_sk#49, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55]
 Condition : ((isnotnull(ss_cdemo_sk#49) AND isnotnull(ss_store_sk#50)) AND isnotnull(ss_item_sk#48))
 
-(32) ReusedExchange [Reuses operator id: 8]
-Output [1]: [cd_demo_sk#56]
-
-(33) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ss_cdemo_sk#49]
-Right keys [1]: [cd_demo_sk#56]
-Join type: Inner
-Join condition: None
-
-(34) Project [codegen id : 11]
-Output [7]: [ss_item_sk#48, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55]
-Input [9]: [ss_item_sk#48, ss_cdemo_sk#49, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55, cd_demo_sk#56]
-
-(35) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#57, s_state#58]
+(32) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#56, s_state#57]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_state), EqualTo(s_state,TN), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_state:string>
 
-(36) ColumnarToRow [codegen id : 8]
-Input [2]: [s_store_sk#57, s_state#58]
+(33) ColumnarToRow [codegen id : 7]
+Input [2]: [s_store_sk#56, s_state#57]
 
-(37) Filter [codegen id : 8]
-Input [2]: [s_store_sk#57, s_state#58]
-Condition : ((isnotnull(s_state#58) AND (s_state#58 = TN)) AND isnotnull(s_store_sk#57))
+(34) Filter [codegen id : 7]
+Input [2]: [s_store_sk#56, s_state#57]
+Condition : ((isnotnull(s_state#57) AND (s_state#57 = TN)) AND isnotnull(s_store_sk#56))
 
-(38) Project [codegen id : 8]
-Output [1]: [s_store_sk#57]
-Input [2]: [s_store_sk#57, s_state#58]
+(35) Project [codegen id : 7]
+Output [1]: [s_store_sk#56]
+Input [2]: [s_store_sk#56, s_state#57]
 
-(39) BroadcastExchange
-Input [1]: [s_store_sk#57]
+(36) BroadcastExchange
+Input [1]: [s_store_sk#56]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=5]
 
-(40) BroadcastHashJoin [codegen id : 11]
+(37) BroadcastHashJoin [codegen id : 11]
 Left keys [1]: [ss_store_sk#50]
-Right keys [1]: [s_store_sk#57]
+Right keys [1]: [s_store_sk#56]
+Join type: Inner
+Join condition: None
+
+(38) Project [codegen id : 11]
+Output [7]: [ss_item_sk#48, ss_cdemo_sk#49, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55]
+Input [9]: [ss_item_sk#48, ss_cdemo_sk#49, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55, s_store_sk#56]
+
+(39) ReusedExchange [Reuses operator id: 78]
+Output [1]: [d_date_sk#58]
+
+(40) BroadcastHashJoin [codegen id : 11]
+Left keys [1]: [ss_sold_date_sk#55]
+Right keys [1]: [d_date_sk#58]
 Join type: Inner
 Join condition: None
 
 (41) Project [codegen id : 11]
-Output [6]: [ss_item_sk#48, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55]
-Input [8]: [ss_item_sk#48, ss_store_sk#50, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55, s_store_sk#57]
+Output [6]: [ss_item_sk#48, ss_cdemo_sk#49, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54]
+Input [8]: [ss_item_sk#48, ss_cdemo_sk#49, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55, d_date_sk#58]
 
-(42) ReusedExchange [Reuses operator id: 78]
-Output [1]: [d_date_sk#59]
+(42) ReusedExchange [Reuses operator id: 11]
+Output [1]: [cd_demo_sk#59]
 
 (43) BroadcastHashJoin [codegen id : 11]
-Left keys [1]: [ss_sold_date_sk#55]
-Right keys [1]: [d_date_sk#59]
+Left keys [1]: [ss_cdemo_sk#49]
+Right keys [1]: [cd_demo_sk#59]
 Join type: Inner
 Join condition: None
 
 (44) Project [codegen id : 11]
 Output [5]: [ss_item_sk#48, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54]
-Input [7]: [ss_item_sk#48, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, ss_sold_date_sk#55, d_date_sk#59]
+Input [7]: [ss_item_sk#48, ss_cdemo_sk#49, ss_quantity#51, ss_list_price#52, ss_sales_price#53, ss_coupon_amt#54, cd_demo_sk#59]
 
 (45) ReusedExchange [Reuses operator id: 23]
 Output [2]: [i_item_sk#60, i_item_id#61]
@@ -327,44 +327,44 @@ Input [8]: [ss_item_sk#92, ss_cdemo_sk#93, ss_store_sk#94, ss_quantity#95, ss_li
 Input [8]: [ss_item_sk#92, ss_cdemo_sk#93, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99]
 Condition : ((isnotnull(ss_cdemo_sk#93) AND isnotnull(ss_store_sk#94)) AND isnotnull(ss_item_sk#92))
 
-(54) ReusedExchange [Reuses operator id: 8]
-Output [1]: [cd_demo_sk#100]
+(54) ReusedExchange [Reuses operator id: 36]
+Output [1]: [s_store_sk#100]
 
 (55) BroadcastHashJoin [codegen id : 17]
-Left keys [1]: [ss_cdemo_sk#93]
-Right keys [1]: [cd_demo_sk#100]
+Left keys [1]: [ss_store_sk#94]
+Right keys [1]: [s_store_sk#100]
 Join type: Inner
 Join condition: None
 
 (56) Project [codegen id : 17]
-Output [7]: [ss_item_sk#92, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99]
-Input [9]: [ss_item_sk#92, ss_cdemo_sk#93, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99, cd_demo_sk#100]
+Output [7]: [ss_item_sk#92, ss_cdemo_sk#93, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99]
+Input [9]: [ss_item_sk#92, ss_cdemo_sk#93, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99, s_store_sk#100]
 
-(57) ReusedExchange [Reuses operator id: 39]
-Output [1]: [s_store_sk#101]
+(57) ReusedExchange [Reuses operator id: 78]
+Output [1]: [d_date_sk#101]
 
 (58) BroadcastHashJoin [codegen id : 17]
-Left keys [1]: [ss_store_sk#94]
-Right keys [1]: [s_store_sk#101]
+Left keys [1]: [ss_sold_date_sk#99]
+Right keys [1]: [d_date_sk#101]
 Join type: Inner
 Join condition: None
 
 (59) Project [codegen id : 17]
-Output [6]: [ss_item_sk#92, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99]
-Input [8]: [ss_item_sk#92, ss_store_sk#94, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99, s_store_sk#101]
+Output [6]: [ss_item_sk#92, ss_cdemo_sk#93, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98]
+Input [8]: [ss_item_sk#92, ss_cdemo_sk#93, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99, d_date_sk#101]
 
-(60) ReusedExchange [Reuses operator id: 78]
-Output [1]: [d_date_sk#102]
+(60) ReusedExchange [Reuses operator id: 11]
+Output [1]: [cd_demo_sk#102]
 
 (61) BroadcastHashJoin [codegen id : 17]
-Left keys [1]: [ss_sold_date_sk#99]
-Right keys [1]: [d_date_sk#102]
+Left keys [1]: [ss_cdemo_sk#93]
+Right keys [1]: [cd_demo_sk#102]
 Join type: Inner
 Join condition: None
 
 (62) Project [codegen id : 17]
 Output [5]: [ss_item_sk#92, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98]
-Input [7]: [ss_item_sk#92, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, ss_sold_date_sk#99, d_date_sk#102]
+Input [7]: [ss_item_sk#92, ss_cdemo_sk#93, ss_quantity#95, ss_list_price#96, ss_sales_price#97, ss_coupon_amt#98, cd_demo_sk#102]
 
 (63) Scan parquet spark_catalog.default.item
 Output [1]: [i_item_sk#103]
@@ -429,25 +429,25 @@ BroadcastExchange (78)
 
 
 (74) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#14, d_year#135]
+Output [2]: [d_date_sk#10, d_year#135]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,1998), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (75) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#14, d_year#135]
+Input [2]: [d_date_sk#10, d_year#135]
 
 (76) Filter [codegen id : 1]
-Input [2]: [d_date_sk#14, d_year#135]
-Condition : ((isnotnull(d_year#135) AND (d_year#135 = 1998)) AND isnotnull(d_date_sk#14))
+Input [2]: [d_date_sk#10, d_year#135]
+Condition : ((isnotnull(d_year#135) AND (d_year#135 = 1998)) AND isnotnull(d_date_sk#10))
 
 (77) Project [codegen id : 1]
-Output [1]: [d_date_sk#14]
-Input [2]: [d_date_sk#14, d_year#135]
+Output [1]: [d_date_sk#10]
+Input [2]: [d_date_sk#10, d_year#135]
 
 (78) BroadcastExchange
-Input [1]: [d_date_sk#14]
+Input [1]: [d_date_sk#10]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
 Subquery:2 Hosting operator id = 29 Hosting Expression = ss_sold_date_sk#55 IN dynamicpruning#9

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q27a.sf100/simplified.txt
@@ -11,9 +11,9 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                     Project [ss_item_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt,s_state]
                       BroadcastHashJoin [ss_store_sk,s_store_sk]
                         Project [ss_item_sk,ss_store_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
-                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                            Project [ss_item_sk,ss_store_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt,ss_sold_date_sk]
-                              BroadcastHashJoin [ss_cdemo_sk,cd_demo_sk]
+                          BroadcastHashJoin [ss_cdemo_sk,cd_demo_sk]
+                            Project [ss_item_sk,ss_cdemo_sk,ss_store_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
+                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                 Filter [ss_cdemo_sk,ss_store_sk,ss_item_sk]
                                   ColumnarToRow
                                     InputAdapter
@@ -27,15 +27,15 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                                                     InputAdapter
                                                       Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                 InputAdapter
-                                  BroadcastExchange #3
-                                    WholeStageCodegen (1)
-                                      Project [cd_demo_sk]
-                                        Filter [cd_gender,cd_marital_status,cd_education_status,cd_demo_sk]
-                                          ColumnarToRow
-                                            InputAdapter
-                                              Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_education_status]
+                                  ReusedExchange [d_date_sk] #2
                             InputAdapter
-                              ReusedExchange [d_date_sk] #2
+                              BroadcastExchange #3
+                                WholeStageCodegen (2)
+                                  Project [cd_demo_sk]
+                                    Filter [cd_gender,cd_marital_status,cd_education_status,cd_demo_sk]
+                                      ColumnarToRow
+                                        InputAdapter
+                                          Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_gender,cd_marital_status,cd_education_status]
                         InputAdapter
                           BroadcastExchange #4
                             WholeStageCodegen (3)
@@ -59,28 +59,28 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                 Project [i_item_id,ss_quantity,ss_list_price,ss_coupon_amt,ss_sales_price]
                   BroadcastHashJoin [ss_item_sk,i_item_sk]
                     Project [ss_item_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
-                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                        Project [ss_item_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt,ss_sold_date_sk]
-                          BroadcastHashJoin [ss_store_sk,s_store_sk]
-                            Project [ss_item_sk,ss_store_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt,ss_sold_date_sk]
-                              BroadcastHashJoin [ss_cdemo_sk,cd_demo_sk]
+                      BroadcastHashJoin [ss_cdemo_sk,cd_demo_sk]
+                        Project [ss_item_sk,ss_cdemo_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
+                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                            Project [ss_item_sk,ss_cdemo_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt,ss_sold_date_sk]
+                              BroadcastHashJoin [ss_store_sk,s_store_sk]
                                 Filter [ss_cdemo_sk,ss_store_sk,ss_item_sk]
                                   ColumnarToRow
                                     InputAdapter
                                       Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_cdemo_sk,ss_store_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt,ss_sold_date_sk]
                                         ReusedSubquery [d_date_sk] #1
                                 InputAdapter
-                                  ReusedExchange [cd_demo_sk] #3
+                                  BroadcastExchange #7
+                                    WholeStageCodegen (7)
+                                      Project [s_store_sk]
+                                        Filter [s_state,s_store_sk]
+                                          ColumnarToRow
+                                            InputAdapter
+                                              Scan parquet spark_catalog.default.store [s_store_sk,s_state]
                             InputAdapter
-                              BroadcastExchange #7
-                                WholeStageCodegen (8)
-                                  Project [s_store_sk]
-                                    Filter [s_state,s_store_sk]
-                                      ColumnarToRow
-                                        InputAdapter
-                                          Scan parquet spark_catalog.default.store [s_store_sk,s_state]
+                              ReusedExchange [d_date_sk] #2
                         InputAdapter
-                          ReusedExchange [d_date_sk] #2
+                          ReusedExchange [cd_demo_sk] #3
                     InputAdapter
                       ReusedExchange [i_item_sk,i_item_id] #5
     WholeStageCodegen (18)
@@ -92,22 +92,22 @@ TakeOrderedAndProject [i_item_id,s_state,g_state,agg1,agg2,agg3,agg4]
                 Project [ss_quantity,ss_list_price,ss_coupon_amt,ss_sales_price]
                   BroadcastHashJoin [ss_item_sk,i_item_sk]
                     Project [ss_item_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
-                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                        Project [ss_item_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt,ss_sold_date_sk]
-                          BroadcastHashJoin [ss_store_sk,s_store_sk]
-                            Project [ss_item_sk,ss_store_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt,ss_sold_date_sk]
-                              BroadcastHashJoin [ss_cdemo_sk,cd_demo_sk]
+                      BroadcastHashJoin [ss_cdemo_sk,cd_demo_sk]
+                        Project [ss_item_sk,ss_cdemo_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt]
+                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                            Project [ss_item_sk,ss_cdemo_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt,ss_sold_date_sk]
+                              BroadcastHashJoin [ss_store_sk,s_store_sk]
                                 Filter [ss_cdemo_sk,ss_store_sk,ss_item_sk]
                                   ColumnarToRow
                                     InputAdapter
                                       Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_cdemo_sk,ss_store_sk,ss_quantity,ss_list_price,ss_sales_price,ss_coupon_amt,ss_sold_date_sk]
                                         ReusedSubquery [d_date_sk] #1
                                 InputAdapter
-                                  ReusedExchange [cd_demo_sk] #3
+                                  ReusedExchange [s_store_sk] #7
                             InputAdapter
-                              ReusedExchange [s_store_sk] #7
+                              ReusedExchange [d_date_sk] #2
                         InputAdapter
-                          ReusedExchange [d_date_sk] #2
+                          ReusedExchange [cd_demo_sk] #3
                     InputAdapter
                       BroadcastExchange #9
                         WholeStageCodegen (16)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q34.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q34.sf100/explain.txt
@@ -13,17 +13,17 @@
          :                    +- * BroadcastHashJoin Inner BuildRight (19)
          :                       :- * Project (13)
          :                       :  +- * BroadcastHashJoin Inner BuildRight (12)
-         :                       :     :- * Project (6)
-         :                       :     :  +- * BroadcastHashJoin Inner BuildRight (5)
+         :                       :     :- * Project (10)
+         :                       :     :  +- * BroadcastHashJoin Inner BuildRight (9)
          :                       :     :     :- * Filter (3)
          :                       :     :     :  +- * ColumnarToRow (2)
          :                       :     :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-         :                       :     :     +- ReusedExchange (4)
-         :                       :     +- BroadcastExchange (11)
-         :                       :        +- * Project (10)
-         :                       :           +- * Filter (9)
-         :                       :              +- * ColumnarToRow (8)
-         :                       :                 +- Scan parquet spark_catalog.default.store (7)
+         :                       :     :     +- BroadcastExchange (8)
+         :                       :     :        +- * Project (7)
+         :                       :     :           +- * Filter (6)
+         :                       :     :              +- * ColumnarToRow (5)
+         :                       :     :                 +- Scan parquet spark_catalog.default.store (4)
+         :                       :     +- ReusedExchange (11)
          :                       +- BroadcastExchange (18)
          :                          +- * Project (17)
          :                             +- * Filter (16)
@@ -51,50 +51,50 @@ Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, 
 Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5]
 Condition : ((isnotnull(ss_store_sk#3) AND isnotnull(ss_hdemo_sk#2)) AND isnotnull(ss_customer_sk#1))
 
-(4) ReusedExchange [Reuses operator id: 40]
-Output [1]: [d_date_sk#7]
-
-(5) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#5]
-Right keys [1]: [d_date_sk#7]
-Join type: Inner
-Join condition: None
-
-(6) Project [codegen id : 4]
-Output [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4]
-Input [6]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5, d_date_sk#7]
-
-(7) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#8, s_county#9]
+(4) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#7, s_county#8]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_county), EqualTo(s_county,Williamson County), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_county:string>
 
-(8) ColumnarToRow [codegen id : 2]
-Input [2]: [s_store_sk#8, s_county#9]
+(5) ColumnarToRow [codegen id : 1]
+Input [2]: [s_store_sk#7, s_county#8]
 
-(9) Filter [codegen id : 2]
-Input [2]: [s_store_sk#8, s_county#9]
-Condition : ((isnotnull(s_county#9) AND (s_county#9 = Williamson County)) AND isnotnull(s_store_sk#8))
+(6) Filter [codegen id : 1]
+Input [2]: [s_store_sk#7, s_county#8]
+Condition : ((isnotnull(s_county#8) AND (s_county#8 = Williamson County)) AND isnotnull(s_store_sk#7))
 
-(10) Project [codegen id : 2]
-Output [1]: [s_store_sk#8]
-Input [2]: [s_store_sk#8, s_county#9]
+(7) Project [codegen id : 1]
+Output [1]: [s_store_sk#7]
+Input [2]: [s_store_sk#7, s_county#8]
 
-(11) BroadcastExchange
-Input [1]: [s_store_sk#8]
+(8) BroadcastExchange
+Input [1]: [s_store_sk#7]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(12) BroadcastHashJoin [codegen id : 4]
+(9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#3]
-Right keys [1]: [s_store_sk#8]
+Right keys [1]: [s_store_sk#7]
+Join type: Inner
+Join condition: None
+
+(10) Project [codegen id : 4]
+Output [4]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4, ss_sold_date_sk#5]
+Input [6]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, ss_sold_date_sk#5, s_store_sk#7]
+
+(11) ReusedExchange [Reuses operator id: 40]
+Output [1]: [d_date_sk#9]
+
+(12) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_sold_date_sk#5]
+Right keys [1]: [d_date_sk#9]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
 Output [3]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4]
-Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_store_sk#3, ss_ticket_number#4, s_store_sk#8]
+Input [5]: [ss_customer_sk#1, ss_hdemo_sk#2, ss_ticket_number#4, ss_sold_date_sk#5, d_date_sk#9]
 
 (14) Scan parquet spark_catalog.default.household_demographics
 Output [4]: [hd_demo_sk#10, hd_buy_potential#11, hd_dep_count#12, hd_vehicle_count#13]
@@ -209,25 +209,25 @@ BroadcastExchange (40)
 
 
 (36) Scan parquet spark_catalog.default.date_dim
-Output [3]: [d_date_sk#7, d_year#23, d_dom#24]
+Output [3]: [d_date_sk#9, d_year#23, d_dom#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [Or(And(GreaterThanOrEqual(d_dom,1),LessThanOrEqual(d_dom,3)),And(GreaterThanOrEqual(d_dom,25),LessThanOrEqual(d_dom,28))), In(d_year, [1999,2000,2001]), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int,d_dom:int>
 
 (37) ColumnarToRow [codegen id : 1]
-Input [3]: [d_date_sk#7, d_year#23, d_dom#24]
+Input [3]: [d_date_sk#9, d_year#23, d_dom#24]
 
 (38) Filter [codegen id : 1]
-Input [3]: [d_date_sk#7, d_year#23, d_dom#24]
-Condition : (((((d_dom#24 >= 1) AND (d_dom#24 <= 3)) OR ((d_dom#24 >= 25) AND (d_dom#24 <= 28))) AND d_year#23 IN (1999,2000,2001)) AND isnotnull(d_date_sk#7))
+Input [3]: [d_date_sk#9, d_year#23, d_dom#24]
+Condition : (((((d_dom#24 >= 1) AND (d_dom#24 <= 3)) OR ((d_dom#24 >= 25) AND (d_dom#24 <= 28))) AND d_year#23 IN (1999,2000,2001)) AND isnotnull(d_date_sk#9))
 
 (39) Project [codegen id : 1]
-Output [1]: [d_date_sk#7]
-Input [3]: [d_date_sk#7, d_year#23, d_dom#24]
+Output [1]: [d_date_sk#9]
+Input [3]: [d_date_sk#9, d_year#23, d_dom#24]
 
 (40) BroadcastExchange
-Input [1]: [d_date_sk#7]
+Input [1]: [d_date_sk#9]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=7]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q34.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q34.sf100/simplified.txt
@@ -20,9 +20,9 @@ WholeStageCodegen (10)
                                       Project [ss_customer_sk,ss_ticket_number]
                                         BroadcastHashJoin [ss_hdemo_sk,hd_demo_sk]
                                           Project [ss_customer_sk,ss_hdemo_sk,ss_ticket_number]
-                                            BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                              Project [ss_customer_sk,ss_hdemo_sk,ss_store_sk,ss_ticket_number]
-                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                            BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                              Project [ss_customer_sk,ss_hdemo_sk,ss_ticket_number,ss_sold_date_sk]
+                                                BroadcastHashJoin [ss_store_sk,s_store_sk]
                                                   Filter [ss_store_sk,ss_hdemo_sk,ss_customer_sk]
                                                     ColumnarToRow
                                                       InputAdapter
@@ -36,15 +36,15 @@ WholeStageCodegen (10)
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_dom]
                                                   InputAdapter
-                                                    ReusedExchange [d_date_sk] #4
+                                                    BroadcastExchange #5
+                                                      WholeStageCodegen (1)
+                                                        Project [s_store_sk]
+                                                          Filter [s_county,s_store_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet spark_catalog.default.store [s_store_sk,s_county]
                                               InputAdapter
-                                                BroadcastExchange #5
-                                                  WholeStageCodegen (2)
-                                                    Project [s_store_sk]
-                                                      Filter [s_county,s_store_sk]
-                                                        ColumnarToRow
-                                                          InputAdapter
-                                                            Scan parquet spark_catalog.default.store [s_store_sk,s_county]
+                                                ReusedExchange [d_date_sk] #4
                                           InputAdapter
                                             BroadcastExchange #6
                                               WholeStageCodegen (3)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a.sf100/explain.txt
@@ -15,17 +15,17 @@ TakeOrderedAndProject (41)
                         :           +- * BroadcastHashJoin Inner BuildRight (18)
                         :              :- * Project (13)
                         :              :  +- * BroadcastHashJoin Inner BuildRight (12)
-                        :              :     :- * Project (6)
-                        :              :     :  +- * BroadcastHashJoin Inner BuildRight (5)
+                        :              :     :- * Project (10)
+                        :              :     :  +- * BroadcastHashJoin Inner BuildRight (9)
                         :              :     :     :- * Filter (3)
                         :              :     :     :  +- * ColumnarToRow (2)
                         :              :     :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-                        :              :     :     +- ReusedExchange (4)
-                        :              :     +- BroadcastExchange (11)
-                        :              :        +- * Project (10)
-                        :              :           +- * Filter (9)
-                        :              :              +- * ColumnarToRow (8)
-                        :              :                 +- Scan parquet spark_catalog.default.store (7)
+                        :              :     :     +- BroadcastExchange (8)
+                        :              :     :        +- * Project (7)
+                        :              :     :           +- * Filter (6)
+                        :              :     :              +- * ColumnarToRow (5)
+                        :              :     :                 +- Scan parquet spark_catalog.default.store (4)
+                        :              :     +- ReusedExchange (11)
                         :              +- BroadcastExchange (17)
                         :                 +- * Filter (16)
                         :                    +- * ColumnarToRow (15)
@@ -57,50 +57,50 @@ Input [5]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, ss_net_profit#4, 
 Input [5]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, ss_net_profit#4, ss_sold_date_sk#5]
 Condition : (isnotnull(ss_item_sk#1) AND isnotnull(ss_store_sk#2))
 
-(4) ReusedExchange [Reuses operator id: 46]
-Output [1]: [d_date_sk#7]
-
-(5) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [ss_sold_date_sk#5]
-Right keys [1]: [d_date_sk#7]
-Join type: Inner
-Join condition: None
-
-(6) Project [codegen id : 4]
-Output [4]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, ss_net_profit#4]
-Input [6]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, ss_net_profit#4, ss_sold_date_sk#5, d_date_sk#7]
-
-(7) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#8, s_state#9]
+(4) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#7, s_state#8]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_state), EqualTo(s_state,TN), IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_state:string>
 
-(8) ColumnarToRow [codegen id : 2]
-Input [2]: [s_store_sk#8, s_state#9]
+(5) ColumnarToRow [codegen id : 1]
+Input [2]: [s_store_sk#7, s_state#8]
 
-(9) Filter [codegen id : 2]
-Input [2]: [s_store_sk#8, s_state#9]
-Condition : ((isnotnull(s_state#9) AND (s_state#9 = TN)) AND isnotnull(s_store_sk#8))
+(6) Filter [codegen id : 1]
+Input [2]: [s_store_sk#7, s_state#8]
+Condition : ((isnotnull(s_state#8) AND (s_state#8 = TN)) AND isnotnull(s_store_sk#7))
 
-(10) Project [codegen id : 2]
-Output [1]: [s_store_sk#8]
-Input [2]: [s_store_sk#8, s_state#9]
+(7) Project [codegen id : 1]
+Output [1]: [s_store_sk#7]
+Input [2]: [s_store_sk#7, s_state#8]
 
-(11) BroadcastExchange
-Input [1]: [s_store_sk#8]
+(8) BroadcastExchange
+Input [1]: [s_store_sk#7]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(12) BroadcastHashJoin [codegen id : 4]
+(9) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [ss_store_sk#2]
-Right keys [1]: [s_store_sk#8]
+Right keys [1]: [s_store_sk#7]
+Join type: Inner
+Join condition: None
+
+(10) Project [codegen id : 4]
+Output [4]: [ss_item_sk#1, ss_ext_sales_price#3, ss_net_profit#4, ss_sold_date_sk#5]
+Input [6]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, ss_net_profit#4, ss_sold_date_sk#5, s_store_sk#7]
+
+(11) ReusedExchange [Reuses operator id: 46]
+Output [1]: [d_date_sk#9]
+
+(12) BroadcastHashJoin [codegen id : 4]
+Left keys [1]: [ss_sold_date_sk#5]
+Right keys [1]: [d_date_sk#9]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 4]
 Output [3]: [ss_item_sk#1, ss_ext_sales_price#3, ss_net_profit#4]
-Input [5]: [ss_item_sk#1, ss_store_sk#2, ss_ext_sales_price#3, ss_net_profit#4, s_store_sk#8]
+Input [5]: [ss_item_sk#1, ss_ext_sales_price#3, ss_net_profit#4, ss_sold_date_sk#5, d_date_sk#9]
 
 (14) Scan parquet spark_catalog.default.item
 Output [3]: [i_item_sk#10, i_class#11, i_category#12]
@@ -255,25 +255,25 @@ BroadcastExchange (46)
 
 
 (42) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#7, d_year#74]
+Output [2]: [d_date_sk#9, d_year#74]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (43) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#7, d_year#74]
+Input [2]: [d_date_sk#9, d_year#74]
 
 (44) Filter [codegen id : 1]
-Input [2]: [d_date_sk#7, d_year#74]
-Condition : ((isnotnull(d_year#74) AND (d_year#74 = 2001)) AND isnotnull(d_date_sk#7))
+Input [2]: [d_date_sk#9, d_year#74]
+Condition : ((isnotnull(d_year#74) AND (d_year#74 = 2001)) AND isnotnull(d_date_sk#9))
 
 (45) Project [codegen id : 1]
-Output [1]: [d_date_sk#7]
-Input [2]: [d_date_sk#7, d_year#74]
+Output [1]: [d_date_sk#9]
+Input [2]: [d_date_sk#9, d_year#74]
 
 (46) BroadcastExchange
-Input [1]: [d_date_sk#7]
+Input [1]: [d_date_sk#9]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=8]
 
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q36a.sf100/simplified.txt
@@ -24,9 +24,9 @@ TakeOrderedAndProject [lochierarchy,i_category,rank_within_parent,gross_margin,i
                                               Project [ss_ext_sales_price,ss_net_profit,i_class,i_category]
                                                 BroadcastHashJoin [ss_item_sk,i_item_sk]
                                                   Project [ss_item_sk,ss_ext_sales_price,ss_net_profit]
-                                                    BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                      Project [ss_item_sk,ss_store_sk,ss_ext_sales_price,ss_net_profit]
-                                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                      Project [ss_item_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk]
+                                                        BroadcastHashJoin [ss_store_sk,s_store_sk]
                                                           Filter [ss_item_sk,ss_store_sk]
                                                             ColumnarToRow
                                                               InputAdapter
@@ -40,15 +40,15 @@ TakeOrderedAndProject [lochierarchy,i_category,rank_within_parent,gross_margin,i
                                                                               InputAdapter
                                                                                 Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                                           InputAdapter
-                                                            ReusedExchange [d_date_sk] #4
+                                                            BroadcastExchange #5
+                                                              WholeStageCodegen (1)
+                                                                Project [s_store_sk]
+                                                                  Filter [s_state,s_store_sk]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet spark_catalog.default.store [s_store_sk,s_state]
                                                       InputAdapter
-                                                        BroadcastExchange #5
-                                                          WholeStageCodegen (2)
-                                                            Project [s_store_sk]
-                                                              Filter [s_state,s_store_sk]
-                                                                ColumnarToRow
-                                                                  InputAdapter
-                                                                    Scan parquet spark_catalog.default.store [s_store_sk,s_state]
+                                                        ReusedExchange [d_date_sk] #4
                                                   InputAdapter
                                                     BroadcastExchange #6
                                                       WholeStageCodegen (3)

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47.sf100/explain.txt
@@ -17,26 +17,26 @@ TakeOrderedAndProject (52)
       :     :                             +- Exchange (23)
       :     :                                +- * HashAggregate (22)
       :     :                                   +- * Project (21)
-      :     :                                      +- * SortMergeJoin Inner (20)
-      :     :                                         :- * Sort (14)
-      :     :                                         :  +- Exchange (13)
-      :     :                                         :     +- * Project (12)
-      :     :                                         :        +- * BroadcastHashJoin Inner BuildRight (11)
-      :     :                                         :           :- * Project (6)
-      :     :                                         :           :  +- * BroadcastHashJoin Inner BuildRight (5)
-      :     :                                         :           :     :- * Filter (3)
-      :     :                                         :           :     :  +- * ColumnarToRow (2)
-      :     :                                         :           :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-      :     :                                         :           :     +- ReusedExchange (4)
-      :     :                                         :           +- BroadcastExchange (10)
-      :     :                                         :              +- * Filter (9)
-      :     :                                         :                 +- * ColumnarToRow (8)
-      :     :                                         :                    +- Scan parquet spark_catalog.default.store (7)
-      :     :                                         +- * Sort (19)
-      :     :                                            +- Exchange (18)
-      :     :                                               +- * Filter (17)
-      :     :                                                  +- * ColumnarToRow (16)
-      :     :                                                     +- Scan parquet spark_catalog.default.item (15)
+      :     :                                      +- * BroadcastHashJoin Inner BuildRight (20)
+      :     :                                         :- * Project (15)
+      :     :                                         :  +- * SortMergeJoin Inner (14)
+      :     :                                         :     :- * Sort (8)
+      :     :                                         :     :  +- Exchange (7)
+      :     :                                         :     :     +- * Project (6)
+      :     :                                         :     :        +- * BroadcastHashJoin Inner BuildRight (5)
+      :     :                                         :     :           :- * Filter (3)
+      :     :                                         :     :           :  +- * ColumnarToRow (2)
+      :     :                                         :     :           :     +- Scan parquet spark_catalog.default.store_sales (1)
+      :     :                                         :     :           +- ReusedExchange (4)
+      :     :                                         :     +- * Sort (13)
+      :     :                                         :        +- Exchange (12)
+      :     :                                         :           +- * Filter (11)
+      :     :                                         :              +- * ColumnarToRow (10)
+      :     :                                         :                 +- Scan parquet spark_catalog.default.item (9)
+      :     :                                         +- BroadcastExchange (19)
+      :     :                                            +- * Filter (18)
+      :     :                                               +- * ColumnarToRow (17)
+      :     :                                                  +- Scan parquet spark_catalog.default.store (16)
       :     +- * Sort (41)
       :        +- Exchange (40)
       :           +- * Project (39)
@@ -61,147 +61,147 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#4), dynamicpruningexpression(ss_sol
 PushedFilters: [IsNotNull(ss_item_sk), IsNotNull(ss_store_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_store_sk:int,ss_sales_price:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 3]
+(2) ColumnarToRow [codegen id : 2]
 Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
 
-(3) Filter [codegen id : 3]
+(3) Filter [codegen id : 2]
 Input [4]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4]
 Condition : (isnotnull(ss_item_sk#1) AND isnotnull(ss_store_sk#2))
 
 (4) ReusedExchange [Reuses operator id: 56]
 Output [3]: [d_date_sk#6, d_year#7, d_moy#8]
 
-(5) BroadcastHashJoin [codegen id : 3]
+(5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#4]
 Right keys [1]: [d_date_sk#6]
 Join type: Inner
 Join condition: None
 
-(6) Project [codegen id : 3]
+(6) Project [codegen id : 2]
 Output [5]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_year#7, d_moy#8]
 Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, ss_sold_date_sk#4, d_date_sk#6, d_year#7, d_moy#8]
 
-(7) Scan parquet spark_catalog.default.store
-Output [3]: [s_store_sk#9, s_store_name#10, s_company_name#11]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_store_name), IsNotNull(s_company_name)]
-ReadSchema: struct<s_store_sk:int,s_store_name:string,s_company_name:string>
+(7) Exchange
+Input [5]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_year#7, d_moy#8]
+Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 
-(8) ColumnarToRow [codegen id : 2]
-Input [3]: [s_store_sk#9, s_store_name#10, s_company_name#11]
-
-(9) Filter [codegen id : 2]
-Input [3]: [s_store_sk#9, s_store_name#10, s_company_name#11]
-Condition : ((isnotnull(s_store_sk#9) AND isnotnull(s_store_name#10)) AND isnotnull(s_company_name#11))
-
-(10) BroadcastExchange
-Input [3]: [s_store_sk#9, s_store_name#10, s_company_name#11]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
-
-(11) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_store_sk#2]
-Right keys [1]: [s_store_sk#9]
-Join type: Inner
-Join condition: None
-
-(12) Project [codegen id : 3]
-Output [6]: [ss_item_sk#1, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11]
-Input [8]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_year#7, d_moy#8, s_store_sk#9, s_store_name#10, s_company_name#11]
-
-(13) Exchange
-Input [6]: [ss_item_sk#1, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11]
-Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
-
-(14) Sort [codegen id : 4]
-Input [6]: [ss_item_sk#1, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11]
+(8) Sort [codegen id : 3]
+Input [5]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_year#7, d_moy#8]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(15) Scan parquet spark_catalog.default.item
-Output [3]: [i_item_sk#12, i_brand#13, i_category#14]
+(9) Scan parquet spark_catalog.default.item
+Output [3]: [i_item_sk#9, i_brand#10, i_category#11]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk), IsNotNull(i_category), IsNotNull(i_brand)]
 ReadSchema: struct<i_item_sk:int,i_brand:string,i_category:string>
 
-(16) ColumnarToRow [codegen id : 5]
-Input [3]: [i_item_sk#12, i_brand#13, i_category#14]
+(10) ColumnarToRow [codegen id : 4]
+Input [3]: [i_item_sk#9, i_brand#10, i_category#11]
 
-(17) Filter [codegen id : 5]
-Input [3]: [i_item_sk#12, i_brand#13, i_category#14]
-Condition : ((isnotnull(i_item_sk#12) AND isnotnull(i_category#14)) AND isnotnull(i_brand#13))
+(11) Filter [codegen id : 4]
+Input [3]: [i_item_sk#9, i_brand#10, i_category#11]
+Condition : ((isnotnull(i_item_sk#9) AND isnotnull(i_category#11)) AND isnotnull(i_brand#10))
 
-(18) Exchange
-Input [3]: [i_item_sk#12, i_brand#13, i_category#14]
-Arguments: hashpartitioning(i_item_sk#12, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+(12) Exchange
+Input [3]: [i_item_sk#9, i_brand#10, i_category#11]
+Arguments: hashpartitioning(i_item_sk#9, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(19) Sort [codegen id : 6]
-Input [3]: [i_item_sk#12, i_brand#13, i_category#14]
-Arguments: [i_item_sk#12 ASC NULLS FIRST], false, 0
+(13) Sort [codegen id : 5]
+Input [3]: [i_item_sk#9, i_brand#10, i_category#11]
+Arguments: [i_item_sk#9 ASC NULLS FIRST], false, 0
 
-(20) SortMergeJoin [codegen id : 7]
+(14) SortMergeJoin [codegen id : 7]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#12]
+Right keys [1]: [i_item_sk#9]
+Join type: Inner
+Join condition: None
+
+(15) Project [codegen id : 7]
+Output [6]: [ss_store_sk#2, ss_sales_price#3, d_year#7, d_moy#8, i_brand#10, i_category#11]
+Input [8]: [ss_item_sk#1, ss_store_sk#2, ss_sales_price#3, d_year#7, d_moy#8, i_item_sk#9, i_brand#10, i_category#11]
+
+(16) Scan parquet spark_catalog.default.store
+Output [3]: [s_store_sk#12, s_store_name#13, s_company_name#14]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [IsNotNull(s_store_sk), IsNotNull(s_store_name), IsNotNull(s_company_name)]
+ReadSchema: struct<s_store_sk:int,s_store_name:string,s_company_name:string>
+
+(17) ColumnarToRow [codegen id : 6]
+Input [3]: [s_store_sk#12, s_store_name#13, s_company_name#14]
+
+(18) Filter [codegen id : 6]
+Input [3]: [s_store_sk#12, s_store_name#13, s_company_name#14]
+Condition : ((isnotnull(s_store_sk#12) AND isnotnull(s_store_name#13)) AND isnotnull(s_company_name#14))
+
+(19) BroadcastExchange
+Input [3]: [s_store_sk#12, s_store_name#13, s_company_name#14]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
+
+(20) BroadcastHashJoin [codegen id : 7]
+Left keys [1]: [ss_store_sk#2]
+Right keys [1]: [s_store_sk#12]
 Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 7]
-Output [7]: [i_brand#13, i_category#14, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11]
-Input [9]: [ss_item_sk#1, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11, i_item_sk#12, i_brand#13, i_category#14]
+Output [7]: [i_brand#10, i_category#11, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#13, s_company_name#14]
+Input [9]: [ss_store_sk#2, ss_sales_price#3, d_year#7, d_moy#8, i_brand#10, i_category#11, s_store_sk#12, s_store_name#13, s_company_name#14]
 
 (22) HashAggregate [codegen id : 7]
-Input [7]: [i_brand#13, i_category#14, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#10, s_company_name#11]
-Keys [6]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8]
+Input [7]: [i_brand#10, i_category#11, ss_sales_price#3, d_year#7, d_moy#8, s_store_name#13, s_company_name#14]
+Keys [6]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8]
 Functions [1]: [partial_sum(UnscaledValue(ss_sales_price#3))]
 Aggregate Attributes [1]: [sum#15]
-Results [7]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum#16]
+Results [7]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum#16]
 
 (23) Exchange
-Input [7]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum#16]
-Arguments: hashpartitioning(i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [7]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum#16]
+Arguments: hashpartitioning(i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (24) HashAggregate [codegen id : 8]
-Input [7]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum#16]
-Keys [6]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8]
+Input [7]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum#16]
+Keys [6]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8]
 Functions [1]: [sum(UnscaledValue(ss_sales_price#3))]
 Aggregate Attributes [1]: [sum(UnscaledValue(ss_sales_price#3))#17]
-Results [8]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#17,17,2) AS sum_sales#18, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#17,17,2) AS _w0#19]
+Results [8]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#17,17,2) AS sum_sales#18, MakeDecimal(sum(UnscaledValue(ss_sales_price#3))#17,17,2) AS _w0#19]
 
 (25) Exchange
-Input [8]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19]
-Arguments: hashpartitioning(i_category#14, i_brand#13, s_store_name#10, s_company_name#11, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+Input [8]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, _w0#19]
+Arguments: hashpartitioning(i_category#11, i_brand#10, s_store_name#13, s_company_name#14, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
 (26) Sort [codegen id : 9]
-Input [8]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19]
-Arguments: [i_category#14 ASC NULLS FIRST, i_brand#13 ASC NULLS FIRST, s_store_name#10 ASC NULLS FIRST, s_company_name#11 ASC NULLS FIRST, d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST], false, 0
+Input [8]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, _w0#19]
+Arguments: [i_category#11 ASC NULLS FIRST, i_brand#10 ASC NULLS FIRST, s_store_name#13 ASC NULLS FIRST, s_company_name#14 ASC NULLS FIRST, d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST], false, 0
 
 (27) Window
-Input [8]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19]
-Arguments: [rank(d_year#7, d_moy#8) windowspecdefinition(i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#20], [i_category#14, i_brand#13, s_store_name#10, s_company_name#11], [d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST]
+Input [8]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, _w0#19]
+Arguments: [rank(d_year#7, d_moy#8) windowspecdefinition(i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST, specifiedwindowframe(RowFrame, unboundedpreceding$(), currentrow$())) AS rn#20], [i_category#11, i_brand#10, s_store_name#13, s_company_name#14], [d_year#7 ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST]
 
 (28) Filter [codegen id : 10]
-Input [9]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20]
+Input [9]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20]
 Condition : (isnotnull(d_year#7) AND (d_year#7 = 1999))
 
 (29) Window
-Input [9]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20]
-Arguments: [avg(_w0#19) windowspecdefinition(i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_monthly_sales#21], [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7]
+Input [9]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20]
+Arguments: [avg(_w0#19) windowspecdefinition(i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, specifiedwindowframe(RowFrame, unboundedpreceding$(), unboundedfollowing$())) AS avg_monthly_sales#21], [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7]
 
 (30) Filter [codegen id : 11]
-Input [10]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20, avg_monthly_sales#21]
+Input [10]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20, avg_monthly_sales#21]
 Condition : ((isnotnull(avg_monthly_sales#21) AND (avg_monthly_sales#21 > 0.000000)) AND CASE WHEN (avg_monthly_sales#21 > 0.000000) THEN ((abs((sum_sales#18 - avg_monthly_sales#21)) / avg_monthly_sales#21) > 0.1000000000000000) END)
 
 (31) Project [codegen id : 11]
-Output [9]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20]
-Input [10]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20, avg_monthly_sales#21]
+Output [9]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20]
+Input [10]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, _w0#19, rn#20, avg_monthly_sales#21]
 
 (32) Exchange
-Input [9]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20]
-Arguments: hashpartitioning(i_category#14, i_brand#13, s_store_name#10, s_company_name#11, rn#20, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [9]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20]
+Arguments: hashpartitioning(i_category#11, i_brand#10, s_store_name#13, s_company_name#14, rn#20, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (33) Sort [codegen id : 12]
-Input [9]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20]
-Arguments: [i_category#14 ASC NULLS FIRST, i_brand#13 ASC NULLS FIRST, s_store_name#10 ASC NULLS FIRST, s_company_name#11 ASC NULLS FIRST, rn#20 ASC NULLS FIRST], false, 0
+Input [9]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20]
+Arguments: [i_category#11 ASC NULLS FIRST, i_brand#10 ASC NULLS FIRST, s_store_name#13 ASC NULLS FIRST, s_company_name#14 ASC NULLS FIRST, rn#20 ASC NULLS FIRST], false, 0
 
 (34) ReusedExchange [Reuses operator id: 23]
 Output [7]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, d_year#26, d_moy#27, sum#28]
@@ -238,14 +238,14 @@ Input [6]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, sum_s
 Arguments: [i_category#22 ASC NULLS FIRST, i_brand#23 ASC NULLS FIRST, s_store_name#24 ASC NULLS FIRST, s_company_name#25 ASC NULLS FIRST, (rn#31 + 1) ASC NULLS FIRST], false, 0
 
 (42) SortMergeJoin [codegen id : 24]
-Left keys [5]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, rn#20]
+Left keys [5]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, rn#20]
 Right keys [5]: [i_category#22, i_brand#23, s_store_name#24, s_company_name#25, (rn#31 + 1)]
 Join type: Inner
 Join condition: None
 
 (43) Project [codegen id : 24]
-Output [10]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20, sum_sales#30]
-Input [15]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20, i_category#22, i_brand#23, s_store_name#24, s_company_name#25, sum_sales#30, rn#31]
+Output [10]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20, sum_sales#30]
+Input [15]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20, i_category#22, i_brand#23, s_store_name#24, s_company_name#25, sum_sales#30, rn#31]
 
 (44) ReusedExchange [Reuses operator id: 36]
 Output [7]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, d_year#36, d_moy#37, sum_sales#38]
@@ -271,18 +271,18 @@ Input [6]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, sum_s
 Arguments: [i_category#32 ASC NULLS FIRST, i_brand#33 ASC NULLS FIRST, s_store_name#34 ASC NULLS FIRST, s_company_name#35 ASC NULLS FIRST, (rn#39 - 1) ASC NULLS FIRST], false, 0
 
 (50) SortMergeJoin [codegen id : 36]
-Left keys [5]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, rn#20]
+Left keys [5]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, rn#20]
 Right keys [5]: [i_category#32, i_brand#33, s_store_name#34, s_company_name#35, (rn#39 - 1)]
 Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 36]
-Output [7]: [i_category#14, d_year#7, d_moy#8, avg_monthly_sales#21, sum_sales#18, sum_sales#30 AS psum#40, sum_sales#38 AS nsum#41]
-Input [16]: [i_category#14, i_brand#13, s_store_name#10, s_company_name#11, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20, sum_sales#30, i_category#32, i_brand#33, s_store_name#34, s_company_name#35, sum_sales#38, rn#39]
+Output [7]: [i_category#11, d_year#7, d_moy#8, avg_monthly_sales#21, sum_sales#18, sum_sales#30 AS psum#40, sum_sales#38 AS nsum#41]
+Input [16]: [i_category#11, i_brand#10, s_store_name#13, s_company_name#14, d_year#7, d_moy#8, sum_sales#18, avg_monthly_sales#21, rn#20, sum_sales#30, i_category#32, i_brand#33, s_store_name#34, s_company_name#35, sum_sales#38, rn#39]
 
 (52) TakeOrderedAndProject
-Input [7]: [i_category#14, d_year#7, d_moy#8, avg_monthly_sales#21, sum_sales#18, psum#40, nsum#41]
-Arguments: 100, [(sum_sales#18 - avg_monthly_sales#21) ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST], [i_category#14, d_year#7, d_moy#8, avg_monthly_sales#21, sum_sales#18, psum#40, nsum#41]
+Input [7]: [i_category#11, d_year#7, d_moy#8, avg_monthly_sales#21, sum_sales#18, psum#40, nsum#41]
+Arguments: 100, [(sum_sales#18 - avg_monthly_sales#21) ASC NULLS FIRST, d_moy#8 ASC NULLS FIRST], [i_category#11, d_year#7, d_moy#8, avg_monthly_sales#21, sum_sales#18, psum#40, nsum#41]
 
 ===== Subqueries =====
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q47.sf100/simplified.txt
@@ -31,15 +31,15 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,d_moy,i_category,d_year,psum,
                                                             WholeStageCodegen (7)
                                                               HashAggregate [i_category,i_brand,s_store_name,s_company_name,d_year,d_moy,ss_sales_price] [sum,sum]
                                                                 Project [i_brand,i_category,ss_sales_price,d_year,d_moy,s_store_name,s_company_name]
-                                                                  SortMergeJoin [ss_item_sk,i_item_sk]
-                                                                    InputAdapter
-                                                                      WholeStageCodegen (4)
-                                                                        Sort [ss_item_sk]
-                                                                          InputAdapter
-                                                                            Exchange [ss_item_sk] #4
-                                                                              WholeStageCodegen (3)
-                                                                                Project [ss_item_sk,ss_sales_price,d_year,d_moy,s_store_name,s_company_name]
-                                                                                  BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                                  BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                                                    Project [ss_store_sk,ss_sales_price,d_year,d_moy,i_brand,i_category]
+                                                                      SortMergeJoin [ss_item_sk,i_item_sk]
+                                                                        InputAdapter
+                                                                          WholeStageCodegen (3)
+                                                                            Sort [ss_item_sk]
+                                                                              InputAdapter
+                                                                                Exchange [ss_item_sk] #4
+                                                                                  WholeStageCodegen (2)
                                                                                     Project [ss_item_sk,ss_store_sk,ss_sales_price,d_year,d_moy]
                                                                                       BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                                         Filter [ss_item_sk,ss_store_sk]
@@ -55,23 +55,23 @@ TakeOrderedAndProject [sum_sales,avg_monthly_sales,d_moy,i_category,d_year,psum,
                                                                                                             Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year,d_moy]
                                                                                         InputAdapter
                                                                                           ReusedExchange [d_date_sk,d_year,d_moy] #5
-                                                                                    InputAdapter
-                                                                                      BroadcastExchange #6
-                                                                                        WholeStageCodegen (2)
-                                                                                          Filter [s_store_sk,s_store_name,s_company_name]
-                                                                                            ColumnarToRow
-                                                                                              InputAdapter
-                                                                                                Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_company_name]
+                                                                        InputAdapter
+                                                                          WholeStageCodegen (5)
+                                                                            Sort [i_item_sk]
+                                                                              InputAdapter
+                                                                                Exchange [i_item_sk] #6
+                                                                                  WholeStageCodegen (4)
+                                                                                    Filter [i_item_sk,i_category,i_brand]
+                                                                                      ColumnarToRow
+                                                                                        InputAdapter
+                                                                                          Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_category]
                                                                     InputAdapter
-                                                                      WholeStageCodegen (6)
-                                                                        Sort [i_item_sk]
-                                                                          InputAdapter
-                                                                            Exchange [i_item_sk] #7
-                                                                              WholeStageCodegen (5)
-                                                                                Filter [i_item_sk,i_category,i_brand]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_category]
+                                                                      BroadcastExchange #7
+                                                                        WholeStageCodegen (6)
+                                                                          Filter [s_store_sk,s_store_name,s_company_name]
+                                                                            ColumnarToRow
+                                                                              InputAdapter
+                                                                                Scan parquet spark_catalog.default.store [s_store_sk,s_store_name,s_company_name]
                 InputAdapter
                   WholeStageCodegen (23)
                     Sort [i_category,i_brand,s_store_name,s_company_name,rn]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6.sf100/explain.txt
@@ -5,45 +5,45 @@ TakeOrderedAndProject (45)
       +- Exchange (42)
          +- * HashAggregate (41)
             +- * Project (40)
-               +- * SortMergeJoin Inner (39)
-                  :- * Sort (24)
-                  :  +- Exchange (23)
-                  :     +- * Project (22)
-                  :        +- * BroadcastHashJoin Inner BuildRight (21)
-                  :           :- * Project (19)
-                  :           :  +- * BroadcastHashJoin Inner BuildLeft (18)
-                  :           :     :- BroadcastExchange (14)
-                  :           :     :  +- * Project (13)
-                  :           :     :     +- * BroadcastHashJoin Inner BuildRight (12)
-                  :           :     :        :- * Filter (3)
-                  :           :     :        :  +- * ColumnarToRow (2)
-                  :           :     :        :     +- Scan parquet spark_catalog.default.item (1)
-                  :           :     :        +- BroadcastExchange (11)
-                  :           :     :           +- * Filter (10)
-                  :           :     :              +- * HashAggregate (9)
-                  :           :     :                 +- Exchange (8)
-                  :           :     :                    +- * HashAggregate (7)
-                  :           :     :                       +- * Filter (6)
-                  :           :     :                          +- * ColumnarToRow (5)
-                  :           :     :                             +- Scan parquet spark_catalog.default.item (4)
-                  :           :     +- * Filter (17)
-                  :           :        +- * ColumnarToRow (16)
-                  :           :           +- Scan parquet spark_catalog.default.store_sales (15)
-                  :           +- ReusedExchange (20)
-                  +- * Sort (38)
-                     +- Exchange (37)
-                        +- * Project (36)
-                           +- * SortMergeJoin Inner (35)
-                              :- * Sort (29)
-                              :  +- Exchange (28)
-                              :     +- * Filter (27)
-                              :        +- * ColumnarToRow (26)
-                              :           +- Scan parquet spark_catalog.default.customer_address (25)
-                              +- * Sort (34)
-                                 +- Exchange (33)
-                                    +- * Filter (32)
-                                       +- * ColumnarToRow (31)
-                                          +- Scan parquet spark_catalog.default.customer (30)
+               +- * BroadcastHashJoin Inner BuildRight (39)
+                  :- * Project (37)
+                  :  +- * SortMergeJoin Inner (36)
+                  :     :- * Sort (21)
+                  :     :  +- Exchange (20)
+                  :     :     +- * Project (19)
+                  :     :        +- * BroadcastHashJoin Inner BuildLeft (18)
+                  :     :           :- BroadcastExchange (14)
+                  :     :           :  +- * Project (13)
+                  :     :           :     +- * BroadcastHashJoin Inner BuildRight (12)
+                  :     :           :        :- * Filter (3)
+                  :     :           :        :  +- * ColumnarToRow (2)
+                  :     :           :        :     +- Scan parquet spark_catalog.default.item (1)
+                  :     :           :        +- BroadcastExchange (11)
+                  :     :           :           +- * Filter (10)
+                  :     :           :              +- * HashAggregate (9)
+                  :     :           :                 +- Exchange (8)
+                  :     :           :                    +- * HashAggregate (7)
+                  :     :           :                       +- * Filter (6)
+                  :     :           :                          +- * ColumnarToRow (5)
+                  :     :           :                             +- Scan parquet spark_catalog.default.item (4)
+                  :     :           +- * Filter (17)
+                  :     :              +- * ColumnarToRow (16)
+                  :     :                 +- Scan parquet spark_catalog.default.store_sales (15)
+                  :     +- * Sort (35)
+                  :        +- Exchange (34)
+                  :           +- * Project (33)
+                  :              +- * SortMergeJoin Inner (32)
+                  :                 :- * Sort (26)
+                  :                 :  +- Exchange (25)
+                  :                 :     +- * Filter (24)
+                  :                 :        +- * ColumnarToRow (23)
+                  :                 :           +- Scan parquet spark_catalog.default.customer_address (22)
+                  :                 +- * Sort (31)
+                  :                    +- Exchange (30)
+                  :                       +- * Filter (29)
+                  :                          +- * ColumnarToRow (28)
+                  :                             +- Scan parquet spark_catalog.default.customer (27)
+                  +- ReusedExchange (38)
 
 
 (1) Scan parquet spark_catalog.default.item
@@ -129,126 +129,126 @@ Input [3]: [ss_item_sk#12, ss_customer_sk#13, ss_sold_date_sk#14]
 Input [3]: [ss_item_sk#12, ss_customer_sk#13, ss_sold_date_sk#14]
 Condition : (isnotnull(ss_customer_sk#13) AND isnotnull(ss_item_sk#12))
 
-(18) BroadcastHashJoin [codegen id : 5]
+(18) BroadcastHashJoin [codegen id : 4]
 Left keys [1]: [i_item_sk#1]
 Right keys [1]: [ss_item_sk#12]
 Join type: Inner
 Join condition: None
 
-(19) Project [codegen id : 5]
+(19) Project [codegen id : 4]
 Output [2]: [ss_customer_sk#13, ss_sold_date_sk#14]
 Input [4]: [i_item_sk#1, ss_item_sk#12, ss_customer_sk#13, ss_sold_date_sk#14]
 
-(20) ReusedExchange [Reuses operator id: 50]
-Output [1]: [d_date_sk#16]
-
-(21) BroadcastHashJoin [codegen id : 5]
-Left keys [1]: [ss_sold_date_sk#14]
-Right keys [1]: [d_date_sk#16]
-Join type: Inner
-Join condition: None
-
-(22) Project [codegen id : 5]
-Output [1]: [ss_customer_sk#13]
-Input [3]: [ss_customer_sk#13, ss_sold_date_sk#14, d_date_sk#16]
-
-(23) Exchange
-Input [1]: [ss_customer_sk#13]
+(20) Exchange
+Input [2]: [ss_customer_sk#13, ss_sold_date_sk#14]
 Arguments: hashpartitioning(ss_customer_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(24) Sort [codegen id : 6]
-Input [1]: [ss_customer_sk#13]
+(21) Sort [codegen id : 5]
+Input [2]: [ss_customer_sk#13, ss_sold_date_sk#14]
 Arguments: [ss_customer_sk#13 ASC NULLS FIRST], false, 0
 
-(25) Scan parquet spark_catalog.default.customer_address
-Output [2]: [ca_address_sk#17, ca_state#18]
+(22) Scan parquet spark_catalog.default.customer_address
+Output [2]: [ca_address_sk#16, ca_state#17]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_address]
 PushedFilters: [IsNotNull(ca_address_sk)]
 ReadSchema: struct<ca_address_sk:int,ca_state:string>
 
-(26) ColumnarToRow [codegen id : 7]
-Input [2]: [ca_address_sk#17, ca_state#18]
+(23) ColumnarToRow [codegen id : 6]
+Input [2]: [ca_address_sk#16, ca_state#17]
 
-(27) Filter [codegen id : 7]
-Input [2]: [ca_address_sk#17, ca_state#18]
-Condition : isnotnull(ca_address_sk#17)
+(24) Filter [codegen id : 6]
+Input [2]: [ca_address_sk#16, ca_state#17]
+Condition : isnotnull(ca_address_sk#16)
 
-(28) Exchange
-Input [2]: [ca_address_sk#17, ca_state#18]
-Arguments: hashpartitioning(ca_address_sk#17, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(25) Exchange
+Input [2]: [ca_address_sk#16, ca_state#17]
+Arguments: hashpartitioning(ca_address_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=5]
 
-(29) Sort [codegen id : 8]
-Input [2]: [ca_address_sk#17, ca_state#18]
-Arguments: [ca_address_sk#17 ASC NULLS FIRST], false, 0
+(26) Sort [codegen id : 7]
+Input [2]: [ca_address_sk#16, ca_state#17]
+Arguments: [ca_address_sk#16 ASC NULLS FIRST], false, 0
 
-(30) Scan parquet spark_catalog.default.customer
-Output [2]: [c_customer_sk#19, c_current_addr_sk#20]
+(27) Scan parquet spark_catalog.default.customer
+Output [2]: [c_customer_sk#18, c_current_addr_sk#19]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer]
 PushedFilters: [IsNotNull(c_current_addr_sk), IsNotNull(c_customer_sk)]
 ReadSchema: struct<c_customer_sk:int,c_current_addr_sk:int>
 
-(31) ColumnarToRow [codegen id : 9]
-Input [2]: [c_customer_sk#19, c_current_addr_sk#20]
+(28) ColumnarToRow [codegen id : 8]
+Input [2]: [c_customer_sk#18, c_current_addr_sk#19]
 
-(32) Filter [codegen id : 9]
-Input [2]: [c_customer_sk#19, c_current_addr_sk#20]
-Condition : (isnotnull(c_current_addr_sk#20) AND isnotnull(c_customer_sk#19))
+(29) Filter [codegen id : 8]
+Input [2]: [c_customer_sk#18, c_current_addr_sk#19]
+Condition : (isnotnull(c_current_addr_sk#19) AND isnotnull(c_customer_sk#18))
 
-(33) Exchange
-Input [2]: [c_customer_sk#19, c_current_addr_sk#20]
-Arguments: hashpartitioning(c_current_addr_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+(30) Exchange
+Input [2]: [c_customer_sk#18, c_current_addr_sk#19]
+Arguments: hashpartitioning(c_current_addr_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(34) Sort [codegen id : 10]
-Input [2]: [c_customer_sk#19, c_current_addr_sk#20]
-Arguments: [c_current_addr_sk#20 ASC NULLS FIRST], false, 0
+(31) Sort [codegen id : 9]
+Input [2]: [c_customer_sk#18, c_current_addr_sk#19]
+Arguments: [c_current_addr_sk#19 ASC NULLS FIRST], false, 0
 
-(35) SortMergeJoin [codegen id : 11]
-Left keys [1]: [ca_address_sk#17]
-Right keys [1]: [c_current_addr_sk#20]
+(32) SortMergeJoin [codegen id : 10]
+Left keys [1]: [ca_address_sk#16]
+Right keys [1]: [c_current_addr_sk#19]
 Join type: Inner
 Join condition: None
 
-(36) Project [codegen id : 11]
-Output [2]: [ca_state#18, c_customer_sk#19]
-Input [4]: [ca_address_sk#17, ca_state#18, c_customer_sk#19, c_current_addr_sk#20]
+(33) Project [codegen id : 10]
+Output [2]: [ca_state#17, c_customer_sk#18]
+Input [4]: [ca_address_sk#16, ca_state#17, c_customer_sk#18, c_current_addr_sk#19]
 
-(37) Exchange
-Input [2]: [ca_state#18, c_customer_sk#19]
-Arguments: hashpartitioning(c_customer_sk#19, 5), ENSURE_REQUIREMENTS, [plan_id=7]
+(34) Exchange
+Input [2]: [ca_state#17, c_customer_sk#18]
+Arguments: hashpartitioning(c_customer_sk#18, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(38) Sort [codegen id : 12]
-Input [2]: [ca_state#18, c_customer_sk#19]
-Arguments: [c_customer_sk#19 ASC NULLS FIRST], false, 0
+(35) Sort [codegen id : 11]
+Input [2]: [ca_state#17, c_customer_sk#18]
+Arguments: [c_customer_sk#18 ASC NULLS FIRST], false, 0
 
-(39) SortMergeJoin [codegen id : 13]
+(36) SortMergeJoin [codegen id : 13]
 Left keys [1]: [ss_customer_sk#13]
-Right keys [1]: [c_customer_sk#19]
+Right keys [1]: [c_customer_sk#18]
+Join type: Inner
+Join condition: None
+
+(37) Project [codegen id : 13]
+Output [2]: [ss_sold_date_sk#14, ca_state#17]
+Input [4]: [ss_customer_sk#13, ss_sold_date_sk#14, ca_state#17, c_customer_sk#18]
+
+(38) ReusedExchange [Reuses operator id: 50]
+Output [1]: [d_date_sk#20]
+
+(39) BroadcastHashJoin [codegen id : 13]
+Left keys [1]: [ss_sold_date_sk#14]
+Right keys [1]: [d_date_sk#20]
 Join type: Inner
 Join condition: None
 
 (40) Project [codegen id : 13]
-Output [1]: [ca_state#18]
-Input [3]: [ss_customer_sk#13, ca_state#18, c_customer_sk#19]
+Output [1]: [ca_state#17]
+Input [3]: [ss_sold_date_sk#14, ca_state#17, d_date_sk#20]
 
 (41) HashAggregate [codegen id : 13]
-Input [1]: [ca_state#18]
-Keys [1]: [ca_state#18]
+Input [1]: [ca_state#17]
+Keys [1]: [ca_state#17]
 Functions [1]: [partial_count(1)]
 Aggregate Attributes [1]: [count#21]
-Results [2]: [ca_state#18, count#22]
+Results [2]: [ca_state#17, count#22]
 
 (42) Exchange
-Input [2]: [ca_state#18, count#22]
-Arguments: hashpartitioning(ca_state#18, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [2]: [ca_state#17, count#22]
+Arguments: hashpartitioning(ca_state#17, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (43) HashAggregate [codegen id : 14]
-Input [2]: [ca_state#18, count#22]
-Keys [1]: [ca_state#18]
+Input [2]: [ca_state#17, count#22]
+Keys [1]: [ca_state#17]
 Functions [1]: [count(1)]
 Aggregate Attributes [1]: [count(1)#23]
-Results [2]: [ca_state#18 AS state#24, count(1)#23 AS cnt#25]
+Results [2]: [ca_state#17 AS state#24, count(1)#23 AS cnt#25]
 
 (44) Filter [codegen id : 14]
 Input [2]: [state#24, cnt#25]
@@ -269,25 +269,25 @@ BroadcastExchange (50)
 
 
 (46) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#16, d_month_seq#26]
+Output [2]: [d_date_sk#20, d_month_seq#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_month_seq), EqualTo(d_month_seq,ScalarSubquery#27), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_month_seq:int>
 
 (47) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#16, d_month_seq#26]
+Input [2]: [d_date_sk#20, d_month_seq#26]
 
 (48) Filter [codegen id : 1]
-Input [2]: [d_date_sk#16, d_month_seq#26]
-Condition : ((isnotnull(d_month_seq#26) AND (d_month_seq#26 = ReusedSubquery Subquery scalar-subquery#27, [id=#28])) AND isnotnull(d_date_sk#16))
+Input [2]: [d_date_sk#20, d_month_seq#26]
+Condition : ((isnotnull(d_month_seq#26) AND (d_month_seq#26 = ReusedSubquery Subquery scalar-subquery#27, [id=#28])) AND isnotnull(d_date_sk#20))
 
 (49) Project [codegen id : 1]
-Output [1]: [d_date_sk#16]
-Input [2]: [d_date_sk#16, d_month_seq#26]
+Output [1]: [d_date_sk#20]
+Input [2]: [d_date_sk#20, d_month_seq#26]
 
 (50) BroadcastExchange
-Input [1]: [d_date_sk#16]
+Input [1]: [d_date_sk#20]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=9]
 
 Subquery:2 Hosting operator id = 48 Hosting Expression = ReusedSubquery Subquery scalar-subquery#27, [id=#28]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q6.sf100/simplified.txt
@@ -7,15 +7,15 @@ TakeOrderedAndProject [cnt,state]
             WholeStageCodegen (13)
               HashAggregate [ca_state] [count,count]
                 Project [ca_state]
-                  SortMergeJoin [ss_customer_sk,c_customer_sk]
-                    InputAdapter
-                      WholeStageCodegen (6)
-                        Sort [ss_customer_sk]
-                          InputAdapter
-                            Exchange [ss_customer_sk] #2
-                              WholeStageCodegen (5)
-                                Project [ss_customer_sk]
-                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                    Project [ss_sold_date_sk,ca_state]
+                      SortMergeJoin [ss_customer_sk,c_customer_sk]
+                        InputAdapter
+                          WholeStageCodegen (5)
+                            Sort [ss_customer_sk]
+                              InputAdapter
+                                Exchange [ss_customer_sk] #2
+                                  WholeStageCodegen (4)
                                     Project [ss_customer_sk,ss_sold_date_sk]
                                       BroadcastHashJoin [i_item_sk,ss_item_sk]
                                         InputAdapter
@@ -65,33 +65,33 @@ TakeOrderedAndProject [cnt,state]
                                                                                   ColumnarToRow
                                                                                     InputAdapter
                                                                                       Scan parquet spark_catalog.default.date_dim [d_month_seq,d_year,d_moy]
-                                    InputAdapter
-                                      ReusedExchange [d_date_sk] #6
+                        InputAdapter
+                          WholeStageCodegen (11)
+                            Sort [c_customer_sk]
+                              InputAdapter
+                                Exchange [c_customer_sk] #8
+                                  WholeStageCodegen (10)
+                                    Project [ca_state,c_customer_sk]
+                                      SortMergeJoin [ca_address_sk,c_current_addr_sk]
+                                        InputAdapter
+                                          WholeStageCodegen (7)
+                                            Sort [ca_address_sk]
+                                              InputAdapter
+                                                Exchange [ca_address_sk] #9
+                                                  WholeStageCodegen (6)
+                                                    Filter [ca_address_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
+                                        InputAdapter
+                                          WholeStageCodegen (9)
+                                            Sort [c_current_addr_sk]
+                                              InputAdapter
+                                                Exchange [c_current_addr_sk] #10
+                                                  WholeStageCodegen (8)
+                                                    Filter [c_current_addr_sk,c_customer_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
                     InputAdapter
-                      WholeStageCodegen (12)
-                        Sort [c_customer_sk]
-                          InputAdapter
-                            Exchange [c_customer_sk] #8
-                              WholeStageCodegen (11)
-                                Project [ca_state,c_customer_sk]
-                                  SortMergeJoin [ca_address_sk,c_current_addr_sk]
-                                    InputAdapter
-                                      WholeStageCodegen (8)
-                                        Sort [ca_address_sk]
-                                          InputAdapter
-                                            Exchange [ca_address_sk] #9
-                                              WholeStageCodegen (7)
-                                                Filter [ca_address_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.customer_address [ca_address_sk,ca_state]
-                                    InputAdapter
-                                      WholeStageCodegen (10)
-                                        Sort [c_current_addr_sk]
-                                          InputAdapter
-                                            Exchange [c_current_addr_sk] #10
-                                              WholeStageCodegen (9)
-                                                Filter [c_current_addr_sk,c_customer_sk]
-                                                  ColumnarToRow
-                                                    InputAdapter
-                                                      Scan parquet spark_catalog.default.customer [c_customer_sk,c_current_addr_sk]
+                      ReusedExchange [d_date_sk] #6

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q67a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q67a.sf100/explain.txt
@@ -12,26 +12,26 @@ TakeOrderedAndProject (73)
                         :  +- Exchange (23)
                         :     +- * HashAggregate (22)
                         :        +- * Project (21)
-                        :           +- * SortMergeJoin Inner (20)
-                        :              :- * Sort (14)
-                        :              :  +- Exchange (13)
-                        :              :     +- * Project (12)
-                        :              :        +- * BroadcastHashJoin Inner BuildRight (11)
-                        :              :           :- * Project (6)
-                        :              :           :  +- * BroadcastHashJoin Inner BuildRight (5)
-                        :              :           :     :- * Filter (3)
-                        :              :           :     :  +- * ColumnarToRow (2)
-                        :              :           :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-                        :              :           :     +- ReusedExchange (4)
-                        :              :           +- BroadcastExchange (10)
-                        :              :              +- * Filter (9)
-                        :              :                 +- * ColumnarToRow (8)
-                        :              :                    +- Scan parquet spark_catalog.default.store (7)
-                        :              +- * Sort (19)
-                        :                 +- Exchange (18)
-                        :                    +- * Filter (17)
-                        :                       +- * ColumnarToRow (16)
-                        :                          +- Scan parquet spark_catalog.default.item (15)
+                        :           +- * BroadcastHashJoin Inner BuildRight (20)
+                        :              :- * Project (15)
+                        :              :  +- * SortMergeJoin Inner (14)
+                        :              :     :- * Sort (8)
+                        :              :     :  +- Exchange (7)
+                        :              :     :     +- * Project (6)
+                        :              :     :        +- * BroadcastHashJoin Inner BuildRight (5)
+                        :              :     :           :- * Filter (3)
+                        :              :     :           :  +- * ColumnarToRow (2)
+                        :              :     :           :     +- Scan parquet spark_catalog.default.store_sales (1)
+                        :              :     :           +- ReusedExchange (4)
+                        :              :     +- * Sort (13)
+                        :              :        +- Exchange (12)
+                        :              :           +- * Filter (11)
+                        :              :              +- * ColumnarToRow (10)
+                        :              :                 +- Scan parquet spark_catalog.default.item (9)
+                        :              +- BroadcastExchange (19)
+                        :                 +- * Filter (18)
+                        :                    +- * ColumnarToRow (17)
+                        :                       +- Scan parquet spark_catalog.default.store (16)
                         :- * HashAggregate (29)
                         :  +- Exchange (28)
                         :     +- * HashAggregate (27)
@@ -82,111 +82,111 @@ PartitionFilters: [isnotnull(ss_sold_date_sk#5), dynamicpruningexpression(ss_sol
 PushedFilters: [IsNotNull(ss_store_sk), IsNotNull(ss_item_sk)]
 ReadSchema: struct<ss_item_sk:int,ss_store_sk:int,ss_quantity:int,ss_sales_price:decimal(7,2)>
 
-(2) ColumnarToRow [codegen id : 3]
+(2) ColumnarToRow [codegen id : 2]
 Input [5]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, ss_sold_date_sk#5]
 
-(3) Filter [codegen id : 3]
+(3) Filter [codegen id : 2]
 Input [5]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, ss_sold_date_sk#5]
 Condition : (isnotnull(ss_store_sk#2) AND isnotnull(ss_item_sk#1))
 
 (4) ReusedExchange [Reuses operator id: 78]
 Output [4]: [d_date_sk#7, d_year#8, d_moy#9, d_qoy#10]
 
-(5) BroadcastHashJoin [codegen id : 3]
+(5) BroadcastHashJoin [codegen id : 2]
 Left keys [1]: [ss_sold_date_sk#5]
 Right keys [1]: [d_date_sk#7]
 Join type: Inner
 Join condition: None
 
-(6) Project [codegen id : 3]
+(6) Project [codegen id : 2]
 Output [7]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10]
 Input [9]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, ss_sold_date_sk#5, d_date_sk#7, d_year#8, d_moy#9, d_qoy#10]
 
-(7) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#11, s_store_id#12]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/store]
-PushedFilters: [IsNotNull(s_store_sk)]
-ReadSchema: struct<s_store_sk:int,s_store_id:string>
+(7) Exchange
+Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10]
+Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=1]
 
-(8) ColumnarToRow [codegen id : 2]
-Input [2]: [s_store_sk#11, s_store_id#12]
-
-(9) Filter [codegen id : 2]
-Input [2]: [s_store_sk#11, s_store_id#12]
-Condition : isnotnull(s_store_sk#11)
-
-(10) BroadcastExchange
-Input [2]: [s_store_sk#11, s_store_id#12]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
-
-(11) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_store_sk#2]
-Right keys [1]: [s_store_sk#11]
-Join type: Inner
-Join condition: None
-
-(12) Project [codegen id : 3]
-Output [7]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_id#12]
-Input [9]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_sk#11, s_store_id#12]
-
-(13) Exchange
-Input [7]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_id#12]
-Arguments: hashpartitioning(ss_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
-
-(14) Sort [codegen id : 4]
-Input [7]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_id#12]
+(8) Sort [codegen id : 3]
+Input [7]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10]
 Arguments: [ss_item_sk#1 ASC NULLS FIRST], false, 0
 
-(15) Scan parquet spark_catalog.default.item
-Output [5]: [i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
+(9) Scan parquet spark_catalog.default.item
+Output [5]: [i_item_sk#11, i_brand#12, i_class#13, i_category#14, i_product_name#15]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_brand:string,i_class:string,i_category:string,i_product_name:string>
 
-(16) ColumnarToRow [codegen id : 5]
-Input [5]: [i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
+(10) ColumnarToRow [codegen id : 4]
+Input [5]: [i_item_sk#11, i_brand#12, i_class#13, i_category#14, i_product_name#15]
 
-(17) Filter [codegen id : 5]
-Input [5]: [i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
-Condition : isnotnull(i_item_sk#13)
+(11) Filter [codegen id : 4]
+Input [5]: [i_item_sk#11, i_brand#12, i_class#13, i_category#14, i_product_name#15]
+Condition : isnotnull(i_item_sk#11)
 
-(18) Exchange
-Input [5]: [i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
-Arguments: hashpartitioning(i_item_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+(12) Exchange
+Input [5]: [i_item_sk#11, i_brand#12, i_class#13, i_category#14, i_product_name#15]
+Arguments: hashpartitioning(i_item_sk#11, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
-(19) Sort [codegen id : 6]
-Input [5]: [i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
-Arguments: [i_item_sk#13 ASC NULLS FIRST], false, 0
+(13) Sort [codegen id : 5]
+Input [5]: [i_item_sk#11, i_brand#12, i_class#13, i_category#14, i_product_name#15]
+Arguments: [i_item_sk#11 ASC NULLS FIRST], false, 0
 
-(20) SortMergeJoin [codegen id : 7]
+(14) SortMergeJoin [codegen id : 7]
 Left keys [1]: [ss_item_sk#1]
-Right keys [1]: [i_item_sk#13]
+Right keys [1]: [i_item_sk#11]
+Join type: Inner
+Join condition: None
+
+(15) Project [codegen id : 7]
+Output [10]: [ss_store_sk#2, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, i_brand#12, i_class#13, i_category#14, i_product_name#15]
+Input [12]: [ss_item_sk#1, ss_store_sk#2, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, i_item_sk#11, i_brand#12, i_class#13, i_category#14, i_product_name#15]
+
+(16) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#16, s_store_id#17]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/store]
+PushedFilters: [IsNotNull(s_store_sk)]
+ReadSchema: struct<s_store_sk:int,s_store_id:string>
+
+(17) ColumnarToRow [codegen id : 6]
+Input [2]: [s_store_sk#16, s_store_id#17]
+
+(18) Filter [codegen id : 6]
+Input [2]: [s_store_sk#16, s_store_id#17]
+Condition : isnotnull(s_store_sk#16)
+
+(19) BroadcastExchange
+Input [2]: [s_store_sk#16, s_store_id#17]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
+
+(20) BroadcastHashJoin [codegen id : 7]
+Left keys [1]: [ss_store_sk#2]
+Right keys [1]: [s_store_sk#16]
 Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 7]
-Output [10]: [ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_id#12, i_brand#14, i_class#15, i_category#16, i_product_name#17]
-Input [12]: [ss_item_sk#1, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_id#12, i_item_sk#13, i_brand#14, i_class#15, i_category#16, i_product_name#17]
+Output [10]: [ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_id#17, i_brand#12, i_class#13, i_category#14, i_product_name#15]
+Input [12]: [ss_store_sk#2, ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, i_brand#12, i_class#13, i_category#14, i_product_name#15, s_store_sk#16, s_store_id#17]
 
 (22) HashAggregate [codegen id : 7]
-Input [10]: [ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_id#12, i_brand#14, i_class#15, i_category#16, i_product_name#17]
-Keys [8]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12]
+Input [10]: [ss_quantity#3, ss_sales_price#4, d_year#8, d_moy#9, d_qoy#10, s_store_id#17, i_brand#12, i_class#13, i_category#14, i_product_name#15]
+Keys [8]: [i_category#14, i_class#13, i_brand#12, i_product_name#15, d_year#8, d_qoy#10, d_moy#9, s_store_id#17]
 Functions [1]: [partial_sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
 Aggregate Attributes [2]: [sum#18, isEmpty#19]
-Results [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#20, isEmpty#21]
+Results [10]: [i_category#14, i_class#13, i_brand#12, i_product_name#15, d_year#8, d_qoy#10, d_moy#9, s_store_id#17, sum#20, isEmpty#21]
 
 (23) Exchange
-Input [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#20, isEmpty#21]
-Arguments: hashpartitioning(i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, 5), ENSURE_REQUIREMENTS, [plan_id=4]
+Input [10]: [i_category#14, i_class#13, i_brand#12, i_product_name#15, d_year#8, d_qoy#10, d_moy#9, s_store_id#17, sum#20, isEmpty#21]
+Arguments: hashpartitioning(i_category#14, i_class#13, i_brand#12, i_product_name#15, d_year#8, d_qoy#10, d_moy#9, s_store_id#17, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (24) HashAggregate [codegen id : 8]
-Input [10]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12, sum#20, isEmpty#21]
-Keys [8]: [i_category#16, i_class#15, i_brand#14, i_product_name#17, d_year#8, d_qoy#10, d_moy#9, s_store_id#12]
+Input [10]: [i_category#14, i_class#13, i_brand#12, i_product_name#15, d_year#8, d_qoy#10, d_moy#9, s_store_id#17, sum#20, isEmpty#21]
+Keys [8]: [i_category#14, i_class#13, i_brand#12, i_product_name#15, d_year#8, d_qoy#10, d_moy#9, s_store_id#17]
 Functions [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))]
 Aggregate Attributes [1]: [sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#22]
-Results [9]: [i_category#16 AS i_category#23, i_class#15 AS i_class#24, i_brand#14 AS i_brand#25, i_product_name#17 AS i_product_name#26, d_year#8 AS d_year#27, d_qoy#10 AS d_qoy#28, d_moy#9 AS d_moy#29, s_store_id#12 AS s_store_id#30, cast(sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#22 as decimal(38,2)) AS sumsales#31]
+Results [9]: [i_category#14 AS i_category#23, i_class#13 AS i_class#24, i_brand#12 AS i_brand#25, i_product_name#15 AS i_product_name#26, d_year#8 AS d_year#27, d_qoy#10 AS d_qoy#28, d_moy#9 AS d_moy#29, s_store_id#17 AS s_store_id#30, cast(sum(coalesce((ss_sales_price#4 * cast(ss_quantity#3 as decimal(10,0))), 0.00))#22 as decimal(38,2)) AS sumsales#31]
 
 (25) ReusedExchange [Reuses operator id: 23]
 Output [10]: [i_category#32, i_class#33, i_brand#34, i_product_name#35, d_year#36, d_qoy#37, d_moy#38, s_store_id#39, sum#40, isEmpty#41]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q67a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q67a.sf100/simplified.txt
@@ -20,15 +20,15 @@ TakeOrderedAndProject [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_
                                       WholeStageCodegen (7)
                                         HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,s_store_id,ss_sales_price,ss_quantity] [sum,isEmpty,sum,isEmpty]
                                           Project [ss_quantity,ss_sales_price,d_year,d_moy,d_qoy,s_store_id,i_brand,i_class,i_category,i_product_name]
-                                            SortMergeJoin [ss_item_sk,i_item_sk]
-                                              InputAdapter
-                                                WholeStageCodegen (4)
-                                                  Sort [ss_item_sk]
-                                                    InputAdapter
-                                                      Exchange [ss_item_sk] #3
-                                                        WholeStageCodegen (3)
-                                                          Project [ss_item_sk,ss_quantity,ss_sales_price,d_year,d_moy,d_qoy,s_store_id]
-                                                            BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                            BroadcastHashJoin [ss_store_sk,s_store_sk]
+                                              Project [ss_store_sk,ss_quantity,ss_sales_price,d_year,d_moy,d_qoy,i_brand,i_class,i_category,i_product_name]
+                                                SortMergeJoin [ss_item_sk,i_item_sk]
+                                                  InputAdapter
+                                                    WholeStageCodegen (3)
+                                                      Sort [ss_item_sk]
+                                                        InputAdapter
+                                                          Exchange [ss_item_sk] #3
+                                                            WholeStageCodegen (2)
                                                               Project [ss_item_sk,ss_store_sk,ss_quantity,ss_sales_price,d_year,d_moy,d_qoy]
                                                                 BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                   Filter [ss_store_sk,ss_item_sk]
@@ -45,23 +45,23 @@ TakeOrderedAndProject [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_
                                                                                         Scan parquet spark_catalog.default.date_dim [d_date_sk,d_month_seq,d_year,d_moy,d_qoy]
                                                                   InputAdapter
                                                                     ReusedExchange [d_date_sk,d_year,d_moy,d_qoy] #4
-                                                              InputAdapter
-                                                                BroadcastExchange #5
-                                                                  WholeStageCodegen (2)
-                                                                    Filter [s_store_sk]
-                                                                      ColumnarToRow
-                                                                        InputAdapter
-                                                                          Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
+                                                  InputAdapter
+                                                    WholeStageCodegen (5)
+                                                      Sort [i_item_sk]
+                                                        InputAdapter
+                                                          Exchange [i_item_sk] #5
+                                                            WholeStageCodegen (4)
+                                                              Filter [i_item_sk]
+                                                                ColumnarToRow
+                                                                  InputAdapter
+                                                                    Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_class,i_category,i_product_name]
                                               InputAdapter
-                                                WholeStageCodegen (6)
-                                                  Sort [i_item_sk]
-                                                    InputAdapter
-                                                      Exchange [i_item_sk] #6
-                                                        WholeStageCodegen (5)
-                                                          Filter [i_item_sk]
-                                                            ColumnarToRow
-                                                              InputAdapter
-                                                                Scan parquet spark_catalog.default.item [i_item_sk,i_brand,i_class,i_category,i_product_name]
+                                                BroadcastExchange #6
+                                                  WholeStageCodegen (6)
+                                                    Filter [s_store_sk]
+                                                      ColumnarToRow
+                                                        InputAdapter
+                                                          Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
                               WholeStageCodegen (17)
                                 HashAggregate [i_category,i_class,i_brand,i_product_name,d_year,d_qoy,d_moy,sum,isEmpty] [sum(sumsales),s_store_id,sumsales,sum,isEmpty]
                                   InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72.sf100/explain.txt
@@ -1,463 +1,456 @@
 == Physical Plan ==
-TakeOrderedAndProject (70)
-+- * HashAggregate (69)
-   +- Exchange (68)
-      +- * HashAggregate (67)
-         +- * Project (66)
-            +- * SortMergeJoin LeftOuter (65)
-               :- * Sort (58)
-               :  +- Exchange (57)
-               :     +- * Project (56)
-               :        +- * BroadcastHashJoin LeftOuter BuildRight (55)
-               :           :- * Project (50)
-               :           :  +- * SortMergeJoin Inner (49)
-               :           :     :- * Sort (37)
-               :           :     :  +- Exchange (36)
-               :           :     :     +- * Project (35)
-               :           :     :        +- * BroadcastHashJoin Inner BuildRight (34)
-               :           :     :           :- * Project (32)
-               :           :     :           :  +- * SortMergeJoin Inner (31)
-               :           :     :           :     :- * Sort (25)
-               :           :     :           :     :  +- Exchange (24)
-               :           :     :           :     :     +- * Project (23)
-               :           :     :           :     :        +- * BroadcastHashJoin Inner BuildRight (22)
-               :           :     :           :     :           :- * Project (17)
-               :           :     :           :     :           :  +- * BroadcastHashJoin Inner BuildRight (16)
-               :           :     :           :     :           :     :- * Project (10)
-               :           :     :           :     :           :     :  +- * BroadcastHashJoin Inner BuildRight (9)
-               :           :     :           :     :           :     :     :- * Filter (3)
-               :           :     :           :     :           :     :     :  +- * ColumnarToRow (2)
-               :           :     :           :     :           :     :     :     +- Scan parquet spark_catalog.default.catalog_sales (1)
-               :           :     :           :     :           :     :     +- BroadcastExchange (8)
-               :           :     :           :     :           :     :        +- * Project (7)
-               :           :     :           :     :           :     :           +- * Filter (6)
-               :           :     :           :     :           :     :              +- * ColumnarToRow (5)
-               :           :     :           :     :           :     :                 +- Scan parquet spark_catalog.default.household_demographics (4)
-               :           :     :           :     :           :     +- BroadcastExchange (15)
-               :           :     :           :     :           :        +- * Project (14)
-               :           :     :           :     :           :           +- * Filter (13)
-               :           :     :           :     :           :              +- * ColumnarToRow (12)
-               :           :     :           :     :           :                 +- Scan parquet spark_catalog.default.customer_demographics (11)
-               :           :     :           :     :           +- BroadcastExchange (21)
-               :           :     :           :     :              +- * Filter (20)
-               :           :     :           :     :                 +- * ColumnarToRow (19)
-               :           :     :           :     :                    +- Scan parquet spark_catalog.default.date_dim (18)
-               :           :     :           :     +- * Sort (30)
-               :           :     :           :        +- Exchange (29)
-               :           :     :           :           +- * Filter (28)
-               :           :     :           :              +- * ColumnarToRow (27)
-               :           :     :           :                 +- Scan parquet spark_catalog.default.item (26)
-               :           :     :           +- ReusedExchange (33)
-               :           :     +- * Sort (48)
-               :           :        +- Exchange (47)
-               :           :           +- * Project (46)
-               :           :              +- * BroadcastHashJoin Inner BuildRight (45)
-               :           :                 :- * Filter (40)
-               :           :                 :  +- * ColumnarToRow (39)
-               :           :                 :     +- Scan parquet spark_catalog.default.inventory (38)
-               :           :                 +- BroadcastExchange (44)
-               :           :                    +- * Filter (43)
-               :           :                       +- * ColumnarToRow (42)
-               :           :                          +- Scan parquet spark_catalog.default.warehouse (41)
-               :           +- BroadcastExchange (54)
-               :              +- * Filter (53)
-               :                 +- * ColumnarToRow (52)
-               :                    +- Scan parquet spark_catalog.default.promotion (51)
-               +- * Sort (64)
-                  +- Exchange (63)
-                     +- * Project (62)
-                        +- * Filter (61)
-                           +- * ColumnarToRow (60)
-                              +- Scan parquet spark_catalog.default.catalog_returns (59)
+TakeOrderedAndProject (81)
++- * HashAggregate (80)
+   +- Exchange (79)
+      +- * HashAggregate (78)
+         +- * Project (77)
+            +- * SortMergeJoin LeftOuter (76)
+               :- * Sort (69)
+               :  +- Exchange (68)
+               :     +- * Project (67)
+               :        +- * BroadcastHashJoin LeftOuter BuildRight (66)
+               :           :- * Project (61)
+               :           :  +- * SortMergeJoin Inner (60)
+               :           :     :- * Sort (41)
+               :           :     :  +- Exchange (40)
+               :           :     :     +- * Project (39)
+               :           :     :        +- * SortMergeJoin Inner (38)
+               :           :     :           :- * Project (26)
+               :           :     :           :  +- * SortMergeJoin Inner (25)
+               :           :     :           :     :- * Sort (19)
+               :           :     :           :     :  +- Exchange (18)
+               :           :     :           :     :     +- * Project (17)
+               :           :     :           :     :        +- * BroadcastHashJoin Inner BuildRight (16)
+               :           :     :           :     :           :- * Project (10)
+               :           :     :           :     :           :  +- * BroadcastHashJoin Inner BuildRight (9)
+               :           :     :           :     :           :     :- * Filter (3)
+               :           :     :           :     :           :     :  +- * ColumnarToRow (2)
+               :           :     :           :     :           :     :     +- Scan parquet spark_catalog.default.catalog_sales (1)
+               :           :     :           :     :           :     +- BroadcastExchange (8)
+               :           :     :           :     :           :        +- * Project (7)
+               :           :     :           :     :           :           +- * Filter (6)
+               :           :     :           :     :           :              +- * ColumnarToRow (5)
+               :           :     :           :     :           :                 +- Scan parquet spark_catalog.default.household_demographics (4)
+               :           :     :           :     :           +- BroadcastExchange (15)
+               :           :     :           :     :              +- * Project (14)
+               :           :     :           :     :                 +- * Filter (13)
+               :           :     :           :     :                    +- * ColumnarToRow (12)
+               :           :     :           :     :                       +- Scan parquet spark_catalog.default.customer_demographics (11)
+               :           :     :           :     +- * Sort (24)
+               :           :     :           :        +- Exchange (23)
+               :           :     :           :           +- * Filter (22)
+               :           :     :           :              +- * ColumnarToRow (21)
+               :           :     :           :                 +- Scan parquet spark_catalog.default.item (20)
+               :           :     :           +- * Sort (37)
+               :           :     :              +- Exchange (36)
+               :           :     :                 +- * Project (35)
+               :           :     :                    +- * BroadcastHashJoin Inner BuildRight (34)
+               :           :     :                       :- * Filter (29)
+               :           :     :                       :  +- * ColumnarToRow (28)
+               :           :     :                       :     +- Scan parquet spark_catalog.default.inventory (27)
+               :           :     :                       +- BroadcastExchange (33)
+               :           :     :                          +- * Filter (32)
+               :           :     :                             +- * ColumnarToRow (31)
+               :           :     :                                +- Scan parquet spark_catalog.default.warehouse (30)
+               :           :     +- * Sort (59)
+               :           :        +- Exchange (58)
+               :           :           +- * Project (57)
+               :           :              +- * BroadcastNestedLoopJoin Inner BuildRight (56)
+               :           :                 :- * Project (51)
+               :           :                 :  +- * BroadcastHashJoin Inner BuildLeft (50)
+               :           :                 :     :- BroadcastExchange (46)
+               :           :                 :     :  +- * Project (45)
+               :           :                 :     :     +- * Filter (44)
+               :           :                 :     :        +- * ColumnarToRow (43)
+               :           :                 :     :           +- Scan parquet spark_catalog.default.date_dim (42)
+               :           :                 :     +- * Filter (49)
+               :           :                 :        +- * ColumnarToRow (48)
+               :           :                 :           +- Scan parquet spark_catalog.default.date_dim (47)
+               :           :                 +- BroadcastExchange (55)
+               :           :                    +- * Filter (54)
+               :           :                       +- * ColumnarToRow (53)
+               :           :                          +- Scan parquet spark_catalog.default.date_dim (52)
+               :           +- BroadcastExchange (65)
+               :              +- * Filter (64)
+               :                 +- * ColumnarToRow (63)
+               :                    +- Scan parquet spark_catalog.default.promotion (62)
+               +- * Sort (75)
+                  +- Exchange (74)
+                     +- * Project (73)
+                        +- * Filter (72)
+                           +- * ColumnarToRow (71)
+                              +- Scan parquet spark_catalog.default.catalog_returns (70)
 
 
 (1) Scan parquet spark_catalog.default.catalog_sales
 Output [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(cs_sold_date_sk#8), dynamicpruningexpression(cs_sold_date_sk#8 IN dynamicpruning#9)]
+PartitionFilters: [isnotnull(cs_sold_date_sk#8), dynamicpruningexpression(true)]
 PushedFilters: [IsNotNull(cs_quantity), IsNotNull(cs_item_sk), IsNotNull(cs_bill_cdemo_sk), IsNotNull(cs_bill_hdemo_sk), IsNotNull(cs_ship_date_sk)]
 ReadSchema: struct<cs_ship_date_sk:int,cs_bill_cdemo_sk:int,cs_bill_hdemo_sk:int,cs_item_sk:int,cs_promo_sk:int,cs_order_number:int,cs_quantity:int>
 
-(2) ColumnarToRow [codegen id : 4]
+(2) ColumnarToRow [codegen id : 3]
 Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
 
-(3) Filter [codegen id : 4]
+(3) Filter [codegen id : 3]
 Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
 Condition : ((((isnotnull(cs_quantity#7) AND isnotnull(cs_item_sk#4)) AND isnotnull(cs_bill_cdemo_sk#2)) AND isnotnull(cs_bill_hdemo_sk#3)) AND isnotnull(cs_ship_date_sk#1))
 
 (4) Scan parquet spark_catalog.default.household_demographics
-Output [2]: [hd_demo_sk#10, hd_buy_potential#11]
+Output [2]: [hd_demo_sk#9, hd_buy_potential#10]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/household_demographics]
 PushedFilters: [IsNotNull(hd_buy_potential), EqualTo(hd_buy_potential,1001-5000      ), IsNotNull(hd_demo_sk)]
 ReadSchema: struct<hd_demo_sk:int,hd_buy_potential:string>
 
 (5) ColumnarToRow [codegen id : 1]
-Input [2]: [hd_demo_sk#10, hd_buy_potential#11]
+Input [2]: [hd_demo_sk#9, hd_buy_potential#10]
 
 (6) Filter [codegen id : 1]
-Input [2]: [hd_demo_sk#10, hd_buy_potential#11]
-Condition : ((isnotnull(hd_buy_potential#11) AND (hd_buy_potential#11 = 1001-5000      )) AND isnotnull(hd_demo_sk#10))
+Input [2]: [hd_demo_sk#9, hd_buy_potential#10]
+Condition : ((isnotnull(hd_buy_potential#10) AND (hd_buy_potential#10 = 1001-5000      )) AND isnotnull(hd_demo_sk#9))
 
 (7) Project [codegen id : 1]
-Output [1]: [hd_demo_sk#10]
-Input [2]: [hd_demo_sk#10, hd_buy_potential#11]
+Output [1]: [hd_demo_sk#9]
+Input [2]: [hd_demo_sk#9, hd_buy_potential#10]
 
 (8) BroadcastExchange
-Input [1]: [hd_demo_sk#10]
+Input [1]: [hd_demo_sk#9]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(9) BroadcastHashJoin [codegen id : 4]
+(9) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_bill_hdemo_sk#3]
-Right keys [1]: [hd_demo_sk#10]
+Right keys [1]: [hd_demo_sk#9]
 Join type: Inner
 Join condition: None
 
-(10) Project [codegen id : 4]
+(10) Project [codegen id : 3]
 Output [7]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
-Input [9]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, hd_demo_sk#10]
+Input [9]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_bill_hdemo_sk#3, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, hd_demo_sk#9]
 
 (11) Scan parquet spark_catalog.default.customer_demographics
-Output [2]: [cd_demo_sk#12, cd_marital_status#13]
+Output [2]: [cd_demo_sk#11, cd_marital_status#12]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/customer_demographics]
 PushedFilters: [IsNotNull(cd_marital_status), EqualTo(cd_marital_status,M), IsNotNull(cd_demo_sk)]
 ReadSchema: struct<cd_demo_sk:int,cd_marital_status:string>
 
 (12) ColumnarToRow [codegen id : 2]
-Input [2]: [cd_demo_sk#12, cd_marital_status#13]
+Input [2]: [cd_demo_sk#11, cd_marital_status#12]
 
 (13) Filter [codegen id : 2]
-Input [2]: [cd_demo_sk#12, cd_marital_status#13]
-Condition : ((isnotnull(cd_marital_status#13) AND (cd_marital_status#13 = M)) AND isnotnull(cd_demo_sk#12))
+Input [2]: [cd_demo_sk#11, cd_marital_status#12]
+Condition : ((isnotnull(cd_marital_status#12) AND (cd_marital_status#12 = M)) AND isnotnull(cd_demo_sk#11))
 
 (14) Project [codegen id : 2]
-Output [1]: [cd_demo_sk#12]
-Input [2]: [cd_demo_sk#12, cd_marital_status#13]
+Output [1]: [cd_demo_sk#11]
+Input [2]: [cd_demo_sk#11, cd_marital_status#12]
 
 (15) BroadcastExchange
-Input [1]: [cd_demo_sk#12]
+Input [1]: [cd_demo_sk#11]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=2]
 
-(16) BroadcastHashJoin [codegen id : 4]
+(16) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [cs_bill_cdemo_sk#2]
-Right keys [1]: [cd_demo_sk#12]
+Right keys [1]: [cd_demo_sk#11]
 Join type: Inner
 Join condition: None
 
-(17) Project [codegen id : 4]
+(17) Project [codegen id : 3]
 Output [6]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
-Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, cd_demo_sk#12]
+Input [8]: [cs_ship_date_sk#1, cs_bill_cdemo_sk#2, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, cd_demo_sk#11]
 
-(18) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#14, d_date#15]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/date_dim]
-PushedFilters: [IsNotNull(d_date), IsNotNull(d_date_sk)]
-ReadSchema: struct<d_date_sk:int,d_date:date>
+(18) Exchange
+Input [6]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
+Arguments: hashpartitioning(cs_item_sk#4, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
-(19) ColumnarToRow [codegen id : 3]
-Input [2]: [d_date_sk#14, d_date#15]
-
-(20) Filter [codegen id : 3]
-Input [2]: [d_date_sk#14, d_date#15]
-Condition : (isnotnull(d_date#15) AND isnotnull(d_date_sk#14))
-
-(21) BroadcastExchange
-Input [2]: [d_date_sk#14, d_date#15]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=3]
-
-(22) BroadcastHashJoin [codegen id : 4]
-Left keys [1]: [cs_ship_date_sk#1]
-Right keys [1]: [d_date_sk#14]
-Join type: Inner
-Join condition: None
-
-(23) Project [codegen id : 4]
-Output [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15]
-Input [8]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date_sk#14, d_date#15]
-
-(24) Exchange
-Input [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15]
-Arguments: hashpartitioning(cs_item_sk#4, 5), ENSURE_REQUIREMENTS, [plan_id=4]
-
-(25) Sort [codegen id : 5]
-Input [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15]
+(19) Sort [codegen id : 4]
+Input [6]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8]
 Arguments: [cs_item_sk#4 ASC NULLS FIRST], false, 0
 
-(26) Scan parquet spark_catalog.default.item
-Output [2]: [i_item_sk#16, i_item_desc#17]
+(20) Scan parquet spark_catalog.default.item
+Output [2]: [i_item_sk#13, i_item_desc#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_item_sk)]
 ReadSchema: struct<i_item_sk:int,i_item_desc:string>
 
-(27) ColumnarToRow [codegen id : 6]
-Input [2]: [i_item_sk#16, i_item_desc#17]
+(21) ColumnarToRow [codegen id : 5]
+Input [2]: [i_item_sk#13, i_item_desc#14]
 
-(28) Filter [codegen id : 6]
-Input [2]: [i_item_sk#16, i_item_desc#17]
-Condition : isnotnull(i_item_sk#16)
+(22) Filter [codegen id : 5]
+Input [2]: [i_item_sk#13, i_item_desc#14]
+Condition : isnotnull(i_item_sk#13)
 
-(29) Exchange
-Input [2]: [i_item_sk#16, i_item_desc#17]
-Arguments: hashpartitioning(i_item_sk#16, 5), ENSURE_REQUIREMENTS, [plan_id=5]
+(23) Exchange
+Input [2]: [i_item_sk#13, i_item_desc#14]
+Arguments: hashpartitioning(i_item_sk#13, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
-(30) Sort [codegen id : 7]
-Input [2]: [i_item_sk#16, i_item_desc#17]
-Arguments: [i_item_sk#16 ASC NULLS FIRST], false, 0
+(24) Sort [codegen id : 6]
+Input [2]: [i_item_sk#13, i_item_desc#14]
+Arguments: [i_item_sk#13 ASC NULLS FIRST], false, 0
 
-(31) SortMergeJoin [codegen id : 10]
+(25) SortMergeJoin [codegen id : 7]
 Left keys [1]: [cs_item_sk#4]
-Right keys [1]: [i_item_sk#16]
+Right keys [1]: [i_item_sk#13]
 Join type: Inner
 Join condition: None
 
-(32) Project [codegen id : 10]
-Output [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15, i_item_desc#17]
-Input [8]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15, i_item_sk#16, i_item_desc#17]
+(26) Project [codegen id : 7]
+Output [7]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, i_item_desc#14]
+Input [8]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, i_item_sk#13, i_item_desc#14]
 
-(33) ReusedExchange [Reuses operator id: 81]
-Output [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_date_sk#21]
-
-(34) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [cs_sold_date_sk#8]
-Right keys [1]: [d_date_sk#18]
-Join type: Inner
-Join condition: (d_date#15 > date_add(d_date#19, 5))
-
-(35) Project [codegen id : 10]
-Output [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#17, d_week_seq#20, d_date_sk#21]
-Input [11]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, d_date#15, i_item_desc#17, d_date_sk#18, d_date#19, d_week_seq#20, d_date_sk#21]
-
-(36) Exchange
-Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#17, d_week_seq#20, d_date_sk#21]
-Arguments: hashpartitioning(cs_item_sk#4, d_date_sk#21, 5), ENSURE_REQUIREMENTS, [plan_id=6]
-
-(37) Sort [codegen id : 11]
-Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#17, d_week_seq#20, d_date_sk#21]
-Arguments: [cs_item_sk#4 ASC NULLS FIRST, d_date_sk#21 ASC NULLS FIRST], false, 0
-
-(38) Scan parquet spark_catalog.default.inventory
-Output [4]: [inv_item_sk#22, inv_warehouse_sk#23, inv_quantity_on_hand#24, inv_date_sk#25]
+(27) Scan parquet spark_catalog.default.inventory
+Output [4]: [inv_item_sk#15, inv_warehouse_sk#16, inv_quantity_on_hand#17, inv_date_sk#18]
 Batched: true
 Location: InMemoryFileIndex []
-PartitionFilters: [isnotnull(inv_date_sk#25), dynamicpruningexpression(true)]
+PartitionFilters: [isnotnull(inv_date_sk#18), dynamicpruningexpression(true)]
 PushedFilters: [IsNotNull(inv_quantity_on_hand), IsNotNull(inv_item_sk), IsNotNull(inv_warehouse_sk)]
 ReadSchema: struct<inv_item_sk:int,inv_warehouse_sk:int,inv_quantity_on_hand:int>
 
-(39) ColumnarToRow [codegen id : 13]
-Input [4]: [inv_item_sk#22, inv_warehouse_sk#23, inv_quantity_on_hand#24, inv_date_sk#25]
+(28) ColumnarToRow [codegen id : 9]
+Input [4]: [inv_item_sk#15, inv_warehouse_sk#16, inv_quantity_on_hand#17, inv_date_sk#18]
 
-(40) Filter [codegen id : 13]
-Input [4]: [inv_item_sk#22, inv_warehouse_sk#23, inv_quantity_on_hand#24, inv_date_sk#25]
-Condition : ((isnotnull(inv_quantity_on_hand#24) AND isnotnull(inv_item_sk#22)) AND isnotnull(inv_warehouse_sk#23))
+(29) Filter [codegen id : 9]
+Input [4]: [inv_item_sk#15, inv_warehouse_sk#16, inv_quantity_on_hand#17, inv_date_sk#18]
+Condition : ((isnotnull(inv_quantity_on_hand#17) AND isnotnull(inv_item_sk#15)) AND isnotnull(inv_warehouse_sk#16))
 
-(41) Scan parquet spark_catalog.default.warehouse
-Output [2]: [w_warehouse_sk#26, w_warehouse_name#27]
+(30) Scan parquet spark_catalog.default.warehouse
+Output [2]: [w_warehouse_sk#19, w_warehouse_name#20]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/warehouse]
 PushedFilters: [IsNotNull(w_warehouse_sk)]
 ReadSchema: struct<w_warehouse_sk:int,w_warehouse_name:string>
 
-(42) ColumnarToRow [codegen id : 12]
-Input [2]: [w_warehouse_sk#26, w_warehouse_name#27]
+(31) ColumnarToRow [codegen id : 8]
+Input [2]: [w_warehouse_sk#19, w_warehouse_name#20]
 
-(43) Filter [codegen id : 12]
-Input [2]: [w_warehouse_sk#26, w_warehouse_name#27]
-Condition : isnotnull(w_warehouse_sk#26)
+(32) Filter [codegen id : 8]
+Input [2]: [w_warehouse_sk#19, w_warehouse_name#20]
+Condition : isnotnull(w_warehouse_sk#19)
 
-(44) BroadcastExchange
-Input [2]: [w_warehouse_sk#26, w_warehouse_name#27]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=7]
+(33) BroadcastExchange
+Input [2]: [w_warehouse_sk#19, w_warehouse_name#20]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
 
-(45) BroadcastHashJoin [codegen id : 13]
-Left keys [1]: [inv_warehouse_sk#23]
-Right keys [1]: [w_warehouse_sk#26]
+(34) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [inv_warehouse_sk#16]
+Right keys [1]: [w_warehouse_sk#19]
 Join type: Inner
 Join condition: None
 
-(46) Project [codegen id : 13]
-Output [4]: [inv_item_sk#22, inv_quantity_on_hand#24, inv_date_sk#25, w_warehouse_name#27]
-Input [6]: [inv_item_sk#22, inv_warehouse_sk#23, inv_quantity_on_hand#24, inv_date_sk#25, w_warehouse_sk#26, w_warehouse_name#27]
+(35) Project [codegen id : 9]
+Output [4]: [inv_item_sk#15, inv_quantity_on_hand#17, inv_date_sk#18, w_warehouse_name#20]
+Input [6]: [inv_item_sk#15, inv_warehouse_sk#16, inv_quantity_on_hand#17, inv_date_sk#18, w_warehouse_sk#19, w_warehouse_name#20]
 
-(47) Exchange
-Input [4]: [inv_item_sk#22, inv_quantity_on_hand#24, inv_date_sk#25, w_warehouse_name#27]
-Arguments: hashpartitioning(inv_item_sk#22, inv_date_sk#25, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+(36) Exchange
+Input [4]: [inv_item_sk#15, inv_quantity_on_hand#17, inv_date_sk#18, w_warehouse_name#20]
+Arguments: hashpartitioning(inv_item_sk#15, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
-(48) Sort [codegen id : 14]
-Input [4]: [inv_item_sk#22, inv_quantity_on_hand#24, inv_date_sk#25, w_warehouse_name#27]
-Arguments: [inv_item_sk#22 ASC NULLS FIRST, inv_date_sk#25 ASC NULLS FIRST], false, 0
+(37) Sort [codegen id : 10]
+Input [4]: [inv_item_sk#15, inv_quantity_on_hand#17, inv_date_sk#18, w_warehouse_name#20]
+Arguments: [inv_item_sk#15 ASC NULLS FIRST], false, 0
 
-(49) SortMergeJoin [codegen id : 16]
-Left keys [2]: [cs_item_sk#4, d_date_sk#21]
-Right keys [2]: [inv_item_sk#22, inv_date_sk#25]
+(38) SortMergeJoin [codegen id : 11]
+Left keys [1]: [cs_item_sk#4]
+Right keys [1]: [inv_item_sk#15]
 Join type: Inner
-Join condition: (inv_quantity_on_hand#24 < cs_quantity#7)
+Join condition: (inv_quantity_on_hand#17 < cs_quantity#7)
 
-(50) Project [codegen id : 16]
-Output [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
-Input [11]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, i_item_desc#17, d_week_seq#20, d_date_sk#21, inv_item_sk#22, inv_quantity_on_hand#24, inv_date_sk#25, w_warehouse_name#27]
+(39) Project [codegen id : 11]
+Output [8]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, i_item_desc#14, inv_date_sk#18, w_warehouse_name#20]
+Input [11]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_quantity#7, cs_sold_date_sk#8, i_item_desc#14, inv_item_sk#15, inv_quantity_on_hand#17, inv_date_sk#18, w_warehouse_name#20]
 
-(51) Scan parquet spark_catalog.default.promotion
-Output [1]: [p_promo_sk#28]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/promotion]
-PushedFilters: [IsNotNull(p_promo_sk)]
-ReadSchema: struct<p_promo_sk:int>
+(40) Exchange
+Input [8]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, i_item_desc#14, inv_date_sk#18, w_warehouse_name#20]
+Arguments: hashpartitioning(cs_sold_date_sk#8, inv_date_sk#18, cs_ship_date_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=7]
 
-(52) ColumnarToRow [codegen id : 15]
-Input [1]: [p_promo_sk#28]
+(41) Sort [codegen id : 12]
+Input [8]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, i_item_desc#14, inv_date_sk#18, w_warehouse_name#20]
+Arguments: [cs_sold_date_sk#8 ASC NULLS FIRST, inv_date_sk#18 ASC NULLS FIRST, cs_ship_date_sk#1 ASC NULLS FIRST], false, 0
 
-(53) Filter [codegen id : 15]
-Input [1]: [p_promo_sk#28]
-Condition : isnotnull(p_promo_sk#28)
-
-(54) BroadcastExchange
-Input [1]: [p_promo_sk#28]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=9]
-
-(55) BroadcastHashJoin [codegen id : 16]
-Left keys [1]: [cs_promo_sk#5]
-Right keys [1]: [p_promo_sk#28]
-Join type: LeftOuter
-Join condition: None
-
-(56) Project [codegen id : 16]
-Output [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
-Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20, p_promo_sk#28]
-
-(57) Exchange
-Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
-Arguments: hashpartitioning(cs_item_sk#4, cs_order_number#6, 5), ENSURE_REQUIREMENTS, [plan_id=10]
-
-(58) Sort [codegen id : 17]
-Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
-Arguments: [cs_item_sk#4 ASC NULLS FIRST, cs_order_number#6 ASC NULLS FIRST], false, 0
-
-(59) Scan parquet spark_catalog.default.catalog_returns
-Output [3]: [cr_item_sk#29, cr_order_number#30, cr_returned_date_sk#31]
-Batched: true
-Location [not included in comparison]/{warehouse_dir}/catalog_returns]
-PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
-ReadSchema: struct<cr_item_sk:int,cr_order_number:int>
-
-(60) ColumnarToRow [codegen id : 18]
-Input [3]: [cr_item_sk#29, cr_order_number#30, cr_returned_date_sk#31]
-
-(61) Filter [codegen id : 18]
-Input [3]: [cr_item_sk#29, cr_order_number#30, cr_returned_date_sk#31]
-Condition : (isnotnull(cr_item_sk#29) AND isnotnull(cr_order_number#30))
-
-(62) Project [codegen id : 18]
-Output [2]: [cr_item_sk#29, cr_order_number#30]
-Input [3]: [cr_item_sk#29, cr_order_number#30, cr_returned_date_sk#31]
-
-(63) Exchange
-Input [2]: [cr_item_sk#29, cr_order_number#30]
-Arguments: hashpartitioning(cr_item_sk#29, cr_order_number#30, 5), ENSURE_REQUIREMENTS, [plan_id=11]
-
-(64) Sort [codegen id : 19]
-Input [2]: [cr_item_sk#29, cr_order_number#30]
-Arguments: [cr_item_sk#29 ASC NULLS FIRST, cr_order_number#30 ASC NULLS FIRST], false, 0
-
-(65) SortMergeJoin [codegen id : 20]
-Left keys [2]: [cs_item_sk#4, cs_order_number#6]
-Right keys [2]: [cr_item_sk#29, cr_order_number#30]
-Join type: LeftOuter
-Join condition: None
-
-(66) Project [codegen id : 20]
-Output [3]: [w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
-Input [7]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#27, i_item_desc#17, d_week_seq#20, cr_item_sk#29, cr_order_number#30]
-
-(67) HashAggregate [codegen id : 20]
-Input [3]: [w_warehouse_name#27, i_item_desc#17, d_week_seq#20]
-Keys [3]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20]
-Functions [1]: [partial_count(1)]
-Aggregate Attributes [1]: [count#32]
-Results [4]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, count#33]
-
-(68) Exchange
-Input [4]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, count#33]
-Arguments: hashpartitioning(i_item_desc#17, w_warehouse_name#27, d_week_seq#20, 5), ENSURE_REQUIREMENTS, [plan_id=12]
-
-(69) HashAggregate [codegen id : 21]
-Input [4]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, count#33]
-Keys [3]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20]
-Functions [1]: [count(1)]
-Aggregate Attributes [1]: [count(1)#34]
-Results [6]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, count(1)#34 AS no_promo#35, count(1)#34 AS promo#36, count(1)#34 AS total_cnt#37]
-
-(70) TakeOrderedAndProject
-Input [6]: [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, no_promo#35, promo#36, total_cnt#37]
-Arguments: 100, [total_cnt#37 DESC NULLS LAST, i_item_desc#17 ASC NULLS FIRST, w_warehouse_name#27 ASC NULLS FIRST, d_week_seq#20 ASC NULLS FIRST], [i_item_desc#17, w_warehouse_name#27, d_week_seq#20, no_promo#35, promo#36, total_cnt#37]
-
-===== Subqueries =====
-
-Subquery:1 Hosting operator id = 1 Hosting Expression = cs_sold_date_sk#8 IN dynamicpruning#9
-BroadcastExchange (81)
-+- * Project (80)
-   +- * BroadcastHashJoin Inner BuildLeft (79)
-      :- BroadcastExchange (75)
-      :  +- * Project (74)
-      :     +- * Filter (73)
-      :        +- * ColumnarToRow (72)
-      :           +- Scan parquet spark_catalog.default.date_dim (71)
-      +- * Filter (78)
-         +- * ColumnarToRow (77)
-            +- Scan parquet spark_catalog.default.date_dim (76)
-
-
-(71) Scan parquet spark_catalog.default.date_dim
-Output [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_year#38]
+(42) Scan parquet spark_catalog.default.date_dim
+Output [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_year#24]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk), IsNotNull(d_week_seq), IsNotNull(d_date)]
 ReadSchema: struct<d_date_sk:int,d_date:date,d_week_seq:int,d_year:int>
 
-(72) ColumnarToRow [codegen id : 1]
-Input [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_year#38]
+(43) ColumnarToRow [codegen id : 13]
+Input [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_year#24]
 
-(73) Filter [codegen id : 1]
-Input [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_year#38]
-Condition : ((((isnotnull(d_year#38) AND (d_year#38 = 2001)) AND isnotnull(d_date_sk#18)) AND isnotnull(d_week_seq#20)) AND isnotnull(d_date#19))
+(44) Filter [codegen id : 13]
+Input [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_year#24]
+Condition : ((((isnotnull(d_year#24) AND (d_year#24 = 2001)) AND isnotnull(d_date_sk#21)) AND isnotnull(d_week_seq#23)) AND isnotnull(d_date#22))
 
-(74) Project [codegen id : 1]
-Output [3]: [d_date_sk#18, d_date#19, d_week_seq#20]
-Input [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_year#38]
+(45) Project [codegen id : 13]
+Output [3]: [d_date_sk#21, d_date#22, d_week_seq#23]
+Input [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_year#24]
 
-(75) BroadcastExchange
-Input [3]: [d_date_sk#18, d_date#19, d_week_seq#20]
-Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [plan_id=13]
+(46) BroadcastExchange
+Input [3]: [d_date_sk#21, d_date#22, d_week_seq#23]
+Arguments: HashedRelationBroadcastMode(List(cast(input[2, int, true] as bigint)),false), [plan_id=8]
 
-(76) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#21, d_week_seq#39]
+(47) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#25, d_week_seq#26]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_week_seq), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_week_seq:int>
 
-(77) ColumnarToRow
-Input [2]: [d_date_sk#21, d_week_seq#39]
+(48) ColumnarToRow
+Input [2]: [d_date_sk#25, d_week_seq#26]
 
-(78) Filter
-Input [2]: [d_date_sk#21, d_week_seq#39]
-Condition : (isnotnull(d_week_seq#39) AND isnotnull(d_date_sk#21))
+(49) Filter
+Input [2]: [d_date_sk#25, d_week_seq#26]
+Condition : (isnotnull(d_week_seq#26) AND isnotnull(d_date_sk#25))
 
-(79) BroadcastHashJoin [codegen id : 2]
-Left keys [1]: [d_week_seq#20]
-Right keys [1]: [d_week_seq#39]
+(50) BroadcastHashJoin [codegen id : 15]
+Left keys [1]: [d_week_seq#23]
+Right keys [1]: [d_week_seq#26]
 Join type: Inner
 Join condition: None
 
-(80) Project [codegen id : 2]
-Output [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_date_sk#21]
-Input [5]: [d_date_sk#18, d_date#19, d_week_seq#20, d_date_sk#21, d_week_seq#39]
+(51) Project [codegen id : 15]
+Output [4]: [d_date_sk#21, d_date#22, d_week_seq#23, d_date_sk#25]
+Input [5]: [d_date_sk#21, d_date#22, d_week_seq#23, d_date_sk#25, d_week_seq#26]
 
-(81) BroadcastExchange
-Input [4]: [d_date_sk#18, d_date#19, d_week_seq#20, d_date_sk#21]
-Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=14]
+(52) Scan parquet spark_catalog.default.date_dim
+Output [2]: [d_date_sk#27, d_date#28]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/date_dim]
+PushedFilters: [IsNotNull(d_date), IsNotNull(d_date_sk)]
+ReadSchema: struct<d_date_sk:int,d_date:date>
 
+(53) ColumnarToRow [codegen id : 14]
+Input [2]: [d_date_sk#27, d_date#28]
+
+(54) Filter [codegen id : 14]
+Input [2]: [d_date_sk#27, d_date#28]
+Condition : (isnotnull(d_date#28) AND isnotnull(d_date_sk#27))
+
+(55) BroadcastExchange
+Input [2]: [d_date_sk#27, d_date#28]
+Arguments: IdentityBroadcastMode, [plan_id=9]
+
+(56) BroadcastNestedLoopJoin [codegen id : 15]
+Join type: Inner
+Join condition: (d_date#28 > date_add(d_date#22, 5))
+
+(57) Project [codegen id : 15]
+Output [4]: [d_date_sk#21, d_week_seq#23, d_date_sk#25, d_date_sk#27]
+Input [6]: [d_date_sk#21, d_date#22, d_week_seq#23, d_date_sk#25, d_date_sk#27, d_date#28]
+
+(58) Exchange
+Input [4]: [d_date_sk#21, d_week_seq#23, d_date_sk#25, d_date_sk#27]
+Arguments: hashpartitioning(d_date_sk#21, d_date_sk#25, d_date_sk#27, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+
+(59) Sort [codegen id : 16]
+Input [4]: [d_date_sk#21, d_week_seq#23, d_date_sk#25, d_date_sk#27]
+Arguments: [d_date_sk#21 ASC NULLS FIRST, d_date_sk#25 ASC NULLS FIRST, d_date_sk#27 ASC NULLS FIRST], false, 0
+
+(60) SortMergeJoin [codegen id : 18]
+Left keys [3]: [cs_sold_date_sk#8, inv_date_sk#18, cs_ship_date_sk#1]
+Right keys [3]: [d_date_sk#21, d_date_sk#25, d_date_sk#27]
+Join type: Inner
+Join condition: None
+
+(61) Project [codegen id : 18]
+Output [6]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#20, i_item_desc#14, d_week_seq#23]
+Input [12]: [cs_ship_date_sk#1, cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, cs_sold_date_sk#8, i_item_desc#14, inv_date_sk#18, w_warehouse_name#20, d_date_sk#21, d_week_seq#23, d_date_sk#25, d_date_sk#27]
+
+(62) Scan parquet spark_catalog.default.promotion
+Output [1]: [p_promo_sk#29]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/promotion]
+PushedFilters: [IsNotNull(p_promo_sk)]
+ReadSchema: struct<p_promo_sk:int>
+
+(63) ColumnarToRow [codegen id : 17]
+Input [1]: [p_promo_sk#29]
+
+(64) Filter [codegen id : 17]
+Input [1]: [p_promo_sk#29]
+Condition : isnotnull(p_promo_sk#29)
+
+(65) BroadcastExchange
+Input [1]: [p_promo_sk#29]
+Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=11]
+
+(66) BroadcastHashJoin [codegen id : 18]
+Left keys [1]: [cs_promo_sk#5]
+Right keys [1]: [p_promo_sk#29]
+Join type: LeftOuter
+Join condition: None
+
+(67) Project [codegen id : 18]
+Output [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#20, i_item_desc#14, d_week_seq#23]
+Input [7]: [cs_item_sk#4, cs_promo_sk#5, cs_order_number#6, w_warehouse_name#20, i_item_desc#14, d_week_seq#23, p_promo_sk#29]
+
+(68) Exchange
+Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#20, i_item_desc#14, d_week_seq#23]
+Arguments: hashpartitioning(cs_item_sk#4, cs_order_number#6, 5), ENSURE_REQUIREMENTS, [plan_id=12]
+
+(69) Sort [codegen id : 19]
+Input [5]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#20, i_item_desc#14, d_week_seq#23]
+Arguments: [cs_item_sk#4 ASC NULLS FIRST, cs_order_number#6 ASC NULLS FIRST], false, 0
+
+(70) Scan parquet spark_catalog.default.catalog_returns
+Output [3]: [cr_item_sk#30, cr_order_number#31, cr_returned_date_sk#32]
+Batched: true
+Location [not included in comparison]/{warehouse_dir}/catalog_returns]
+PushedFilters: [IsNotNull(cr_item_sk), IsNotNull(cr_order_number)]
+ReadSchema: struct<cr_item_sk:int,cr_order_number:int>
+
+(71) ColumnarToRow [codegen id : 20]
+Input [3]: [cr_item_sk#30, cr_order_number#31, cr_returned_date_sk#32]
+
+(72) Filter [codegen id : 20]
+Input [3]: [cr_item_sk#30, cr_order_number#31, cr_returned_date_sk#32]
+Condition : (isnotnull(cr_item_sk#30) AND isnotnull(cr_order_number#31))
+
+(73) Project [codegen id : 20]
+Output [2]: [cr_item_sk#30, cr_order_number#31]
+Input [3]: [cr_item_sk#30, cr_order_number#31, cr_returned_date_sk#32]
+
+(74) Exchange
+Input [2]: [cr_item_sk#30, cr_order_number#31]
+Arguments: hashpartitioning(cr_item_sk#30, cr_order_number#31, 5), ENSURE_REQUIREMENTS, [plan_id=13]
+
+(75) Sort [codegen id : 21]
+Input [2]: [cr_item_sk#30, cr_order_number#31]
+Arguments: [cr_item_sk#30 ASC NULLS FIRST, cr_order_number#31 ASC NULLS FIRST], false, 0
+
+(76) SortMergeJoin [codegen id : 22]
+Left keys [2]: [cs_item_sk#4, cs_order_number#6]
+Right keys [2]: [cr_item_sk#30, cr_order_number#31]
+Join type: LeftOuter
+Join condition: None
+
+(77) Project [codegen id : 22]
+Output [3]: [w_warehouse_name#20, i_item_desc#14, d_week_seq#23]
+Input [7]: [cs_item_sk#4, cs_order_number#6, w_warehouse_name#20, i_item_desc#14, d_week_seq#23, cr_item_sk#30, cr_order_number#31]
+
+(78) HashAggregate [codegen id : 22]
+Input [3]: [w_warehouse_name#20, i_item_desc#14, d_week_seq#23]
+Keys [3]: [i_item_desc#14, w_warehouse_name#20, d_week_seq#23]
+Functions [1]: [partial_count(1)]
+Aggregate Attributes [1]: [count#33]
+Results [4]: [i_item_desc#14, w_warehouse_name#20, d_week_seq#23, count#34]
+
+(79) Exchange
+Input [4]: [i_item_desc#14, w_warehouse_name#20, d_week_seq#23, count#34]
+Arguments: hashpartitioning(i_item_desc#14, w_warehouse_name#20, d_week_seq#23, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+
+(80) HashAggregate [codegen id : 23]
+Input [4]: [i_item_desc#14, w_warehouse_name#20, d_week_seq#23, count#34]
+Keys [3]: [i_item_desc#14, w_warehouse_name#20, d_week_seq#23]
+Functions [1]: [count(1)]
+Aggregate Attributes [1]: [count(1)#35]
+Results [6]: [i_item_desc#14, w_warehouse_name#20, d_week_seq#23, count(1)#35 AS no_promo#36, count(1)#35 AS promo#37, count(1)#35 AS total_cnt#38]
+
+(81) TakeOrderedAndProject
+Input [6]: [i_item_desc#14, w_warehouse_name#20, d_week_seq#23, no_promo#36, promo#37, total_cnt#38]
+Arguments: 100, [total_cnt#38 DESC NULLS LAST, i_item_desc#14 ASC NULLS FIRST, w_warehouse_name#20 ASC NULLS FIRST, d_week_seq#23 ASC NULLS FIRST], [i_item_desc#14, w_warehouse_name#20, d_week_seq#23, no_promo#36, promo#37, total_cnt#38]
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q72.sf100/simplified.txt
@@ -1,40 +1,40 @@
 TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_promo,promo]
-  WholeStageCodegen (21)
+  WholeStageCodegen (23)
     HashAggregate [i_item_desc,w_warehouse_name,d_week_seq,count] [count(1),no_promo,promo,total_cnt,count]
       InputAdapter
         Exchange [i_item_desc,w_warehouse_name,d_week_seq] #1
-          WholeStageCodegen (20)
+          WholeStageCodegen (22)
             HashAggregate [i_item_desc,w_warehouse_name,d_week_seq] [count,count]
               Project [w_warehouse_name,i_item_desc,d_week_seq]
                 SortMergeJoin [cs_item_sk,cs_order_number,cr_item_sk,cr_order_number]
                   InputAdapter
-                    WholeStageCodegen (17)
+                    WholeStageCodegen (19)
                       Sort [cs_item_sk,cs_order_number]
                         InputAdapter
                           Exchange [cs_item_sk,cs_order_number] #2
-                            WholeStageCodegen (16)
+                            WholeStageCodegen (18)
                               Project [cs_item_sk,cs_order_number,w_warehouse_name,i_item_desc,d_week_seq]
                                 BroadcastHashJoin [cs_promo_sk,p_promo_sk]
                                   Project [cs_item_sk,cs_promo_sk,cs_order_number,w_warehouse_name,i_item_desc,d_week_seq]
-                                    SortMergeJoin [cs_item_sk,d_date_sk,inv_item_sk,inv_date_sk,inv_quantity_on_hand,cs_quantity]
+                                    SortMergeJoin [cs_sold_date_sk,inv_date_sk,cs_ship_date_sk,d_date_sk,d_date_sk,d_date_sk]
                                       InputAdapter
-                                        WholeStageCodegen (11)
-                                          Sort [cs_item_sk,d_date_sk]
+                                        WholeStageCodegen (12)
+                                          Sort [cs_sold_date_sk,inv_date_sk,cs_ship_date_sk]
                                             InputAdapter
-                                              Exchange [cs_item_sk,d_date_sk] #3
-                                                WholeStageCodegen (10)
-                                                  Project [cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,i_item_desc,d_week_seq,d_date_sk]
-                                                    BroadcastHashJoin [cs_sold_date_sk,d_date_sk,d_date,d_date]
-                                                      Project [cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk,d_date,i_item_desc]
-                                                        SortMergeJoin [cs_item_sk,i_item_sk]
-                                                          InputAdapter
-                                                            WholeStageCodegen (5)
-                                                              Sort [cs_item_sk]
-                                                                InputAdapter
-                                                                  Exchange [cs_item_sk] #4
-                                                                    WholeStageCodegen (4)
-                                                                      Project [cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk,d_date]
-                                                                        BroadcastHashJoin [cs_ship_date_sk,d_date_sk]
+                                              Exchange [cs_sold_date_sk,inv_date_sk,cs_ship_date_sk] #3
+                                                WholeStageCodegen (11)
+                                                  Project [cs_ship_date_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_sold_date_sk,i_item_desc,inv_date_sk,w_warehouse_name]
+                                                    SortMergeJoin [cs_item_sk,inv_item_sk,inv_quantity_on_hand,cs_quantity]
+                                                      InputAdapter
+                                                        WholeStageCodegen (7)
+                                                          Project [cs_ship_date_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk,i_item_desc]
+                                                            SortMergeJoin [cs_item_sk,i_item_sk]
+                                                              InputAdapter
+                                                                WholeStageCodegen (4)
+                                                                  Sort [cs_item_sk]
+                                                                    InputAdapter
+                                                                      Exchange [cs_item_sk] #4
+                                                                        WholeStageCodegen (3)
                                                                           Project [cs_ship_date_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk]
                                                                             BroadcastHashJoin [cs_bill_cdemo_sk,cd_demo_sk]
                                                                               Project [cs_ship_date_sk,cs_bill_cdemo_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk]
@@ -43,25 +43,8 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                                                                     ColumnarToRow
                                                                                       InputAdapter
                                                                                         Scan parquet spark_catalog.default.catalog_sales [cs_ship_date_sk,cs_bill_cdemo_sk,cs_bill_hdemo_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_quantity,cs_sold_date_sk]
-                                                                                          SubqueryBroadcast [d_date_sk] #1
-                                                                                            BroadcastExchange #5
-                                                                                              WholeStageCodegen (2)
-                                                                                                Project [d_date_sk,d_date,d_week_seq,d_date_sk]
-                                                                                                  BroadcastHashJoin [d_week_seq,d_week_seq]
-                                                                                                    InputAdapter
-                                                                                                      BroadcastExchange #6
-                                                                                                        WholeStageCodegen (1)
-                                                                                                          Project [d_date_sk,d_date,d_week_seq]
-                                                                                                            Filter [d_year,d_date_sk,d_week_seq,d_date]
-                                                                                                              ColumnarToRow
-                                                                                                                InputAdapter
-                                                                                                                  Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date,d_week_seq,d_year]
-                                                                                                    Filter [d_week_seq,d_date_sk]
-                                                                                                      ColumnarToRow
-                                                                                                        InputAdapter
-                                                                                                          Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq]
                                                                                   InputAdapter
-                                                                                    BroadcastExchange #7
+                                                                                    BroadcastExchange #5
                                                                                       WholeStageCodegen (1)
                                                                                         Project [hd_demo_sk]
                                                                                           Filter [hd_buy_potential,hd_demo_sk]
@@ -69,64 +52,84 @@ TakeOrderedAndProject [total_cnt,i_item_desc,w_warehouse_name,d_week_seq,no_prom
                                                                                               InputAdapter
                                                                                                 Scan parquet spark_catalog.default.household_demographics [hd_demo_sk,hd_buy_potential]
                                                                               InputAdapter
-                                                                                BroadcastExchange #8
+                                                                                BroadcastExchange #6
                                                                                   WholeStageCodegen (2)
                                                                                     Project [cd_demo_sk]
                                                                                       Filter [cd_marital_status,cd_demo_sk]
                                                                                         ColumnarToRow
                                                                                           InputAdapter
                                                                                             Scan parquet spark_catalog.default.customer_demographics [cd_demo_sk,cd_marital_status]
-                                                                          InputAdapter
-                                                                            BroadcastExchange #9
-                                                                              WholeStageCodegen (3)
-                                                                                Filter [d_date,d_date_sk]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
-                                                          InputAdapter
-                                                            WholeStageCodegen (7)
-                                                              Sort [i_item_sk]
-                                                                InputAdapter
-                                                                  Exchange [i_item_sk] #10
-                                                                    WholeStageCodegen (6)
-                                                                      Filter [i_item_sk]
+                                                              InputAdapter
+                                                                WholeStageCodegen (6)
+                                                                  Sort [i_item_sk]
+                                                                    InputAdapter
+                                                                      Exchange [i_item_sk] #7
+                                                                        WholeStageCodegen (5)
+                                                                          Filter [i_item_sk]
+                                                                            ColumnarToRow
+                                                                              InputAdapter
+                                                                                Scan parquet spark_catalog.default.item [i_item_sk,i_item_desc]
+                                                      InputAdapter
+                                                        WholeStageCodegen (10)
+                                                          Sort [inv_item_sk]
+                                                            InputAdapter
+                                                              Exchange [inv_item_sk] #8
+                                                                WholeStageCodegen (9)
+                                                                  Project [inv_item_sk,inv_quantity_on_hand,inv_date_sk,w_warehouse_name]
+                                                                    BroadcastHashJoin [inv_warehouse_sk,w_warehouse_sk]
+                                                                      Filter [inv_quantity_on_hand,inv_item_sk,inv_warehouse_sk]
                                                                         ColumnarToRow
                                                                           InputAdapter
-                                                                            Scan parquet spark_catalog.default.item [i_item_sk,i_item_desc]
-                                                      InputAdapter
-                                                        ReusedExchange [d_date_sk,d_date,d_week_seq,d_date_sk] #5
+                                                                            Scan parquet spark_catalog.default.inventory [inv_item_sk,inv_warehouse_sk,inv_quantity_on_hand,inv_date_sk]
+                                                                      InputAdapter
+                                                                        BroadcastExchange #9
+                                                                          WholeStageCodegen (8)
+                                                                            Filter [w_warehouse_sk]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet spark_catalog.default.warehouse [w_warehouse_sk,w_warehouse_name]
                                       InputAdapter
-                                        WholeStageCodegen (14)
-                                          Sort [inv_item_sk,inv_date_sk]
+                                        WholeStageCodegen (16)
+                                          Sort [d_date_sk,d_date_sk,d_date_sk]
                                             InputAdapter
-                                              Exchange [inv_item_sk,inv_date_sk] #11
-                                                WholeStageCodegen (13)
-                                                  Project [inv_item_sk,inv_quantity_on_hand,inv_date_sk,w_warehouse_name]
-                                                    BroadcastHashJoin [inv_warehouse_sk,w_warehouse_sk]
-                                                      Filter [inv_quantity_on_hand,inv_item_sk,inv_warehouse_sk]
-                                                        ColumnarToRow
+                                              Exchange [d_date_sk,d_date_sk,d_date_sk] #10
+                                                WholeStageCodegen (15)
+                                                  Project [d_date_sk,d_week_seq,d_date_sk,d_date_sk]
+                                                    BroadcastNestedLoopJoin [d_date,d_date]
+                                                      Project [d_date_sk,d_date,d_week_seq,d_date_sk]
+                                                        BroadcastHashJoin [d_week_seq,d_week_seq]
                                                           InputAdapter
-                                                            Scan parquet spark_catalog.default.inventory [inv_item_sk,inv_warehouse_sk,inv_quantity_on_hand,inv_date_sk]
+                                                            BroadcastExchange #11
+                                                              WholeStageCodegen (13)
+                                                                Project [d_date_sk,d_date,d_week_seq]
+                                                                  Filter [d_year,d_date_sk,d_week_seq,d_date]
+                                                                    ColumnarToRow
+                                                                      InputAdapter
+                                                                        Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date,d_week_seq,d_year]
+                                                          Filter [d_week_seq,d_date_sk]
+                                                            ColumnarToRow
+                                                              InputAdapter
+                                                                Scan parquet spark_catalog.default.date_dim [d_date_sk,d_week_seq]
                                                       InputAdapter
                                                         BroadcastExchange #12
-                                                          WholeStageCodegen (12)
-                                                            Filter [w_warehouse_sk]
+                                                          WholeStageCodegen (14)
+                                                            Filter [d_date,d_date_sk]
                                                               ColumnarToRow
                                                                 InputAdapter
-                                                                  Scan parquet spark_catalog.default.warehouse [w_warehouse_sk,w_warehouse_name]
+                                                                  Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
                                   InputAdapter
                                     BroadcastExchange #13
-                                      WholeStageCodegen (15)
+                                      WholeStageCodegen (17)
                                         Filter [p_promo_sk]
                                           ColumnarToRow
                                             InputAdapter
                                               Scan parquet spark_catalog.default.promotion [p_promo_sk]
                   InputAdapter
-                    WholeStageCodegen (19)
+                    WholeStageCodegen (21)
                       Sort [cr_item_sk,cr_order_number]
                         InputAdapter
                           Exchange [cr_item_sk,cr_order_number] #14
-                            WholeStageCodegen (18)
+                            WholeStageCodegen (20)
                               Project [cr_item_sk,cr_order_number]
                                 Filter [cr_item_sk,cr_order_number]
                                   ColumnarToRow

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75.sf100/explain.txt
@@ -18,17 +18,17 @@ TakeOrderedAndProject (129)
       :                             :     :  +- Exchange (14)
       :                             :     :     +- * Project (13)
       :                             :     :        +- * BroadcastHashJoin Inner BuildRight (12)
-      :                             :     :           :- * Project (10)
-      :                             :     :           :  +- * BroadcastHashJoin Inner BuildRight (9)
+      :                             :     :           :- * Project (6)
+      :                             :     :           :  +- * BroadcastHashJoin Inner BuildRight (5)
       :                             :     :           :     :- * Filter (3)
       :                             :     :           :     :  +- * ColumnarToRow (2)
       :                             :     :           :     :     +- Scan parquet spark_catalog.default.catalog_sales (1)
-      :                             :     :           :     +- BroadcastExchange (8)
-      :                             :     :           :        +- * Project (7)
-      :                             :     :           :           +- * Filter (6)
-      :                             :     :           :              +- * ColumnarToRow (5)
-      :                             :     :           :                 +- Scan parquet spark_catalog.default.item (4)
-      :                             :     :           +- ReusedExchange (11)
+      :                             :     :           :     +- ReusedExchange (4)
+      :                             :     :           +- BroadcastExchange (11)
+      :                             :     :              +- * Project (10)
+      :                             :     :                 +- * Filter (9)
+      :                             :     :                    +- * ColumnarToRow (8)
+      :                             :     :                       +- Scan parquet spark_catalog.default.item (7)
       :                             :     +- * Sort (21)
       :                             :        +- Exchange (20)
       :                             :           +- * Project (19)
@@ -145,57 +145,57 @@ Input [5]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4
 Input [5]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, cs_sold_date_sk#5]
 Condition : isnotnull(cs_item_sk#1)
 
-(4) Scan parquet spark_catalog.default.item
-Output [6]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_category#11, i_manufact_id#12]
+(4) ReusedExchange [Reuses operator id: 133]
+Output [2]: [d_date_sk#7, d_year#8]
+
+(5) BroadcastHashJoin [codegen id : 3]
+Left keys [1]: [cs_sold_date_sk#5]
+Right keys [1]: [d_date_sk#7]
+Join type: Inner
+Join condition: None
+
+(6) Project [codegen id : 3]
+Output [5]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, d_year#8]
+Input [7]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, cs_sold_date_sk#5, d_date_sk#7, d_year#8]
+
+(7) Scan parquet spark_catalog.default.item
+Output [6]: [i_item_sk#9, i_brand_id#10, i_class_id#11, i_category_id#12, i_category#13, i_manufact_id#14]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/item]
 PushedFilters: [IsNotNull(i_category), EqualTo(i_category,Books                                             ), IsNotNull(i_item_sk), IsNotNull(i_brand_id), IsNotNull(i_class_id), IsNotNull(i_category_id), IsNotNull(i_manufact_id)]
 ReadSchema: struct<i_item_sk:int,i_brand_id:int,i_class_id:int,i_category_id:int,i_category:string,i_manufact_id:int>
 
-(5) ColumnarToRow [codegen id : 1]
-Input [6]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_category#11, i_manufact_id#12]
+(8) ColumnarToRow [codegen id : 2]
+Input [6]: [i_item_sk#9, i_brand_id#10, i_class_id#11, i_category_id#12, i_category#13, i_manufact_id#14]
 
-(6) Filter [codegen id : 1]
-Input [6]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_category#11, i_manufact_id#12]
-Condition : ((((((isnotnull(i_category#11) AND (i_category#11 = Books                                             )) AND isnotnull(i_item_sk#7)) AND isnotnull(i_brand_id#8)) AND isnotnull(i_class_id#9)) AND isnotnull(i_category_id#10)) AND isnotnull(i_manufact_id#12))
+(9) Filter [codegen id : 2]
+Input [6]: [i_item_sk#9, i_brand_id#10, i_class_id#11, i_category_id#12, i_category#13, i_manufact_id#14]
+Condition : ((((((isnotnull(i_category#13) AND (i_category#13 = Books                                             )) AND isnotnull(i_item_sk#9)) AND isnotnull(i_brand_id#10)) AND isnotnull(i_class_id#11)) AND isnotnull(i_category_id#12)) AND isnotnull(i_manufact_id#14))
 
-(7) Project [codegen id : 1]
-Output [5]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
-Input [6]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_category#11, i_manufact_id#12]
+(10) Project [codegen id : 2]
+Output [5]: [i_item_sk#9, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14]
+Input [6]: [i_item_sk#9, i_brand_id#10, i_class_id#11, i_category_id#12, i_category#13, i_manufact_id#14]
 
-(8) BroadcastExchange
-Input [5]: [i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
+(11) BroadcastExchange
+Input [5]: [i_item_sk#9, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=1]
 
-(9) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [cs_item_sk#1]
-Right keys [1]: [i_item_sk#7]
-Join type: Inner
-Join condition: None
-
-(10) Project [codegen id : 3]
-Output [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, cs_sold_date_sk#5, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
-Input [10]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, cs_sold_date_sk#5, i_item_sk#7, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
-
-(11) ReusedExchange [Reuses operator id: 133]
-Output [2]: [d_date_sk#13, d_year#14]
-
 (12) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [cs_sold_date_sk#5]
-Right keys [1]: [d_date_sk#13]
+Left keys [1]: [cs_item_sk#1]
+Right keys [1]: [i_item_sk#9]
 Join type: Inner
 Join condition: None
 
 (13) Project [codegen id : 3]
-Output [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#14]
-Input [11]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, cs_sold_date_sk#5, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_date_sk#13, d_year#14]
+Output [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, d_year#8]
+Input [10]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, d_year#8, i_item_sk#9, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14]
 
 (14) Exchange
-Input [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#14]
+Input [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, d_year#8]
 Arguments: hashpartitioning(cs_order_number#2, cs_item_sk#1, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (15) Sort [codegen id : 4]
-Input [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#14]
+Input [9]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, d_year#8]
 Arguments: [cs_order_number#2 ASC NULLS FIRST, cs_item_sk#1 ASC NULLS FIRST], false, 0
 
 (16) Scan parquet spark_catalog.default.catalog_returns
@@ -231,8 +231,8 @@ Join type: LeftOuter
 Join condition: None
 
 (23) Project [codegen id : 7]
-Output [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, (cs_quantity#3 - coalesce(cr_return_quantity#17, 0)) AS sales_cnt#20, (cs_ext_sales_price#4 - coalesce(cr_return_amount#18, 0.00)) AS sales_amt#21]
-Input [13]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, d_year#14, cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18]
+Output [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, (cs_quantity#3 - coalesce(cr_return_quantity#17, 0)) AS sales_cnt#20, (cs_ext_sales_price#4 - coalesce(cr_return_amount#18, 0.00)) AS sales_amt#21]
+Input [13]: [cs_item_sk#1, cs_order_number#2, cs_quantity#3, cs_ext_sales_price#4, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, d_year#8, cr_item_sk#15, cr_order_number#16, cr_return_quantity#17, cr_return_amount#18]
 
 (24) Scan parquet spark_catalog.default.store_sales
 Output [5]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26]
@@ -249,38 +249,38 @@ Input [5]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_pri
 Input [5]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26]
 Condition : isnotnull(ss_item_sk#22)
 
-(27) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#27, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31]
+(27) ReusedExchange [Reuses operator id: 133]
+Output [2]: [d_date_sk#27, d_year#28]
 
 (28) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [ss_item_sk#22]
-Right keys [1]: [i_item_sk#27]
+Left keys [1]: [ss_sold_date_sk#26]
+Right keys [1]: [d_date_sk#27]
 Join type: Inner
 Join condition: None
 
 (29) Project [codegen id : 10]
-Output [9]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31]
-Input [10]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26, i_item_sk#27, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31]
+Output [5]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, d_year#28]
+Input [7]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26, d_date_sk#27, d_year#28]
 
-(30) ReusedExchange [Reuses operator id: 133]
-Output [2]: [d_date_sk#32, d_year#33]
+(30) ReusedExchange [Reuses operator id: 11]
+Output [5]: [i_item_sk#29, i_brand_id#30, i_class_id#31, i_category_id#32, i_manufact_id#33]
 
 (31) BroadcastHashJoin [codegen id : 10]
-Left keys [1]: [ss_sold_date_sk#26]
-Right keys [1]: [d_date_sk#32]
+Left keys [1]: [ss_item_sk#22]
+Right keys [1]: [i_item_sk#29]
 Join type: Inner
 Join condition: None
 
 (32) Project [codegen id : 10]
-Output [9]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, d_year#33]
-Input [11]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, ss_sold_date_sk#26, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, d_date_sk#32, d_year#33]
+Output [9]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#30, i_class_id#31, i_category_id#32, i_manufact_id#33, d_year#28]
+Input [10]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, d_year#28, i_item_sk#29, i_brand_id#30, i_class_id#31, i_category_id#32, i_manufact_id#33]
 
 (33) Exchange
-Input [9]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, d_year#33]
+Input [9]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#30, i_class_id#31, i_category_id#32, i_manufact_id#33, d_year#28]
 Arguments: hashpartitioning(ss_ticket_number#23, ss_item_sk#22, 5), ENSURE_REQUIREMENTS, [plan_id=4]
 
 (34) Sort [codegen id : 11]
-Input [9]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, d_year#33]
+Input [9]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#30, i_class_id#31, i_category_id#32, i_manufact_id#33, d_year#28]
 Arguments: [ss_ticket_number#23 ASC NULLS FIRST, ss_item_sk#22 ASC NULLS FIRST], false, 0
 
 (35) Scan parquet spark_catalog.default.store_returns
@@ -316,8 +316,8 @@ Join type: LeftOuter
 Join condition: None
 
 (42) Project [codegen id : 14]
-Output [7]: [d_year#33, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, (ss_quantity#24 - coalesce(sr_return_quantity#36, 0)) AS sales_cnt#39, (ss_ext_sales_price#25 - coalesce(sr_return_amt#37, 0.00)) AS sales_amt#40]
-Input [13]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#28, i_class_id#29, i_category_id#30, i_manufact_id#31, d_year#33, sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37]
+Output [7]: [d_year#28, i_brand_id#30, i_class_id#31, i_category_id#32, i_manufact_id#33, (ss_quantity#24 - coalesce(sr_return_quantity#36, 0)) AS sales_cnt#39, (ss_ext_sales_price#25 - coalesce(sr_return_amt#37, 0.00)) AS sales_amt#40]
+Input [13]: [ss_item_sk#22, ss_ticket_number#23, ss_quantity#24, ss_ext_sales_price#25, i_brand_id#30, i_class_id#31, i_category_id#32, i_manufact_id#33, d_year#28, sr_item_sk#34, sr_ticket_number#35, sr_return_quantity#36, sr_return_amt#37]
 
 (43) Scan parquet spark_catalog.default.web_sales
 Output [5]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45]
@@ -334,38 +334,38 @@ Input [5]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_pric
 Input [5]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45]
 Condition : isnotnull(ws_item_sk#41)
 
-(46) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#46, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50]
+(46) ReusedExchange [Reuses operator id: 133]
+Output [2]: [d_date_sk#46, d_year#47]
 
 (47) BroadcastHashJoin [codegen id : 17]
-Left keys [1]: [ws_item_sk#41]
-Right keys [1]: [i_item_sk#46]
+Left keys [1]: [ws_sold_date_sk#45]
+Right keys [1]: [d_date_sk#46]
 Join type: Inner
 Join condition: None
 
 (48) Project [codegen id : 17]
-Output [9]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50]
-Input [10]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45, i_item_sk#46, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50]
+Output [5]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, d_year#47]
+Input [7]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45, d_date_sk#46, d_year#47]
 
-(49) ReusedExchange [Reuses operator id: 133]
-Output [2]: [d_date_sk#51, d_year#52]
+(49) ReusedExchange [Reuses operator id: 11]
+Output [5]: [i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51, i_manufact_id#52]
 
 (50) BroadcastHashJoin [codegen id : 17]
-Left keys [1]: [ws_sold_date_sk#45]
-Right keys [1]: [d_date_sk#51]
+Left keys [1]: [ws_item_sk#41]
+Right keys [1]: [i_item_sk#48]
 Join type: Inner
 Join condition: None
 
 (51) Project [codegen id : 17]
-Output [9]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, d_year#52]
-Input [11]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, ws_sold_date_sk#45, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, d_date_sk#51, d_year#52]
+Output [9]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#49, i_class_id#50, i_category_id#51, i_manufact_id#52, d_year#47]
+Input [10]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, d_year#47, i_item_sk#48, i_brand_id#49, i_class_id#50, i_category_id#51, i_manufact_id#52]
 
 (52) Exchange
-Input [9]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, d_year#52]
+Input [9]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#49, i_class_id#50, i_category_id#51, i_manufact_id#52, d_year#47]
 Arguments: hashpartitioning(ws_order_number#42, ws_item_sk#41, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (53) Sort [codegen id : 18]
-Input [9]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, d_year#52]
+Input [9]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#49, i_class_id#50, i_category_id#51, i_manufact_id#52, d_year#47]
 Arguments: [ws_order_number#42 ASC NULLS FIRST, ws_item_sk#41 ASC NULLS FIRST], false, 0
 
 (54) Scan parquet spark_catalog.default.web_returns
@@ -401,58 +401,58 @@ Join type: LeftOuter
 Join condition: None
 
 (61) Project [codegen id : 21]
-Output [7]: [d_year#52, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, (ws_quantity#43 - coalesce(wr_return_quantity#55, 0)) AS sales_cnt#58, (ws_ext_sales_price#44 - coalesce(wr_return_amt#56, 0.00)) AS sales_amt#59]
-Input [13]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#47, i_class_id#48, i_category_id#49, i_manufact_id#50, d_year#52, wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56]
+Output [7]: [d_year#47, i_brand_id#49, i_class_id#50, i_category_id#51, i_manufact_id#52, (ws_quantity#43 - coalesce(wr_return_quantity#55, 0)) AS sales_cnt#58, (ws_ext_sales_price#44 - coalesce(wr_return_amt#56, 0.00)) AS sales_amt#59]
+Input [13]: [ws_item_sk#41, ws_order_number#42, ws_quantity#43, ws_ext_sales_price#44, i_brand_id#49, i_class_id#50, i_category_id#51, i_manufact_id#52, d_year#47, wr_item_sk#53, wr_order_number#54, wr_return_quantity#55, wr_return_amt#56]
 
 (62) Union
 
 (63) HashAggregate [codegen id : 22]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-Keys [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
+Input [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#20, sales_amt#21]
+Keys [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#20, sales_amt#21]
 Functions: []
 Aggregate Attributes: []
-Results [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
+Results [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#20, sales_amt#21]
 
 (64) Exchange
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-Arguments: hashpartitioning(d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21, 5), ENSURE_REQUIREMENTS, [plan_id=8]
+Input [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#20, sales_amt#21]
+Arguments: hashpartitioning(d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#20, sales_amt#21, 5), ENSURE_REQUIREMENTS, [plan_id=8]
 
 (65) HashAggregate [codegen id : 23]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-Keys [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
+Input [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#20, sales_amt#21]
+Keys [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#20, sales_amt#21]
 Functions: []
 Aggregate Attributes: []
-Results [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
+Results [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#20, sales_amt#21]
 
 (66) HashAggregate [codegen id : 23]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#20, sales_amt#21]
-Keys [5]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
+Input [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#20, sales_amt#21]
+Keys [5]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14]
 Functions [2]: [partial_sum(sales_cnt#20), partial_sum(UnscaledValue(sales_amt#21))]
 Aggregate Attributes [2]: [sum#60, sum#61]
-Results [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum#62, sum#63]
+Results [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sum#62, sum#63]
 
 (67) Exchange
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum#62, sum#63]
-Arguments: hashpartitioning(d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Input [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sum#62, sum#63]
+Arguments: hashpartitioning(d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (68) HashAggregate [codegen id : 24]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum#62, sum#63]
-Keys [5]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
+Input [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sum#62, sum#63]
+Keys [5]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14]
 Functions [2]: [sum(sales_cnt#20), sum(UnscaledValue(sales_amt#21))]
 Aggregate Attributes [2]: [sum(sales_cnt#20)#64, sum(UnscaledValue(sales_amt#21))#65]
-Results [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sum(sales_cnt#20)#64 AS sales_cnt#66, MakeDecimal(sum(UnscaledValue(sales_amt#21))#65,18,2) AS sales_amt#67]
+Results [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sum(sales_cnt#20)#64 AS sales_cnt#66, MakeDecimal(sum(UnscaledValue(sales_amt#21))#65,18,2) AS sales_amt#67]
 
 (69) Filter [codegen id : 24]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#66, sales_amt#67]
+Input [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#66, sales_amt#67]
 Condition : isnotnull(sales_cnt#66)
 
 (70) Exchange
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#66, sales_amt#67]
-Arguments: hashpartitioning(i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#66, sales_amt#67]
+Arguments: hashpartitioning(i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (71) Sort [codegen id : 25]
-Input [7]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#66, sales_amt#67]
-Arguments: [i_brand_id#8 ASC NULLS FIRST, i_class_id#9 ASC NULLS FIRST, i_category_id#10 ASC NULLS FIRST, i_manufact_id#12 ASC NULLS FIRST], false, 0
+Input [7]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#66, sales_amt#67]
+Arguments: [i_brand_id#10 ASC NULLS FIRST, i_class_id#11 ASC NULLS FIRST, i_category_id#12 ASC NULLS FIRST, i_manufact_id#14 ASC NULLS FIRST], false, 0
 
 (72) Scan parquet spark_catalog.default.catalog_sales
 Output [5]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72]
@@ -469,38 +469,38 @@ Input [5]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_pric
 Input [5]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72]
 Condition : isnotnull(cs_item_sk#68)
 
-(75) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#74, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
+(75) ReusedExchange [Reuses operator id: 137]
+Output [2]: [d_date_sk#74, d_year#75]
 
 (76) BroadcastHashJoin [codegen id : 28]
-Left keys [1]: [cs_item_sk#68]
-Right keys [1]: [i_item_sk#74]
+Left keys [1]: [cs_sold_date_sk#72]
+Right keys [1]: [d_date_sk#74]
 Join type: Inner
 Join condition: None
 
 (77) Project [codegen id : 28]
-Output [9]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
-Input [10]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72, i_item_sk#74, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
+Output [5]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, d_year#75]
+Input [7]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72, d_date_sk#74, d_year#75]
 
-(78) ReusedExchange [Reuses operator id: 137]
-Output [2]: [d_date_sk#79, d_year#80]
+(78) ReusedExchange [Reuses operator id: 11]
+Output [5]: [i_item_sk#76, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80]
 
 (79) BroadcastHashJoin [codegen id : 28]
-Left keys [1]: [cs_sold_date_sk#72]
-Right keys [1]: [d_date_sk#79]
+Left keys [1]: [cs_item_sk#68]
+Right keys [1]: [i_item_sk#76]
 Join type: Inner
 Join condition: None
 
 (80) Project [codegen id : 28]
-Output [9]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, d_year#80]
-Input [11]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, cs_sold_date_sk#72, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, d_date_sk#79, d_year#80]
+Output [9]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, d_year#75]
+Input [10]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, d_year#75, i_item_sk#76, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80]
 
 (81) Exchange
-Input [9]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, d_year#80]
+Input [9]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, d_year#75]
 Arguments: hashpartitioning(cs_order_number#69, cs_item_sk#68, 5), ENSURE_REQUIREMENTS, [plan_id=11]
 
 (82) Sort [codegen id : 29]
-Input [9]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, d_year#80]
+Input [9]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, d_year#75]
 Arguments: [cs_order_number#69 ASC NULLS FIRST, cs_item_sk#68 ASC NULLS FIRST], false, 0
 
 (83) ReusedExchange [Reuses operator id: 20]
@@ -517,8 +517,8 @@ Join type: LeftOuter
 Join condition: None
 
 (86) Project [codegen id : 32]
-Output [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, (cs_quantity#70 - coalesce(cr_return_quantity#83, 0)) AS sales_cnt#85, (cs_ext_sales_price#71 - coalesce(cr_return_amount#84, 0.00)) AS sales_amt#86]
-Input [13]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, d_year#80, cr_item_sk#81, cr_order_number#82, cr_return_quantity#83, cr_return_amount#84]
+Output [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, (cs_quantity#70 - coalesce(cr_return_quantity#83, 0)) AS sales_cnt#85, (cs_ext_sales_price#71 - coalesce(cr_return_amount#84, 0.00)) AS sales_amt#86]
+Input [13]: [cs_item_sk#68, cs_order_number#69, cs_quantity#70, cs_ext_sales_price#71, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, d_year#75, cr_item_sk#81, cr_order_number#82, cr_return_quantity#83, cr_return_amount#84]
 
 (87) Scan parquet spark_catalog.default.store_sales
 Output [5]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, ss_sold_date_sk#91]
@@ -535,38 +535,38 @@ Input [5]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_pri
 Input [5]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, ss_sold_date_sk#91]
 Condition : isnotnull(ss_item_sk#87)
 
-(90) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#92, i_brand_id#93, i_class_id#94, i_category_id#95, i_manufact_id#96]
+(90) ReusedExchange [Reuses operator id: 137]
+Output [2]: [d_date_sk#92, d_year#93]
 
 (91) BroadcastHashJoin [codegen id : 35]
-Left keys [1]: [ss_item_sk#87]
-Right keys [1]: [i_item_sk#92]
+Left keys [1]: [ss_sold_date_sk#91]
+Right keys [1]: [d_date_sk#92]
 Join type: Inner
 Join condition: None
 
 (92) Project [codegen id : 35]
-Output [9]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, ss_sold_date_sk#91, i_brand_id#93, i_class_id#94, i_category_id#95, i_manufact_id#96]
-Input [10]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, ss_sold_date_sk#91, i_item_sk#92, i_brand_id#93, i_class_id#94, i_category_id#95, i_manufact_id#96]
+Output [5]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, d_year#93]
+Input [7]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, ss_sold_date_sk#91, d_date_sk#92, d_year#93]
 
-(93) ReusedExchange [Reuses operator id: 137]
-Output [2]: [d_date_sk#97, d_year#98]
+(93) ReusedExchange [Reuses operator id: 11]
+Output [5]: [i_item_sk#94, i_brand_id#95, i_class_id#96, i_category_id#97, i_manufact_id#98]
 
 (94) BroadcastHashJoin [codegen id : 35]
-Left keys [1]: [ss_sold_date_sk#91]
-Right keys [1]: [d_date_sk#97]
+Left keys [1]: [ss_item_sk#87]
+Right keys [1]: [i_item_sk#94]
 Join type: Inner
 Join condition: None
 
 (95) Project [codegen id : 35]
-Output [9]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, i_brand_id#93, i_class_id#94, i_category_id#95, i_manufact_id#96, d_year#98]
-Input [11]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, ss_sold_date_sk#91, i_brand_id#93, i_class_id#94, i_category_id#95, i_manufact_id#96, d_date_sk#97, d_year#98]
+Output [9]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, i_brand_id#95, i_class_id#96, i_category_id#97, i_manufact_id#98, d_year#93]
+Input [10]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, d_year#93, i_item_sk#94, i_brand_id#95, i_class_id#96, i_category_id#97, i_manufact_id#98]
 
 (96) Exchange
-Input [9]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, i_brand_id#93, i_class_id#94, i_category_id#95, i_manufact_id#96, d_year#98]
+Input [9]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, i_brand_id#95, i_class_id#96, i_category_id#97, i_manufact_id#98, d_year#93]
 Arguments: hashpartitioning(ss_ticket_number#88, ss_item_sk#87, 5), ENSURE_REQUIREMENTS, [plan_id=12]
 
 (97) Sort [codegen id : 36]
-Input [9]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, i_brand_id#93, i_class_id#94, i_category_id#95, i_manufact_id#96, d_year#98]
+Input [9]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, i_brand_id#95, i_class_id#96, i_category_id#97, i_manufact_id#98, d_year#93]
 Arguments: [ss_ticket_number#88 ASC NULLS FIRST, ss_item_sk#87 ASC NULLS FIRST], false, 0
 
 (98) ReusedExchange [Reuses operator id: 39]
@@ -583,8 +583,8 @@ Join type: LeftOuter
 Join condition: None
 
 (101) Project [codegen id : 39]
-Output [7]: [d_year#98, i_brand_id#93, i_class_id#94, i_category_id#95, i_manufact_id#96, (ss_quantity#89 - coalesce(sr_return_quantity#101, 0)) AS sales_cnt#103, (ss_ext_sales_price#90 - coalesce(sr_return_amt#102, 0.00)) AS sales_amt#104]
-Input [13]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, i_brand_id#93, i_class_id#94, i_category_id#95, i_manufact_id#96, d_year#98, sr_item_sk#99, sr_ticket_number#100, sr_return_quantity#101, sr_return_amt#102]
+Output [7]: [d_year#93, i_brand_id#95, i_class_id#96, i_category_id#97, i_manufact_id#98, (ss_quantity#89 - coalesce(sr_return_quantity#101, 0)) AS sales_cnt#103, (ss_ext_sales_price#90 - coalesce(sr_return_amt#102, 0.00)) AS sales_amt#104]
+Input [13]: [ss_item_sk#87, ss_ticket_number#88, ss_quantity#89, ss_ext_sales_price#90, i_brand_id#95, i_class_id#96, i_category_id#97, i_manufact_id#98, d_year#93, sr_item_sk#99, sr_ticket_number#100, sr_return_quantity#101, sr_return_amt#102]
 
 (102) Scan parquet spark_catalog.default.web_sales
 Output [5]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, ws_sold_date_sk#109]
@@ -601,38 +601,38 @@ Input [5]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_p
 Input [5]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, ws_sold_date_sk#109]
 Condition : isnotnull(ws_item_sk#105)
 
-(105) ReusedExchange [Reuses operator id: 8]
-Output [5]: [i_item_sk#110, i_brand_id#111, i_class_id#112, i_category_id#113, i_manufact_id#114]
+(105) ReusedExchange [Reuses operator id: 137]
+Output [2]: [d_date_sk#110, d_year#111]
 
 (106) BroadcastHashJoin [codegen id : 42]
-Left keys [1]: [ws_item_sk#105]
-Right keys [1]: [i_item_sk#110]
+Left keys [1]: [ws_sold_date_sk#109]
+Right keys [1]: [d_date_sk#110]
 Join type: Inner
 Join condition: None
 
 (107) Project [codegen id : 42]
-Output [9]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, ws_sold_date_sk#109, i_brand_id#111, i_class_id#112, i_category_id#113, i_manufact_id#114]
-Input [10]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, ws_sold_date_sk#109, i_item_sk#110, i_brand_id#111, i_class_id#112, i_category_id#113, i_manufact_id#114]
+Output [5]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, d_year#111]
+Input [7]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, ws_sold_date_sk#109, d_date_sk#110, d_year#111]
 
-(108) ReusedExchange [Reuses operator id: 137]
-Output [2]: [d_date_sk#115, d_year#116]
+(108) ReusedExchange [Reuses operator id: 11]
+Output [5]: [i_item_sk#112, i_brand_id#113, i_class_id#114, i_category_id#115, i_manufact_id#116]
 
 (109) BroadcastHashJoin [codegen id : 42]
-Left keys [1]: [ws_sold_date_sk#109]
-Right keys [1]: [d_date_sk#115]
+Left keys [1]: [ws_item_sk#105]
+Right keys [1]: [i_item_sk#112]
 Join type: Inner
 Join condition: None
 
 (110) Project [codegen id : 42]
-Output [9]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, i_brand_id#111, i_class_id#112, i_category_id#113, i_manufact_id#114, d_year#116]
-Input [11]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, ws_sold_date_sk#109, i_brand_id#111, i_class_id#112, i_category_id#113, i_manufact_id#114, d_date_sk#115, d_year#116]
+Output [9]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, i_brand_id#113, i_class_id#114, i_category_id#115, i_manufact_id#116, d_year#111]
+Input [10]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, d_year#111, i_item_sk#112, i_brand_id#113, i_class_id#114, i_category_id#115, i_manufact_id#116]
 
 (111) Exchange
-Input [9]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, i_brand_id#111, i_class_id#112, i_category_id#113, i_manufact_id#114, d_year#116]
+Input [9]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, i_brand_id#113, i_class_id#114, i_category_id#115, i_manufact_id#116, d_year#111]
 Arguments: hashpartitioning(ws_order_number#106, ws_item_sk#105, 5), ENSURE_REQUIREMENTS, [plan_id=13]
 
 (112) Sort [codegen id : 43]
-Input [9]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, i_brand_id#111, i_class_id#112, i_category_id#113, i_manufact_id#114, d_year#116]
+Input [9]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, i_brand_id#113, i_class_id#114, i_category_id#115, i_manufact_id#116, d_year#111]
 Arguments: [ws_order_number#106 ASC NULLS FIRST, ws_item_sk#105 ASC NULLS FIRST], false, 0
 
 (113) ReusedExchange [Reuses operator id: 58]
@@ -649,72 +649,72 @@ Join type: LeftOuter
 Join condition: None
 
 (116) Project [codegen id : 46]
-Output [7]: [d_year#116, i_brand_id#111, i_class_id#112, i_category_id#113, i_manufact_id#114, (ws_quantity#107 - coalesce(wr_return_quantity#119, 0)) AS sales_cnt#121, (ws_ext_sales_price#108 - coalesce(wr_return_amt#120, 0.00)) AS sales_amt#122]
-Input [13]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, i_brand_id#111, i_class_id#112, i_category_id#113, i_manufact_id#114, d_year#116, wr_item_sk#117, wr_order_number#118, wr_return_quantity#119, wr_return_amt#120]
+Output [7]: [d_year#111, i_brand_id#113, i_class_id#114, i_category_id#115, i_manufact_id#116, (ws_quantity#107 - coalesce(wr_return_quantity#119, 0)) AS sales_cnt#121, (ws_ext_sales_price#108 - coalesce(wr_return_amt#120, 0.00)) AS sales_amt#122]
+Input [13]: [ws_item_sk#105, ws_order_number#106, ws_quantity#107, ws_ext_sales_price#108, i_brand_id#113, i_class_id#114, i_category_id#115, i_manufact_id#116, d_year#111, wr_item_sk#117, wr_order_number#118, wr_return_quantity#119, wr_return_amt#120]
 
 (117) Union
 
 (118) HashAggregate [codegen id : 47]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#85, sales_amt#86]
-Keys [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#85, sales_amt#86]
+Input [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#85, sales_amt#86]
+Keys [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#85, sales_amt#86]
 Functions: []
 Aggregate Attributes: []
-Results [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#85, sales_amt#86]
+Results [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#85, sales_amt#86]
 
 (119) Exchange
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#85, sales_amt#86]
-Arguments: hashpartitioning(d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#85, sales_amt#86, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+Input [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#85, sales_amt#86]
+Arguments: hashpartitioning(d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#85, sales_amt#86, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
 (120) HashAggregate [codegen id : 48]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#85, sales_amt#86]
-Keys [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#85, sales_amt#86]
+Input [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#85, sales_amt#86]
+Keys [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#85, sales_amt#86]
 Functions: []
 Aggregate Attributes: []
-Results [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#85, sales_amt#86]
+Results [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#85, sales_amt#86]
 
 (121) HashAggregate [codegen id : 48]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#85, sales_amt#86]
-Keys [5]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
+Input [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#85, sales_amt#86]
+Keys [5]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80]
 Functions [2]: [partial_sum(sales_cnt#85), partial_sum(UnscaledValue(sales_amt#86))]
 Aggregate Attributes [2]: [sum#123, sum#124]
-Results [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sum#125, sum#126]
+Results [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sum#125, sum#126]
 
 (122) Exchange
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sum#125, sum#126]
-Arguments: hashpartitioning(d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, 5), ENSURE_REQUIREMENTS, [plan_id=15]
+Input [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sum#125, sum#126]
+Arguments: hashpartitioning(d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, 5), ENSURE_REQUIREMENTS, [plan_id=15]
 
 (123) HashAggregate [codegen id : 49]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sum#125, sum#126]
-Keys [5]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
+Input [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sum#125, sum#126]
+Keys [5]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80]
 Functions [2]: [sum(sales_cnt#85), sum(UnscaledValue(sales_amt#86))]
 Aggregate Attributes [2]: [sum(sales_cnt#85)#64, sum(UnscaledValue(sales_amt#86))#65]
-Results [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sum(sales_cnt#85)#64 AS sales_cnt#127, MakeDecimal(sum(UnscaledValue(sales_amt#86))#65,18,2) AS sales_amt#128]
+Results [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sum(sales_cnt#85)#64 AS sales_cnt#127, MakeDecimal(sum(UnscaledValue(sales_amt#86))#65,18,2) AS sales_amt#128]
 
 (124) Filter [codegen id : 49]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#127, sales_amt#128]
+Input [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#127, sales_amt#128]
 Condition : isnotnull(sales_cnt#127)
 
 (125) Exchange
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#127, sales_amt#128]
-Arguments: hashpartitioning(i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, 5), ENSURE_REQUIREMENTS, [plan_id=16]
+Input [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#127, sales_amt#128]
+Arguments: hashpartitioning(i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, 5), ENSURE_REQUIREMENTS, [plan_id=16]
 
 (126) Sort [codegen id : 50]
-Input [7]: [d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#127, sales_amt#128]
-Arguments: [i_brand_id#75 ASC NULLS FIRST, i_class_id#76 ASC NULLS FIRST, i_category_id#77 ASC NULLS FIRST, i_manufact_id#78 ASC NULLS FIRST], false, 0
+Input [7]: [d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#127, sales_amt#128]
+Arguments: [i_brand_id#77 ASC NULLS FIRST, i_class_id#78 ASC NULLS FIRST, i_category_id#79 ASC NULLS FIRST, i_manufact_id#80 ASC NULLS FIRST], false, 0
 
 (127) SortMergeJoin [codegen id : 51]
-Left keys [4]: [i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12]
-Right keys [4]: [i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78]
+Left keys [4]: [i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14]
+Right keys [4]: [i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80]
 Join type: Inner
 Join condition: ((cast(sales_cnt#66 as decimal(17,2)) / cast(sales_cnt#127 as decimal(17,2))) < 0.90000000000000000000)
 
 (128) Project [codegen id : 51]
-Output [10]: [d_year#80 AS prev_year#129, d_year#14 AS year#130, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#127 AS prev_yr_cnt#131, sales_cnt#66 AS curr_yr_cnt#132, (sales_cnt#66 - sales_cnt#127) AS sales_cnt_diff#133, (sales_amt#67 - sales_amt#128) AS sales_amt_diff#134]
-Input [14]: [d_year#14, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, sales_cnt#66, sales_amt#67, d_year#80, i_brand_id#75, i_class_id#76, i_category_id#77, i_manufact_id#78, sales_cnt#127, sales_amt#128]
+Output [10]: [d_year#75 AS prev_year#129, d_year#8 AS year#130, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#127 AS prev_yr_cnt#131, sales_cnt#66 AS curr_yr_cnt#132, (sales_cnt#66 - sales_cnt#127) AS sales_cnt_diff#133, (sales_amt#67 - sales_amt#128) AS sales_amt_diff#134]
+Input [14]: [d_year#8, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, sales_cnt#66, sales_amt#67, d_year#75, i_brand_id#77, i_class_id#78, i_category_id#79, i_manufact_id#80, sales_cnt#127, sales_amt#128]
 
 (129) TakeOrderedAndProject
-Input [10]: [prev_year#129, year#130, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, prev_yr_cnt#131, curr_yr_cnt#132, sales_cnt_diff#133, sales_amt_diff#134]
-Arguments: 100, [sales_cnt_diff#133 ASC NULLS FIRST, sales_amt_diff#134 ASC NULLS FIRST], [prev_year#129, year#130, i_brand_id#8, i_class_id#9, i_category_id#10, i_manufact_id#12, prev_yr_cnt#131, curr_yr_cnt#132, sales_cnt_diff#133, sales_amt_diff#134]
+Input [10]: [prev_year#129, year#130, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, prev_yr_cnt#131, curr_yr_cnt#132, sales_cnt_diff#133, sales_amt_diff#134]
+Arguments: 100, [sales_cnt_diff#133 ASC NULLS FIRST, sales_amt_diff#134 ASC NULLS FIRST], [prev_year#129, year#130, i_brand_id#10, i_class_id#11, i_category_id#12, i_manufact_id#14, prev_yr_cnt#131, curr_yr_cnt#132, sales_cnt_diff#133, sales_amt_diff#134]
 
 ===== Subqueries =====
 
@@ -726,21 +726,21 @@ BroadcastExchange (133)
 
 
 (130) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#13, d_year#14]
+Output [2]: [d_date_sk#7, d_year#8]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2002), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (131) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#13, d_year#14]
+Input [2]: [d_date_sk#7, d_year#8]
 
 (132) Filter [codegen id : 1]
-Input [2]: [d_date_sk#13, d_year#14]
-Condition : ((isnotnull(d_year#14) AND (d_year#14 = 2002)) AND isnotnull(d_date_sk#13))
+Input [2]: [d_date_sk#7, d_year#8]
+Condition : ((isnotnull(d_year#8) AND (d_year#8 = 2002)) AND isnotnull(d_date_sk#7))
 
 (133) BroadcastExchange
-Input [2]: [d_date_sk#13, d_year#14]
+Input [2]: [d_date_sk#7, d_year#8]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=17]
 
 Subquery:2 Hosting operator id = 24 Hosting Expression = ss_sold_date_sk#26 IN dynamicpruning#6
@@ -755,21 +755,21 @@ BroadcastExchange (137)
 
 
 (134) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#79, d_year#80]
+Output [2]: [d_date_sk#74, d_year#75]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_year), EqualTo(d_year,2001), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_year:int>
 
 (135) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#79, d_year#80]
+Input [2]: [d_date_sk#74, d_year#75]
 
 (136) Filter [codegen id : 1]
-Input [2]: [d_date_sk#79, d_year#80]
-Condition : ((isnotnull(d_year#80) AND (d_year#80 = 2001)) AND isnotnull(d_date_sk#79))
+Input [2]: [d_date_sk#74, d_year#75]
+Condition : ((isnotnull(d_year#75) AND (d_year#75 = 2001)) AND isnotnull(d_date_sk#74))
 
 (137) BroadcastExchange
-Input [2]: [d_date_sk#79, d_year#80]
+Input [2]: [d_date_sk#74, d_year#75]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=18]
 
 Subquery:5 Hosting operator id = 87 Hosting Expression = ss_sold_date_sk#91 IN dynamicpruning#73

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q75.sf100/simplified.txt
@@ -31,9 +31,9 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                             Exchange [cs_order_number,cs_item_sk] #4
                                                               WholeStageCodegen (3)
                                                                 Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                  BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                    Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,cs_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                      BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                  BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                    Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,d_year]
+                                                                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                                         Filter [cs_item_sk]
                                                                           ColumnarToRow
                                                                             InputAdapter
@@ -46,15 +46,15 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                                                           InputAdapter
                                                                                             Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                                                         InputAdapter
-                                                                          BroadcastExchange #6
-                                                                            WholeStageCodegen (1)
-                                                                              Project [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                                Filter [i_category,i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                                  ColumnarToRow
-                                                                                    InputAdapter
-                                                                                      Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_class_id,i_category_id,i_category,i_manufact_id]
+                                                                          ReusedExchange [d_date_sk,d_year] #5
                                                                     InputAdapter
-                                                                      ReusedExchange [d_date_sk,d_year] #5
+                                                                      BroadcastExchange #6
+                                                                        WholeStageCodegen (2)
+                                                                          Project [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                            Filter [i_category,i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
+                                                                              ColumnarToRow
+                                                                                InputAdapter
+                                                                                  Scan parquet spark_catalog.default.item [i_item_sk,i_brand_id,i_class_id,i_category_id,i_category,i_manufact_id]
                                                     InputAdapter
                                                       WholeStageCodegen (6)
                                                         Sort [cr_order_number,cr_item_sk]
@@ -76,18 +76,18 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                             Exchange [ss_ticket_number,ss_item_sk] #8
                                                               WholeStageCodegen (10)
                                                                 Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                    Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,ss_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                      BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                  BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                    Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,d_year]
+                                                                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                         Filter [ss_item_sk]
                                                                           ColumnarToRow
                                                                             InputAdapter
                                                                               Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,ss_sold_date_sk]
                                                                                 ReusedSubquery [d_date_sk] #1
                                                                         InputAdapter
-                                                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
+                                                                          ReusedExchange [d_date_sk,d_year] #5
                                                                     InputAdapter
-                                                                      ReusedExchange [d_date_sk,d_year] #5
+                                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
                                                     InputAdapter
                                                       WholeStageCodegen (13)
                                                         Sort [sr_ticket_number,sr_item_sk]
@@ -109,18 +109,18 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                             Exchange [ws_order_number,ws_item_sk] #10
                                                               WholeStageCodegen (17)
                                                                 Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                  BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                    Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,ws_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                      BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                  BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                    Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,d_year]
+                                                                      BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                                         Filter [ws_item_sk]
                                                                           ColumnarToRow
                                                                             InputAdapter
                                                                               Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,ws_sold_date_sk]
                                                                                 ReusedSubquery [d_date_sk] #1
                                                                         InputAdapter
-                                                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
+                                                                          ReusedExchange [d_date_sk,d_year] #5
                                                                     InputAdapter
-                                                                      ReusedExchange [d_date_sk,d_year] #5
+                                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
                                                     InputAdapter
                                                       WholeStageCodegen (20)
                                                         Sort [wr_order_number,wr_item_sk]
@@ -161,9 +161,9 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                             Exchange [cs_order_number,cs_item_sk] #15
                                                               WholeStageCodegen (28)
                                                                 Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                  BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
-                                                                    Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,cs_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                      BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                  BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                    Project [cs_item_sk,cs_order_number,cs_quantity,cs_ext_sales_price,d_year]
+                                                                      BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
                                                                         Filter [cs_item_sk]
                                                                           ColumnarToRow
                                                                             InputAdapter
@@ -176,9 +176,9 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                                                           InputAdapter
                                                                                             Scan parquet spark_catalog.default.date_dim [d_date_sk,d_year]
                                                                         InputAdapter
-                                                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
+                                                                          ReusedExchange [d_date_sk,d_year] #16
                                                                     InputAdapter
-                                                                      ReusedExchange [d_date_sk,d_year] #16
+                                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
                                                     InputAdapter
                                                       WholeStageCodegen (31)
                                                         Sort [cr_order_number,cr_item_sk]
@@ -194,18 +194,18 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                             Exchange [ss_ticket_number,ss_item_sk] #17
                                                               WholeStageCodegen (35)
                                                                 Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                  BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
-                                                                    Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,ss_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                      BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                  BroadcastHashJoin [ss_item_sk,i_item_sk]
+                                                                    Project [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,d_year]
+                                                                      BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
                                                                         Filter [ss_item_sk]
                                                                           ColumnarToRow
                                                                             InputAdapter
                                                                               Scan parquet spark_catalog.default.store_sales [ss_item_sk,ss_ticket_number,ss_quantity,ss_ext_sales_price,ss_sold_date_sk]
                                                                                 ReusedSubquery [d_date_sk] #2
                                                                         InputAdapter
-                                                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
+                                                                          ReusedExchange [d_date_sk,d_year] #16
                                                                     InputAdapter
-                                                                      ReusedExchange [d_date_sk,d_year] #16
+                                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
                                                     InputAdapter
                                                       WholeStageCodegen (38)
                                                         Sort [sr_ticket_number,sr_item_sk]
@@ -221,18 +221,18 @@ TakeOrderedAndProject [sales_cnt_diff,sales_amt_diff,prev_year,year,i_brand_id,i
                                                             Exchange [ws_order_number,ws_item_sk] #18
                                                               WholeStageCodegen (42)
                                                                 Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,i_brand_id,i_class_id,i_category_id,i_manufact_id,d_year]
-                                                                  BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
-                                                                    Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,ws_sold_date_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id]
-                                                                      BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                  BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                    Project [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,d_year]
+                                                                      BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
                                                                         Filter [ws_item_sk]
                                                                           ColumnarToRow
                                                                             InputAdapter
                                                                               Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_order_number,ws_quantity,ws_ext_sales_price,ws_sold_date_sk]
                                                                                 ReusedSubquery [d_date_sk] #2
                                                                         InputAdapter
-                                                                          ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
+                                                                          ReusedExchange [d_date_sk,d_year] #16
                                                                     InputAdapter
-                                                                      ReusedExchange [d_date_sk,d_year] #16
+                                                                      ReusedExchange [i_item_sk,i_brand_id,i_class_id,i_category_id,i_manufact_id] #6
                                                     InputAdapter
                                                       WholeStageCodegen (45)
                                                         Sort [wr_order_number,wr_item_sk]

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a.sf100/explain.txt
@@ -15,16 +15,16 @@ TakeOrderedAndProject (98)
             :           :     :     +- * HashAggregate (13)
             :           :     :        +- * Project (12)
             :           :     :           +- * BroadcastHashJoin Inner BuildRight (11)
-            :           :     :              :- * Project (6)
-            :           :     :              :  +- * BroadcastHashJoin Inner BuildRight (5)
+            :           :     :              :- * Project (9)
+            :           :     :              :  +- * BroadcastHashJoin Inner BuildRight (8)
             :           :     :              :     :- * Filter (3)
             :           :     :              :     :  +- * ColumnarToRow (2)
             :           :     :              :     :     +- Scan parquet spark_catalog.default.store_sales (1)
-            :           :     :              :     +- ReusedExchange (4)
-            :           :     :              +- BroadcastExchange (10)
-            :           :     :                 +- * Filter (9)
-            :           :     :                    +- * ColumnarToRow (8)
-            :           :     :                       +- Scan parquet spark_catalog.default.store (7)
+            :           :     :              :     +- BroadcastExchange (7)
+            :           :     :              :        +- * Filter (6)
+            :           :     :              :           +- * ColumnarToRow (5)
+            :           :     :              :              +- Scan parquet spark_catalog.default.store (4)
+            :           :     :              +- ReusedExchange (10)
             :           :     +- BroadcastExchange (28)
             :           :        +- * HashAggregate (27)
             :           :           +- Exchange (26)
@@ -64,16 +64,16 @@ TakeOrderedAndProject (98)
             :                 :     +- * HashAggregate (62)
             :                 :        +- * Project (61)
             :                 :           +- * BroadcastHashJoin Inner BuildRight (60)
-            :                 :              :- * Project (55)
-            :                 :              :  +- * BroadcastHashJoin Inner BuildRight (54)
+            :                 :              :- * Project (58)
+            :                 :              :  +- * BroadcastHashJoin Inner BuildRight (57)
             :                 :              :     :- * Filter (52)
             :                 :              :     :  +- * ColumnarToRow (51)
             :                 :              :     :     +- Scan parquet spark_catalog.default.web_sales (50)
-            :                 :              :     +- ReusedExchange (53)
-            :                 :              +- BroadcastExchange (59)
-            :                 :                 +- * Filter (58)
-            :                 :                    +- * ColumnarToRow (57)
-            :                 :                       +- Scan parquet spark_catalog.default.web_page (56)
+            :                 :              :     +- BroadcastExchange (56)
+            :                 :              :        +- * Filter (55)
+            :                 :              :           +- * ColumnarToRow (54)
+            :                 :              :              +- Scan parquet spark_catalog.default.web_page (53)
+            :                 :              +- ReusedExchange (59)
             :                 +- BroadcastExchange (77)
             :                    +- * HashAggregate (76)
             :                       +- Exchange (75)
@@ -114,64 +114,64 @@ Input [4]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_s
 Input [4]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4]
 Condition : isnotnull(ss_store_sk#1)
 
-(4) ReusedExchange [Reuses operator id: 103]
-Output [1]: [d_date_sk#6]
-
-(5) BroadcastHashJoin [codegen id : 3]
-Left keys [1]: [ss_sold_date_sk#4]
-Right keys [1]: [d_date_sk#6]
-Join type: Inner
-Join condition: None
-
-(6) Project [codegen id : 3]
-Output [3]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3]
-Input [5]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4, d_date_sk#6]
-
-(7) Scan parquet spark_catalog.default.store
-Output [1]: [s_store_sk#7]
+(4) Scan parquet spark_catalog.default.store
+Output [1]: [s_store_sk#6]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int>
 
-(8) ColumnarToRow [codegen id : 2]
-Input [1]: [s_store_sk#7]
+(5) ColumnarToRow [codegen id : 1]
+Input [1]: [s_store_sk#6]
 
-(9) Filter [codegen id : 2]
-Input [1]: [s_store_sk#7]
-Condition : isnotnull(s_store_sk#7)
+(6) Filter [codegen id : 1]
+Input [1]: [s_store_sk#6]
+Condition : isnotnull(s_store_sk#6)
 
-(10) BroadcastExchange
-Input [1]: [s_store_sk#7]
+(7) BroadcastExchange
+Input [1]: [s_store_sk#6]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=1]
 
-(11) BroadcastHashJoin [codegen id : 3]
+(8) BroadcastHashJoin [codegen id : 3]
 Left keys [1]: [ss_store_sk#1]
-Right keys [1]: [s_store_sk#7]
+Right keys [1]: [s_store_sk#6]
+Join type: Inner
+Join condition: None
+
+(9) Project [codegen id : 3]
+Output [4]: [ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4, s_store_sk#6]
+Input [5]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4, s_store_sk#6]
+
+(10) ReusedExchange [Reuses operator id: 103]
+Output [1]: [d_date_sk#7]
+
+(11) BroadcastHashJoin [codegen id : 3]
+Left keys [1]: [ss_sold_date_sk#4]
+Right keys [1]: [d_date_sk#7]
 Join type: Inner
 Join condition: None
 
 (12) Project [codegen id : 3]
-Output [3]: [ss_ext_sales_price#2, ss_net_profit#3, s_store_sk#7]
-Input [4]: [ss_store_sk#1, ss_ext_sales_price#2, ss_net_profit#3, s_store_sk#7]
+Output [3]: [ss_ext_sales_price#2, ss_net_profit#3, s_store_sk#6]
+Input [5]: [ss_ext_sales_price#2, ss_net_profit#3, ss_sold_date_sk#4, s_store_sk#6, d_date_sk#7]
 
 (13) HashAggregate [codegen id : 3]
-Input [3]: [ss_ext_sales_price#2, ss_net_profit#3, s_store_sk#7]
-Keys [1]: [s_store_sk#7]
+Input [3]: [ss_ext_sales_price#2, ss_net_profit#3, s_store_sk#6]
+Keys [1]: [s_store_sk#6]
 Functions [2]: [partial_sum(UnscaledValue(ss_ext_sales_price#2)), partial_sum(UnscaledValue(ss_net_profit#3))]
 Aggregate Attributes [2]: [sum#8, sum#9]
-Results [3]: [s_store_sk#7, sum#10, sum#11]
+Results [3]: [s_store_sk#6, sum#10, sum#11]
 
 (14) Exchange
-Input [3]: [s_store_sk#7, sum#10, sum#11]
-Arguments: hashpartitioning(s_store_sk#7, 5), ENSURE_REQUIREMENTS, [plan_id=2]
+Input [3]: [s_store_sk#6, sum#10, sum#11]
+Arguments: hashpartitioning(s_store_sk#6, 5), ENSURE_REQUIREMENTS, [plan_id=2]
 
 (15) HashAggregate [codegen id : 8]
-Input [3]: [s_store_sk#7, sum#10, sum#11]
-Keys [1]: [s_store_sk#7]
+Input [3]: [s_store_sk#6, sum#10, sum#11]
+Keys [1]: [s_store_sk#6]
 Functions [2]: [sum(UnscaledValue(ss_ext_sales_price#2)), sum(UnscaledValue(ss_net_profit#3))]
 Aggregate Attributes [2]: [sum(UnscaledValue(ss_ext_sales_price#2))#12, sum(UnscaledValue(ss_net_profit#3))#13]
-Results [3]: [s_store_sk#7, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#12,17,2) AS sales#14, MakeDecimal(sum(UnscaledValue(ss_net_profit#3))#13,17,2) AS profit#15]
+Results [3]: [s_store_sk#6, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#2))#12,17,2) AS sales#14, MakeDecimal(sum(UnscaledValue(ss_net_profit#3))#13,17,2) AS profit#15]
 
 (16) Scan parquet spark_catalog.default.store_returns
 Output [4]: [sr_store_sk#16, sr_return_amt#17, sr_net_loss#18, sr_returned_date_sk#19]
@@ -188,63 +188,63 @@ Input [4]: [sr_store_sk#16, sr_return_amt#17, sr_net_loss#18, sr_returned_date_s
 Input [4]: [sr_store_sk#16, sr_return_amt#17, sr_net_loss#18, sr_returned_date_sk#19]
 Condition : isnotnull(sr_store_sk#16)
 
-(19) ReusedExchange [Reuses operator id: 103]
-Output [1]: [d_date_sk#20]
+(19) ReusedExchange [Reuses operator id: 7]
+Output [1]: [s_store_sk#20]
 
 (20) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [sr_returned_date_sk#19]
-Right keys [1]: [d_date_sk#20]
+Left keys [1]: [sr_store_sk#16]
+Right keys [1]: [s_store_sk#20]
 Join type: Inner
 Join condition: None
 
 (21) Project [codegen id : 6]
-Output [3]: [sr_store_sk#16, sr_return_amt#17, sr_net_loss#18]
-Input [5]: [sr_store_sk#16, sr_return_amt#17, sr_net_loss#18, sr_returned_date_sk#19, d_date_sk#20]
+Output [4]: [sr_return_amt#17, sr_net_loss#18, sr_returned_date_sk#19, s_store_sk#20]
+Input [5]: [sr_store_sk#16, sr_return_amt#17, sr_net_loss#18, sr_returned_date_sk#19, s_store_sk#20]
 
-(22) ReusedExchange [Reuses operator id: 10]
-Output [1]: [s_store_sk#21]
+(22) ReusedExchange [Reuses operator id: 103]
+Output [1]: [d_date_sk#21]
 
 (23) BroadcastHashJoin [codegen id : 6]
-Left keys [1]: [sr_store_sk#16]
-Right keys [1]: [s_store_sk#21]
+Left keys [1]: [sr_returned_date_sk#19]
+Right keys [1]: [d_date_sk#21]
 Join type: Inner
 Join condition: None
 
 (24) Project [codegen id : 6]
-Output [3]: [sr_return_amt#17, sr_net_loss#18, s_store_sk#21]
-Input [4]: [sr_store_sk#16, sr_return_amt#17, sr_net_loss#18, s_store_sk#21]
+Output [3]: [sr_return_amt#17, sr_net_loss#18, s_store_sk#20]
+Input [5]: [sr_return_amt#17, sr_net_loss#18, sr_returned_date_sk#19, s_store_sk#20, d_date_sk#21]
 
 (25) HashAggregate [codegen id : 6]
-Input [3]: [sr_return_amt#17, sr_net_loss#18, s_store_sk#21]
-Keys [1]: [s_store_sk#21]
+Input [3]: [sr_return_amt#17, sr_net_loss#18, s_store_sk#20]
+Keys [1]: [s_store_sk#20]
 Functions [2]: [partial_sum(UnscaledValue(sr_return_amt#17)), partial_sum(UnscaledValue(sr_net_loss#18))]
 Aggregate Attributes [2]: [sum#22, sum#23]
-Results [3]: [s_store_sk#21, sum#24, sum#25]
+Results [3]: [s_store_sk#20, sum#24, sum#25]
 
 (26) Exchange
-Input [3]: [s_store_sk#21, sum#24, sum#25]
-Arguments: hashpartitioning(s_store_sk#21, 5), ENSURE_REQUIREMENTS, [plan_id=3]
+Input [3]: [s_store_sk#20, sum#24, sum#25]
+Arguments: hashpartitioning(s_store_sk#20, 5), ENSURE_REQUIREMENTS, [plan_id=3]
 
 (27) HashAggregate [codegen id : 7]
-Input [3]: [s_store_sk#21, sum#24, sum#25]
-Keys [1]: [s_store_sk#21]
+Input [3]: [s_store_sk#20, sum#24, sum#25]
+Keys [1]: [s_store_sk#20]
 Functions [2]: [sum(UnscaledValue(sr_return_amt#17)), sum(UnscaledValue(sr_net_loss#18))]
 Aggregate Attributes [2]: [sum(UnscaledValue(sr_return_amt#17))#26, sum(UnscaledValue(sr_net_loss#18))#27]
-Results [3]: [s_store_sk#21, MakeDecimal(sum(UnscaledValue(sr_return_amt#17))#26,17,2) AS returns#28, MakeDecimal(sum(UnscaledValue(sr_net_loss#18))#27,17,2) AS profit_loss#29]
+Results [3]: [s_store_sk#20, MakeDecimal(sum(UnscaledValue(sr_return_amt#17))#26,17,2) AS returns#28, MakeDecimal(sum(UnscaledValue(sr_net_loss#18))#27,17,2) AS profit_loss#29]
 
 (28) BroadcastExchange
-Input [3]: [s_store_sk#21, returns#28, profit_loss#29]
+Input [3]: [s_store_sk#20, returns#28, profit_loss#29]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=4]
 
 (29) BroadcastHashJoin [codegen id : 8]
-Left keys [1]: [s_store_sk#7]
-Right keys [1]: [s_store_sk#21]
+Left keys [1]: [s_store_sk#6]
+Right keys [1]: [s_store_sk#20]
 Join type: LeftOuter
 Join condition: None
 
 (30) Project [codegen id : 8]
-Output [5]: [store channel AS channel#30, s_store_sk#7 AS id#31, sales#14, coalesce(returns#28, 0.00) AS returns#32, (profit#15 - coalesce(profit_loss#29, 0.00)) AS profit#33]
-Input [6]: [s_store_sk#7, sales#14, profit#15, s_store_sk#21, returns#28, profit_loss#29]
+Output [5]: [store channel AS channel#30, s_store_sk#6 AS id#31, sales#14, coalesce(returns#28, 0.00) AS returns#32, (profit#15 - coalesce(profit_loss#29, 0.00)) AS profit#33]
+Input [6]: [s_store_sk#6, sales#14, profit#15, s_store_sk#20, returns#28, profit_loss#29]
 
 (31) Scan parquet spark_catalog.default.catalog_sales
 Output [4]: [cs_call_center_sk#34, cs_ext_sales_price#35, cs_net_profit#36, cs_sold_date_sk#37]
@@ -355,64 +355,64 @@ Input [4]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, ws_sold_
 Input [4]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, ws_sold_date_sk#65]
 Condition : isnotnull(ws_web_page_sk#62)
 
-(53) ReusedExchange [Reuses operator id: 103]
-Output [1]: [d_date_sk#66]
-
-(54) BroadcastHashJoin [codegen id : 17]
-Left keys [1]: [ws_sold_date_sk#65]
-Right keys [1]: [d_date_sk#66]
-Join type: Inner
-Join condition: None
-
-(55) Project [codegen id : 17]
-Output [3]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64]
-Input [5]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, ws_sold_date_sk#65, d_date_sk#66]
-
-(56) Scan parquet spark_catalog.default.web_page
-Output [1]: [wp_web_page_sk#67]
+(53) Scan parquet spark_catalog.default.web_page
+Output [1]: [wp_web_page_sk#66]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_page]
 PushedFilters: [IsNotNull(wp_web_page_sk)]
 ReadSchema: struct<wp_web_page_sk:int>
 
-(57) ColumnarToRow [codegen id : 16]
-Input [1]: [wp_web_page_sk#67]
+(54) ColumnarToRow [codegen id : 15]
+Input [1]: [wp_web_page_sk#66]
 
-(58) Filter [codegen id : 16]
-Input [1]: [wp_web_page_sk#67]
-Condition : isnotnull(wp_web_page_sk#67)
+(55) Filter [codegen id : 15]
+Input [1]: [wp_web_page_sk#66]
+Condition : isnotnull(wp_web_page_sk#66)
 
-(59) BroadcastExchange
-Input [1]: [wp_web_page_sk#67]
+(56) BroadcastExchange
+Input [1]: [wp_web_page_sk#66]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=8]
 
-(60) BroadcastHashJoin [codegen id : 17]
+(57) BroadcastHashJoin [codegen id : 17]
 Left keys [1]: [ws_web_page_sk#62]
-Right keys [1]: [wp_web_page_sk#67]
+Right keys [1]: [wp_web_page_sk#66]
+Join type: Inner
+Join condition: None
+
+(58) Project [codegen id : 17]
+Output [4]: [ws_ext_sales_price#63, ws_net_profit#64, ws_sold_date_sk#65, wp_web_page_sk#66]
+Input [5]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, ws_sold_date_sk#65, wp_web_page_sk#66]
+
+(59) ReusedExchange [Reuses operator id: 103]
+Output [1]: [d_date_sk#67]
+
+(60) BroadcastHashJoin [codegen id : 17]
+Left keys [1]: [ws_sold_date_sk#65]
+Right keys [1]: [d_date_sk#67]
 Join type: Inner
 Join condition: None
 
 (61) Project [codegen id : 17]
-Output [3]: [ws_ext_sales_price#63, ws_net_profit#64, wp_web_page_sk#67]
-Input [4]: [ws_web_page_sk#62, ws_ext_sales_price#63, ws_net_profit#64, wp_web_page_sk#67]
+Output [3]: [ws_ext_sales_price#63, ws_net_profit#64, wp_web_page_sk#66]
+Input [5]: [ws_ext_sales_price#63, ws_net_profit#64, ws_sold_date_sk#65, wp_web_page_sk#66, d_date_sk#67]
 
 (62) HashAggregate [codegen id : 17]
-Input [3]: [ws_ext_sales_price#63, ws_net_profit#64, wp_web_page_sk#67]
-Keys [1]: [wp_web_page_sk#67]
+Input [3]: [ws_ext_sales_price#63, ws_net_profit#64, wp_web_page_sk#66]
+Keys [1]: [wp_web_page_sk#66]
 Functions [2]: [partial_sum(UnscaledValue(ws_ext_sales_price#63)), partial_sum(UnscaledValue(ws_net_profit#64))]
 Aggregate Attributes [2]: [sum#68, sum#69]
-Results [3]: [wp_web_page_sk#67, sum#70, sum#71]
+Results [3]: [wp_web_page_sk#66, sum#70, sum#71]
 
 (63) Exchange
-Input [3]: [wp_web_page_sk#67, sum#70, sum#71]
-Arguments: hashpartitioning(wp_web_page_sk#67, 5), ENSURE_REQUIREMENTS, [plan_id=9]
+Input [3]: [wp_web_page_sk#66, sum#70, sum#71]
+Arguments: hashpartitioning(wp_web_page_sk#66, 5), ENSURE_REQUIREMENTS, [plan_id=9]
 
 (64) HashAggregate [codegen id : 22]
-Input [3]: [wp_web_page_sk#67, sum#70, sum#71]
-Keys [1]: [wp_web_page_sk#67]
+Input [3]: [wp_web_page_sk#66, sum#70, sum#71]
+Keys [1]: [wp_web_page_sk#66]
 Functions [2]: [sum(UnscaledValue(ws_ext_sales_price#63)), sum(UnscaledValue(ws_net_profit#64))]
 Aggregate Attributes [2]: [sum(UnscaledValue(ws_ext_sales_price#63))#72, sum(UnscaledValue(ws_net_profit#64))#73]
-Results [3]: [wp_web_page_sk#67, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#63))#72,17,2) AS sales#74, MakeDecimal(sum(UnscaledValue(ws_net_profit#64))#73,17,2) AS profit#75]
+Results [3]: [wp_web_page_sk#66, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#63))#72,17,2) AS sales#74, MakeDecimal(sum(UnscaledValue(ws_net_profit#64))#73,17,2) AS profit#75]
 
 (65) Scan parquet spark_catalog.default.web_returns
 Output [4]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79]
@@ -429,63 +429,63 @@ Input [4]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wr_returned_dat
 Input [4]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79]
 Condition : isnotnull(wr_web_page_sk#76)
 
-(68) ReusedExchange [Reuses operator id: 103]
-Output [1]: [d_date_sk#80]
+(68) ReusedExchange [Reuses operator id: 56]
+Output [1]: [wp_web_page_sk#80]
 
 (69) BroadcastHashJoin [codegen id : 20]
-Left keys [1]: [wr_returned_date_sk#79]
-Right keys [1]: [d_date_sk#80]
+Left keys [1]: [wr_web_page_sk#76]
+Right keys [1]: [wp_web_page_sk#80]
 Join type: Inner
 Join condition: None
 
 (70) Project [codegen id : 20]
-Output [3]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78]
-Input [5]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79, d_date_sk#80]
+Output [4]: [wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79, wp_web_page_sk#80]
+Input [5]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79, wp_web_page_sk#80]
 
-(71) ReusedExchange [Reuses operator id: 59]
-Output [1]: [wp_web_page_sk#81]
+(71) ReusedExchange [Reuses operator id: 103]
+Output [1]: [d_date_sk#81]
 
 (72) BroadcastHashJoin [codegen id : 20]
-Left keys [1]: [wr_web_page_sk#76]
-Right keys [1]: [wp_web_page_sk#81]
+Left keys [1]: [wr_returned_date_sk#79]
+Right keys [1]: [d_date_sk#81]
 Join type: Inner
 Join condition: None
 
 (73) Project [codegen id : 20]
-Output [3]: [wr_return_amt#77, wr_net_loss#78, wp_web_page_sk#81]
-Input [4]: [wr_web_page_sk#76, wr_return_amt#77, wr_net_loss#78, wp_web_page_sk#81]
+Output [3]: [wr_return_amt#77, wr_net_loss#78, wp_web_page_sk#80]
+Input [5]: [wr_return_amt#77, wr_net_loss#78, wr_returned_date_sk#79, wp_web_page_sk#80, d_date_sk#81]
 
 (74) HashAggregate [codegen id : 20]
-Input [3]: [wr_return_amt#77, wr_net_loss#78, wp_web_page_sk#81]
-Keys [1]: [wp_web_page_sk#81]
+Input [3]: [wr_return_amt#77, wr_net_loss#78, wp_web_page_sk#80]
+Keys [1]: [wp_web_page_sk#80]
 Functions [2]: [partial_sum(UnscaledValue(wr_return_amt#77)), partial_sum(UnscaledValue(wr_net_loss#78))]
 Aggregate Attributes [2]: [sum#82, sum#83]
-Results [3]: [wp_web_page_sk#81, sum#84, sum#85]
+Results [3]: [wp_web_page_sk#80, sum#84, sum#85]
 
 (75) Exchange
-Input [3]: [wp_web_page_sk#81, sum#84, sum#85]
-Arguments: hashpartitioning(wp_web_page_sk#81, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [3]: [wp_web_page_sk#80, sum#84, sum#85]
+Arguments: hashpartitioning(wp_web_page_sk#80, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (76) HashAggregate [codegen id : 21]
-Input [3]: [wp_web_page_sk#81, sum#84, sum#85]
-Keys [1]: [wp_web_page_sk#81]
+Input [3]: [wp_web_page_sk#80, sum#84, sum#85]
+Keys [1]: [wp_web_page_sk#80]
 Functions [2]: [sum(UnscaledValue(wr_return_amt#77)), sum(UnscaledValue(wr_net_loss#78))]
 Aggregate Attributes [2]: [sum(UnscaledValue(wr_return_amt#77))#86, sum(UnscaledValue(wr_net_loss#78))#87]
-Results [3]: [wp_web_page_sk#81, MakeDecimal(sum(UnscaledValue(wr_return_amt#77))#86,17,2) AS returns#88, MakeDecimal(sum(UnscaledValue(wr_net_loss#78))#87,17,2) AS profit_loss#89]
+Results [3]: [wp_web_page_sk#80, MakeDecimal(sum(UnscaledValue(wr_return_amt#77))#86,17,2) AS returns#88, MakeDecimal(sum(UnscaledValue(wr_net_loss#78))#87,17,2) AS profit_loss#89]
 
 (77) BroadcastExchange
-Input [3]: [wp_web_page_sk#81, returns#88, profit_loss#89]
+Input [3]: [wp_web_page_sk#80, returns#88, profit_loss#89]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=11]
 
 (78) BroadcastHashJoin [codegen id : 22]
-Left keys [1]: [wp_web_page_sk#67]
-Right keys [1]: [wp_web_page_sk#81]
+Left keys [1]: [wp_web_page_sk#66]
+Right keys [1]: [wp_web_page_sk#80]
 Join type: LeftOuter
 Join condition: None
 
 (79) Project [codegen id : 22]
-Output [5]: [web channel AS channel#90, wp_web_page_sk#67 AS id#91, sales#74, coalesce(returns#88, 0.00) AS returns#92, (profit#75 - coalesce(profit_loss#89, 0.00)) AS profit#93]
-Input [6]: [wp_web_page_sk#67, sales#74, profit#75, wp_web_page_sk#81, returns#88, profit_loss#89]
+Output [5]: [web channel AS channel#90, wp_web_page_sk#66 AS id#91, sales#74, coalesce(returns#88, 0.00) AS returns#92, (profit#75 - coalesce(profit_loss#89, 0.00)) AS profit#93]
+Input [6]: [wp_web_page_sk#66, sales#74, profit#75, wp_web_page_sk#80, returns#88, profit_loss#89]
 
 (80) Union
 
@@ -598,25 +598,25 @@ BroadcastExchange (103)
 
 
 (99) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#6, d_date#179]
+Output [2]: [d_date_sk#7, d_date#179]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1998-08-04), LessThanOrEqual(d_date,1998-09-03), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (100) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#6, d_date#179]
+Input [2]: [d_date_sk#7, d_date#179]
 
 (101) Filter [codegen id : 1]
-Input [2]: [d_date_sk#6, d_date#179]
-Condition : (((isnotnull(d_date#179) AND (d_date#179 >= 1998-08-04)) AND (d_date#179 <= 1998-09-03)) AND isnotnull(d_date_sk#6))
+Input [2]: [d_date_sk#7, d_date#179]
+Condition : (((isnotnull(d_date#179) AND (d_date#179 >= 1998-08-04)) AND (d_date#179 <= 1998-09-03)) AND isnotnull(d_date_sk#7))
 
 (102) Project [codegen id : 1]
-Output [1]: [d_date_sk#6]
-Input [2]: [d_date_sk#6, d_date#179]
+Output [1]: [d_date_sk#7]
+Input [2]: [d_date_sk#7, d_date#179]
 
 (103) BroadcastExchange
-Input [1]: [d_date_sk#6]
+Input [1]: [d_date_sk#7]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=16]
 
 Subquery:2 Hosting operator id = 16 Hosting Expression = sr_returned_date_sk#19 IN dynamicpruning#5

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q77a.sf100/simplified.txt
@@ -24,9 +24,9 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                               WholeStageCodegen (3)
                                                 HashAggregate [s_store_sk,ss_ext_sales_price,ss_net_profit] [sum,sum,sum,sum]
                                                   Project [ss_ext_sales_price,ss_net_profit,s_store_sk]
-                                                    BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                      Project [ss_store_sk,ss_ext_sales_price,ss_net_profit]
-                                                        BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                      Project [ss_ext_sales_price,ss_net_profit,ss_sold_date_sk,s_store_sk]
+                                                        BroadcastHashJoin [ss_store_sk,s_store_sk]
                                                           Filter [ss_store_sk]
                                                             ColumnarToRow
                                                               InputAdapter
@@ -40,14 +40,14 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                               InputAdapter
                                                                                 Scan parquet spark_catalog.default.date_dim [d_date_sk,d_date]
                                                           InputAdapter
-                                                            ReusedExchange [d_date_sk] #4
+                                                            BroadcastExchange #5
+                                                              WholeStageCodegen (1)
+                                                                Filter [s_store_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet spark_catalog.default.store [s_store_sk]
                                                       InputAdapter
-                                                        BroadcastExchange #5
-                                                          WholeStageCodegen (2)
-                                                            Filter [s_store_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet spark_catalog.default.store [s_store_sk]
+                                                        ReusedExchange [d_date_sk] #4
                                         InputAdapter
                                           BroadcastExchange #6
                                             WholeStageCodegen (7)
@@ -57,18 +57,18 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                     WholeStageCodegen (6)
                                                       HashAggregate [s_store_sk,sr_return_amt,sr_net_loss] [sum,sum,sum,sum]
                                                         Project [sr_return_amt,sr_net_loss,s_store_sk]
-                                                          BroadcastHashJoin [sr_store_sk,s_store_sk]
-                                                            Project [sr_store_sk,sr_return_amt,sr_net_loss]
-                                                              BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
+                                                          BroadcastHashJoin [sr_returned_date_sk,d_date_sk]
+                                                            Project [sr_return_amt,sr_net_loss,sr_returned_date_sk,s_store_sk]
+                                                              BroadcastHashJoin [sr_store_sk,s_store_sk]
                                                                 Filter [sr_store_sk]
                                                                   ColumnarToRow
                                                                     InputAdapter
                                                                       Scan parquet spark_catalog.default.store_returns [sr_store_sk,sr_return_amt,sr_net_loss,sr_returned_date_sk]
                                                                         ReusedSubquery [d_date_sk] #1
                                                                 InputAdapter
-                                                                  ReusedExchange [d_date_sk] #4
+                                                                  ReusedExchange [s_store_sk] #5
                                                             InputAdapter
-                                                              ReusedExchange [s_store_sk] #5
+                                                              ReusedExchange [d_date_sk] #4
                                   WholeStageCodegen (14)
                                     Project [cs_call_center_sk,sales,returns,profit,profit_loss]
                                       BroadcastNestedLoopJoin
@@ -110,23 +110,23 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                               WholeStageCodegen (17)
                                                 HashAggregate [wp_web_page_sk,ws_ext_sales_price,ws_net_profit] [sum,sum,sum,sum]
                                                   Project [ws_ext_sales_price,ws_net_profit,wp_web_page_sk]
-                                                    BroadcastHashJoin [ws_web_page_sk,wp_web_page_sk]
-                                                      Project [ws_web_page_sk,ws_ext_sales_price,ws_net_profit]
-                                                        BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                    BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                      Project [ws_ext_sales_price,ws_net_profit,ws_sold_date_sk,wp_web_page_sk]
+                                                        BroadcastHashJoin [ws_web_page_sk,wp_web_page_sk]
                                                           Filter [ws_web_page_sk]
                                                             ColumnarToRow
                                                               InputAdapter
                                                                 Scan parquet spark_catalog.default.web_sales [ws_web_page_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk]
                                                                   ReusedSubquery [d_date_sk] #1
                                                           InputAdapter
-                                                            ReusedExchange [d_date_sk] #4
+                                                            BroadcastExchange #12
+                                                              WholeStageCodegen (15)
+                                                                Filter [wp_web_page_sk]
+                                                                  ColumnarToRow
+                                                                    InputAdapter
+                                                                      Scan parquet spark_catalog.default.web_page [wp_web_page_sk]
                                                       InputAdapter
-                                                        BroadcastExchange #12
-                                                          WholeStageCodegen (16)
-                                                            Filter [wp_web_page_sk]
-                                                              ColumnarToRow
-                                                                InputAdapter
-                                                                  Scan parquet spark_catalog.default.web_page [wp_web_page_sk]
+                                                        ReusedExchange [d_date_sk] #4
                                         InputAdapter
                                           BroadcastExchange #13
                                             WholeStageCodegen (21)
@@ -136,18 +136,18 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                     WholeStageCodegen (20)
                                                       HashAggregate [wp_web_page_sk,wr_return_amt,wr_net_loss] [sum,sum,sum,sum]
                                                         Project [wr_return_amt,wr_net_loss,wp_web_page_sk]
-                                                          BroadcastHashJoin [wr_web_page_sk,wp_web_page_sk]
-                                                            Project [wr_web_page_sk,wr_return_amt,wr_net_loss]
-                                                              BroadcastHashJoin [wr_returned_date_sk,d_date_sk]
+                                                          BroadcastHashJoin [wr_returned_date_sk,d_date_sk]
+                                                            Project [wr_return_amt,wr_net_loss,wr_returned_date_sk,wp_web_page_sk]
+                                                              BroadcastHashJoin [wr_web_page_sk,wp_web_page_sk]
                                                                 Filter [wr_web_page_sk]
                                                                   ColumnarToRow
                                                                     InputAdapter
                                                                       Scan parquet spark_catalog.default.web_returns [wr_web_page_sk,wr_return_amt,wr_net_loss,wr_returned_date_sk]
                                                                         ReusedSubquery [d_date_sk] #1
                                                                 InputAdapter
-                                                                  ReusedExchange [d_date_sk] #4
+                                                                  ReusedExchange [wp_web_page_sk] #12
                                                             InputAdapter
-                                                              ReusedExchange [wp_web_page_sk] #12
+                                                              ReusedExchange [d_date_sk] #4
                   WholeStageCodegen (49)
                     HashAggregate [channel,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),id,sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a.sf100/explain.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a.sf100/explain.txt
@@ -13,8 +13,8 @@ TakeOrderedAndProject (202)
             :           :     +- * HashAggregate (37)
             :           :        +- * Project (36)
             :           :           +- * BroadcastHashJoin Inner BuildRight (35)
-            :           :              :- * Project (30)
-            :           :              :  +- * BroadcastHashJoin Inner BuildRight (29)
+            :           :              :- * Project (33)
+            :           :              :  +- * BroadcastHashJoin Inner BuildRight (32)
             :           :              :     :- * Project (27)
             :           :              :     :  +- * BroadcastHashJoin Inner BuildRight (26)
             :           :              :     :     :- * Project (20)
@@ -42,18 +42,18 @@ TakeOrderedAndProject (202)
             :           :              :     :           +- * Filter (23)
             :           :              :     :              +- * ColumnarToRow (22)
             :           :              :     :                 +- Scan parquet spark_catalog.default.promotion (21)
-            :           :              :     +- ReusedExchange (28)
-            :           :              +- BroadcastExchange (34)
-            :           :                 +- * Filter (33)
-            :           :                    +- * ColumnarToRow (32)
-            :           :                       +- Scan parquet spark_catalog.default.store (31)
+            :           :              :     +- BroadcastExchange (31)
+            :           :              :        +- * Filter (30)
+            :           :              :           +- * ColumnarToRow (29)
+            :           :              :              +- Scan parquet spark_catalog.default.store (28)
+            :           :              +- ReusedExchange (34)
             :           :- * HashAggregate (70)
             :           :  +- Exchange (69)
             :           :     +- * HashAggregate (68)
             :           :        +- * Project (67)
             :           :           +- * BroadcastHashJoin Inner BuildRight (66)
-            :           :              :- * Project (61)
-            :           :              :  +- * BroadcastHashJoin Inner BuildRight (60)
+            :           :              :- * Project (64)
+            :           :              :  +- * BroadcastHashJoin Inner BuildRight (63)
             :           :              :     :- * Project (58)
             :           :              :     :  +- * BroadcastHashJoin Inner BuildRight (57)
             :           :              :     :     :- * Project (55)
@@ -73,18 +73,18 @@ TakeOrderedAndProject (202)
             :           :              :     :     :     :                    +- Scan parquet spark_catalog.default.catalog_returns (45)
             :           :              :     :     :     +- ReusedExchange (53)
             :           :              :     :     +- ReusedExchange (56)
-            :           :              :     +- ReusedExchange (59)
-            :           :              +- BroadcastExchange (65)
-            :           :                 +- * Filter (64)
-            :           :                    +- * ColumnarToRow (63)
-            :           :                       +- Scan parquet spark_catalog.default.catalog_page (62)
+            :           :              :     +- BroadcastExchange (62)
+            :           :              :        +- * Filter (61)
+            :           :              :           +- * ColumnarToRow (60)
+            :           :              :              +- Scan parquet spark_catalog.default.catalog_page (59)
+            :           :              +- ReusedExchange (65)
             :           +- * HashAggregate (101)
             :              +- Exchange (100)
             :                 +- * HashAggregate (99)
             :                    +- * Project (98)
             :                       +- * BroadcastHashJoin Inner BuildRight (97)
-            :                          :- * Project (92)
-            :                          :  +- * BroadcastHashJoin Inner BuildRight (91)
+            :                          :- * Project (95)
+            :                          :  +- * BroadcastHashJoin Inner BuildRight (94)
             :                          :     :- * Project (89)
             :                          :     :  +- * BroadcastHashJoin Inner BuildRight (88)
             :                          :     :     :- * Project (86)
@@ -104,11 +104,11 @@ TakeOrderedAndProject (202)
             :                          :     :     :     :                    +- Scan parquet spark_catalog.default.web_returns (76)
             :                          :     :     :     +- ReusedExchange (84)
             :                          :     :     +- ReusedExchange (87)
-            :                          :     +- ReusedExchange (90)
-            :                          +- BroadcastExchange (96)
-            :                             +- * Filter (95)
-            :                                +- * ColumnarToRow (94)
-            :                                   +- Scan parquet spark_catalog.default.web_site (93)
+            :                          :     +- BroadcastExchange (93)
+            :                          :        +- * Filter (92)
+            :                          :           +- * ColumnarToRow (91)
+            :                          :              +- Scan parquet spark_catalog.default.web_site (90)
+            :                          +- ReusedExchange (96)
             :- * HashAggregate (140)
             :  +- Exchange (139)
             :     +- * HashAggregate (138)
@@ -326,64 +326,64 @@ Join condition: None
 Output [6]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16]
 Input [8]: [ss_store_sk#2, ss_promo_sk#3, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, p_promo_sk#20]
 
-(28) ReusedExchange [Reuses operator id: 221]
-Output [1]: [d_date_sk#22]
-
-(29) BroadcastHashJoin [codegen id : 9]
-Left keys [1]: [ss_sold_date_sk#7]
-Right keys [1]: [d_date_sk#22]
-Join type: Inner
-Join condition: None
-
-(30) Project [codegen id : 9]
-Output [5]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16]
-Input [7]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, d_date_sk#22]
-
-(31) Scan parquet spark_catalog.default.store
-Output [2]: [s_store_sk#23, s_store_id#24]
+(28) Scan parquet spark_catalog.default.store
+Output [2]: [s_store_sk#22, s_store_id#23]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/store]
 PushedFilters: [IsNotNull(s_store_sk)]
 ReadSchema: struct<s_store_sk:int,s_store_id:string>
 
-(32) ColumnarToRow [codegen id : 8]
-Input [2]: [s_store_sk#23, s_store_id#24]
+(29) ColumnarToRow [codegen id : 7]
+Input [2]: [s_store_sk#22, s_store_id#23]
 
-(33) Filter [codegen id : 8]
-Input [2]: [s_store_sk#23, s_store_id#24]
-Condition : isnotnull(s_store_sk#23)
+(30) Filter [codegen id : 7]
+Input [2]: [s_store_sk#22, s_store_id#23]
+Condition : isnotnull(s_store_sk#22)
 
-(34) BroadcastExchange
-Input [2]: [s_store_sk#23, s_store_id#24]
+(31) BroadcastExchange
+Input [2]: [s_store_sk#22, s_store_id#23]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=5]
 
-(35) BroadcastHashJoin [codegen id : 9]
+(32) BroadcastHashJoin [codegen id : 9]
 Left keys [1]: [ss_store_sk#2]
-Right keys [1]: [s_store_sk#23]
+Right keys [1]: [s_store_sk#22]
+Join type: Inner
+Join condition: None
+
+(33) Project [codegen id : 9]
+Output [6]: [ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, s_store_id#23]
+Input [8]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, s_store_sk#22, s_store_id#23]
+
+(34) ReusedExchange [Reuses operator id: 221]
+Output [1]: [d_date_sk#24]
+
+(35) BroadcastHashJoin [codegen id : 9]
+Left keys [1]: [ss_sold_date_sk#7]
+Right keys [1]: [d_date_sk#24]
 Join type: Inner
 Join condition: None
 
 (36) Project [codegen id : 9]
-Output [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_id#24]
-Input [7]: [ss_store_sk#2, ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_sk#23, s_store_id#24]
+Output [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_id#23]
+Input [7]: [ss_ext_sales_price#5, ss_net_profit#6, ss_sold_date_sk#7, sr_return_amt#15, sr_net_loss#16, s_store_id#23, d_date_sk#24]
 
 (37) HashAggregate [codegen id : 9]
-Input [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_id#24]
-Keys [1]: [s_store_id#24]
+Input [5]: [ss_ext_sales_price#5, ss_net_profit#6, sr_return_amt#15, sr_net_loss#16, s_store_id#23]
+Keys [1]: [s_store_id#23]
 Functions [3]: [partial_sum(UnscaledValue(ss_ext_sales_price#5)), partial_sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00)), partial_sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))]
 Aggregate Attributes [5]: [sum#25, sum#26, isEmpty#27, sum#28, isEmpty#29]
-Results [6]: [s_store_id#24, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
+Results [6]: [s_store_id#23, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
 
 (38) Exchange
-Input [6]: [s_store_id#24, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
-Arguments: hashpartitioning(s_store_id#24, 5), ENSURE_REQUIREMENTS, [plan_id=6]
+Input [6]: [s_store_id#23, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
+Arguments: hashpartitioning(s_store_id#23, 5), ENSURE_REQUIREMENTS, [plan_id=6]
 
 (39) HashAggregate [codegen id : 10]
-Input [6]: [s_store_id#24, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
-Keys [1]: [s_store_id#24]
+Input [6]: [s_store_id#23, sum#30, sum#31, isEmpty#32, sum#33, isEmpty#34]
+Keys [1]: [s_store_id#23]
 Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#5)), sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00)), sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))]
 Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#5))#35, sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00))#36, sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))#37]
-Results [5]: [store channel AS channel#38, concat(store, s_store_id#24) AS id#39, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#5))#35,17,2) AS sales#40, sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00))#36 AS returns#41, sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))#37 AS profit#42]
+Results [5]: [store channel AS channel#38, concat(store, s_store_id#23) AS id#39, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#5))#35,17,2) AS sales#40, sum(coalesce(cast(sr_return_amt#15 as decimal(12,2)), 0.00))#36 AS returns#41, sum((ss_net_profit#6 - coalesce(cast(sr_net_loss#16 as decimal(12,2)), 0.00)))#37 AS profit#42]
 
 (40) Scan parquet spark_catalog.default.catalog_sales
 Output [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
@@ -398,7 +398,7 @@ Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_numbe
 
 (42) Filter [codegen id : 11]
 Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
-Condition : ((((isnotnull(cs_catalog_page_sk#43) AND isnotnull(cs_item_sk#44)) AND isnotnull(cs_promo_sk#45)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(cs_item_sk#44, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(cs_promo_sk#45, 42)))
+Condition : ((((isnotnull(cs_catalog_page_sk#43) AND isnotnull(cs_item_sk#44)) AND isnotnull(cs_promo_sk#45)) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(cs_promo_sk#45, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(cs_item_sk#44, 42)))
 
 (43) Exchange
 Input [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49]
@@ -444,90 +444,90 @@ Join condition: None
 Output [8]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53]
 Input [11]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_order_number#46, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_item_sk#50, cr_order_number#51, cr_return_amount#52, cr_net_loss#53]
 
-(53) ReusedExchange [Reuses operator id: 18]
-Output [1]: [i_item_sk#55]
+(53) ReusedExchange [Reuses operator id: 25]
+Output [1]: [p_promo_sk#55]
 
 (54) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_item_sk#44]
-Right keys [1]: [i_item_sk#55]
+Left keys [1]: [cs_promo_sk#45]
+Right keys [1]: [p_promo_sk#55]
 Join type: Inner
 Join condition: None
 
 (55) Project [codegen id : 19]
-Output [7]: [cs_catalog_page_sk#43, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53]
-Input [9]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, i_item_sk#55]
+Output [7]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53]
+Input [9]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, p_promo_sk#55]
 
-(56) ReusedExchange [Reuses operator id: 25]
-Output [1]: [p_promo_sk#56]
+(56) ReusedExchange [Reuses operator id: 18]
+Output [1]: [i_item_sk#56]
 
 (57) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_promo_sk#45]
-Right keys [1]: [p_promo_sk#56]
+Left keys [1]: [cs_item_sk#44]
+Right keys [1]: [i_item_sk#56]
 Join type: Inner
 Join condition: None
 
 (58) Project [codegen id : 19]
 Output [6]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53]
-Input [8]: [cs_catalog_page_sk#43, cs_promo_sk#45, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, p_promo_sk#56]
+Input [8]: [cs_catalog_page_sk#43, cs_item_sk#44, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, i_item_sk#56]
 
-(59) ReusedExchange [Reuses operator id: 221]
-Output [1]: [d_date_sk#57]
-
-(60) BroadcastHashJoin [codegen id : 19]
-Left keys [1]: [cs_sold_date_sk#49]
-Right keys [1]: [d_date_sk#57]
-Join type: Inner
-Join condition: None
-
-(61) Project [codegen id : 19]
-Output [5]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53]
-Input [7]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, d_date_sk#57]
-
-(62) Scan parquet spark_catalog.default.catalog_page
-Output [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
+(59) Scan parquet spark_catalog.default.catalog_page
+Output [2]: [cp_catalog_page_sk#57, cp_catalog_page_id#58]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/catalog_page]
 PushedFilters: [IsNotNull(cp_catalog_page_sk)]
 ReadSchema: struct<cp_catalog_page_sk:int,cp_catalog_page_id:string>
 
-(63) ColumnarToRow [codegen id : 18]
-Input [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
+(60) ColumnarToRow [codegen id : 17]
+Input [2]: [cp_catalog_page_sk#57, cp_catalog_page_id#58]
 
-(64) Filter [codegen id : 18]
-Input [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
-Condition : isnotnull(cp_catalog_page_sk#58)
+(61) Filter [codegen id : 17]
+Input [2]: [cp_catalog_page_sk#57, cp_catalog_page_id#58]
+Condition : isnotnull(cp_catalog_page_sk#57)
 
-(65) BroadcastExchange
-Input [2]: [cp_catalog_page_sk#58, cp_catalog_page_id#59]
+(62) BroadcastExchange
+Input [2]: [cp_catalog_page_sk#57, cp_catalog_page_id#58]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=9]
 
-(66) BroadcastHashJoin [codegen id : 19]
+(63) BroadcastHashJoin [codegen id : 19]
 Left keys [1]: [cs_catalog_page_sk#43]
-Right keys [1]: [cp_catalog_page_sk#58]
+Right keys [1]: [cp_catalog_page_sk#57]
+Join type: Inner
+Join condition: None
+
+(64) Project [codegen id : 19]
+Output [6]: [cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_id#58]
+Input [8]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_sk#57, cp_catalog_page_id#58]
+
+(65) ReusedExchange [Reuses operator id: 221]
+Output [1]: [d_date_sk#59]
+
+(66) BroadcastHashJoin [codegen id : 19]
+Left keys [1]: [cs_sold_date_sk#49]
+Right keys [1]: [d_date_sk#59]
 Join type: Inner
 Join condition: None
 
 (67) Project [codegen id : 19]
-Output [5]: [cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_id#59]
-Input [7]: [cs_catalog_page_sk#43, cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_sk#58, cp_catalog_page_id#59]
+Output [5]: [cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_id#58]
+Input [7]: [cs_ext_sales_price#47, cs_net_profit#48, cs_sold_date_sk#49, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_id#58, d_date_sk#59]
 
 (68) HashAggregate [codegen id : 19]
-Input [5]: [cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_id#59]
-Keys [1]: [cp_catalog_page_id#59]
+Input [5]: [cs_ext_sales_price#47, cs_net_profit#48, cr_return_amount#52, cr_net_loss#53, cp_catalog_page_id#58]
+Keys [1]: [cp_catalog_page_id#58]
 Functions [3]: [partial_sum(UnscaledValue(cs_ext_sales_price#47)), partial_sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00)), partial_sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))]
 Aggregate Attributes [5]: [sum#60, sum#61, isEmpty#62, sum#63, isEmpty#64]
-Results [6]: [cp_catalog_page_id#59, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
+Results [6]: [cp_catalog_page_id#58, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
 
 (69) Exchange
-Input [6]: [cp_catalog_page_id#59, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
-Arguments: hashpartitioning(cp_catalog_page_id#59, 5), ENSURE_REQUIREMENTS, [plan_id=10]
+Input [6]: [cp_catalog_page_id#58, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
+Arguments: hashpartitioning(cp_catalog_page_id#58, 5), ENSURE_REQUIREMENTS, [plan_id=10]
 
 (70) HashAggregate [codegen id : 20]
-Input [6]: [cp_catalog_page_id#59, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
-Keys [1]: [cp_catalog_page_id#59]
+Input [6]: [cp_catalog_page_id#58, sum#65, sum#66, isEmpty#67, sum#68, isEmpty#69]
+Keys [1]: [cp_catalog_page_id#58]
 Functions [3]: [sum(UnscaledValue(cs_ext_sales_price#47)), sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00)), sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))]
 Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_sales_price#47))#70, sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00))#71, sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))#72]
-Results [5]: [catalog channel AS channel#73, concat(catalog_page, cp_catalog_page_id#59) AS id#74, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#47))#70,17,2) AS sales#75, sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00))#71 AS returns#76, sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))#72 AS profit#77]
+Results [5]: [catalog channel AS channel#73, concat(catalog_page, cp_catalog_page_id#58) AS id#74, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#47))#70,17,2) AS sales#75, sum(coalesce(cast(cr_return_amount#52 as decimal(12,2)), 0.00))#71 AS returns#76, sum((cs_net_profit#48 - coalesce(cast(cr_net_loss#53 as decimal(12,2)), 0.00)))#72 AS profit#77]
 
 (71) Scan parquet spark_catalog.default.web_sales
 Output [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
@@ -542,7 +542,7 @@ Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81
 
 (73) Filter [codegen id : 21]
 Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
-Condition : ((((isnotnull(ws_web_site_sk#79) AND isnotnull(ws_item_sk#78)) AND isnotnull(ws_promo_sk#80)) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(ws_item_sk#78, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(ws_promo_sk#80, 42)))
+Condition : ((((isnotnull(ws_web_site_sk#79) AND isnotnull(ws_item_sk#78)) AND isnotnull(ws_promo_sk#80)) AND might_contain(ReusedSubquery Subquery scalar-subquery#11, [id=#12], xxhash64(ws_promo_sk#80, 42))) AND might_contain(ReusedSubquery Subquery scalar-subquery#9, [id=#10], xxhash64(ws_item_sk#78, 42)))
 
 (74) Exchange
 Input [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84]
@@ -588,90 +588,90 @@ Join condition: None
 Output [8]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88]
 Input [11]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_order_number#81, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_item_sk#85, wr_order_number#86, wr_return_amt#87, wr_net_loss#88]
 
-(84) ReusedExchange [Reuses operator id: 18]
-Output [1]: [i_item_sk#90]
+(84) ReusedExchange [Reuses operator id: 25]
+Output [1]: [p_promo_sk#90]
 
 (85) BroadcastHashJoin [codegen id : 29]
-Left keys [1]: [ws_item_sk#78]
-Right keys [1]: [i_item_sk#90]
+Left keys [1]: [ws_promo_sk#80]
+Right keys [1]: [p_promo_sk#90]
 Join type: Inner
 Join condition: None
 
 (86) Project [codegen id : 29]
-Output [7]: [ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88]
-Input [9]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, i_item_sk#90]
+Output [7]: [ws_item_sk#78, ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88]
+Input [9]: [ws_item_sk#78, ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, p_promo_sk#90]
 
-(87) ReusedExchange [Reuses operator id: 25]
-Output [1]: [p_promo_sk#91]
+(87) ReusedExchange [Reuses operator id: 18]
+Output [1]: [i_item_sk#91]
 
 (88) BroadcastHashJoin [codegen id : 29]
-Left keys [1]: [ws_promo_sk#80]
-Right keys [1]: [p_promo_sk#91]
+Left keys [1]: [ws_item_sk#78]
+Right keys [1]: [i_item_sk#91]
 Join type: Inner
 Join condition: None
 
 (89) Project [codegen id : 29]
 Output [6]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88]
-Input [8]: [ws_web_site_sk#79, ws_promo_sk#80, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, p_promo_sk#91]
+Input [8]: [ws_item_sk#78, ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, i_item_sk#91]
 
-(90) ReusedExchange [Reuses operator id: 221]
-Output [1]: [d_date_sk#92]
-
-(91) BroadcastHashJoin [codegen id : 29]
-Left keys [1]: [ws_sold_date_sk#84]
-Right keys [1]: [d_date_sk#92]
-Join type: Inner
-Join condition: None
-
-(92) Project [codegen id : 29]
-Output [5]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88]
-Input [7]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, d_date_sk#92]
-
-(93) Scan parquet spark_catalog.default.web_site
-Output [2]: [web_site_sk#93, web_site_id#94]
+(90) Scan parquet spark_catalog.default.web_site
+Output [2]: [web_site_sk#92, web_site_id#93]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/web_site]
 PushedFilters: [IsNotNull(web_site_sk)]
 ReadSchema: struct<web_site_sk:int,web_site_id:string>
 
-(94) ColumnarToRow [codegen id : 28]
-Input [2]: [web_site_sk#93, web_site_id#94]
+(91) ColumnarToRow [codegen id : 27]
+Input [2]: [web_site_sk#92, web_site_id#93]
 
-(95) Filter [codegen id : 28]
-Input [2]: [web_site_sk#93, web_site_id#94]
-Condition : isnotnull(web_site_sk#93)
+(92) Filter [codegen id : 27]
+Input [2]: [web_site_sk#92, web_site_id#93]
+Condition : isnotnull(web_site_sk#92)
 
-(96) BroadcastExchange
-Input [2]: [web_site_sk#93, web_site_id#94]
+(93) BroadcastExchange
+Input [2]: [web_site_sk#92, web_site_id#93]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, false] as bigint)),false), [plan_id=13]
 
-(97) BroadcastHashJoin [codegen id : 29]
+(94) BroadcastHashJoin [codegen id : 29]
 Left keys [1]: [ws_web_site_sk#79]
-Right keys [1]: [web_site_sk#93]
+Right keys [1]: [web_site_sk#92]
+Join type: Inner
+Join condition: None
+
+(95) Project [codegen id : 29]
+Output [6]: [ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, web_site_id#93]
+Input [8]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, web_site_sk#92, web_site_id#93]
+
+(96) ReusedExchange [Reuses operator id: 221]
+Output [1]: [d_date_sk#94]
+
+(97) BroadcastHashJoin [codegen id : 29]
+Left keys [1]: [ws_sold_date_sk#84]
+Right keys [1]: [d_date_sk#94]
 Join type: Inner
 Join condition: None
 
 (98) Project [codegen id : 29]
-Output [5]: [ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88, web_site_id#94]
-Input [7]: [ws_web_site_sk#79, ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88, web_site_sk#93, web_site_id#94]
+Output [5]: [ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88, web_site_id#93]
+Input [7]: [ws_ext_sales_price#82, ws_net_profit#83, ws_sold_date_sk#84, wr_return_amt#87, wr_net_loss#88, web_site_id#93, d_date_sk#94]
 
 (99) HashAggregate [codegen id : 29]
-Input [5]: [ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88, web_site_id#94]
-Keys [1]: [web_site_id#94]
+Input [5]: [ws_ext_sales_price#82, ws_net_profit#83, wr_return_amt#87, wr_net_loss#88, web_site_id#93]
+Keys [1]: [web_site_id#93]
 Functions [3]: [partial_sum(UnscaledValue(ws_ext_sales_price#82)), partial_sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00)), partial_sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))]
 Aggregate Attributes [5]: [sum#95, sum#96, isEmpty#97, sum#98, isEmpty#99]
-Results [6]: [web_site_id#94, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
+Results [6]: [web_site_id#93, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
 
 (100) Exchange
-Input [6]: [web_site_id#94, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
-Arguments: hashpartitioning(web_site_id#94, 5), ENSURE_REQUIREMENTS, [plan_id=14]
+Input [6]: [web_site_id#93, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
+Arguments: hashpartitioning(web_site_id#93, 5), ENSURE_REQUIREMENTS, [plan_id=14]
 
 (101) HashAggregate [codegen id : 30]
-Input [6]: [web_site_id#94, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
-Keys [1]: [web_site_id#94]
+Input [6]: [web_site_id#93, sum#100, sum#101, isEmpty#102, sum#103, isEmpty#104]
+Keys [1]: [web_site_id#93]
 Functions [3]: [sum(UnscaledValue(ws_ext_sales_price#82)), sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00)), sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))]
 Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_sales_price#82))#105, sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00))#106, sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))#107]
-Results [5]: [web channel AS channel#108, concat(web_site, web_site_id#94) AS id#109, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#82))#105,17,2) AS sales#110, sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00))#106 AS returns#111, sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))#107 AS profit#112]
+Results [5]: [web channel AS channel#108, concat(web_site, web_site_id#93) AS id#109, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#82))#105,17,2) AS sales#110, sum(coalesce(cast(wr_return_amt#87 as decimal(12,2)), 0.00))#106 AS returns#111, sum((ws_net_profit#83 - coalesce(cast(wr_net_loss#88 as decimal(12,2)), 0.00)))#107 AS profit#112]
 
 (102) Union
 
@@ -753,75 +753,75 @@ Join condition: None
 Output [8]: [ws_item_sk#161, ws_web_site_sk#162, ws_promo_sk#163, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171]
 Input [11]: [ws_item_sk#161, ws_web_site_sk#162, ws_promo_sk#163, ws_order_number#164, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_item_sk#168, wr_order_number#169, wr_return_amt#170, wr_net_loss#171]
 
-(119) ReusedExchange [Reuses operator id: 18]
-Output [1]: [i_item_sk#172]
+(119) ReusedExchange [Reuses operator id: 25]
+Output [1]: [p_promo_sk#172]
 
 (120) BroadcastHashJoin [codegen id : 61]
-Left keys [1]: [ws_item_sk#161]
-Right keys [1]: [i_item_sk#172]
+Left keys [1]: [ws_promo_sk#163]
+Right keys [1]: [p_promo_sk#172]
 Join type: Inner
 Join condition: None
 
 (121) Project [codegen id : 61]
-Output [7]: [ws_web_site_sk#162, ws_promo_sk#163, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171]
-Input [9]: [ws_item_sk#161, ws_web_site_sk#162, ws_promo_sk#163, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171, i_item_sk#172]
+Output [7]: [ws_item_sk#161, ws_web_site_sk#162, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171]
+Input [9]: [ws_item_sk#161, ws_web_site_sk#162, ws_promo_sk#163, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171, p_promo_sk#172]
 
-(122) ReusedExchange [Reuses operator id: 25]
-Output [1]: [p_promo_sk#173]
+(122) ReusedExchange [Reuses operator id: 18]
+Output [1]: [i_item_sk#173]
 
 (123) BroadcastHashJoin [codegen id : 61]
-Left keys [1]: [ws_promo_sk#163]
-Right keys [1]: [p_promo_sk#173]
+Left keys [1]: [ws_item_sk#161]
+Right keys [1]: [i_item_sk#173]
 Join type: Inner
 Join condition: None
 
 (124) Project [codegen id : 61]
 Output [6]: [ws_web_site_sk#162, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171]
-Input [8]: [ws_web_site_sk#162, ws_promo_sk#163, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171, p_promo_sk#173]
+Input [8]: [ws_item_sk#161, ws_web_site_sk#162, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171, i_item_sk#173]
 
-(125) ReusedExchange [Reuses operator id: 221]
-Output [1]: [d_date_sk#174]
+(125) ReusedExchange [Reuses operator id: 93]
+Output [2]: [web_site_sk#174, web_site_id#175]
 
 (126) BroadcastHashJoin [codegen id : 61]
-Left keys [1]: [ws_sold_date_sk#167]
-Right keys [1]: [d_date_sk#174]
+Left keys [1]: [ws_web_site_sk#162]
+Right keys [1]: [web_site_sk#174]
 Join type: Inner
 Join condition: None
 
 (127) Project [codegen id : 61]
-Output [5]: [ws_web_site_sk#162, ws_ext_sales_price#165, ws_net_profit#166, wr_return_amt#170, wr_net_loss#171]
-Input [7]: [ws_web_site_sk#162, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171, d_date_sk#174]
+Output [6]: [ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171, web_site_id#175]
+Input [8]: [ws_web_site_sk#162, ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171, web_site_sk#174, web_site_id#175]
 
-(128) ReusedExchange [Reuses operator id: 96]
-Output [2]: [web_site_sk#175, web_site_id#176]
+(128) ReusedExchange [Reuses operator id: 221]
+Output [1]: [d_date_sk#176]
 
 (129) BroadcastHashJoin [codegen id : 61]
-Left keys [1]: [ws_web_site_sk#162]
-Right keys [1]: [web_site_sk#175]
+Left keys [1]: [ws_sold_date_sk#167]
+Right keys [1]: [d_date_sk#176]
 Join type: Inner
 Join condition: None
 
 (130) Project [codegen id : 61]
-Output [5]: [ws_ext_sales_price#165, ws_net_profit#166, wr_return_amt#170, wr_net_loss#171, web_site_id#176]
-Input [7]: [ws_web_site_sk#162, ws_ext_sales_price#165, ws_net_profit#166, wr_return_amt#170, wr_net_loss#171, web_site_sk#175, web_site_id#176]
+Output [5]: [ws_ext_sales_price#165, ws_net_profit#166, wr_return_amt#170, wr_net_loss#171, web_site_id#175]
+Input [7]: [ws_ext_sales_price#165, ws_net_profit#166, ws_sold_date_sk#167, wr_return_amt#170, wr_net_loss#171, web_site_id#175, d_date_sk#176]
 
 (131) HashAggregate [codegen id : 61]
-Input [5]: [ws_ext_sales_price#165, ws_net_profit#166, wr_return_amt#170, wr_net_loss#171, web_site_id#176]
-Keys [1]: [web_site_id#176]
+Input [5]: [ws_ext_sales_price#165, ws_net_profit#166, wr_return_amt#170, wr_net_loss#171, web_site_id#175]
+Keys [1]: [web_site_id#175]
 Functions [3]: [partial_sum(UnscaledValue(ws_ext_sales_price#165)), partial_sum(coalesce(cast(wr_return_amt#170 as decimal(12,2)), 0.00)), partial_sum((ws_net_profit#166 - coalesce(cast(wr_net_loss#171 as decimal(12,2)), 0.00)))]
 Aggregate Attributes [5]: [sum#177, sum#178, isEmpty#179, sum#180, isEmpty#181]
-Results [6]: [web_site_id#176, sum#182, sum#183, isEmpty#184, sum#185, isEmpty#186]
+Results [6]: [web_site_id#175, sum#182, sum#183, isEmpty#184, sum#185, isEmpty#186]
 
 (132) Exchange
-Input [6]: [web_site_id#176, sum#182, sum#183, isEmpty#184, sum#185, isEmpty#186]
-Arguments: hashpartitioning(web_site_id#176, 5), ENSURE_REQUIREMENTS, [plan_id=17]
+Input [6]: [web_site_id#175, sum#182, sum#183, isEmpty#184, sum#185, isEmpty#186]
+Arguments: hashpartitioning(web_site_id#175, 5), ENSURE_REQUIREMENTS, [plan_id=17]
 
 (133) HashAggregate [codegen id : 62]
-Input [6]: [web_site_id#176, sum#182, sum#183, isEmpty#184, sum#185, isEmpty#186]
-Keys [1]: [web_site_id#176]
+Input [6]: [web_site_id#175, sum#182, sum#183, isEmpty#184, sum#185, isEmpty#186]
+Keys [1]: [web_site_id#175]
 Functions [3]: [sum(UnscaledValue(ws_ext_sales_price#165)), sum(coalesce(cast(wr_return_amt#170 as decimal(12,2)), 0.00)), sum((ws_net_profit#166 - coalesce(cast(wr_net_loss#171 as decimal(12,2)), 0.00)))]
 Aggregate Attributes [3]: [sum(UnscaledValue(ws_ext_sales_price#165))#105, sum(coalesce(cast(wr_return_amt#170 as decimal(12,2)), 0.00))#106, sum((ws_net_profit#166 - coalesce(cast(wr_net_loss#171 as decimal(12,2)), 0.00)))#107]
-Results [5]: [web channel AS channel#187, concat(web_site, web_site_id#176) AS id#188, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#165))#105,17,2) AS sales#189, sum(coalesce(cast(wr_return_amt#170 as decimal(12,2)), 0.00))#106 AS returns#190, sum((ws_net_profit#166 - coalesce(cast(wr_net_loss#171 as decimal(12,2)), 0.00)))#107 AS profit#191]
+Results [5]: [web channel AS channel#187, concat(web_site, web_site_id#175) AS id#188, MakeDecimal(sum(UnscaledValue(ws_ext_sales_price#165))#105,17,2) AS sales#189, sum(coalesce(cast(wr_return_amt#170 as decimal(12,2)), 0.00))#106 AS returns#190, sum((ws_net_profit#166 - coalesce(cast(wr_net_loss#171 as decimal(12,2)), 0.00)))#107 AS profit#191]
 
 (134) Union
 
@@ -927,49 +927,49 @@ Join condition: None
 Output [6]: [ss_store_sk#227, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232, sr_return_amt#235, sr_net_loss#236]
 Input [8]: [ss_store_sk#227, ss_promo_sk#228, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232, sr_return_amt#235, sr_net_loss#236, p_promo_sk#238]
 
-(156) ReusedExchange [Reuses operator id: 221]
-Output [1]: [d_date_sk#239]
+(156) ReusedExchange [Reuses operator id: 31]
+Output [2]: [s_store_sk#239, s_store_id#240]
 
 (157) BroadcastHashJoin [codegen id : 74]
-Left keys [1]: [ss_sold_date_sk#232]
-Right keys [1]: [d_date_sk#239]
+Left keys [1]: [ss_store_sk#227]
+Right keys [1]: [s_store_sk#239]
 Join type: Inner
 Join condition: None
 
 (158) Project [codegen id : 74]
-Output [5]: [ss_store_sk#227, ss_ext_sales_price#230, ss_net_profit#231, sr_return_amt#235, sr_net_loss#236]
-Input [7]: [ss_store_sk#227, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232, sr_return_amt#235, sr_net_loss#236, d_date_sk#239]
+Output [6]: [ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232, sr_return_amt#235, sr_net_loss#236, s_store_id#240]
+Input [8]: [ss_store_sk#227, ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232, sr_return_amt#235, sr_net_loss#236, s_store_sk#239, s_store_id#240]
 
-(159) ReusedExchange [Reuses operator id: 34]
-Output [2]: [s_store_sk#240, s_store_id#241]
+(159) ReusedExchange [Reuses operator id: 221]
+Output [1]: [d_date_sk#241]
 
 (160) BroadcastHashJoin [codegen id : 74]
-Left keys [1]: [ss_store_sk#227]
-Right keys [1]: [s_store_sk#240]
+Left keys [1]: [ss_sold_date_sk#232]
+Right keys [1]: [d_date_sk#241]
 Join type: Inner
 Join condition: None
 
 (161) Project [codegen id : 74]
-Output [5]: [ss_ext_sales_price#230, ss_net_profit#231, sr_return_amt#235, sr_net_loss#236, s_store_id#241]
-Input [7]: [ss_store_sk#227, ss_ext_sales_price#230, ss_net_profit#231, sr_return_amt#235, sr_net_loss#236, s_store_sk#240, s_store_id#241]
+Output [5]: [ss_ext_sales_price#230, ss_net_profit#231, sr_return_amt#235, sr_net_loss#236, s_store_id#240]
+Input [7]: [ss_ext_sales_price#230, ss_net_profit#231, ss_sold_date_sk#232, sr_return_amt#235, sr_net_loss#236, s_store_id#240, d_date_sk#241]
 
 (162) HashAggregate [codegen id : 74]
-Input [5]: [ss_ext_sales_price#230, ss_net_profit#231, sr_return_amt#235, sr_net_loss#236, s_store_id#241]
-Keys [1]: [s_store_id#241]
+Input [5]: [ss_ext_sales_price#230, ss_net_profit#231, sr_return_amt#235, sr_net_loss#236, s_store_id#240]
+Keys [1]: [s_store_id#240]
 Functions [3]: [partial_sum(UnscaledValue(ss_ext_sales_price#230)), partial_sum(coalesce(cast(sr_return_amt#235 as decimal(12,2)), 0.00)), partial_sum((ss_net_profit#231 - coalesce(cast(sr_net_loss#236 as decimal(12,2)), 0.00)))]
 Aggregate Attributes [5]: [sum#242, sum#243, isEmpty#244, sum#245, isEmpty#246]
-Results [6]: [s_store_id#241, sum#247, sum#248, isEmpty#249, sum#250, isEmpty#251]
+Results [6]: [s_store_id#240, sum#247, sum#248, isEmpty#249, sum#250, isEmpty#251]
 
 (163) Exchange
-Input [6]: [s_store_id#241, sum#247, sum#248, isEmpty#249, sum#250, isEmpty#251]
-Arguments: hashpartitioning(s_store_id#241, 5), ENSURE_REQUIREMENTS, [plan_id=21]
+Input [6]: [s_store_id#240, sum#247, sum#248, isEmpty#249, sum#250, isEmpty#251]
+Arguments: hashpartitioning(s_store_id#240, 5), ENSURE_REQUIREMENTS, [plan_id=21]
 
 (164) HashAggregate [codegen id : 75]
-Input [6]: [s_store_id#241, sum#247, sum#248, isEmpty#249, sum#250, isEmpty#251]
-Keys [1]: [s_store_id#241]
+Input [6]: [s_store_id#240, sum#247, sum#248, isEmpty#249, sum#250, isEmpty#251]
+Keys [1]: [s_store_id#240]
 Functions [3]: [sum(UnscaledValue(ss_ext_sales_price#230)), sum(coalesce(cast(sr_return_amt#235 as decimal(12,2)), 0.00)), sum((ss_net_profit#231 - coalesce(cast(sr_net_loss#236 as decimal(12,2)), 0.00)))]
 Aggregate Attributes [3]: [sum(UnscaledValue(ss_ext_sales_price#230))#35, sum(coalesce(cast(sr_return_amt#235 as decimal(12,2)), 0.00))#36, sum((ss_net_profit#231 - coalesce(cast(sr_net_loss#236 as decimal(12,2)), 0.00)))#37]
-Results [5]: [store channel AS channel#252, concat(store, s_store_id#241) AS id#253, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#230))#35,17,2) AS sales#254, sum(coalesce(cast(sr_return_amt#235 as decimal(12,2)), 0.00))#36 AS returns#255, sum((ss_net_profit#231 - coalesce(cast(sr_net_loss#236 as decimal(12,2)), 0.00)))#37 AS profit#256]
+Results [5]: [store channel AS channel#252, concat(store, s_store_id#240) AS id#253, MakeDecimal(sum(UnscaledValue(ss_ext_sales_price#230))#35,17,2) AS sales#254, sum(coalesce(cast(sr_return_amt#235 as decimal(12,2)), 0.00))#36 AS returns#255, sum((ss_net_profit#231 - coalesce(cast(sr_net_loss#236 as decimal(12,2)), 0.00)))#37 AS profit#256]
 
 (165) Scan parquet spark_catalog.default.catalog_sales
 Output [7]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_promo_sk#259, cs_order_number#260, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263]
@@ -1011,75 +1011,75 @@ Join condition: None
 Output [8]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_promo_sk#259, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267]
 Input [11]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_promo_sk#259, cs_order_number#260, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_item_sk#264, cr_order_number#265, cr_return_amount#266, cr_net_loss#267]
 
-(174) ReusedExchange [Reuses operator id: 18]
-Output [1]: [i_item_sk#268]
+(174) ReusedExchange [Reuses operator id: 25]
+Output [1]: [p_promo_sk#268]
 
 (175) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [cs_item_sk#258]
-Right keys [1]: [i_item_sk#268]
+Left keys [1]: [cs_promo_sk#259]
+Right keys [1]: [p_promo_sk#268]
 Join type: Inner
 Join condition: None
 
 (176) Project [codegen id : 84]
-Output [7]: [cs_catalog_page_sk#257, cs_promo_sk#259, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267]
-Input [9]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_promo_sk#259, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267, i_item_sk#268]
+Output [7]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267]
+Input [9]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_promo_sk#259, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267, p_promo_sk#268]
 
-(177) ReusedExchange [Reuses operator id: 25]
-Output [1]: [p_promo_sk#269]
+(177) ReusedExchange [Reuses operator id: 18]
+Output [1]: [i_item_sk#269]
 
 (178) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [cs_promo_sk#259]
-Right keys [1]: [p_promo_sk#269]
+Left keys [1]: [cs_item_sk#258]
+Right keys [1]: [i_item_sk#269]
 Join type: Inner
 Join condition: None
 
 (179) Project [codegen id : 84]
 Output [6]: [cs_catalog_page_sk#257, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267]
-Input [8]: [cs_catalog_page_sk#257, cs_promo_sk#259, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267, p_promo_sk#269]
+Input [8]: [cs_catalog_page_sk#257, cs_item_sk#258, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267, i_item_sk#269]
 
-(180) ReusedExchange [Reuses operator id: 221]
-Output [1]: [d_date_sk#270]
+(180) ReusedExchange [Reuses operator id: 62]
+Output [2]: [cp_catalog_page_sk#270, cp_catalog_page_id#271]
 
 (181) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [cs_sold_date_sk#263]
-Right keys [1]: [d_date_sk#270]
+Left keys [1]: [cs_catalog_page_sk#257]
+Right keys [1]: [cp_catalog_page_sk#270]
 Join type: Inner
 Join condition: None
 
 (182) Project [codegen id : 84]
-Output [5]: [cs_catalog_page_sk#257, cs_ext_sales_price#261, cs_net_profit#262, cr_return_amount#266, cr_net_loss#267]
-Input [7]: [cs_catalog_page_sk#257, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267, d_date_sk#270]
+Output [6]: [cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267, cp_catalog_page_id#271]
+Input [8]: [cs_catalog_page_sk#257, cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267, cp_catalog_page_sk#270, cp_catalog_page_id#271]
 
-(183) ReusedExchange [Reuses operator id: 65]
-Output [2]: [cp_catalog_page_sk#271, cp_catalog_page_id#272]
+(183) ReusedExchange [Reuses operator id: 221]
+Output [1]: [d_date_sk#272]
 
 (184) BroadcastHashJoin [codegen id : 84]
-Left keys [1]: [cs_catalog_page_sk#257]
-Right keys [1]: [cp_catalog_page_sk#271]
+Left keys [1]: [cs_sold_date_sk#263]
+Right keys [1]: [d_date_sk#272]
 Join type: Inner
 Join condition: None
 
 (185) Project [codegen id : 84]
-Output [5]: [cs_ext_sales_price#261, cs_net_profit#262, cr_return_amount#266, cr_net_loss#267, cp_catalog_page_id#272]
-Input [7]: [cs_catalog_page_sk#257, cs_ext_sales_price#261, cs_net_profit#262, cr_return_amount#266, cr_net_loss#267, cp_catalog_page_sk#271, cp_catalog_page_id#272]
+Output [5]: [cs_ext_sales_price#261, cs_net_profit#262, cr_return_amount#266, cr_net_loss#267, cp_catalog_page_id#271]
+Input [7]: [cs_ext_sales_price#261, cs_net_profit#262, cs_sold_date_sk#263, cr_return_amount#266, cr_net_loss#267, cp_catalog_page_id#271, d_date_sk#272]
 
 (186) HashAggregate [codegen id : 84]
-Input [5]: [cs_ext_sales_price#261, cs_net_profit#262, cr_return_amount#266, cr_net_loss#267, cp_catalog_page_id#272]
-Keys [1]: [cp_catalog_page_id#272]
+Input [5]: [cs_ext_sales_price#261, cs_net_profit#262, cr_return_amount#266, cr_net_loss#267, cp_catalog_page_id#271]
+Keys [1]: [cp_catalog_page_id#271]
 Functions [3]: [partial_sum(UnscaledValue(cs_ext_sales_price#261)), partial_sum(coalesce(cast(cr_return_amount#266 as decimal(12,2)), 0.00)), partial_sum((cs_net_profit#262 - coalesce(cast(cr_net_loss#267 as decimal(12,2)), 0.00)))]
 Aggregate Attributes [5]: [sum#273, sum#274, isEmpty#275, sum#276, isEmpty#277]
-Results [6]: [cp_catalog_page_id#272, sum#278, sum#279, isEmpty#280, sum#281, isEmpty#282]
+Results [6]: [cp_catalog_page_id#271, sum#278, sum#279, isEmpty#280, sum#281, isEmpty#282]
 
 (187) Exchange
-Input [6]: [cp_catalog_page_id#272, sum#278, sum#279, isEmpty#280, sum#281, isEmpty#282]
-Arguments: hashpartitioning(cp_catalog_page_id#272, 5), ENSURE_REQUIREMENTS, [plan_id=23]
+Input [6]: [cp_catalog_page_id#271, sum#278, sum#279, isEmpty#280, sum#281, isEmpty#282]
+Arguments: hashpartitioning(cp_catalog_page_id#271, 5), ENSURE_REQUIREMENTS, [plan_id=23]
 
 (188) HashAggregate [codegen id : 85]
-Input [6]: [cp_catalog_page_id#272, sum#278, sum#279, isEmpty#280, sum#281, isEmpty#282]
-Keys [1]: [cp_catalog_page_id#272]
+Input [6]: [cp_catalog_page_id#271, sum#278, sum#279, isEmpty#280, sum#281, isEmpty#282]
+Keys [1]: [cp_catalog_page_id#271]
 Functions [3]: [sum(UnscaledValue(cs_ext_sales_price#261)), sum(coalesce(cast(cr_return_amount#266 as decimal(12,2)), 0.00)), sum((cs_net_profit#262 - coalesce(cast(cr_net_loss#267 as decimal(12,2)), 0.00)))]
 Aggregate Attributes [3]: [sum(UnscaledValue(cs_ext_sales_price#261))#70, sum(coalesce(cast(cr_return_amount#266 as decimal(12,2)), 0.00))#71, sum((cs_net_profit#262 - coalesce(cast(cr_net_loss#267 as decimal(12,2)), 0.00)))#72]
-Results [5]: [catalog channel AS channel#283, concat(catalog_page, cp_catalog_page_id#272) AS id#284, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#261))#70,17,2) AS sales#285, sum(coalesce(cast(cr_return_amount#266 as decimal(12,2)), 0.00))#71 AS returns#286, sum((cs_net_profit#262 - coalesce(cast(cr_net_loss#267 as decimal(12,2)), 0.00)))#72 AS profit#287]
+Results [5]: [catalog channel AS channel#283, concat(catalog_page, cp_catalog_page_id#271) AS id#284, MakeDecimal(sum(UnscaledValue(cs_ext_sales_price#261))#70,17,2) AS sales#285, sum(coalesce(cast(cr_return_amount#266 as decimal(12,2)), 0.00))#71 AS returns#286, sum((cs_net_profit#262 - coalesce(cast(cr_net_loss#267 as decimal(12,2)), 0.00)))#72 AS profit#287]
 
 (189) ReusedExchange [Reuses operator id: 132]
 Output [6]: [web_site_id#288, sum#289, sum#290, isEmpty#291, sum#292, isEmpty#293]
@@ -1256,36 +1256,36 @@ BroadcastExchange (221)
 
 
 (217) Scan parquet spark_catalog.default.date_dim
-Output [2]: [d_date_sk#22, d_date#346]
+Output [2]: [d_date_sk#24, d_date#346]
 Batched: true
 Location [not included in comparison]/{warehouse_dir}/date_dim]
 PushedFilters: [IsNotNull(d_date), GreaterThanOrEqual(d_date,1998-08-04), LessThanOrEqual(d_date,1998-09-03), IsNotNull(d_date_sk)]
 ReadSchema: struct<d_date_sk:int,d_date:date>
 
 (218) ColumnarToRow [codegen id : 1]
-Input [2]: [d_date_sk#22, d_date#346]
+Input [2]: [d_date_sk#24, d_date#346]
 
 (219) Filter [codegen id : 1]
-Input [2]: [d_date_sk#22, d_date#346]
-Condition : (((isnotnull(d_date#346) AND (d_date#346 >= 1998-08-04)) AND (d_date#346 <= 1998-09-03)) AND isnotnull(d_date_sk#22))
+Input [2]: [d_date_sk#24, d_date#346]
+Condition : (((isnotnull(d_date#346) AND (d_date#346 >= 1998-08-04)) AND (d_date#346 <= 1998-09-03)) AND isnotnull(d_date_sk#24))
 
 (220) Project [codegen id : 1]
-Output [1]: [d_date_sk#22]
-Input [2]: [d_date_sk#22, d_date#346]
+Output [1]: [d_date_sk#24]
+Input [2]: [d_date_sk#24, d_date#346]
 
 (221) BroadcastExchange
-Input [1]: [d_date_sk#22]
+Input [1]: [d_date_sk#24]
 Arguments: HashedRelationBroadcastMode(List(cast(input[0, int, true] as bigint)),false), [plan_id=29]
 
-Subquery:4 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#10]
+Subquery:4 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
 
-Subquery:5 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
+Subquery:5 Hosting operator id = 42 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#10]
 
 Subquery:6 Hosting operator id = 40 Hosting Expression = cs_sold_date_sk#49 IN dynamicpruning#8
 
-Subquery:7 Hosting operator id = 73 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#10]
+Subquery:7 Hosting operator id = 73 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
 
-Subquery:8 Hosting operator id = 73 Hosting Expression = ReusedSubquery Subquery scalar-subquery#11, [id=#12]
+Subquery:8 Hosting operator id = 73 Hosting Expression = ReusedSubquery Subquery scalar-subquery#9, [id=#10]
 
 Subquery:9 Hosting operator id = 71 Hosting Expression = ws_sold_date_sk#84 IN dynamicpruning#8
 

--- a/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a.sf100/simplified.txt
+++ b/sql/core/src/test/resources/tpcds-plan-stability/approved-plans-v2_7/q80a.sf100/simplified.txt
@@ -22,9 +22,9 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                           WholeStageCodegen (9)
                                             HashAggregate [s_store_id,ss_ext_sales_price,sr_return_amt,ss_net_profit,sr_net_loss] [sum,sum,isEmpty,sum,isEmpty,sum,sum,isEmpty,sum,isEmpty]
                                               Project [ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss,s_store_id]
-                                                BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                  Project [ss_store_sk,ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss]
-                                                    BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                  Project [ss_ext_sales_price,ss_net_profit,ss_sold_date_sk,sr_return_amt,sr_net_loss,s_store_id]
+                                                    BroadcastHashJoin [ss_store_sk,s_store_sk]
                                                       Project [ss_store_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk,sr_return_amt,sr_net_loss]
                                                         BroadcastHashJoin [ss_promo_sk,p_promo_sk]
                                                           Project [ss_store_sk,ss_promo_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk,sr_return_amt,sr_net_loss]
@@ -97,14 +97,14 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                       InputAdapter
                                                                         Scan parquet spark_catalog.default.promotion [p_promo_sk,p_channel_tv]
                                                       InputAdapter
-                                                        ReusedExchange [d_date_sk] #5
+                                                        BroadcastExchange #11
+                                                          WholeStageCodegen (7)
+                                                            Filter [s_store_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
                                                   InputAdapter
-                                                    BroadcastExchange #11
-                                                      WholeStageCodegen (8)
-                                                        Filter [s_store_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.store [s_store_sk,s_store_id]
+                                                    ReusedExchange [d_date_sk] #5
                                   WholeStageCodegen (20)
                                     HashAggregate [cp_catalog_page_id,sum,sum,isEmpty,sum,isEmpty] [sum(UnscaledValue(cs_ext_sales_price)),sum(coalesce(cast(cr_return_amount as decimal(12,2)), 0.00)),sum((cs_net_profit - coalesce(cast(cr_net_loss as decimal(12,2)), 0.00))),channel,id,sales,returns,profit,sum,sum,isEmpty,sum,isEmpty]
                                       InputAdapter
@@ -112,13 +112,13 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                           WholeStageCodegen (19)
                                             HashAggregate [cp_catalog_page_id,cs_ext_sales_price,cr_return_amount,cs_net_profit,cr_net_loss] [sum,sum,isEmpty,sum,isEmpty,sum,sum,isEmpty,sum,isEmpty]
                                               Project [cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss,cp_catalog_page_id]
-                                                BroadcastHashJoin [cs_catalog_page_sk,cp_catalog_page_sk]
-                                                  Project [cs_catalog_page_sk,cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss]
-                                                    BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                  Project [cs_ext_sales_price,cs_net_profit,cs_sold_date_sk,cr_return_amount,cr_net_loss,cp_catalog_page_id]
+                                                    BroadcastHashJoin [cs_catalog_page_sk,cp_catalog_page_sk]
                                                       Project [cs_catalog_page_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk,cr_return_amount,cr_net_loss]
-                                                        BroadcastHashJoin [cs_promo_sk,p_promo_sk]
-                                                          Project [cs_catalog_page_sk,cs_promo_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk,cr_return_amount,cr_net_loss]
-                                                            BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                        BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                          Project [cs_catalog_page_sk,cs_item_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk,cr_return_amount,cr_net_loss]
+                                                            BroadcastHashJoin [cs_promo_sk,p_promo_sk]
                                                               Project [cs_catalog_page_sk,cs_item_sk,cs_promo_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk,cr_return_amount,cr_net_loss]
                                                                 SortMergeJoin [cs_item_sk,cs_order_number,cr_item_sk,cr_order_number]
                                                                   InputAdapter
@@ -128,8 +128,8 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                           Exchange [cs_item_sk,cs_order_number] #13
                                                                             WholeStageCodegen (11)
                                                                               Filter [cs_catalog_page_sk,cs_item_sk,cs_promo_sk]
-                                                                                ReusedSubquery [bloomFilter] #2
                                                                                 ReusedSubquery [bloomFilter] #3
+                                                                                ReusedSubquery [bloomFilter] #2
                                                                                 ColumnarToRow
                                                                                   InputAdapter
                                                                                     Scan parquet spark_catalog.default.catalog_sales [cs_catalog_page_sk,cs_item_sk,cs_promo_sk,cs_order_number,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk]
@@ -146,18 +146,18 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                                     InputAdapter
                                                                                       Scan parquet spark_catalog.default.catalog_returns [cr_item_sk,cr_order_number,cr_return_amount,cr_net_loss,cr_returned_date_sk]
                                                               InputAdapter
-                                                                ReusedExchange [i_item_sk] #9
+                                                                ReusedExchange [p_promo_sk] #10
                                                           InputAdapter
-                                                            ReusedExchange [p_promo_sk] #10
+                                                            ReusedExchange [i_item_sk] #9
                                                       InputAdapter
-                                                        ReusedExchange [d_date_sk] #5
+                                                        BroadcastExchange #15
+                                                          WholeStageCodegen (17)
+                                                            Filter [cp_catalog_page_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet spark_catalog.default.catalog_page [cp_catalog_page_sk,cp_catalog_page_id]
                                                   InputAdapter
-                                                    BroadcastExchange #15
-                                                      WholeStageCodegen (18)
-                                                        Filter [cp_catalog_page_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.catalog_page [cp_catalog_page_sk,cp_catalog_page_id]
+                                                    ReusedExchange [d_date_sk] #5
                                   WholeStageCodegen (30)
                                     HashAggregate [web_site_id,sum,sum,isEmpty,sum,isEmpty] [sum(UnscaledValue(ws_ext_sales_price)),sum(coalesce(cast(wr_return_amt as decimal(12,2)), 0.00)),sum((ws_net_profit - coalesce(cast(wr_net_loss as decimal(12,2)), 0.00))),channel,id,sales,returns,profit,sum,sum,isEmpty,sum,isEmpty]
                                       InputAdapter
@@ -165,13 +165,13 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                           WholeStageCodegen (29)
                                             HashAggregate [web_site_id,ws_ext_sales_price,wr_return_amt,ws_net_profit,wr_net_loss] [sum,sum,isEmpty,sum,isEmpty,sum,sum,isEmpty,sum,isEmpty]
                                               Project [ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss,web_site_id]
-                                                BroadcastHashJoin [ws_web_site_sk,web_site_sk]
-                                                  Project [ws_web_site_sk,ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss]
-                                                    BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                  Project [ws_ext_sales_price,ws_net_profit,ws_sold_date_sk,wr_return_amt,wr_net_loss,web_site_id]
+                                                    BroadcastHashJoin [ws_web_site_sk,web_site_sk]
                                                       Project [ws_web_site_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk,wr_return_amt,wr_net_loss]
-                                                        BroadcastHashJoin [ws_promo_sk,p_promo_sk]
-                                                          Project [ws_web_site_sk,ws_promo_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk,wr_return_amt,wr_net_loss]
-                                                            BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                        BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                          Project [ws_item_sk,ws_web_site_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk,wr_return_amt,wr_net_loss]
+                                                            BroadcastHashJoin [ws_promo_sk,p_promo_sk]
                                                               Project [ws_item_sk,ws_web_site_sk,ws_promo_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk,wr_return_amt,wr_net_loss]
                                                                 SortMergeJoin [ws_item_sk,ws_order_number,wr_item_sk,wr_order_number]
                                                                   InputAdapter
@@ -181,8 +181,8 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                           Exchange [ws_item_sk,ws_order_number] #17
                                                                             WholeStageCodegen (21)
                                                                               Filter [ws_web_site_sk,ws_item_sk,ws_promo_sk]
-                                                                                ReusedSubquery [bloomFilter] #2
                                                                                 ReusedSubquery [bloomFilter] #3
+                                                                                ReusedSubquery [bloomFilter] #2
                                                                                 ColumnarToRow
                                                                                   InputAdapter
                                                                                     Scan parquet spark_catalog.default.web_sales [ws_item_sk,ws_web_site_sk,ws_promo_sk,ws_order_number,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk]
@@ -199,18 +199,18 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                                     InputAdapter
                                                                                       Scan parquet spark_catalog.default.web_returns [wr_item_sk,wr_order_number,wr_return_amt,wr_net_loss,wr_returned_date_sk]
                                                               InputAdapter
-                                                                ReusedExchange [i_item_sk] #9
+                                                                ReusedExchange [p_promo_sk] #10
                                                           InputAdapter
-                                                            ReusedExchange [p_promo_sk] #10
+                                                            ReusedExchange [i_item_sk] #9
                                                       InputAdapter
-                                                        ReusedExchange [d_date_sk] #5
+                                                        BroadcastExchange #19
+                                                          WholeStageCodegen (27)
+                                                            Filter [web_site_sk]
+                                                              ColumnarToRow
+                                                                InputAdapter
+                                                                  Scan parquet spark_catalog.default.web_site [web_site_sk,web_site_id]
                                                   InputAdapter
-                                                    BroadcastExchange #19
-                                                      WholeStageCodegen (28)
-                                                        Filter [web_site_sk]
-                                                          ColumnarToRow
-                                                            InputAdapter
-                                                              Scan parquet spark_catalog.default.web_site [web_site_sk,web_site_id]
+                                                    ReusedExchange [d_date_sk] #5
                   WholeStageCodegen (65)
                     HashAggregate [channel,sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),id,sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
@@ -239,13 +239,13 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                     WholeStageCodegen (61)
                                                       HashAggregate [web_site_id,ws_ext_sales_price,wr_return_amt,ws_net_profit,wr_net_loss] [sum,sum,isEmpty,sum,isEmpty,sum,sum,isEmpty,sum,isEmpty]
                                                         Project [ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss,web_site_id]
-                                                          BroadcastHashJoin [ws_web_site_sk,web_site_sk]
-                                                            Project [ws_web_site_sk,ws_ext_sales_price,ws_net_profit,wr_return_amt,wr_net_loss]
-                                                              BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                          BroadcastHashJoin [ws_sold_date_sk,d_date_sk]
+                                                            Project [ws_ext_sales_price,ws_net_profit,ws_sold_date_sk,wr_return_amt,wr_net_loss,web_site_id]
+                                                              BroadcastHashJoin [ws_web_site_sk,web_site_sk]
                                                                 Project [ws_web_site_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk,wr_return_amt,wr_net_loss]
-                                                                  BroadcastHashJoin [ws_promo_sk,p_promo_sk]
-                                                                    Project [ws_web_site_sk,ws_promo_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk,wr_return_amt,wr_net_loss]
-                                                                      BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                  BroadcastHashJoin [ws_item_sk,i_item_sk]
+                                                                    Project [ws_item_sk,ws_web_site_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk,wr_return_amt,wr_net_loss]
+                                                                      BroadcastHashJoin [ws_promo_sk,p_promo_sk]
                                                                         Project [ws_item_sk,ws_web_site_sk,ws_promo_sk,ws_ext_sales_price,ws_net_profit,ws_sold_date_sk,wr_return_amt,wr_net_loss]
                                                                           SortMergeJoin [ws_item_sk,ws_order_number,wr_item_sk,wr_order_number]
                                                                             InputAdapter
@@ -265,13 +265,13 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                                   InputAdapter
                                                                                     ReusedExchange [wr_item_sk,wr_order_number,wr_return_amt,wr_net_loss] #18
                                                                         InputAdapter
-                                                                          ReusedExchange [i_item_sk] #9
+                                                                          ReusedExchange [p_promo_sk] #10
                                                                     InputAdapter
-                                                                      ReusedExchange [p_promo_sk] #10
+                                                                      ReusedExchange [i_item_sk] #9
                                                                 InputAdapter
-                                                                  ReusedExchange [d_date_sk] #5
+                                                                  ReusedExchange [web_site_sk,web_site_id] #19
                                                             InputAdapter
-                                                              ReusedExchange [web_site_sk,web_site_id] #19
+                                                              ReusedExchange [d_date_sk] #5
                   WholeStageCodegen (98)
                     HashAggregate [sum,isEmpty,sum,isEmpty,sum,isEmpty] [sum(sales),sum(returns),sum(profit),channel,id,sales,returns,profit,sum,isEmpty,sum,isEmpty,sum,isEmpty]
                       InputAdapter
@@ -292,9 +292,9 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                     WholeStageCodegen (74)
                                                       HashAggregate [s_store_id,ss_ext_sales_price,sr_return_amt,ss_net_profit,sr_net_loss] [sum,sum,isEmpty,sum,isEmpty,sum,sum,isEmpty,sum,isEmpty]
                                                         Project [ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss,s_store_id]
-                                                          BroadcastHashJoin [ss_store_sk,s_store_sk]
-                                                            Project [ss_store_sk,ss_ext_sales_price,ss_net_profit,sr_return_amt,sr_net_loss]
-                                                              BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                          BroadcastHashJoin [ss_sold_date_sk,d_date_sk]
+                                                            Project [ss_ext_sales_price,ss_net_profit,ss_sold_date_sk,sr_return_amt,sr_net_loss,s_store_id]
+                                                              BroadcastHashJoin [ss_store_sk,s_store_sk]
                                                                 Project [ss_store_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk,sr_return_amt,sr_net_loss]
                                                                   BroadcastHashJoin [ss_promo_sk,p_promo_sk]
                                                                     Project [ss_store_sk,ss_promo_sk,ss_ext_sales_price,ss_net_profit,ss_sold_date_sk,sr_return_amt,sr_net_loss]
@@ -322,9 +322,9 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                     InputAdapter
                                                                       ReusedExchange [p_promo_sk] #10
                                                                 InputAdapter
-                                                                  ReusedExchange [d_date_sk] #5
+                                                                  ReusedExchange [s_store_sk,s_store_id] #11
                                                             InputAdapter
-                                                              ReusedExchange [s_store_sk,s_store_id] #11
+                                                              ReusedExchange [d_date_sk] #5
                                             WholeStageCodegen (85)
                                               HashAggregate [cp_catalog_page_id,sum,sum,isEmpty,sum,isEmpty] [sum(UnscaledValue(cs_ext_sales_price)),sum(coalesce(cast(cr_return_amount as decimal(12,2)), 0.00)),sum((cs_net_profit - coalesce(cast(cr_net_loss as decimal(12,2)), 0.00))),channel,id,sales,returns,profit,sum,sum,isEmpty,sum,isEmpty]
                                                 InputAdapter
@@ -332,13 +332,13 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                     WholeStageCodegen (84)
                                                       HashAggregate [cp_catalog_page_id,cs_ext_sales_price,cr_return_amount,cs_net_profit,cr_net_loss] [sum,sum,isEmpty,sum,isEmpty,sum,sum,isEmpty,sum,isEmpty]
                                                         Project [cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss,cp_catalog_page_id]
-                                                          BroadcastHashJoin [cs_catalog_page_sk,cp_catalog_page_sk]
-                                                            Project [cs_catalog_page_sk,cs_ext_sales_price,cs_net_profit,cr_return_amount,cr_net_loss]
-                                                              BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                          BroadcastHashJoin [cs_sold_date_sk,d_date_sk]
+                                                            Project [cs_ext_sales_price,cs_net_profit,cs_sold_date_sk,cr_return_amount,cr_net_loss,cp_catalog_page_id]
+                                                              BroadcastHashJoin [cs_catalog_page_sk,cp_catalog_page_sk]
                                                                 Project [cs_catalog_page_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk,cr_return_amount,cr_net_loss]
-                                                                  BroadcastHashJoin [cs_promo_sk,p_promo_sk]
-                                                                    Project [cs_catalog_page_sk,cs_promo_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk,cr_return_amount,cr_net_loss]
-                                                                      BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                  BroadcastHashJoin [cs_item_sk,i_item_sk]
+                                                                    Project [cs_catalog_page_sk,cs_item_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk,cr_return_amount,cr_net_loss]
+                                                                      BroadcastHashJoin [cs_promo_sk,p_promo_sk]
                                                                         Project [cs_catalog_page_sk,cs_item_sk,cs_promo_sk,cs_ext_sales_price,cs_net_profit,cs_sold_date_sk,cr_return_amount,cr_net_loss]
                                                                           SortMergeJoin [cs_item_sk,cs_order_number,cr_item_sk,cr_order_number]
                                                                             InputAdapter
@@ -358,13 +358,13 @@ TakeOrderedAndProject [channel,id,sales,returns,profit]
                                                                                   InputAdapter
                                                                                     ReusedExchange [cr_item_sk,cr_order_number,cr_return_amount,cr_net_loss] #14
                                                                         InputAdapter
-                                                                          ReusedExchange [i_item_sk] #9
+                                                                          ReusedExchange [p_promo_sk] #10
                                                                     InputAdapter
-                                                                      ReusedExchange [p_promo_sk] #10
+                                                                      ReusedExchange [i_item_sk] #9
                                                                 InputAdapter
-                                                                  ReusedExchange [d_date_sk] #5
+                                                                  ReusedExchange [cp_catalog_page_sk,cp_catalog_page_id] #15
                                                             InputAdapter
-                                                              ReusedExchange [cp_catalog_page_sk,cp_catalog_page_id] #15
+                                                              ReusedExchange [d_date_sk] #5
                                             WholeStageCodegen (95)
                                               HashAggregate [web_site_id,sum,sum,isEmpty,sum,isEmpty] [sum(UnscaledValue(ws_ext_sales_price)),sum(coalesce(cast(wr_return_amt as decimal(12,2)), 0.00)),sum((ws_net_profit - coalesce(cast(wr_net_loss as decimal(12,2)), 0.00))),channel,id,sales,returns,profit,sum,sum,isEmpty,sum,isEmpty]
                                                 InputAdapter


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR improve Join stats estimate when column stats exist.

For example:
Left side:
```
36126 bytes, 2150 rows
```

info_name | info_value
-- | --
col_name | key-1980
data_type | string
comment | NULL
min | NULL
max | NULL
num_nulls | 1
distinct_count | 1980
avg_col_len | 9
max_col_len | 38
histogram | NULL

Right side:
```
13250653950 bytes, 1470064309 rows
```

info_name | info_value
-- | --
col_name | key-3896196
data_type | string
comment | NULL
min | NULL
max | NULL
num_nulls | 320713790
distinct_count | 3896196
avg_col_len | 8
max_col_len | 69
histogram | NULL

Before this PR:
```
+- Join Inner, (key-1980#388 = key-3896196#382), Statistics(sizeInBytes=71.1 MiB, rowCount=8.11E+5)
```
After this PR:
```
+- Join Inner, (key-1980#388 = key-3896196#382), Statistics(sizeInBytes=106.9 GiB, rowCount=1.25E+9)
```
The actual number of rows is [380,857,863](https://issues.apache.org/jira/secure/attachment/13071429/enable%20CBO.png). The new statistics make much more reasonable than the previous ones.


### Why are the changes needed?

1. Avoid broadcast join fail.
   ```
   org.apache.spark.SparkException: Cannot broadcast the table that is larger than 4GB: 4GB
   ```
2. Avoid Spark driver OOM.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.

### Was this patch authored or co-authored using generative AI tooling?

No.