### PR TITLE
[SPARK-49648][DOCS] Update `Configuring Ports for Network Security` section with JWS

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -55,7 +55,8 @@ To enable authorization, Spark Master should have
 `spark.master.rest.filters=org.apache.spark.ui.JWSFilter` and
 `spark.org.apache.spark.ui.JWSFilter.param.secretKey=BASE64URL-ENCODED-KEY` configurations, and
 client should provide HTTP `Authorization` header which contains JSON Web Token signed by
-the shared secret key.
+the shared secret key. Please note that this feature requires a Spark distribution built with
+`jjwt` profile.
 
 ### YARN
 
@@ -812,6 +813,12 @@ Generally speaking, a Spark cluster and its services are not deployed on the pub
 They are generally private services, and should only be accessible within the network of the
 organization that deploys Spark. Access to the hosts and ports used by Spark services should
 be limited to origin hosts that need to access the services.
+
+However, like the REST Submission port, Spark also supports HTTP `Authorization` header
+with a cryptographically signed JSON Web Token (JWT) for all UI ports.
+To use it, a user needs the Spark distribution built with `jjwt` profile and to configure
+`spark.ui.filters=org.apache.spark.ui.JWSFilter` and
+`spark.org.apache.spark.ui.JWSFilter.param.secretKey=BASE64URL-ENCODED-KEY`.
 
 Below are the primary ports that Spark uses for its communication and how to
 configure those ports.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `Configuring Ports for Network Security` section of `Security` page with new JWS feature.

### Why are the changes needed?

In addition to the existing restriction, Spark 4 can take advantage of new JWS feature. This PR informs it more clearly.

https://github.com/apache/spark/blob/08a26bb56cfb48f27c68a79be1e15bc4c9e466e0/docs/security.md?plain=1#L811-L814

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual review.

<img width="921" alt="Screenshot 2024-09-13 at 15 04 43" src="https://github.com/user-attachments/assets/2250e65b-cddd-4541-b42f-5284d5ce4b02">

<img width="930" alt="Screenshot 2024-09-13 at 15 04 16" src="https://github.com/user-attachments/assets/0c853380-081a-41a3-b66b-7774ec62fd3e">




### Was this patch authored or co-authored using generative AI tooling?

No.