### PR TITLE
[SPARK-49655][BUILD] Link `python3` to `python3.9` in `spark-rm` Docker image

### DIFF
--- a/dev/create-release/spark-rm/Dockerfile
+++ b/dev/create-release/spark-rm/Dockerfile
@@ -137,6 +137,7 @@ RUN python3.9 -m pip list
 
 RUN gem install --no-document "bundler:2.4.22"
 RUN ln -s "$(which python3.9)" "/usr/local/bin/python"
+RUN ln -s "$(which python3.9)" "/usr/local/bin/python3"
 
 WORKDIR /opt/spark-rm/output
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to link `python3` to `python3.9` in `spark-rm` docker image.

### Why are the changes needed?

We already link `python` to `python3.9` in `Dockerfile`.
https://github.com/apache/spark/blob/931ab065df3952487028316ebd49c2895d947bf2/dev/create-release/spark-rm/Dockerfile#L139

Also, we link `python3` to `python3.9` in Documentation CI.
https://github.com/apache/spark/blob/b4f4d9b7a7d470158af39d75824bcc501e3506da/.github/workflows/build_and_test.yml#L871-L874

We need to link `python3` to `python3.9` to fix Spark Documentation generation failure in release script.

```
$ dev/create-release/do-release-docker.sh -d /run/user/1000/spark -s docs
...
= Building documentation...
Command: /opt/spark-rm/release-build.sh docs
Log file: docs.log
Command FAILED. Check full logs for details.
        from /opt/spark-rm/output/spark/docs/.local_ruby_bundle/ruby/3.0.0/gems/jekyll-4.3.3/lib/jekyll/command.rb:91:in `process_with_graceful_fail'
```

The root cause is `mkdocs` module import error during `error-conditions.html` generation.

### Does this PR introduce _any_ user-facing change?

No. This is a release-script.

### How was this patch tested?

Manual review.

After this PR, `error docs` generation succeeds.
```
************************
* Building error docs. *
************************
Generated: docs/_generated/error-conditions.html
```

### Was this patch authored or co-authored using generative AI tooling?

No.