### PR TITLE
[DO-NOT-REVIEW][SPARK-49722][CONNECT] Fix Column ordering of dropDuplicates and dropDuplicatesWithinWatermarks

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/planner/SparkConnectPlanner.scala
@@ -1195,7 +1195,8 @@ class SparkConnectPlanner(
   }
 
   private def groupColsFromDropDuplicates(
-      colNames: Seq[String], allColumns: Seq[Attribute]): Seq[Attribute] = {
+      colNames: Seq[String],
+      allColumns: Seq[Attribute]): Seq[Attribute] = {
     val resolver = session.sessionState.analyzer.resolver
     // [SPARK-31990][SPARK-49722]: We must keep `toSet.toSeq` here because of the backward
     // compatibility issue (the Streaming's state store depends on the `groupCols` order).
@@ -1226,11 +1227,11 @@ class SparkConnectPlanner(
     val resolver = session.sessionState.analyzer.resolver
     val allColumns = queryExecution.analyzed.output
     if (rel.getAllColumnsAsKeys) {
-      val groupCals = groupColsFromDropDuplicates(allColumns.map(_.name), allColumns)
+      val groupCols = groupColsFromDropDuplicates(allColumns.map(_.name), allColumns)
       if (rel.getWithinWatermark) {
-        DeduplicateWithinWatermark(groupCals, queryExecution.analyzed)
+        DeduplicateWithinWatermark(groupCols, queryExecution.analyzed)
       } else {
-        Deduplicate(groupCals, queryExecution.analyzed)
+        Deduplicate(groupCols, queryExecution.analyzed)
       }
     } else {
       val toGroupColumnNames = rel.getColumnNamesList.asScala.toSeq

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -1304,6 +1304,8 @@ class Dataset[T] private[sql](
     val allColumns = queryExecution.analyzed.output
     // SPARK-31990: We must keep `toSet.toSeq` here because of the backward compatibility issue
     // (the Streaming's state store depends on the `groupCols` order).
+    // SPARK-49722: If you modify this function, please please also modify the same function in
+    // `SparkConnectPlanner.scala` in connect.
     colNames.toSet.toSeq.flatMap { (colName: String) =>
       // It is possibly there are more than one columns with the same name,
       // so we call filter instead of find.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Similar to SPARK-31990, We must keep `toSet.toSeq` here because of the backward compatibility issue (the Streaming's state store depends on the `groupCols` order). Without this patch, a stateful streaming query cannot be rerun under spark connect if it was previous ran under vanilla spark (and vice versa)

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Bug fix

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing CI should pass, functional wise this is straightforward

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No