### PR TITLE
[SPARK-49978][R]Move sparkR deprecation warning to package attach time

### DIFF
--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -57,6 +57,7 @@ Collate:
     'types.R'
     'utils.R'
     'window.R'
+    'zzz.R'
 RoxygenNote: 7.1.2
 VignetteBuilder: knitr
 NeedsCompilation: no

--- a/R/pkg/R/sparkR.R
+++ b/R/pkg/R/sparkR.R
@@ -403,12 +403,6 @@ sparkR.session <- function(
   sparkPackages = "",
   enableHiveSupport = TRUE,
   ...) {
-
-  if (Sys.getenv("SPARKR_SUPPRESS_DEPRECATION_WARNING") == "") {
-    warning(
-      "SparkR is deprecated from Apache Spark 4.0.0 and will be removed in a future version.")
-  }
-
   sparkConfigMap <- convertNamedListToEnv(sparkConfig)
   namedParams <- list(...)
   if (length(namedParams) > 0) {

--- a/R/pkg/R/zzz.R
+++ b/R/pkg/R/zzz.R
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# zzz.R - package startup message
+
+.onAttach <- function(...) {
+  if (Sys.getenv("SPARKR_SUPPRESS_DEPRECATION_WARNING") == "") {
+    packageStartupMessage(
+      paste0(
+        "Warning: sparkR is deprecated in Apache Spark 4.0.0 and will be removed in a future release. ",
+        "To conitnue using spark in R, we recommend using sparklyr instead: ",
+        "https://spark.posit.co/"
+      )
+    )
+  }
+}

--- a/R/pkg/R/zzz.R
+++ b/R/pkg/R/zzz.R
@@ -20,9 +20,10 @@
   if (Sys.getenv("SPARKR_SUPPRESS_DEPRECATION_WARNING") == "") {
     packageStartupMessage(
       paste0(
-        "Warning: sparkR is deprecated in Apache Spark 4.0.0 and will be removed in a future release. ",
-        "To conitnue using spark in R, we recommend using sparklyr instead: ",
-        "https://spark.posit.co/"
+        "Warning: ",
+        "SparkR is deprecated in Apache Spark 4.0.0 and will be removed in a future release. ",
+        "To continue using Spark in R, we recommend using sparklyr instead: ",
+        "https://spark.posit.co/get-started/"
       )
     )
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Previously, the output deprecation warning happens in the `spark.session` function, in this PR, we move it to the `.onAttach` function so it will be triggered whenever library is attached 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
I believe having the warning message on attach time have the following benefits:

- **Have a more prompt warning.** If the deprecation is for the whole package instead of just the `sparkR.session` function, it is more intuitive for the warning to show up on attach time instead of waiting til later time
- **Do not rely on the assumption of "every sparkR user will run sparkR.session method".** This asumption may not hold true all the time. For example, some hosted spark platform like Databricks already configure the spark session in the background and therefore will not show the error message. So making this change should make sure a broader reach for this warning notification
- **Less intrusive warning**. Previous warning show up every time `sparkR.session` is called, but the new warning message will only show up once even if user run multiple `library`/`require` commands

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
**Yes**
1. No more waring message in sparkR.session method
2. Warning message on library attach (when calling `library`/`require` function)
<img width="859" alt="image" src="https://github.com/user-attachments/assets/d88d9108-ec63-4f69-8de6-3f34eeafdd0c">
3. Able to surpress warning by setting `SPARKR_SUPPRESS_DEPRECATION_WARNING`
<img width="733" alt="image" src="https://github.com/user-attachments/assets/0266e6dd-3dc7-4c20-b999-b83906f381cd">


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Just a simple migration change, will rely on existing pre/post-merge check, and this existing test
Also did manual testing(see previous section for screenshot)

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No