### PR TITLE
[SPARK-37687][K8S] Removes the compile time dependency on the OkHttp http client

### DIFF
--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
@@ -79,8 +79,6 @@ object SparkKubernetesClientFactory extends Logging {
       .getOption(s"$kubernetesAuthConfPrefix.$CLIENT_KEY_FILE_CONF_SUFFIX")
     val clientCertFile = sparkConf
       .getOption(s"$kubernetesAuthConfPrefix.$CLIENT_CERT_FILE_CONF_SUFFIX")
-    // TODO(SPARK-37687): clean up direct usage of OkHttpClient, see also:
-    // https://github.com/fabric8io/kubernetes-client/issues/3547
 
     // Allow for specifying a context used to auto-configure from the users K8S config file
     val kubeContext = sparkConf.get(KUBERNETES_CONTEXT).filter(_.nonEmpty)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
@@ -106,12 +106,11 @@ object SparkKubernetesClientFactory extends Logging {
         (token, configBuilder) => configBuilder.withOauthToken(token)
       }
       .withOption(oauthTokenFile) {
-        (file, configBuilder) => configBuilder.withOauthToken(Files.asCharSource(file, Charsets.UTF_8).read())
-      }
-      .withOption(caCertFile) {
+        (file, configBuilder) =>
+          configBuilder.withOauthToken(Files.asCharSource(file, Charsets.UTF_8).read())
+      }.withOption(caCertFile) {
         (file, configBuilder) => configBuilder.withCaCertFile(file)
-      }
-      .withOption(clientKeyFile) {
+      }.withOption(clientKeyFile) {
         (file, configBuilder) => configBuilder.withClientKeyFile(file)
       }.withOption(clientCertFile) {
         (file, configBuilder) => configBuilder.withClientCertFile(file)

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
@@ -24,10 +24,7 @@ import com.google.common.io.Files
 import io.fabric8.kubernetes.client.{ConfigBuilder, KubernetesClient, KubernetesClientBuilder}
 import io.fabric8.kubernetes.client.Config.KUBERNETES_REQUEST_RETRY_BACKOFFLIMIT_SYSTEM_PROPERTY
 import io.fabric8.kubernetes.client.Config.autoConfigure
-import io.fabric8.kubernetes.client.okhttp.OkHttpClientFactory
 import io.fabric8.kubernetes.client.utils.Utils.getSystemPropertyOrEnvVar
-import okhttp3.Dispatcher
-import okhttp3.OkHttpClient
 
 import org.apache.spark.SparkConf
 import org.apache.spark.annotation.{DeveloperApi, Since, Stable}
@@ -35,7 +32,6 @@ import org.apache.spark.deploy.k8s.Config._
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys.K8S_CONTEXT
 import org.apache.spark.internal.config.ConfigEntry
-import org.apache.spark.util.ThreadUtils
 
 /**
  * :: DeveloperApi ::
@@ -62,7 +58,8 @@ object SparkKubernetesClientFactory extends Logging {
       defaultServiceAccountCaCert: Option[File]): KubernetesClient = {
     val oauthTokenFileConf = s"$kubernetesAuthConfPrefix.$OAUTH_TOKEN_FILE_CONF_SUFFIX"
     val oauthTokenConf = s"$kubernetesAuthConfPrefix.$OAUTH_TOKEN_CONF_SUFFIX"
-    val oauthTokenFile = sparkConf.getOption(oauthTokenFileConf)
+    val oauthTokenFile = sparkConf
+      .getOption(oauthTokenFileConf)
       .map(new File(_))
     val oauthTokenValue = sparkConf.getOption(oauthTokenConf)
     KubernetesUtils.requireNandDefined(
@@ -80,17 +77,17 @@ object SparkKubernetesClientFactory extends Logging {
       .getOption(s"$kubernetesAuthConfPrefix.$CLIENT_CERT_FILE_CONF_SUFFIX")
     // TODO(SPARK-37687): clean up direct usage of OkHttpClient, see also:
     // https://github.com/fabric8io/kubernetes-client/issues/3547
-    val dispatcher = new Dispatcher(
-      ThreadUtils.newDaemonCachedThreadPool("kubernetes-dispatcher"))
 
     // Allow for specifying a context used to auto-configure from the users K8S config file
     val kubeContext = sparkConf.get(KUBERNETES_CONTEXT).filter(_.nonEmpty)
-    logInfo(log"Auto-configuring K8S client using " +
-      log"${MDC(K8S_CONTEXT, kubeContext.map("context " + _).getOrElse("current context"))}" +
-      log" from users K8S config file")
+    logInfo(
+      log"Auto-configuring K8S client using " +
+        log"${MDC(K8S_CONTEXT, kubeContext.map("context " + _).getOrElse("current context"))}" +
+        log" from users K8S config file")
 
     // if backoff limit is not set then set it to 3
-    if (getSystemPropertyOrEnvVar(KUBERNETES_REQUEST_RETRY_BACKOFFLIMIT_SYSTEM_PROPERTY) == null) {
+    if (getSystemPropertyOrEnvVar(
+        KUBERNETES_REQUEST_RETRY_BACKOFFLIMIT_SYSTEM_PROPERTY) == null) {
       System.setProperty(KUBERNETES_REQUEST_RETRY_BACKOFFLIMIT_SYSTEM_PROPERTY, "3")
     }
 
@@ -103,42 +100,43 @@ object SparkKubernetesClientFactory extends Logging {
       .withRequestTimeout(clientType.requestTimeout(sparkConf))
       .withConnectionTimeout(clientType.connectionTimeout(sparkConf))
       .withTrustCerts(sparkConf.get(KUBERNETES_TRUST_CERTIFICATES))
-      .withOption(oauthTokenValue) {
-        (token, configBuilder) => configBuilder.withOauthToken(token)
-      }.withOption(oauthTokenFile) {
-        (file, configBuilder) =>
-            configBuilder.withOauthToken(Files.asCharSource(file, Charsets.UTF_8).read())
-      }.withOption(caCertFile) {
-        (file, configBuilder) => configBuilder.withCaCertFile(file)
-      }.withOption(clientKeyFile) {
-        (file, configBuilder) => configBuilder.withClientKeyFile(file)
-      }.withOption(clientCertFile) {
-        (file, configBuilder) => configBuilder.withClientCertFile(file)
-      }.withOption(namespace) {
-        (ns, configBuilder) => configBuilder.withNamespace(ns)
-      }.build()
-    val factoryWithCustomDispatcher = new OkHttpClientFactory() {
-      override protected def additionalConfig(builder: OkHttpClient.Builder): Unit = {
-        builder.dispatcher(dispatcher)
+      .withOption(oauthTokenValue) { (token, configBuilder) =>
+        configBuilder.withOauthToken(token)
       }
-    }
-    logDebug("Kubernetes client config: " +
-      new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(config))
+      .withOption(oauthTokenFile) { (file, configBuilder) =>
+        configBuilder.withOauthToken(Files.asCharSource(file, Charsets.UTF_8).read())
+      }
+      .withOption(caCertFile) { (file, configBuilder) =>
+        configBuilder.withCaCertFile(file)
+      }
+      .withOption(clientKeyFile) { (file, configBuilder) =>
+        configBuilder.withClientKeyFile(file)
+      }
+      .withOption(clientCertFile) { (file, configBuilder) =>
+        configBuilder.withClientCertFile(file)
+      }
+      .withOption(namespace) { (ns, configBuilder) =>
+        configBuilder.withNamespace(ns)
+      }
+      .build()
+    logDebug(
+      "Kubernetes client config: " +
+        new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(config))
     new KubernetesClientBuilder()
-      .withHttpClientFactory(factoryWithCustomDispatcher)
       .withConfig(config)
       .build()
   }
 
   private implicit class OptionConfigurableConfigBuilder(val configBuilder: ConfigBuilder)
-    extends AnyVal {
+      extends AnyVal {
 
-    def withOption[T]
-        (option: Option[T])
-        (configurator: ((T, ConfigBuilder) => ConfigBuilder)): ConfigBuilder = {
-      option.map { opt =>
-        configurator(opt, configBuilder)
-      }.getOrElse(configBuilder)
+    def withOption[T](option: Option[T])(
+        configurator: ((T, ConfigBuilder) => ConfigBuilder)): ConfigBuilder = {
+      option
+        .map { opt =>
+          configurator(opt, configBuilder)
+        }
+        .getOrElse(configBuilder)
     }
   }
 
@@ -150,7 +148,7 @@ object SparkKubernetesClientFactory extends Logging {
     protected case class Val(
         requestTimeoutEntry: ConfigEntry[Int],
         connectionTimeoutEntry: ConfigEntry[Int])
-      extends super.Val {
+        extends super.Val {
       def requestTimeout(conf: SparkConf): Int = conf.get(requestTimeoutEntry)
       def connectionTimeout(conf: SparkConf): Int = conf.get(connectionTimeoutEntry)
     }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
@@ -85,8 +85,8 @@ object SparkKubernetesClientFactory extends Logging {
     // Allow for specifying a context used to auto-configure from the users K8S config file
     val kubeContext = sparkConf.get(KUBERNETES_CONTEXT).filter(_.nonEmpty)
     logInfo(log"Auto-configuring K8S client using " +
-        log"${MDC(K8S_CONTEXT, kubeContext.map("context " + _).getOrElse("current context"))}" +
-        log" from users K8S config file")
+      log"${MDC(K8S_CONTEXT, kubeContext.map("context " + _).getOrElse("current context"))}" +
+      log" from users K8S config file")
 
     // if backoff limit is not set then set it to 3
     if (getSystemPropertyOrEnvVar(KUBERNETES_REQUEST_RETRY_BACKOFFLIMIT_SYSTEM_PROPERTY) == null) {
@@ -102,8 +102,8 @@ object SparkKubernetesClientFactory extends Logging {
       .withRequestTimeout(clientType.requestTimeout(sparkConf))
       .withConnectionTimeout(clientType.connectionTimeout(sparkConf))
       .withTrustCerts(sparkConf.get(KUBERNETES_TRUST_CERTIFICATES))
-      .withOption(oauthTokenValue) { (token, configBuilder) =>
-        configBuilder.withOauthToken(token)
+      .withOption(oauthTokenValue) {
+        (token, configBuilder) => configBuilder.withOauthToken(token)
       }
       .withOption(oauthTokenFile) {
         (file, configBuilder) => configBuilder.withOauthToken(Files.asCharSource(file, Charsets.UTF_8).read())
@@ -113,11 +113,9 @@ object SparkKubernetesClientFactory extends Logging {
       }
       .withOption(clientKeyFile) {
         (file, configBuilder) => configBuilder.withClientKeyFile(file)
-      }
-      .withOption(clientCertFile) {
+      }.withOption(clientCertFile) {
         (file, configBuilder) => configBuilder.withClientCertFile(file)
-      }
-      .withOption(namespace) {
+      }.withOption(namespace) {
         (ns, configBuilder) => configBuilder.withNamespace(ns)
       }
       .build()
@@ -143,11 +141,11 @@ object SparkKubernetesClientFactory extends Logging {
     extends AnyVal {
 
     def withOption[T]
-        (option: Option[T])(
-        configurator: ((T, ConfigBuilder) => ConfigBuilder)): ConfigBuilder = {
+        (option: Option[T])
+        (configurator: ((T, ConfigBuilder) => ConfigBuilder)): ConfigBuilder = {
       option.map { opt =>
-          configurator(opt, configBuilder)
-        }.getOrElse(configBuilder)
+        configurator(opt, configBuilder)
+      }.getOrElse(configBuilder)
     }
   }
 

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
@@ -27,7 +27,8 @@ import io.fabric8.kubernetes.client.Config.autoConfigure
 import io.fabric8.kubernetes.client.okhttp.OkHttpClientFactory
 import io.fabric8.kubernetes.client.utils.HttpClientUtils
 import io.fabric8.kubernetes.client.utils.Utils.getSystemPropertyOrEnvVar
-import okhttp3.{Dispatcher, OkHttpClient}
+import okhttp3.Dispatcher
+import okhttp3.OkHttpClient
 
 import org.apache.spark.SparkConf
 import org.apache.spark.annotation.{DeveloperApi, Since, Stable}
@@ -62,8 +63,7 @@ object SparkKubernetesClientFactory extends Logging {
       defaultServiceAccountCaCert: Option[File]): KubernetesClient = {
     val oauthTokenFileConf = s"$kubernetesAuthConfPrefix.$OAUTH_TOKEN_FILE_CONF_SUFFIX"
     val oauthTokenConf = s"$kubernetesAuthConfPrefix.$OAUTH_TOKEN_CONF_SUFFIX"
-    val oauthTokenFile = sparkConf
-      .getOption(oauthTokenFileConf)
+    val oauthTokenFile = sparkConf.getOption(oauthTokenFileConf)
       .map(new File(_))
     val oauthTokenValue = sparkConf.getOption(oauthTokenConf)
     KubernetesUtils.requireNandDefined(
@@ -84,14 +84,12 @@ object SparkKubernetesClientFactory extends Logging {
 
     // Allow for specifying a context used to auto-configure from the users K8S config file
     val kubeContext = sparkConf.get(KUBERNETES_CONTEXT).filter(_.nonEmpty)
-    logInfo(
-      log"Auto-configuring K8S client using " +
+    logInfo(log"Auto-configuring K8S client using " +
         log"${MDC(K8S_CONTEXT, kubeContext.map("context " + _).getOrElse("current context"))}" +
         log" from users K8S config file")
 
     // if backoff limit is not set then set it to 3
-    if (getSystemPropertyOrEnvVar(
-        KUBERNETES_REQUEST_RETRY_BACKOFFLIMIT_SYSTEM_PROPERTY) == null) {
+    if (getSystemPropertyOrEnvVar(KUBERNETES_REQUEST_RETRY_BACKOFFLIMIT_SYSTEM_PROPERTY) == null) {
       System.setProperty(KUBERNETES_REQUEST_RETRY_BACKOFFLIMIT_SYSTEM_PROPERTY, "3")
     }
 
@@ -107,24 +105,23 @@ object SparkKubernetesClientFactory extends Logging {
       .withOption(oauthTokenValue) { (token, configBuilder) =>
         configBuilder.withOauthToken(token)
       }
-      .withOption(oauthTokenFile) { (file, configBuilder) =>
-        configBuilder.withOauthToken(Files.asCharSource(file, Charsets.UTF_8).read())
+      .withOption(oauthTokenFile) {
+        (file, configBuilder) => configBuilder.withOauthToken(Files.asCharSource(file, Charsets.UTF_8).read())
       }
-      .withOption(caCertFile) { (file, configBuilder) =>
-        configBuilder.withCaCertFile(file)
+      .withOption(caCertFile) {
+        (file, configBuilder) => configBuilder.withCaCertFile(file)
       }
-      .withOption(clientKeyFile) { (file, configBuilder) =>
-        configBuilder.withClientKeyFile(file)
+      .withOption(clientKeyFile) {
+        (file, configBuilder) => configBuilder.withClientKeyFile(file)
       }
-      .withOption(clientCertFile) { (file, configBuilder) =>
-        configBuilder.withClientCertFile(file)
+      .withOption(clientCertFile) {
+        (file, configBuilder) => configBuilder.withClientCertFile(file)
       }
-      .withOption(namespace) { (ns, configBuilder) =>
-        configBuilder.withNamespace(ns)
+      .withOption(namespace) {
+        (ns, configBuilder) => configBuilder.withNamespace(ns)
       }
       .build()
-    logDebug(
-      "Kubernetes client config: " +
+    logDebug("Kubernetes client config: " +
         new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(config))
     val clientFactory = HttpClientUtils.getHttpClientFactory
     val clientBuilder = new KubernetesClientBuilder().withConfig(config)
@@ -143,15 +140,14 @@ object SparkKubernetesClientFactory extends Logging {
   }
 
   private implicit class OptionConfigurableConfigBuilder(val configBuilder: ConfigBuilder)
-      extends AnyVal {
+    extends AnyVal {
 
-    def withOption[T](option: Option[T])(
+    def withOption[T]
+        (option: Option[T])(
         configurator: ((T, ConfigBuilder) => ConfigBuilder)): ConfigBuilder = {
-      option
-        .map { opt =>
+      option.map { opt =>
           configurator(opt, configBuilder)
-        }
-        .getOrElse(configBuilder)
+        }.getOrElse(configBuilder)
     }
   }
 
@@ -163,7 +159,7 @@ object SparkKubernetesClientFactory extends Logging {
     protected case class Val(
         requestTimeoutEntry: ConfigEntry[Int],
         connectionTimeoutEntry: ConfigEntry[Int])
-        extends super.Val {
+      extends super.Val {
       def requestTimeout(conf: SparkConf): Int = conf.get(requestTimeoutEntry)
       def connectionTimeout(conf: SparkConf): Int = conf.get(connectionTimeoutEntry)
     }

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.deploy.k8s
 
 import java.io.File
+
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.common.base.Charsets
 import com.google.common.io.Files
@@ -27,6 +28,7 @@ import io.fabric8.kubernetes.client.okhttp.OkHttpClientFactory
 import io.fabric8.kubernetes.client.utils.HttpClientUtils
 import io.fabric8.kubernetes.client.utils.Utils.getSystemPropertyOrEnvVar
 import okhttp3.{Dispatcher, OkHttpClient}
+
 import org.apache.spark.SparkConf
 import org.apache.spark.annotation.{DeveloperApi, Since, Stable}
 import org.apache.spark.deploy.k8s.Config._

--- a/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
+++ b/resource-managers/kubernetes/core/src/main/scala/org/apache/spark/deploy/k8s/SparkKubernetesClientFactory.scala
@@ -104,10 +104,9 @@ object SparkKubernetesClientFactory extends Logging {
       .withTrustCerts(sparkConf.get(KUBERNETES_TRUST_CERTIFICATES))
       .withOption(oauthTokenValue) {
         (token, configBuilder) => configBuilder.withOauthToken(token)
-      }
-      .withOption(oauthTokenFile) {
+      }.withOption(oauthTokenFile) {
         (file, configBuilder) =>
-          configBuilder.withOauthToken(Files.asCharSource(file, Charsets.UTF_8).read())
+            configBuilder.withOauthToken(Files.asCharSource(file, Charsets.UTF_8).read())
       }.withOption(caCertFile) {
         (file, configBuilder) => configBuilder.withCaCertFile(file)
       }.withOption(clientKeyFile) {

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/K8sSubmitOpSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/K8sSubmitOpSuite.scala
@@ -18,22 +18,21 @@ package org.apache.spark.deploy.k8s.submit
 
 import java.io.PrintStream
 import java.util.Arrays
-
 import scala.jdk.CollectionConverters._
-
 import io.fabric8.kubernetes.api.model._
 import io.fabric8.kubernetes.client.{KubernetesClient, PropagationPolicyConfigurable}
 import io.fabric8.kubernetes.client.dsl.{Deletable, NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable, PodResource}
+import io.fabric8.kubernetes.client.okhttp.OkHttpClientImpl
 import org.mockito.{ArgumentMatchers, Mock, MockitoAnnotations}
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatest.BeforeAndAfter
-
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.k8s.Config.KUBERNETES_SUBMIT_GRACE_PERIOD
 import org.apache.spark.deploy.k8s.Constants.{SPARK_APP_ID_LABEL, SPARK_POD_DRIVER_ROLE, SPARK_ROLE_LABEL}
 import org.apache.spark.deploy.k8s.Fabric8Aliases.{PODS, PODS_WITH_NAMESPACE}
+import org.apache.spark.deploy.k8s.SparkKubernetesClientFactory
+import org.apache.spark.deploy.k8s.SparkKubernetesClientFactory.ClientType
 import org.apache.spark.scheduler.cluster.k8s.ExecutorLifecycleTestUtils.TEST_SPARK_APP_ID
-
 
 class K8sSubmitOpSuite extends SparkFunSuite with BeforeAndAfter {
   private val driverPodName1 = "driver1"
@@ -62,8 +61,8 @@ class K8sSubmitOpSuite extends SparkFunSuite with BeforeAndAfter {
   private var deletable: PropagationPolicyConfigurable[_ <: Deletable] = _
 
   @Mock
-  private var deletableList:
-    NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable[HasMetadata] = _
+  private var deletableList
+      : NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable[HasMetadata] = _
 
   @Mock
   private var err: PrintStream = _
@@ -133,22 +132,33 @@ class K8sSubmitOpSuite extends SparkFunSuite with BeforeAndAfter {
     // scalastyle:on
   }
 
+  test("Init kubernetes client") {
+    val kubeClient = SparkKubernetesClientFactory.createKubernetesClient(
+      "master",
+      None,
+      "",
+      ClientType.Driver,
+      new SparkConf(false),
+      None)
+    assert(kubeClient.getHttpClient.isInstanceOf[OkHttpClientImpl])
+  }
+
   private def buildDriverPod(podName: String, id: String): Pod = {
     new PodBuilder()
       .withNewMetadata()
-        .withName(podName)
-        .withNamespace(namespace)
-        .addToLabels(SPARK_APP_ID_LABEL, TEST_SPARK_APP_ID)
-        .addToLabels(SPARK_ROLE_LABEL, SPARK_POD_DRIVER_ROLE)
-        .withUid(s"driver-pod-$id")
+      .withName(podName)
+      .withNamespace(namespace)
+      .addToLabels(SPARK_APP_ID_LABEL, TEST_SPARK_APP_ID)
+      .addToLabels(SPARK_ROLE_LABEL, SPARK_POD_DRIVER_ROLE)
+      .withUid(s"driver-pod-$id")
       .endMetadata()
       .withNewSpec()
-        .withServiceAccountName(s"test$id")
-        .withVolumes()
-        .withNodeName(s"testNode$id")
+      .withServiceAccountName(s"test$id")
+      .withVolumes()
+      .withNodeName(s"testNode$id")
       .endSpec()
       .withNewStatus()
-        .withPhase("Running")
+      .withPhase("Running")
       .endStatus()
       .build()
   }

--- a/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/K8sSubmitOpSuite.scala
+++ b/resource-managers/kubernetes/core/src/test/scala/org/apache/spark/deploy/k8s/submit/K8sSubmitOpSuite.scala
@@ -18,7 +18,9 @@ package org.apache.spark.deploy.k8s.submit
 
 import java.io.PrintStream
 import java.util.Arrays
+
 import scala.jdk.CollectionConverters._
+
 import io.fabric8.kubernetes.api.model._
 import io.fabric8.kubernetes.client.{KubernetesClient, PropagationPolicyConfigurable}
 import io.fabric8.kubernetes.client.dsl.{Deletable, NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable, PodResource}
@@ -26,6 +28,7 @@ import io.fabric8.kubernetes.client.okhttp.OkHttpClientImpl
 import org.mockito.{ArgumentMatchers, Mock, MockitoAnnotations}
 import org.mockito.Mockito.{times, verify, when}
 import org.scalatest.BeforeAndAfter
+
 import org.apache.spark.{SparkConf, SparkFunSuite}
 import org.apache.spark.deploy.k8s.Config.KUBERNETES_SUBMIT_GRACE_PERIOD
 import org.apache.spark.deploy.k8s.Constants.{SPARK_APP_ID_LABEL, SPARK_POD_DRIVER_ROLE, SPARK_ROLE_LABEL}
@@ -61,8 +64,8 @@ class K8sSubmitOpSuite extends SparkFunSuite with BeforeAndAfter {
   private var deletable: PropagationPolicyConfigurable[_ <: Deletable] = _
 
   @Mock
-  private var deletableList
-      : NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable[HasMetadata] = _
+  private var deletableList:
+    NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable[HasMetadata] = _
 
   @Mock
   private var err: PrintStream = _
@@ -146,19 +149,19 @@ class K8sSubmitOpSuite extends SparkFunSuite with BeforeAndAfter {
   private def buildDriverPod(podName: String, id: String): Pod = {
     new PodBuilder()
       .withNewMetadata()
-      .withName(podName)
-      .withNamespace(namespace)
-      .addToLabels(SPARK_APP_ID_LABEL, TEST_SPARK_APP_ID)
-      .addToLabels(SPARK_ROLE_LABEL, SPARK_POD_DRIVER_ROLE)
-      .withUid(s"driver-pod-$id")
+        .withName(podName)
+        .withNamespace(namespace)
+        .addToLabels(SPARK_APP_ID_LABEL, TEST_SPARK_APP_ID)
+        .addToLabels(SPARK_ROLE_LABEL, SPARK_POD_DRIVER_ROLE)
+        .withUid(s"driver-pod-$id")
       .endMetadata()
       .withNewSpec()
-      .withServiceAccountName(s"test$id")
-      .withVolumes()
-      .withNodeName(s"testNode$id")
+        .withServiceAccountName(s"test$id")
+        .withVolumes()
+        .withNodeName(s"testNode$id")
       .endSpec()
       .withNewStatus()
-      .withPhase("Running")
+        .withPhase("Running")
       .endStatus()
       .build()
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Removes the dependency on the OkHttp http client for the kubernetes client.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
The Kubernetes client supports plugging in different http clients via the Java service provider interface. Since we have a dependency on OkHttp it is not possible to plug in other http clients.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Added a unit test
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
No
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
