### PR TITLE
[SPARK-49921][CORE] Add task write data time to SQL tab's graph node

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/DataWriter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/DataWriter.java
@@ -109,6 +109,11 @@ public interface DataWriter<T> extends Closeable {
    */
   WriterCommitMessage commit() throws IOException;
 
+  default WriterCommitMessage commit(long taskWriteDataTime) throws IOException {
+    // Do nothing
+    return null;
+  }
+
   /**
    * Aborts this writer if it is failed. Implementations should clean up the data for already
    * written records.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatDataWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatDataWriter.scala
@@ -127,7 +127,18 @@ abstract class FileFormatDataWriter(
     }
     val summary = ExecutedWriteSummary(
       updatedPartitions = updatedPartitions.toSet,
-      stats = statsTrackers.map(_.getFinalStats(taskCommitTime)))
+      stats = statsTrackers.map(_.getFinalStats(taskCommitTime, 0)))
+    WriteTaskResult(taskCommitMessage, summary)
+  }
+
+  override def commit(taskWriteDataTime: Long): WriteTaskResult = {
+    releaseResources()
+    val (taskCommitMessage, taskCommitTime) = Utils.timeTakenMs {
+      committer.commitTask(taskAttemptContext)
+    }
+    val summary = ExecutedWriteSummary(
+      updatedPartitions = updatedPartitions.toSet,
+      stats = statsTrackers.map(_.getFinalStats(taskCommitTime, taskWriteDataTime)))
     WriteTaskResult(taskCommitMessage, summary)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatWriter.scala
@@ -404,7 +404,10 @@ object FileFormatWriter extends Logging {
 
       // Execute the task to write rows out and commit the task.
       dataWriter.writeWithIterator(iterator)
-      dataWriter.commit()
+      val (_, taskWriteDataTime) = Utils.timeTakenMs {
+        dataWriter.writeWithIterator(iterator)
+      }
+      dataWriter.commit(taskWriteDataTime)
     })(catchBlock = {
       // If there is an error, abort the task
       if (dataWriter != null) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/WriteStatsTracker.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/WriteStatsTracker.scala
@@ -70,7 +70,7 @@ trait WriteTaskStatsTracker {
    * @note This may only be called once. Further use of the object may lead to undefined behavior.
    * @return An object of subtype of [[WriteTaskStats]], to be sent to the driver.
    */
-  def getFinalStats(taskCommitTime: Long): WriteTaskStats
+  def getFinalStats(taskCommitTime: Long, taskWriteDataTime: Long): WriteTaskStats
 }
 
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/BasicWriteTaskStatsTrackerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/BasicWriteTaskStatsTrackerSuite.scala
@@ -73,7 +73,7 @@ class BasicWriteTaskStatsTrackerSuite extends SparkFunSuite {
   }
 
   private def finalStatus(tracker: BasicWriteTaskStatsTracker): BasicWriteTaskStats = {
-    tracker.getFinalStats(0L).asInstanceOf[BasicWriteTaskStats]
+    tracker.getFinalStats(0L, 0L).asInstanceOf[BasicWriteTaskStats]
   }
 
   test("No files in run") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/CustomWriteTaskStatsTrackerSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/CustomWriteTaskStatsTrackerSuite.scala
@@ -25,7 +25,8 @@ import org.apache.spark.sql.catalyst.InternalRow
 class CustomWriteTaskStatsTrackerSuite extends SparkFunSuite {
 
   def checkFinalStats(tracker: CustomWriteTaskStatsTracker, result: Map[String, Int]): Unit = {
-    assert(tracker.getFinalStats(0L).asInstanceOf[CustomWriteTaskStats].numRowsPerFile == result)
+    assert(tracker.getFinalStats(0L, 0L)
+      .asInstanceOf[CustomWriteTaskStats].numRowsPerFile == result)
   }
 
   test("sequential file writing") {
@@ -64,7 +65,7 @@ class CustomWriteTaskStatsTracker extends WriteTaskStatsTracker {
     numRowsPerFile(filePath) += 1
   }
 
-  override def getFinalStats(taskCommitTime: Long): WriteTaskStats = {
+  override def getFinalStats(taskCommitTime: Long, taskWriteDataTime: Long): WriteTaskStats = {
     CustomWriteTaskStats(numRowsPerFile.toMap)
   }
 }


### PR DESCRIPTION

### What changes were proposed in this pull request?
Add task write data time to SQL tab's graph node. After adding the metric, the following figure is shown.
<img width="441" alt="image" src="https://github.com/user-attachments/assets/64b864b5-52cb-4bc2-8f04-8c5cdc26d3d4">



### Why are the changes needed?
To facilitate viewing of how much time the write operator uses, to help optimize performance, and to view task bottlenecks


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Tests were added


### Was this patch authored or co-authored using generative AI tooling?
No
