### PR TITLE
[SPARK-49864][SQL] Improve message of BINARY_ARITHMETIC_OVERFLOW

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -127,20 +127,8 @@
   },
   "BINARY_ARITHMETIC_OVERFLOW" : {
     "message" : [
-      "<value1> <symbol> <value2> caused overflow."
+      "<value1> <symbol> <value2> caused overflow. Use <functionName> to ignore overflow problem and return NULL."
     ],
-    "subClass" : {
-      "WITHOUT_SUGGESTION" : {
-        "message" : [
-          "Try fixing values passed in the function, so that they do not produce overflow."
-        ]
-      },
-      "WITH_SUGGESTION" : {
-        "message" : [
-          "Use <functionName> to ignore overflow problem and return NULL."
-        ]
-      }
-    },
     "sqlState" : "22003"
   },
   "BOOLEAN_STATEMENT_WITH_EMPTY_ROW" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -127,7 +127,7 @@
   },
   "BINARY_ARITHMETIC_OVERFLOW" : {
     "message" : [
-      "<value1> <symbol> <value2> caused overflow."
+      "<value1> <symbol> <value2> caused overflow.<alternative>"
     ],
     "sqlState" : "22003"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -127,8 +127,20 @@
   },
   "BINARY_ARITHMETIC_OVERFLOW" : {
     "message" : [
-      "<value1> <symbol> <value2> caused overflow.<alternative>"
+      "<value1> <symbol> <value2> caused overflow."
     ],
+    "subClass" : {
+      "WITHOUT_SUGGESTION" : {
+        "message" : [
+          " Try fixing values passed in the function, so that they do not produce overflow."
+        ]
+      },
+      "WITH_SUGGESTION" : {
+        "message" : [
+          " Use `<hint>` to ignore overflow problem and return NULL."
+        ]
+      }
+    },
     "sqlState" : "22003"
   },
   "BOOLEAN_STATEMENT_WITH_EMPTY_ROW" : {

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -132,12 +132,12 @@
     "subClass" : {
       "WITHOUT_SUGGESTION" : {
         "message" : [
-          " Try fixing values passed in the function, so that they do not produce overflow."
+          "Try fixing values passed in the function, so that they do not produce overflow."
         ]
       },
       "WITH_SUGGESTION" : {
         "message" : [
-          " Use `<hint>` to ignore overflow problem and return NULL."
+          "Use <functionName> to ignore overflow problem and return NULL."
         ]
       }
     },

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
@@ -95,7 +95,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
         " bonus BINARY_DOUBLE)").executeUpdate()
     connection.prepareStatement(
       s"""CREATE TABLE pattern_testing_table (
-         |pattern_testing_col VARCHAR(50)
+         |pattern_testing_col VARCHAR2(50)
          |)
                    """.stripMargin
     ).executeUpdate()

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
@@ -95,7 +95,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
         " bonus BINARY_DOUBLE)").executeUpdate()
     connection.prepareStatement(
       s"""CREATE TABLE pattern_testing_table (
-         |pattern_testing_col VARCHAR2(50)
+         |pattern_testing_col VARCHAR(50)
          |)
                    """.stripMargin
     ).executeUpdate()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -294,12 +294,18 @@ abstract class BinaryArithmetic extends BinaryOperator
     case ByteType | ShortType =>
       nullSafeCodeGen(ctx, ev, (eval1, eval2) => {
         val tmpResult = ctx.freshName("tmpResult")
+        val try_suggestion = symbol match {
+          case "+" => "try_add"
+          case "-" => "try_subtract"
+          case "*" => "try_multiply"
+          case _ => ""
+        }
         val overflowCheck = if (failOnError) {
           val javaType = CodeGenerator.boxedType(dataType)
           s"""
              |if ($tmpResult < $javaType.MIN_VALUE || $tmpResult > $javaType.MAX_VALUE) {
              |  throw QueryExecutionErrors.binaryArithmeticCauseOverflowError(
-             |  $eval1, "$symbol", $eval2);
+             |  $eval1, "$symbol", $eval2, "$try_suggestion");
              |}
            """.stripMargin
         } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -611,18 +611,26 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
 
   def binaryArithmeticCauseOverflowError(
       eval1: Short, symbol: String, eval2: Short, hint: String): SparkArithmeticException = {
-    val alternative = if (hint != "") {
-      s" Use `$hint` to ignore overflow problem and return NULL."
-    } else ""
-    new SparkArithmeticException(
-      errorClass = "BINARY_ARITHMETIC_OVERFLOW",
-      messageParameters = Map(
-        "value1" -> toSQLValue(eval1, ShortType),
-        "symbol" -> symbol,
-        "value2" -> toSQLValue(eval2, ShortType),
-        "alternative" -> alternative),
-      context = Array.empty,
-      summary = "")
+    if (hint == "") {
+      new SparkArithmeticException(
+        errorClass = "BINARY_ARITHMETIC_OVERFLOW.WITHOUT_SUGGESTION",
+        messageParameters = Map(
+          "value1" -> toSQLValue(eval1, ShortType),
+          "symbol" -> symbol,
+          "value2" -> toSQLValue(eval2, ShortType)),
+        context = Array.empty,
+        summary = "")
+    } else {
+      new SparkArithmeticException(
+        errorClass = "BINARY_ARITHMETIC_OVERFLOW.WITH_SUGGESTION",
+        messageParameters = Map(
+          "value1" -> toSQLValue(eval1, ShortType),
+          "symbol" -> symbol,
+          "value2" -> toSQLValue(eval2, ShortType),
+          "hint" -> hint),
+        context = Array.empty,
+        summary = "")
+    }
   }
 
   def intervalArithmeticOverflowError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -610,27 +610,31 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def binaryArithmeticCauseOverflowError(
-      eval1: Short, symbol: String, eval2: Short, hint: String): SparkArithmeticException = {
-    if (hint == "") {
-      new SparkArithmeticException(
-        errorClass = "BINARY_ARITHMETIC_OVERFLOW.WITHOUT_SUGGESTION",
-        messageParameters = Map(
-          "value1" -> toSQLValue(eval1, ShortType),
-          "symbol" -> symbol,
-          "value2" -> toSQLValue(eval2, ShortType)),
-        context = Array.empty,
-        summary = "")
-    } else {
-      new SparkArithmeticException(
-        errorClass = "BINARY_ARITHMETIC_OVERFLOW.WITH_SUGGESTION",
-        messageParameters = Map(
-          "value1" -> toSQLValue(eval1, ShortType),
-          "symbol" -> symbol,
-          "value2" -> toSQLValue(eval2, ShortType),
-          "hint" -> hint),
-        context = Array.empty,
-        summary = "")
-    }
+      eval1: Short, symbol: String, eval2: Short): SparkArithmeticException = {
+    new SparkArithmeticException(
+      errorClass = "BINARY_ARITHMETIC_OVERFLOW.WITHOUT_SUGGESTION",
+      messageParameters = Map(
+        "value1" -> toSQLValue(eval1, ShortType),
+        "symbol" -> symbol,
+        "value2" -> toSQLValue(eval2, ShortType)),
+      context = Array.empty,
+      summary = "")
+  }
+
+  def binaryArithmeticCauseOverflowError(
+      eval1: Short,
+      symbol: String,
+      eval2: Short,
+      functionName: String): SparkArithmeticException = {
+    new SparkArithmeticException(
+      errorClass = "BINARY_ARITHMETIC_OVERFLOW.WITH_SUGGESTION",
+      messageParameters = Map(
+        "value1" -> toSQLValue(eval1, ShortType),
+        "symbol" -> symbol,
+        "value2" -> toSQLValue(eval2, ShortType),
+        "functionName" -> toSQLId(functionName)),
+      context = Array.empty,
+      summary = "")
   }
 
   def intervalArithmeticOverflowError(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -610,13 +610,17 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def binaryArithmeticCauseOverflowError(
-      eval1: Short, symbol: String, eval2: Short): SparkArithmeticException = {
+      eval1: Short, symbol: String, eval2: Short, hint: String): SparkArithmeticException = {
+    val alternative = if (hint != "") {
+      s" Use `$hint` to ignore overflow problem and return NULL."
+    } else ""
     new SparkArithmeticException(
       errorClass = "BINARY_ARITHMETIC_OVERFLOW",
       messageParameters = Map(
         "value1" -> toSQLValue(eval1, ShortType),
         "symbol" -> symbol,
-        "value2" -> toSQLValue(eval2, ShortType)),
+        "value2" -> toSQLValue(eval2, ShortType),
+        "alternative" -> alternative),
       context = Array.empty,
       summary = "")
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -625,14 +625,14 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
       eval1: Short,
       symbol: String,
       eval2: Short,
-      functionName: String): SparkArithmeticException = {
+      suggestedFunc: String): SparkArithmeticException = {
     new SparkArithmeticException(
       errorClass = "BINARY_ARITHMETIC_OVERFLOW.WITH_SUGGESTION",
       messageParameters = Map(
         "value1" -> toSQLValue(eval1, ShortType),
         "symbol" -> symbol,
         "value2" -> toSQLValue(eval2, ShortType),
-        "functionName" -> toSQLId(functionName)),
+        "functionName" -> toSQLId(suggestedFunc)),
       context = Array.empty,
       summary = "")
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryExecutionErrors.scala
@@ -610,24 +610,12 @@ private[sql] object QueryExecutionErrors extends QueryErrorsBase with ExecutionE
   }
 
   def binaryArithmeticCauseOverflowError(
-      eval1: Short, symbol: String, eval2: Short): SparkArithmeticException = {
-    new SparkArithmeticException(
-      errorClass = "BINARY_ARITHMETIC_OVERFLOW.WITHOUT_SUGGESTION",
-      messageParameters = Map(
-        "value1" -> toSQLValue(eval1, ShortType),
-        "symbol" -> symbol,
-        "value2" -> toSQLValue(eval2, ShortType)),
-      context = Array.empty,
-      summary = "")
-  }
-
-  def binaryArithmeticCauseOverflowError(
       eval1: Short,
       symbol: String,
       eval2: Short,
       suggestedFunc: String): SparkArithmeticException = {
     new SparkArithmeticException(
-      errorClass = "BINARY_ARITHMETIC_OVERFLOW.WITH_SUGGESTION",
+      errorClass = "BINARY_ARITHMETIC_OVERFLOW",
       messageParameters = Map(
         "value1" -> toSQLValue(eval1, ShortType),
         "symbol" -> symbol,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
@@ -24,27 +24,27 @@ import org.apache.spark.sql.errors.QueryExecutionErrors
 import org.apache.spark.sql.types.Decimal.DecimalIsConflicted
 
 private[sql] object ByteExactNumeric extends ByteIsIntegral with Ordering.ByteOrdering {
-  private def checkOverflow(res: Int, x: Byte, y: Byte, op: String): Unit = {
+  private def checkOverflow(res: Int, x: Byte, y: Byte, op: String, hint: String): Unit = {
     if (res > Byte.MaxValue || res < Byte.MinValue) {
-      throw QueryExecutionErrors.binaryArithmeticCauseOverflowError(x, op, y)
+      throw QueryExecutionErrors.binaryArithmeticCauseOverflowError(x, op, y, hint)
     }
   }
 
   override def plus(x: Byte, y: Byte): Byte = {
     val tmp = x + y
-    checkOverflow(tmp, x, y, "+")
+    checkOverflow(tmp, x, y, "+", "try_add")
     tmp.toByte
   }
 
   override def minus(x: Byte, y: Byte): Byte = {
     val tmp = x - y
-    checkOverflow(tmp, x, y, "-")
+    checkOverflow(tmp, x, y, "-", "try_subtract")
     tmp.toByte
   }
 
   override def times(x: Byte, y: Byte): Byte = {
     val tmp = x * y
-    checkOverflow(tmp, x, y, "*")
+    checkOverflow(tmp, x, y, "*", "try_multiply")
     tmp.toByte
   }
 
@@ -55,27 +55,27 @@ private[sql] object ByteExactNumeric extends ByteIsIntegral with Ordering.ByteOr
 
 
 private[sql] object ShortExactNumeric extends ShortIsIntegral with Ordering.ShortOrdering {
-  private def checkOverflow(res: Int, x: Short, y: Short, op: String): Unit = {
+  private def checkOverflow(res: Int, x: Short, y: Short, op: String, hint: String): Unit = {
     if (res > Short.MaxValue || res < Short.MinValue) {
-      throw QueryExecutionErrors.binaryArithmeticCauseOverflowError(x, op, y)
+      throw QueryExecutionErrors.binaryArithmeticCauseOverflowError(x, op, y, hint)
     }
   }
 
   override def plus(x: Short, y: Short): Short = {
     val tmp = x + y
-    checkOverflow(tmp, x, y, "+")
+    checkOverflow(tmp, x, y, "+", "try_add")
     tmp.toShort
   }
 
   override def minus(x: Short, y: Short): Short = {
     val tmp = x - y
-    checkOverflow(tmp, x, y, "-")
+    checkOverflow(tmp, x, y, "-", "try_subtract")
     tmp.toShort
   }
 
   override def times(x: Short, y: Short): Short = {
     val tmp = x * y
-    checkOverflow(tmp, x, y, "*")
+    checkOverflow(tmp, x, y, "*", "try_multiply")
     tmp.toShort
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -768,7 +768,7 @@ class QueryExecutionErrorsSuite
           "value1" -> "127S",
           "symbol" -> "+",
           "value2" -> "5S",
-          "hint" -> "try_add"),
+          "functionName" -> "`try_add`"),
         sqlState = "22003")
     }
   }
@@ -784,7 +784,7 @@ class QueryExecutionErrorsSuite
           "value1" -> "-2S",
           "symbol" -> "-",
           "value2" -> "127S",
-          "hint" -> "try_subtract"),
+          "functionName" -> "`try_subtract`"),
         sqlState = "22003")
     }
   }
