### PR TITLE
[SPARK-49801][FOLLOWUP][INFRA] Update `pandas` to 2.2.3 in `pages.yml` too

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install Python dependencies
         run: |
          pip install 'sphinx==4.5.0' mkdocs 'pydata_sphinx_theme>=0.13' sphinx-copybutton nbsphinx numpydoc jinja2 markupsafe 'pyzmq<24.0.0' \
-            ipython ipython_genutils sphinx_plotly_directive 'numpy>=1.20.0' pyarrow 'pandas==2.2.2' 'plotly>=4.8' 'docutils<0.18.0' \
+            ipython ipython_genutils sphinx_plotly_directive 'numpy>=1.20.0' pyarrow 'pandas==2.2.3' 'plotly>=4.8' 'docutils<0.18.0' \
             'flake8==3.9.0' 'mypy==1.8.0' 'pytest==7.1.3' 'pytest-mypy-plugins==1.9.3' 'black==23.9.1' \
             'pandas-stubs==1.2.0.53' 'grpcio==1.62.0' 'grpcio-status==1.62.0' 'grpc-stubs==1.24.11' 'googleapis-common-protos-stubs==2.2.0' \
             'sphinxcontrib-applehelp==1.0.4' 'sphinxcontrib-devhelp==1.0.2' 'sphinxcontrib-htmlhelp==2.0.1' 'sphinxcontrib-qthelp==1.0.3' 'sphinxcontrib-serializinghtml==1.1.5'


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix doc build.

### Why are the changes needed?
in https://github.com/apache/spark/pull/48269 

> Oh, this seems to break GitHub Action Jekyll.

https://github.com/apache/spark/actions/runs/11063509911/job/30742286270
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.9.20/x64/lib/python3.9/site-packages/sphinx/config.py", line 332, in eval_config_file
    exec(code, namespace)
  File "/home/runner/work/spark/spark/python/docs/source/conf.py", line 33, in <module>
    generate_supported_api(output_rst_file_path)
  File "/home/runner/work/spark/spark/python/pyspark/pandas/supported_api_gen.py", line 102, in generate_supported_api
    _check_pandas_version()
  File "/home/runner/work/spark/spark/python/pyspark/pandas/supported_api_gen.py", line 116, in _check_pandas_version
    raise ImportError(msg)
ImportError: Warning: pandas 2.2.3 is required; your version is 2.2.2"

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA

### Was this patch authored or co-authored using generative AI tooling?
No.