### PR TITLE
[SPARK-49996][SQL][TESTS] Upgrade `mysql-connector-j` to 9.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,7 +327,7 @@
       -Dio.netty.tryReflectionSetAccessible=true
     </extraJavaTestArgs>
     <mariadb.java.client.version>2.7.12</mariadb.java.client.version>
-    <mysql.connector.version>9.0.0</mysql.connector.version>
+    <mysql.connector.version>9.1.0</mysql.connector.version>
     <postgresql.version>42.7.4</postgresql.version>
     <db2.jcc.version>11.5.9.0</db2.jcc.version>
     <mssql.jdbc.version>12.8.1.jre11</mssql.jdbc.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `mysql-connector-j` from `9.0.0` to `9.1.0`.


### Why are the changes needed?
The full release notes of `mysql-connector-j` 9.1.0:
https://dev.mysql.com/doc/relnotes/connector-j/en/news-9-1-0.html


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