@@ -800,7 +800,7 @@ class QueryExecutionErrorsSuite
           "value1" -> "127S",
           "symbol" -> "*",
           "value2" -> "5S",
-          "hint" -> "try_multiply"),
+          "functionName" -> "`try_multiply`"),
         sqlState = "22003")
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -767,7 +767,40 @@ class QueryExecutionErrorsSuite
         parameters = Map(
           "value1" -> "127S",
           "symbol" -> "+",
-          "value2" -> "5S"),
+          "value2" -> "5S",
+          "alternative" -> " Use `try_add` to ignore overflow problem and return NULL."),
+        sqlState = "22003")
+    }
+  }
+
+  test("BINARY_ARITHMETIC_OVERFLOW: byte minus byte result overflow") {
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
+      checkError(
+        exception = intercept[SparkArithmeticException] {
+          sql(s"select -2Y - 127Y").collect()
+        },
+        condition = "BINARY_ARITHMETIC_OVERFLOW",
+        parameters = Map(
+          "value1" -> "-2S",
+          "symbol" -> "-",
+          "value2" -> "127S",
+          "alternative" -> " Use `try_subtract` to ignore overflow problem and return NULL."),
+        sqlState = "22003")
+    }
+  }
+
+  test("BINARY_ARITHMETIC_OVERFLOW: byte multiply byte result overflow") {
+    withSQLConf(SQLConf.ANSI_ENABLED.key -> "true") {
+      checkError(
+        exception = intercept[SparkArithmeticException] {
+          sql(s"select 127Y * 5Y").collect()
+        },
+        condition = "BINARY_ARITHMETIC_OVERFLOW",
+        parameters = Map(
+          "value1" -> "127S",
+          "symbol" -> "*",
+          "value2" -> "5S",
+          "alternative" -> " Use `try_multiply` to ignore overflow problem and return NULL."),
         sqlState = "22003")
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -763,12 +763,12 @@ class QueryExecutionErrorsSuite
         exception = intercept[SparkArithmeticException] {
           sql(s"select 127Y + 5Y").collect()
         },
-        condition = "BINARY_ARITHMETIC_OVERFLOW",
+        condition = "BINARY_ARITHMETIC_OVERFLOW.WITH_SUGGESTION",
         parameters = Map(
           "value1" -> "127S",
           "symbol" -> "+",
           "value2" -> "5S",
-          "alternative" -> " Use `try_add` to ignore overflow problem and return NULL."),
+          "hint" -> "try_add"),
         sqlState = "22003")
     }
   }
