### PR TITLE
[SPARK-50001][PYTHON][PS][CONNECT] Adjust "precision" to be part of kwargs for box plots

### DIFF
--- a/python/pyspark/pandas/plot/core.py
+++ b/python/pyspark/pandas/plot/core.py
@@ -858,12 +858,11 @@ class PandasOnSparkPlotAccessor(PandasObject):
         Parameters
         ----------
         **kwds : dict, optional
-            Additional keyword arguments are documented in
+            Extra arguments to `precision `: refer to a float that is used by
+            pandas-on-Spark to compute approximate statistics for building a
+            boxplot. The default value is 0.01. Use smaller values to get more
+            precise statistics. Additional keyword arguments are documented in
             :meth:`pyspark.pandas.Series.plot`.
-        precision: scalar, default = 0.01
-            This argument is used by pandas-on-Spark to compute approximate statistics
-            for building a boxplot. Use smaller values to get more precise
-            statistics.
 
         Returns
         -------

--- a/python/pyspark/pandas/plot/core.py
+++ b/python/pyspark/pandas/plot/core.py
@@ -857,12 +857,13 @@ class PandasOnSparkPlotAccessor(PandasObject):
 
         Parameters
         ----------
-        **kwds : optional
+        **kwds : dict, optional
             Additional keyword arguments are documented in
             :meth:`pyspark.pandas.Series.plot`.
-            One of the optional keyword arguments is `precision`, a float that is used by
-            pandas-on-Spark to compute approximate statistics for building a boxplot.
-            The default value is 0.01. Use smaller values to get more precise statistics.
+        precision: scalar, default = 0.01
+            This argument is used by pandas-on-Spark to compute approximate statistics
+            for building a boxplot. Use smaller values to get more precise
+            statistics.
 
         Returns
         -------

--- a/python/pyspark/pandas/plot/core.py
+++ b/python/pyspark/pandas/plot/core.py
@@ -841,7 +841,7 @@ class PandasOnSparkPlotAccessor(PandasObject):
         elif isinstance(self.data, DataFrame):
             return self(kind="barh", x=x, y=y, **kwargs)
 
-    def box(self, precision=0.01, **kwds):
+    def box(self, **kwds):
         """
         Make a box plot of the DataFrame columns.
 
@@ -857,13 +857,12 @@ class PandasOnSparkPlotAccessor(PandasObject):
 
         Parameters
         ----------
-        precision: scalar, default = 0.01
-            This argument is used by pandas-on-Spark to compute approximate statistics
-            for building a boxplot. Use *smaller* values to get more precise
-            statistics.
         **kwds : optional
             Additional keyword arguments are documented in
             :meth:`pyspark.pandas.Series.plot`.
+            One of the optional keyword arguments is `precision`, a float that is used by
+            pandas-on-Spark to compute approximate statistics for building a boxplot.
+            The default value is 0.01. Use smaller values to get more precise statistics.
 
         Returns
         -------

--- a/python/pyspark/pandas/plot/core.py
+++ b/python/pyspark/pandas/plot/core.py
@@ -901,7 +901,7 @@ class PandasOnSparkPlotAccessor(PandasObject):
         from pyspark.pandas import DataFrame, Series
 
         if isinstance(self.data, (Series, DataFrame)):
-            return self(kind="box", precision=precision, **kwds)
+            return self(kind="box", **kwds)
 
     def hist(self, bins=10, **kwds):
         """

--- a/python/pyspark/pandas/plot/core.py
+++ b/python/pyspark/pandas/plot/core.py
@@ -858,7 +858,7 @@ class PandasOnSparkPlotAccessor(PandasObject):
         Parameters
         ----------
         **kwds : dict, optional
-            Extra arguments to `precision `: refer to a float that is used by
+            Extra arguments to `precision`: refer to a float that is used by
             pandas-on-Spark to compute approximate statistics for building a
             boxplot. The default value is 0.01. Use smaller values to get more
             precise statistics. Additional keyword arguments are documented in

--- a/python/pyspark/sql/plot/core.py
+++ b/python/pyspark/sql/plot/core.py
@@ -376,7 +376,7 @@ class PySparkPlotAccessor:
         column: str or list of str
             Column name or list of names to be used for creating the boxplot.
         **kwargs
-            Extra arguments to `precision `: refer to a float that is used by
+            Extra arguments to `precision`: refer to a float that is used by
             pyspark to compute approximate statistics for building a boxplot.
             The default value is 0.01. Use smaller values to get more precise statistics.
 

--- a/python/pyspark/sql/plot/core.py
+++ b/python/pyspark/sql/plot/core.py
@@ -402,7 +402,7 @@ class PySparkPlotAccessor:
         >>> df.plot.box(column="math_score")  # doctest: +SKIP
         >>> df.plot.box(column=["math_score", "english_score"])  # doctest: +SKIP
         """
-        return self(kind="box", column=column, precision=precision, **kwargs)
+        return self(kind="box", column=column, **kwargs)
 
     def kde(
         self,

--- a/python/pyspark/sql/plot/core.py
+++ b/python/pyspark/sql/plot/core.py
@@ -376,10 +376,9 @@ class PySparkPlotAccessor:
         column: str or list of str
             Column name or list of names to be used for creating the boxplot.
         **kwargs
-            Additional keyword arguments.
-            One of the optional keyword arguments is `precision`, a float that is used by
-            pyspark to compute approximate statistics for building a boxplot. The default
-            value is 0.01. Use smaller values to get more precise statistics.
+            Extra arguments to `precision `: refer to a float that is used by
+            pyspark to compute approximate statistics for building a boxplot.
+            The default value is 0.01. Use smaller values to get more precise statistics.
 
         Returns
         -------

--- a/python/pyspark/sql/plot/core.py
+++ b/python/pyspark/sql/plot/core.py
@@ -359,9 +359,7 @@ class PySparkPlotAccessor:
             )
         return self(kind="pie", x=x, y=y, **kwargs)
 
-    def box(
-        self, column: Union[str, List[str]], precision: float = 0.01, **kwargs: Any
-    ) -> "Figure":
+    def box(self, column: Union[str, List[str]], **kwargs: Any) -> "Figure":
         """
         Make a box plot of the DataFrame columns.
 
@@ -377,11 +375,11 @@ class PySparkPlotAccessor:
         ----------
         column: str or list of str
             Column name or list of names to be used for creating the boxplot.
-        precision: float, default = 0.01
-            This argument is used by pyspark to compute approximate statistics
-            for building a boxplot.
         **kwargs
             Additional keyword arguments.
+            One of the optional keyword arguments is `precision`, a float that is used by
+            pyspark to compute approximate statistics for building a boxplot. The default
+            value is 0.01. Use smaller values to get more precise statistics.
 
         Returns
         -------


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adjust "precision" to be kwargs for box plots in both Pandas on Spark and PySpark.

### Why are the changes needed?
Per discussion here (https://github.com/apache/spark/pull/48445#discussion_r1804042377), precision is Spark-specific implementation detail, so we wanted to keep “precision” as part of kwargs for box plots.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing tests.

### Was this patch authored or co-authored using generative AI tooling?
No.
