### PR TITLE
[SPARK-50041][PYTHON] Show a proper error message when memory_profiler not found

### DIFF
--- a/python/pyspark/profiler.py
+++ b/python/pyspark/profiler.py
@@ -459,6 +459,12 @@ class MemoryProfiler(Profiler):
     def _show_results(
         code_map: CodeMapDict, stream: Optional[Any] = None, precision: int = 1
     ) -> None:
+        if has_memory_profiler:
+            raise PySparkRuntimeError(
+                errorClass="MISSING_LIBRARY_FOR_PROFILER",
+                messageParameters={},
+            )
+
         if stream is None:
             stream = sys.stdout
         template = "{0:>6} {1:>12} {2:>12}  {3:>10}   {4:<}"


### PR DESCRIPTION
### What changes were proposed in this pull request?


```python
from pyspark.sql.functions import pandas_udf
df = spark.range(10)

@pandas_udf("long")
def add1(x):
  return x + 1

spark.conf.set("spark.sql.pyspark.udf.profiler", "memory")

added = df.select(add1("id"))
added.show()
spark.profile.show(type="memory")
```

**Before**

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../python/pyspark/sql/profiler.py", line 320, in show
    self.profiler_collector.show_memory_profiles(id)
  File "/.../python/pyspark/sql/profiler.py", line 145, in show_memory_profiles
    show(id)
  File "/.../python/pyspark/sql/profiler.py", line 139, in show
    MemoryProfiler._show_results(cm)
  File "/.../python/pyspark/profiler.py", line 497, in _show_results
    tmp = template.format(lineno, total_mem, inc, occurrences, all_lines[lineno - 1])
```


**After**

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/.../python/pyspark/sql/profiler.py", line 320, in show
    self.profiler_collector.show_memory_profiles(id)
  File "/.../python/pyspark/sql/profiler.py", line 145, in show_memory_profiles
    show(id)
  File "/.../python/pyspark/sql/profiler.py", line 139, in show
    MemoryProfiler._show_results(cm)
  File "/.../python/pyspark/profiler.py", line 463, in _show_results
    raise PySparkRuntimeError(
pyspark.errors.exceptions.base.PySparkRuntimeError: [MISSING_LIBRARY_FOR_PROFILER] Install the 'memory_profiler' library in the cluster to enable memory profiling.
```

### Why are the changes needed?

To guide users properly for installing the package.

### Does this PR introduce _any_ user-facing change?

Yes, it changes the user-facing error message.

### How was this patch tested?

Manually tested via running the example at https://apache.github.io/spark/api/python/development/debugging.html#identifying-hot-loops-python-profilers

### Was this patch authored or co-authored using generative AI tooling?

No.