### PR TITLE
[SPARK-49600][PYTHON] Remove `Python 3.6 and older`-related logic from `try_simplify_traceback`

### DIFF
--- a/python/pyspark/util.py
+++ b/python/pyspark/util.py
@@ -262,10 +262,6 @@ def try_simplify_traceback(tb: TracebackType) -> Optional[TracebackType]:
     if "pypy" in platform.python_implementation().lower():
         # Traceback modification is not supported with PyPy in PySpark.
         return None
-    if sys.version_info[:2] < (3, 7):
-        # Traceback creation is not supported Python < 3.7.
-        # See https://bugs.python.org/issue30579.
-        return None
 
     import pyspark
 
@@ -791,7 +787,7 @@ def is_remote_only() -> bool:
 
 
 if __name__ == "__main__":
-    if "pypy" not in platform.python_implementation().lower() and sys.version_info[:2] >= (3, 7):
+    if "pypy" not in platform.python_implementation().lower() and sys.version_info[:2] >= (3, 9):
         import doctest
         import pyspark.util
         from pyspark.core.context import SparkContext


### PR DESCRIPTION
### What changes were proposed in this pull request?

Apache Spark 4.0.0 supports only Python 3.9+.
- #46228 

### Why are the changes needed?

To simplify and clarify the logic. I manually confirmed that this is the last logic about `sys.version_info` and `(3, 7)`.

```
$ git grep 'sys.version_info' | grep '(3, 7)'
python/pyspark/util.py:    if sys.version_info[:2] < (3, 7):
python/pyspark/util.py:    if "pypy" not in platform.python_implementation().lower() and sys.version_info[:2] >= (3, 7):
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.