### PR TITLE
[SPARK-49869][INFRA] Add NumPy in Python 3.13 image

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -148,7 +148,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.13
 # TODO(SPARK-49862) Add BASIC_PIP_PKGS and CONNECT_PIP_PKGS to Python 3.13 image when it supports Python 3.13
 RUN python3.13 -m pip install --ignore-installed blinker>=1.6.2 # mlflow needs this
-RUN python3.13 -m pip install lxml && \
+RUN python3.13 -m pip install lxml numpy>=2.1 && \
     python3.13 -m pip cache purge
 
 # Remove unused installation packages to free up disk space


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR add NumPy in Python 3.13 image. Note that this is different from SPARK-49862 because NumPy is a required dependency for ML in Python.

### Why are the changes needed?

To fix Python 3.13 (https://github.com/apache/spark/actions/runs/11168860784/job/31048343334).

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Will monitor the build.

### Was this patch authored or co-authored using generative AI tooling?

No.
