### PR TITLE
[SPARK-49915][SQL] Handle zeros and ones in ReorderAssociativeOperator

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -260,22 +260,38 @@ object ReorderAssociativeOperator extends Rule[LogicalPlan] {
       q.transformExpressionsDownWithPruning(_.containsPattern(BINARY_ARITHMETIC)) {
       case a @ Add(_, _, f) if a.deterministic && a.dataType.isInstanceOf[IntegralType] =>
         val (foldables, others) = flattenAdd(a, groupingExpressionSet).partition(_.foldable)
-        if (foldables.size > 1) {
+        val newExpr = if (foldables.nonEmpty) {
           val foldableExpr = foldables.reduce((x, y) => Add(x, y, f))
-          val c = Literal.create(foldableExpr.eval(EmptyRow), a.dataType)
-          if (others.isEmpty) c else Add(others.reduce((x, y) => Add(x, y, f)), c, f)
+          val foldableValue = foldableExpr.eval(EmptyRow)
+          val c = Literal.create(foldableValue, a.dataType)
+          if (others.isEmpty) {
+            Literal.create(foldableValue, a.dataType)
+          } else if (foldableValue == 0) {
+            others.reduce((x, y) => Add(x, y, f))
+          } else {
+            Add(others.reduce((x, y) => Add(x, y, f)), Literal.create(foldableValue, a.dataType), f)
+          }
         } else {
           a
         }
+        newExpr
       case m @ Multiply(_, _, f) if m.deterministic && m.dataType.isInstanceOf[IntegralType] =>
         val (foldables, others) = flattenMultiply(m, groupingExpressionSet).partition(_.foldable)
-        if (foldables.size > 1) {
+        val newExpr = if (foldables.nonEmpty) {
           val foldableExpr = foldables.reduce((x, y) => Multiply(x, y, f))
-          val c = Literal.create(foldableExpr.eval(EmptyRow), m.dataType)
-          if (others.isEmpty) c else Multiply(others.reduce((x, y) => Multiply(x, y, f)), c, f)
+          val foldableValue = foldableExpr.eval(EmptyRow)
+          if (others.isEmpty || foldableValue == 0) {
+            Literal.create(foldableValue, m.dataType)
+          } else if (foldableValue == 1) {
+            others.reduce((x, y) => Multiply(x, y, f))
+          } else {
+            Multiply(others.reduce((x, y) => Multiply(x, y, f)),
+              Literal.create(foldableValue, m.dataType), f)
+          }
         } else {
           m
         }
+        newExpr
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -278,7 +278,7 @@ object ReorderAssociativeOperator extends Rule[LogicalPlan] {
         if (foldables.nonEmpty) {
           val foldableExpr = foldables.reduce((x, y) => Multiply(x, y, f))
           val foldableValue = foldableExpr.eval(EmptyRow)
-          if (others.isEmpty || foldableValue == 0) {
+          if (others.isEmpty || (foldableValue == 0 && !m.nullable)) {
             Literal.create(foldableValue, m.dataType)
           } else if (foldableValue == 1) {
             others.reduce((x, y) => Multiply(x, y, f))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/expressions.scala
@@ -260,10 +260,9 @@ object ReorderAssociativeOperator extends Rule[LogicalPlan] {
       q.transformExpressionsDownWithPruning(_.containsPattern(BINARY_ARITHMETIC)) {
       case a @ Add(_, _, f) if a.deterministic && a.dataType.isInstanceOf[IntegralType] =>
         val (foldables, others) = flattenAdd(a, groupingExpressionSet).partition(_.foldable)
-        val newExpr = if (foldables.nonEmpty) {
+        if (foldables.nonEmpty) {
           val foldableExpr = foldables.reduce((x, y) => Add(x, y, f))
           val foldableValue = foldableExpr.eval(EmptyRow)
-          val c = Literal.create(foldableValue, a.dataType)
           if (others.isEmpty) {
             Literal.create(foldableValue, a.dataType)
           } else if (foldableValue == 0) {
@@ -274,10 +273,9 @@ object ReorderAssociativeOperator extends Rule[LogicalPlan] {
         } else {
           a
         }
-        newExpr
       case m @ Multiply(_, _, f) if m.deterministic && m.dataType.isInstanceOf[IntegralType] =>
         val (foldables, others) = flattenMultiply(m, groupingExpressionSet).partition(_.foldable)
-        val newExpr = if (foldables.nonEmpty) {
+        if (foldables.nonEmpty) {
           val foldableExpr = foldables.reduce((x, y) => Multiply(x, y, f))
           val foldableValue = foldableExpr.eval(EmptyRow)
           if (others.isEmpty || foldableValue == 0) {
@@ -291,7 +289,6 @@ object ReorderAssociativeOperator extends Rule[LogicalPlan] {
         } else {
           m
         }
-        newExpr
     }
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReorderAssociativeOperatorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReorderAssociativeOperatorSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.catalyst.optimizer
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.aggregate.Count
 import org.apache.spark.sql.catalyst.plans.{Inner, PlanTest}
 import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
@@ -81,6 +82,7 @@ class ReorderAssociativeOperatorSuite extends PlanTest {
         $"a" + 0,
         Literal(-3) + $"a" + 3,
         $"b" * 0 * 1 * 2 * 3,
+        Count($"b") * 0,
         $"b" * 1 * 1,
         ($"b" + 0) * 1 * 2 * 3 * 4,
         $"a" + 0 + $"b" + 0 + $"c" + 0,
@@ -95,6 +97,7 @@ class ReorderAssociativeOperatorSuite extends PlanTest {
           $"a".as("(a + 0)"),
           $"a".as("((-3 + a) + 3)"),
           ($"b" * 0).as("((((b * 0) * 1) * 2) * 3)"),
+          Literal(0L).as("(count(b) * 0)"),
           $"b".as("((b * 1) * 1)"),
           ($"b" * 24).as("(((((b + 0) * 1) * 2) * 3) * 4)"),
           ($"a" + $"b" + $"c").as("""(((((a + 0) + b) + 0) + c) + 0)"""),

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReorderAssociativeOperatorSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/ReorderAssociativeOperatorSuite.scala
@@ -94,7 +94,7 @@ class ReorderAssociativeOperatorSuite extends PlanTest {
         .select(
           $"a".as("(a + 0)"),
           $"a".as("((-3 + a) + 3)"),
-          Literal(0).as("((((b * 0) * 1) * 2) * 3)"),
+          ($"b" * 0).as("((((b * 0) * 1) * 2) * 3)"),
           $"b".as("((b * 1) * 1)"),
           ($"b" * 24).as("(((((b + 0) * 1) * 2) * 3) * 4)"),
           ($"a" + $"b" + $"c").as("""(((((a + 0) + b) + 0) + c) + 0)"""),

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/null-handling.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/null-handling.sql.out
@@ -70,6 +70,24 @@ Project [a#x, (b#x + c#x) AS (b + c)#x]
 
 
 -- !query
+select b + 0 from t1 where a = 5
+-- !query analysis
+Project [(b#x + 0) AS (b + 0)#x]
++- Filter (a#x = 5)
+   +- SubqueryAlias spark_catalog.default.t1
+      +- Relation spark_catalog.default.t1[a#x,b#x,c#x] parquet
+
+
+-- !query
+select -100 + b + 100 from t1 where a = 5
+-- !query analysis
+Project [((-100 + b#x) + 100) AS ((-100 + b) + 100)#x]
++- Filter (a#x = 5)
+   +- SubqueryAlias spark_catalog.default.t1
+      +- Relation spark_catalog.default.t1[a#x,b#x,c#x] parquet
+
+
+-- !query
 select a+10, b*0 from t1
 -- !query analysis
 Project [(a#x + 10) AS (a + 10)#x, (b#x * 0) AS (b * 0)#x]

--- a/sql/core/src/test/resources/sql-tests/inputs/null-handling.sql
+++ b/sql/core/src/test/resources/sql-tests/inputs/null-handling.sql
@@ -10,6 +10,8 @@ insert into t1 values(7,null,null);
 
 -- Adding anything to null gives null
 select a, b+c from t1;
+select b + 0 from t1 where a = 5;
+select -100 + b + 100 from t1 where a = 5;
 
 -- Multiplying null by zero gives null
 select a+10, b*0 from t1;

--- a/sql/core/src/test/resources/sql-tests/results/null-handling.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/null-handling.sql.out
@@ -78,6 +78,22 @@ struct<a:int,(b + c):int>
 
 
 -- !query
+select b + 0 from t1 where a = 5
+-- !query schema
+struct<(b + 0):int>
+-- !query output
+NULL
+
+
+-- !query
+select -100 + b + 100 from t1 where a = 5
+-- !query schema
+struct<((-100 + b) + 100):int>
+-- !query output
+NULL
+
+
+-- !query
 select a+10, b*0 from t1
 -- !query schema
 struct<(a + 10):int,(b * 0):int>

--- a/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/jdbc/JDBCV2Suite.scala
@@ -2688,7 +2688,7 @@ class JDBCV2Suite extends QueryTest with SharedSparkSession with ExplainSuiteHel
         val df = sql("SELECT SUM(2147483647 + DEPT) FROM h2.test.employee")
         checkAggregateRemoved(df, ansiMode)
         val expectedPlanFragment = if (ansiMode) {
-          "PushedAggregates: [SUM(2147483647 + DEPT)], " +
+          "PushedAggregates: [SUM(DEPT + 2147483647)], " +
             "PushedFilters: [], " +
             "PushedGroupByExpressions: []"
         } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?

For additions, we omit the `Add` operation if the foldable ones finally result in 0, e.g. `-3 + a + 3` is simplified to `a` instead of `a + 0`.
For multiplication,
- we simplify the expression to `Literal(0, dt)` if the foldable ones finally result in 0 && the expression itself isn't nullable
- we omit the `Multiply` operation if the foldable ones finally result in 1



### Why are the changes needed?

Improve the simplicity of expression evaluation and the opportunities for predicates to be pushed down to data sources  


### Does this PR introduce _any_ user-facing change?

no, the result shall be identical 


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no