### PR TITLE
[SPARK-49954][SQL] Codegen Support for `SchemaOfJson` (by Invoke & RuntimeReplaceable) - Java Version

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/json/JsonExpressionUtils.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/json/JsonExpressionUtils.java
@@ -101,7 +101,7 @@ public class JsonExpressionUtils {
       JsonFactory jsonFactory,
       JSONOptions jsonOptions,
       JsonInferSchema jsonInferSchema,
-      UTF8String json) throws IOException {
+      UTF8String json) {
     DataType schema;
     try (JsonParser jsonParser = CreateJacksonParser.utf8String(jsonFactory, json)) {
       jsonParser.nextToken();
@@ -112,8 +112,8 @@ public class JsonExpressionUtils {
         schema = canonicalType.isDefined() ?
           canonicalType.get() : new StructType(new StructField[0]);
       } else if (inferSchema instanceof ArrayType at && at.elementType() instanceof StructType et) {
-        Option<DataType> canonicalType = jsonInferSchema.canonicalizeType(et, jsonOptions).
-          map(dt -> ArrayType.apply(dt, at.containsNull()));
+        Option<DataType> canonicalType = jsonInferSchema.canonicalizeType(et, jsonOptions)
+          .map(dt -> ArrayType.apply(dt, at.containsNull()));
         schema = canonicalType.isDefined() ? canonicalType.get() :
           ArrayType.apply(new StructType(new StructField[0]), at.containsNull());
       } else {
@@ -121,6 +121,8 @@ public class JsonExpressionUtils {
         schema = canonicalType.isDefined() ?
           canonicalType.get() : SQLConf.get().defaultStringType();
       }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
 
     return UTF8String.fromString(schema.sql());

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/json/JsonExpressionUtils.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/json/JsonExpressionUtils.java
@@ -21,12 +21,22 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import scala.Option;
+
+import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 
 import org.apache.spark.sql.catalyst.expressions.SharedFactory;
 import org.apache.spark.sql.catalyst.json.CreateJacksonParser;
+import org.apache.spark.sql.catalyst.json.JSONOptions;
+import org.apache.spark.sql.catalyst.json.JsonInferSchema;
 import org.apache.spark.sql.catalyst.util.GenericArrayData;
+import org.apache.spark.sql.internal.SQLConf;
+import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.types.UTF8String;
 
 public class JsonExpressionUtils {
@@ -85,5 +95,34 @@ public class JsonExpressionUtils {
     } catch (IOException e) {
       return null;
     }
+  }
+
+  public static UTF8String schemaOfJson(
+      JsonFactory jsonFactory,
+      JSONOptions jsonOptions,
+      JsonInferSchema jsonInferSchema,
+      UTF8String json) throws IOException {
+    DataType schema;
+    try (JsonParser jsonParser = CreateJacksonParser.utf8String(jsonFactory, json)) {
+      jsonParser.nextToken();
+      // To match with schema inference from JSON datasource.
+      DataType inferSchema = jsonInferSchema.inferField(jsonParser);
+      if (inferSchema instanceof StructType) {
+        Option<DataType> canonicalType = jsonInferSchema.canonicalizeType(inferSchema, jsonOptions);
+        schema = canonicalType.isDefined() ?
+          canonicalType.get() : new StructType(new StructField[0]);
+      } else if (inferSchema instanceof ArrayType at && at.elementType() instanceof StructType et) {
+        Option<DataType> canonicalType = jsonInferSchema.canonicalizeType(et, jsonOptions).
+          map(dt -> ArrayType.apply(dt, at.containsNull()));
+        schema = canonicalType.isDefined() ? canonicalType.get() :
+          ArrayType.apply(new StructType(new StructField[0]), at.containsNull());
+      } else {
+        Option<DataType> canonicalType = jsonInferSchema.canonicalizeType(inferSchema, jsonOptions);
+        schema = canonicalType.isDefined() ?
+          canonicalType.get() : SQLConf.get().defaultStringType();
+      }
+    }
+
+    return UTF8String.fromString(schema.sql());
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExprUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/ExprUtils.scala
@@ -32,11 +32,11 @@ import org.apache.spark.sql.internal.types.{AbstractMapType, StringTypeWithCaseA
 import org.apache.spark.sql.types.{DataType, MapType, StringType, StructType, VariantType}
 import org.apache.spark.unsafe.types.UTF8String
 
-object ExprUtils extends QueryErrorsBase {
+object ExprUtils extends EvalHelper with QueryErrorsBase {
 
   def evalTypeExpr(exp: Expression): DataType = {
     if (exp.foldable) {
-      exp.eval() match {
+      prepareForEval(exp).eval() match {
         case s: UTF8String if s != null =>
           val dataType = DataType.parseTypeWithFallback(
             s.toString,

--- a/sql/connect/common/src/test/resources/query-tests/explain-results/function_schema_of_json.explain
+++ b/sql/connect/common/src/test/resources/query-tests/explain-results/function_schema_of_json.explain
@@ -1,2 +1,2 @@
-Project [schema_of_json([{"col":01}]) AS schema_of_json([{"col":01}])#0]
+Project [static_invoke(JsonExpressionUtils.schemaOfJson(com.fasterxml.jackson.core.JsonFactory, org.apache.spark.sql.catalyst.json.JSONOptions, org.apache.spark.sql.catalyst.json.JsonInferSchema, [{"col":01}])) AS schema_of_json([{"col":01}])#0]
 +- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]

--- a/sql/connect/common/src/test/resources/query-tests/explain-results/function_schema_of_json_with_options.explain
+++ b/sql/connect/common/src/test/resources/query-tests/explain-results/function_schema_of_json_with_options.explain
@@ -1,2 +1,2 @@
-Project [schema_of_json([{"col":01}], (allowNumericLeadingZeros,true)) AS schema_of_json([{"col":01}])#0]
+Project [static_invoke(JsonExpressionUtils.schemaOfJson(com.fasterxml.jackson.core.JsonFactory, org.apache.spark.sql.catalyst.json.JSONOptions, org.apache.spark.sql.catalyst.json.JsonInferSchema, [{"col":01}])) AS schema_of_json([{"col":01}])#0]
 +- LocalRelation <empty>, [id#0L, a#0, b#0, d#0, e#0, f#0, g#0]


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to add `Codegen` Support for `schema_of_json`.


### Why are the changes needed?
- improve codegen coverage.
- simplified code.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA & Existed UT (eg: JsonFunctionsSuite#`*schema_of_json*`)


### Was this patch authored or co-authored using generative AI tooling?
No.
