### PR TITLE
[SPARK-49602][BUILD] Fix `assembly/pom.xml` to use `{project.version}` instead of `{version}`

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -200,7 +200,7 @@
             <configuration>
               <executable>cp</executable>
               <arguments>
-                <argument>${basedir}/../connector/connect/client/jvm/target/spark-connect-client-jvm_${scala.binary.version}-${version}.jar</argument>
+                <argument>${basedir}/../connector/connect/client/jvm/target/spark-connect-client-jvm_${scala.binary.version}-${project.version}.jar</argument>
                 <argument>${basedir}/target/scala-${scala.binary.version}/jars/connect-repl</argument>
               </arguments>
             </configuration>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `assembly/pom.xml` to use `{project.version}` instead of `{version}`.

The original change was introduced recently by
- #47402

### Why are the changes needed?

**BEFORE**
```
$ mvn clean | head -n9
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.apache.spark:spark-assembly_2.13:pom:4.0.0-SNAPSHOT
[WARNING] The expression ${version} is deprecated. Please use ${project.version} instead.
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```

**AFTER**
```
$ mvn clean | head -n9
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Detecting the operating system and CPU architecture
[INFO] ------------------------------------------------------------------------
[INFO] os.detected.name: osx
[INFO] os.detected.arch: aarch_64
[INFO] os.detected.version: 15.0
[INFO] os.detected.version.major: 15
[INFO] os.detected.version.minor: 0
```

### Does this PR introduce _any_ user-facing change?

No, this is a dev-only change for building distribution.

### How was this patch tested?

Manual test.

### Was this patch authored or co-authored using generative AI tooling?

No.