### PR TITLE
[SPARK-49733][SQL][DOCS] Delete `ExpressionInfo[between]` from `gen-sql-api-docs.py` to avoid duplication

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Between.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Between.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.internal.SQLConf
       * lower - Lower bound of the between check.
       * upper - Upper bound of the between check.
   """,
-  since = "4.0.0",
+  since = "1.0.0",
   group = "conditional_funcs")
 case class Between private(input: Expression, lower: Expression, upper: Expression, replacement: Expression)
   extends RuntimeReplaceable with InheritAnalysisRules  {

--- a/sql/gen-sql-api-docs.py
+++ b/sql/gen-sql-api-docs.py
@@ -71,19 +71,6 @@ _virtual_operator_infos = [
         deprecated=""),
     ExpressionInfo(
         className="",
-        name="between",
-        usage="expr1 [NOT] BETWEEN expr2 AND expr3 - " +
-              "evaluate if `expr1` is [not] in between `expr2` and `expr3`.",
-        arguments="",
-        examples="\n    Examples:\n      " +
-                 "> SELECT col1 FROM VALUES 1, 3, 5, 7 WHERE col1 BETWEEN 2 AND 5;\n      " +
-                 " 3\n      " +
-                 " 5",
-        note="",
-        since="1.0.0",
-        deprecated=""),
-    ExpressionInfo(
-        className="",
         name="case",
         usage="CASE expr1 WHEN expr2 THEN expr3 " +
               "[WHEN expr4 THEN expr5]* [ELSE expr6] END - " +


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to delete `ExpressionInfo[between]` from `gen-sql-api-docs.py` to avoid duplication.

### Why are the changes needed?
- In the following doc, `between` is repeatedly displayed `twice`
  https://spark.apache.org/docs/preview/api/sql/index.html#between
  <img width="1062" alt="image" src="https://github.com/user-attachments/assets/1aa2ad22-6346-40d7-be1d-cab73b79959a">

After the pr:
<img width="751" alt="image" src="https://github.com/user-attachments/assets/a66d607a-9dcb-4d96-a8f9-024f3844055b">


- After https://github.com/apache/spark/pull/44299, the expression 'between' has been added to `Spark 4.0`.


### Does this PR introduce _any_ user-facing change?
Yes, only for docs.


### How was this patch tested?
Manually check.


### Was this patch authored or co-authored using generative AI tooling?
No.
