### PR TITLE
[SPARK-49964][BUILD] Remove `ws-rs-api` package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1116,11 +1116,6 @@
         <version>${jersey.version}</version>
       </dependency>
       <dependency>
-        <groupId>javax.ws.rs</groupId>
-        <artifactId>javax.ws.rs-api</artifactId>
-        <version>2.0.1</version>
-      </dependency>
-      <dependency>
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
         <version>${jaxb.version}</version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

- To Remove the dependency of `javax.ws.rs.ws-rs-api` as it's no longer required. 

Prior discussion can be found on:
 - https://github.com/apache/spark/pull/41340
 - https://github.com/apache/spark/pull/45154

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
In the past, the codebase used to have a few .scala classes referencing and using the `ws-rs-api`, such as https://github.com/apache/spark/commit/b7fdc23ccc5967de5799d8cf6f14289e71f29a1e#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R624-R627

However as the time passed by, all usages of `ws-rs-api` are either got removed / refactored. Hence there is no need to have it import on root POM as now and we can always re-introduce it later, if the usage can be justified again.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Unit-test, to make sure the codebase is not impacted by the removal of the dependency.


### Was this patch authored or co-authored using generative AI tooling?
No

