### PR TITLE
[SPARK-49797][INFRA] Align the running OS image of `maven_test.yml` to `ubuntu-latest`

### DIFF
--- a/.github/workflows/maven_test.yml
+++ b/.github/workflows/maven_test.yml
@@ -40,7 +40,7 @@ on:
         description: OS to run this build.
         required: false
         type: string
-        default: ubuntu-22.04
+        default: ubuntu-latest
       envs:
         description: Additional environment variables to set when running the tests. Should be in JSON format.
         required: false


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to align the running OS image of `maven_test.yml` to `ubuntu-latest` (from `ubuntu-22.04` to `ubuntu-24.04`)


### Why are the changes needed?
https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20240922.1
<img width="627" alt="image" src="https://github.com/user-attachments/assets/f42fd7ed-c52a-4b39-9a92-02657c53d734">
After https://github.com/actions/runner-images/issues/10636, `ubuntu-latest` has already pointed to `ubuntu-24.04` instead of `ubuntu-22.04`. 
<img width="811" alt="image" src="https://github.com/user-attachments/assets/adf6b3a8-5ca5-4daa-b35d-ea1386fa07a6">
I have checked all tasks running on `Ubuntu OS` (except for the 2 related to `TPCDS`), and they are all using `ubuntu-latest`. Currently, only `maven_test.yml` is using `ubuntu-22.04`. Let's align it.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