@@ -779,12 +779,12 @@ class QueryExecutionErrorsSuite
         exception = intercept[SparkArithmeticException] {
           sql(s"select -2Y - 127Y").collect()
         },
-        condition = "BINARY_ARITHMETIC_OVERFLOW",
+        condition = "BINARY_ARITHMETIC_OVERFLOW.WITH_SUGGESTION",
         parameters = Map(
           "value1" -> "-2S",
           "symbol" -> "-",
           "value2" -> "127S",
-          "alternative" -> " Use `try_subtract` to ignore overflow problem and return NULL."),
+          "hint" -> "try_subtract"),
         sqlState = "22003")
     }
   }
@@ -795,12 +795,12 @@ class QueryExecutionErrorsSuite
         exception = intercept[SparkArithmeticException] {
           sql(s"select 127Y * 5Y").collect()
         },
-        condition = "BINARY_ARITHMETIC_OVERFLOW",
+        condition = "BINARY_ARITHMETIC_OVERFLOW.WITH_SUGGESTION",
         parameters = Map(
           "value1" -> "127S",
           "symbol" -> "*",
           "value2" -> "5S",
-          "alternative" -> " Use `try_multiply` to ignore overflow problem and return NULL."),
+          "hint" -> "try_multiply"),
         sqlState = "22003")
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -763,7 +763,7 @@ class QueryExecutionErrorsSuite
         exception = intercept[SparkArithmeticException] {
           sql(s"select 127Y + 5Y").collect()
         },
