### PR TITLE
[SPARK-49763] [CSV] [SQL] [Schema Detection]

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkDateTimeUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkDateTimeUtils.scala
@@ -603,6 +603,33 @@ trait SparkDateTimeUtils {
     }
   }
 
+  /**
+   * Trims and parses a given UTF8 time string value, returning the corresponding [[String]] value.
+   *
+   * - If the input string is not a valid time string, the return value is [[None]].
+   * - If the input is a valid time string and `parseAsString` is true,
+   * the return value is a [[String]].
+   *
+   * @param input The UTF8 time string to be parsed.
+   * @param inferTimeAsString Boolean flag to determine whether to return the time
+   *                      string as [[String]] if valid.
+   */
+
+  def stringToTime(s: UTF8String, inferTimeAsString: Boolean): Option[String] = {
+    try {
+      val (segments, parsedZoneId, justTime) = parseTimestampString(s)
+      if (segments.isEmpty) {
+        return None
+      }
+      if(inferTimeAsString && justTime) {
+        return Some(s.toString)
+      }
+      None
+    } catch {
+      case NonFatal(_) => None
+    }
+  }
+
   def stringToTimestampAnsi(
       s: UTF8String,
       timeZoneId: ZoneId,

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkDateTimeUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkDateTimeUtils.scala
@@ -604,15 +604,17 @@ trait SparkDateTimeUtils {
   }
 
   /**
-   * Trims and parses a given UTF8 time string value, returning the corresponding [[String]] value.
+   * Trims and parses a given UTF8 time string value, returning the corresponding [[String]]
+   * value.
    *
-   * - If the input string is not a valid time string, the return value is [[None]].
-   * - If the input is a valid time string and `parseAsString` is true,
-   * the return value is a [[String]].
+   *   - If the input string is not a valid time string, the return value is [[None]].
+   *   - If the input is a valid time string and `parseAsString` is true, the return value is a
+   *     [[String]].
    *
-   * @param input The UTF8 time string to be parsed.
-   * @param inferTimeAsString Boolean flag to determine whether to return the time
-   *                      string as [[String]] if valid.
+   * @param input
+   *   The UTF8 time string to be parsed.
+   * @param inferTimeAsString
+   *   Boolean flag to determine whether to return the time string as [[String]] if valid.
    */
 
   def stringToTime(s: UTF8String, inferTimeAsString: Boolean): Option[String] = {
@@ -621,7 +623,7 @@ trait SparkDateTimeUtils {
       if (segments.isEmpty) {
         return None
       }
-      if(inferTimeAsString && justTime) {
+      if (inferTimeAsString && justTime) {
         return Some(s.toString)
       }
       None

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
@@ -176,6 +176,19 @@ sealed trait TimestampFormatter extends Serializable {
    *   string.
    */
   def validatePatternString(checkLegacy: Boolean): Unit
+
+  /**
+   * Parses a time in a string and if the string is valid time, then returns the
+   * Optional String value.
+   *
+   * @param s - string with time to parse
+   * @return An optional string of time. The result is None on invalid input.
+   * @throws ParseException can be thrown by legacy parser
+   */
+  @throws(classOf[ParseException])
+  def parseTimeOptional(s: String, inferTimeAsString: Boolean): Option[String] = {
+    SparkDateTimeUtils.stringToTime(UTF8String.fromString(s), inferTimeAsString)
+  }
 }
 
 class Iso8601TimestampFormatter(

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/TimestampFormatter.scala
@@ -178,12 +178,15 @@ sealed trait TimestampFormatter extends Serializable {
   def validatePatternString(checkLegacy: Boolean): Unit
 
   /**
-   * Parses a time in a string and if the string is valid time, then returns the
-   * Optional String value.
+   * Parses a time in a string and if the string is valid time, then returns the Optional String
+   * value.
    *
-   * @param s - string with time to parse
-   * @return An optional string of time. The result is None on invalid input.
-   * @throws ParseException can be thrown by legacy parser
+   * @param s
+   *   \- string with time to parse
+   * @return
+   *   An optional string of time. The result is None on invalid input.
+   * @throws ParseException
+   *   can be thrown by legacy parser
    */
   @throws(classOf[ParseException])
   def parseTimeOptional(s: String, inferTimeAsString: Boolean): Option[String] = {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchema.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchema.scala
@@ -213,8 +213,15 @@ class CSVInferSchema(val options: CSVOptions) extends Serializable {
   }
 
   private def tryParseTimestamp(field: String): DataType = {
-    // This case infers a custom `dataFormat` is set.
-    if (timestampParser.parseOptional(field).isDefined) {
+    /**
+     * This case infers Time only column to String
+     * if the `inferStringTypeForTimeOnlyColumnFlag` is true
+     */
+    if (timestampParser.parseTimeOptional
+    (field, options.inferStringTypeForTimeOnlyColumnFlag).isDefined) {
+      stringType()
+    } // This case infers a custom `dataFormat` is set.
+    else if (timestampParser.parseOptional(field).isDefined) {
       TimestampType
     } else {
       tryParseBoolean(field)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/csv/CSVOptions.scala
@@ -122,6 +122,8 @@ class CSVOptions(
 
   val headerFlag = getBool(HEADER)
   val inferSchemaFlag = getBool(INFER_SCHEMA)
+  val inferStringTypeForTimeOnlyColumnFlag =
+    getBool(INFER_STRING_TYPE_FOR_TIME_ONLY_COLUMN, default = false)
   val ignoreLeadingWhiteSpaceInRead = getBool(IGNORE_LEADING_WHITESPACE, default = false)
   val ignoreTrailingWhiteSpaceInRead = getBool(IGNORE_TRAILING_WHITESPACE, default = false)
 
@@ -396,4 +398,5 @@ object CSVOptions extends DataSourceOptions {
   val DELIMITER = "delimiter"
   newOption(SEP, DELIMITER)
   val COLUMN_PRUNING = newOption("columnPruning")
+  val INFER_STRING_TYPE_FOR_TIME_ONLY_COLUMN = newOption("inferStringTypeForTimeOnlyColumn")
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchemaSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/csv/CSVInferSchemaSuite.scala
@@ -68,6 +68,48 @@ class CSVInferSchemaSuite extends SparkFunSuite with SQLHelper {
     assert(inferSchema.inferField(IntegerType, textValueOne) == expectedTypeOne)
   }
 
+  test("String fields types are inferred for time only columns") {
+    val options = new CSVOptions(Map("inferStringTypeForTimeOnlyColumn" -> "true"), false, "UTC")
+    val inferSchema = new CSVInferSchema(options)
+
+    assert(inferSchema.inferField(NullType, "") == NullType)
+    assert(inferSchema.inferField(NullType, null) == NullType)
+    assert(inferSchema.inferField(NullType, "100000000000") == LongType)
+    assert(inferSchema.inferField(NullType, "60") == IntegerType)
+    assert(inferSchema.inferField(NullType, "3.5") == DoubleType)
+    assert(inferSchema.inferField(NullType, "test") == StringType)
+    assert(inferSchema.inferField(NullType, "2015-08-20 15:57:00") == TimestampType)
+    assert(inferSchema.inferField(NullType, "True") == BooleanType)
+    assert(inferSchema.inferField(NullType, "FAlSE") == BooleanType)
+    assert(inferSchema.inferField(NullType, "10:11:12") == StringType)
+
+    val textValueOne = Long.MaxValue.toString + "0"
+    val decimalValueOne = new java.math.BigDecimal(textValueOne)
+    val expectedTypeOne = DecimalType(decimalValueOne.precision, decimalValueOne.scale)
+    assert(inferSchema.inferField(NullType, textValueOne) == expectedTypeOne)
+  }
+
+  test("Timestamp field types are inferred for time only columns") {
+    val options = new CSVOptions(Map.empty[String, String], false, "UTC")
+    val inferSchema = new CSVInferSchema(options)
+
+    assert(inferSchema.inferField(NullType, "") == NullType)
+    assert(inferSchema.inferField(NullType, null) == NullType)
+    assert(inferSchema.inferField(NullType, "100000000000") == LongType)
+    assert(inferSchema.inferField(NullType, "60") == IntegerType)
+    assert(inferSchema.inferField(NullType, "3.5") == DoubleType)
+    assert(inferSchema.inferField(NullType, "test") == StringType)
+    assert(inferSchema.inferField(NullType, "2015-08-20 15:57:00") == TimestampType)
+    assert(inferSchema.inferField(NullType, "True") == BooleanType)
+    assert(inferSchema.inferField(NullType, "FAlSE") == BooleanType)
+    assert(inferSchema.inferField(NullType, "10:11:12") == TimestampType)
+
+    val textValueOne = Long.MaxValue.toString + "0"
+    val decimalValueOne = new java.math.BigDecimal(textValueOne)
+    val expectedTypeOne = DecimalType(decimalValueOne.precision, decimalValueOne.scale)
+    assert(inferSchema.inferField(NullType, textValueOne) == expectedTypeOne)
+  }
+
   test("Timestamp field types are inferred correctly via custom data format") {
     var options = new CSVOptions(Map("timestampFormat" -> "yyyy-mm"), false, "UTC")
     var inferSchema = new CSVInferSchema(options)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -3306,7 +3306,7 @@ abstract class CSVSuite
   }
 
   test("SPARK-40667: validate CSV Options") {
-    assert(CSVOptions.getAllOptions.size == 39)
+    assert(CSVOptions.getAllOptions.size == 40)
     // Please add validation on any new CSV options here
     assert(CSVOptions.isValidOption("header"))
     assert(CSVOptions.isValidOption("inferSchema"))
@@ -3347,6 +3347,7 @@ abstract class CSVSuite
     assert(CSVOptions.isValidOption("sep"))
     assert(CSVOptions.isValidOption("delimiter"))
     assert(CSVOptions.isValidOption("columnPruning"))
+    assert(CSVOptions.isValidOption("inferStringTypeForTimeOnlyColumn"))
     // Please add validation on any new parquet options with alternative here
     assert(CSVOptions.getAlternativeOption("sep").contains("delimiter"))
     assert(CSVOptions.getAlternativeOption("delimiter").contains("sep"))


### PR DESCRIPTION
**What changes were proposed in this pull request?**

[CSV Reader] Add Flag to Control Inference of Time-Only Columns as String or Timestamp During Schema Detection

**Why are the changes needed?**

By default, Spark converts time-only columns to Timestamp type, which can lead to unintended behavior in certain use cases. This new flag will allow users to specify whether time-only columns should be inferred as Timestamp or as String.
This flag `inferStringTypeForTimeOnlyColumn` can be supplied while reading the CSV files , true will infer as String, default behaviour is false and infers as timestamp.

![image](https://github.com/user-attachments/assets/615f60f5-4884-499f-97d5-438e409df43d)


[Default/"inferStringTypeForTimeOnlyColumn" -> "false"]

![image](https://github.com/user-attachments/assets/35716f32-07c3-4652-b227-7f8a55f8b097)


["inferStringTypeForTimeOnlyColumn" -> "true"]

![image](https://github.com/user-attachments/assets/2ae1a203-b57b-4e92-b814-bc8e44b97acb)

**Does this PR introduce _any_ user-facing change?**
No


**How was this patch tested?**
Unit tests.


**Was this patch authored or co-authored using generative AI tooling?**
No
