### PR TITLE
[SPARK-46647][INFRA] Add `unittest-xml-reporting` into Python 3.12 image

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -135,9 +135,8 @@ RUN apt-get update && apt-get install -y \
     python3.12 \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12
-# TODO(SPARK-46647) Add unittest-xml-reporting into Python 3.12 image when it supports Python 3.12
 RUN python3.12 -m pip install --ignore-installed blinker>=1.6.2 # mlflow needs this
-RUN python3.12 -m pip install $BASIC_PIP_PKGS $CONNECT_PIP_PKGS lxml && \
+RUN python3.12 -m pip install $BASIC_PIP_PKGS unittest-xml-reporting $CONNECT_PIP_PKGS lxml && \
     python3.12 -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu && \
     python3.12 -m pip install torcheval && \
     python3.12 -m pip cache purge


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `unittest-xml-reporting` into Python 3.12.

### Why are the changes needed?

It seems that we can install it with the latest Python 3.12.6.
```
$ python3 --version
Python 3.12.6
```

```
$ pip3 install unittest-xml-reporting
Looking in indexes: https://pypi.python.org/simple, https://pypi.apple.com/simple
Collecting unittest-xml-reporting
  Using cached https://pypi.apple.com/packages/packages/39/88/f6e9b87428584a3c62cac768185c438ca6d561367a5d267b293259d76075/unittest_xml_reporting-3.2.0-py2.py3-none-any.whl (20 kB)
Requirement already satisfied: lxml in /Users/dongjoon/.pyenv/versions/3.12.6/lib/python3.12/site-packages (from unittest-xml-reporting) (5.3.0)
Installing collected packages: unittest-xml-reporting
Successfully installed unittest-xml-reporting-3.2.0
```

