### PR TITLE
[SPARK-49495][DOCS][FOLLOWUP] Enable GitHub Pages settings via .asf.yml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -31,6 +31,8 @@ github:
     merge: false
     squash: true
     rebase: true
+  ghp_branch: master
+  ghp_path: /docs/_site
 
 notifications:
   pullrequests: reviews@spark.apache.org


### PR DESCRIPTION


### What changes were proposed in this pull request?

A followup of SPARK-49495 to enable GitHub Pages settings via [.asf.yaml](https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=git+-+.asf.yaml+features#Git.asf.yamlfeatures-GitHubPages)


### Why are the changes needed?
Meet the requirement for `actions/configure-pages@v5` action

```
Run actions/configure-pages@v5
  with:
    token: ***
    enablement: false
  env:
    SPARK_TESTING: 1
    RELEASE_VERSION: In-Progress
    JAVA_HOME: /opt/hostedtoolcache/Java_Zulu_jdk/17.0.1[2](https://github.com/apache/spark/actions/runs/10916383676/job/30297716064#step:10:2)-7/x64
    JAVA_HOME_17_X64: /opt/hostedtoolcache/Java_Zulu_jdk/17.0.12-7/x64
    pythonLocation: /opt/hostedtoolcache/Python/[3](https://github.com/apache/spark/actions/runs/10916383676/job/30297716064#step:10:3).9.19/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.9.19/x6[4](https://github.com/apache/spark/actions/runs/10916383676/job/30297716064#step:10:4)/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.9.19/x[6](https://github.com/apache/spark/actions/runs/10916383676/job/30297716064#step:10:6)4
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.9.19/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.[9](https://github.com/apache/spark/actions/runs/10916383676/job/30297716064#step:10:9).19/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.9.19/x64/lib
Error: Get Pages site failed. Please verify that the repository has Pages enabled and configured to build using GitHub Actions, or consider exploring the `enablement` parameter for this action. Error: Not Found - https://docs.github.com/rest/pages/pages#get-a-apiname-pages-site
Error: HttpError: Not Found - https://docs.github.com/rest/pages/pages#get-a-apiname-pages-site
```


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
NA


### Was this patch authored or co-authored using generative AI tooling?

no
