### PR TITLE
[SPARK-50009][INFRA] Exclude pandas/resource/testing from `pyspark-core` module

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -427,7 +427,7 @@ examples = Module(
 pyspark_core = Module(
     name="pyspark-core",
     dependencies=[core],
-    source_file_regexes=["python/(?!pyspark/(ml|mllib|sql|streaming))"],
+    source_file_regexes=["python/(?!pyspark/(ml|mllib|sql|streaming|pandas|resource|testing))"],
     python_test_goals=[
         # doctests
         "pyspark.conf",


### PR DESCRIPTION
### What changes were proposed in this pull request?
Exclude pandas/resource/testing from `pyspark-core` module

### Why are the changes needed?
avoid unnecessary tests, e.g. in https://github.com/apache/spark/pull/48516, a pyspark-pandas only change trigger `spark-core` and then all the pyspark tests.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
manually check like:
```
In [6]: re.match("python/(?!pyspark/(ml|mllib|sql|streaming))", "python/pyspark/pandas/plots")
Out[6]: <re.Match object; span=(0, 7), match='python/'>

In [7]: re.match("python/(?!pyspark/(ml|mllib|sql|streaming|pandas))", "python/pyspark/pandas/plots")
```

### Was this patch authored or co-authored using generative AI tooling?
no
