### PR TITLE
[SPARK-49599][BUILD] Upgrade snappy-java to 1.1.10.7

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -256,7 +256,7 @@ scala-xml_2.13/2.3.0//scala-xml_2.13-2.3.0.jar
 slf4j-api/2.0.16//slf4j-api-2.0.16.jar
 snakeyaml-engine/2.7//snakeyaml-engine-2.7.jar
 snakeyaml/2.2//snakeyaml-2.2.jar
-snappy-java/1.1.10.6//snappy-java-1.1.10.6.jar
+snappy-java/1.1.10.7//snappy-java-1.1.10.7.jar
 spire-macros_2.13/0.18.0//spire-macros_2.13-0.18.0.jar
 spire-platform_2.13/0.18.0//spire-platform_2.13-0.18.0.jar
 spire-util_2.13/0.18.0//spire-util_2.13-0.18.0.jar

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
     <fasterxml.jackson.version>2.17.2</fasterxml.jackson.version>
     <fasterxml.jackson.databind.version>2.17.2</fasterxml.jackson.databind.version>
     <ws.xmlschema.version>2.3.1</ws.xmlschema.version>
-    <snappy.version>1.1.10.6</snappy.version>
+    <snappy.version>1.1.10.7</snappy.version>
     <netlib.ludovic.dev.version>3.0.3</netlib.ludovic.dev.version>
     <commons-codec.version>1.17.1</commons-codec.version>
     <commons-compress.version>1.27.1</commons-compress.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade snappy-java from 1.1.10.6 to 1.1.10.7.

### Why are the changes needed?
The new version bring a small performance improvement reading crc32c values in SnappyFramedInputStream
- https://github.com/xerial/snappy-java/pull/594

The full release notes as follows:
- https://github.com/xerial/snappy-java/releases/tag/v1.1.10.7

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass Github Actions

### Was this patch authored or co-authored using generative AI tooling?
No