### PR TITLE
[SPARK-49545][INFRA] Increase timeout for build from 3 to 4 hours

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -141,7 +141,7 @@ jobs:
     needs: precondition
     if: fromJson(needs.precondition.outputs.required).build == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 240
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to increase timeout for build from 3 to 4 hours

### Why are the changes needed?

In order to recover https://github.com/apache/spark/actions/workflows/build_python_3.12.yml. It fails with hitting 3 hours limit.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Will monitor the build.

### Was this patch authored or co-authored using generative AI tooling?

No.
