### PR TITLE
[SPARK-49879][CORE] Move `TransportCipherUtil` to a separate file to eliminate Java compilation warnings

### DIFF
--- a/common/network-common/src/main/java/org/apache/spark/network/crypto/TransportCipherUtil.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/crypto/TransportCipherUtil.java
@@ -17,12 +17,25 @@
 
 package org.apache.spark.network.crypto;
 
-import io.netty.channel.Channel;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.crypto.tink.subtle.Hex;
+import com.google.crypto.tink.subtle.Hkdf;
 
-import java.io.IOException;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 
-interface TransportCipher {
-    String getKeyId() throws GeneralSecurityException;
-    void addToChannel(Channel channel) throws IOException, GeneralSecurityException;
+class TransportCipherUtil {
+    /*
+     * This method is used for testing to verify key derivation.
+     */
+    @VisibleForTesting
+    static String getKeyId(SecretKeySpec key) throws GeneralSecurityException {
+        byte[] keyIdBytes = Hkdf.computeHkdf("HmacSha256",
+                key.getEncoded(),
+                null,
+                "keyID".getBytes(StandardCharsets.UTF_8),
+                32);
+        return Hex.encode(keyIdBytes);
+    }
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/crypto/TransportCipherUtil.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/crypto/TransportCipherUtil.java
@@ -26,16 +26,16 @@ import com.google.crypto.tink.subtle.Hex;
 import com.google.crypto.tink.subtle.Hkdf;
 
 class TransportCipherUtil {
-    /*
-     * This method is used for testing to verify key derivation.
-     */
-    @VisibleForTesting
-    static String getKeyId(SecretKeySpec key) throws GeneralSecurityException {
-        byte[] keyIdBytes = Hkdf.computeHkdf("HmacSha256",
-                key.getEncoded(),
-                null,
-                "keyID".getBytes(StandardCharsets.UTF_8),
-                32);
-        return Hex.encode(keyIdBytes);
-    }
+  /**
+   * This method is used for testing to verify key derivation.
+   */
+  @VisibleForTesting
+  static String getKeyId(SecretKeySpec key) throws GeneralSecurityException {
+    byte[] keyIdBytes = Hkdf.computeHkdf("HmacSha256",
+        key.getEncoded(),
+        null,
+        "keyID".getBytes(StandardCharsets.UTF_8),
+        32);
+    return Hex.encode(keyIdBytes);
+  }
 }

--- a/common/network-common/src/main/java/org/apache/spark/network/crypto/TransportCipherUtil.java
+++ b/common/network-common/src/main/java/org/apache/spark/network/crypto/TransportCipherUtil.java
@@ -17,13 +17,13 @@
 
 package org.apache.spark.network.crypto;
 
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import javax.crypto.spec.SecretKeySpec;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.crypto.tink.subtle.Hex;
 import com.google.crypto.tink.subtle.Hkdf;
-
-import javax.crypto.spec.SecretKeySpec;
-import java.nio.charset.StandardCharsets;
-import java.security.GeneralSecurityException;
 
 class TransportCipherUtil {
     /*


### PR DESCRIPTION
### What changes were proposed in this pull request?
Run `build/mvn clean install -pl common/network-common`, we can see the following compilation warnings:

```
[WARNING] [Warn] /Users/yangjie01/SourceCode/git/spark-maven/common/network-common/src/main/java/org/apache/spark/network/crypto/CtrTransportCipher.java:73:11:  
auxiliary class TransportCipherUtil in /Users/yangjie01/SourceCode/git/spark-maven/common/network-common/src/main/java/org/apache/spark/network/crypto/TransportCipher.java should not be accessed from outside its own source file
[WARNING] [Warn] /Users/yangjie01/SourceCode/git/spark-maven/common/network-common/src/main/java/org/apache/spark/network/crypto/GcmTransportCipher.java:63:15:
auxiliary class TransportCipherUtil in /Users/yangjie01/SourceCode/git/spark-maven/common/network-common/src/main/java/org/apache/spark/network/crypto/TransportCipher.java should not be accessed from outside its own source file
```

So this pr moves `TransportCipherUtil` to a separate file to eliminate the aforementioned Java compilation warnings.

### Why are the changes needed?
Fix compilation warnings. 


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
- Pass GitHub Actions
- locally run `build/mvn clean install -pl common/network-common`, no longer have the aforementioned compilation warnings.


### Was this patch authored or co-authored using generative AI tooling?
No