### PR TITLE
[SPARK-50062][SQL] Support collations by `InSet`

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -661,9 +661,9 @@ case class InSet(child: Expression, hset: Set[Any]) extends UnaryExpression with
       if (st.supportsBinaryEquality) {
         hset
       } else if (st.supportsLowercaseEquality) {
-        new InSet.LCaseSet(hset)
+        new InSet.LowercaseSet(hset)
       } else {
-        new InSet.CollationSet(hset, st.collationId)
+        new InSet.CollationAwareSet(hset, st.collationId)
       }
     case t: AtomicType if !t.isInstanceOf[BinaryType] => hset
     case _: NullType => hset
@@ -778,7 +778,7 @@ case class InSet(child: Expression, hset: Set[Any]) extends UnaryExpression with
 }
 
 object InSet {
-  class LCaseSet(inputSet: Set[Any]) extends immutable.Set[Any] with Serializable {
+  class LowercaseSet(inputSet: Set[Any]) extends immutable.Set[Any] with Serializable {
     private val strSet = inputSet.map { s =>
       if (s == null) null
       else CollationAwareUTF8String.lowerCaseCodePoints(s.asInstanceOf[UTF8String])
@@ -791,7 +791,7 @@ object InSet {
       strSet.contains(CollationAwareUTF8String.lowerCaseCodePoints(elem.asInstanceOf[UTF8String]))
     }
   }
-  class CollationSet(inputSet: Set[Any], collationId: Int)
+  class CollationAwareSet(inputSet: Set[Any], collationId: Int)
     extends immutable.Set[Any] with Serializable {
     override def incl(elem: Any): Set[Any] = inputSet.incl(elem)
     override def excl(elem: Any): Set[Any] = inputSet.excl(elem)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -21,7 +21,6 @@ import scala.collection.immutable
 import scala.collection.immutable.TreeSet
 
 import org.apache.spark.SparkUnsupportedOperationException
-
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -20,6 +20,8 @@ package org.apache.spark.sql.catalyst.expressions
 import scala.collection.immutable
 import scala.collection.immutable.TreeSet
 
+import org.apache.spark.SparkUnsupportedOperationException
+
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
@@ -783,9 +785,9 @@ object InSet {
       if (s == null) null
       else CollationAwareUTF8String.lowerCaseCodePoints(s.asInstanceOf[UTF8String])
     }
-    override def incl(elem: Any): Set[Any] = inputSet.incl(elem)
-    override def excl(elem: Any): Set[Any] = inputSet.excl(elem)
-    override def iterator: Iterator[Any] = inputSet.iterator
+    override def incl(elem: Any): Set[Any] = throw SparkUnsupportedOperationException()
+    override def excl(elem: Any): Set[Any] = throw SparkUnsupportedOperationException()
+    override def iterator: Iterator[Any] = throw SparkUnsupportedOperationException()
     override def contains(elem: Any): Boolean = {
       assert(elem != null, "InSet guarantees non-null input")
       strSet.contains(CollationAwareUTF8String.lowerCaseCodePoints(elem.asInstanceOf[UTF8String]))
@@ -793,9 +795,9 @@ object InSet {
   }
   class CollationAwareSet(inputSet: Set[Any], collationId: Int)
     extends immutable.Set[Any] with Serializable {
-    override def incl(elem: Any): Set[Any] = inputSet.incl(elem)
-    override def excl(elem: Any): Set[Any] = inputSet.excl(elem)
-    override def iterator: Iterator[Any] = inputSet.iterator
+    override def incl(elem: Any): Set[Any] = throw SparkUnsupportedOperationException()
+    override def excl(elem: Any): Set[Any] = throw SparkUnsupportedOperationException()
+    override def iterator: Iterator[Any] = throw SparkUnsupportedOperationException()
     override def contains(elem: Any): Boolean = {
       assert(elem != null, "InSet guarantees non-null input")
       val collation = CollationFactory.fetchCollation(collationId)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -786,7 +786,6 @@ object InSet {
     override def incl(elem: Any): Set[Any] = inputSet.incl(elem)
     override def excl(elem: Any): Set[Any] = inputSet.excl(elem)
     override def iterator: Iterator[Any] = inputSet.iterator
-
     override def contains(elem: Any): Boolean = {
       assert(elem != null, "InSet guarantees non-null input")
       strSet.contains(CollationAwareUTF8String.lowerCaseCodePoints(elem.asInstanceOf[UTF8String]))
@@ -794,13 +793,12 @@ object InSet {
   }
   class CollationSet(inputSet: Set[Any], collationId: Int)
     extends immutable.Set[Any] with Serializable {
-    private val collation = CollationFactory.fetchCollation(collationId)
     override def incl(elem: Any): Set[Any] = inputSet.incl(elem)
     override def excl(elem: Any): Set[Any] = inputSet.excl(elem)
     override def iterator: Iterator[Any] = inputSet.iterator
-
     override def contains(elem: Any): Boolean = {
       assert(elem != null, "InSet guarantees non-null input")
+      val collation = CollationFactory.fetchCollation(collationId)
       inputSet.exists { p =>
         collation.equalsFunction(p.asInstanceOf[UTF8String], elem.asInstanceOf[UTF8String])
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -778,7 +778,7 @@ case class InSet(child: Expression, hset: Set[Any]) extends UnaryExpression with
 }
 
 object InSet {
-  class LCaseSet(inputSet: Set[Any]) extends immutable.Set[Any] {
+  class LCaseSet(inputSet: Set[Any]) extends immutable.Set[Any] with Serializable {
     private val strSet = inputSet.map { s =>
       if (s == null) null
       else CollationAwareUTF8String.lowerCaseCodePoints(s.asInstanceOf[UTF8String])
@@ -792,7 +792,8 @@ object InSet {
       strSet.contains(CollationAwareUTF8String.lowerCaseCodePoints(elem.asInstanceOf[UTF8String]))
     }
   }
-  class CollationSet(inputSet: Set[Any], collationId: Int) extends immutable.Set[Any] {
+  class CollationSet(inputSet: Set[Any], collationId: Int)
+    extends immutable.Set[Any] with Serializable {
     private val collation = CollationFactory.fetchCollation(collationId)
     override def incl(elem: Any): Set[Any] = inputSet.incl(elem)
     override def excl(elem: Any): Set[Any] = inputSet.excl(elem)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollationExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollationExpressionSuite.scala
@@ -231,10 +231,15 @@ class CollationExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
       ("aBc", "UTF8_LCASE", Set("b", "aa", "xyz")) -> false,
       ("aBc", "UTF8_LCASE", Set("b", "AbC", null)) -> true,
       (null, "UTF8_LCASE", Set("b", "AbC", null)) -> null,
+      (" aa", "UTF8_BINARY_RTRIM", Set(" aa")) -> true,
+      (" aa ", "UTF8_BINARY_RTRIM", Set(" aa")) -> true,
+      ("a  ", "UTF8_BINARY_RTRIM", Set()) -> false,
+      ("a  ", "UTF8_BINARY_RTRIM", Set("a", "b", null)) -> true,
+      (null, "UTF8_BINARY_RTRIM", Set("1", "2")) -> null
     ).foreach { case ((elem, collation, inputSet), result) =>
-      val hset = inputSet.map(UTF8String.fromString).asInstanceOf[Set[Any]]
+      val iset = inputSet.map(UTF8String.fromString).asInstanceOf[Set[Any]]
       checkEvaluation(
-        InSet(Literal.create(elem, StringType(collation)), hset),
+        InSet(Literal.create(elem, StringType(collation)), iset),
         result
       )
     }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollationExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollationExpressionSuite.scala
@@ -220,4 +220,21 @@ class CollationExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
           normalized)
     }
   }
+
+  test("InSet") {
+    Seq(
+      ("a", "UTF8_LCASE", Set("a")) -> true,
+      ("a", "UTF8_LCASE", Set("A", "b")) -> true,
+      ("Belgrade", "UTF8_LCASE", Set()) -> false,
+      ("aBc", "UTF8_LCASE", Set("b", "aa", "xyz")) -> false,
+      ("aBc", "UTF8_LCASE", Set("b", "AbC", null)) -> true,
+      (null, "UTF8_LCASE", Set("b", "AbC", null)) -> null,
+    ).foreach { case ((elem, collation, inputSet), result) =>
+      val hset = inputSet.map(UTF8String.fromString).asInstanceOf[Set[Any]]
+      checkEvaluation(
+        InSet(Literal.create(elem, StringType(collation)), hset),
+        result
+      )
+    }
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollationExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollationExpressionSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.{SparkException, SparkFunSuite}
-import org.apache.spark.sql.catalyst.util.{CollationFactory, GenericArrayData}
+import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, CollationFactory, GenericArrayData}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -253,6 +253,21 @@ class CollationExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
           inputSet
             .map(s => new GenericArrayData(Array(UTF8String.fromString(s))))
             .asInstanceOf[Set[Any]]),
+        result)
+      checkEvaluation(
+        InSet(
+          Literal.create(
+            if (elem == null) null
+            else new ArrayBasedMapData(
+              new GenericArrayData(Array(UTF8String.fromString(elem))),
+              new GenericArrayData(Array(UTF8String.fromString("aBc")))),
+            MapType(StringType(collation), StringType("UTF8_BINARY"))),
+          inputSet
+            .map { s =>
+              new ArrayBasedMapData(
+                new GenericArrayData(Array(UTF8String.fromString(s))),
+                new GenericArrayData(Array(UTF8String.fromString("aBc"))))
+            }.asInstanceOf[Set[Any]]),
         result)
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollationExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollationExpressionSuite.scala
@@ -244,30 +244,22 @@ class CollationExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
             StringType(collation)),
           inputSet.map(UTF8String.fromString).asInstanceOf[Set[Any]]),
         result)
+      def arr(s: String): GenericArrayData = new GenericArrayData(Array(UTF8String.fromString(s)))
       checkEvaluation(
         InSet(
           Literal.create(
-            if (elem == null) null
-            else new GenericArrayData(Array(UTF8String.fromString(elem))),
+            if (elem == null) null else arr(elem),
             ArrayType(StringType(collation))),
-          inputSet
-            .map(s => new GenericArrayData(Array(UTF8String.fromString(s))))
-            .asInstanceOf[Set[Any]]),
+          inputSet.map(arr).asInstanceOf[Set[Any]]),
         result)
       checkEvaluation(
         InSet(
           Literal.create(
             if (elem == null) null
-            else new ArrayBasedMapData(
-              new GenericArrayData(Array(UTF8String.fromString(elem))),
-              new GenericArrayData(Array(UTF8String.fromString("aBc")))),
+            else new ArrayBasedMapData(arr(elem), arr("aBc")),
             MapType(StringType(collation), StringType("UTF8_BINARY"))),
           inputSet
-            .map { s =>
-              new ArrayBasedMapData(
-                new GenericArrayData(Array(UTF8String.fromString(s))),
-                new GenericArrayData(Array(UTF8String.fromString("aBc"))))
-            }.asInstanceOf[Set[Any]]),
+            .map(s => new ArrayBasedMapData(arr(s), arr("aBc"))).asInstanceOf[Set[Any]]),
         result)
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollationExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollationExpressionSuite.scala
@@ -223,6 +223,8 @@ class CollationExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
 
   test("InSet") {
     Seq(
+      ("1", "UTF8_BINARY", Set("1", "2", "3")) -> true,
+      ("aaa", "UTF8_BINARY", Set("b", "c", "Aaa")) -> false,
       ("a", "UTF8_LCASE", Set("a")) -> true,
       ("a", "UTF8_LCASE", Set("A", "b")) -> true,
       ("Belgrade", "UTF8_LCASE", Set()) -> false,


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to extend the `InSet` expression, and support collated string columns:
- If the string type supports binary equality like for the collation `UTF8_BINARY`, just follow the existing implementation and use regular `Set`
- In the case of the `STRING` type w/ non-`UTF8_BINARY` collation, `InSet` uses new class `InSet.CollationAwareSet` which provides the `Set[UTF8String]` partially. It implements the `contains()` method but not others. The class preprocesses the input set of `UTF8String` by calculating collation keys, put them to new set. The `contains()` method also calculates a collation key over the input `elem` before checking it existence in the set.
- In other cases including nested collated strings, `InSet` uses `TreeSet` with interpreted ordering instance `Ordering` which respects collations of the `STRING` type.

### Why are the changes needed?
Since the `InSet` expression is used internally in a few places like in Dynamic Partition Pruning, the changes will extend usage of collated string columns. Currently, `InSet` doesn't distinguish any collations and can return wrong results.  

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
By running new test:
```
$ build/sbt "test:testOnly *CollationExpressionSuite"
```
which checks:
- the `STRING` type w/ `UTF8_BINARY`, `UTF8_LCASE` and `UTF8_BINARY_RTRIM` collations
- ARRAY of `STRING` w/ the same collation as above
- mixed collated string in `MAP` of `STRING`

### Was this patch authored or co-authored using generative AI tooling?
No.