### PR TITLE
[SPARK-49927][SS][PYTHON][TESTS] pyspark.sql.tests.streaming.test_streaming_listener to wait for longer

### DIFF
--- a/python/pyspark/sql/tests/streaming/test_streaming_listener.py
+++ b/python/pyspark/sql/tests/streaming/test_streaming_listener.py
@@ -381,7 +381,12 @@ class StreamingListenerTests(StreamingListenerTestsMixin, ReusedSQLTestCase):
                     .start()
                 )
                 self.assertTrue(q.isActive)
-                q.awaitTermination(10)
+                wait_count = 0
+                while progress_event is None or progress_event.progress.batchId == 0:
+                    q.awaitTermination(0.5)
+                    wait_count = wait_count + 1
+                    if wait_count > 100:
+                        self.fail("Not getting progress event after 50 seconds")
                 q.stop()
 
                 # Make sure all events are empty


### PR DESCRIPTION

### What changes were proposed in this pull request?
In test pyspark.sql.tests.streaming.test_streaming_listener, instead of waiting for fixed 10 seconds, we wait for progress made.


### Why are the changes needed?
In some environment, the test fails with progress_event appears to be None. Likely the wait time is not sufficient.



### Does this PR introduce _any_ user-facing change?
No, test-only.

### How was this patch tested?
Run the patch and make sure it still passes




### Was this patch authored or co-authored using generative AI tooling?
No
