### PR TITLE
[SPARK-49592][SS] Modify OperatorStateMetadataV2Reader to return the right metadata for the provided batchId  

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/OperatorStateMetadata.scala
@@ -310,13 +310,6 @@ class OperatorStateMetadataV2Reader(
     hadoopConf: Configuration,
     batchId: Long) extends OperatorStateMetadataReader {
 
-  // Check that the requested batchId is available in the checkpoint directory
-  val baseCheckpointDir = stateCheckpointPath.getParent.getParent
-  val lastAvailOffset = listOffsets(baseCheckpointDir).lastOption.getOrElse(-1L)
-  if (batchId > lastAvailOffset) {
-    throw StateDataSourceErrors.failedToReadOperatorMetadata(baseCheckpointDir.toString, batchId)
-  }
-
   private val metadataDirPath = OperatorStateMetadataV2.metadataDirPath(stateCheckpointPath)
   private lazy val fm = CheckpointFileManager.create(metadataDirPath, hadoopConf)
 
@@ -346,7 +339,7 @@ class OperatorStateMetadataV2Reader(
 
   override def read(): Option[OperatorStateMetadata] = {
     val batches = listOperatorMetadataBatches()
-    val lastBatchId = batches.filter(_ <= batchId).lastOption
+    val lastBatchId = batches.filter(_ == batchId).lastOption
     if (lastBatchId.isEmpty) {
       throw StateDataSourceErrors.failedToReadOperatorMetadata(stateCheckpointPath.toString,
         batchId)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes a bug in the `OperatorStateMetadataV2Reader` where the `read` method, if called in isolation, could return the wrong metadata.

### Why are the changes needed?

The `OperatorStateMetadataV2Reader` has _end-behavior_ that is desirable, but it only "accidentally" works. Currently, if you have the offsets `0 1 2` and ask for `batchId = 3`, the `read` method could return you the operator state metadata for `2` instead of throwing an error. In practice, this doesn't happen, since we have a check in the constructor that the `batchId` provided must be less than or equal to the last offset.

Really, what we want is that if `read` ever gets called and the asked-for `batchId` doesn't exist, an error should be thrown there instead of silently returning wrong metadata.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

All existing UTs should pass.

### Was this patch authored or co-authored using generative AI tooling?

No.