### PR TITLE
[SPARK-49579][SQL][TESTS][FOLLOWUP] Use `condition` instead of `errorClass` in `SparkThrowableSuite` and in `DateTimeFormatterHelperSuite`

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -518,7 +518,7 @@ class SparkThrowableSuite extends SparkFunSuite {
             "details" -> "implicit cast"
           ))
       },
-      errorClass = "INTERNAL_ERROR",
+      condition = "INTERNAL_ERROR",
       parameters = Map(
         "message" ->
           ("Found unused message parameters of the error class 'CANNOT_UP_CAST_DATATYPE'. " +

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelperSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/util/DateTimeFormatterHelperSuite.scala
@@ -90,7 +90,7 @@ class DateTimeFormatterHelperSuite extends SparkFunSuite {
       exception = intercept[SparkIllegalArgumentException] {
         createBuilderWithVarLengthSecondFraction(pattern)
       },
-      errorClass = "INVALID_DATETIME_PATTERN.SECONDS_FRACTION",
+      condition = "INVALID_DATETIME_PATTERN.SECONDS_FRACTION",
       parameters = Map("pattern" -> pattern))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to use `condition` instead of `errorClass` in two test suites:
- SparkThrowableSuite
- DateTimeFormatterHelperSuite

### Why are the changes needed?
Because the changes from the PR https://github.com/apache/spark/pull/48027 conflict to https://github.com/apache/spark/pull/48058 and https://github.com/apache/spark/pull/48026, and tests in #48027 were passed earlier than the last PRs were merged to master.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By compiling and running the following tests locally:
```
$ build/sbt "test:testOnly *org.apache.spark.sql.catalyst.util.DateTimeFormatterHelperSuite"
$ build/sbt "test:testOnly *SparkThrowableSuite"
```

### Was this patch authored or co-authored using generative AI tooling?
No.
