### PR TITLE
[SPARK-48195][FOLLOWUP] Accumulator reset() no longer needed in CollectMetricsExec.doExecute()

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CollectMetricsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CollectMetricsExec.scala
@@ -67,7 +67,6 @@ case class CollectMetricsExec(
 
   override protected def doExecute(): RDD[InternalRow] = {
     val collector = accumulator
-    collector.reset()
     child.execute().mapPartitions { rows =>
       // Only publish the value of the accumulator when the task has completed. This is done by
       // updating a task local accumulator ('updater') which will be merged with the actual


### PR DESCRIPTION
### What changes were proposed in this pull request?

Small followup to https://github.com/apache/spark/pull/48037.
`collector.reset()` is no longer needed in `CollectMetricsExec.doExecute()` because it is reset in `resetMetrics()`. This doesn't really matter in practice, but removing to clean up.

### Why are the changes needed?

Tiny cleanup.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This change doesn't matter in practice. Just cleanup.

### Was this patch authored or co-authored using generative AI tooling?

No.