### PR TITLE
[SPARK-49923][core]Add a configuration item for disabling the setting of javaOptions.

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -381,6 +381,12 @@ package object config {
       .stringConf
       .createOptional
 
+  private[spark] val SUBMIT_JAVA_OPTION_PURE_MODE =
+    ConfigBuilder("spark.submit.javaOptionPureMode")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val EXECUTOR_LIBRARY_PATH =
     ConfigBuilder(SparkLauncher.EXECUTOR_EXTRA_LIBRARY_PATH)
       .version("1.0.0")

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/Client.scala
@@ -193,6 +193,7 @@ private[spark] class Client(
    */
   def submitApplication(): Unit = {
     ResourceRequestHelper.validateResources(sparkConf)
+    ResourceRequestHelper.validateJavaOptions(sparkConf)
 
     try {
       launcherBackend.connect()

--- a/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ResourceRequestHelper.scala
+++ b/resource-managers/yarn/src/main/scala/org/apache/spark/deploy/yarn/ResourceRequestHelper.scala
@@ -130,6 +130,28 @@ private object ResourceRequestHelper extends Logging {
   }
 
   /**
+   * Validates sparkConf and throw a IllegalArgumentException if SUBMIT_JAVA_OPTION_PURE_MODE is
+   * true
+   * @param sparkConf
+   */
+  def validateJavaOptions(sparkConf: SparkConf): Unit = {
+    if (sparkConf.get(SUBMIT_JAVA_OPTION_PURE_MODE)) {
+      val javaOptionsToCheck = List(
+        "spark.driver.defaultJavaOptions",
+        "spark.driver.extraJavaOptions",
+        "spark.executor.defaultJavaOptions",
+        "spark.executor.extraJavaOptions"
+      ).foreach { option =>
+        if (sparkConf.getOption(option).isDefined) {
+          val msg = s"$option parameters cannot be set, because the pure mode config " +
+            s"spark.executor.javaOptionPureMode is enabled. "
+          throw new IllegalArgumentException(msg)
+        }
+      }
+    }
+  }
+
+  /**
    * Sets resource amount with the corresponding unit to the passed resource object.
    * @param resources resource values to set
    * @param resource resource object to update

--- a/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
+++ b/resource-managers/yarn/src/test/scala/org/apache/spark/deploy/yarn/ClientSuite.scala
@@ -671,6 +671,34 @@ class ClientSuite extends SparkFunSuite
     assertUserClasspathUrls(cluster = true, replacementRootPath)
   }
 
+  test("SPARK-49923: test SUBMIT_JAVA_OPTION_PURE_MODE enabled, JVM parameters cannot be set") {
+    val sparkConf = new SparkConf()
+
+    sparkConf.set("spark.driver.defaultJavaOptions", "-Xmx1024m")
+      .set("spark.executor.defaultJavaOptions", "-Xmx1024m")
+      .set("spark.driver.extraJavaOptions", "-Xmx1024m")
+      .set("spark.executor.extraJavaOptions", "-Xmx1024m")
+      .set(SUBMIT_JAVA_OPTION_PURE_MODE, true)
+
+    intercept[IllegalArgumentException] {
+      ResourceRequestHelper.validateJavaOptions(sparkConf)
+    }
+  }
+
+  test("SPARK-49923: test SUBMIT_JAVA_OPTION_PURE_MODE disabled, JVM parameters can be set") {
+    val sparkConf = new SparkConf()
+
+    sparkConf.set("spark.driver.defaultJavaOptions", "-Xmx1024m")
+      .set("spark.executor.defaultJavaOptions", "-Xmx1024m")
+      .set("spark.driver.extraJavaOptions", "-Xmx1024m")
+      .set("spark.executor.extraJavaOptions", "-Xmx1024m")
+      .set(SUBMIT_JAVA_OPTION_PURE_MODE, false)
+
+    noException should be thrownBy {
+      ResourceRequestHelper.validateJavaOptions(sparkConf)
+    }
+  }
+
   test("SPARK-44306: test directoriesToBePreloaded") {
     val sparkConf = new SparkConf()
       .set(YARN_CLIENT_STAT_CACHE_PRELOAD_PER_DIRECTORY_THRESHOLD, 3)


### PR DESCRIPTION
What changes were proposed in this pull request?
The pr is add AVA_OPTION_PURE_MODE configuration item. When the configuration item is set to true, JavaOptions cannot be configured.

Why are the changes needed?
Adding JAVA_OPTION_PURE_MODE can completely prevent command injection caused by Java parameters in Yarn mode. This is more secure when JVM parameters do not need to be customized.

Does this PR introduce any user-facing change?
Yes. If JAVA_OPTION_PURE_MODE is set to true, JavaOptions cannot be set.

How was this patch tested?
Added a new UT.

Was this patch authored or co-authored using generative AI tooling?
No.