-        condition = "BINARY_ARITHMETIC_OVERFLOW.WITH_SUGGESTION",
+        condition = "BINARY_ARITHMETIC_OVERFLOW",
         parameters = Map(
           "value1" -> "127S",
           "symbol" -> "+",
@@ -779,7 +779,7 @@ class QueryExecutionErrorsSuite
         exception = intercept[SparkArithmeticException] {
           sql(s"select -2Y - 127Y").collect()
         },
-        condition = "BINARY_ARITHMETIC_OVERFLOW.WITH_SUGGESTION",
+        condition = "BINARY_ARITHMETIC_OVERFLOW",
         parameters = Map(
           "value1" -> "-2S",
           "symbol" -> "-",
@@ -795,7 +795,7 @@ class QueryExecutionErrorsSuite
         exception = intercept[SparkArithmeticException] {
           sql(s"select 127Y * 5Y").collect()
         },
-        condition = "BINARY_ARITHMETIC_OVERFLOW.WITH_SUGGESTION",
+        condition = "BINARY_ARITHMETIC_OVERFLOW",
         parameters = Map(
           "value1" -> "127S",
           "symbol" -> "*",


### PR DESCRIPTION
### What changes were proposed in this pull request?
BINARY_ARITHMETIC_OVERFLOW did not have a suggestion on bypassing the error. This PR improves on that.


### Why are the changes needed?
All errors should suggest a way to overcome an issue, so that customers can fix problems easier.


### Does this PR introduce _any_ user-facing change?
Yes, change in error message.


### How was this patch tested?
Tests added for all paths for bytes.


### Was this patch authored or co-authored using generative AI tooling?
No.
