### PR TITLE
[SPARK-50051][PYTHON][CONNECT] Make `lit` works with empty numpy ndarray

### DIFF
--- a/python/pyspark/sql/tests/connect/test_parity_functions.py
+++ b/python/pyspark/sql/tests/connect/test_parity_functions.py
@@ -38,10 +38,6 @@ class FunctionsParityTests(FunctionsTestsMixin, ReusedConnectTestCase):
     def test_str_ndarray(self):
         super().test_str_ndarray()
 
-    @unittest.skip("SPARK-50051: Spark Connect should empty ndarray.")
-    def test_empty_ndarray(self):
-        super().test_empty_ndarray()
-
 
 if __name__ == "__main__":
     from pyspark.sql.tests.connect.test_parity_functions import *  # noqa: F401

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1281,10 +1281,19 @@ class FunctionsTestsMixin:
     def test_empty_ndarray(self):
         import numpy as np
 
-        self.assertEqual(
-            [("a", "array<int>")],
-            self.spark.range(1).select(F.lit(np.array([], np.int32)).alias("a")).dtypes,
-        )
+        arr_dtype_to_spark_dtypes = [
+            ("int8", [("b", "array<smallint>")]),
+            ("int16", [("b", "array<smallint>")]),
+            ("int32", [("b", "array<int>")]),
+            ("int64", [("b", "array<bigint>")]),
+            ("float32", [("b", "array<float>")]),
+            ("float64", [("b", "array<double>")]),
+        ]
+        for t, expected_spark_dtypes in arr_dtype_to_spark_dtypes:
+            arr = np.array([]).astype(t)
+            self.assertEqual(
+                expected_spark_dtypes, self.spark.range(1).select(F.lit(arr).alias("b")).dtypes
+            )
 
     def test_binary_math_function(self):
         funcs, expected = zip(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `lit` works with empty numpy ndarray


### Why are the changes needed?
bug fix, the schema for empty ndarray is incorrect

PySpark Classic:
```
In [3]: spark.range(1).select(sf.lit(np.array([1,2,3], np.int32))).schema
Out[3]: StructType([StructField('ARRAY(1, 2, 3)', ArrayType(IntegerType(), True), False)])

In [4]: spark.range(1).select(sf.lit(np.array([], np.int32))).schema
Out[4]: StructType([StructField('ARRAY()', ArrayType(IntegerType(), True), False)])
```




### Does this PR introduce _any_ user-facing change?
before:
```
In [7]: spark.range(1).select(sf.lit(np.array([], np.int32))).schema
Out[7]: StructType([StructField('array()', ArrayType(NullType(), False), False)])
```

after:
```
In [3]: spark.range(1).select(sf.lit(np.array([], np.int32))).schema
Out[3]: StructType([StructField('array()', ArrayType(IntegerType(), True), False)])
```


### How was this patch tested?
added tests


### Was this patch authored or co-authored using generative AI tooling?
no
