### PR TITLE
[SPARK-49495][INFRA][FOLLOW-UP] Disable GitHub Pages workflow in forked repository

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -40,6 +40,7 @@ jobs:
     env:
       SPARK_TESTING: 1 # Reduce some noise in the logs
       RELEASE_VERSION: 'In-Progress'
+    if: github.repository == 'apache/spark'
     steps:
       - name: Checkout Spark repository
         uses: actions/checkout@v4


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a followup of https://github.com/apache/spark/commit/4f640e2485d24088345b3f2d894c696ef29e2923 that disables GitHub Pages workflow in forked repository

### Why are the changes needed?

To automatically disable GitHub packages workflow in developers' forked repository. We can manually disable them too but this is a bit easier.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.