### PR TITLE
[SPARK-49820] [PYTHON] Change `raise IOError` to `raise OSError`

### DIFF
--- a/python/pyspark/install.py
+++ b/python/pyspark/install.py
@@ -163,7 +163,7 @@ def install_spark(dest, spark_version, hadoop_version, hive_version):
                 tar.close()
             if os.path.exists(package_local_path):
                 os.remove(package_local_path)
-    raise IOError("Unable to download %s." % pretty_pkg_name)
+    raise OSError("Unable to download %s." % pretty_pkg_name)
 
 
 def get_preferred_mirrors():


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change `raise IOError` to `raise OSError`

### Why are the changes needed?

> OSError is the builtin error type used for exceptions that relate to the operating system.
> 
> In Python 3.3, a variety of other exceptions, like WindowsError were aliased to OSError. These aliases remain in place for compatibility with older versions of Python, but may be removed in future versions.
> 
> Prefer using OSError directly, as it is more idiomatic and future-proof.
> 

[RUFF rule](https://docs.astral.sh/ruff/rules/os-error-alias/)
[Python OSError](https://docs.python.org/3/library/exceptions.html#OSError)

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA

### Was this patch authored or co-authored using generative AI tooling?
No.