### PR TITLE
[SPARK-49495][DOCS][FOLLOWUP] Fix Pandoc installation for GitHub Pages publication action

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -63,9 +63,9 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
       - name: Install Pandoc
-        uses: pandoc/actions/setup@d6abb76f6c8a1a9a5e15a5190c96a02aabffd1ee
-        with:
-          version: 3.3
+        run: |
+          apt-get update -y
+          apt-get install pandoc
       - name: Install dependencies for documentation generation
         run: |
           cd docs

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -64,8 +64,8 @@ jobs:
           bundler-cache: true
       - name: Install Pandoc
         run: |
-          apt-get update -y
-          apt-get install pandoc
+          sudo apt-get update -y
+          sudo apt-get install pandoc
       - name: Install dependencies for documentation generation
         run: |
           cd docs


### PR DESCRIPTION
### What changes were proposed in this pull request?

Action 'pandoc/actions/setup' is now allowed by the ASF organization account. This followup makes the installation step manual.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix ci

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
https://github.com/yaooqinn/spark/actions/runs/10914663049/job/30293151174


### Was this patch authored or co-authored using generative AI tooling?
no
