### PR TITLE
[SPARK-49650][SQL][DOCS] Updates references to deprecated Hive JDBC client params in tests and docs

### DIFF
--- a/docs/sql-distributed-sql-engine.md
+++ b/docs/sql-distributed-sql-engine.md
@@ -83,7 +83,7 @@ Use the following setting to enable HTTP mode as system property or in `hive-sit
 
 To test, use beeline to connect to the JDBC/ODBC server in http mode with:
 
-    beeline> !connect jdbc:hive2://<host>:<port>/<database>?hive.server2.transport.mode=http;hive.server2.thrift.http.path=<http_endpoint>
+    beeline> !connect jdbc:hive2://<host>:<port>/<database>?transportMode=http;httpPath=<http_endpoint>
 
 If you closed a session and do CTAS, you must set `fs.%s.impl.disable.cache` to true in `hive-site.xml`.
 See more details in [[SPARK-21067]](https://issues.apache.org/jira/browse/SPARK-21067).

--- a/docs/sql-distributed-sql-engine.md
+++ b/docs/sql-distributed-sql-engine.md
@@ -83,7 +83,7 @@ Use the following setting to enable HTTP mode as system property or in `hive-sit
 
 To test, use beeline to connect to the JDBC/ODBC server in http mode with:
 
-    beeline> !connect jdbc:hive2://<host>:<port>/<database>?transportMode=http;httpPath=<http_endpoint>
+    beeline> !connect jdbc:hive2://<host>:<port>/<database>;transportMode=http;httpPath=<http_endpoint>
 
 If you closed a session and do CTAS, you must set `fs.%s.impl.disable.cache` to true in `hive-site.xml`.
 See more details in [[SPARK-21067]](https://issues.apache.org/jira/browse/SPARK-21067).

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
@@ -1432,11 +1432,11 @@ abstract class HiveThriftServer2TestBase extends SparkFunSuite with BeforeAndAft
     s"""jdbc:hive2://$localhost:$serverPort/
        |$database;
        |transportMode=http;
-       |httpPath=cliservice;
+       |httpPath=cliservice;?
        |${hiveConfList}#${hiveVarList}
      """.stripMargin.split("\n").mkString.trim
   } else {
-    s"jdbc:hive2://$localhost:$serverPort/$database;${hiveConfList}#${hiveVarList}"
+    s"jdbc:hive2://$localhost:$serverPort/$database?${hiveConfList}#${hiveVarList}"
   }
 
   private def tryCaptureSysLog(f: => Unit): Unit = {

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
@@ -1431,8 +1431,8 @@ abstract class HiveThriftServer2TestBase extends SparkFunSuite with BeforeAndAft
   protected def jdbcUri(database: String = "default"): String = if (mode == ServerMode.http) {
     s"""jdbc:hive2://$localhost:$serverPort/
        |$database?
-       |hive.server2.transport.mode=http;
-       |hive.server2.thrift.http.path=cliservice;
+       |transportMode=http;
+       |httpPath=cliservice;
        |${hiveConfList}#${hiveVarList}
      """.stripMargin.split("\n").mkString.trim
   } else {

--- a/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/HiveThriftServer2Suites.scala
@@ -1430,13 +1430,13 @@ abstract class HiveThriftServer2TestBase extends SparkFunSuite with BeforeAndAft
 
   protected def jdbcUri(database: String = "default"): String = if (mode == ServerMode.http) {
     s"""jdbc:hive2://$localhost:$serverPort/
-       |$database?
+       |$database;
        |transportMode=http;
        |httpPath=cliservice;
        |${hiveConfList}#${hiveVarList}
      """.stripMargin.split("\n").mkString.trim
   } else {
-    s"jdbc:hive2://$localhost:$serverPort/$database?${hiveConfList}#${hiveVarList}"
+    s"jdbc:hive2://$localhost:$serverPort/$database;${hiveConfList}#${hiveVarList}"
   }
 
   private def tryCaptureSysLog(f: => Unit): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates unit tests and docs to update references to long-deprecated Hive JDBC client connection string parameters.

The current docs and some test code are using parameters that have been deprecated for nearly a decade since https://issues.apache.org/jira/browse/HIVE-6972 / https://github.com/apache/hive/commit/07082e8a851cb44a95dcae50bc84fb43cb1e84c6 , so I think it's safe to clean up the usages now.

### Why are the changes needed?

While looking at some hive-thriftserver unit tests logs, I saw repeated spam of
```
20/06/05 06:35:55.442 pool-1-thread-1 WARN Utils: ***** JDBC param deprecation *****
20/06/05 06:35:55.442 pool-1-thread-1 WARN Utils: The use of hive.server2.transport.mode is deprecated.
20/06/05 06:35:55.442 pool-1-thread-1 WARN Utils: Please use transportMode like so: jdbc:hive2://<host>:<port>/dbName;transportMode=<transport_mode_value>
20/06/05 06:35:55.442 pool-1-thread-1 WARN Utils: ***** JDBC param deprecation *****
20/06/05 06:35:55.442 pool-1-thread-1 WARN Utils: The use of hive.server2.thrift.http.path is deprecated.
20/06/05 06:35:55.442 pool-1-thread-1 WARN Utils: Please use httpPath like so: jdbc:hive2://<host>:<port>/dbName;httpPath=<http_path_value> 
```

### Does this PR introduce _any_ user-facing change?

No, it's just a test + documentation change, recommending syntax which has been long-supported (some tests were [already using the new parameters](https://github.com/apache/spark/blob/d3eb99f79e508d62fdb7e9bc595f0240ac021df5/sql/hive-thriftserver/src/test/scala/org/apache/spark/sql/hive/thriftserver/SharedThriftServer.scala#L81-L85)).

### How was this patch tested?

Existing tests (let's wait to confirm that they pass in CI).

### Was this patch authored or co-authored using generative AI tooling?

No.