### PR TITLE
[SPARK-49593][SS] Throw RocksDB exception to the caller on DB close if an error is seen

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -263,7 +263,7 @@ class RocksDB(
     logInfo(log"Loading ${MDC(LogKeys.VERSION_NUM, version)}")
     try {
       if (loadedVersion != version) {
-        closeDB()
+        closeDB(ignoreException = false)
         // deep copy is needed to avoid race condition
         // between maintenance and task threads
         fileManager.copyFileMapping()
@@ -945,13 +945,17 @@ class RocksDB(
     logInfo(log"Opened DB with conf ${MDC(LogKeys.CONFIG, conf)}")
   }
 
-  private def closeDB(): Unit = {
+  private def closeDB(ignoreException: Boolean = true): Unit = {
     if (db != null) {
-
       // Cancel and wait until all background work finishes
       db.cancelAllBackgroundWork(true)
-      // Close the DB instance and throw the exception if any
-      db.closeE()
+      if (ignoreException) {
+        // Close the DB instance and throw the exception if any
+        db.closeE()
+      } else {
+        // Close the DB instance
+        db.close()
+      }
       db = null
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -950,11 +950,11 @@ class RocksDB(
       // Cancel and wait until all background work finishes
       db.cancelAllBackgroundWork(true)
       if (ignoreException) {
-        // Close the DB instance and throw the exception if any
-        db.closeE()
-      } else {
         // Close the DB instance
         db.close()
+      } else {
+        // Close the DB instance and throw the exception if any
+        db.closeE()
       }
       db = null
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -950,8 +950,8 @@ class RocksDB(
 
       // Cancel and wait until all background work finishes
       db.cancelAllBackgroundWork(true)
-      // Close the DB instance
-      db.close()
+      // Close the DB instance and throw the exception if any
+      db.closeE()
       db = null
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Throw RocksDB exception to the caller on DB close

API here: https://javadoc.io/doc/org.rocksdb/rocksdbjni/6.8.1/org/rocksdb/RocksDB.html#closeE()

### Why are the changes needed?
Without this, errors on close are being silently ignored and we attempt to open the DB again in the context of the same task. Trying to ensure that we exit in this scenario and try as part of a separate attempt.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing unit tests

```
[info] Total number of tests run: 205
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 205, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```

### Was this patch authored or co-authored using generative AI tooling?
No
