### PR TITLE
Revert "[SPARK-50007][SQL][SS] Provide default values for metrics on observe API when physical node is lost in executed plan"

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -243,7 +243,7 @@ class QueryExecution(
   def toRdd: RDD[InternalRow] = lazyToRdd.get
 
   /** Get the metrics observed during the execution of the query plan. */
-  def observedMetrics: Map[String, Row] = CollectMetricsExec.collect(executedPlan, Some(analyzed))
+  def observedMetrics: Map[String, Row] = CollectMetricsExec.collect(executedPlan)
 
   protected def preparations: Seq[Rule[SparkPlan]] = {
     QueryExecution.preparations(sparkSession,

--- a/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SQLQuerySuite.scala
@@ -4941,20 +4941,6 @@ class SQLQuerySuite extends QueryTest with SharedSparkSession with AdaptiveSpark
       Row(Array(0), Array(0)), Row(Array(1), Array(1)), Row(Array(2), Array(2)))
     checkAnswer(df, expectedAnswer)
   }
-
-  test("SPARK-50007: default metrics is provided even observe node is pruned out") {
-    val namedObservation = Observation("observation")
-    spark.range(10)
-      .observe(namedObservation, count(lit(1)).as("rows"))
-      // Enforce PruneFilters to come into play and prune subtree. We could do the same
-      // with the reproducer of SPARK-48267, but let's just be simpler.
-      .filter(expr("false"))
-      .collect()
-
-    // This should produce the default value of metrics. Before SPARK-50007, the test fails
-    // because `namedObservation.getOrEmpty` is an empty Map.
-    assert(namedObservation.getOrEmpty.get("rows") === Some(0L))
-  }
 }
 
 case class Foo(bar: Option[String])


### PR DESCRIPTION
This reverts commit 0705e102292323551b3f6dfbb7edabc06d31ceb3.

Rationale: 
@hvanhovell helped to clarify the semantic of the API - it should capture the data itself and not just evaluating against flowing inputs. For example, suppose the query `df.observe("name", count(lit(1)).as("rc")).filter(false)`, the intention of the API is to "rc" to have 4 if there are 4 rows in df, regardless whether the 4 rows will be soon discarded. The commit 0705e102292323551b3f6dfbb7edabc06d31ceb3 is against this.

Furthermore, if we lost the node due to optimization, users wouldn't know whether Spark somehow dropped the node hence metric is not available, with the commit 0705e102292323551b3f6dfbb7edabc06d31ceb3. Before the commit, users may encounter the issue with unavailability of the metric they just registered, but that is at least playing as distinguishing the case of node loss vs no input.