### PR TITLE
[SPARK-47193][SQL] Ensure SQL conf is propagated to executors when actions are called on RDD returned by `Dataset#rdd`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -186,6 +186,21 @@ object SQLConf {
   // load SqlConf to make sure both classes are in sync from the get go.
   SqlApiConfHelper.setConfGetter(() => SQLConf.get)
 
+  def set(confOpt: Option[SQLConf]): Option[SQLConf] = {
+    val old = existingConf.get()
+    if (confOpt.isEmpty) {
+      existingConf.remove()
+    } else {
+      existingConf.set(confOpt.get)
+    }
+
+    if (old == null) {
+      None
+    } else {
+      Some(old)
+    }
+  }
+
   /**
    * Returns the active config object within the current scope. If there is an active SparkSession,
    * the proper SQLConf associated with the thread's active session is used. If it's called from

--- a/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/QueryTest.scala
@@ -27,7 +27,7 @@ import org.scalatest.Assertions
 import org.apache.spark.sql.catalyst.ExtendedAnalysisException
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.util._
-import org.apache.spark.sql.execution.{QueryExecution, SQLExecution}
+import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.execution.columnar.InMemoryRelation
 import org.apache.spark.sql.util.QueryExecutionListener
 import org.apache.spark.storage.StorageLevel
@@ -286,9 +286,7 @@ object QueryTest extends Assertions {
       checkToRDD: Boolean = true): Option[String] = {
     val isSorted = df.logicalPlan.collect { case s: logical.Sort => s }.nonEmpty
     if (checkToRDD) {
-      SQLExecution.withSQLConfPropagated(df.sparkSession) {
-        df.rdd.count() // Also attempt to deserialize as an RDD [SPARK-15791]
-      }
+      df.rdd.count() // Also attempt to deserialize as an RDD [SPARK-15791]
     }
 
     val sparkAnswer = try df.collect().toSeq catch {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/csv/CSVSuite.scala
@@ -3120,7 +3120,8 @@ abstract class CSVSuite
         .add("id", IntegerType)
         .add("date", DateType)
         .add("ts", TimestampType)
-      val output = spark.read
+
+      def output: DataFrame = spark.read
         .schema(schema)
         .option("dateFormat", "yyyyMMdd")
         .option("timestampFormat", "yyyyMMdd")

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/json/JsonSuite.scala
@@ -3457,7 +3457,8 @@ abstract class JsonSuite
       val schema = new StructType()
         .add("date", DateType)
         .add("ts", TimestampType)
-      val output = spark.read
+
+      def output: DataFrame = spark.read
         .schema(schema)
         .option("dateFormat", "yyyyMMdd")
         .option("timestampFormat", "yyyyMMdd")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This change wraps the iterator returned by `SQLExecutionRDD#compute` so that it propagates the SQL conf at the time the iterator is actually used. This ensures that the SQL conf is propagated when actions are called on the RDD stored in `Dataset#rdd`.

Similarly, this PR fixes `SparkPlan#executeToIterator` so that the returned iterator will propagate the SQL conf at the time the iterator is actually used. This ensures that the SQL conf is propagated when `next` or `hasNext` is called on the iterator returned by `Dataset#toLocalIterator`.

Note three things:

* `Dataset#rdd` is a val, not a method, so the `SQLExecutionRDD` instance is created only once per dataset.
* The `SQLExecutionRDD` constructor takes a snapshot of the driver-side SQL conf (this code already exists in `SQLExecutionRDD`). This PR simply ensures that the existing snapshot is pushed to the executors when actions are called on the `SQLExecutionRDD` instance (or its children).
* Because the `SQLExecutionRDD` instance is created only once and keeps a snapshot of the SQL conf, it does not pick up changes to the SQL conf after `Dataset#rdd` is referenced.

Because of the above limitation, this PR also changed a single test in both `CSVSuite` and `JsonSuite`. These two tests create a single dataset and then change config between calls to `checkAnswer`. It turns out that `QueryTest` will reflect back exceptions only from `Dataset#rdd#count` (it captures and converts exceptions from `Dataset.collect` into assert failures). Since the two modified tests expect exceptions after certain config changes, and those config changes are not picked up by the cached `SQLExecutionRDD` instance, I changed the test to create a new dataset between calls to `checkAnswer`.

Those two tests worked in the past only because `QueryTest` wrapped the call to `Dataset#rdd#count` with `SQLExecution.withSQLConfPropagated`.


### Why are the changes needed?

`SQLExecutionRDD#compute` currently propagates the SQL conf to the executors when obtaining and returning the iterator. However, that iterator is not actually used until after the SQL conf on the executor has been reset to its old state. Therefore, when the job actually runs, the executors have the wrong SQL conf.

Similarly, `Dataset#toLocalIterator` returns an iterator that doesn't even attempt to propagate the SQL conf.

This results in data correctness issues. E.g.:
```
scala> val df = Seq("{'data': {'a': [19], 'b': 123456}}").toDF("str").cache()
val df: org.apache.spark.sql.Dataset[org.apache.spark.sql.Row] = [str: string]

scala> val query = df.selectExpr("from_json(str, 'data struct<a: int, b: int>')")
val query: org.apache.spark.sql.DataFrame = [from_json(str): struct<data: struct<a: int, b: int>>]

scala> sql("set spark.sql.json.enablePartialResults=false")
val res0: org.apache.spark.sql.DataFrame = [key: string, value: string]

scala> query.collect()(0)
val res1: org.apache.spark.sql.Row = [[null]]          <----- correct result

scala> query.rdd.collect()(0)
val res2: org.apache.spark.sql.Row = [[[null,123456]]] <----- incorrect result!

scala> query.toLocalIterator.next()
warning: 1 deprecation (since 2.13.3); for details, enable `:setting -deprecation` or `:replay -deprecation`
val res3: org.apache.spark.sql.Row = [[[null,123456]]] <----- incorrect result!

scala> 
```
This PR attempts to fix the above, with the caveat that the RDD stored in `Dataset#rdd`, once created, will not pick up changes to the SQL conf.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

New test.

### Was this patch authored or co-authored using generative AI tooling?

No.
