### PR TITLE
[MINOR][BUILD] Pom compiler source target

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>17</java.version>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <maven.version>3.9.9</maven.version>
     <exec-maven-plugin.version>3.2.0</exec-maven-plugin.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `maven.compiler.source` and `maven.compiler.target` properties to parent `pom.xml`.

### Why are the changes needed?
But IntelliJ IDEA IDE cannot compile Spark sources without this:

```
error: release version 6 not supported

Language level is invalid or missing in pom.xml. Current project JDK is 17. Specify language level in Spark Project Tags
```

Property `maven.compiler.release` exists already, but does not seem to be sufficient. 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Local build with IntelliJ IDEA IDE.

### Was this patch authored or co-authored using generative AI tooling?
No.