### PR TITLE
[SPARK-49765][DOCS][PYTHON] Adjust documentation of "spark.sql.pyspark.plotting.max_rows"

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3171,9 +3171,9 @@ object SQLConf {
 
   val PYSPARK_PLOT_MAX_ROWS =
     buildConf("spark.sql.pyspark.plotting.max_rows")
-      .doc(
-        "The visual limit on top-n-based plots. If set to 1000, the first 1000 data points " +
-        "will be used for plotting.")
+      .doc("The visual limit on plots. If set to 1000 for top-n-based plots, the first 1000 " +
+        "data points will be used for plotting. For sampled-based plots, 1000 data points " +
+        "will be randomly sampled.")
       .version("4.0.0")
       .intConf
       .createWithDefault(1000)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3172,8 +3172,8 @@ object SQLConf {
   val PYSPARK_PLOT_MAX_ROWS =
     buildConf("spark.sql.pyspark.plotting.max_rows")
       .doc("The visual limit on plots. If set to 1000 for top-n-based plots (pie, bar, barh), " +
-        "the first 1000 data points will be used for plotting. For sampled-based plots (scatter, area, line), " +
-        "1000 data points will be randomly sampled.")
+        "the first 1000 data points will be used for plotting. For sampled-based plots " +
+        "(scatter, area, line), 1000 data points will be randomly sampled.")
       .version("4.0.0")
       .intConf
       .createWithDefault(1000)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3171,9 +3171,9 @@ object SQLConf {
 
   val PYSPARK_PLOT_MAX_ROWS =
     buildConf("spark.sql.pyspark.plotting.max_rows")
-      .doc("The visual limit on plots. If set to 1000 for top-n-based plots, the first 1000 " +
-        "data points will be used for plotting. For sampled-based plots, 1000 data points " +
-        "will be randomly sampled.")
+      .doc("The visual limit on plots. If set to 1000 for top-n-based plots(pie, bar, barh), " +
+        "the first 1000 data points will be used for plotting. For sampled-based plots(scatter, area, line), " +
+        "1000 data points will be randomly sampled.")
       .version("4.0.0")
       .intConf
       .createWithDefault(1000)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3171,8 +3171,8 @@ object SQLConf {
 
   val PYSPARK_PLOT_MAX_ROWS =
     buildConf("spark.sql.pyspark.plotting.max_rows")
-      .doc("The visual limit on plots. If set to 1000 for top-n-based plots(pie, bar, barh), " +
-        "the first 1000 data points will be used for plotting. For sampled-based plots(scatter, area, line), " +
+      .doc("The visual limit on plots. If set to 1000 for top-n-based plots (pie, bar, barh), " +
+        "the first 1000 data points will be used for plotting. For sampled-based plots (scatter, area, line), " +
         "1000 data points will be randomly sampled.")
       .version("4.0.0")
       .intConf


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adjust documentation of "spark.sql.pyspark.plotting.max_rows".

### Why are the changes needed?
Adjust for https://github.com/apache/spark/pull/48218, which eliminates the need for the "spark.sql.pyspark.plotting.sample_ratio" config.


### Does this PR introduce _any_ user-facing change?
Doc change only.


### How was this patch tested?
Existing tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
