### PR TITLE
[SPARK-49957][SQL] Scala API for string validation functions

### DIFF
--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -83,7 +83,8 @@ class FunctionsTestsMixin:
         missing_in_py = jvm_fn_set.difference(py_fn_set)
 
         # Functions that we expect to be missing in python until they are added to pyspark
-        expected_missing_in_py = set()
+        expected_missing_in_py = set([
+            "is_valid_utf8", "make_valid_utf8", "is_valid_utf8", "try_validate_utf8"])
 
         self.assertEqual(
             expected_missing_in_py, missing_in_py, "Missing functions in pyspark not as expected"

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -83,8 +83,9 @@ class FunctionsTestsMixin:
         missing_in_py = jvm_fn_set.difference(py_fn_set)
 
         # Functions that we expect to be missing in python until they are added to pyspark
-        expected_missing_in_py = set([
-            "is_valid_utf8", "make_valid_utf8", "is_valid_utf8", "try_validate_utf8"])
+        expected_missing_in_py = set(
+            ["is_valid_utf8", "make_valid_utf8", "is_valid_utf8", "try_validate_utf8"]
+        )
 
         self.assertEqual(
             expected_missing_in_py, missing_in_py, "Missing functions in pyspark not as expected"

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -84,7 +84,7 @@ class FunctionsTestsMixin:
 
         # Functions that we expect to be missing in python until they are added to pyspark
         expected_missing_in_py = set(
-            ["is_valid_utf8", "make_valid_utf8", "is_valid_utf8", "try_validate_utf8"]
+            ["is_valid_utf8", "make_valid_utf8", "validate_utf8", "try_validate_utf8"]
         )
 
         self.assertEqual(

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3931,7 +3931,8 @@ object functions {
     Column.fn("make_valid_utf8", str)
 
   /**
-   * Returns the input value if it corresponds to a valid UTF-8 string, or emits an error otherwise.
+   * Returns the input value if it corresponds to a valid UTF-8 string, or emits an error
+   * otherwise.
    *
    * @group string_funcs
    * @since 4.0.0

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3912,6 +3912,43 @@ object functions {
     Column.fn("encode", value, lit(charset))
 
   /**
+   * Returns true if the input is a valid UTF-8 string, otherwise returns false.
+   *
+   * @group string_funcs
+   * @since 4.0.0
+   */
+  def is_valid_utf8(str: Column): Column =
+    Column.fn("is_valid_utf8", str)
+
+  /**
+   * Returns a new string in which all invalid UTF-8 byte sequences, if any, are replaced by the
+   * Unicode replacement character (U+FFFD).
+   *
+   * @group string_funcs
+   * @since 4.0.0
+   */
+  def make_valid_utf8(str: Column): Column =
+    Column.fn("make_valid_utf8", str)
+
+  /**
+   * Returns the input value if it corresponds to a valid UTF-8 string, or emits an error otherwise.
+   *
+   * @group string_funcs
+   * @since 4.0.0
+   */
+  def validate_utf8(str: Column): Column =
+    Column.fn("validate_utf8", str)
+
+  /**
+   * Returns the input value if it corresponds to a valid UTF-8 string, or NULL otherwise.
+   *
+   * @group string_funcs
+   * @since 4.0.0
+   */
+  def try_validate_utf8(str: Column): Column =
+    Column.fn("try_validate_utf8", str)
+
+  /**
    * Formats numeric column x to a format like '#,###,###.##', rounded to d decimal places with
    * HALF_EVEN round mode, and returns the result as a string column.
    *

--- a/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/functions.scala
@@ -3931,8 +3931,8 @@ object functions {
     Column.fn("make_valid_utf8", str)
 
   /**
-   * Returns the input value if it corresponds to a valid UTF-8 string, or emits an error
-   * otherwise.
+   * Returns the input value if it corresponds to a valid UTF-8 string, or emits a
+   * SparkIllegalArgumentException exception otherwise.
    *
    * @group string_funcs
    * @since 4.0.0

--- a/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/StringFunctionsSuite.scala
@@ -354,27 +354,27 @@ class StringFunctionsSuite extends QueryTest with SharedSparkSession {
 
   test("UTF-8 string is valid") {
     // scalastyle:off
-    checkAnswer(Seq("大千世界").toDF("a").selectExpr("is_valid_utf8(a)"), Row(true))
-    checkAnswer(Seq(("abc", null)).toDF("a", "b").selectExpr("is_valid_utf8(b)"), Row(null))
-    checkAnswer(Seq(Array[Byte](-1)).toDF("a").selectExpr("is_valid_utf8(a)"), Row(false))
+    checkAnswer(Seq("大千世界").toDF("a").select(is_valid_utf8($"a")), Row(true))
+    checkAnswer(Seq(("abc", null)).toDF("a", "b").select(is_valid_utf8($"b")), Row(null))
+    checkAnswer(Seq(Array[Byte](-1)).toDF("a").select(is_valid_utf8($"a")), Row(false))
     // scalastyle:on
   }
 
   test("UTF-8 string make valid") {
     // scalastyle:off
-    checkAnswer(Seq("大千世界").toDF("a").selectExpr("make_valid_utf8(a)"), Row("大千世界"))
-    checkAnswer(Seq(("abc", null)).toDF("a", "b").selectExpr("make_valid_utf8(b)"), Row(null))
-    checkAnswer(Seq(Array[Byte](-1)).toDF("a").selectExpr("make_valid_utf8(a)"), Row("\uFFFD"))
+    checkAnswer(Seq("大千世界").toDF("a").select(make_valid_utf8($"a")), Row("大千世界"))
+    checkAnswer(Seq(("abc", null)).toDF("a", "b").select(make_valid_utf8($"b")), Row(null))
+    checkAnswer(Seq(Array[Byte](-1)).toDF("a").select(make_valid_utf8($"a")), Row("\uFFFD"))
     // scalastyle:on
   }
 
   test("UTF-8 string validate") {
     // scalastyle:off
-    checkAnswer(Seq("大千世界").toDF("a").selectExpr("validate_utf8(a)"), Row("大千世界"))
-    checkAnswer(Seq(("abc", null)).toDF("a", "b").selectExpr("validate_utf8(b)"), Row(null))
+    checkAnswer(Seq("大千世界").toDF("a").select(validate_utf8($"a")), Row("大千世界"))
+    checkAnswer(Seq(("abc", null)).toDF("a", "b").select(validate_utf8($"b")), Row(null))
     checkError(
       exception = intercept[SparkIllegalArgumentException] {
-        Seq(Array[Byte](-1)).toDF("a").selectExpr("validate_utf8(a)").collect()
+        Seq(Array[Byte](-1)).toDF("a").select(validate_utf8($"a")).collect()
       },
       condition = "INVALID_UTF8_STRING",
       parameters = Map("str" -> "\\xFF")
@@ -384,9 +384,9 @@ class StringFunctionsSuite extends QueryTest with SharedSparkSession {
 
   test("UTF-8 string try validate") {
     // scalastyle:off
-    checkAnswer(Seq("大千世界").toDF("a").selectExpr("try_validate_utf8(a)"), Row("大千世界"))
-    checkAnswer(Seq(("abc", null)).toDF("a", "b").selectExpr("try_validate_utf8(b)"), Row(null))
-    checkAnswer(Seq(Array[Byte](-1)).toDF("a").selectExpr("try_validate_utf8(a)"), Row(null))
+    checkAnswer(Seq("大千世界").toDF("a").select(try_validate_utf8($"a")), Row("大千世界"))
+    checkAnswer(Seq(("abc", null)).toDF("a", "b").select(try_validate_utf8($"b")), Row(null))
+    checkAnswer(Seq(Array[Byte](-1)).toDF("a").select(try_validate_utf8($"a")), Row(null))
     // scalastyle:on
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Adding the Scala API for the 4 new string validation expressions:
- is_valid_utf8
- make_valid_utf8
- validate_utf8
- try_validate_utf8


### Why are the changes needed?
Offer a complete Scala API for the new expressions in Spark 4.0.


### Does this PR introduce _any_ user-facing change?
Yes, adding Scala API for the 4 new Spark expressions.


### How was this patch tested?
New tests for the Scala API.


### Was this patch authored or co-authored using generative AI tooling?
No.
