### PR TITLE
[SPARK-49920][INFRA] Install `R` for `ubuntu 24.04` when GA run `k8s-integration-tests`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1114,8 +1114,8 @@ jobs:
           java-version: ${{ inputs.java }}
       - name: Install R
         run: |
-          apt update
-          apt-get install r-base
+          sudo apt update
+          sudo apt-get install r-base
       - name: Start Minikube
         uses: medyagh/setup-minikube@v0.0.18
         with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1112,6 +1112,10 @@ jobs:
         with:
           distribution: zulu
           java-version: ${{ inputs.java }}
+      - name: Install R
+        run: |
+          apt update
+          apt-get install r-base
       - name: Start Minikube
         uses: medyagh/setup-minikube@v0.0.18
         with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1074,7 +1074,7 @@ jobs:
     needs: precondition
     if: fromJson(needs.precondition.outputs.required).k8s-integration-tests == 'true'
     name: Run Spark on Kubernetes Integration test
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
       - name: Checkout Spark repository

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1074,7 +1074,7 @@ jobs:
     needs: precondition
     if: fromJson(needs.precondition.outputs.required).k8s-integration-tests == 'true'
     name: Run Spark on Kubernetes Integration test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 180
     steps:
       - name: Checkout Spark repository

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala
@@ -30,6 +30,7 @@ import org.apache.spark.launcher.SparkLauncher
 
 private[spark] trait BasicTestsSuite { k8sSuite: KubernetesSuite =>
 
+
   import BasicTestsSuite._
   import KubernetesSuite.{k8sTestTag, localTestTag}
   import KubernetesSuite.{TIMEOUT, INTERVAL}

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/BasicTestsSuite.scala
@@ -30,7 +30,6 @@ import org.apache.spark.launcher.SparkLauncher
 
 private[spark] trait BasicTestsSuite { k8sSuite: KubernetesSuite =>
 
-
   import BasicTestsSuite._
   import KubernetesSuite.{k8sTestTag, localTestTag}
   import KubernetesSuite.{TIMEOUT, INTERVAL}


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to install `R` for `ubuntu 24.04` when GA run `k8s-integration-tests`.


### Why are the changes needed?
- As the GitHub community switches the default version of `ubuntu-latest` from `ubuntu-22.04` to `ubuntu-24.04`.
https://github.com/actions/runner-images/issues/10636

- In `ubuntu-24.04`, `R` is `not installed` by default
  A.`ubuntu-24.04`(`R` is `not installed` by default)
  https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#tools
  <img width="342" alt="image" src="https://github.com/user-attachments/assets/23e4d377-ba7c-4969-b720-5c8ff9790985">

  B.`ubuntu-22.04`(`R` is `installed` by default)
  https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#tools
  <img width="356" alt="image" src="https://github.com/user-attachments/assets/126861df-d1a0-49d9-b52d-48102ab2db74">

 

- Fix the failure issue of GA
  https://github.com/LuciferYang/spark/actions/runs/11268158324/job/31334445659
  <img width="959" alt="image" src="https://github.com/user-attachments/assets/4bfd8da4-4ced-422a-9ea7-dbdf6478675b">

### Does this PR introduce _any_ user-facing change?
No, only for tests.

### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
