### PR TITLE
[MINOR][SQL][TESTS] Use `formatString.format(value)` instead of `value.formatted(formatString)`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/compression/CompressionSchemeBenchmark.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/columnar/compression/CompressionSchemeBenchmark.scala
@@ -91,7 +91,7 @@ object CompressionSchemeBenchmark extends BenchmarkBase with AllCompressionSchem
 
     schemes.filter(_.supports(tpe)).foreach { scheme =>
       val (compressFunc, compressionRatio, buf) = prepareEncodeInternal(count, tpe, scheme, input)
-      val label = s"${getFormattedClassName(scheme)}(${compressionRatio.formatted("%.3f")})"
+      val label = s"${getFormattedClassName(scheme)}(${"%.3f".format(compressionRatio)})"
 
       benchmark.addCase(label)({ i: Int =>
         for (n <- 0L until iters) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to use `formatString.format(value)` instead of `value.formatted(formatString)` for eliminating Warning.


### Why are the changes needed?
<img width="876" alt="image" src="https://github.com/user-attachments/assets/0e5798f4-ec53-41f7-aba9-8f8e51347f59">


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
