### PR TITLE
[MINOR][TESTS] Fix appname from `sql.protobuf.functions` to `sql.connect.protobuf.functions`

### DIFF
--- a/python/pyspark/sql/connect/protobuf/functions.py
+++ b/python/pyspark/sql/connect/protobuf/functions.py
@@ -142,7 +142,7 @@ def _test() -> None:
 
     globs = pyspark.sql.connect.protobuf.functions.__dict__.copy()
     globs["spark"] = (
-        PySparkSession.builder.appName("sql.protobuf.functions tests")
+        PySparkSession.builder.appName("sql.connect.protobuf.functions tests")
         .remote(os.environ.get("SPARK_CONNECT_TESTING_REMOTE", "local[2]"))
         .getOrCreate()
     )


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to fix appname from `sql.protobuf.functions` to `sql.connect.protobuf.functions`

### Why are the changes needed?

For consistency


### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually checked.

### Was this patch authored or co-authored using generative AI tooling?

No.