### PR TITLE
[SPARK-49621][SQL][TESTS] Remove the flaky `EXEC IMMEDIATE STACK OVERFLOW` test case

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
@@ -38,7 +38,8 @@ class ExecuteImmediateEndToEndSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("EXEC IMMEDIATE STACK OVERFLOW") {
+  // TODO(SPARK-49622) Re-enable `EXEC IMMEDIATE STACK OVERFLOW` test case
+  ignore("EXEC IMMEDIATE STACK OVERFLOW") {
     try {
       spark.sql("DECLARE parm = 1;")
       val query = (1 to 20000).map(x => "SELECT 1 as a").mkString(" UNION ALL ")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
@@ -37,31 +37,4 @@ class ExecuteImmediateEndToEndSuite extends QueryTest with SharedSparkSession {
       spark.sql("DROP TEMPORARY VARIABLE IF EXISTS parm;")
     }
   }
-
-  // TODO(SPARK-49622) Re-enable `EXEC IMMEDIATE STACK OVERFLOW` test case
-  ignore("EXEC IMMEDIATE STACK OVERFLOW") {
-    try {
-      spark.sql("DECLARE parm = 1;")
-      val query = (1 to 20000).map(x => "SELECT 1 as a").mkString(" UNION ALL ")
-      Seq(
-        s"EXECUTE IMMEDIATE '$query'",
-        s"EXECUTE IMMEDIATE '$query' INTO parm").foreach { q =>
-        val e = intercept[ParseException] {
-          spark.sql(q)
-        }
-
-        checkError(
-          exception = e,
-          condition = "FAILED_TO_PARSE_TOO_COMPLEX",
-          parameters = Map(),
-          context = ExpectedContext(
-            query,
-            start = 0,
-            stop = query.length - 1)
-        )
-      }
-    } finally {
-      spark.sql("DROP TEMPORARY VARIABLE IF EXISTS parm;")
-    }
-  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/ExecuteImmediateEndToEndSuite.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql.execution
 
 import org.apache.spark.sql.{QueryTest}
-import org.apache.spark.sql.catalyst.parser.ParseException
 import org.apache.spark.sql.test.SharedSparkSession
 
 class ExecuteImmediateEndToEndSuite extends QueryTest with SharedSparkSession {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove the flaky `EXEC IMMEDIATE STACK OVERFLOW` test case.

### Why are the changes needed?

To stabilize the CIs. `QueryParsingErrorsSuite` still has a test coverage for the original PR.

### Does this PR introduce _any_ user-facing change?

No, this is a test-only change.

### How was this patch tested?

Manual review because this is a test case removal.

### Was this patch authored or co-authored using generative AI tooling?

No.