### PR TITLE
[SPARK-50085][PYTHON] Make `lit(ndarray)` with np.int8 respect the numpy datatype

### DIFF
--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -275,16 +275,8 @@ def lit(col: Any) -> Column:
                 errorClass="UNSUPPORTED_NUMPY_ARRAY_SCALAR",
                 messageParameters={"dtype": col.dtype.name},
             )
-
-        # NumpyArrayConverter for Py4J can not support ndarray with int8 values.
-        # Actually this is not a problem for Connect, but here still convert it
-        # to int16 for compatibility.
-        if dt == ByteType():
-            dt = ShortType()
-
         return array(*[lit(c) for c in col]).cast(ArrayType(dt))
-    else:
-        return ConnectColumn(LiteralExpression._from_value(col))
+    return ConnectColumn(LiteralExpression._from_value(col))
 
 
 lit.__doc__ = pysparkfuncs.lit.__doc__

--- a/python/pyspark/sql/connect/functions/builtin.py
+++ b/python/pyspark/sql/connect/functions/builtin.py
@@ -68,8 +68,6 @@ from pyspark.sql.types import (
     StructType,
     ArrayType,
     StringType,
-    ByteType,
-    ShortType,
 )
 from pyspark.sql.utils import enum_to_value as _enum_to_value
 

--- a/python/pyspark/sql/tests/test_functions.py
+++ b/python/pyspark/sql/tests/test_functions.py
@@ -1253,7 +1253,7 @@ class FunctionsTestsMixin:
         import numpy as np
 
         arr_dtype_to_spark_dtypes = [
-            ("int8", [("b", "array<smallint>")]),
+            ("int8", [("b", "array<tinyint>")]),
             ("int16", [("b", "array<smallint>")]),
             ("int32", [("b", "array<int>")]),
             ("int64", [("b", "array<bigint>")]),
@@ -1310,7 +1310,7 @@ class FunctionsTestsMixin:
         import numpy as np
 
         arr_dtype_to_spark_dtypes = [
-            ("int8", [("b", "array<smallint>")]),
+            ("int8", [("b", "array<tinyint>")]),
             ("int16", [("b", "array<smallint>")]),
             ("int32", [("b", "array<int>")]),
             ("int64", [("b", "array<bigint>")]),


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `lit(ndarray)` with np.int8 respect the numpy datatype


### Why are the changes needed?
there was a py4j limitation so `NumpyArrayConverter` for Py4J converts `Array[Byte]` to `Array[Short]`, we should convert it back to `Array[Byte]` to respect the numpy datatype


### Does this PR introduce _any_ user-facing change?
before:
```
In [8]: spark.range(1).select(sf.lit(np.int8(123)), sf.lit(np.array([1,2,3], np.int8)))
Out[8]: DataFrame[123: tinyint, ARRAY(1S, 2S, 3S): array<smallint>]
```

after:
```
In [3]: spark.range(1).select(sf.lit(np.int8(123)), sf.lit(np.array([1,2,3], np.int8)))
Out[3]: DataFrame[123: tinyint, ARRAY(1S, 2S, 3S): array<tinyint>]
```


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
