### PR TITLE
[SPARK-49827][SQL] Adding batches with retry mechanism for fetching …

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4423,6 +4423,29 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val HMS_BATCH_SIZE = buildConf("spark.sql.hive.metastore.batchSize")
+    .internal()
+    .doc("This setting defines the batch size for fetching metadata partitions from the" +
+        "Hive Metastore. A value of -1 disables batching by default. To enable batching," +
+        "specify a positive integer, which will determine the batch size for partition fetching."
+    )
+    .version("3.5.3")
+    .intConf
+    .createWithDefault(-1)
+
+  val METASTORE_PARTITION_BATCH_RETRY_COUNT = buildConf(
+  "spark.sql.metastore.partition.batch.retry.count")
+  .internal()
+  .doc(
+    "This setting specifies the number of retries for fetching partitions from the metastore" +
+    "in case of failure to fetch batch metadata. This retry mechanism is applicable only" +
+    "when HMS_BATCH_SIZE is enabled. It defines the count for the number of " +
+    "retries to be done."
+  )
+  .version("3.5.3")
+  .intConf
+  .createWithDefault(3)
+
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -5277,6 +5300,10 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def legacyNegativeIndexInArrayInsert: Boolean = {
     getConf(SQLConf.LEGACY_NEGATIVE_INDEX_IN_ARRAY_INSERT)
   }
+
+  def getHiveMetaStoreBatchSize: Int = getConf(HMS_BATCH_SIZE)
+
+  def metastorePartitionBatchRetryCount: Int = getConf(METASTORE_PARTITION_BATCH_RETRY_COUNT)
 
   /** ********************** SQLConf functionality methods ************ */
 


### PR DESCRIPTION
…all partitions from metastore

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
When there is any predicate missing in getPartitionsbyFilter and it tries to fetch all the partitions, the request is broken into smaller chunks as:
1. Retrieve the names of all partitions using getPartitionNames
2. Divide the partition names list into smaller batches.
3. Fetch the partitions using their names with function getPartitionsByNames.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The change is to address the issue of heavy load on HMS, when there are huge number of partitions(~600,000), the metadata size exceeds the 2Gb limit on the thrift server buffer size. Hence we get socket time out and HMS crashes with OOM as well. Tried to replicate same behaviour as [HIVE-27505](https://issues.apache.org/jira/browse/HIVE-27505) 

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes
To enable batching they should be using parameters as:
spark.sql.hive.metastore.batchSize = 1000 , by default it is disabled
spark.sql.metastore.partition.batch.retry.count = 3

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Tested in local environment with following performance 
With batch size = 1
24/09/28 18:11:21 INFO Shim_v2_3: Fetching all partitions completed in 718 ms
 
With batch size = -1
24/09/28 18:14:16 INFO Shim_v2_3: Fetching all partitions completed in 51 ms.
 
With batch size = 10
24/09/28 18:16:20 INFO Shim_v2_3: Fetching all partitions completed in 127 ms.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
