### PR TITLE
[SPARK-49693][PYTHON][CONNECT] Refine the string representation of `timedelta`

### DIFF
--- a/python/pyspark/sql/connect/expressions.py
+++ b/python/pyspark/sql/connect/expressions.py
@@ -492,17 +492,14 @@ class LiteralExpression(Expression):
         elif isinstance(self._dataType, DayTimeIntervalType):
             delta = DayTimeIntervalType().fromInternal(self._value)
             if delta is not None and isinstance(delta, datetime.timedelta):
-                try:
-                    import pandas as pd
+                import pandas as pd
 
-                    # Note: timedelta itself does not provide isoformat method.
-                    # Both Pandas and java.time.Duration provide it, but the format
-                    # is sightly different:
-                    # java.time.Duration only applies HOURS, MINUTES, SECONDS units,
-                    # while Pandas applies all supported units.
-                    return pd.Timedelta(delta).isoformat()  # type: ignore[attr-defined]
-                except Exception:
-                    pass
+                # Note: timedelta itself does not provide isoformat method.
+                # Both Pandas and java.time.Duration provide it, but the format
+                # is sightly different:
+                # java.time.Duration only applies HOURS, MINUTES, SECONDS units,
+                # while Pandas applies all supported units.
+                return pd.Timedelta(delta).isoformat()  # type: ignore[attr-defined]
         return f"{self._value}"
 
 

--- a/python/pyspark/sql/connect/expressions.py
+++ b/python/pyspark/sql/connect/expressions.py
@@ -500,7 +500,7 @@ class LiteralExpression(Expression):
                     # is sightly different:
                     # java.time.Duration only applies HOURS, MINUTES, SECONDS units,
                     # while Pandas applies all supported units.
-                    return pd.Timedelta(delta).isoformat()
+                    return pd.Timedelta(delta).isoformat()  # type: ignore[attr-defined]
                 except Exception:
                     pass
         return f"{self._value}"

--- a/python/pyspark/sql/connect/expressions.py
+++ b/python/pyspark/sql/connect/expressions.py
@@ -489,7 +489,20 @@ class LiteralExpression(Expression):
             ts = TimestampNTZType().fromInternal(self._value)
             if ts is not None and isinstance(ts, datetime.datetime):
                 return ts.strftime("%Y-%m-%d %H:%M:%S.%f")
-        # TODO(SPARK-49693): Refine the string representation of timedelta
+        elif isinstance(self._dataType, DayTimeIntervalType):
+            delta = DayTimeIntervalType().fromInternal(self._value)
+            if delta is not None and isinstance(delta, datetime.timedelta):
+                try:
+                    import pandas as pd
+
+                    # Note: timedelta itself does not provide isoformat method.
+                    # Both Pandas and java.time.Duration provide it, but the format
+                    # is sightly different:
+                    # java.time.Duration only applies HOURS, MINUTES, SECONDS units,
+                    # while Pandas applies all supported units.
+                    return pd.Timedelta(delta).isoformat()
+                except Exception:
+                    pass
         return f"{self._value}"
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Refine the string representation of `timedelta`, by following the ISO format.
Note that the used units in JVM side (`Duration`) and Pandas are different.


### Why are the changes needed?
We should not leak the raw data


### Does this PR introduce _any_ user-facing change?
yes

PySpark Classic:
```
In [1]: from pyspark.sql import functions as sf

In [2]: import datetime

In [3]: sf.lit(datetime.timedelta(1, 1))
Out[3]: Column<'PT24H1S'>
```

PySpark Connect (before):
```
In [1]: from pyspark.sql import functions as sf

In [2]: import datetime

In [3]: sf.lit(datetime.timedelta(1, 1))
Out[3]: Column<'86401000000'>
```

PySpark Connect (after):
```
In [1]: from pyspark.sql import functions as sf

In [2]: import datetime

In [3]: sf.lit(datetime.timedelta(1, 1))
Out[3]: Column<'P1DT0H0M1S'>
```


### How was this patch tested?
added test


### Was this patch authored or co-authored using generative AI tooling?
no
