### PR TITLE
[SPARK-49867] [SQL] Improve the error message when index is out of bounds when calling GetColumnByOrdinal

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -623,7 +623,7 @@
       "Column ordinal out of bounds. The number of columns in the table is <attributesLength>, but the column ordinal is <ordinal>.",
       "Attributes are the following: <attributes>."
     ],
-    "sqlState" : "42K0E"
+    "sqlState" : "22003"
   },
   "COMPARATOR_RETURNS_NULL" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -618,6 +618,13 @@
     ],
     "sqlState" : "42703"
   },
+  "COLUMN_ORDINAL_OUT_OF_BOUNDS" : {
+    "message" : [
+      "Column ordinal out of bounds. The number of columns in the table is <attributesLength>, but the column ordinal is <ordinal>.",
+      "Attributes are the following: <attributes>."
+    ],
+    "sqlState" : "42K0E"
+  },
   "COMPARATOR_RETURNS_NULL" : {
     "message" : [
       "The comparator has returned a NULL for a comparison between <firstValue> and <secondValue>.",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -146,7 +146,12 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
 
         case GetColumnByOrdinal(ordinal, _) =>
           val attrCandidates = getAttrCandidates()
-          assert(ordinal >= 0 && ordinal < attrCandidates.length)
+          if(ordinal < 0 || ordinal >= attrCandidates.length) {
+            throw QueryCompilationErrors.ordinalOutOfBoundsError(
+              ordinal,
+              attrCandidates
+            )
+          }
           attrCandidates(ordinal)
 
         case GetViewColumnByNameAndOrdinal(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ColumnResolutionHelper.scala
@@ -146,7 +146,7 @@ trait ColumnResolutionHelper extends Logging with DataTypeErrorsBase {
 
         case GetColumnByOrdinal(ordinal, _) =>
           val attrCandidates = getAttrCandidates()
-          if(ordinal < 0 || ordinal >= attrCandidates.length) {
+          if (ordinal < 0 || ordinal >= attrCandidates.length) {
             throw QueryCompilationErrors.ordinalOutOfBoundsError(
               ordinal,
               attrCandidates

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -4142,7 +4142,7 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map(
         "ordinal" -> ordinal.toString,
         "attributesLength" -> attributes.length.toString,
-        "attributes" -> attributes.map(_.name).mkString(", ")
+        "attributes" -> attributes.map(attr => toSQLId(attr.name)).mkString(", ")
       )
     )
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -4133,4 +4133,17 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       origin = inlineTable.origin
     )
   }
+
+  def ordinalOutOfBoundsError(
+      ordinal: Int,
+      attributes: Seq[Attribute]): Throwable = {
+    new AnalysisException(
+      errorClass = "COLUMN_ORDINAL_OUT_OF_BOUNDS",
+      messageParameters = Map(
+        "ordinal" -> ordinal.toString,
+        "attributesLength" -> attributes.length.toString,
+        "attributes" -> attributes.map(_.name).mkString(", ")
+      )
+    )
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Provide more user facing error when ordinal of the column is out of bounds.

### Why are the changes needed?
There's an issue where `GetColumnByOrdinal` can return attributes which length doesn't match ordinal which is used as a parameter. When that happens we throw an assertion error which is not user friendly. Because of that we introduced new QueryExecutionError in order to make it more user facing.

### Does this PR introduce _any_ user-facing change?
Yes, error message is more user friendly.

### Was this patch authored or co-authored using generative AI tooling?
No