### PR TITLE
[SPARK-49864][SQL][FOLLOW-UP] Fix default suggestion for binary arithmetic overflow

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
@@ -95,7 +95,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
         " bonus BINARY_DOUBLE)").executeUpdate()
     connection.prepareStatement(
       s"""CREATE TABLE pattern_testing_table (
-         |pattern_testing_col VARCHAR(50)
+         |pattern_testing_col VARCHAR2(50)
          |)
                    """.stripMargin
     ).executeUpdate()

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
@@ -95,7 +95,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
         " bonus BINARY_DOUBLE)").executeUpdate()
     connection.prepareStatement(
       s"""CREATE TABLE pattern_testing_table (
-         |pattern_testing_col VARCHAR2(50)
+         |pattern_testing_col VARCHAR(50)
          |)
                    """.stripMargin
     ).executeUpdate()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala
@@ -298,7 +298,7 @@ abstract class BinaryArithmetic extends BinaryOperator
           case "+" => "try_add"
           case "-" => "try_subtract"
           case "*" => "try_multiply"
-          case _ => ""
+          case _ => "unknown_function"
         }
         val overflowCheck = if (failOnError) {
           val javaType = CodeGenerator.boxedType(dataType)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/types/numerics.scala
@@ -55,7 +55,12 @@ private[sql] object ByteExactNumeric extends ByteIsIntegral with Ordering.ByteOr
 
 
 private[sql] object ShortExactNumeric extends ShortIsIntegral with Ordering.ShortOrdering {
-  private def checkOverflow(res: Int, x: Short, y: Short, op: String, hint: String): Unit = {
+  private def checkOverflow(
+      res: Int,
+      x: Short,
+      y: Short,
+      op: String,
+      hint: String = "unknown_function"): Unit = {
     if (res > Short.MaxValue || res < Short.MinValue) {
       throw QueryExecutionErrors.binaryArithmeticCauseOverflowError(x, op, y, hint)
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Improvement on default branch for try suggestion.


### Why are the changes needed?
When we hit default branch in codeGen, we need to return a default value that would specify that we do not know the function, and not just a blank string.


### Does this PR introduce _any_ user-facing change?
Yes.


### How was this patch tested?
No branch hits this behaviour so far, but we need to safeguard from the possible errors.


### Was this patch authored or co-authored using generative AI tooling?
No.
