### PR TITLE
[SPARK-49542][SQL] Partition transform exception evaluate error

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3814,6 +3814,12 @@
     ],
     "sqlState" : "42000"
   },
+  "PARTITION_TRANSFORM_EXPRESSION_NOT_IN_PARTITIONED_BY" : {
+    "message" : [
+      "The expression <expression> must be inside 'partitionedBy'."
+    ],
+    "sqlState" : "42S23"
+  },
   "PATH_ALREADY_EXISTS" : {
     "message" : [
       "Path <outputPath> already exists. Set mode as \"overwrite\" to overwrite the existing path."
@@ -4187,12 +4193,6 @@
       "Cannot change <stateVarName> to <newType> between query restarts. Please set <stateVarName> to <oldType>, or restart with a new checkpoint directory."
     ],
     "sqlState" : "42K06"
-  },
-  "PARTITION_TRANSFORM_EXPRESSION_NOT_IN_PARTITIONED_BY" : {
-    "message" : [
-      "The expression <expression> must be inside 'partitionedBy'."
-    ],
-    "sqlState": "42S23"
   },
   "STATE_STORE_KEY_ROW_FORMAT_VALIDATION_FAILURE" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4188,6 +4188,12 @@
     ],
     "sqlState" : "42K06"
   },
+  "PARTITION_TRANSFORM_NOT_IN_PARTITIONED_BY" : {
+    "message" : [
+      "The expression <expression> must be inside 'partitionedBy'"
+    ],
+    "sqlState": "42S23"
+  },
   "STATE_STORE_KEY_ROW_FORMAT_VALIDATION_FAILURE" : {
     "message" : [
       "The streaming query failed to validate written state for key row.",

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4188,7 +4188,7 @@
     ],
     "sqlState" : "42K06"
   },
-  "PARTITION_TRANSFORM_NOT_IN_PARTITIONED_BY" : {
+  "PARTITION_TRANSFORM_EXPRESSION_NOT_IN_PARTITIONED_BY" : {
     "message" : [
       "The expression <expression> must be inside 'partitionedBy'"
     ],

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4190,7 +4190,7 @@
   },
   "PARTITION_TRANSFORM_EXPRESSION_NOT_IN_PARTITIONED_BY" : {
     "message" : [
-      "The expression <expression> must be inside 'partitionedBy'"
+      "The expression <expression> must be inside 'partitionedBy'."
     ],
     "sqlState": "42S23"
   },

--- a/common/utils/src/main/resources/error/error-states.json
+++ b/common/utils/src/main/resources/error/error-states.json
@@ -4901,6 +4901,12 @@
         "standard": "N",
         "usedBy": ["SQL Server"]
     },
+    "42S23": {
+        "description": "Partition transform expression not in 'partitionedBy'",
+        "origin": "Spark",
+        "standard": "N",
+        "usedBy": ["Spark"]
+    },
     "44000": {
         "description": "with check option violation",
         "origin": "SQL/Foundation",

--- a/python/pyspark/sql/tests/connect/test_parity_readwriter.py
+++ b/python/pyspark/sql/tests/connect/test_parity_readwriter.py
@@ -35,6 +35,7 @@ class ReadwriterV2ParityTests(ReadwriterV2TestsMixin, ReusedConnectTestCase):
         self.check_partitioning_functions(DataFrameWriterV2)
         self.partitioning_functions_user_error()
 
+
 if __name__ == "__main__":
     import unittest
     from pyspark.sql.tests.connect.test_parity_readwriter import *  # noqa: F401

--- a/python/pyspark/sql/tests/connect/test_parity_readwriter.py
+++ b/python/pyspark/sql/tests/connect/test_parity_readwriter.py
@@ -33,7 +33,7 @@ class ReadwriterV2ParityTests(ReadwriterV2TestsMixin, ReusedConnectTestCase):
 
     def test_partitioning_functions(self):
         self.check_partitioning_functions(DataFrameWriterV2)
-
+        self.partitioning_functions_user_error()
 
 if __name__ == "__main__":
     import unittest

--- a/python/pyspark/sql/tests/test_readwriter.py
+++ b/python/pyspark/sql/tests/test_readwriter.py
@@ -298,6 +298,10 @@ class ReadwriterV2TestsMixin:
         with self.assertRaisesRegex(
             Exception, "PARTITION_TRANSFORM_EXPRESSION_NOT_IN_PARTITIONED_BY"
         ):
+            df.select(hours("ts")).collect()
+        with self.assertRaisesRegex(
+            Exception, "PARTITION_TRANSFORM_EXPRESSION_NOT_IN_PARTITIONED_BY"
+        ):
             df.select(bucket(2, "ts")).collect()
 
     def test_create(self):

--- a/python/pyspark/sql/tests/test_readwriter.py
+++ b/python/pyspark/sql/tests/test_readwriter.py
@@ -283,13 +283,21 @@ class ReadwriterV2TestsMixin:
             [(1, datetime.datetime(2000, 1, 1), "foo")], ("id", "ts", "value")
         )
 
