### PR TITLE
[SPARK-48355][SQL][TESTS][FOLLOWUP] Enable a SQL Scripting test in ANSI and non-ANSI modes

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -702,7 +702,6 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
     verifySqlScriptResult(commands, expected)
   }
 
-  // This is disabled because it fails in non-ANSI mode
   test("simple case mismatched types") {
     val commands =
       """


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to enable the test which https://github.com/apache/spark/pull/48115 turned off, and run in the ANSI and non-ANSI modes.

### Why are the changes needed?
To make this test stable, and don't depend on the default setting for ANSI mode.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the modified test locally:
```
$ PYSPARK_PYTHON=python3 build/sbt "sql/testOnly org.apache.spark.sql.scripting.SqlScriptingInterpreterSuite"
```

### Was this patch authored or co-authored using generative AI tooling?
No.