### PR TITLE
[SPARK-49604][SQL] GROUP_BY_POS_OUT_OF_RANGE should not appear if group by Literal

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveReferencesInAggregate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveReferencesInAggregate.scala
@@ -152,11 +152,12 @@ class ResolveReferencesInAggregate(val catalogManager: CatalogManager) extends S
       }
     } else {
       // Check if grouping expressions contain the integer literal
-      if (groupExprs.exists(expr =>
+      val containsIntegerLiteral = groupExprs.exists(expr =>
         trimAliases(expr) match {
           case IntegerLiteral(_) => true
           case _ => false
-        })) {
+        })
+      if (containsIntegerLiteral) {
         val expandedGroupExprs = expandGroupByAll(selectList)
         if (expandedGroupExprs.isEmpty) {
           groupExprs

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4635,7 +4635,11 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     withTable("t1", "t2", "t3") {
       sql("CREATE TABLE t1(c1 int) USING PARQUET")
       sql("CREATE TABLE t2 USING PARQUET AS SELECT c1, -1 AS x from t1 group by c1, x")
-      sql("CREATE TABLE t3 USING PARQUET AS SELECT c1, -1 AS x, 3 AS y from t1 group by c1, x, y")
+      sql("CREATE TABLE t3 USING PARQUET AS SELECT c1, 5 AS x, 5 AS y from t1 group by c1, x, y")
+      val error = intercept[AnalysisException] {
+        sql("CREATE TABLE t4 USING PARQUET AS SELECT c1, -1 AS x, 5 AS y from t1 group by c1, x, 5")
+      }
+      assert(error.message contains "GROUP_BY_POS_OUT_OF_RANGE")
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4631,6 +4631,14 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
     }
   }
 
+  test("SPARK-49604: GROUP_BY_POS_OUT_OF_RANGE should not appear if group by Literal") {
+    withTable("t1", "t2", "t3") {
+      sql("CREATE TABLE t1(c1 int) USING PARQUET")
+      sql("CREATE TABLE t2 USING PARQUET AS SELECT c1, -1 AS x from t1 group by c1, x")
+      sql("CREATE TABLE t3 USING PARQUET AS SELECT c1, -1 AS x, 3 AS y from t1 group by c1, x, y")
+    }
+  }
+
   test("SPARK-39548: CreateView will make queries go into inline CTE code path thus" +
     "trigger a mis-clarified `window definition not found` issue") {
     sql(

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4632,12 +4632,13 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
   }
 
   test("SPARK-49604: GROUP_BY_POS_OUT_OF_RANGE should not appear if group by Literal") {
-    withTable("t1", "t2", "t3", "t4") {
+    withTable("t1", "t2", "t3", "t4", "t5") {
       sql("CREATE TABLE t1(c1 int) USING PARQUET")
       sql("CREATE TABLE t2 USING PARQUET AS SELECT c1, -1 AS x from t1 group by c1, x")
       sql("CREATE TABLE t3 USING PARQUET AS SELECT c1, 5 AS x, 5 AS y from t1 group by c1, x, y")
+      sql("CREATE TABLE t4 USING PARQUET AS SELECT c1, 1 + sum(c1), 5 AS y from t1 group by c1, y")
       val error = intercept[AnalysisException] {
-        sql("CREATE TABLE t4 USING PARQUET AS SELECT c1, -1 AS x, 5 AS y from t1 group by c1, x, 5")
+        sql("CREATE TABLE t5 USING PARQUET AS SELECT c1, -1 AS x, 5 AS y from t1 group by c1, x, 5")
       }
       assert(error.message contains "GROUP_BY_POS_OUT_OF_RANGE")
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4632,7 +4632,7 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
   }
 
   test("SPARK-49604: GROUP_BY_POS_OUT_OF_RANGE should not appear if group by Literal") {
-    withTable("t1", "t2", "t3") {
+    withTable("t1", "t2", "t3", "t4") {
       sql("CREATE TABLE t1(c1 int) USING PARQUET")
       sql("CREATE TABLE t2 USING PARQUET AS SELECT c1, -1 AS x from t1 group by c1, x")
       sql("CREATE TABLE t3 USING PARQUET AS SELECT c1, 5 AS x, 5 AS y from t1 group by c1, x, y")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
The PR adds a check in resolveGroupByAlias to check if any integer literal is presented in the group expressions. If found, replace the original integer literal with an integer literal of the index from the select list. The original integer literal may cause failures with a later GROUP BY ordinal resolution as described below. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
https://issues.apache.org/jira/browse/SPARK-49604 
As described in the issue,
```
create table t1(id int);
create table t2 as select id, -1 as x from t1 group by id, x;
```
will throw:
`[GROUP_BY_POS_OUT_OF_RANGE] GROUP BY position -1 is not in select list (valid range is [1, 2]).;
`
We should support group by Literal as it's a valid operation.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit Test


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
