### PR TITLE
[SPARK-49682][BUILD] Upgrade joda-time to 2.13.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -146,7 +146,7 @@ jjwt-api/0.12.6//jjwt-api-0.12.6.jar
 jline/2.14.6//jline-2.14.6.jar
 jline/3.25.1//jline-3.25.1.jar
 jna/5.14.0//jna-5.14.0.jar
-joda-time/2.12.7//joda-time-2.12.7.jar
+joda-time/2.13.0//joda-time-2.13.0.jar
 jodd-core/3.5.2//jodd-core-3.5.2.jar
 jpam/1.1//jpam-1.1.jar
 json/1.8//json-1.8.jar

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
     <gson.version>2.11.0</gson.version>
     <janino.version>3.1.9</janino.version>
     <jersey.version>3.0.12</jersey.version>
-    <joda.version>2.12.7</joda.version>
+    <joda.version>2.13.0</joda.version>
     <jodd.version>3.5.2</jodd.version>
     <jsr305.version>3.0.0</jsr305.version>
     <jaxb.version>2.2.11</jaxb.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade joda-time from `2.12.7` to `2.13.0`.

### Why are the changes needed?
The version `DateTimeZone` data updated to version `2024bgtz`.
The full release notes: https://www.joda.org/joda-time/changes-report.html#a2.13.0


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
