### PR TITLE
[SPARK-49870][PYTHON] Add Python 3.13 support in Spark Classic

### DIFF
--- a/python/packaging/classic/setup.py
+++ b/python/packaging/classic/setup.py
@@ -374,6 +374,7 @@ try:
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
             "Programming Language :: Python :: 3.12",
+            "Programming Language :: Python :: 3.13",
             "Programming Language :: Python :: Implementation :: CPython",
             "Programming Language :: Python :: Implementation :: PyPy",
             "Typing :: Typed",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds the note for Python 3.13 support in `setup.py` for Spark Classic.

### Why are the changes needed?

Basic tests pass with Python 3.13 for Spark Classic (https://github.com/apache/spark/actions/runs/11168860784)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Via CI.

### Was this patch authored or co-authored using generative AI tooling?

No.