### PR TITLE
[SPARK-49853][SQL][TESTS] Increase test timeout of `PythonForeachWriterSuite` to `60s`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonForeachWriterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonForeachWriterSuite.scala
@@ -99,7 +99,7 @@ class PythonForeachWriterSuite extends SparkFunSuite with Eventually with Mockit
     }
     private val iterator = buffer.iterator
     private val outputBuffer = new ArrayBuffer[Int]
-    private val testTimeout = timeout(20.seconds)
+    private val testTimeout = timeout(60.seconds)
     private val intProj = UnsafeProjection.create(Array[DataType](IntegerType))
     private val thread = new Thread() {
       override def run(): Unit = {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to increase test timeout of `PythonForeachWriterSuite` to `60s`.

### Why are the changes needed?

To stablize `PythonForeachWriterSuite` in GitHub Action MacOS 15 Runner. For the failed cases, the data is still under generation.
- https://github.com/apache/spark/actions/runs/11132652698/job/30936988757

```
- UnsafeRowBuffer: handles more data than memory *** FAILED ***
  The code passed to eventually never returned normally. Attempted 237 times over 20.075615666999997 seconds.
  Last failure message: ArraySeq(1, ..., 1815) did not equal Range$Inclusive(1, ..., 2000)
```

GitHub Runners have different spec and macOS has very limited resources among them.
- https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

| Virtual Machine | Processor (CPU) | Memory (RAM) | Storage (SSD) | Workflow label |
| -- | -- | -- | -- | -- |
| Linux | 4 | 16 GB | 14 GB | ubuntu-latest,ubuntu-24.04,ubuntu-22.04,ubuntu-20.04 |
| macOS | 3 (M1) | 7 GB | 14 GB | macos-latest,macos-14, macos-15 [Beta] |

### Does this PR introduce _any_ user-facing change?

No, this is a test-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.