### PR TITLE
[SPARK-49609][PYTHON][TESTS][FOLLOW-UP] Avoid import connect modules when connect dependencies not installed

### DIFF
--- a/python/pyspark/sql/tests/test_connect_compatibility.py
+++ b/python/pyspark/sql/tests/test_connect_compatibility.py
@@ -21,11 +21,13 @@ import inspect
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
 from pyspark.testing.sqlutils import ReusedSQLTestCase
 from pyspark.sql.classic.dataframe import DataFrame as ClassicDataFrame
-from pyspark.sql.connect.dataframe import DataFrame as ConnectDataFrame
 from pyspark.sql.classic.column import Column as ClassicColumn
-from pyspark.sql.connect.column import Column as ConnectColumn
 from pyspark.sql.session import SparkSession as ClassicSparkSession
-from pyspark.sql.connect.session import SparkSession as ConnectSparkSession
+
+if should_test_connect:
+    from pyspark.sql.connect.dataframe import DataFrame as ConnectDataFrame
+    from pyspark.sql.connect.column import Column as ConnectColumn
+    from pyspark.sql.connect.session import SparkSession as ConnectSparkSession
 
 
 class ConnectCompatibilityTestsMixin:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/48085 that skips the connect import which requires Connect dependencies.

### Why are the changes needed?

To recover the PyPy3 build https://github.com/apache/spark/actions/runs/11035779484/job/30652736098 which does not have PyArrow installed.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No