### PR TITLE
[SPARK-49575][SS] Add logging for lock release only if acquiredThreadInfo is not null

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -927,10 +927,12 @@ class RocksDB(
    * @param opType - operation type releasing the lock
    */
   private def release(opType: RocksDBOpType): Unit = acquireLock.synchronized {
-    logInfo(log"RocksDB instance was released by ${MDC(LogKeys.THREAD, acquiredThreadInfo)} " +
-      log"for opType=${MDC(LogKeys.OP_TYPE, opType.toString)}")
-    acquiredThreadInfo = null
-    acquireLock.notifyAll()
+    if (acquiredThreadInfo != null) {
+      logInfo(log"RocksDB instance was released by ${MDC(LogKeys.THREAD,
+        acquiredThreadInfo)} " + log"for opType=${MDC(LogKeys.OP_TYPE, opType.toString)}")
+      acquiredThreadInfo = null
+      acquireLock.notifyAll()
+    }
   }
 
   private def getDBProperty(property: String): Long = db.getProperty(property).toLong


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add logging for lock release only if acquiredThreadInfo is not null

### Why are the changes needed?
Without this, there are a lot of extraneous executor logs of the following type

```
24/09/05 21:38:19 INFO RocksDB StateStoreId(opId=0,partId=45,name=default): RocksDB instance was released by null for opType=store_task_completion_listener
24/09/05 21:38:19 INFO RocksDB StateStoreId(opId=0,partId=45,name=default): RocksDB instance was released by null for opType=store_task_completion_listener
24/09/05 21:38:20 INFO RocksDB StateStoreId(opId=0,partId=173,name=default): RocksDB instance was released by null for opType=store_task_completion_listener
24/09/05 21:38:20 INFO RocksDB StateStoreId(opId=0,partId=173,name=default): RocksDB instance was released by null for opType=store_task_completion_listener
24/09/05 21:38:21 INFO RocksDB StateStoreId(opId=0,partId=13,name=default): RocksDB instance was released by null for opType=store_task_completion_listener
24/09/05 21:38:21 INFO RocksDB StateStoreId(opId=0,partId=13,name=default): RocksDB instance was released by null for opType=store_task_completion_listener
24/09/05 21:38:21 INFO RocksDB StateStoreId(opId=0,partId=141,name=default): RocksDB instance was released by null for opType=store_task_completion_listener
24/09/05 21:38:21 INFO RocksDB StateStoreId(opId=0,partId=141,name=default): RocksDB instance was released by null for opType=store_task_completion_listener
24/09/05 21:38:25 INFO RocksDB StateStoreId(opId=0,partId=109,name=default): RocksDB instance was released by null for opType=store_task_completion_listener
24/09/05 21:38:25 INFO RocksDB StateStoreId(opId=0,partId=109,name=default): RocksDB instance was released by null for opType=store_task_completion_listener
```


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing unit tests


### Was this patch authored or co-authored using generative AI tooling?
No
