### PR TITLE
[SPARK-49927][SS][PYTHON][TESTS][FOLLOW-UP] Fixes `q.lastProgress.batchId` to `q.lastProgress.progress.batchId`

### DIFF
--- a/python/pyspark/sql/tests/streaming/test_streaming_listener.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_listener.py
@@ -230,7 +230,7 @@ class StreamingListenerTestsMixin:
 
             q = observed_ds.writeStream.format("noop").start()
 
-            while q.lastProgress is None or q.lastProgress.batchId == 0:
+            while q.lastProgress is None or q.lastProgress.progress.batchId == 0:
                 q.awaitTermination(0.5)
 
             time.sleep(5)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/pull/48414 that fixes `q.lastProgress.batchId` -> `q.lastProgress.progress.batchId` to fix the test.

### Why are the changes needed?

`q.lastProgress` does not have `progress`. We should fix it to fix up the broken build.

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually

### Was this patch authored or co-authored using generative AI tooling?

No.