### PR TITLE
[SPARK-49806][PYTHON][TESTS][FOLLOW-UP] Skip newline difference in Spark Connect compatibility test

### DIFF
--- a/python/pyspark/sql/tests/test_dataframe.py
+++ b/python/pyspark/sql/tests/test_dataframe.py
@@ -1550,6 +1550,9 @@ class DataFrameTestsMixin:
         df = self.spark.createDataFrame(pd.DataFrame({"a": [timedelta(microseconds=123)]}))
         self.assertEqual(df.toPandas().a.iloc[0], timedelta(microseconds=123))
 
+    @unittest.skipIf(
+        "SPARK_SKIP_CONNECT_COMPAT_TESTS" in os.environ, "Newline difference from the server"
+    )
     def test_repr_behaviors(self):
         import re
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/48277 that disables newline related tests in Spark Connect compatibility test.

### Why are the changes needed?

To make the Spark Connect build pass. Currently, it fails as below (https://github.com/apache/spark/actions/runs/11186932292/job/31102993825):

```
======================================================================
FAIL [0.100s]: test_repr_behaviors (pyspark.sql.tests.connect.test_parity_dataframe.DataFrameParityTests.test_repr_behaviors)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/spark/spark-3.5/python/pyspark/sql/tests/test_dataframe.py", line 1586, in test_repr_behaviors
    self.assertEqual(re.sub(pattern, "", expected3), df.__repr__())
AssertionError: '+---[23 chars]---+-----+\n|  1|    1|\n+---+-----+\nonly showing top 1 row\n' != '+---[23 chars]---+-----+\n|  1|    1|\n+---+-----+\nonly showing top 1 row'
  +---+-----+
  |key|value|
  +---+-----+
  |  1|    1|
  +---+-----+
- only showing top 1 row
?                       -
+ only showing top 1 row
```

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manaully.

### Was this patch authored or co-authored using generative AI tooling?

No.