### PR TITLE
[SPARK-49819] Disable CollapseProject for correlated subqueries in projection over aggregate correctly

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -2155,7 +2155,7 @@ class SubquerySuite extends QueryTest
   }
 
   test("SPARK-49819: Do not collapse projects with exist subqueries") {
-    withTempView("t1", "t2") {
+    withTempView("v") {
       Seq((0, 1), (1, 2)).toDF("c1", "c2").createOrReplaceTempView("v")
       checkAnswer(
         sql("""

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -2154,7 +2154,7 @@ class SubquerySuite extends QueryTest
     }
   }
 
-  test("SPARK-49819: Do not collapse projects with exist subqueries ") {
+  test("SPARK-49819: Do not collapse projects with exist subqueries") {
     withTempView("v") {
       Seq((0, 1), (1, 2)).toDF("c1", "c2").createOrReplaceTempView("v")
       checkAnswer(

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -2154,7 +2154,7 @@ class SubquerySuite extends QueryTest
     }
   }
 
-  test("SPARK-49819: Do not collapse projects with exist subqueries") {
+  test("SPARK-49819: Do not collapse projects with exist subqueries ") {
     withTempView("v") {
       Seq((0, 1), (1, 2)).toDF("c1", "c2").createOrReplaceTempView("v")
       checkAnswer(

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -2154,7 +2154,7 @@ class SubquerySuite extends QueryTest
     }
   }
 
-  test("SPARK-36656: Do not collapse projects with exist subqueries") {
+  test("SPARK-49819: Do not collapse projects with exist subqueries") {
     withTempView("t1", "t2") {
       Seq((0, 1), (1, 2)).toDF("c1", "c2").createOrReplaceTempView("v")
       checkAnswer(


### PR DESCRIPTION
### What changes were proposed in this pull request?

CollapseProject should block collapsing with an aggregate if any correlated subquery is present. There are other correlated subqueries that are not ScalarSubquery that are not accounted for here.

### Why are the changes needed?

Availability issue.

### Does this PR introduce _any_ user-facing change?

Previously failing queries will not fail anymore.

### How was this patch tested?

UT.

### Was this patch authored or co-authored using generative AI tooling?

No.