### PR TITLE
[SPARK-50049][SQL] Support custom driver metrics in writing to v2 table

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/Write.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/Write.java
@@ -24,6 +24,7 @@ import org.apache.spark.annotation.Evolving;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCapability;
 import org.apache.spark.sql.connector.metric.CustomMetric;
+import org.apache.spark.sql.connector.metric.CustomTaskMetric;
 import org.apache.spark.sql.connector.write.streaming.StreamingWrite;
 
 /**
@@ -76,4 +77,14 @@ public interface Write {
   default CustomMetric[] supportedCustomMetrics() {
     return new CustomMetric[]{};
   }
+
+  /**
+   * Returns an array of custom metrics which are collected with values at the driver side only.
+   * Note that these metrics must be included in the supported custom metrics reported by
+   * `supportedCustomMetrics`.
+   */
+  default CustomTaskMetric[] reportDriverMetrics() {
+    return new CustomTaskMetric[]{};
+  }
+
 }

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/Write.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/Write.java
@@ -83,7 +83,7 @@ public interface Write {
    * Note that these metrics must be included in the supported custom metrics reported by
    * `supportedCustomMetrics`.
    */
-  default CustomTaskMetric [] reportDriverMetrics() {
+  default CustomTaskMetric[] reportDriverMetrics() {
     return new CustomTaskMetric[]{};
   }
 

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/Write.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/write/Write.java
@@ -83,7 +83,7 @@ public interface Write {
    * Note that these metrics must be included in the supported custom metrics reported by
    * `supportedCustomMetrics`.
    */
-  default CustomTaskMetric[] reportDriverMetrics() {
+  default CustomTaskMetric [] reportDriverMetrics() {
     return new CustomTaskMetric[]{};
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/InMemoryTableMetricSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/InMemoryTableMetricSuite.scala
@@ -42,7 +42,7 @@ class InMemoryTableMetricSuite
     spark.sessionState.conf.clear()
   }
 
-  private def testMetricOnDSv2(func: String => Unit, checker: Map[Long, String] => Unit): Unit = {
+  private def testMetricOnDSv2(func: String => Unit, checker: Map[String, String] => Unit): Unit = {
     withTable("testcat.table_name") {
       val statusStore = spark.sharedState.statusStore
       val oldCount = statusStore.executionsList().size
@@ -67,8 +67,14 @@ class InMemoryTableMetricSuite
           statusStore.executionsList().last.metricValues != null)
       }
 
+      val exec = statusStore.executionsList().last
       val execId = statusStore.executionsList().last.executionId
-      val metrics = statusStore.executionMetrics(execId)
+      val sqlMetrics = exec.metrics.map { metric =>
+        metric.accumulatorId -> metric.name
+      }.toMap
+      val metrics = statusStore.executionMetrics(execId).map { case (k, v) =>
+        sqlMetrics(k) -> v
+      }
       checker(metrics)
     }
   }
@@ -79,8 +85,8 @@ class InMemoryTableMetricSuite
       val v2Writer = df.writeTo(table)
       v2Writer.append()
     }, metrics => {
-      val customMetric = metrics.find(_._2 == "in-memory rows: 1")
-      assert(customMetric.isDefined)
+      assert(metrics.get("number of rows in buffer").contains("in-memory rows: 1"))
+      assert(metrics.get("number of rows from driver").contains("1"))
     })
   }
 
@@ -90,8 +96,8 @@ class InMemoryTableMetricSuite
       val v2Writer = df.writeTo(table)
       v2Writer.overwrite(lit(true))
     }, metrics => {
-      val customMetric = metrics.find(_._2 == "in-memory rows: 3")
-      assert(customMetric.isDefined)
+      assert(metrics.get("number of rows in buffer").contains("in-memory rows: 3"))
+      assert(metrics.get("number of rows from driver").contains("3"))
     })
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/InMemoryTableMetricSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/datasources/InMemoryTableMetricSuite.scala
@@ -68,7 +68,7 @@ class InMemoryTableMetricSuite
       }
 
       val exec = statusStore.executionsList().last
-      val execId = statusStore.executionsList().last.executionId
+      val execId = exec.executionId
       val sqlMetrics = exec.metrics.map { metric =>
         metric.accumulatorId -> metric.name
       }.toMap


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add `reportDriverMetrics` method to `Write` API and post custom metrics from driver after v2 write commits.

### Why are the changes needed?


### Does this PR introduce _any_ user-facing change?
#37205 supported reporting custom driver metrics when reading from v2 table. This is to support that when writing to v2 table.


### How was this patch tested?
UT.


### Was this patch authored or co-authored using generative AI tooling?
No.
