### PR TITLE
[SPARK-49644][SQL] Support drop multi-level partition V2 table with partial partition spec

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/v2Commands.scala
@@ -1161,6 +1161,7 @@ case class DropPartitions(
     parts: Seq[PartitionSpec],
     ifExists: Boolean,
     purge: Boolean) extends V2PartitionCommand {
+  override def allowPartialPartitionSpec: Boolean = true
   override protected def withNewChildInternal(newChild: LogicalPlan): DropPartitions =
     copy(table = newChild)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DropPartitionExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DropPartitionExec.scala
@@ -39,16 +39,16 @@ case class DropPartitionExec(
   override def output: Seq[Attribute] = Seq.empty
 
   override protected def run(): Seq[InternalRow] = {
-    val existsPartIdents: mutable.Set[InternalRow] = mutable.Set()
-    val notExistsPartIdents: mutable.Set[InternalRow] = mutable.Set()
-    partSpecs.foreach(partSpec => {
+    val existsPartIdents = mutable.Set[InternalRow]()
+    val notExistsPartIdents = mutable.Set[InternalRow]()
+    partSpecs.foreach { partSpec =>
       val partIdents = table.listPartitionIdentifiers(partSpec.names.toArray, partSpec.ident)
       if (partIdents.nonEmpty) {
         existsPartIdents.addAll(partIdents)
       } else {
         notExistsPartIdents.add(partSpec.ident)
       }
-    })
+    }
 
     if (notExistsPartIdents.nonEmpty && !ignoreIfNotExists) {
       throw new NoSuchPartitionsException(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Support drop multi-level partition V2 table with partial partition spec, e.g.
```
CREATE TABLE t (id string) USING DSV2 PARTITIONED BY (p1 int, p2 int, p3 int)
ALTER TABLE t DROP PARTITION (p1=1)
```

### Why are the changes needed?
This feature is useful when the user has a lot of secondary partitions and wants to delete all of them by specifying a primary partition.
v1 table support this now, v2 can support too, besides v2's truncate partition alreadly support partial partition spec now.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Support drop multi-level partition V2 table with partial partition spec

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
add test case

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
