### PR TITLE
[SPARK-49901][BUILD] Upgrade dropwizard metrics to 4.2.28

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -196,11 +196,11 @@ log4j-layout-template-json/2.24.1//log4j-layout-template-json-2.24.1.jar
 log4j-slf4j2-impl/2.24.1//log4j-slf4j2-impl-2.24.1.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
-metrics-core/4.2.27//metrics-core-4.2.27.jar
-metrics-graphite/4.2.27//metrics-graphite-4.2.27.jar
-metrics-jmx/4.2.27//metrics-jmx-4.2.27.jar
-metrics-json/4.2.27//metrics-json-4.2.27.jar
-metrics-jvm/4.2.27//metrics-jvm-4.2.27.jar
+metrics-core/4.2.28//metrics-core-4.2.28.jar
+metrics-graphite/4.2.28//metrics-graphite-4.2.28.jar
+metrics-jmx/4.2.28//metrics-jmx-4.2.28.jar
+metrics-json/4.2.28//metrics-json-4.2.28.jar
+metrics-jvm/4.2.28//metrics-jvm-4.2.28.jar
 minlog/1.3.0//minlog-1.3.0.jar
 netty-all/4.1.110.Final//netty-all-4.1.110.Final.jar
 netty-buffer/4.1.110.Final//netty-buffer-4.1.110.Final.jar

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     If you change codahale.metrics.version, you also need to change
     the link to metrics.dropwizard.io in docs/monitoring.md.
     -->
-    <codahale.metrics.version>4.2.27</codahale.metrics.version>
+    <codahale.metrics.version>4.2.28</codahale.metrics.version>
     <!-- Should be consistent with SparkBuild.scala and docs -->
     <avro.version>1.12.0</avro.version>
     <aws.kinesis.client.version>1.12.0</aws.kinesis.client.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to upgrade `dropwizard metrics` from `4.2.27` to  `4.2.28`.


### Why are the changes needed?
v4.2.127 VS v.4.2.28
https://github.com/dropwizard/metrics/compare/v4.2.27...v4.2.28


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
