### PR TITLE
[SPARK-47741][SQL][TESTS][FOLLOWUP] Reduce test query size by reducing iterations from 20k to 5k

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -33,7 +33,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession with SQL
   }
 
   test("PARSE_STACK_OVERFLOW_ERROR: Stack overflow hit") {
-    val query = (1 to 20000).map(x => "SELECT 1 as a").mkString(" UNION ALL ")
+    val query = (1 to 5000).map(x => "SELECT 1 as a").mkString(" UNION ALL ")
     val e = intercept[ParseException] {
       spark.sql(query)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
@@ -41,7 +41,7 @@ class ExecuteImmediateEndToEndSuite extends QueryTest with SharedSparkSession {
   test("EXEC IMMEDIATE STACK OVERFLOW") {
     try {
       spark.sql("DECLARE parm = 1;")
-      val query = (1 to 20000).map(x => "SELECT 1 as a").mkString(" UNION ALL ")
+      val query = (1 to 5000).map(x => "SELECT 1 as a").mkString(" UNION ALL ")
       Seq(
         s"EXECUTE IMMEDIATE '$query'",
         s"EXECUTE IMMEDIATE '$query' INTO parm").foreach { q =>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to reduce test query size by reducing iterations from 20k to 5k.

### Why are the changes needed?

To reduce the flakiness.

### Does this PR introduce _any_ user-facing change?

No. This is a test-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.