### PR TITLE
[SPARK-49782][SQL] ResolveDataFrameDropColumns rule resolves UnresolvedAttribute with child output

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDataFrameDropColumns.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveDataFrameDropColumns.scala
@@ -36,7 +36,7 @@ class ResolveDataFrameDropColumns(val catalogManager: CatalogManager)
       //   df.drop(col("non-existing-column"))
       val dropped = d.dropList.map {
         case u: UnresolvedAttribute =>
-          resolveExpressionByPlanChildren(u, d.child)
+          resolveExpressionByPlanChildren(u, d)
         case e => e
       }
       val remaining = d.child.output.filterNot(attr => dropped.exists(_.semanticEquals(attr)))


### PR DESCRIPTION
### What changes were proposed in this pull request?
When the drop list of `DataFrameDropColumns` contains an UnresolvedAttribute. Current rule mistakenly resolve the column with its grand-children's output attributes.
In dataframe/dataset API application, issue cannot be encountered since the `dropList` are all AttributeReferences.
But when we use Spark LogicalPlan, the bug will be encountered, the UnresolvedAttribute in dropList cannot work.


### Why are the changes needed?
In `ResolveDataFrameDropColumns`
```scala
      val dropped = d.dropList.map {
        case u: UnresolvedAttribute =>
          resolveExpressionByPlanChildren(u, d.child)   //mistakenly resolve the column with its grand-children's output attributes
        case e => e
      }
```
To fix it, change to `resolveExpressionByPlanChildren(u, d)` or `resolveExpressionByPlanOutput(u, d.child)`


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT added.


### Was this patch authored or co-authored using generative AI tooling?
No.
