### PR TITLE
Revert "[SPARK-49808][SQL] Fix a deadlock in subquery execution due o lazy vals"

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/QueryPlan.scala
@@ -32,7 +32,6 @@ import org.apache.spark.sql.catalyst.trees.TreePatternBits
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.{DataType, StructType}
-import org.apache.spark.util.LazyTry
 import org.apache.spark.util.collection.BitSet
 
 /**
@@ -95,11 +94,9 @@ abstract class QueryPlan[PlanType <: QueryPlan[PlanType]]
    * All Attributes that appear in expressions from this operator.  Note that this set does not
    * include attributes that are implicitly referenced by being passed through to the output tuple.
    */
-  def references: AttributeSet = lazyReferences.get
-
   @transient
-  private val lazyReferences = LazyTry {
-    AttributeSet(expressions) -- producedAttributes
+  lazy val references: AttributeSet = {
+    AttributeSet.fromAttributeSets(expressions.map(_.references)) -- producedAttributes
   }
 
   /**


### PR DESCRIPTION

This reverts commit d7abddc454ffef6ac16e8f6df6f601eec621ddfd.

We had offline discussion, and @JoshRosen pointed out that:
> The use of LazyTry vs. a non-try Lazy wrappers needs discussion:
LazyTry caches failures. As a result, there is a potential risk of cancellation exceptions being cached here.
This is possibly an issue in case AQE interrupts subquery execution threads during planning, or otherwise can interrupt a subset of a query plan.
