### PR TITLE
[SPARK-49841][PYTHON][TESTS][3.5] Skip PySpark `test_cast_to_udt_with_udt`test during `SPARK_SKIP_CONNECT_COMPAT_TESTS`

### DIFF
--- a/python/pyspark/sql/tests/test_types.py
+++ b/python/pyspark/sql/tests/test_types.py
@@ -753,6 +753,9 @@ class TypesTestsMixin:
         result = df.select(F.col("point").cast("string"), F.col("pypoint").cast("string")).head()
         self.assertEqual(result, Row(point="(1.0, 2.0)", pypoint="[3.0, 4.0]"))
 
+    @unittest.skipIf(
+        "SPARK_SKIP_CONNECT_COMPAT_TESTS" in os.environ, "SPARK-49787: Supported since Spark 4.0.0"
+    )
     def test_cast_to_udt_with_udt(self):
         row = Row(point=ExamplePoint(1.0, 2.0), python_only_point=PythonOnlyPoint(1.0, 2.0))
         df = self.spark.createDataFrame([row])


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to skip PySpark `test_cast_to_udt_with_udt`test during `SPARK_SKIP_CONNECT_COMPAT_TESTS` in branch-3.5.

### Why are the changes needed?

Currently, Apache Spark 4.0.0's PySpark Connect compatibility test fails.
- https://github.com/apache/spark/actions/workflows/build_python_connect35.yml

This is due to the newly added feature. Although this is a kind of Apache Spark 4.0.0 test suite, we need to disable this test case from `branch-3.5`.
- #48251 

### Does this PR introduce _any_ user-facing change?

No. This is a test-only PR.

### How was this patch tested?

This should be tested after merging via Daily CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.