### PR TITLE
[MINOR][PYTHON][DOCS] Fix the type hint for `extract`, `date_part` and `datepart`

### DIFF
--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -3190,21 +3190,21 @@ def dayname(col: "ColumnOrName") -> Column:
 dayname.__doc__ = pysparkfuncs.dayname.__doc__
 
 
-def extract(field: "ColumnOrName", source: "ColumnOrName") -> Column:
+def extract(field: Column, source: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("extract", field, source)
 
 
 extract.__doc__ = pysparkfuncs.extract.__doc__
 
 
-def date_part(field: "ColumnOrName", source: "ColumnOrName") -> Column:
+def date_part(field: Column, source: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("date_part", field, source)
 
 
 extract.__doc__ = pysparkfuncs.extract.__doc__
 
 
-def datepart(field: "ColumnOrName", source: "ColumnOrName") -> Column:
+def datepart(field: Column, source: "ColumnOrName") -> Column:
     return _invoke_function_over_columns("datepart", field, source)
 
 

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -8608,7 +8608,7 @@ def date_part(field: Column, source: "ColumnOrName") -> Column:
 
     Parameters
     ----------
-    field : :class:`~pyspark.sql.Column` or str
+    field : :class:`~pyspark.sql.Column`
         selects which part of the source should be extracted, and supported string values
         are as same as the fields of the equivalent function `extract`.
     source : :class:`~pyspark.sql.Column` or str
@@ -8645,7 +8645,7 @@ def datepart(field: Column, source: "ColumnOrName") -> Column:
 
     Parameters
     ----------
-    field : :class:`~pyspark.sql.Column` or str
+    field : :class:`~pyspark.sql.Column`
         selects which part of the source should be extracted, and supported string values
         are as same as the fields of the equivalent function `extract`.
     source : :class:`~pyspark.sql.Column` or str

--- a/python/pyspark/sql/functions/builtin.py
+++ b/python/pyspark/sql/functions/builtin.py
@@ -8564,7 +8564,7 @@ def dayname(col: "ColumnOrName") -> Column:
 
 
 @_try_remote_functions
-def extract(field: "ColumnOrName", source: "ColumnOrName") -> Column:
+def extract(field: Column, source: "ColumnOrName") -> Column:
     """
     Extracts a part of the date/timestamp or interval source.
 
@@ -8572,7 +8572,7 @@ def extract(field: "ColumnOrName", source: "ColumnOrName") -> Column:
 
     Parameters
     ----------
-    field : :class:`~pyspark.sql.Column` or str
+    field : :class:`~pyspark.sql.Column`
         selects which part of the source should be extracted.
     source : :class:`~pyspark.sql.Column` or str
         a date/timestamp or interval column from where `field` should be extracted.
@@ -8600,7 +8600,7 @@ def extract(field: "ColumnOrName", source: "ColumnOrName") -> Column:
 
 
 @_try_remote_functions
-def date_part(field: "ColumnOrName", source: "ColumnOrName") -> Column:
+def date_part(field: Column, source: "ColumnOrName") -> Column:
     """
     Extracts a part of the date/timestamp or interval source.
 
@@ -8637,7 +8637,7 @@ def date_part(field: "ColumnOrName", source: "ColumnOrName") -> Column:
 
 
 @_try_remote_functions
-def datepart(field: "ColumnOrName", source: "ColumnOrName") -> Column:
+def datepart(field: Column, source: "ColumnOrName") -> Column:
     """
     Extracts a part of the date/timestamp or interval source.
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the type hint for `extract`, `date_part` and `datepart`


### Why are the changes needed?
argument `field` never supports column name:

```python
In [6]: df = spark.createDataFrame([(datetime.datetime(2015, 4, 8, 13, 8, 15), "YEAR",)], ['ts', 'field'])

In [7]: df.select(sf.extract("field", "ts"))

...


AnalysisException: [NON_FOLDABLE_ARGUMENT] The function `extract` requires the parameter `field` to be a foldable expression of the type "STRING", but the actual argument is a non-foldable. SQLSTATE: 42K08
```

### Does this PR introduce _any_ user-facing change?
yes, doc only change


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no