### PR TITLE
[MINOR][CORE] Fix the regenerate command in `SparkThrowableSuite`

### DIFF
--- a/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
+++ b/core/src/test/scala/org/apache/spark/SparkThrowableSuite.scala
@@ -47,7 +47,7 @@ class SparkThrowableSuite extends SparkFunSuite {
    }}}
    */
   private val regenerateCommand = "SPARK_GENERATE_GOLDEN_FILES=1 build/sbt " +
-    "\"core/testOnly *SparkThrowableSuite -- -t \\\"Error classes match with document\\\"\""
+    "\"core/testOnly *SparkThrowableSuite -- -t \\\"Error conditions are correctly formatted\\\"\""
 
   private val errorJsonFilePath = getWorkspaceFilePath(
     "common", "utils", "src", "main", "resources", "error", "error-conditions.json")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the command in `SparkThrowableSuite` which regenerates/re-formats `error-conditions.json`.

### Why are the changes needed?
To don't confuses other devs.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running the changes command:
```
$ SPARK_GENERATE_GOLDEN_FILES=1 build/sbt "core/testOnly *SparkThrowableSuite -- -t \"Error conditions are correctly formatted\""
```

### Was this patch authored or co-authored using generative AI tooling?
No.