### PR TITLE
[SPARK-50007][SQL][SS] Provide default values for metrics on observe API when physical node is lost in executed plan

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/CollectMetricsExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/CollectMetricsExec.scala
@@ -21,6 +21,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, NamedExpression, SortOrder}
+import org.apache.spark.sql.catalyst.plans.logical.{CollectMetrics, LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
@@ -98,13 +99,30 @@ object CollectMetricsExec extends AdaptiveSparkPlanHelper {
   /**
    * Recursively collect all collected metrics from a query tree.
    */
-  def collect(plan: SparkPlan): Map[String, Row] = {
-    val metrics = collectWithSubqueries(plan) {
+  def collect(physicalPlan: SparkPlan, analyzedOpt: Option[LogicalPlan]): Map[String, Row] = {
+    val collectorsInLogicalPlan = analyzedOpt.map {
+      _.collectWithSubqueries {
+        case c: CollectMetrics => c
+      }
+    }.getOrElse(Seq.empty[CollectMetrics])
+    val metrics = collectWithSubqueries(physicalPlan) {
       case collector: CollectMetricsExec =>
         Map(collector.name -> collector.collectedMetrics)
       case tableScan: InMemoryTableScanExec =>
-        CollectMetricsExec.collect(tableScan.relation.cachedPlan)
+        CollectMetricsExec.collect(
+          tableScan.relation.cachedPlan, tableScan.relation.cachedPlan.logicalLink)
     }
-    metrics.reduceOption(_ ++ _).getOrElse(Map.empty)
+    val metricsCollected = metrics.reduceOption(_ ++ _).getOrElse(Map.empty)
+    val initialMetricsForMissing = collectorsInLogicalPlan.flatMap { collector =>
+      if (!metricsCollected.contains(collector.name)) {
+        val exec = CollectMetricsExec(collector.name, collector.metrics,
+          EmptyRelationExec(LocalRelation(collector.child.output)))
+        val initialMetrics = exec.collectedMetrics
+        Some((collector.name -> initialMetrics))
+      } else {
+        None
+      }
+    }.toMap
+    metricsCollected ++ initialMetricsForMissing
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -243,7 +243,7 @@ class QueryExecution(
   def toRdd: RDD[InternalRow] = lazyToRdd.get
 
   /** Get the metrics observed during the execution of the query plan. */
-  def observedMetrics: Map[String, Row] = CollectMetricsExec.collect(executedPlan)
+  def observedMetrics: Map[String, Row] = CollectMetricsExec.collect(executedPlan, Some(analyzed))
 
   protected def preparations: Seq[Rule[SparkPlan]] = {
     QueryExecution.preparations(sparkSession,

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4941,6 +4941,20 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
       Row(Array(0), Array(0)), Row(Array(1), Array(1)), Row(Array(2), Array(2)))
     checkAnswer(df, expectedAnswer)
   }
+
+  test("SPARK-50007: default metrics is provided even observe node is pruned out") {
+    val namedObservation = Observation("observation")
+    spark.range(10)
+      .observe(namedObservation, count(lit(1)).as("rows"))
+      // Enforce PruneFilters to come into play and prune subtree. We could do the same
+      // with the reproducer of SPARK-48267, but let's just be simpler.
+      .filter(expr("false"))
+      .collect()
+
+    // This should produce the default value of metrics. Before SPARK-50007, the test fails
+    // because `namedObservation.getOrEmpty` is an empty Map.
+    assert(namedObservation.getOrEmpty.get("rows") === Some(0L))
+  }
 }
 
 case class Foo(bar: Option[String])

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryOptimizationCorrectnessSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamingQueryOptimizationCorrectnessSuite.scala
@@ -586,4 +586,28 @@ class StreamingQueryOptimizationCorrectnessSuite extends StreamTest {
       }
     )
   }
+
+  test("SPARK-50007: default metrics is provided even observe node is pruned out") {
+    // We disable SPARK-49699 to test the case observe node is pruned out.
+    withSQLConf(SQLConf.PRUNE_FILTERS_CAN_PRUNE_STREAMING_SUBPLAN.key -> "true") {
+      val input1 = MemoryStream[Int]
+      val df = input1.toDF()
+        .withColumn("eventTime", timestamp_seconds($"value"))
+        .observe("observation", count(lit(1)).as("rows"))
+        // Enforce PruneFilters to come into play and prune subtree. We could do the same
+        // with the reproducer of SPARK-48267, but let's just be simpler.
+        .filter(expr("false"))
+
+      testStream(df)(
+        AddData(input1, 1, 2, 3),
+        CheckNewAnswer(),
+        Execute { qe =>
+          val observeRow = qe.lastExecution.observedMetrics.get("observation")
+          // This should produce the default value of metrics. Before SPARK-50007, the test fails
+          // because `observeRow` is None. (Spark fails to find the metrics by name.)
+          assert(observeRow.get.getAs[Long]("rows") == 0L)
+        }
+      )
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to provide default values for metrics on observe API, when physical node (CollectMetricsExec) is lost in executed plan. This includes the case where logical node (CollectMetrics) is lost during optimization (and it's mostly the case).

### Why are the changes needed?

When user defines the metrics via observe API, they expect the metrics to be retrieved via Observation (batch query) or update event of StreamingQueryListener.

But when the node (CollectMetrics) is lost in any reason (e.g. subtree is pruned by PruneFilters), Spark does behave like the metrics were not defined, instead of providing default values.

When the query runs successfully, user wouldn't expect the metric being bound to the query to be unavailable, hence they missed to guard the code for this case and encountered some issue. Arguably it's lot better to provide default values - when the node is pruned out from optimizer, it is mostly logically equivalent that there were no input being processed with the node (except the bug in analyzer/optimizer/etc which drop the node incorrectly), hence it's valid to just have default value.

### Does this PR introduce _any_ user-facing change?

Yes, user can consistently query about metrics being defined with observe API. It is available even with aggressive optimization which drop the CollectMetrics(Exec) node.

### How was this patch tested?

New UTs.

### Was this patch authored or co-authored using generative AI tooling?

No.