### PR TITLE
[SPARK-48782][SQL][TESTS][FOLLOW-UP] Enable ANSI for malformed input test in ProcedureSuite

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ProcedureSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ProcedureSuite.scala
@@ -258,18 +258,20 @@ class ProcedureSuite extends QueryTest with SharedSparkSession with BeforeAndAft
   }
 
   test("malformed input to implicit cast") {
-    catalog.createProcedure(Identifier.of(Array("ns"), "sum"), UnboundSum)
-    val call = "CALL cat.ns.sum('A', 2)"
-    checkError(
-      exception = intercept[SparkNumberFormatException](
-        sql(call)
-      ),
-      condition = "CAST_INVALID_INPUT",
-      parameters = Map(
-        "expression" -> toSQLValue("A"),
-        "sourceType" -> toSQLType("STRING"),
-        "targetType" -> toSQLType("INT")),
-      context = ExpectedContext(fragment = call, start = 0, stop = call.length - 1))
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> true.toString) {
+      catalog.createProcedure(Identifier.of(Array("ns"), "sum"), UnboundSum)
+      val call = "CALL cat.ns.sum('A', 2)"
+      checkError(
+        exception = intercept[SparkNumberFormatException](
+          sql(call)
+        ),
+        condition = "CAST_INVALID_INPUT",
+        parameters = Map(
+          "expression" -> toSQLValue("A"),
+          "sourceType" -> toSQLType("STRING"),
+          "targetType" -> toSQLType("INT")),
+        context = ExpectedContext(fragment = call, start = 0, stop = call.length - 1))
+    }
   }
 
   test("required parameters after optional") {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/47943 that enables ANSI for malformed input test in ProcedureSuite.

### Why are the changes needed?

The specific test fails with ANSI mode disabled
https://github.com/apache/spark/actions/runs/10951615244/job/30408963913

```
- malformed input to implicit cast *** FAILED *** (4 milliseconds)
  Expected exception org.apache.spark.SparkNumberFormatException to be thrown, but no exception was thrown (ProcedureSuite.scala:264)
  org.scalatest.exceptions.TestFailedException:
  at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
  at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:471)
  at org.scalatest.funsuite.AnyFunSuite.newAssertionFailedException(AnyFunSuite.scala:1564)
...
```

The test depends on `sum`'s failure so this PR simply enables ANSI mode for that specific test.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually ran with ANSI mode off.

### Was this patch authored or co-authored using generative AI tooling?

No.