### PR TITLE
[SPARK-49794][SQL] Fix the expression `ArrayContains` bug where `value` is null

### DIFF
--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollectionExpressionsSuite.scala
@@ -131,7 +131,7 @@ class CollectionExpressionsSuite
     val m1 = Literal.create(null, MapType(StringType, StringType))
     checkEvaluation(ArrayContains(MapKeys(m0), Literal("a")), true)
     checkEvaluation(ArrayContains(MapKeys(m0), Literal("c")), false)
-    checkEvaluation(ArrayContains(MapKeys(m0), Literal(null, StringType)), null)
+    checkEvaluation(ArrayContains(MapKeys(m0), Literal(null, StringType)), false)
     checkEvaluation(ArrayContains(MapKeys(m1), Literal("a")), null)
   }
 
@@ -591,15 +591,15 @@ class CollectionExpressionsSuite
 
     checkEvaluation(ArrayContains(a0, Literal(1)), true)
     checkEvaluation(ArrayContains(a0, Literal(0)), false)
-    checkEvaluation(ArrayContains(a0, Literal.create(null, IntegerType)), null)
+    checkEvaluation(ArrayContains(a0, Literal.create(null, IntegerType)), false)
     checkEvaluation(ArrayContains(a5, Literal(1)), true)
 
     checkEvaluation(ArrayContains(a1, Literal("")), true)
-    checkEvaluation(ArrayContains(a1, Literal("a")), null)
-    checkEvaluation(ArrayContains(a1, Literal.create(null, StringType)), null)
+    checkEvaluation(ArrayContains(a1, Literal("a")), false)
+    checkEvaluation(ArrayContains(a1, Literal.create(null, StringType)), true)
 
-    checkEvaluation(ArrayContains(a2, Literal(1L)), null)
-    checkEvaluation(ArrayContains(a2, Literal.create(null, LongType)), null)
+    checkEvaluation(ArrayContains(a2, Literal(1L)), false)
+    checkEvaluation(ArrayContains(a2, Literal.create(null, LongType)), true)
 
     checkEvaluation(ArrayContains(a3, Literal("")), null)
     checkEvaluation(ArrayContains(a3, Literal.create(null, StringType)), null)
@@ -623,8 +623,8 @@ class CollectionExpressionsSuite
 
     checkEvaluation(ArrayContains(b0, be), true)
     checkEvaluation(ArrayContains(b1, be), false)
-    checkEvaluation(ArrayContains(b0, nullBinary), null)
-    checkEvaluation(ArrayContains(b2, be), null)
+    checkEvaluation(ArrayContains(b0, nullBinary), false)
+    checkEvaluation(ArrayContains(b2, be), false)
     checkEvaluation(ArrayContains(b3, be), true)
 
     // complex data types

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameFunctionsSuite.scala
@@ -1785,6 +1785,13 @@ class DataFrameFunctionsSuite extends QueryTest with SharedSparkSession {
       ),
       queryContext = Array(ExpectedContext("", "", 0, 32, "array_contains('a string', 'foo')"))
     )
+
+    val schema = StructType(Seq(
+      StructField("a", ArrayType(IntegerType, containsNull = true)),
+      StructField("b", IntegerType)))
+    val data = Seq(Row(Seq[Integer](1, 2, 3, null), null))
+    val df1 = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+    checkAnswer(df1.select(array_contains(col("a"), col("b"))), Seq(Row(true)))
   }
 
   test("SPARK-29600: ArrayContains function may return incorrect result for DecimalType") {


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to fix the expression `ArrayContains` bug where `value` is `null`.


### Why are the changes needed?
- Give an example with the following code:
```scala
sql("CREATE TABLE t(data array<int>, value int) USING PARQUET")
sql("INSERT INTO TABLE t VALUES (array(1, 2, 3, null), null)")
sql("SELECT * FROM t").show(false)
sql("SELECT array_contains(data, value) FROM T").show(false)
```

- Before
```scala
+---------------+-----+
|data           |value|
+---------------+-----+
|[1, 2, 3, NULL]|NULL |
+---------------+-----+

+---------------------------+
|array_contains(data, value)|
+---------------------------+
|NULL                       |
+---------------------------+
```

**Note: Obviously, the result of `array_contains(data, value)` does not meet common sense expectations.**

- After
```scala
+---------------+-----+
|data           |value|
+---------------+-----+
|[1, 2, 3, NULL]|NULL |
+---------------+-----+

+---------------------------+
|array_contains(data, value)|
+---------------------------+
|true                       |
+---------------------------+
```

### Does this PR introduce _any_ user-facing change?
Yes, corrected incorrect results about `ArrayContains`.


### How was this patch tested?
- Pass GA.
- Add new UT & update UT.


### Was this patch authored or co-authored using generative AI tooling?
No.