### PR TITLE
[SPARK-49781][SQL] Optimize size of `MapFromArrays` / `MapFromEntries` to be the size of its children

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -73,6 +73,11 @@ object ConstantFolding extends Rule[LogicalPlan] {
       Literal(c.children.length)
     case Size(c: CreateMap, _) if c.children.forall(hasNoSideEffect) =>
       Literal(c.children.length / 2)
+    case Size(MapFromArrays(l: CreateArray, r: CreateArray), _)
+      if l.children.forall(hasNoSideEffect) && r.children.forall(hasNoSideEffect) =>
+      Literal(l.children.length)
+    case Size(MapFromEntries(c: CreateArray), _) if c.children.forall(hasNoSideEffect) =>
+      Literal(c.children.length)
 
     case e if e.getTagValue(FAILED_TO_EVALUATE).isDefined => e
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to optimize size of `MapFromArrays` / `MapFromEntries` to be the size of its children.


### Why are the changes needed?
In the optimized scenario, the following logic can be hit `ConstantFolding` without the need for exploit data, and the results can be obtained directly.

Inspiration comes from: https://github.com/apache/spark/pull/30504

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Pass GA.
- Manually check.


### Was this patch authored or co-authored using generative AI tooling?
No.
