### PR TITLE
[Minor] Catch exception from snapshot uploading

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -644,8 +644,14 @@ class RocksDB(
           // If we have changed the columnFamilyId mapping, we have set a new
           // snapshot and need to upload this to the DFS even if changelog checkpointing
           // is enabled.
+          var ex: Throwable = null
           if (shouldForceSnapshot.get()) {
-            uploadSnapshot()
+            try {
+              uploadSnapshot()
+            } catch {
+              case t: Throwable =>
+                ex = t
+            }
             shouldForceSnapshot.set(false)
           }
 
@@ -656,6 +662,7 @@ class RocksDB(
           } finally {
             changelogWriter = None
           }
+          if (ex != null) throw ex;
         } else {
           assert(changelogWriter.isEmpty)
           uploadSnapshot()


### PR DESCRIPTION
### What changes were proposed in this pull request?
When `enableChangelogCheckpointing` is true, we call `uploadSnapshot`. If there is exception coming out of this call, currently changelog files are not written.

This PR catches the potential exception from `uploadSnapshot`, write the changelog files and throw the exception.

### Why are the changes needed?
This is to ensure that changelog files are always written.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing test suite.

### Was this patch authored or co-authored using generative AI tooling?
No.