### PR TITLE
[SPARK-50052][PYTHON] Make `NumpyArrayConverter` support empty str ndarray

### DIFF
--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -3273,6 +3273,8 @@ class NumpyArrayConverter:
             return gateway.jvm.double
         elif nt == np.dtype("bool"):
             return gateway.jvm.boolean
+        elif np.issubdtype(nt, np.str_):
+            return gateway.jvm.String
 
         return None
 
@@ -3286,15 +3288,12 @@ class NumpyArrayConverter:
         assert gateway is not None
         plist = obj.tolist()
 
-        if len(obj) > 0 and isinstance(plist[0], str):
-            jtpe = gateway.jvm.String
-        else:
-            jtpe = self._from_numpy_type_to_java_type(obj.dtype, gateway)
-            if jtpe is None:
-                raise PySparkTypeError(
-                    errorClass="UNSUPPORTED_NUMPY_ARRAY_SCALAR",
-                    messageParameters={"dtype": str(obj.dtype)},
-                )
+        jtpe = self._from_numpy_type_to_java_type(obj.dtype, gateway)
+        if jtpe is None:
+            raise PySparkTypeError(
+                errorClass="UNSUPPORTED_NUMPY_ARRAY_SCALAR",
+                messageParameters={"dtype": str(obj.dtype)},
+            )
         jarr = gateway.new_array(jtpe, len(obj))
         for i in range(len(plist)):
             jarr[i] = plist[i]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `NumpyArrayConverter` support empty str ndarray


### Why are the changes needed?
existing implementation needs the str ndarray to be non-empty, so fails:
```
In [6]: spark.range(1).select(sf.lit(np.array(["a", "b"], np.str_)))
Out[6]: DataFrame[ARRAY('a', 'b'): array<string>]

In [7]: spark.range(1).select(sf.lit(np.array([], np.int32)))
Out[7]: DataFrame[ARRAY(): array<int>]

In [8]: spark.range(1).select(sf.lit(np.array([], np.str_)))
...

PySparkTypeError: [UNSUPPORTED_NUMPY_ARRAY_SCALAR] The type of array scalar '<U1' is not supported.

```

### Does this PR introduce _any_ user-facing change?
support empty string array


### How was this patch tested?
added test

### Was this patch authored or co-authored using generative AI tooling?
no