### PR TITLE
[SPARK-49976] [SQL] Disallow lambda functions from being clauses in CASE WHEN expressions

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1028,12 +1028,6 @@
           "cannot find a static method <methodName> that matches the argument types in <className>."
         ]
       },
-      "UNSUPPORTED_CASE_WHEN_CLAUSE" : {
-        "message" : [
-          "The CASE WHEN clause of type <clause> is not supported."
-        ],
-        "sqlState" : "42601"
-      },
       "UNSUPPORTED_INPUT_TYPE" : {
         "message" : [
           "The input of <functionName> can't be <dataType> type data."
@@ -2688,6 +2682,12 @@
       }
     },
     "sqlState" : "42K0D"
+  },
+  "INVALID_LAMBDA_USAGE" : {
+    "message" : [
+      "The lambda function <lambdaExpr> cannot be used in this context. Lambda functions must be passed as arguments to functions defined to accept them, such as array_sort."
+    ],
+    "sqlState" : "42K0E"
   },
   "INVALID_LATERAL_JOIN_TYPE" : {
     "message" : [

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1028,6 +1028,12 @@
           "cannot find a static method <methodName> that matches the argument types in <className>."
         ]
       },
+      "UNSUPPORTED_CASE_WHEN_CLAUSE" : {
+        "message" : [
+          "The CASE WHEN clause of type <clause> is not supported."
+        ],
+        "sqlState" : "42601"
+      },
       "UNSUPPORTED_INPUT_TYPE" : {
         "message" : [
           "The input of <functionName> can't be <dataType> type data."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2932,6 +2932,10 @@ class AstBuilder extends DataTypeAstBuilder
     val branches = ctx.whenClause.asScala.map { wCtx =>
       (expression(wCtx.condition), expression(wCtx.result))
     }
+    branches.foreach(
+      branch => if (branch._1.isInstanceOf[LambdaFunction]) throw new ParseException(
+        "UNSUPPORTED_CASE_WHEN_CLAUSE", Map("clause" -> "LambdaFunction"), ctx)
+    )
     CaseWhen(branches.toSeq, Option(ctx.elseExpression).map(expression))
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2933,8 +2933,16 @@ class AstBuilder extends DataTypeAstBuilder
       (expression(wCtx.condition), expression(wCtx.result))
     }
     branches.foreach(
-      branch => if (branch._1.isInstanceOf[LambdaFunction]) throw new ParseException(
-        "UNSUPPORTED_CASE_WHEN_CLAUSE", Map("clause" -> "LambdaFunction"), ctx)
+      branch =>
+        branch._1 match {
+          case _: LambdaFunction =>
+            throw new ParseException(
+              "UNSUPPORTED_CASE_WHEN_CLAUSE",
+              Map("clause" -> "LambdaFunction"),
+              ctx
+            )
+          case _ => _
+        }
     )
     CaseWhen(branches.toSeq, Option(ctx.elseExpression).map(expression))
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -48,7 +48,7 @@ import org.apache.spark.sql.catalyst.util.DateTimeUtils.{convertSpecialDate, con
 import org.apache.spark.sql.connector.catalog.{CatalogV2Util, IdentityColumnSpec, SupportsNamespaces, TableCatalog, TableWritePrivilege}
 import org.apache.spark.sql.connector.catalog.TableChange.ColumnPosition
 import org.apache.spark.sql.connector.expressions.{ApplyTransform, BucketTransform, DaysTransform, Expression => V2Expression, FieldReference, HoursTransform, IdentityTransform, LiteralValue, MonthsTransform, Transform, YearsTransform}
-import org.apache.spark.sql.errors.{DataTypeErrorsBase, QueryCompilationErrors, QueryParsingErrors, SqlScriptingErrors}
+import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryErrorsBase, QueryParsingErrors, SqlScriptingErrors}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.LEGACY_BANG_EQUALS_NOT
 import org.apache.spark.sql.types._
@@ -62,7 +62,7 @@ import org.apache.spark.util.random.RandomSampler
  * TableIdentifier.
  */
 class AstBuilder extends DataTypeAstBuilder
-  with SQLConfHelper with Logging with DataTypeErrorsBase {
+  with SQLConfHelper with Logging with QueryErrorsBase {
   import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
   import ParserUtils._
 
@@ -2938,7 +2938,7 @@ class AstBuilder extends DataTypeAstBuilder
           case _: LambdaFunction =>
             throw new ParseException(
               "INVALID_LAMBDA_USAGE",
-              Map("lambdaExpr" -> branch._1.sql),
+              Map("lambdaExpr" -> toSQLExpr(branch._1)),
               ctx
             )
           case _ =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -2937,11 +2937,11 @@ class AstBuilder extends DataTypeAstBuilder
         branch._1 match {
           case _: LambdaFunction =>
             throw new ParseException(
-              "UNSUPPORTED_CASE_WHEN_CLAUSE",
-              Map("clause" -> "LambdaFunction"),
+              "INVALID_LAMBDA_USAGE",
+              Map("lambdaExpr" -> branch._1.sql),
               ctx
             )
-          case _ => _
+          case _ =>
         }
     )
     CaseWhen(branches.toSeq, Option(ctx.elseExpression).map(expression))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -1978,9 +1978,9 @@ class PlanParserSuite extends AnalysisTest {
     val query = "select (case when a->b = true then 1 else 0 end)"
     checkError(
       exception = parseException(query),
-      condition = "UNSUPPORTED_CASE_WHEN_CLAUSE",
-      sqlState = Some("42601"),
-      parameters = Map("clause" -> "LambdaFunction"),
+      condition = "INVALID_LAMBDA_USAGE",
+      sqlState = Some("42K0E"),
+      parameters = Map("lambdaExpr" -> "lambdafunction((b = true), a)"),
       context = ExpectedContext(
         fragment = "case when a->b = true then 1 else 0 end",
         start = 8,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -1980,7 +1980,7 @@ class PlanParserSuite extends AnalysisTest {
       exception = parseException(query),
       condition = "INVALID_LAMBDA_USAGE",
       sqlState = Some("42K0E"),
-      parameters = Map("lambdaExpr" -> "lambdafunction((b = true), a)"),
+      parameters = Map("lambdaExpr" -> "\"lambdafunction((b = true), a)\""),
       context = ExpectedContext(
         fragment = "case when a->b = true then 1 else 0 end",
         start = 8,

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -1973,4 +1973,18 @@ class PlanParserSuite extends AnalysisTest {
     assert(unresolvedRelation2.options == CaseInsensitiveStringMap.empty)
     assert(unresolvedRelation2.isStreaming)
   }
+
+  test("SPARK-49976: Disable lambda functions as case when clauses") {
+    val query = "select (case when a->b = true then 1 else 0 end)"
+    checkError(
+      exception = parseException(query),
+      condition = "UNSUPPORTED_CASE_WHEN_CLAUSE",
+      sqlState = Some("42601"),
+      parameters = Map("clause" -> "LambdaFunction"),
+      context = ExpectedContext(
+        fragment = "case when a->b = true then 1 else 0 end",
+        start = 8,
+        stop = 46)
+    )
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Throw the exception from the proper place in code.

### Why are the changes needed?
Lambda functions can only be used as arguments of a small list of functions and therefore should be disallowed when they are part of CASE WHEN clauses.

### Does this PR introduce _any_ user-facing change?
Yes, the error will be thrown from the parser instead of the analyzer.

### How was this patch tested?
Added test.

### Was this patch authored or co-authored using generative AI tooling?
Copilot.
