### PR TITLE
[SPARK-48712][SQL][FOLLOWUP] Check whether input is valid utf-8 string or not before entering fast path

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -3039,16 +3039,20 @@ object Encode {
       legacyCharsets: Boolean,
       legacyErrorAction: Boolean): Array[Byte] = {
     val toCharset = charset.toString
-    if (input.numBytes == 0 || ("UTF-8".equalsIgnoreCase(toCharset) && input.isValid)) {
-      return input.getBytes
-    }
-    val encoder = CharsetProvider.newEncoder(toCharset, legacyCharsets, legacyErrorAction)
-    try {
-      val bb = encoder.encode(CharBuffer.wrap(input.toString))
-      JavaUtils.bufferToArray(bb)
-    } catch {
-      case _: CharacterCodingException =>
-        throw QueryExecutionErrors.malformedCharacterCoding("encode", toCharset)
+    if ("UTF-8".equalsIgnoreCase(toCharset) && input.isValid) {
+      input.getBytes
+    } else {
+      val encoder = CharsetProvider.newEncoder(toCharset, legacyCharsets, legacyErrorAction)
+      if (input.numBytes == 0) {
+        return input.getBytes
+      }
+      try {
+        val bb = encoder.encode(CharBuffer.wrap(input.toString))
+        JavaUtils.bufferToArray(bb)
+      } catch {
+        case _: CharacterCodingException =>
+          throw QueryExecutionErrors.malformedCharacterCoding("encode", toCharset)
+      }
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -3039,7 +3039,7 @@ object Encode {
       legacyCharsets: Boolean,
       legacyErrorAction: Boolean): Array[Byte] = {
     val toCharset = charset.toString
-    if (input.numBytes == 0 || ("UTF-8".equalsIgnoreCase(toCharset) && input.isValid())) {
+    if (input.numBytes == 0 || ("UTF-8".equalsIgnoreCase(toCharset) && input.isValid)) {
       return input.getBytes
     }
     val encoder = CharsetProvider.newEncoder(toCharset, legacyCharsets, legacyErrorAction)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -3039,7 +3039,7 @@ object Encode {
       legacyCharsets: Boolean,
       legacyErrorAction: Boolean): Array[Byte] = {
     val toCharset = charset.toString
-    if (input.numBytes == 0 || "UTF-8".equalsIgnoreCase(toCharset)) {
+    if (input.numBytes == 0 || ("UTF-8".equalsIgnoreCase(toCharset) && input.isValid())) {
       return input.getBytes
     }
     val encoder = CharsetProvider.newEncoder(toCharset, legacyCharsets, legacyErrorAction)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -3039,20 +3039,15 @@ object Encode {
       legacyCharsets: Boolean,
       legacyErrorAction: Boolean): Array[Byte] = {
     val toCharset = charset.toString
-    if ("UTF-8".equalsIgnoreCase(toCharset) && input.isValid) {
-      input.getBytes
-    } else {
-      val encoder = CharsetProvider.newEncoder(toCharset, legacyCharsets, legacyErrorAction)
-      if (input.numBytes == 0) {
-        return input.getBytes
-      }
-      try {
-        val bb = encoder.encode(CharBuffer.wrap(input.toString))
-        JavaUtils.bufferToArray(bb)
-      } catch {
-        case _: CharacterCodingException =>
-          throw QueryExecutionErrors.malformedCharacterCoding("encode", toCharset)
-      }
+    if ("UTF-8".equalsIgnoreCase(toCharset) && input.isValid) return input.getBytes
+    val encoder = CharsetProvider.newEncoder(toCharset, legacyCharsets, legacyErrorAction)
+    if (input.numBytes == 0) return input.getBytes
+    try {
+      val bb = encoder.encode(CharBuffer.wrap(input.toString))
+      JavaUtils.bufferToArray(bb)
+    } catch {
+      case _: CharacterCodingException =>
+        throw QueryExecutionErrors.malformedCharacterCoding("encode", toCharset)
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

Check whether input is valid utf-8 string or not before entering fast path

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Avoid behavior change on a corner case where users provide invalid UTF-8 strings for UTF-8 encoding


### Does this PR introduce _any_ user-facing change?
no, this is a followup to avoid potential breaking change


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->existing tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->no
