### PR TITLE
[SPARK-49958][PYTHON] Python API for string validation functions

### DIFF
--- a/python/docs/source/reference/pyspark.sql/functions.rst
+++ b/python/docs/source/reference/pyspark.sql/functions.rst
@@ -177,6 +177,7 @@ String Functions
     format_string
     initcap
     instr
+    is_valid_utf8
     lcase
     left
     length
@@ -185,6 +186,7 @@ String Functions
     lower
     lpad
     ltrim
+    make_valid_utf8
     mask
     octet_length
     overlay
@@ -218,9 +220,11 @@ String Functions
     trim
     try_to_binary
     try_to_number
+    try_validate_utf8
     ucase
     unbase64
     upper
+    validate_utf8
 
 
 Bitwise Functions

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -2446,28 +2446,28 @@ encode.__doc__ = pysparkfuncs.encode.__doc__
 
 
 def is_valid_utf8(str: "ColumnOrName") -> Column:
-    return _invoke_function_over_columns("is_valid_utf8", str)
+    return _invoke_function_over_columns("is_valid_utf8", _to_col(str))
 
 
 is_valid_utf8.__doc__ = pysparkfuncs.is_valid_utf8.__doc__
 
 
 def make_valid_utf8(str: "ColumnOrName") -> Column:
-    return _invoke_function_over_columns("make_valid_utf8", str)
+    return _invoke_function_over_columns("make_valid_utf8", _to_col(str))
 
 
 make_valid_utf8.__doc__ = pysparkfuncs.make_valid_utf8.__doc__
 
 
 def validate_utf8(str: "ColumnOrName") -> Column:
-    return _invoke_function_over_columns("validate_utf8", str)
+    return _invoke_function_over_columns("validate_utf8", _to_col(str))
 
 
 validate_utf8.__doc__ = pysparkfuncs.validate_utf8.__doc__
 
 
 def try_validate_utf8(str: "ColumnOrName") -> Column:
-    return _invoke_function_over_columns("try_validate_utf8", str)
+    return _invoke_function_over_columns("try_validate_utf8", _to_col(str))
 
 
 try_validate_utf8.__doc__ = pysparkfuncs.try_validate_utf8.__doc__

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -2445,6 +2445,34 @@ def encode(col: "ColumnOrName", charset: str) -> Column:
 encode.__doc__ = pysparkfuncs.encode.__doc__
 
 
+def is_valid_utf8(str: "ColumnOrName") -> Column:
+    return _invoke_function("is_valid_utf8", str)
+
+
+is_valid_utf8.__doc__ = pysparkfuncs.is_valid_utf8.__doc__
+
+
+def make_valid_utf8(str: "ColumnOrName") -> Column:
+    return _invoke_function("make_valid_utf8", str)
+
+
+make_valid_utf8.__doc__ = pysparkfuncs.make_valid_utf8.__doc__
+
+
+def validate_utf8(str: "ColumnOrName") -> Column:
+    return _invoke_function("validate_utf8", str)
+
+
+validate_utf8.__doc__ = pysparkfuncs.validate_utf8.__doc__
+
+
+def try_validate_utf8(str: "ColumnOrName") -> Column:
+    return _invoke_function("try_validate_utf8", str)
+
+
+try_validate_utf8.__doc__ = pysparkfuncs.try_validate_utf8.__doc__
+
+
 def format_number(col: "ColumnOrName", d: int) -> Column:
     return _invoke_function("format_number", _to_col(col), lit(d))
 

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -2446,28 +2446,28 @@ encode.__doc__ = pysparkfuncs.encode.__doc__
 
 
 def is_valid_utf8(str: "ColumnOrName") -> Column:
-    return _invoke_function("is_valid_utf8", str)
+    return _invoke_function_over_columns("is_valid_utf8", str)
 
 
 is_valid_utf8.__doc__ = pysparkfuncs.is_valid_utf8.__doc__
 
 
 def make_valid_utf8(str: "ColumnOrName") -> Column:
-    return _invoke_function("make_valid_utf8", str)
+    return _invoke_function_over_columns("make_valid_utf8", str)
 
 
 make_valid_utf8.__doc__ = pysparkfuncs.make_valid_utf8.__doc__
 
 
 def validate_utf8(str: "ColumnOrName") -> Column:
-    return _invoke_function("validate_utf8", str)
+    return _invoke_function_over_columns("validate_utf8", str)
 
 
 validate_utf8.__doc__ = pysparkfuncs.validate_utf8.__doc__
 
 
 def try_validate_utf8(str: "ColumnOrName") -> Column:
-    return _invoke_function("try_validate_utf8", str)
+    return _invoke_function_over_columns("try_validate_utf8", str)
 
 
 try_validate_utf8.__doc__ = pysparkfuncs.try_validate_utf8.__doc__

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -11198,6 +11198,127 @@ def encode(col: "ColumnOrName", charset: str) -> Column:
 
 
 @_try_remote_functions
