### PR TITLE
[SPARK-49787][SQL] Cast between UDT and other types

### DIFF
--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -1130,10 +1130,21 @@ class TypesTestsMixin:
     def test_cast_to_udt_with_udt(self):
         row = Row(point=ExamplePoint(1.0, 2.0), python_only_point=PythonOnlyPoint(1.0, 2.0))
         df = self.spark.createDataFrame([row])
-        with self.assertRaises(AnalysisException):
-            df.select(F.col("point").cast(PythonOnlyUDT())).collect()
-        with self.assertRaises(AnalysisException):
-            df.select(F.col("python_only_point").cast(ExamplePointUDT())).collect()
+        result = df.select(F.col("point").cast(PythonOnlyUDT())).collect()
+        self.assertEqual(
+            result,
+            [
+                Row(point=PythonOnlyPoint(1.0, 2.0))
+            ],
+        )
+
+        result = df.select(F.col("python_only_point").cast(ExamplePointUDT())).collect()
+        self.assertEqual(
+            result,
+            [
+                Row(python_only_point=ExamplePoint(1.0, 2.0))
+            ],
+        )
 
     def test_struct_type(self):
         struct1 = StructType().add("f1", StringType(), True).add("f2", StringType(), True, None)

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -28,7 +28,6 @@ from dataclasses import dataclass, asdict
 from pyspark.sql import Row
 from pyspark.sql import functions as F
 from pyspark.errors import (
-    AnalysisException,
     ParseException,
     PySparkTypeError,
     PySparkValueError,

--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -1133,17 +1133,13 @@ class TypesTestsMixin:
         result = df.select(F.col("point").cast(PythonOnlyUDT())).collect()
         self.assertEqual(
             result,
-            [
-                Row(point=PythonOnlyPoint(1.0, 2.0))
-            ],
+            [Row(point=PythonOnlyPoint(1.0, 2.0))],
         )
 
         result = df.select(F.col("python_only_point").cast(ExamplePointUDT())).collect()
         self.assertEqual(
             result,
-            [
-                Row(python_only_point=ExamplePoint(1.0, 2.0))
-            ],
+            [Row(python_only_point=ExamplePoint(1.0, 2.0))],
         )
 
     def test_struct_type(self):

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/UpCastRule.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/UpCastRule.scala
@@ -66,6 +66,10 @@ private[sql] object UpCastRule {
 
     case (from: UserDefinedType[_], to: UserDefinedType[_]) if to.acceptsType(from) => true
 
+    case (udt: UserDefinedType[_], toType) => canUpCast(udt.sqlType, toType)
+
+    case (fromType, udt: UserDefinedType[_]) => canUpCast(fromType, udt.sqlType)
+
     case _ => false
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -441,47 +441,53 @@ case class Literal (value: Any, dataType: DataType) extends LeafExpression {
   override def eval(input: InternalRow): Any = value
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
-    val javaType = CodeGenerator.javaType(dataType)
-    if (value == null) {
-      ExprCode.forNullValue(dataType)
-    } else {
-      def toExprCode(code: String): ExprCode = {
-        ExprCode.forNonNullValue(JavaCode.literal(code, dataType))
-      }
-      dataType match {
-        case BooleanType | IntegerType | DateType | _: YearMonthIntervalType =>
-          toExprCode(value.toString)
-        case FloatType =>
-          value.asInstanceOf[Float] match {
-            case v if v.isNaN =>
-              toExprCode("Float.NaN")
-            case Float.PositiveInfinity =>
-              toExprCode("Float.POSITIVE_INFINITY")
-            case Float.NegativeInfinity =>
-              toExprCode("Float.NEGATIVE_INFINITY")
-            case _ =>
-              toExprCode(s"${value}F")
-          }
-        case DoubleType =>
-          value.asInstanceOf[Double] match {
-            case v if v.isNaN =>
-              toExprCode("Double.NaN")
-            case Double.PositiveInfinity =>
-              toExprCode("Double.POSITIVE_INFINITY")
-            case Double.NegativeInfinity =>
-              toExprCode("Double.NEGATIVE_INFINITY")
-            case _ =>
-              toExprCode(s"${value}D")
-          }
-        case ByteType | ShortType =>
-          ExprCode.forNonNullValue(JavaCode.expression(s"($javaType)$value", dataType))
-        case TimestampType | TimestampNTZType | LongType | _: DayTimeIntervalType =>
-          toExprCode(s"${value}L")
-        case _ =>
-          val constRef = ctx.addReferenceObj("literal", value, javaType)
-          ExprCode.forNonNullValue(JavaCode.global(constRef, dataType))
+    def gen(ctx: CodegenContext, ev: ExprCode, dataType: DataType): ExprCode = {
+      val javaType = CodeGenerator.javaType(dataType)
+      if (value == null) {
+        ExprCode.forNullValue(dataType)
+      } else {
+        def toExprCode(code: String): ExprCode = {
+          ExprCode.forNonNullValue(JavaCode.literal(code, dataType))
+        }
+
+        dataType match {
+          case BooleanType | IntegerType | DateType | _: YearMonthIntervalType =>
+            toExprCode(value.toString)
+          case FloatType =>
+            value.asInstanceOf[Float] match {
+              case v if v.isNaN =>
+                toExprCode("Float.NaN")
+              case Float.PositiveInfinity =>
+                toExprCode("Float.POSITIVE_INFINITY")
+              case Float.NegativeInfinity =>
+                toExprCode("Float.NEGATIVE_INFINITY")
+              case _ =>
+                toExprCode(s"${value}F")
+            }
+          case DoubleType =>
+            value.asInstanceOf[Double] match {
+              case v if v.isNaN =>
+                toExprCode("Double.NaN")
+              case Double.PositiveInfinity =>
+                toExprCode("Double.POSITIVE_INFINITY")
+              case Double.NegativeInfinity =>
+                toExprCode("Double.NEGATIVE_INFINITY")
+              case _ =>
+                toExprCode(s"${value}D")
+            }
+          case ByteType | ShortType =>
+            ExprCode.forNonNullValue(JavaCode.expression(s"($javaType)$value", dataType))
+          case TimestampType | TimestampNTZType | LongType | _: DayTimeIntervalType =>
+            toExprCode(s"${value}L")
+          case udt: UserDefinedType[_] =>
+            gen(ctx, ev, udt.sqlType)
+          case _ =>
+            val constRef = ctx.addReferenceObj("literal", value, javaType)
+            ExprCode.forNonNullValue(JavaCode.global(constRef, dataType))
+        }
       }
     }
+    gen(ctx, ev, dataType)
   }
 
   override def sql: String = (value, dataType) match {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This patch adds UDT support to `Cast` expression.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Our customer faced an error when migrating queries that write UDT column from Hive to Iceberg table.

The error happens when Spark tries to cast UDT column to the data type (i.e., the sql type of the UDT) of the table column. The cast is added by table column resolution rule for V2 writing commands.

Currently `Cast` expression doesn't support casting between UDT and other types. However, underlying an UDT, it is serialized as its `sqlType`, `Cast` should be able to cast between the `sqlType` and other types.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. User query can cast between UDT and other types.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

Unit test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
