### PR TITLE
[SPARK-49725][SQL][DOC] Enhance the doc of spark.sql.codegen.wholeStage

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -1859,8 +1859,10 @@ object SQLConf {
 
   val WHOLESTAGE_CODEGEN_ENABLED = buildConf("spark.sql.codegen.wholeStage")
     .internal()
-    .doc("When true, the whole stage (of multiple operators) will be compiled into single java" +
-      " method.")
+    .doc("When true, the whole stage (of multiple operators) will be compiled into single java " +
+      "method. In some scenarios(for example, long running Spark Thrift Server), you may need " +
+      "to set the JVM flags(for example, `-XX:PerMethodRecompilationCutoff=10000`) to avoid " +
+      "performance regression.")
     .version("2.0.0")
     .booleanConf
     .createWithDefault(true)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Enabling `spark.sql.codegen.wholeStage` may cause significant performance regression in some cases. On the executor side, you can see that 47.99% of the CPU is in `[deoptimization]`. This scenario can be avoided by increasing `PerMethodRecompilationCutoff`. This PR adds this workaround to the doc.

![profile-executor-before](https://github.com/user-attachments/assets/3f035c3b-1525-4a74-9aab-93a58e3bdf89)


### Why are the changes needed?

Enhance the doc.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A.

### Was this patch authored or co-authored using generative AI tooling?

No.