### PR TITLE
[MINOR][SQL][TESTS] Check `sqlState` in `checkError()`

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkFunSuite.scala
@@ -415,7 +415,7 @@ abstract class SparkFunSuite
       errorClass: String,
       sqlState: String,
       context: ExpectedContext): Unit =
-    checkError(exception, errorClass, None, Map.empty, false, Array(context))
+    checkError(exception, errorClass, Some(sqlState), Map.empty, false, Array(context))
 
   protected def checkError(
       exception: SparkThrowable,


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to bypass the `sqlState` parameter in `checkError()` to another `checkError()` to take it into account.

### Why are the changes needed?
At the moment, the `sqlState` argument is not checked in some tests.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the affected tests:
```
$ build/sbt "test:testOnly *QueryParsingErrorsSuite"
```

### Was this patch authored or co-authored using generative AI tooling?
No.