### PR TITLE
[SPARK-48413][SQL][FOLLOW-UP] Fix ALTER COLUMN with collation

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -1549,7 +1549,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
           val sameTypeExceptCollations =
             DataType.equalsIgnoreCompatibleCollation(field.dataType, newDataType)
           newDataType match {
-            case _ if sameTypeExceptCollations =>
+            case _ if sameTypeExceptCollations => // Allow changing type collations.
             case _: StructType => alter.failAnalysis(
               "CANNOT_UPDATE_FIELD.STRUCT_TYPE",
               Map("table" -> toSQLId(table.name), "fieldName" -> toSQLId(fieldName)))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -1546,7 +1546,10 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
             .map(dt => col.field.copy(dataType = dt))
             .getOrElse(col.field)
           val newDataType = a.dataType.get
+          val sameTypeExceptCollations =
+            DataType.equalsIgnoreCompatibleCollation(field.dataType, newDataType)
           newDataType match {
+            case _ if sameTypeExceptCollations =>
             case _: StructType => alter.failAnalysis(
               "CANNOT_UPDATE_FIELD.STRUCT_TYPE",
               Map("table" -> toSQLId(table.name), "fieldName" -> toSQLId(fieldName)))
@@ -1576,7 +1579,7 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
             case _ => Cast.canUpCast(from, to)
           }
 
-          if (!canAlterColumnType(field.dataType, newDataType)) {
+          if (!sameTypeExceptCollations && !canAlterColumnType(field.dataType, newDataType)) {
             alter.failAnalysis(
               errorClass = "NOT_SUPPORTED_CHANGE_COLUMN",
               messageParameters = Map(

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
@@ -519,10 +519,22 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
   test("SPARK-48413: Alter column with collation") {
     val tableName = "testcat.alter_column_tbl"
     withTable(tableName) {
-      sql(s"CREATE TABLE $tableName (c1 STRING) USING PARQUET")
-      sql(s"INSERT INTO $tableName VALUES ('a')")
+      spark.sql(
+        s"""CREATE TABLE $tableName (
+           |c1 STRING,
+           |c2 ARRAY<STRING>,
+           |c3 MAP<INT, STRING>,
+           |c4 STRUCT<t: STRING>)
+           |USING PARQUET
+           |""".stripMargin)
+      sql(s"INSERT INTO $tableName VALUES ('a', array('b'), map(1, 'c'), struct('d'))")
       sql(s"ALTER TABLE $tableName ALTER COLUMN c1 TYPE STRING COLLATE UTF8_LCASE")
-      checkAnswer(sql(s"SELECT collation(c1) FROM $tableName"), Seq(Row("UTF8_LCASE")))
+      sql(s"ALTER TABLE $tableName ALTER COLUMN c2 TYPE ARRAY<STRING COLLATE UNICODE_CI>")
+      sql(s"ALTER TABLE $tableName ALTER COLUMN c3 TYPE MAP<INT, STRING COLLATE UTF8_BINARY>")
+      sql(s"ALTER TABLE $tableName ALTER COLUMN c4 TYPE STRUCT<t: STRING COLLATE UNICODE>")
+      checkAnswer(sql(s"SELECT collation(c1), collation(c2[0]), " +
+        s"collation(c3[1]), collation(c4.t) FROM $tableName"),
+        Seq(Row("UTF8_LCASE", "UNICODE_CI", "UTF8_BINARY", "UNICODE")))
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
@@ -516,6 +516,14 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
     }
   }
 
+  test("SPARK-48413: Alter column with collation") {
+    val tableName = "testcat.alter_column_tbl"
+    withTable(tableName) {
+      sql(s"CREATE TABLE $tableName (c1 STRING) USING PARQUET")
+      sql(s"ALTER TABLE $tableName ALTER COLUMN c1 TYPE STRING COLLATE UTF8_LCASE")
+    }
+  }
+
   test("SPARK-47210: Implicit casting of collated strings") {
     val tableName = "parquet_dummy_implicit_cast_t22"
     withTable(tableName) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
@@ -520,8 +520,8 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
     val tableName = "testcat.alter_column_tbl"
     withTable(tableName) {
       sql(s"CREATE TABLE $tableName (c1 STRING) USING PARQUET")
-      sql(s"ALTER TABLE $tableName ALTER COLUMN c1 TYPE STRING COLLATE UTF8_LCASE")
       sql(s"INSERT INTO $tableName VALUES ('a')")
+      sql(s"ALTER TABLE $tableName ALTER COLUMN c1 TYPE STRING COLLATE UTF8_LCASE")
       checkAnswer(sql(s"SELECT collation(c1) FROM $tableName"), Seq(Row("UTF8_LCASE")))
     }
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
@@ -521,6 +521,8 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
     withTable(tableName) {
       sql(s"CREATE TABLE $tableName (c1 STRING) USING PARQUET")
       sql(s"ALTER TABLE $tableName ALTER COLUMN c1 TYPE STRING COLLATE UTF8_LCASE")
+      sql(s"INSERT INTO $tableName VALUES ('a')")
+      checkAnswer(sql(s"SELECT collation(c1) FROM $tableName"), Seq(Row("UTF8_LCASE")))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixing the analysis check error introduced in [this](https://github.com/apache/spark/pull/46734) PR, where the `ALTER COLUMN` command would fail on tables that contain catalog in their names, ensuring consistent behavior across all table naming conventions. 


### Why are the changes needed?
Change is needed to enable altering column with all datasources and identifier variations. 


### Does this PR introduce _any_ user-facing change?
No. 


### How was this patch tested?
Added tests to `CollationSuite`. 


### Was this patch authored or co-authored using generative AI tooling?
No. 
