### PR TITLE
[SPARK-49162][SQL] Push down date_trunc function

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
@@ -22,6 +22,7 @@ import java.sql.Connection
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
+import org.apache.spark.sql.catalyst.plans.logical.Filter
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
 import org.apache.spark.sql.jdbc.DatabaseOnDocker
 import org.apache.spark.sql.types._

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
@@ -23,7 +23,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException
-import org.apache.spark.sql.catalyst.plans.logical.Aggregate
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter}
 import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
 import org.apache.spark.sql.jdbc.DatabaseOnDocker
 import org.apache.spark.sql.types._
@@ -133,8 +133,8 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCT
     }
   }
 
-  test("SPARK-49162: Push down date_trunc function") {
-    def testDateTruncPushdown(format: String, expectedResult: Set[Row]): Unit = {
+  test("SPARK-49162: Push down aggregate date_trunc function") {
+    def testAggregatePushdown(format: String, expectedResult: Set[Row]): Unit = {
       val df = sql(
         s"""
             SELECT DATE_TRUNC('$format', time), COUNT(*)
@@ -149,32 +149,64 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCT
       assert(df.collect().toSet === expectedResult)
     }
 
-    testDateTruncPushdown("YEAR",
+    testAggregatePushdown("YEAR",
       Set(Row(Timestamp.valueOf("2024-01-01 00:00:00.0"), 2)))
-    testDateTruncPushdown("MONTH",
+    testAggregatePushdown("MONTH",
       Set(
         Row(Timestamp.valueOf("2024-02-01 00:00:00.0"), 1),
         Row(Timestamp.valueOf("2024-01-01 00:00:00.0"), 1)
       ))
-    testDateTruncPushdown("DAY",
+    testAggregatePushdown("DAY",
       Set(
         Row(Timestamp.valueOf("2024-02-02 00:00:00.0"), 1),
         Row(Timestamp.valueOf("2024-01-01 00:00:00.0"), 1)
       ))
-    testDateTruncPushdown("HOUR",
+    testAggregatePushdown("HOUR",
       Set(
         Row(Timestamp.valueOf("2024-02-02 02:00:00.0"), 1),
         Row(Timestamp.valueOf("2024-01-01 01:00:00.0"), 1)
       ))
-    testDateTruncPushdown("MINUTE",
+    testAggregatePushdown("MINUTE",
       Set(
         Row(Timestamp.valueOf("2024-02-02 02:02:00.0"), 1),
         Row(Timestamp.valueOf("2024-01-01 01:01:00.0"), 1)
       ))
-    testDateTruncPushdown("SECOND",
+    testAggregatePushdown("SECOND",
       Set(
         Row(Timestamp.valueOf("2024-02-02 02:02:02.0"), 1),
         Row(Timestamp.valueOf("2024-01-01 01:01:01.0"), 1)
       ))
+  }
+
+  test("SPARK-49162: Push down filter date_trunc function") {
+    def testFilterPushdown(format: String, date: String, expectedResult: Set[Row]): Unit = {
+      val df = sql(
+        s"""
+            SELECT *
+           | FROM $catalogName.datetime_table
+           | WHERE DATE_TRUNC('$format', time) = '$date'
+         """.stripMargin
+      )
+      val filters = df.queryExecution.optimizedPlan.collect {
+        case f: Filter => f
+      }
+      assert(filters.isEmpty)
+      assert(df.collect().toSet === expectedResult)
+    }
+
+    testFilterPushdown("YEAR", "2024-01-01 00:00:00.0",
+      Set(
+        Row(1, Timestamp.valueOf("2024-01-01 01:01:01.0")),
+        Row(2, Timestamp.valueOf("2024-02-02 02:02:02.0"))
+      ))
+    testFilterPushdown("MONTH", "2024-02-01 00:00:00.0",
+      Set(Row(2, Timestamp.valueOf("2024-02-02 02:02:02.0"))))
+    testFilterPushdown("DAY", "2024-01-01 00:00:00.0",
+      Set(Row(1, Timestamp.valueOf("2024-01-01 01:01:01.0"))))
+    testFilterPushdown("HOUR", "2024-02-02 02:00:00.0",
+      Set(Row(2, Timestamp.valueOf("2024-02-02 02:02:02.0"))))
+    testFilterPushdown("MINUTE", "2024-01-01 01:01:00.0",
+      Set(Row(1, Timestamp.valueOf("2024-01-01 01:01:01.0"))))
+    testFilterPushdown("SECOND", "2024-02-02 02:02:03.0", Set())
   }
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/util/V2ExpressionSQLBuilder.java
@@ -117,8 +117,8 @@ public class V2ExpressionSQLBuilder {
           "POWER", "SQRT", "FLOOR", "CEIL", "ROUND", "SIN", "SINH", "COS", "COSH", "TAN", "TANH",
           "COT", "ASIN", "ASINH", "ACOS", "ACOSH", "ATAN", "ATANH", "ATAN2", "CBRT", "DEGREES",
           "RADIANS", "SIGN", "WIDTH_BUCKET", "SUBSTRING", "UPPER", "LOWER", "TRANSLATE",
-          "DATE_ADD", "DATE_DIFF", "TRUNC", "AES_ENCRYPT", "AES_DECRYPT", "SHA1", "SHA2", "MD5",
-          "CRC32", "BIT_LENGTH", "CHAR_LENGTH", "CONCAT" ->
+          "DATE_ADD", "DATE_DIFF", "TRUNC", "DATE_TRUNC", "AES_ENCRYPT", "AES_DECRYPT", "SHA1",
+          "SHA2", "MD5", "CRC32", "BIT_LENGTH", "CHAR_LENGTH", "CONCAT" ->
           visitSQLFunction(name, expressionsToStringArray(e.children()));
         case "CASE_WHEN" -> visitCaseWhen(expressionsToStringArray(e.children()));
         case "TRIM" -> visitTrim("BOTH", expressionsToStringArray(e.children()));

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/util/V2ExpressionBuilder.scala
@@ -237,6 +237,7 @@ class V2ExpressionBuilder(e: Expression, isPredicate: Boolean = false) {
     case _: DateAdd => generateExpressionWithName("DATE_ADD", expr, isPredicate)
     case _: DateDiff => generateExpressionWithName("DATE_DIFF", expr, isPredicate)
     case _: TruncDate => generateExpressionWithName("TRUNC", expr, isPredicate)
+    case _: TruncTimestamp => generateExpressionWithName("DATE_TRUNC", expr, isPredicate)
     case Second(child, _) =>
       generateExpression(child).map(v => new V2Extract("SECOND", v))
     case Minute(child, _) =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/H2Dialect.scala
@@ -53,7 +53,7 @@ private[sql] case class H2Dialect() extends JdbcDialect with NoLegacyJDBCError {
       "POWER", "SQRT", "FLOOR", "CEIL", "ROUND", "SIN", "SINH", "COS", "COSH", "TAN",
       "TANH", "COT", "ASIN", "ACOS", "ATAN", "ATAN2", "DEGREES", "RADIANS", "SIGN",
       "PI", "SUBSTRING", "UPPER", "LOWER", "TRANSLATE", "TRIM", "MD5", "SHA1", "SHA2",
-      "BIT_LENGTH", "CHAR_LENGTH", "CONCAT")
+      "BIT_LENGTH", "CHAR_LENGTH", "CONCAT", "DATE_TRUNC")
 
   override def isSupportedFunction(funcName: String): Boolean =
     supportedFunctions.contains(funcName)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -47,10 +47,7 @@ private case class PostgresDialect()
   private val supportedAggregateFunctions = Set("MAX", "MIN", "SUM", "COUNT", "AVG",
     "VAR_POP", "VAR_SAMP", "STDDEV_POP", "STDDEV_SAMP", "COVAR_POP", "COVAR_SAMP", "CORR",
     "REGR_INTERCEPT", "REGR_R2", "REGR_SLOPE", "REGR_SXY")
-  private val supportedDatetimeFunctions = Set("DATE_TRUNC")
-  private val supportedFunctions =
-    supportedAggregateFunctions ++
-      supportedDatetimeFunctions
+  private val supportedFunctions = supportedAggregateFunctions ++ Set("DATE_TRUNC")
 
   override def isSupportedFunction(funcName: String): Boolean =
     supportedFunctions.contains(funcName)

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -47,7 +47,10 @@ private case class PostgresDialect()
   private val supportedAggregateFunctions = Set("MAX", "MIN", "SUM", "COUNT", "AVG",
     "VAR_POP", "VAR_SAMP", "STDDEV_POP", "STDDEV_SAMP", "COVAR_POP", "COVAR_SAMP", "CORR",
     "REGR_INTERCEPT", "REGR_R2", "REGR_SLOPE", "REGR_SXY")
-  private val supportedFunctions = supportedAggregateFunctions
+  private val supportedDatetimeFunctions = Set("DATE_TRUNC")
+  private val supportedFunctions =
+    supportedAggregateFunctions ++
+      supportedDatetimeFunctions
 
   override def isSupportedFunction(funcName: String): Boolean =
     supportedFunctions.contains(funcName)

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -1590,6 +1590,14 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
       "PushedTopN: ORDER BY [EXTRACT(DAY_OF_YEAR FROM DATE1) ASC NULLS FIRST] LIMIT 1,"
     checkPushedInfo(df9, expectedPlanFragment9)
     checkAnswer(df9, Seq(Row("alex")))
+
+    val df10 = sql("SELECT name FROM h2.test.datetime WHERE " +
+      "DATE_TRUNC('DAY', date1) = date'2022-05-19'")
+    checkFiltersRemoved(df10)
+    val expectedPlanFragment10 =
+      "PushedFilters: [(DATE_TRUNC('DAY', CAST(DATE1 AS timestamp))) = 1652943600000000]"
+    checkPushedInfo(df10, expectedPlanFragment10)
+    checkAnswer(df10, Seq(Row("amy")))
   }
 
   test("scan with filter push-down with misc functions") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR introduces support for Postgres and H2 date_trunc function push down.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Performance improvements.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New integration test in PostgresIntegrationSuite.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
