### PR TITLE
[SPARK-50051][PYTHON][FOLLOW-UP] Fix data type check for Numpy 1.x 

### DIFF
--- a/python/pyspark/sql/types.py
+++ b/python/pyspark/sql/types.py
@@ -3273,7 +3273,7 @@ class NumpyArrayConverter:
             return gateway.jvm.double
         elif nt == np.dtype("bool"):
             return gateway.jvm.boolean
-        elif np.isdtype(nt, np.str_):
+        elif nt.type == np.dtype("str"):
             return gateway.jvm.String
 
         return None


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix type check for Numpy 1.x: `np.isdtype` is not available in Numpy 1.x

### Why are the changes needed?
```
In [13]: np.__version__
Out[13]: '1.26.4'

In [14]: a = np.str_("123")

In [15]: np.isdtype(a.dtype, np.str_)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[15], line 1
----> 1 np.isdtype(a.dtype, np.str_)

File ~/.dev/venv/py_312/lib/python3.12/site-packages/numpy/__init__.py:333, in __getattr__(attr)
    330     "Removed in NumPy 1.25.0"
    331     raise RuntimeError("Tester was removed in NumPy 1.25.")
--> 333 raise AttributeError("module {!r} has no attribute "
    334                      "{!r}".format(__name__, attr))

AttributeError: module 'numpy' has no attribute 'isdtype'

In [16]: a.dtype.type == np.dtype("str")
Out[16]: True
```


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
