### PR TITLE
[SPARK-49922][BUILD] Upgrade `sbt-assembly` to `2.3.0`

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -24,7 +24,7 @@ libraryDependencies += "com.puppycrawl.tools" % "checkstyle" % "10.17.0"
 // checkstyle uses guava 33.1.0-jre.
 libraryDependencies += "com.google.guava" % "guava" % "33.1.0-jre"
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.2.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-eclipse" % "6.2.0")
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `sbt-assembly` from `2.2.0` to `2.3.0`

### Why are the changes needed?
- `sbt-assembly`, the full release notes: https://github.com/sbt/sbt-assembly/releases/tag/v2.3.0
- Bug fixed:
  Fixes assembly not creating parent directories by @Roiocam in https://github.com/sbt/sbt-assembly/pull/525
  Throws error when a misconfigured assemblyOutputPath is detected by @hygt in https://github.com/sbt/sbt-assembly/pull/523

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
