### PR TITLE
[SPARK-49871][CORE][TESTS] Fix `(Ssl)CoarseGrainedExecutorBackendSuite` to reduce test resource and increase timeout

### DIFF
--- a/core/src/test/scala/org/apache/spark/executor/CoarseGrainedExecutorBackendSuite.scala
+++ b/core/src/test/scala/org/apache/spark/executor/CoarseGrainedExecutorBackendSuite.scala
@@ -37,7 +37,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import org.apache.spark._
 import org.apache.spark.TestUtils._
 import org.apache.spark.api.plugin.{DriverPlugin, ExecutorPlugin, PluginContext, SparkPlugin}
-import org.apache.spark.internal.config.PLUGINS
+import org.apache.spark.internal.config.{EXECUTOR_MEMORY, PLUGINS}
 import org.apache.spark.resource._
 import org.apache.spark.resource.ResourceUtils._
 import org.apache.spark.resource.TestResourceIDs._
@@ -581,7 +581,8 @@ class CoarseGrainedExecutorBackendSuite extends SparkFunSuite
    */
   test("SPARK-40320 Executor should exit when initialization failed for fatal error") {
     val conf = createSparkConf()
-      .setMaster("local-cluster[1, 1, 1024]")
+      .setMaster("local-cluster[1, 1, 512]")
+      .set(EXECUTOR_MEMORY.key, "512m")
       .set(PLUGINS, Seq(classOf[TestFatalErrorPlugin].getName))
       .setAppName("test")
     sc = new SparkContext(conf)
@@ -599,7 +600,7 @@ class CoarseGrainedExecutorBackendSuite extends SparkFunSuite
     }
     try {
       sc.addSparkListener(listener)
-      eventually(timeout(15.seconds)) {
+      eventually(timeout(30.seconds)) {
         assert(executorAddCounter.get() >= 2)
         assert(executorRemovedCounter.get() >= 2)
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `(Ssl)CoarseGrainedExecutorBackendSuite` to reduce test resource and increase timeout in order to reduce the flakiness in the resource hungry GitHub Action environment.

### Why are the changes needed?

The test case of `(Ssl)CoarseGrainedExecutorBackendSuite` injects a faulty plugin to check the executor restart. Sometime, it fails due to the timeout during restarting the executors.

- https://github.com/apache/spark/actions/runs/11168954174/job/31048566907
```
- SPARK-40320 Executor should exit when initialization failed for fatal error *** FAILED ***
  The code passed to eventually never returned normally. Attempted 187 times over 15.001016415999999 seconds.
  Last failure message: 1 was not greater than or equal to 2.
 (CoarseGrainedExecutorBackendSuite.scala:602)
```

### Does this PR introduce _any_ user-facing change?

No, this is a test-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.