+def is_valid_utf8(str: "ColumnOrName") -> Column:
+    """
+    Returns true if the input is a valid UTF-8 string, otherwise returns false.
+
+    .. versionadded:: 4.0.0
+
+    Parameters
+    ----------
+    str : :class:`~pyspark.sql.Column` or str
+        A column of strings, each representing a URL-encoded string.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        whether the input string is a valid UTF-8 string.
+
+    Examples
+    --------
+    >>> import pyspark.sql.functions as sf
+    >>> spark.range(1).select(sf.is_valid_utf8(sf.lit("SparkSQL"))).show()
+    +-----------------------+
+    |is_valid_utf8(SparkSQL)|
+    +-----------------------+
+    |                   true|
+    +-----------------------+
+    """
+    return _invoke_function("is_valid_utf8", str)
+
+
+@_try_remote_functions
+def make_valid_utf8(str: "ColumnOrName") -> Column:
+    """
+    Returns a new string in which all invalid UTF-8 byte sequences, if any, are replaced by the
+    Unicode replacement character (U+FFFD).
+
+    .. versionadded:: 4.0.0
+
+    Parameters
+    ----------
+    str : :class:`~pyspark.sql.Column` or str
+        A column of strings, each representing a URL-encoded string.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        the valid UTF-8 version of the given input string.
+
+    Examples
+    --------
+    >>> import pyspark.sql.functions as sf
+    >>> spark.range(1).select(sf.make_valid_utf8(sf.lit("SparkSQL"))).show()
+    +-------------------------+
+    |make_valid_utf8(SparkSQL)|
+    +-------------------------+
+    |                 SparkSQL|
+    +-------------------------+
+    """
+    return _invoke_function("make_valid_utf8", str)
+
+
+@_try_remote_functions
+def validate_utf8(str: "ColumnOrName") -> Column:
+    """
+    Returns the input value if it corresponds to a valid UTF-8 string, or emits an error otherwise.
+
+    .. versionadded:: 4.0.0
+
+    Parameters
+    ----------
+    str : :class:`~pyspark.sql.Column` or str
+        A column of strings, each representing a URL-encoded string.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        the input string if it is a valid UTF-8 string, error otherwise.
+
+    Examples
+    --------
+    >>> import pyspark.sql.functions as sf
+    >>> spark.range(1).select(sf.validate_utf8(sf.lit("SparkSQL"))).show()
+    +-----------------------+
+    |validate_utf8(SparkSQL)|
+    +-----------------------+
+    |               SparkSQL|
+    +-----------------------+
+    """
+    return _invoke_function("validate_utf8", str)
+
+
+@_try_remote_functions
+def try_validate_utf8(str: "ColumnOrName") -> Column:
+    """
+    Returns the input value if it corresponds to a valid UTF-8 string, or NULL otherwise.
+
+    .. versionadded:: 4.0.0
+
+    Parameters
+    ----------
+    str : :class:`~pyspark.sql.Column` or str
+        A column of strings, each representing a URL-encoded string.
+
+    Returns
+    -------
+    :class:`~pyspark.sql.Column`
+        the input string if it is a valid UTF-8 string, null otherwise.
+
+    Examples
+    --------
+    >>> import pyspark.sql.functions as sf
+    >>> spark.range(1).select(sf.try_validate_utf8(sf.lit("SparkSQL"))).show()
+    +---------------------------+
+    |try_validate_utf8(SparkSQL)|
+    +---------------------------+
+    |                   SparkSQL|
+    +---------------------------+
+    """
+    return _invoke_function("try_validate_utf8", str)
+
+
+@_try_remote_functions
 def format_number(col: "ColumnOrName", d: int) -> Column:
     """
     Formats the number X to a format like '#,--#,--#.--', rounded to d decimal places

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -11224,7 +11224,7 @@ def is_valid_utf8(str: "ColumnOrName") -> Column:
     |                   true|
     +-----------------------+
     """
-    return _invoke_function("is_valid_utf8", str)
+    return _invoke_function_over_columns("is_valid_utf8", str)
 
 
 @_try_remote_functions
@@ -11255,7 +11255,7 @@ def make_valid_utf8(str: "ColumnOrName") -> Column:
     |                 SparkSQL|
     +-------------------------+
     """
-    return _invoke_function("make_valid_utf8", str)
+    return _invoke_function_over_columns("make_valid_utf8", str)
 
 
 @_try_remote_functions
@@ -11285,7 +11285,7 @@ def validate_utf8(str: "ColumnOrName") -> Column:
     |               SparkSQL|
     +-----------------------+
     """
-    return _invoke_function("validate_utf8", str)
+    return _invoke_function_over_columns("validate_utf8", str)
 
 
 @_try_remote_functions
