### PR TITLE
[SPARK-49814][CONNECT] When Spark Connect Client starts, show the `spark version` of the `connect server`

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/application/ConnectRepl.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/application/ConnectRepl.scala
@@ -50,8 +50,9 @@ object ConnectRepl {
       /_/
 
 Type in expressions to have them evaluated.
+Spark connect server version %s.
 Spark session available as 'spark'.
-   """.format(spark_version)
+   """
 
   def main(args: Array[String]): Unit = doMain(args)
 
@@ -102,7 +103,7 @@ Spark session available as 'spark'.
     // Please note that we make ammonite generate classes instead of objects.
     // Classes tend to have superior serialization behavior when using UDFs.
     val main = new ammonite.Main(
-      welcomeBanner = Option(splash),
+      welcomeBanner = Option(splash.format(spark_version, spark.version)),
       predefCode = predefCode,
       replCodeWrapper = ExtendedCodeClassWrapper,
       scriptCodeWrapper = ExtendedCodeClassWrapper,


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to show the spark version of the connect server when Spark Connect Client starts.


### Why are the changes needed?
With the gradual popularize of Spark Connect module, when the Spark Connect client starts, explicitly displaying the spark version of the `connect server`, will reduce confusion for users during execution, such as the new version having some features. However, if it connects to an old version and encounters some problems, it will have to manually troubleshoot.
<img width="878" alt="image" src="https://github.com/user-attachments/assets/c93026e8-03e7-4292-bae2-c3a0f4422191">

### Does this PR introduce _any_ user-facing change?
Yes, Connect‘s end-users can intuitively know the `Spark version` on the `server side` when starting the client, reducing confusion.


### How was this patch tested?
Manually check.


### Was this patch authored or co-authored using generative AI tooling?
No.
