### PR TITLE
[SPARK-49739][SQL] Throw Custom error condition for invalid options in SaveIntoDataSourceCommand class

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -2752,6 +2752,11 @@
         "message" : [
           "A type of keys and values in `map()` must be string, but got <mapType>."
         ]
+      },
+      "NULL_VALUE" : {
+        "message" : [
+          "Values of keys and values in `map()` must be string, but got null in value."
+        ]
       }
     },
     "sqlState" : "42K06"

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommand.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/SaveIntoDataSourceCommand.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.execution.datasources
 
 import scala.util.control.NonFatal
 
-import org.apache.spark.SparkThrowable
+import org.apache.spark.{SparkIllegalArgumentException, SparkThrowable}
 import org.apache.spark.sql.{Dataset, Row, SaveMode, SparkSession}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.catalyst.plans.logical.{CTEInChildren, CTERelationDef, LogicalPlan, WithCTE}
@@ -46,6 +46,10 @@ case class SaveIntoDataSourceCommand(
   override def innerChildren: Seq[QueryPlan[_]] = Seq(query)
 
   override def run(sparkSession: SparkSession): Seq[Row] = {
+    if (options.values.exists(_ == null)) {
+      throw new SparkIllegalArgumentException(
+        errorClass = "INVALID_OPTIONS.NULL_VALUE")
+    }
     var relation: BaseRelation = null
 
     try {


### PR DESCRIPTION
### What changes were proposed in this pull request?

NullPointerException was thrown when invalid options were provided in the run function of SaveIntoDataSourceCommand up to now. That is because this map is propagated [here](https://github.com/apache/spark/blob/branch-3.5/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala#L54), and java.util.Properties throws NPE if key/value is null. In map, a key cannot be null, but a value can, so that is why this NPE is possible to produce.
I propose we send the client an appropriate error condition. I've created a new error condition `INVALID_OPTIONS.NULL_VALUE`. Options are checked, and the error is thrown if there exists an entry in options map where the value is null.

### Why are the changes needed?
To send the client an appropriate error.

### Does this PR introduce _any_ user-facing change?
Yes, in case invalid options are sent, we throw `INVALID_OPTIONS.NULL_VALUE` instead of NullPointerException.

### How was this patch tested?
Wrote a unit test.

### Was this patch authored or co-authored using generative AI tooling?
No.