### PR TITLE
[MINOR][PYTHON][TESTS] Skip test_artifact if grpc isn't installed

### DIFF
--- a/python/pyspark/sql/tests/connect/client/test_artifact.py
+++ b/python/pyspark/sql/tests/connect/client/test_artifact.py
@@ -21,7 +21,6 @@ import unittest
 import os
 
 from pyspark.util import is_remote_only
-from pyspark.errors.exceptions.connect import SparkConnectGrpcException
 from pyspark.sql import SparkSession
 from pyspark.testing.connectutils import ReusedConnectTestCase, should_test_connect
 from pyspark.testing.utils import SPARK_HOME
@@ -30,6 +29,7 @@ from pyspark.sql.functions import udf, assert_true, lit
 if should_test_connect:
     from pyspark.sql.connect.client.artifact import ArtifactManager
     from pyspark.sql.connect.client import DefaultChannelBuilder
+    from pyspark.errors.exceptions.connect import SparkConnectGrpcException
 
 
 class ArtifactTestsMixin:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix test_artifact to skip test if grpc isn't installed

### Why are the changes needed?

To fix Python 3.13 build (https://github.com/apache/spark/actions/runs/11168860784/job/31048343683)

```
Running PySpark tests. Output is in /__w/spark/spark/python/unit-tests.log
Will test against the following Python executables: ['python3.13']
Will test the following Python modules: ['pyspark-connect']
python3.13 python_implementation is CPython
python3.13 version is: Python 3.13.0rc3
Starting test(python3.13): pyspark.sql.tests.connect.client.test_artifact (temp output: /__w/spark/spark/python/target/176e36e6-3f4f-4ab4-9861-fa131061be94/python3.13__pyspark.sql.tests.connect.client.test_artifact__u6l46s5d.log)
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/__w/spark/spark/python/pyspark/sql/tests/connect/client/test_artifact.py", line 24, in <module>
    from pyspark.errors.exceptions.connect import SparkConnectGrpcException
  File "/__w/spark/spark/python/pyspark/errors/exceptions/connect.py", line 17, in <module>
    import pyspark.sql.connect.proto as pb2
  File "/__w/spark/spark/python/pyspark/sql/connect/proto/__init__.py", line 18, in <module>
    from pyspark.sql.connect.proto.base_pb2_grpc import *
  File "/__w/spark/spark/python/pyspark/sql/connect/proto/base_pb2_grpc.py", line 19, in <module>
    import grpc
ModuleNotFoundError: No module named 'grpc'
```

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No