### PR TITLE
[SPARK-49981][CORE][TESTS] Fix `AsyncRDDActionsSuite.FutureAction result, timeout` test case to be robust

### DIFF
--- a/core/src/test/scala/org/apache/spark/rdd/AsyncRDDActionsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/rdd/AsyncRDDActionsSuite.scala
@@ -201,10 +201,10 @@ class AsyncRDDActionsSuite extends SparkFunSuite with TimeLimits {
 
   test("FutureAction result, timeout") {
     val f = sc.parallelize(1 to 100, 4)
-              .mapPartitions(itr => { Thread.sleep(20); itr })
+              .mapPartitions(itr => { Thread.sleep(200); itr })
               .countAsync()
     intercept[TimeoutException] {
-      ThreadUtils.awaitResult(f, Duration(20, "milliseconds"))
+      ThreadUtils.awaitResult(f, Duration(2, "milliseconds"))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `AsyncRDDActionsSuite.FutureAction result, timeout` test case to be robust.

### Why are the changes needed?

To reduce the flakiness in GitHub Action CI. Previously, the sleep time is identical to the timeout time. It causes a flakiness in some environments like GitHub Action.
- https://github.com/apache/spark/actions/runs/11298639789/job/31428018075
```
AsyncRDDActionsSuite:
...
- FutureAction result, timeout *** FAILED ***
  Expected exception java.util.concurrent.TimeoutException to be thrown, but no exception was thrown (AsyncRDDActionsSuite.scala:206)
```

### Does this PR introduce _any_ user-facing change?

No, this is a test-only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.