### PR TITLE
[SPARK-49398][SQL] Improve the error for parameters in the query of CACHE TABLE and CREATE VIEW

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -5078,16 +5078,16 @@ class AstBuilder extends DataTypeAstBuilder
         throw QueryParsingErrors.addCatalogInCacheTableAsSelectNotAllowedError(
           catalogAndNamespace.quoted, ctx)
       }
-      // Disallow parameter markers in the body of the cache.
-      // We need this limitation because we store the original query text, pre substitution.
-      // To lift this we would need to reconstitute the body with parameter markers replaced with
-      // the values given at CACHE TABLE time, or we would need to store the parameter values
-      // alongside the text.
-      // The same rule can be found in CREATE VIEW builder.
-      query.foreach(p => checkInvalidParameter(p, "CACHE TABLE body"))
       val options = Option(ctx.options).map(visitPropertyKeyValues).getOrElse(Map.empty)
       val isLazy = ctx.LAZY != null
       if (query.isDefined) {
+        // Disallow parameter markers in the body of the cache.
+        // We need this limitation because we store the original query text, pre substitution.
+        // To lift this we would need to reconstitute the body with parameter markers replaced with
+        // the values given at CACHE TABLE time, or we would need to store the parameter values
+        // alongside the text.
+        // The same rule can be found in CREATE VIEW builder.
+        checkInvalidParameter(query.get, "CACHE TABLE body")
         CacheTableAsSelect(ident.head, query.get, source(ctx.query()), isLazy, options)
       } else {
         CacheTable(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -5081,13 +5081,13 @@ class AstBuilder extends DataTypeAstBuilder
       val options = Option(ctx.options).map(visitPropertyKeyValues).getOrElse(Map.empty)
       val isLazy = ctx.LAZY != null
       if (query.isDefined) {
-        // Disallow parameter markers in the body of the cache.
+        // Disallow parameter markers in the query of the cache.
         // We need this limitation because we store the original query text, pre substitution.
-        // To lift this we would need to reconstitute the body with parameter markers replaced with
+        // To lift this we would need to reconstitute the query with parameter markers replaced with
         // the values given at CACHE TABLE time, or we would need to store the parameter values
         // alongside the text.
         // The same rule can be found in CREATE VIEW builder.
-        checkInvalidParameter(query.get, "CACHE TABLE body")
+        checkInvalidParameter(query.get, "the query of CACHE TABLE")
         CacheTableAsSelect(ident.head, query.get, source(ctx.query()), isLazy, options)
       } else {
         CacheTable(
@@ -5690,8 +5690,7 @@ class AstBuilder extends DataTypeAstBuilder
    * If it finds any throws UNSUPPORTED_FEATURE.PARAMETER_MARKER_IN_UNEXPECTED_STATEMENT.
    * This method is used to ban parameters in some contexts.
    */
-  protected def checkInvalidParameter(plan: LogicalPlan, statement: String):
-  Unit = {
+  protected def checkInvalidParameter(plan: LogicalPlan, statement: String): Unit = {
     plan.foreach { p =>
       p.expressions.foreach { expr =>
         if (expr.containsPattern(PARAMETER)) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -5078,6 +5078,13 @@ class AstBuilder extends DataTypeAstBuilder
         throw QueryParsingErrors.addCatalogInCacheTableAsSelectNotAllowedError(
           catalogAndNamespace.quoted, ctx)
       }
+      // Disallow parameter markers in the body of the cache.
+      // We need this limitation because we store the original query text, pre substitution.
+      // To lift this we would need to reconstitute the body with parameter markers replaced with
+      // the values given at CACHE TABLE time, or we would need to store the parameter values
+      // alongside the text.
+      // The same rule can be found in CREATE VIEW builder.
+      query.foreach(p => checkInvalidParameter(p, "CACHE TABLE body"))
       val options = Option(ctx.options).map(visitPropertyKeyValues).getOrElse(Map.empty)
       val isLazy = ctx.LAZY != null
       if (query.isDefined) {
@@ -5677,4 +5684,24 @@ class AstBuilder extends DataTypeAstBuilder
     withOrigin(ctx) {
       visitSetVariableImpl(ctx.query(), ctx.multipartIdentifierList(), ctx.assignmentList())
     }
+
+  /**
+   * Check plan for any parameters.
+   * If it finds any throws UNSUPPORTED_FEATURE.PARAMETER_MARKER_IN_UNEXPECTED_STATEMENT.
+   * This method is used to ban parameters in some contexts.
+   */
+  protected def checkInvalidParameter(plan: LogicalPlan, statement: String):
+  Unit = {
+    plan.foreach { p =>
+      p.expressions.foreach { expr =>
+        if (expr.containsPattern(PARAMETER)) {
+          throw QueryParsingErrors.parameterMarkerNotAllowed(statement, p.origin)
+        }
+      }
+    }
+    plan.children.foreach(p => checkInvalidParameter(p, statement))
+    plan.innerChildren.collect {
+      case child: LogicalPlan => checkInvalidParameter(child, statement)
+    }
+  }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -520,13 +520,13 @@ class SparkSqlAstBuilder extends AstBuilder {
     }
     val qPlan: LogicalPlan = plan(ctx.query)
 
-    // Disallow parameter markers in the body of the view.
+    // Disallow parameter markers in the query of the view.
     // We need this limitation because we store the original query text, pre substitution.
-    // To lift this we would need to reconstitute the body with parameter markers replaced with the
+    // To lift this we would need to reconstitute the query with parameter markers replaced with the
     // values given at CREATE VIEW time, or we would need to store the parameter values alongside
     // the text.
     // The same rule can be found in CACHE TABLE builder.
-    checkInvalidParameter(qPlan, "CREATE VIEW body")
+    checkInvalidParameter(qPlan, "the query of CREATE VIEW")
     if (viewType == PersistedView) {
       val originalText = source(ctx.query)
       assert(Option(originalText).isDefined,

--- a/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
@@ -716,7 +716,7 @@ class ParametersSuite extends QueryTest with SharedSparkSession with PlanTest {
     checkAnswer(df, Row(11))
   }
 
-  test("SPARK-49398: Cache Table with Parameter markers should throw " +
+  test("SPARK-49398: Cache Table with parameter markers in select query should throw " +
     "UNSUPPORTED_FEATURE.PARAMETER_MARKER_IN_UNEXPECTED_STATEMENT") {
     val sqlText = "CACHE TABLE CacheTable as SELECT 1 + :param1"
     checkError(
@@ -730,5 +730,15 @@ class ParametersSuite extends QueryTest with SharedSparkSession with PlanTest {
         start = 0,
         stop = sqlText.length - 1)
     )
+  }
+
+  test("SPARK-49398: Cache Table with parameter in identifier should work") {
+    val cacheName = "MyCacheTable"
+    withCache(cacheName) {
+      spark.sql("CACHE TABLE IDENTIFIER(:param) as SELECT 1 as c1", Map("param" -> cacheName))
+      checkAnswer(
+        spark.sql("SHOW COLUMNS FROM IDENTIFIER(?)", args = Array(cacheName)),
+        Row("c1"))
+    }
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
@@ -247,7 +247,7 @@ class ParametersSuite extends QueryTest with SharedSparkSession with PlanTest {
         spark.sql(sqlText, args)
       },
       condition = "UNSUPPORTED_FEATURE.PARAMETER_MARKER_IN_UNEXPECTED_STATEMENT",
-      parameters = Map("statement" -> "CREATE VIEW body"),
+      parameters = Map("statement" -> "the query of CREATE VIEW"),
       context = ExpectedContext(
         fragment = sqlText,
         start = 0,
@@ -262,7 +262,7 @@ class ParametersSuite extends QueryTest with SharedSparkSession with PlanTest {
         spark.sql(sqlText, args)
       },
       condition = "UNSUPPORTED_FEATURE.PARAMETER_MARKER_IN_UNEXPECTED_STATEMENT",
-      parameters = Map("statement" -> "CREATE VIEW body"),
+      parameters = Map("statement" -> "the query of CREATE VIEW"),
       context = ExpectedContext(
         fragment = sqlText,
         start = 0,
@@ -277,7 +277,7 @@ class ParametersSuite extends QueryTest with SharedSparkSession with PlanTest {
         spark.sql(sqlText, args)
       },
       condition = "UNSUPPORTED_FEATURE.PARAMETER_MARKER_IN_UNEXPECTED_STATEMENT",
-      parameters = Map("statement" -> "CREATE VIEW body"),
+      parameters = Map("statement" -> "the query of CREATE VIEW"),
       context = ExpectedContext(
         fragment = sqlText,
         start = 0,
@@ -292,7 +292,7 @@ class ParametersSuite extends QueryTest with SharedSparkSession with PlanTest {
         spark.sql(sqlText, args)
       },
       condition = "UNSUPPORTED_FEATURE.PARAMETER_MARKER_IN_UNEXPECTED_STATEMENT",
-      parameters = Map("statement" -> "CREATE VIEW body"),
+      parameters = Map("statement" -> "the query of CREATE VIEW"),
       context = ExpectedContext(
         fragment = sqlText,
         start = 0,
@@ -311,7 +311,7 @@ class ParametersSuite extends QueryTest with SharedSparkSession with PlanTest {
         spark.sql(sqlText, args)
       },
       condition = "UNSUPPORTED_FEATURE.PARAMETER_MARKER_IN_UNEXPECTED_STATEMENT",
-      parameters = Map("statement" -> "CREATE VIEW body"),
+      parameters = Map("statement" -> "the query of CREATE VIEW"),
       context = ExpectedContext(
         fragment = sqlText,
         start = 0,
@@ -330,7 +330,7 @@ class ParametersSuite extends QueryTest with SharedSparkSession with PlanTest {
         spark.sql(sqlText, args)
       },
       condition = "UNSUPPORTED_FEATURE.PARAMETER_MARKER_IN_UNEXPECTED_STATEMENT",
-      parameters = Map("statement" -> "CREATE VIEW body"),
+      parameters = Map("statement" -> "the query of CREATE VIEW"),
       context = ExpectedContext(
         fragment = sqlText,
         start = 0,
@@ -723,8 +723,8 @@ class ParametersSuite extends QueryTest with SharedSparkSession with PlanTest {
       exception = intercept[AnalysisException] {
         spark.sql(sqlText, Map("param1" -> "1")).show()
       },
-      errorClass = "UNSUPPORTED_FEATURE.PARAMETER_MARKER_IN_UNEXPECTED_STATEMENT",
-      parameters = Map("statement" -> "CACHE TABLE body"),
+      condition = "UNSUPPORTED_FEATURE.PARAMETER_MARKER_IN_UNEXPECTED_STATEMENT",
+      parameters = Map("statement" -> "the query of CACHE TABLE"),
       context = ExpectedContext(
         fragment = sqlText,
         start = 0,

--- a/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
@@ -716,20 +716,19 @@ class ParametersSuite extends QueryTest with SharedSparkSession with PlanTest {
     checkAnswer(df, Row(11))
   }
 
-  test("SPARK-49398: Cache Table with Parameter markers should return " +
+  test("SPARK-49398: Cache Table with Parameter markers should throw " +
     "UNSUPPORTED_FEATURE.PARAMETER_MARKER_IN_UNEXPECTED_STATEMENT") {
+    val sqlText = "CACHE TABLE CacheTable as SELECT 1 + :param1"
     checkError(
       exception = intercept[AnalysisException] {
-        spark.sql("CACHE TABLE CacheTable as SELECT 1 + :param1", Map("param1" -> "1")).show()
+        spark.sql(sqlText, Map("param1" -> "1")).show()
       },
       errorClass = "UNSUPPORTED_FEATURE.PARAMETER_MARKER_IN_UNEXPECTED_STATEMENT",
-      parameters = Map("name" -> "param1"),
+      parameters = Map("statement" -> "CACHE TABLE body"),
       context = ExpectedContext(
-        objectType = "VIEW",
-        objectName = "CacheTable",
-        fragment = ":param1",
-        startIndex = 11,
-        stopIndex = 17)
+        fragment = sqlText,
+        start = 0,
+        stop = sqlText.length - 1)
     )
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Change type of error that is thrown on `CACHE TABLE` statement with parameter markers.
(`UNBOUND_SQL_PARAMETER` -> `UNSUPPORTED_FEATURE.PARAMETER_MARKER_IN_UNEXPECTED_STATEMENT`)


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`UNBOUND_SQL_PARAMETER` is a confusing error for a user. From his point of view he can pass all parameters argument but still have the error.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, error type changed for `CACHE TABLE` statement with parameters

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Was added a new specific test, that would fail without fixes in this pr

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
