### PR TITLE
[SPARK-49932][CORE] Use `tryWithResource` release `JsonUtils#toJsonString` resources to avoid memory leaks

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/util/JsonUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/JsonUtils.scala
@@ -35,8 +35,8 @@ private[spark] trait JsonUtils {
     tryWithResource(new ByteArrayOutputStream()) { baos =>
       tryWithResource(mapper.createGenerator(baos, JsonEncoding.UTF8)) { generator =>
         block(generator)
-        new String(baos.toByteArray, StandardCharsets.UTF_8)
       }
+      new String(baos.toByteArray, StandardCharsets.UTF_8)
     }
   }
 }

--- a/common/utils/src/main/scala/org/apache/spark/util/JsonUtils.scala
+++ b/common/utils/src/main/scala/org/apache/spark/util/JsonUtils.scala
@@ -31,12 +31,21 @@ private[spark] trait JsonUtils {
     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
   def toJsonString(block: JsonGenerator => Unit): String = {
-    val baos = new ByteArrayOutputStream()
-    val generator = mapper.createGenerator(baos, JsonEncoding.UTF8)
-    block(generator)
-    generator.close()
-    baos.close()
-    new String(baos.toByteArray, StandardCharsets.UTF_8)
+    var baos: ByteArrayOutputStream = null
+    var generator: JsonGenerator = null
+    try {
+      baos = new ByteArrayOutputStream()
+      generator = mapper.createGenerator(baos, JsonEncoding.UTF8)
+      block(generator)
+      new String(baos.toByteArray, StandardCharsets.UTF_8)
+    } finally {
+      if (generator != null) {
+        generator.close()
+      }
+      if (baos != null) {
+        baos.close()
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to use `tryWithResource` release `JsonUtils#toJsonString` resources to avoid memory leaks.


### Why are the changes needed?
Avoiding potential memory leaks.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
