### PR TITLE
[SPARK-49896][K8S][DOCS] Drop K8s v1.28 Support

### DIFF
--- a/docs/running-on-kubernetes.md
+++ b/docs/running-on-kubernetes.md
@@ -44,7 +44,7 @@ Cluster administrators should use [Pod Security Policies](https://kubernetes.io/
 
 # Prerequisites
 
-* A running Kubernetes cluster at version >= 1.28 with access configured to it using
+* A running Kubernetes cluster at version >= 1.29 with access configured to it using
 [kubectl](https://kubernetes.io/docs/reference/kubectl/).  If you do not already have a working Kubernetes cluster,
 you may set up a test cluster on your local machine using
 [minikube](https://kubernetes.io/docs/getting-started-guides/minikube/).


### PR DESCRIPTION
### What changes were proposed in this pull request?

Apache Spark 4.0.0 RC1 vote will start on February 15th 2025
- https://spark.apache.org/versioning-policy.html

This PR aims to update K8s docs to recommend K8s v1.29+ for Apache Spark 4.0.0.

### Why are the changes needed?

**1. K8s community will release v1.32.0 on 2024-12-11**
- https://github.com/kubernetes/sig-release/tree/master/releases/release-1.32#kubernetes-132

**2. Default K8s Versions in Public Cloud environments**

The default K8s versions of public cloud providers are already moving to K8s 1.30 like the following.

- EKS: v1.30 (Default)
- GKE: v1.30 (Stable), v1.30 (Regular), v1.31 (Rapid)
- AKS: v1.29 (Default), v1.30 (Support)

**3. End Of Support**

In addition, K8s 1.28 reached or will reach a standard support EOL around Apache Spark 4.0.0 release. 

| K8s  |   EKS   |  GKE  |  AKS  |
| ---- | ------- | ------- | ------- |
| 1.28 | 2024-11 | 2025-02-04 | 2025-03 |

- [EKS EOL Schedule](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar)
- [AKS EOL Schedule](https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar)
- [GKE EOL Schedule](https://cloud.google.com/kubernetes-engine/docs/release-schedule)

### Does this PR introduce _any_ user-facing change?

- No, this is a documentation-only change about K8s versions.
- Apache Spark K8s Integration Test is currently using K8s **v1.31.0** on Minikube already.
```
* Preparing Kubernetes v1.31.0 on Docker 27.2.0 ...
```

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.