### PR TITLE
[SPARK-49615] Bugfix: Make ML column schema validation conforms with spark config `spark.sql.caseSensitive`.

### DIFF
--- a/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
@@ -17,13 +17,14 @@
 
 package org.apache.spark.ml.util
 
+import scala.collection.immutable
+
 import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.linalg.VectorUDT
 import org.apache.spark.sql.catalyst.util.AttributeNameParser
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types._
-
 
 /**
  * Utils for handling schemas.
@@ -217,7 +218,13 @@ private[spark] object SchemaUtils {
     val colSplits = AttributeNameParser.parseAttributeName(colName)
     val fieldOpt = schema.findNestedField(colSplits, resolver = SQLConf.get.resolver)
     if (fieldOpt.isEmpty) {
-      throw new SparkIllegalArgumentException("FIELD_NOT_FOUND")
+      throw new SparkIllegalArgumentException(
+        errorClass = "FIELD_NOT_FOUND",
+        messageParameters = immutable.Map(
+          "fieldName" -> colName,
+          "fields" -> schema.simpleString
+        )
+      )
     }
     fieldOpt.get._2
   }

--- a/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
@@ -19,10 +19,9 @@ package org.apache.spark.ml.util
 
 import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.linalg.VectorUDT
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.util.AttributeNameParser
-import org.apache.spark.sql.types._
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types._
 
 
 /**

--- a/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.ml.util
 
+import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.linalg.VectorUDT
 import org.apache.spark.sql.catalyst.util.AttributeNameParser
@@ -214,7 +215,11 @@ private[spark] object SchemaUtils {
    */
   def getSchemaField(schema: StructType, colName: String): StructField = {
     val colSplits = AttributeNameParser.parseAttributeName(colName)
-    schema.findNestedField(colSplits, resolver = SQLConf.get.resolver).get._2
+    val fieldOpt = schema.findNestedField(colSplits, resolver = SQLConf.get.resolver)
+    if (fieldOpt.isEmpty) {
+      throw new SparkIllegalArgumentException("FIELD_NOT_FOUND")
+    }
+    fieldOpt.get._2
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
@@ -215,15 +215,7 @@ private[spark] object SchemaUtils {
    */
   def getSchemaField(schema: StructType, colName: String): StructField = {
     val colSplits = AttributeNameParser.parseAttributeName(colName)
-    val sqlConf = SparkSession.getActiveSession.get.sessionState.conf
-    val caseSensitive = sqlConf.getConf(SQLConf.CASE_SENSITIVE)
-
-    val field = if (caseSensitive) {
-      schema.findNestedField(colSplits).get._2
-    } else {
-      schema.findNestedFieldIgnoreCase(colSplits).get
-    }
-    field
+    schema.findNestedField(colSplits, resolver = SQLConf.get.resolver).get._2
   }
 
   /**

--- a/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
+++ b/mllib/src/main/scala/org/apache/spark/ml/util/SchemaUtils.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.ml.util
 
-import scala.collection.immutable
-
 import org.apache.spark.SparkIllegalArgumentException
 import org.apache.spark.ml.attribute._
 import org.apache.spark.ml.linalg.VectorUDT

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -377,62 +377,6 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
     findFieldInStruct(this, fieldNames, Nil)
   }
 
-  /**
-   * Returns a field in this struct and its child structs, case insensitively. This is slightly less
-   * performant than the case sensitive version.
-   *
-   * If includeCollections is true, this will return fields that are nested in maps and arrays.
-   *
-   * @param fieldNames The path to the field, in order from the root. For example, the column
-   *                   nested.a.b.c would be Seq("nested", "a", "b", "c").
-   */
-  private[spark] def findNestedFieldIgnoreCase(
-      fieldNames: Seq[String],
-      includeCollections: Boolean = false): Option[StructField] = {
-    val fieldOption = fieldNames.headOption.flatMap {
-      fieldName => this.find(_.name.equalsIgnoreCase(fieldName))
-    }
-    fieldOption match {
-      case Some(field) =>
-        (fieldNames.tail, field.dataType, includeCollections) match {
-          case (Seq(), _, _) =>
-            Some(field)
-
-          case (names, struct: StructType, _) =>
-            struct.findNestedFieldIgnoreCase(names, includeCollections)
-
-          case (_, _, false) =>
-            None // types nested in maps and arrays are not used
-
-          case (Seq("key"), MapType(keyType, _, _), true) =>
-            // return the key type as a struct field to include nullability
-            Some(StructField("key", keyType, nullable = false))
-
-          case (Seq("key", names @ _*), MapType(struct: StructType, _, _), true) =>
-            struct.findNestedFieldIgnoreCase(names, includeCollections)
-
-          case (Seq("value"), MapType(_, valueType, isNullable), true) =>
-            // return the value type as a struct field to include nullability
-            Some(StructField("value", valueType, nullable = isNullable))
-
-          case (Seq("value", names @ _*), MapType(_, struct: StructType, _), true) =>
-            struct.findNestedFieldIgnoreCase(names, includeCollections)
-
-          case (Seq("element"), ArrayType(elementType, isNullable), true) =>
-            // return the element type as a struct field to include nullability
-            Some(StructField("element", elementType, nullable = isNullable))
-
-          case (Seq("element", names @ _*), ArrayType(struct: StructType, _), true) =>
-            struct.findNestedFieldIgnoreCase(names, includeCollections)
-
-          case _ =>
-            None
-        }
-      case _ =>
-        None
-    }
-  }
-
   def treeString: String = treeString(Int.MaxValue)
 
   def treeString(maxDepth: Int): String = {

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/StructType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/StructType.scala
@@ -321,7 +321,7 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
    *
    * If includeCollections is true, this will return fields that are nested in maps and arrays.
    */
-  private[sql] def findNestedField(
+  private[spark] def findNestedField(
       fieldNames: Seq[String],
       includeCollections: Boolean = false,
       resolver: SqlApiAnalysis.Resolver = _ == _,
@@ -375,6 +375,62 @@ case class StructType(fields: Array[StructField]) extends DataType with Seq[Stru
     }
 
     findFieldInStruct(this, fieldNames, Nil)
+  }
+
+  /**
+   * Returns a field in this struct and its child structs, case insensitively. This is slightly less
+   * performant than the case sensitive version.
+   *
+   * If includeCollections is true, this will return fields that are nested in maps and arrays.
+   *
+   * @param fieldNames The path to the field, in order from the root. For example, the column
+   *                   nested.a.b.c would be Seq("nested", "a", "b", "c").
+   */
+  private[spark] def findNestedFieldIgnoreCase(
+      fieldNames: Seq[String],
+      includeCollections: Boolean = false): Option[StructField] = {
+    val fieldOption = fieldNames.headOption.flatMap {
+      fieldName => this.find(_.name.equalsIgnoreCase(fieldName))
+    }
+    fieldOption match {
+      case Some(field) =>
+        (fieldNames.tail, field.dataType, includeCollections) match {
+          case (Seq(), _, _) =>
+            Some(field)
+
+          case (names, struct: StructType, _) =>
+            struct.findNestedFieldIgnoreCase(names, includeCollections)
+
+          case (_, _, false) =>
+            None // types nested in maps and arrays are not used
+
+          case (Seq("key"), MapType(keyType, _, _), true) =>
+            // return the key type as a struct field to include nullability
+            Some(StructField("key", keyType, nullable = false))
+
+          case (Seq("key", names @ _*), MapType(struct: StructType, _, _), true) =>
+            struct.findNestedFieldIgnoreCase(names, includeCollections)
+
+          case (Seq("value"), MapType(_, valueType, isNullable), true) =>
+            // return the value type as a struct field to include nullability
+            Some(StructField("value", valueType, nullable = isNullable))
+
+          case (Seq("value", names @ _*), MapType(_, struct: StructType, _), true) =>
+            struct.findNestedFieldIgnoreCase(names, includeCollections)
+
+          case (Seq("element"), ArrayType(elementType, isNullable), true) =>
+            // return the element type as a struct field to include nullability
+            Some(StructField("element", elementType, nullable = isNullable))
+
+          case (Seq("element", names @ _*), ArrayType(struct: StructType, _), true) =>
+            struct.findNestedFieldIgnoreCase(names, includeCollections)
+
+          case _ =>
+            None
+        }
+      case _ =>
+        None
+    }
   }
 
   def treeString: String = treeString(Int.MaxValue)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Bugfix: Make ML column schema validation conforms with spark config `spark.sql.caseSensitive`.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Bugfix: Make ML column schema validation conforms with spark config `spark.sql.caseSensitive`.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
N/A

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
N/A