### PR TITLE
[MINOR][CONNECT] Fix missing request metadata in RPC call

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -1786,7 +1786,7 @@ class SparkConnectClient(object):
             req.user_context.user_id = self._user_id
 
         try:
-            return self._stub.FetchErrorDetails(req)
+            return self._stub.FetchErrorDetails(req, metadata=self._builder.metadata())
         except grpc.RpcError:
             return None
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The RPC call for fetching the enriched error messages did not receive the GPRC channel per-request metadata, similar to all other other cases of calling the stub. This patch fixes this issue.

### Why are the changes needed?
Compatibility

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests.


### Was this patch authored or co-authored using generative AI tooling?
No