### PR TITLE
[SPARK-48549][SQL][DOCS][FOLLOWUP] Add migration guide for SQL function `sentences` behavior changes

### DIFF
--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -60,6 +60,7 @@ license: |
 - Since Spark 4.0, By default views tolerate column type changes in the query and compensate with casts. To restore the previous behavior, allowing up-casts only, set `spark.sql.legacy.viewSchemaCompensation` to `false`.
 - Since Spark 4.0, Views allow control over how they react to underlying query changes. By default views tolerate column type changes in the query and compensate with casts. To disable this feature set `spark.sql.legacy.viewSchemaBindingMode` to `false`. This also removes the clause from `DESCRIBE EXTENDED` and `SHOW CREATE TABLE`.
 - Since Spark 4.0, The Storage-Partitioned Join feature flag `spark.sql.sources.v2.bucketing.pushPartValues.enabled` is set to `true`. To restore the previous behavior, set `spark.sql.sources.v2.bucketing.pushPartValues.enabled` to `false`.
+- Since Spark 4.0, the `sentences` function, when `language` parameter is not null and `country` parameter is null, we no longer use `Locale US`, instead use `Locale(language)`.
 
 ## Upgrading from Spark SQL 3.5.1 to 3.5.2
 

--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -60,7 +60,7 @@ license: |
 - Since Spark 4.0, By default views tolerate column type changes in the query and compensate with casts. To restore the previous behavior, allowing up-casts only, set `spark.sql.legacy.viewSchemaCompensation` to `false`.
 - Since Spark 4.0, Views allow control over how they react to underlying query changes. By default views tolerate column type changes in the query and compensate with casts. To disable this feature set `spark.sql.legacy.viewSchemaBindingMode` to `false`. This also removes the clause from `DESCRIBE EXTENDED` and `SHOW CREATE TABLE`.
 - Since Spark 4.0, The Storage-Partitioned Join feature flag `spark.sql.sources.v2.bucketing.pushPartValues.enabled` is set to `true`. To restore the previous behavior, set `spark.sql.sources.v2.bucketing.pushPartValues.enabled` to `false`.
-- Since Spark 4.0, the `sentences` function, when `language` parameter is not null and `country` parameter is null, we no longer use `Locale.US`, instead use `Locale(language)`.
+- Since Spark 4.0, the `sentences` function uses `Locale(language)` instead of `Locale.US` when `language` parameter is not `NULL` and `country` parameter is `NULL`.
 
 ## Upgrading from Spark SQL 3.5.1 to 3.5.2
 

--- a/docs/sql-migration-guide.md
+++ b/docs/sql-migration-guide.md
@@ -60,7 +60,7 @@ license: |
 - Since Spark 4.0, By default views tolerate column type changes in the query and compensate with casts. To restore the previous behavior, allowing up-casts only, set `spark.sql.legacy.viewSchemaCompensation` to `false`.
 - Since Spark 4.0, Views allow control over how they react to underlying query changes. By default views tolerate column type changes in the query and compensate with casts. To disable this feature set `spark.sql.legacy.viewSchemaBindingMode` to `false`. This also removes the clause from `DESCRIBE EXTENDED` and `SHOW CREATE TABLE`.
 - Since Spark 4.0, The Storage-Partitioned Join feature flag `spark.sql.sources.v2.bucketing.pushPartValues.enabled` is set to `true`. To restore the previous behavior, set `spark.sql.sources.v2.bucketing.pushPartValues.enabled` to `false`.
-- Since Spark 4.0, the `sentences` function, when `language` parameter is not null and `country` parameter is null, we no longer use `Locale US`, instead use `Locale(language)`.
+- Since Spark 4.0, the `sentences` function, when `language` parameter is not null and `country` parameter is null, we no longer use `Locale.US`, instead use `Locale(language)`.
 
 ## Upgrading from Spark SQL 3.5.1 to 3.5.2
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr is following up https://github.com/apache/spark/pull/46880, to add migration guide for SQL function `sentences` behavior changes.


### Why are the changes needed?
As discussed below:
https://github.com/apache/spark/pull/46880#discussion_r1756774840
https://github.com/apache/spark/pull/46880#discussion_r1757102950
All behavior changes need to add migration guide for it.



### Does this PR introduce _any_ user-facing change?
Yes, provide clear doc for end-users.


### How was this patch tested?
No, only update doc.


### Was this patch authored or co-authored using generative AI tooling?
No.