-        with self.assertRaisesRegex(Exception, "PARTITION_TRANSFORM_EXPRESSION_NOT_IN_PARTITIONED_BY"):
+        with self.assertRaisesRegex(
+            Exception, "PARTITION_TRANSFORM_EXPRESSION_NOT_IN_PARTITIONED_BY"
+        ):
             df.select(years("ts")).collect()
-        with self.assertRaisesRegex(Exception, "PARTITION_TRANSFORM_EXPRESSION_NOT_IN_PARTITIONED_BY"):
+        with self.assertRaisesRegex(
+            Exception, "PARTITION_TRANSFORM_EXPRESSION_NOT_IN_PARTITIONED_BY"
+        ):
             df.select(months("ts")).collect()
-        with self.assertRaisesRegex(Exception, "PARTITION_TRANSFORM_EXPRESSION_NOT_IN_PARTITIONED_BY"):
+        with self.assertRaisesRegex(
+            Exception, "PARTITION_TRANSFORM_EXPRESSION_NOT_IN_PARTITIONED_BY"
+        ):
             df.select(days("ts")).collect()
-        with self.assertRaisesRegex(Exception, "PARTITION_TRANSFORM_EXPRESSION_NOT_IN_PARTITIONED_BY"):
+        with self.assertRaisesRegex(
+            Exception, "PARTITION_TRANSFORM_EXPRESSION_NOT_IN_PARTITIONED_BY"
+        ):
             df.select(bucket(2, "ts")).collect()
 
     def test_create(self):

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -383,10 +383,10 @@ abstract class Expression extends TreeNode[Expression] {
 trait FoldableUnevaluable extends Expression {
   override def foldable: Boolean = true
 
-  final override def eval(input: InternalRow = null): Any =
+  override def eval(input: InternalRow = null): Any =
     throw QueryExecutionErrors.cannotEvaluateExpressionError(this)
 
-  final override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode =
+  override protected def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode =
     throw QueryExecutionErrors.cannotGenerateCodeForExpressionError(this)
 }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PartitionTransforms.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PartitionTransforms.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.trees.UnaryLike
+import org.apache.spark.sql.errors.DataTypeErrors.toSQLStmt
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.types.{DataType, IntegerType}
 
@@ -43,13 +44,13 @@ abstract class PartitionTransformExpression extends Expression with Unevaluable
 
   override def eval(input: InternalRow): Any =
     throw new AnalysisException(
-      errorClass = "PARTITION_TRANSFORM_NOT_IN_PARTITIONED_BY",
-      messageParameters = Map("expression" -> toString)
+      errorClass = "PARTITION_TRANSFORM_EXPRESSION_NOT_IN_PARTITIONED_BY",
+      messageParameters = Map("expression" -> toSQLStmt(toString))
     )
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode =
     throw new AnalysisException(
-      errorClass = "PARTITION_TRANSFORM_NOT_IN_PARTITIONED_BY",
+      errorClass = "PARTITION_TRANSFORM_EXPRESSION_NOT_IN_PARTITIONED_BY",
       messageParameters = Map("expression" -> toString)
     )
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PartitionTransforms.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PartitionTransforms.scala
@@ -17,11 +17,11 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
-import org.apache.spark.sql.AnalysisException
+import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.trees.UnaryLike
-import org.apache.spark.sql.errors.DataTypeErrors.toSQLStmt
+import org.apache.spark.sql.catalyst.util.TypeUtils.toSQLExpr
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.types.{DataType, IntegerType}
 
@@ -43,15 +43,17 @@ abstract class PartitionTransformExpression extends Expression with Unevaluable
   override def nullable: Boolean = true
 
   override def eval(input: InternalRow): Any =
-    throw new AnalysisException(
+    throw new SparkException(
       errorClass = "PARTITION_TRANSFORM_EXPRESSION_NOT_IN_PARTITIONED_BY",
-      messageParameters = Map("expression" -> toSQLStmt(toString))
+      messageParameters = Map("expression" -> toSQLExpr(this)),
+      cause = null
     )
 
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode =
-    throw new AnalysisException(
+    throw new SparkException(
       errorClass = "PARTITION_TRANSFORM_EXPRESSION_NOT_IN_PARTITIONED_BY",
-      messageParameters = Map("expression" -> toString)
+      messageParameters = Map("expression" -> toSQLExpr(this)),
+      cause = null
     )
 }
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PartitionTransforms.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PartitionTransforms.scala
@@ -17,6 +17,9 @@
 
 package org.apache.spark.sql.catalyst.expressions
 
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.trees.UnaryLike
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.types.{DataType, IntegerType}
@@ -37,8 +40,19 @@ import org.apache.spark.sql.types.{DataType, IntegerType}
 abstract class PartitionTransformExpression extends Expression with Unevaluable
   with UnaryLike[Expression] {
   override def nullable: Boolean = true
-}
 
+  override def eval(input: InternalRow): Any =
+    throw new AnalysisException(
+      errorClass = "PARTITION_TRANSFORM_NOT_IN_PARTITIONED_BY",
+      messageParameters = Map("expression" -> toString)
+    )
+
+  override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode =
+    throw new AnalysisException(
+      errorClass = "PARTITION_TRANSFORM_NOT_IN_PARTITIONED_BY",
+      messageParameters = Map("expression" -> toString)
+    )
+}
 /**
  * Expression for the v2 partition transform years.
  */

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -1007,15 +1007,14 @@ class QueryExecutionErrorsSuite
   }
 
   test("PartitionTransformExpression throws error on eval") {
-    val expr = Years(Literal("foo")).eval()
+
     val e = intercept[AnalysisException] {
-      expr
+      Years(Literal("foo")).eval()
     }
     checkError(
       exception = e,
       condition = "PARTITION_TRANSFORM_EXPRESSION_NOT_IN_PARTITIONED_BY",
-      parameters = Map("expression" -> ""),
-      sqlState = "42123")
+      parameters = Map("expression" -> "YEARS(FOO)"))
   }
 
   test("INTERNAL_ERROR: Calling doGenCode on unresolved") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -35,7 +35,7 @@ import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, Encoder, Kry
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.{NamedParameter, UnresolvedGenerator}
 import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Concat, CreateArray, EmptyRow, Expression, Flatten, Grouping, Literal, RowNumber, UnaryExpression}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Concat, CreateArray, EmptyRow, Expression, Flatten, Grouping, Literal, RowNumber, UnaryExpression, Years}
 import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode._
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.expressions.objects.InitializeJavaBean
@@ -1004,6 +1004,18 @@ class QueryExecutionErrorsSuite
       condition = "INTERNAL_ERROR",
       parameters = Map("message" -> "Cannot evaluate expression: namedparameter(foo)"),
       sqlState = "XX000")
