### PR TITLE
[SPARK-49893] Respect user schema nullability for file data sources when DSV2 Table is used.

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3902,6 +3902,15 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val RESPECT_USER_SCHEMA_NULLABILITY_FOR_FILE_DATA_SOURCES =
+    buildConf("spark.sql.respectUserSchemaNullabilityForFileDataSources")
+      .internal()
+      .doc("When true, the nullability in the user-specified schema for " +
+        "`DataFrameReader.schema(schema).json(path)` and .csv(path) and .xml(path) is respected" +
+        "Otherwise, they are turned to a nullable schema forcibly.")
+      .version("4.0.0")
+      .fallbackConf(LEGACY_RESPECT_NULLABILITY_IN_TEXT_DATASET_CONVERSION)
+
   val REPL_EAGER_EVAL_ENABLED = buildConf("spark.sql.repl.eagerEval.enabled")
     .doc("Enables eager evaluation or not. When true, the top K rows of Dataset will be " +
       "displayed if and only if the REPL supports the eager evaluation. Currently, the " +
@@ -6021,6 +6030,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def legacyNullInEmptyBehavior: Boolean = {
     getConf(SQLConf.LEGACY_NULL_IN_EMPTY_LIST_BEHAVIOR).getOrElse(!ansiEnabled)
   }
+
+  def respectUserSchemaNullabilityForFileDataSources: Boolean =
+    getConf(SQLConf.RESPECT_USER_SCHEMA_NULLABILITY_FOR_FILE_DATA_SOURCES)
 
   def isReplEagerEvalEnabled: Boolean = getConf(SQLConf.REPL_EAGER_EVAL_ENABLED)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3903,13 +3903,13 @@ object SQLConf {
       .createWithDefault(false)
 
   val RESPECT_USER_SCHEMA_NULLABILITY_FOR_FILE_DATA_SOURCES =
-    buildConf("spark.sql.respectUserSchemaNullabilityForFileDataSources")
-      .internal()
+    buildConf("spark.sql.respectUserSchemaNullabilityForFileDataSourceWithFilePath")
       .doc("When true, the nullability in the user-specified schema for " +
         "`DataFrameReader.schema(schema).json(path)` and .csv(path) and .xml(path) is respected" +
         "Otherwise, they are turned to a nullable schema forcibly.")
       .version("4.0.0")
-      .fallbackConf(LEGACY_RESPECT_NULLABILITY_IN_TEXT_DATASET_CONVERSION)
+      .booleanConf
+      .createWithDefault(false)
 
   val REPL_EAGER_EVAL_ENABLED = buildConf("spark.sql.repl.eagerEval.enabled")
     .doc("Enables eager evaluation or not. When true, the top K rows of Dataset will be " +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileTable.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/FileTable.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.connector.expressions.Transform
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.streaming.{FileStreamSink, MetadataLogFileIndex}
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.sql.util.SchemaUtils
@@ -74,6 +75,7 @@ abstract class FileTable(
     }
     fileIndex match {
       case _: MetadataLogFileIndex => schema
+      case _ if SQLConf.get.respectUserSchemaNullabilityForFileDataSources => schema
       case _ => schema.asNullable
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
DataFrameReader has 3 APIs for JSON reading

json(DataSet[String])
json(Rdd)
json(filePath)

First two APIs respects provided user schema nullability when spark flag `spark.sql.legacy.respectNullabilityInTextDatasetConversion` is set to true, but third one does not respect and provided schema nullability is always overriden to true.

E.g.
`dataFrameReader.json(jsonRDD)` and `dataFrameReader.json(jsonDataSet)` will check mentioned config, but `dataFrameReader.json(path)` will hit totally different code path, and it will end up in `FileTable` where `dataSchema` getter will override fields nullability to true.

### Why are the changes needed?
Some users just want to have a validation of data and to get exception when some field is nullable.

### Does this PR introduce _any_ user-facing change?
When customer set newly added Spark conf `spark.sql.respectUserSchemaNullabilityForFileDataSourceWithFilePath`, provided user schema nullability will not be overriden to true anymore.
Default value for flag is false.

### How was this patch tested?
Using integration test in base JsonSuite class.

### Was this patch authored or co-authored using generative AI tooling?
No
