### PR TITLE
[SPARK-50052][PYTHON] Make NumpyArrayConverter support empty str ndarray

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_functions.py
+++ b/python/pyspark/sql/tests/connect/test_parity_functions.py
@@ -34,6 +34,14 @@ class FunctionsParityTests(FunctionsTestsMixin, ReusedConnectTestCase):
     def test_input_file_name_reset_for_rdd(self):
         super().test_input_file_name_reset_for_rdd()
 
+    @unittest.skip("SPARK-50050: Spark Connect should support str ndarray.")
+    def test_str_ndarray(self):
+        super().test_str_ndarray()
+
+    @unittest.skip("SPARK-50051: Spark Connect should empty ndarray.")
+    def test_empty_ndarray(self):
+        super().test_empty_ndarray()
+
 
 if __name__ == "__main__":
     from pyspark.sql.tests.connect.test_parity_functions import *  # noqa: F401

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1263,6 +1263,29 @@ class FunctionsTestsMixin:
             },
         )
 
+    @unittest.skipIf(not have_numpy, "NumPy not installed")
+    def test_str_ndarray(self):
+        import numpy as np
+
+        for arr in [
+            np.array([], np.str_),
+            np.array(["a"], np.str_),
+            np.array([1, 2, 3], np.str_),
+        ]:
+            self.assertEqual(
+                [("a", "array<string>")],
+                self.spark.range(1).select(F.lit(arr).alias("a")).dtypes,
+            )
+
+    @unittest.skipIf(not have_numpy, "NumPy not installed")
+    def test_empty_ndarray(self):
+        import numpy as np
+
+        self.assertEqual(
+            [("a", "array<int>")],
+            self.spark.range(1).select(F.lit(np.array([], np.int32)).alias("a")).dtypes,
+        )
+
     def test_binary_math_function(self):
         funcs, expected = zip(
             *[(F.atan2, 0.13664), (F.hypot, 8.07527), (F.pow, 2.14359), (F.pmod, 1.1)]

--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -3273,6 +3273,8 @@ class NumpyArrayConverter:
             return gateway.jvm.double
         elif nt == np.dtype("bool"):
             return gateway.jvm.boolean
+        elif np.isdtype(nt, np.str_):
+            return gateway.jvm.String
 
         return None
 
@@ -3286,15 +3288,12 @@ class NumpyArrayConverter:
         assert gateway is not None
         plist = obj.tolist()
 
-        if len(obj) > 0 and isinstance(plist[0], str):
-            jtpe = gateway.jvm.String
-        else:
-            jtpe = self._from_numpy_type_to_java_type(obj.dtype, gateway)
-            if jtpe is None:
-                raise PySparkTypeError(
-                    errorClass="UNSUPPORTED_NUMPY_ARRAY_SCALAR",
-                    messageParameters={"dtype": str(obj.dtype)},
-                )
+        jtpe = self._from_numpy_type_to_java_type(obj.dtype, gateway)
+        if jtpe is None:
+            raise PySparkTypeError(
+                errorClass="UNSUPPORTED_NUMPY_ARRAY_SCALAR",
+                messageParameters={"dtype": str(obj.dtype)},
+            )
         jarr = gateway.new_array(jtpe, len(obj))
         for i in range(len(plist)):
             jarr[i] = plist[i]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `NumpyArrayConverter` support empty str ndarray


### Why are the changes needed?
existing implementation needs the str ndarray to be non-empty, so fails:
```
In [6]: spark.range(1).select(sf.lit(np.array(["a", "b"], np.str_)))
Out[6]: DataFrame[ARRAY('a', 'b'): array<string>]

In [7]: spark.range(1).select(sf.lit(np.array([], np.int32)))
Out[7]: DataFrame[ARRAY(): array<int>]

In [8]: spark.range(1).select(sf.lit(np.array([], np.str_)))
...

PySparkTypeError: [UNSUPPORTED_NUMPY_ARRAY_SCALAR] The type of array scalar '<U1' is not supported.

```

### Does this PR introduce _any_ user-facing change?
support empty string array

```
In [3]: spark.range(1).select(sf.lit(np.array([], np.str_)))
Out[3]: DataFrame[ARRAY(): array<string>]
```


### How was this patch tested?
added test

### Was this patch authored or co-authored using generative AI tooling?
no