### PR TITLE
[SPARK-48358][SQL][TESTS][FOLLOWUP] Use `condition` instead of `errorClass` in `SqlScriptingInterpreterSuite`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -670,7 +670,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
       exception = intercept[SqlScriptingException] (
         runSqlScript(commands)
       ),
-      errorClass = "INVALID_BOOLEAN_STATEMENT",
+      condition = "INVALID_BOOLEAN_STATEMENT",
       parameters = Map("invalidStatement" -> "1")
     )
   }
@@ -693,7 +693,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         exception = intercept[SqlScriptingException] (
           runSqlScript(commands)
         ),
-        errorClass = "BOOLEAN_STATEMENT_WITH_EMPTY_ROW",
+        condition = "BOOLEAN_STATEMENT_WITH_EMPTY_ROW",
         parameters = Map("invalidStatement" -> "(SELECT * FROM T)")
       )
     }
@@ -719,7 +719,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         exception = intercept[SparkException] (
           runSqlScript(commands)
         ),
-        errorClass = "SCALAR_SUBQUERY_TOO_MANY_ROWS",
+        condition = "SCALAR_SUBQUERY_TOO_MANY_ROWS",
         parameters = Map.empty,
         context = ExpectedContext(fragment = "(SELECT * FROM t)", start = 141, stop = 157)
       )


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to replace `errorClass` by `condition` in `SqlScriptingInterpreterSuite`

### Why are the changes needed?
The changes from the PR https://github.com/apache/spark/pull/47756 conflict to https://github.com/apache/spark/pull/48027

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the modified test:
```
$ build/sbt "test:testOnly *SqlScriptingInterpreterSuite"
```

### Was this patch authored or co-authored using generative AI tooling?
No.