### PR TITLE
[MINOR] Abort changelog writer before resetting

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -646,8 +646,8 @@ class RocksDB(
           // is enabled.
           if (shouldForceSnapshot.get()) {
             uploadSnapshot()
-            changelogWriter = None
             changelogWriter.foreach(_.abort())
+            changelogWriter = None
           } else {
             try {
               assert(changelogWriter.isDefined)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -646,8 +646,11 @@ class RocksDB(
           // is enabled.
           if (shouldForceSnapshot.get()) {
             uploadSnapshot()
-            changelogWriter.foreach(_.abort())
-            changelogWriter = None
+            try {
+              changelogWriter.foreach(_.abort())
+            } finally {
+              changelogWriter = None
+            }
           } else {
             try {
               assert(changelogWriter.isDefined)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -114,7 +114,7 @@ private[sql] class RocksDBStateStoreProvider
       val valueEncoder = kvEncoder._2
       val keyEncoder = kvEncoder._1
 
-      verify(valueEncoder.supportsMultipleValuesPerKey, "valuesIterator requires a encoder " +
+      verify(valueEncoder.supportsMultipleValuesPerKey, "valuesIterator requires an encoder " +
       "that supports multiple values for a single key.")
 
       val encodedValues = rocksDB.get(keyEncoder.encodeKey(key))


### PR DESCRIPTION
### What changes were proposed in this pull request?
In `commit()`, `changelogWriter` is set to `None` before iterating.

This PR calls `abort()` on the `changelogWriter` before resetting.
This is consistent with what `rollback` does.

### Why are the changes needed?
To properly handle the abort of `changelogWriter`.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing test suite.

### Was this patch authored or co-authored using generative AI tooling?
No