### PR TITLE
[SPARK-50018][SQL] Make AbstractStringType serializable

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/types/AbstractStringType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/types/AbstractStringType.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.types.{AbstractDataType, DataType, StringType}
  * AbstractStringType is an abstract class for StringType with collation support.
  */
 abstract class AbstractStringType(supportsTrimCollation: Boolean = false)
-    extends AbstractDataType {
+    extends AbstractDataType with Serializable {
   override private[sql] def defaultConcreteType: DataType = SqlApiConf.get.defaultStringType
   override private[sql] def simpleString: String = "string"
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/types/AbstractStringType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/types/AbstractStringType.scala
@@ -24,7 +24,8 @@ import org.apache.spark.sql.types.{AbstractDataType, DataType, StringType}
  * AbstractStringType is an abstract class for StringType with collation support.
  */
 abstract class AbstractStringType(supportsTrimCollation: Boolean = false)
-    extends AbstractDataType with Serializable {
+    extends AbstractDataType
+    with Serializable {
   override private[sql] def defaultConcreteType: DataType = SqlApiConf.get.defaultStringType
   override private[sql] def simpleString: String = "string"
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Make `AbstractStringType` class serializable, so that the derived classes can be used in expressions that perform replacement using `Invoke`-like Spark expressions.


### Why are the changes needed?
Objects with custom parameters cannot be used as inputTypes unless the underlying class is serializable. For example, `ValidateUTF8` is a string function that uses `StaticInvoke` replacement, and an object derived from `AbstractStringType` as one of the input types.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing tests suffice. More will be added with appropriate collation support in various Spark expressions.


### Was this patch authored or co-authored using generative AI tooling?
No.