+  }
+
+  test("PartitionTransformExpression throws error on eval") {
+    val expr = Years(Literal("foo")).eval()
+    val e = intercept[AnalysisException] {
+      expr
+    }
+    checkError(
+      exception = e,
+      condition = "PARTITION_TRANSFORM_EXPRESSION_NOT_IN_PARTITIONED_BY",
+      parameters = Map("expression" -> ""),
+      sqlState = "42123")
   }
 
   test("INTERNAL_ERROR: Calling doGenCode on unresolved") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryExecutionErrorsSuite.scala
@@ -40,6 +40,7 @@ import org.apache.spark.sql.catalyst.expressions.CodegenObjectFactoryMode._
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.expressions.objects.InitializeJavaBean
 import org.apache.spark.sql.catalyst.rules.RuleIdCollection
+import org.apache.spark.sql.catalyst.util.TypeUtils.toSQLExpr
 import org.apache.spark.sql.execution.datasources.jdbc.{DriverRegistry, JDBCOptions}
 import org.apache.spark.sql.execution.datasources.jdbc.connection.ConnectionProvider
 import org.apache.spark.sql.execution.datasources.orc.OrcTest
@@ -1006,15 +1007,15 @@ class QueryExecutionErrorsSuite
       sqlState = "XX000")
   }
 
-  test("PartitionTransformExpression throws error on eval") {
-
-    val e = intercept[AnalysisException] {
-      Years(Literal("foo")).eval()
+  test("PartitionTransformExpression error on eval") {
+    val expr = Years(Literal("foo"))
+    val e = intercept[SparkException] {
+      expr.eval()
     }
     checkError(
       exception = e,
       condition = "PARTITION_TRANSFORM_EXPRESSION_NOT_IN_PARTITIONED_BY",
-      parameters = Map("expression" -> "YEARS(FOO)"))
+      parameters = Map("expression" -> toSQLExpr(expr)))
   }
 
   test("INTERNAL_ERROR: Calling doGenCode on unresolved") {


### PR DESCRIPTION

### What changes were proposed in this pull request?
Add user facing error for improper use of partition transform expressions.


### Why are the changes needed?
Replace internal error with user facing one.


### Does this PR introduce _any_ user-facing change?
Yes, new error condition.


### How was this patch tested?
Added tests to QueryExecutionErrorsSuite


### Was this patch authored or co-authored using generative AI tooling?
No
