### PR TITLE
[SPARK-49975][SQL] Disallow LEGACY storeAssignmentPolicy with DataFrameWriterV2 API

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameWriterV2Suite.scala
@@ -839,4 +839,18 @@ class DataFrameWriterV2Suite extends QueryTest with SharedSparkSession with Befo
       condition = "CALL_ON_STREAMING_DATASET_UNSUPPORTED",
       parameters = Map("methodName" -> "`writeTo`"))
   }
+
+  test("SPARK-49975: write should fail with legacy store assignment policy") {
+    withSQLConf((SQLConf.STORE_ASSIGNMENT_POLICY.key, "LEGACY")) {
+      checkError(
+        exception = intercept[AnalysisException] {
+          spark.range(10)
+            .writeTo("table_name")
+            .append()
+        },
+        condition = "_LEGACY_ERROR_TEMP_1000",
+        parameters = Map("configKey" -> "spark.sql.storeAssignmentPolicy")
+      )
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Before this PR, store assignment policy is validated for `V2Write` command when `v2Write.table.resolved && v2Write.query.resolved && !v2Write.outputResolved` is true. However, `!v2Write.outputResolved` doesn't hold for DataFrameWriterV2 API and the policy is not validated. This PR validates store assignment policy for `V2Write` command without any conditions.


### Why are the changes needed?
LEGACY store assignment policy should not be allowed writing to v2 table with DataFrameWriterV2 API.


### Does this PR introduce _any_ user-facing change?
An `AnalysisError` will be thrown when users write to v2 table with DataFrameWriterV2 API and  `spark.sql.storeAssignmentPolicy=LEGACY`  


### How was this patch tested?
UT.


### Was this patch authored or co-authored using generative AI tooling?
No.