### PR TITLE
[SPARK-50019][INFRA] Install BASIC_PIP_PKGS except `pyarrow` in Python 3.13 image

### DIFF
--- a/dev/infra/base/Dockerfile
+++ b/dev/infra/base/Dockerfile
@@ -148,7 +148,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.13
 # TODO(SPARK-49862) Add BASIC_PIP_PKGS and CONNECT_PIP_PKGS to Python 3.13 image when it supports Python 3.13
 RUN python3.13 -m pip install --ignore-installed blinker>=1.6.2 # mlflow needs this
-RUN python3.13 -m pip install grpcio==1.67.0 grpcio-status==1.67.0 lxml numpy>=2.1 && \
+RUN python3.13 -m pip install numpy six==1.16.0 pandas==2.2.3 scipy coverage matplotlib openpyxl grpcio==1.67.0 grpcio-status==1.67.0 lxml numpy>=2.1 && \
     python3.13 -m pip cache purge
 
 # Remove unused installation packages to free up disk space


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to install `BASIC_PIP_PKGS` except `pyarrow` in Python 3.13 image.

### Why are the changes needed?

- https://github.com/apache/spark/actions/runs/11392144577/job/31698382766
```
Traceback (most recent call last):
  File "/__w/spark/spark/python/pyspark/sql/pandas/utils.py", line 28, in require_minimum_pandas_version
    import pandas
ModuleNotFoundError: No module named 'pandas'
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Manual check with the built image of this PR builder.

```
$ docker run -it --rm ghcr.io/dongjoon-hyun/apache-spark-ci-image:master-11392974455 python3.13 -m pip list | grep pandas
pandas                   2.2.3
```

### Was this patch authored or co-authored using generative AI tooling?

No.