@@ -11315,7 +11315,7 @@ def try_validate_utf8(str: "ColumnOrName") -> Column:
     |                   SparkSQL|
     +---------------------------+
     """
-    return _invoke_function("try_validate_utf8", str)
+    return _invoke_function_over_columns("try_validate_utf8", str)
 
 
 @_try_remote_functions

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -11207,7 +11207,7 @@ def is_valid_utf8(str: "ColumnOrName") -> Column:
     Parameters
     ----------
     str : :class:`~pyspark.sql.Column` or str
-        A column of strings, each representing a URL-encoded string.
+        A column of strings, each representing a UTF-8 byte sequence.
 
     Returns
     -------
@@ -11238,7 +11238,7 @@ def make_valid_utf8(str: "ColumnOrName") -> Column:
     Parameters
     ----------
     str : :class:`~pyspark.sql.Column` or str
-        A column of strings, each representing a URL-encoded string.
+        A column of strings, each representing a UTF-8 byte sequence.
 
     Returns
     -------
@@ -11268,7 +11268,7 @@ def validate_utf8(str: "ColumnOrName") -> Column:
     Parameters
     ----------
     str : :class:`~pyspark.sql.Column` or str
-        A column of strings, each representing a URL-encoded string.
+        A column of strings, each representing a UTF-8 byte sequence.
 
     Returns
     -------
@@ -11298,7 +11298,7 @@ def try_validate_utf8(str: "ColumnOrName") -> Column:
     Parameters
     ----------
     str : :class:`~pyspark.sql.Column` or str
-        A column of strings, each representing a URL-encoded string.
+        A column of strings, each representing a UTF-8 byte sequence.
 
     Returns
     -------

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -2078,6 +2078,46 @@ class SparkConnectFunctionTests(ReusedConnectTestCase, PandasOnSparkTestUtils, S
         cdf = self.connect.sql(query)
         sdf = self.spark.sql(query)
 
+        # test is_valid_utf8
+        self.assert_eq(
+            cdf.select(CF.is_valid_utf8(cdf.d)).toPandas(),
+            sdf.select(SF.is_valid_utf8(sdf.d)).toPandas(),
+        )
+        self.assert_eq(
+            cdf.select(CF.is_valid_utf8("abc")).toPandas(),
+            sdf.select(SF.is_valid_utf8("abc")).toPandas(),
+        )
+
+        # test make_valid_utf8
+        self.assert_eq(
+            cdf.select(CF.make_valid_utf8(cdf.d)).toPandas(),
+            sdf.select(SF.make_valid_utf8(sdf.d)).toPandas(),
+        )
+        self.assert_eq(
+            cdf.select(CF.make_valid_utf8("abc")).toPandas(),
+            sdf.select(SF.make_valid_utf8("abc")).toPandas(),
+        )
+
+        # test validate_utf8
+        self.assert_eq(
+            cdf.select(CF.validate_utf8(cdf.d)).toPandas(),
+            sdf.select(SF.validate_utf8(sdf.d)).toPandas(),
+        )
+        self.assert_eq(
+            cdf.select(CF.validate_utf8("abc")).toPandas(),
+            sdf.select(SF.validate_utf8("abc")).toPandas(),
+        )
+
+        # test try_validate_utf8
+        self.assert_eq(
+            cdf.select(CF.try_validate_utf8(cdf.d)).toPandas(),
+            sdf.select(SF.try_validate_utf8(sdf.d)).toPandas(),
+        )
+        self.assert_eq(
+            cdf.select(CF.try_validate_utf8("abc")).toPandas(),
+            sdf.select(SF.try_validate_utf8("abc")).toPandas(),
+        )
+
         self.assert_eq(
             cdf.select(CF.format_number(cdf.a, 2)).toPandas(),
             sdf.select(SF.format_number(sdf.a, 2)).toPandas(),

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -2083,19 +2083,11 @@ class SparkConnectFunctionTests(ReusedConnectTestCase, PandasOnSparkTestUtils, S
             cdf.select(CF.is_valid_utf8(cdf.d)).toPandas(),
             sdf.select(SF.is_valid_utf8(sdf.d)).toPandas(),
         )
-        self.assert_eq(
-            cdf.select(CF.is_valid_utf8("abc")).toPandas(),
-            sdf.select(SF.is_valid_utf8("abc")).toPandas(),
-        )
 
         # test make_valid_utf8
         self.assert_eq(
             cdf.select(CF.make_valid_utf8(cdf.d)).toPandas(),
             sdf.select(SF.make_valid_utf8(sdf.d)).toPandas(),
-        )
-        self.assert_eq(
-            cdf.select(CF.make_valid_utf8("abc")).toPandas(),
-            sdf.select(SF.make_valid_utf8("abc")).toPandas(),
         )
 
         # test validate_utf8
@@ -2103,19 +2095,11 @@ class SparkConnectFunctionTests(ReusedConnectTestCase, PandasOnSparkTestUtils, S
             cdf.select(CF.validate_utf8(cdf.d)).toPandas(),
             sdf.select(SF.validate_utf8(sdf.d)).toPandas(),
         )
-        self.assert_eq(
-            cdf.select(CF.validate_utf8("abc")).toPandas(),
-            sdf.select(SF.validate_utf8("abc")).toPandas(),
-        )
 
         # test try_validate_utf8
         self.assert_eq(
             cdf.select(CF.try_validate_utf8(cdf.d)).toPandas(),
             sdf.select(SF.try_validate_utf8(sdf.d)).toPandas(),
-        )
-        self.assert_eq(
-            cdf.select(CF.try_validate_utf8("abc")).toPandas(),
-            sdf.select(SF.try_validate_utf8("abc")).toPandas(),
         )
 
         self.assert_eq(

--- a/python/pyspark/sql/tests/connect/test_connect_function.py
+++ b/python/pyspark/sql/tests/connect/test_connect_function.py
@@ -2078,30 +2078,6 @@ class SparkConnectFunctionTests(ReusedConnectTestCase, PandasOnSparkTestUtils, S
         cdf = self.connect.sql(query)
         sdf = self.spark.sql(query)
 
-        # test is_valid_utf8
-        self.assert_eq(
-            cdf.select(CF.is_valid_utf8(cdf.d)).toPandas(),
-            sdf.select(SF.is_valid_utf8(sdf.d)).toPandas(),
-        )
-
-        # test make_valid_utf8
-        self.assert_eq(
-            cdf.select(CF.make_valid_utf8(cdf.d)).toPandas(),
-            sdf.select(SF.make_valid_utf8(sdf.d)).toPandas(),
-        )
-
-        # test validate_utf8
-        self.assert_eq(
-            cdf.select(CF.validate_utf8(cdf.d)).toPandas(),
-            sdf.select(SF.validate_utf8(sdf.d)).toPandas(),
-        )
-
-        # test try_validate_utf8
-        self.assert_eq(
-            cdf.select(CF.try_validate_utf8(cdf.d)).toPandas(),
-            sdf.select(SF.try_validate_utf8(sdf.d)).toPandas(),
-        )
-
         self.assert_eq(
             cdf.select(CF.format_number(cdf.a, 2)).toPandas(),
             sdf.select(SF.format_number(sdf.a, 2)).toPandas(),

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1629,6 +1629,21 @@ class FunctionsTestsMixin:
         result = df.select(uniform(F.lit(10), F.lit(20)).alias("x")).selectExpr("x > 5").collect()
         self.assertEqual([Row(True)], result)
 
+    def test_string_validation(self):
+        df = self.spark.createDataFrame([("abc",)], ["a"])
+        # test is_valid_utf8
+        result_is_valid_utf8 = df.select(F.is_valid_utf8(df.a).alias("r")).collect()
+        self.assertEqual([Row(r=True)], result_is_valid_utf8)
+        # test make_valid_utf8
+        result_make_valid_utf8 = df.select(F.make_valid_utf8(df.a).alias("r")).collect()
+        self.assertEqual([Row(r="abc")], result_make_valid_utf8)
+        # test validate_utf8
+        result_validate_utf8 = df.select(F.validate_utf8(df.a).alias("r")).collect()
+        self.assertEqual([Row(r="abc")], result_validate_utf8)
+        # test try_validate_utf8
+        result_try_validate_utf8 = df.select(F.try_validate_utf8(df.a).alias("r")).collect()
+        self.assertEqual([Row(r="abc")], result_try_validate_utf8)
+
 
 class FunctionsTests(ReusedSQLTestCase, FunctionsTestsMixin):
     pass

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -83,9 +83,7 @@ class FunctionsTestsMixin:
         missing_in_py = jvm_fn_set.difference(py_fn_set)
 
         # Functions that we expect to be missing in python until they are added to pyspark
-        expected_missing_in_py = set(
-            ["is_valid_utf8", "make_valid_utf8", "validate_utf8", "try_validate_utf8"]
-        )
+        expected_missing_in_py = set()
 
         self.assertEqual(
             expected_missing_in_py, missing_in_py, "Missing functions in pyspark not as expected"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Adding the Python API for the 4 new string validation expressions:
- is_valid_utf8
- make_valid_utf8
- validate_utf8
- try_validate_utf8


### Why are the changes needed?
Offer a complete Python API for the new expressions in Spark 4.0.


### Does this PR introduce _any_ user-facing change?
Yes, adding Python API for the 4 new Spark expressions.


### How was this patch tested?
New tests for the Python API.


### Was this patch authored or co-authored using generative AI tooling?
No.
