### PR TITLE
[SPARK-49085][FOLLOWUP] Update the scope of `spark-protobuf`

### DIFF
--- a/sql/connect/server/pom.xml
+++ b/sql/connect/server/pom.xml
@@ -111,7 +111,8 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-protobuf_${scala.binary.version}</artifactId>
       <version>${project.version}</version>
-      <scope>provided</scope>
+      <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update the scope of `spark-protobuf`


### Why are the changes needed?
after https://github.com/apache/spark/pull/47885, `org.apache.spark.sql.protobuf` is only used for testing


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
CI


### Was this patch authored or co-authored using generative AI tooling?
No
