### PR TITLE
[SPARK-49443][SQL][FOLLOWUP] Fix formatting of a comment for `to_variant_object()`

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -6853,8 +6853,8 @@ object functions {
 
   /**
    * Converts a column containing nested inputs (array/map/struct) into a variants where maps and
-   * structs are converted to variant objects which are unordered unlike SQL structs. Input maps can
-   * only have string keys.
+   * structs are converted to variant objects which are unordered unlike SQL structs. Input maps
+   * can only have string keys.
    *
    * @param col
    *   a column with a nested schema or column name.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix formatting of comments for the function `to_variant_object()`.

### Why are the changes needed?
To fix the failure:
```
Error:  Failed to execute goal org.antipathy:mvn-scalafmt_2.13:1.1.1713302731.c3d0074:format (default-cli) on project spark-sql-api_2.13: Error formatting Scala files: Scalafmt: Unformatted files found -> [Help 1]
```

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the formatting:
```
$ ./build/mvn scalafmt:format -Dscalafmt.skip=false -Dscalafmt.validateOnly=false -Dscalafmt.changedOnly=false -pl sql/api -pl sql/connect/common -pl sql/connect/server -pl connector/connect/client/jvm
```

### Was this patch authored or co-authored using generative AI tooling?
No.