```
$ python/run-tests.py --python-executables python3 --modules pyspark-core
Running PySpark tests. Output is in /Users/dongjoon/APACHE/spark-merge/python/unit-tests.log
Will test against the following Python executables: ['python3']
Will test the following Python modules: ['pyspark-core']
python3 python_implementation is CPython
python3 version is: Python 3.12.6
Starting test(python3): pyspark.tests.test_appsubmit (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/7073e04c-e2ce-4d4b-b0a1-6f2aff30b612/python3__pyspark.tests.test_appsubmit__7odeq3cw.log)
Starting test(python3): pyspark.tests.test_conf (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/461b38b4-f5fb-4165-b80f-b14756eb29bb/python3__pyspark.tests.test_conf__vexpdrlq.log)
Starting test(python3): pyspark.tests.test_context (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/9135fed0-31f6-4b10-87fa-c0742038ba53/python3__pyspark.tests.test_context__gk6e0wnr.log)
Starting test(python3): pyspark.tests.test_broadcast (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/d62e53d4-0252-4156-b6ca-b3c76244a6db/python3__pyspark.tests.test_broadcast__xcxa09t_.log)
Finished test(python3): pyspark.tests.test_conf (10s)
Starting test(python3): pyspark.tests.test_daemon (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/84088bb9-dcb6-4d5d-ba0e-e25479ffd9d2/python3__pyspark.tests.test_daemon__z4icjtza.log)
Finished test(python3): pyspark.tests.test_daemon (5s)
Starting test(python3): pyspark.tests.test_install_spark (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/02babefb-606a-4e34-b8cc-c56584924156/python3__pyspark.tests.test_install_spark__2jd6ytn9.log)
Finished test(python3): pyspark.tests.test_broadcast (28s)
Starting test(python3): pyspark.tests.test_join (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/9eab61a5-033b-42b1-a9c3-22908a6401a0/python3__pyspark.tests.test_join__wdgw71cw.log)
Finished test(python3): pyspark.tests.test_appsubmit (33s)
Starting test(python3): pyspark.tests.test_memory_profiler (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/c7fc91c2-7e6a-46c9-8924-eab74f60e6c9/python3__pyspark.tests.test_memory_profiler__ke2pdufb.log)
Finished test(python3): pyspark.tests.test_install_spark (17s)
Starting test(python3): pyspark.tests.test_profiler (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/148a2214-6c50-4baa-aba5-2e9511a0071d/python3__pyspark.tests.test_profiler__d7w8fl7g.log)
Finished test(python3): pyspark.tests.test_join (5s)
Starting test(python3): pyspark.tests.test_rdd (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/341893e3-ae96-421c-8314-c942fa65ae92/python3__pyspark.tests.test_rdd__1oqi_hpo.log)
Finished test(python3): pyspark.tests.test_context (35s)
Starting test(python3): pyspark.tests.test_rddbarrier (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/9ff06ab8-751a-4905-8ad5-f3cade17a3d9/python3__pyspark.tests.test_rddbarrier__t7nne4vg.log)
Finished test(python3): pyspark.tests.test_rddbarrier (4s)
Starting test(python3): pyspark.tests.test_rddsampler (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/05f2c30f-c85d-439c-909d-02f0bfdf9344/python3__pyspark.tests.test_rddsampler__2kjo59wq.log)
Finished test(python3): pyspark.tests.test_profiler (7s) ... 1 tests were skipped
Starting test(python3): pyspark.tests.test_readwrite (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/e59723dc-d7fa-448d-8336-d10a75a5a3d6/python3__pyspark.tests.test_readwrite__6xyu1xjz.log)
Finished test(python3): pyspark.tests.test_readwrite (2s)
Starting test(python3): pyspark.tests.test_serializers (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/c75b82d3-b63e-4b33-95e5-22a07d200b72/python3__pyspark.tests.test_serializers__cspd98j2.log)
Finished test(python3): pyspark.tests.test_rddsampler (5s)
Starting test(python3): pyspark.tests.test_shuffle (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/d9348ebb-576c-4c90-8b29-8ff4d90ae89c/python3__pyspark.tests.test_shuffle__0ip92g_e.log)
Finished test(python3): pyspark.tests.test_serializers (6s)
Starting test(python3): pyspark.tests.test_stage_sched (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/f274b3a1-a579-4c90-8b7c-178eabd13e12/python3__pyspark.tests.test_stage_sched__tlkac1aj.log)
Finished test(python3): pyspark.tests.test_shuffle (7s)
Starting test(python3): pyspark.tests.test_statcounter (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/4bc8ceef-e1f2-4566-9653-7acf98440a8a/python3__pyspark.tests.test_statcounter__4fan6599.log)
Finished test(python3): pyspark.tests.test_memory_profiler (20s)
Starting test(python3): pyspark.tests.test_taskcontext (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/9ae70357-86d7-4115-b6fa-e50a52ce7588/python3__pyspark.tests.test_taskcontext__ve_ei2cb.log)
Finished test(python3): pyspark.tests.test_statcounter (4s)
Starting test(python3): pyspark.tests.test_util (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/8dcfade3-e1d4-4f03-ba69-10376ad229f6/python3__pyspark.tests.test_util__m87nldnp.log)
Finished test(python3): pyspark.tests.test_util (6s)
Starting test(python3): pyspark.tests.test_worker (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/0f82d2bd-a221-471b-8634-86c94a415962/python3__pyspark.tests.test_worker__q_4tfdgg.log)
Finished test(python3): pyspark.tests.test_stage_sched (23s)
Starting test(python3): pyspark.accumulators (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/4c9c01df-938d-4433-923e-c384d58dc5d7/python3__pyspark.accumulators__c6f1z1w2.log)
Finished test(python3): pyspark.accumulators (3s)
Starting test(python3): pyspark.conf (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/36f0848b-a831-47b1-a80f-fb215fcf54d7/python3__pyspark.conf__1_nmps1k.log)
Finished test(python3): pyspark.conf (1s)
Starting test(python3): pyspark.core.broadcast (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/38222bab-a54d-4141-8c9b-ec066cd9df81/python3__pyspark.core.broadcast__qz98z0c0.log)
Finished test(python3): pyspark.tests.test_worker (19s) ... 3 tests were skipped
Starting test(python3): pyspark.core.context (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/2cfe1fd3-cdd2-412f-98de-a1759ef99557/python3__pyspark.core.context__jrfebewg.log)
Finished test(python3): pyspark.core.broadcast (4s)
Starting test(python3): pyspark.core.files (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/7e99dae7-399c-48ce-af54-3bd897d5ba13/python3__pyspark.core.files__yn6t4ze1.log)
Finished test(python3): pyspark.core.files (3s)
Starting test(python3): pyspark.core.rdd (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/f879d50d-4e9e-420a-becb-a1c3738cf90d/python3__pyspark.core.rdd__e9bhllsb.log)
Finished test(python3): pyspark.core.rdd (19s)
Starting test(python3): pyspark.profiler (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/8228af67-5834-4493-bd71-c5fcbce877ec/python3__pyspark.profiler__yzut311n.log)
Finished test(python3): pyspark.core.context (26s)
Starting test(python3): pyspark.serializers (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/9248860c-aa6d-4608-95d2-96b50501696b/python3__pyspark.serializers__yjb7i9f4.log)
Finished test(python3): pyspark.profiler (3s)
Starting test(python3): pyspark.shuffle (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/927866d3-940a-471c-a736-d68ec9fe082d/python3__pyspark.shuffle__vdg9m5rm.log)
Finished test(python3): pyspark.shuffle (0s)
Starting test(python3): pyspark.taskcontext (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/1e4ee756-c80e-4705-be6b-2cb72d73ce03/python3__pyspark.taskcontext__3ueryqa7.log)
Finished test(python3): pyspark.tests.test_rdd (80s)
Starting test(python3): pyspark.util (temp output: /Users/dongjoon/APACHE/spark-merge/python/target/5b0024fd-c92b-4ac0-8507-6d2981f34a86/python3__pyspark.util___86sm79x.log)
Finished test(python3): pyspark.serializers (5s)
Finished test(python3): pyspark.util (2s)
Finished test(python3): pyspark.taskcontext (35s)
Finished test(python3): pyspark.tests.test_taskcontext (140s)
Tests passed in 193 seconds

Skipped tests in pyspark.tests.test_profiler with python3:
      test_no_memory_profile_installed (pyspark.tests.test_profiler.ProfilerTests2.test_no_memory_profile_installed) ... skip (0.000s)

Skipped tests in pyspark.tests.test_worker with python3:
      test_memory_limit (pyspark.tests.test_worker.WorkerMemoryTest.test_memory_limit) ... skip (0.001s)
      test_python_segfault (pyspark.tests.test_worker.WorkerSegfaultNonDaemonTest.test_python_segfault) ... skip (0.000s)
      test_python_segfault (pyspark.tests.test_worker.WorkerSegfaultTest.test_python_segfault) ... skip (0.000s)
```
### Does this PR introduce _any_ user-facing change?

No. This is an infra change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.