### PR TITLE
[SPARK-49683][SQL]Block trim collations on all collation code paths.

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/types/AbstractStringType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/types/AbstractStringType.scala
@@ -58,7 +58,7 @@ case object StringTypeWithCaseAccentSensitivity extends AbstractStringType {
 
 /**
  * Use StringTypeNonTrimCSAICollation for expressions supporting all possible collation types except
- * CS_AI collation types.
+ * CS_AI and Trim collation types.
  */
 case object StringTypeNonTrimCSAICollation extends AbstractStringType {
   override private[sql] def acceptsType(other: DataType): Boolean =

--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/types/AbstractStringType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/types/AbstractStringType.scala
@@ -33,7 +33,8 @@ abstract class AbstractStringType extends AbstractDataType {
  */
 case object StringTypeBinary extends AbstractStringType {
   override private[sql] def acceptsType(other: DataType): Boolean =
-    other.isInstanceOf[StringType] && other.asInstanceOf[StringType].supportsBinaryEquality
+    other.isInstanceOf[StringType] && other.asInstanceOf[StringType].supportsBinaryEquality &&
+      !other.asInstanceOf[StringType].usesTrimCollation
 }
 
 /**
@@ -42,7 +43,8 @@ case object StringTypeBinary extends AbstractStringType {
 case object StringTypeBinaryLcase extends AbstractStringType {
   override private[sql] def acceptsType(other: DataType): Boolean =
     other.isInstanceOf[StringType] && (other.asInstanceOf[StringType].supportsBinaryEquality ||
-      other.asInstanceOf[StringType].isUTF8LcaseCollation)
+      other.asInstanceOf[StringType].isUTF8LcaseCollation) &&
+      !other.asInstanceOf[StringType].usesTrimCollation
 }
 
 /**
@@ -50,14 +52,16 @@ case object StringTypeBinaryLcase extends AbstractStringType {
  * and ICU) but limited to using case and accent sensitivity specifiers.
  */
 case object StringTypeWithCaseAccentSensitivity extends AbstractStringType {
-  override private[sql] def acceptsType(other: DataType): Boolean = other.isInstanceOf[StringType]
+  override private[sql] def acceptsType(other: DataType): Boolean =
+    other.isInstanceOf[StringType] && !other.asInstanceOf[StringType].usesTrimCollation
 }
 
 /**
- * Use StringTypeNonCSAICollation for expressions supporting all possible collation types except
+ * Use StringTypeNonTrimCSAICollation for expressions supporting all possible collation types except
  * CS_AI collation types.
  */
-case object StringTypeNonCSAICollation extends AbstractStringType {
+case object StringTypeNonTrimCSAICollation extends AbstractStringType {
   override private[sql] def acceptsType(other: DataType): Boolean =
-    other.isInstanceOf[StringType] && other.asInstanceOf[StringType].isNonCSAI
+    other.isInstanceOf[StringType] && other.asInstanceOf[StringType].isNonCSAI &&
+      !other.asInstanceOf[StringType].usesTrimCollation
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/StringType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/StringType.scala
@@ -47,6 +47,9 @@ class StringType private (val collationId: Int) extends AtomicType with Serializ
   private[sql] def isNonCSAI: Boolean =
     !CollationFactory.isCaseSensitiveAndAccentInsensitive(collationId)
 
+  private[sql] def usesTrimCollation: Boolean =
+    CollationFactory.usesTrimCollation(collationId)
+
   private[sql] def isUTF8BinaryCollation: Boolean =
     collationId == CollationFactory.UTF8_BINARY_COLLATION_ID
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeCreator.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.catalyst.trees.TreePattern._
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.internal.types.StringTypeNonCSAICollation
+import org.apache.spark.sql.internal.types.StringTypeNonTrimCSAICollation
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.ArrayImplicits._
@@ -579,7 +579,8 @@ case class StringToMap(text: Expression, pairDelim: Expression, keyValueDelim: E
   override def third: Expression = keyValueDelim
 
   override def inputTypes: Seq[AbstractDataType] =
-    Seq(StringTypeNonCSAICollation, StringTypeNonCSAICollation, StringTypeNonCSAICollation)
+    Seq(StringTypeNonTrimCSAICollation, StringTypeNonTrimCSAICollation,
+      StringTypeNonTrimCSAICollation)
 
   override def dataType: DataType = MapType(first.dataType, first.dataType)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -39,7 +39,7 @@ import org.apache.spark.sql.catalyst.util.{ArrayData, CharsetProvider, Collation
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.types.{AbstractArrayType,
-  StringTypeNonCSAICollation, StringTypeWithCaseAccentSensitivity}
+  StringTypeNonTrimCSAICollation, StringTypeWithCaseAccentSensitivity}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.UTF8StringBuilder
 import org.apache.spark.unsafe.array.ByteArrayMethods
@@ -613,7 +613,7 @@ case class Contains(left: Expression, right: Expression) extends StringPredicate
       CollationSupport.Contains.genCode(c1, c2, collationId))
   }
   override def inputTypes : Seq[AbstractDataType] =
-    Seq(StringTypeNonCSAICollation, StringTypeNonCSAICollation)
+    Seq(StringTypeNonTrimCSAICollation, StringTypeNonTrimCSAICollation)
   override protected def withNewChildrenInternal(
     newLeft: Expression, newRight: Expression): Contains = copy(left = newLeft, right = newRight)
 }
@@ -657,7 +657,8 @@ case class StartsWith(left: Expression, right: Expression) extends StringPredica
   }
 
   override def inputTypes : Seq[AbstractDataType] =
-    Seq(StringTypeNonCSAICollation, StringTypeNonCSAICollation, StringTypeNonCSAICollation)
+    Seq(StringTypeNonTrimCSAICollation, StringTypeNonTrimCSAICollation,
+      StringTypeNonTrimCSAICollation)
 
   override protected def withNewChildrenInternal(
     newLeft: Expression, newRight: Expression): StartsWith = copy(left = newLeft, right = newRight)
@@ -702,7 +703,8 @@ case class EndsWith(left: Expression, right: Expression) extends StringPredicate
   }
 
   override def inputTypes : Seq[AbstractDataType] =
-    Seq(StringTypeNonCSAICollation, StringTypeNonCSAICollation, StringTypeNonCSAICollation)
+    Seq(StringTypeNonTrimCSAICollation, StringTypeNonTrimCSAICollation,
+      StringTypeNonTrimCSAICollation)
 
   override protected def withNewChildrenInternal(
     newLeft: Expression, newRight: Expression): EndsWith = copy(left = newLeft, right = newRight)
@@ -932,7 +934,8 @@ case class StringReplace(srcExpr: Expression, searchExpr: Expression, replaceExp
 
   override def dataType: DataType = srcExpr.dataType
   override def inputTypes: Seq[AbstractDataType] =
-    Seq(StringTypeNonCSAICollation, StringTypeNonCSAICollation, StringTypeNonCSAICollation)
+    Seq(StringTypeNonTrimCSAICollation, StringTypeNonTrimCSAICollation,
+      StringTypeNonTrimCSAICollation)
   override def first: Expression = srcExpr
   override def second: Expression = searchExpr
   override def third: Expression = replaceExpr
@@ -1180,7 +1183,8 @@ case class StringTranslate(srcExpr: Expression, matchingExpr: Expression, replac
 
   override def dataType: DataType = srcExpr.dataType
   override def inputTypes: Seq[AbstractDataType] =
-    Seq(StringTypeNonCSAICollation, StringTypeNonCSAICollation, StringTypeNonCSAICollation)
+    Seq(StringTypeNonTrimCSAICollation, StringTypeNonTrimCSAICollation,
+      StringTypeNonTrimCSAICollation)
   override def first: Expression = srcExpr
   override def second: Expression = matchingExpr
   override def third: Expression = replaceExpr
@@ -1409,7 +1413,7 @@ case class StringTrim(srcStr: Expression, trimStr: Option[Expression] = None)
     CollationSupport.StringTrim.exec(srcString, trimString, collationId)
 
   override def inputTypes: Seq[AbstractDataType] =
-    Seq(StringTypeNonCSAICollation, StringTypeNonCSAICollation)
+    Seq(StringTypeNonTrimCSAICollation, StringTypeNonTrimCSAICollation)
 
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression =
     copy(
@@ -1519,7 +1523,7 @@ case class StringTrimLeft(srcStr: Expression, trimStr: Option[Expression] = None
     CollationSupport.StringTrimLeft.exec(srcString, trimString, collationId)
 
   override def inputTypes: Seq[AbstractDataType] =
-    Seq(StringTypeNonCSAICollation, StringTypeNonCSAICollation)
+    Seq(StringTypeNonTrimCSAICollation, StringTypeNonTrimCSAICollation)
 
   override protected def withNewChildrenInternal(
       newChildren: IndexedSeq[Expression]): StringTrimLeft =
@@ -1582,7 +1586,7 @@ case class StringTrimRight(srcStr: Expression, trimStr: Option[Expression] = Non
     CollationSupport.StringTrimRight.exec(srcString, trimString, collationId)
 
   override def inputTypes: Seq[AbstractDataType] =
-    Seq(StringTypeNonCSAICollation, StringTypeNonCSAICollation)
+    Seq(StringTypeNonTrimCSAICollation, StringTypeNonTrimCSAICollation)
 
   override protected def withNewChildrenInternal(
       newChildren: IndexedSeq[Expression]): StringTrimRight =
@@ -1618,7 +1622,7 @@ case class StringInstr(str: Expression, substr: Expression)
   override def right: Expression = substr
   override def dataType: DataType = IntegerType
   override def inputTypes: Seq[AbstractDataType] =
-    Seq(StringTypeNonCSAICollation, StringTypeNonCSAICollation)
+    Seq(StringTypeNonTrimCSAICollation, StringTypeNonTrimCSAICollation)
 
   override def nullSafeEval(string: Any, sub: Any): Any = {
     CollationSupport.StringInstr.
@@ -1666,7 +1670,7 @@ case class SubstringIndex(strExpr: Expression, delimExpr: Expression, countExpr:
 
   override def dataType: DataType = strExpr.dataType
   override def inputTypes: Seq[AbstractDataType] =
-    Seq(StringTypeNonCSAICollation, StringTypeNonCSAICollation, IntegerType)
+    Seq(StringTypeNonTrimCSAICollation, StringTypeNonTrimCSAICollation, IntegerType)
   override def first: Expression = strExpr
   override def second: Expression = delimExpr
   override def third: Expression = countExpr
@@ -1724,7 +1728,7 @@ case class StringLocate(substr: Expression, str: Expression, start: Expression)
   override def nullable: Boolean = substr.nullable || str.nullable
   override def dataType: DataType = IntegerType
   override def inputTypes: Seq[AbstractDataType] =
-    Seq(StringTypeNonCSAICollation, StringTypeNonCSAICollation, IntegerType)
+    Seq(StringTypeNonTrimCSAICollation, StringTypeNonTrimCSAICollation, IntegerType)
 
   override def eval(input: InternalRow): Any = {
     val s = start.eval(input)
@@ -3499,7 +3503,7 @@ case class SplitPart (
       false)
   override def nodeName: String = "split_part"
   override def inputTypes: Seq[AbstractDataType] =
-    Seq(StringTypeNonCSAICollation, StringTypeNonCSAICollation, IntegerType)
+    Seq(StringTypeNonTrimCSAICollation, StringTypeNonTrimCSAICollation, IntegerType)
   def children: Seq[Expression] = Seq(str, delimiter, partNum)
   protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression = {
     copy(str = newChildren.apply(0), delimiter = newChildren.apply(1),

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSQLExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSQLExpressionsSuite.scala
@@ -987,7 +987,6 @@ class CollationSQLExpressionsSuite
       StringToMapTestCase("a:1,b:2,c:3", "?", "?", "UNICODE_TRIM", null),
       StringToMapTestCase("a:1,b:2,c:3", "?", "?", "UTF8_BINARY_TRIM", null),
       StringToMapTestCase("a:1,b:2,c:3", "?", "?", "UTF8_LCASE_TRIM", null))
-
     testCases.foreach(t => {
       // Unit test.
       val text = Literal.create(t.text, StringType(t.collation))

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSQLExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSQLExpressionsSuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.collection.OpenHashMap
 
-// scalastyle:off nonascii
+// scalastyle:off
 class CollationSQLExpressionsSuite
     extends QueryTest
     with SharedSparkSession
@@ -3221,7 +3221,7 @@ class CollationSQLExpressionsSuite
   // TODO: Add more tests for other SQL expressions
 
 }
-// scalastyle:on nonascii
+// scalastyle:on
 
 class CollationSQLExpressionsANSIOffSuite extends CollationSQLExpressionsSuite {
   override protected def sparkConf: SparkConf =

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
@@ -212,7 +212,7 @@ class CollationStringExpressionsSuite
       }
     })
     // Test unsupported collation.
-    unsupportedTestCase.foreach(t =>{
+    unsupportedTestCase.foreach(t => {
       withSQLConf(SQLConf.DEFAULT_COLLATION.key -> t.collation) {
         val query =
           s"select contains('${t.left}', '${t.right}')"

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types._
 
-// scalastyle:off nonascii
+// scalastyle:off
 class CollationStringExpressionsSuite
   extends QueryTest
   with SharedSparkSession
@@ -1553,7 +1553,7 @@ class CollationStringExpressionsSuite
   }
 
 }
-// scalastyle:on nonascii
+// scalastyle:on
 
 class CollationStringExpressionsANSISuite extends CollationStringExpressionsSuite {
   override protected def sparkConf: SparkConf =

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationStringExpressionsSuite.scala
@@ -129,7 +129,8 @@ class CollationStringExpressionsSuite
           condition = "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
           sqlState = Some("42K09"),
           parameters = Map(
-            "sqlExpr" -> s"\"split_part('1a2' collate ${t.collation}, 'a' collate ${t.collation}, 2)\"",
+            "sqlExpr" ->
+              s"\"split_part('1a2' collate ${t.collation}, 'a' collate ${t.collation}, 2)\"",
             "paramIndex" -> "first",
             "inputSql" -> s"\"'1a2' collate ${t.collation}\"",
             "inputType" -> s"\"STRING COLLATE ${t.collation}\"",
@@ -222,7 +223,8 @@ class CollationStringExpressionsSuite
           condition = "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
           sqlState = Some("42K09"),
           parameters = Map(
-            "sqlExpr" -> s"\"contains('abcde' collate ${t.collation}, 'A' collate ${t.collation})\"",
+            "sqlExpr" ->
+              s"\"contains('abcde' collate ${t.collation}, 'A' collate ${t.collation})\"",
             "paramIndex" -> "first",
             "inputSql" -> s"\"'abcde' collate ${t.collation}\"",
             "inputType" -> s"\"STRING COLLATE ${t.collation}\"",
@@ -1348,7 +1350,8 @@ class CollationStringExpressionsSuite
           condition = "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
           sqlState = Some("42K09"),
           parameters = Map(
-            "sqlExpr" -> s"\"locate('aa' collate ${t.collation}, 'Aaads' collate ${t.collation}, 0)\"",
+            "sqlExpr" ->
+              s"\"locate('aa' collate ${t.collation}, 'Aaads' collate ${t.collation}, 0)\"",
             "paramIndex" -> "first",
             "inputSql" -> s"\"'aa' collate ${t.collation}\"",
             "inputType" -> s"\"STRING COLLATE ${t.collation}\"",
@@ -1401,7 +1404,8 @@ class CollationStringExpressionsSuite
           condition = "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
           sqlState = Some("42K09"),
           parameters = Map(
-            "sqlExpr" -> s"\"TRIM(LEADING 'x' collate ${t.collation} FROM 'xxasdxx' collate ${t.collation})\"",
+            "sqlExpr" ->
+              s"\"TRIM(LEADING 'x' collate ${t.collation} FROM 'xxasdxx' collate ${t.collation})\"",
             "paramIndex" -> "first",
             "inputSql" -> s"\"'xxasdxx' collate ${t.collation}\"",
             "inputType" -> s"\"STRING COLLATE ${t.collation}\"",
@@ -1508,7 +1512,8 @@ class CollationStringExpressionsSuite
           condition = "DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE",
           sqlState = Some("42K09"),
           parameters = Map(
-            "sqlExpr" -> s"\"TRIM(BOTH 'x' collate ${t.collation} FROM 'xxasdxx' collate ${t.collation})\"",
+            "sqlExpr" ->
+              s"\"TRIM(BOTH 'x' collate ${t.collation} FROM 'xxasdxx' collate ${t.collation})\"",
             "paramIndex" -> "first",
             "inputSql" -> s"\"'xxasdxx' collate ${t.collation}\"",
             "inputType" -> s"\"STRING COLLATE ${t.collation}\"",


### PR DESCRIPTION
### Why are the changes needed?
Trim collation is currently in implementation phase. These change blocks all paths from using it and afterwards trim collation gets enabled for different expressions it will be gradually whitelisted.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Add negative path tests.


### Was this patch authored or co-authored using generative AI tooling?
No.