### PR TITLE
[SPARK-49734][PYTHON] Add `seed` argument for function `shuffle` 

### DIFF
--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -2206,12 +2206,9 @@ def schema_of_xml(xml: Union[str, Column], options: Optional[Mapping[str, str]] 
 schema_of_xml.__doc__ = pysparkfuncs.schema_of_xml.__doc__
 
 
-def shuffle(col: "ColumnOrName") -> Column:
-    return _invoke_function(
-        "shuffle",
-        _to_col(col),
-        LiteralExpression(random.randint(0, sys.maxsize), LongType()),
-    )
+def shuffle(col: "ColumnOrName", seed: Optional[Union[Column, int]] = None) -> Column:
+    _seed = lit(random.randint(0, sys.maxsize)) if seed is None else lit(seed)
+    return _invoke_function("shuffle", _to_col(col), _seed)
 
 
 shuffle.__doc__ = pysparkfuncs.shuffle.__doc__

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -65,7 +65,6 @@ from pyspark.sql import functions as pysparkfuncs
 from pyspark.sql.types import (
     _from_numpy_type,
     DataType,
-    LongType,
     StructType,
     ArrayType,
     StringType,

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -17756,40 +17756,40 @@ def shuffle(col: "ColumnOrName", seed: Optional[Union[Column, int]] = None) -> C
     Example 1: Shuffling a simple array
 
     >>> import pyspark.sql.functions as sf
-    >>> df = spark.createDataFrame([([1, 20, 3, 5],)], ['data'])
+    >>> df = spark.sql("SELECT ARRAY(1, 20, 3, 5) AS data")
     >>> df.select("*", sf.shuffle(df.data, sf.lit(123))).show()
     +-------------+-------------+
     |         data|shuffle(data)|
     +-------------+-------------+
-    |[1, 20, 3, 5]|[1, 5, 20, 3]|
+    |[1, 20, 3, 5]|[5, 1, 20, 3]|
     +-------------+-------------+
 
     Example 2: Shuffling an array with null values
 
     >>> import pyspark.sql.functions as sf
-    >>> df = spark.createDataFrame([([1, 20, None, 3],)], ['data'])
+    >>> df = spark.sql("SELECT ARRAY(1, 20, NULL, 5) AS data")
     >>> df.select("*", sf.shuffle(sf.col("data"), 234)).show()
     +----------------+----------------+
     |            data|   shuffle(data)|
     +----------------+----------------+
-    |[1, 20, NULL, 3]|[3, 20, NULL, 1]|
+    |[1, 20, NULL, 5]|[NULL, 5, 20, 1]|
     +----------------+----------------+
 
     Example 3: Shuffling an array with duplicate values
 
     >>> import pyspark.sql.functions as sf
-    >>> df = spark.createDataFrame([([1, 2, 2, 3, 3, 3],)], ['data'])
+    >>> df = spark.sql("SELECT ARRAY(1, 2, 2, 3, 3, 3) AS data")
     >>> df.select("*", sf.shuffle("data", 345)).show()
     +------------------+------------------+
     |              data|     shuffle(data)|
     +------------------+------------------+
-    |[1, 2, 2, 3, 3, 3]|[3, 1, 3, 3, 2, 2]|
+    |[1, 2, 2, 3, 3, 3]|[2, 3, 3, 1, 2, 3]|
     +------------------+------------------+
 
     Example 4: Shuffling an array with random seed
 
     >>> import pyspark.sql.functions as sf
-    >>> df = spark.createDataFrame([([1, 2, 2, 3, 3, 3],)], ['data'])
+    >>> df = spark.sql("SELECT ARRAY(1, 2, 2, 3, 3, 3) AS data")
     >>> df.select("*", sf.shuffle("data")).show() # doctest: +SKIP
     +------------------+------------------+
     |              data|     shuffle(data)|

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -7252,18 +7252,7 @@ object functions {
    * @group array_funcs
    * @since 2.4.0
    */
-  def shuffle(e: Column): Column = shuffle(e, SparkClassUtils.random.nextLong)
-
-  /**
-   * Returns a random permutation of the given array.
-   *
-   * @note
-   *   The function is non-deterministic.
-   *
-   * @group array_funcs
-   * @since 4.0.0
-   */
-  def shuffle(e: Column, seed: Long): Column = shuffle(e, lit(seed))
+  def shuffle(e: Column): Column = shuffle(e, lit(SparkClassUtils.random.nextLong))
 
   /**
    * Returns a random permutation of the given array.

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -7252,7 +7252,29 @@ object functions {
    * @group array_funcs
    * @since 2.4.0
    */
-  def shuffle(e: Column): Column = Column.fn("shuffle", e, lit(SparkClassUtils.random.nextLong))
+  def shuffle(e: Column): Column = shuffle(e, SparkClassUtils.random.nextLong)
+
+  /**
+   * Returns a random permutation of the given array.
+   *
+   * @note
+   *   The function is non-deterministic.
+   *
+   * @group array_funcs
+   * @since 4.0.0
+   */
+  def shuffle(e: Column, seed: Long): Column = shuffle(e, lit(seed))
+
+  /**
+   * Returns a random permutation of the given array.
+   *
+   * @note
+   *   The function is non-deterministic.
+   *
+   * @group array_funcs
+   * @since 4.0.0
+   */
+  def shuffle(e: Column, seed: Column): Column = Column.fn("shuffle", e, seed)
 
   /**
    * Returns a reversed string or an array with reverse order of elements.


### PR DESCRIPTION
### What changes were proposed in this pull request?
1, Add `seed` argument for function `shuffle`;
2, Rewrite and enable the doctest by specify the seed and control the partitioning;


### Why are the changes needed?
feature parity, seed is support in SQL side


### Does this PR introduce _any_ user-facing change?
yes, new argument


### How was this patch tested?
updated doctest


### Was this patch authored or co-authored using generative AI tooling?
no