### PR TITLE
[SPARK-50008][PS][CONNECT] Avoid unnecessary operations in `attach_distributed_sequence_column`

### DIFF
--- a/python/pyspark/pandas/internal.py
+++ b/python/pyspark/pandas/internal.py
@@ -930,19 +930,7 @@ class InternalFrame:
         |       2|  c|
         +--------+---+
         """
-        if len(sdf.columns) > 0:
-            return sdf.select(
-                SF.distributed_sequence_id().alias(column_name),
-                "*",
-            )
-        else:
-            cnt = sdf.count()
-            if cnt > 0:
-                return default_session().range(cnt).toDF(column_name)
-            else:
-                return default_session().createDataFrame(
-                    [], schema=StructType().add(column_name, data_type=LongType(), nullable=False)
-                )
+        return sdf.select(SF.distributed_sequence_id().alias(column_name), "*")
 
     def spark_column_for(self, label: Label) -> PySparkColumn:
         """Return Spark Column for the given column label."""


### PR DESCRIPTION
### What changes were proposed in this pull request?
Avoid unnecessary operations in `attach_distributed_sequence_column`

### Why are the changes needed?
1, `attach_distributed_sequence_column` always needs `sdf.columns`, which may trigger an analysis task in Spark Connect if the `sdf.schema` has not been cached;
2, for zero columns dataframe, it trigger `sdf.count` which seems redundant;


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
added ut


### Was this patch authored or co-authored using generative AI tooling?
no
