### PR TITLE
[SPARK-49678][CORE][FOLLOWUP] Support `spark.master` in `SparkSubmitArguments`

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala
@@ -44,7 +44,7 @@ private[deploy] class SparkSubmitArguments(args: Seq[String], env: Map[String, S
   var maybeMaster: Option[String] = None
   // Global defaults. These should be keep to minimum to avoid confusing behavior.
   def master: String =
-    maybeMaster.getOrElse(System.getProperty("spark.test.master", "local[*]"))
+    maybeMaster.getOrElse(System.getProperty("spark.master", "local[*]"))
   var maybeRemote: Option[String] = None
   var deployMode: String = null
   var executorMemory: String = null


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a follow-up in order to support `spark.master` instead of `spark.test.master`.
- #48126 

### Why are the changes needed?

By reusing the official config name, we can avoid to add a new test configuration.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.