### PR TITLE
[SPARK-49930][SS] Ensure that socket updates are flushed on exception from the python worker

### DIFF
--- a/python/pyspark/sql/streaming/python_streaming_source_runner.py
+++ b/python/pyspark/sql/streaming/python_streaming_source_runner.py
@@ -193,6 +193,8 @@ def main(infile: IO, outfile: IO) -> None:
             reader.stop()
     except BaseException as e:
         handle_worker_exception(e, outfile)
+        # ensure that the updates to the socket are flushed
+        outfile.flush()
         sys.exit(-1)
     send_accumulator_updates(outfile)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Ensure that socket updates are flushed on exception from the python worker


### Why are the changes needed?
Without this, updates to the socket from the python worker are not delivered to the jvm side


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests were failing on a different Python version and pass after

```
Run completed in 1 minute, 13 seconds.
Total number of tests run: 8
Suites: completed 1, aborted 0
Tests: succeeded 8, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
```

### Was this patch authored or co-authored using generative AI tooling?
No
