### PR TITLE
[SPARK-50092][SQL] Fix PostgreSQL connector behaviour for multidimensional arrays

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
@@ -326,13 +326,12 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCT
   }
 
   test("Test reading multiple dimension array from table created via CTAS command") {
-    val exception = intercept[org.apache.spark.SparkSQLException] {
-      sql(s"SELECT * FROM $catalogName.unsupported_array_of_array_of_int").collect()
-    }.getMessage
-
-    // There is 2d and 1d array in unsupported_array_of_array_of_int. Reading this table
-    // is not supported
-    assert(exception.contains("Some values in field 0 are incompatible with the" +
-      " column array type. Expected type \"ARRAY<ARRAY<INT>>\""))
+    checkError(
+      exception = intercept[org.apache.spark.SparkSQLException] {
+        sql(s"SELECT * FROM $catalogName.unsupported_array_of_array_of_int").collect()
+      },
+      condition = "COLUMN_ARRAY_ELEMENT_TYPE_MISMATCH",
+      parameters = Map("pos" -> "0", "type" -> "\"ARRAY<ARRAY<INT>>\""),
+    )
   }
 }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
@@ -331,7 +331,7 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCT
         sql(s"SELECT * FROM $catalogName.unsupported_array_of_array_of_int").collect()
       },
       condition = "COLUMN_ARRAY_ELEMENT_TYPE_MISMATCH",
-      parameters = Map("pos" -> "0", "type" -> "\"ARRAY<ARRAY<INT>>\""),
+      parameters = Map("pos" -> "0", "type" -> "\"ARRAY<ARRAY<INT>>\"")
     )
   }
 }

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.jdbc.DatabaseOnDocker
 import org.apache.spark.sql.types._
 import org.apache.spark.tags.DockerTest
+
 /**
  * To run this test suite for a specific version (e.g., postgres:17.0-alpine)
  * {{{
@@ -107,21 +108,25 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCT
     connection.prepareStatement("CREATE TABLE array_timestamptz (col timestamptz[])")
       .executeUpdate()
 
-    connection.prepareStatement("INSERT INTO array_int VALUES (array[array[10]])").executeUpdate()
-    connection.prepareStatement("INSERT INTO array_bigint VALUES (array[array[10]])")
+    connection.prepareStatement("INSERT INTO array_int VALUES " +
+      "(array[array[10]]), (array[10])").executeUpdate()
+    connection.prepareStatement("INSERT INTO array_bigint VALUES (array[array[10]]), (array[10])")
       .executeUpdate()
-    connection.prepareStatement("INSERT INTO array_smallint VALUES (array[array[10]])")
+    connection.prepareStatement("INSERT INTO array_smallint VALUES (array[array[10]]), (array[10])")
       .executeUpdate()
-    connection.prepareStatement("INSERT INTO array_boolean VALUES (array[array[true]])")
+    connection.prepareStatement("INSERT INTO array_boolean VALUES " +
+        "(array[array[true]]), (array[true])")
       .executeUpdate()
-    connection.prepareStatement("INSERT INTO array_float VALUES (array[array[10.5]])")
+    connection.prepareStatement("INSERT INTO array_float VALUES " +
+      "(array[array[10.5]]), (array[10.5])").executeUpdate()
+    connection.prepareStatement("INSERT INTO array_double " +
+      "VALUES (array[array[10.1]]), (array[10.1])").executeUpdate()
+    connection.prepareStatement("INSERT INTO array_timestamp VALUES " +
+        "(array[array['2022-01-01 09:15'::timestamp]]), (array['2022-01-01 09:15'::timestamp])")
       .executeUpdate()
-    connection.prepareStatement("INSERT INTO array_double VALUES (array[array[10.1]])")
-      .executeUpdate()
-    connection.prepareStatement("INSERT INTO array_timestamp VALUES (" +
-      "array[array['2022-01-01 09:15'::timestamp]])").executeUpdate()
     connection.prepareStatement("INSERT INTO array_timestamptz VALUES " +
-      "(array[array['2022-01-01 09:15'::timestamptz]])").executeUpdate()
+        "(array[array['2022-01-01 09:15'::timestamptz]]), (array['2022-01-01 09:15'::timestamptz])")
+      .executeUpdate()
     connection.prepareStatement(
     "CREATE TABLE datetime (name VARCHAR(32), date1 DATE, time1 TIMESTAMP)")
     .executeUpdate()

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/PostgresIntegrationSuite.scala
@@ -129,6 +129,13 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCT
     "CREATE TABLE datetime (name VARCHAR(32), date1 DATE, time1 TIMESTAMP)")
     .executeUpdate()
 
+    connection.prepareStatement("CREATE TABLE array_of_int (col int[])")
+      .executeUpdate()
+    connection.prepareStatement("INSERT INTO array_of_int " +
+      "VALUES (array[1])").executeUpdate()
+    connection.prepareStatement("CREATE TABLE ctas_array_of_int " +
+      "AS SELECT * FROM array_of_int").executeUpdate()
+
     connection.prepareStatement("CREATE TABLE array_of_array_of_int (col int[][])")
       .executeUpdate()
     connection.prepareStatement("INSERT INTO array_of_array_of_int " +
@@ -318,11 +325,24 @@ class PostgresIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCT
     assert(rows10(1).getString(0) === "alex")
   }
 
-  test("Test reading 2d array from table created via CTAS command") {
-    val dfWithNewBehaviour = sql(s"SELECT * FROM $catalogName.array_of_array_of_int")
-    val CTASdfWithNewBehaviour = sql(s"SELECT * FROM $catalogName.ctas_array_of_array_of_int")
+  test("Test reading 2d array from table created via CTAS command - positive test") {
+    val dfNoCTASTable = sql(s"SELECT * FROM $catalogName.array_of_int")
+    val dfWithCTASTable = sql(s"SELECT * FROM $catalogName.ctas_array_of_int")
 
-    checkAnswer(CTASdfWithNewBehaviour, dfWithNewBehaviour.collect())
+    checkAnswer(dfWithCTASTable, dfNoCTASTable.collect())
+  }
+
+  test("Test reading 2d array from table created via CTAS command - negative test") {
+    val dfNoCTASTable = sql(s"SELECT * FROM $catalogName.array_of_int")
+
+    checkError(
+      exception = intercept[org.apache.spark.SparkSQLException] {
+        // This should fail as only 1D CTAS tables are supported
+        sql(s"SELECT * FROM $catalogName.ctas_array_of_array_of_int").collect()
+      },
+      condition = "COLUMN_ARRAY_ELEMENT_TYPE_MISMATCH",
+      parameters = Map("pos" -> "0", "type" -> "\"ARRAY<INT>\"")
+    )
   }
 
   test("Test reading multiple dimension array from table created via CTAS command") {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4463,12 +4463,12 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
-  val POSTGRES_PROPER_READING_OF_ARRAY_DIMENSIONALITY =
-    buildConf("spark.sql.legacy.postgres.properReadingOfArrayDimensionality")
+  val POSTGRES_GET_ARRAY_DIM_FROM_PG_ATTRIBUTE_METADATA_TABLE =
+    buildConf("spark.sql.legacy.postgres.getArrayDimFromPgAttribute")
       .internal()
       .doc("When true postgres will be asked to return the dimension of array column" +
-        "by calling array_ndims(col). When false, old way of calling pg_attribute.attndims" +
-        "will be done.")
+        "by querying the pg_attribute table. When false, function array_ndims will be called on" +
+        "first record of the table to get the dimension of array column")
       .version("4.0.0")
       .booleanConf
       .createWithDefault(false)
@@ -5738,8 +5738,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def legacyPostgresDatetimeMappingEnabled: Boolean =
     getConf(LEGACY_POSTGRES_DATETIME_MAPPING_ENABLED)
 
-  def postgresProperReadingOfArrayDimensionality: Boolean =
-    getConf(POSTGRES_PROPER_READING_OF_ARRAY_DIMENSIONALITY)
+  def getArrayDimFromPgAttribute: Boolean =
+    getConf(POSTGRES_GET_ARRAY_DIM_FROM_PG_ATTRIBUTE_METADATA_TABLE)
 
   override def legacyTimeParserPolicy: LegacyBehaviorPolicy.Value = {
     LegacyBehaviorPolicy.withName(getConf(SQLConf.LEGACY_TIME_PARSER_POLICY))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4463,6 +4463,16 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
+  val POSTGRES_PROPER_READING_OF_ARRAY_DIMENSIONALITY =
+    buildConf("spark.sql.legacy.postgres.properReadingOfArrayDimensionality")
+      .internal()
+      .doc("When true postgres will be asked to return the dimension of array column" +
+        "by calling array_ndims(col). When false, old way of calling pg_attribute.attndims" +
+        "will be done.")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(true)
+
   val CSV_FILTER_PUSHDOWN_ENABLED = buildConf("spark.sql.csv.filterPushdown.enabled")
     .doc("When true, enable filter pushdown to CSV datasource.")
     .version("3.0.0")
@@ -5727,6 +5737,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def legacyPostgresDatetimeMappingEnabled: Boolean =
     getConf(LEGACY_POSTGRES_DATETIME_MAPPING_ENABLED)
+
+  def postgresProperReadingOfArrayDimensionality: Boolean =
+    getConf(POSTGRES_PROPER_READING_OF_ARRAY_DIMENSIONALITY)
 
   override def legacyTimeParserPolicy: LegacyBehaviorPolicy.Value = {
     LegacyBehaviorPolicy.withName(getConf(SQLConf.LEGACY_TIME_PARSER_POLICY))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4463,16 +4463,6 @@ object SQLConf {
       .booleanConf
       .createWithDefault(false)
 
-  val POSTGRES_GET_ARRAY_DIM_FROM_PG_ATTRIBUTE_METADATA_TABLE =
-    buildConf("spark.sql.legacy.postgres.getArrayDimFromPgAttribute")
-      .internal()
-      .doc("When true postgres will be asked to return the dimension of array column" +
-        "by querying the pg_attribute table. When false, function array_ndims will be called on" +
-        "first record of the table to get the dimension of array column")
-      .version("4.0.0")
-      .booleanConf
-      .createWithDefault(false)
-
   val CSV_FILTER_PUSHDOWN_ENABLED = buildConf("spark.sql.csv.filterPushdown.enabled")
     .doc("When true, enable filter pushdown to CSV datasource.")
     .version("3.0.0")
@@ -5737,9 +5727,6 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def legacyPostgresDatetimeMappingEnabled: Boolean =
     getConf(LEGACY_POSTGRES_DATETIME_MAPPING_ENABLED)
-
-  def getArrayDimFromPgAttribute: Boolean =
-    getConf(POSTGRES_GET_ARRAY_DIM_FROM_PG_ATTRIBUTE_METADATA_TABLE)
 
   override def legacyTimeParserPolicy: LegacyBehaviorPolicy.Value = {
     LegacyBehaviorPolicy.withName(getConf(SQLConf.LEGACY_TIME_PARSER_POLICY))

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -4471,7 +4471,7 @@ object SQLConf {
         "will be done.")
       .version("4.0.0")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
 
   val CSV_FILTER_PUSHDOWN_ENABLED = buildConf("spark.sql.csv.filterPushdown.enabled")
     .doc("When true, enable filter pushdown to CSV datasource.")

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -382,17 +382,45 @@ private case class PostgresDialect()
       case Types.ARRAY =>
         val tableName = rsmd.getTableName(columnIdx)
         val columnName = rsmd.getColumnName(columnIdx)
+
         /*
          Spark does not support different dimensionality per row, therefore we retrieve the
          dimensionality of any row from Postgres. This might fail later on as Postgres allows
          different dimensions per row for arrays.
          */
-
         val query = s"SELECT array_ndims($columnName) FROM $tableName LIMIT 1"
+        var arrayDimensionalityResolveNeedsFallback = true
+
         try {
           Using.resource(conn.createStatement()) { stmt =>
             Using.resource(stmt.executeQuery(query)) { rs =>
-              if (rs.next()) metadata.putLong("arrayDimension", rs.getLong(1))
+              if (rs.next()) {
+                metadata.putLong("arrayDimension", rs.getLong(1))
+                arrayDimensionalityResolveNeedsFallback = false
+              }
+            }
+          }
+
+          if (arrayDimensionalityResolveNeedsFallback) {
+            /*
+            In case that table doesn't contain any rows, previous query won't resolve dimensionality.
+            Therefore, fallback to dimension resolution from metadata table.
+             */
+            val fallbackQuery =
+              s"""
+                 |SELECT pg_attribute.attndims
+                 |FROM pg_attribute
+                 |  JOIN pg_class ON pg_attribute.attrelid = pg_class.oid
+                 |  JOIN pg_namespace ON pg_class.relnamespace = pg_namespace.oid
+                 |WHERE pg_class.relname = '$tableName' and pg_attribute.attname = '$columnName'
+                 |""".stripMargin
+
+            Using.resource(conn.createStatement()) { stmt =>
+              Using.resource(stmt.executeQuery(fallbackQuery)) { rs =>
+                if (rs.next()) {
+                  metadata.putLong("arrayDimension", rs.getLong(1))
+                }
+              }
             }
           }
         } catch {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -383,9 +383,7 @@ private case class PostgresDialect()
         val tableName = rsmd.getTableName(columnIdx)
         val columnName = rsmd.getColumnName(columnIdx)
         val query = if (conf.postgresProperReadingOfArrayDimensionality) {
-          s"""
-             |SELECT min(array_ndims($columnName)) FROM $tableName
-             |""".stripMargin
+             s"SELECT array_ndims($columnName)) FROM $tableName LIMIT 1"
         } else {
           s"""
              |SELECT pg_attribute.attndims
@@ -398,7 +396,7 @@ private case class PostgresDialect()
         try {
           Using.resource(conn.createStatement()) { stmt =>
             Using.resource(stmt.executeQuery(query)) { rs =>
-              if (rs.next()) metadata.putLong("arrayDimension", rs.getLong(1))
+              if (rs.next()) metadata.putLong("arrayDimension", Math.max(rs.getLong(1), 1))
             }
           }
         } catch {

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -382,25 +382,7 @@ private case class PostgresDialect()
       case Types.ARRAY =>
         val tableName = rsmd.getTableName(columnIdx)
         val columnName = rsmd.getColumnName(columnIdx)
-        val query = if (conf.getArrayDimFromPgAttribute) {
-          /*
-            We send the query to Pg to read from pg_attribute table. There is one caveat here:
-            If table is created with CTAS command on Pg side, the information about dimensionality
-            of array column will be lost and attndims will be 0. Therefore, for example,
-            array<int> will be mapped to int. If this is the case, it can be resolved by setting
-            spark.sql.legacy.postgres.getArrayDimFromPgAttribute flag to false.
-          */
-
-          s"""
-             |SELECT pg_attribute.attndims
-             |FROM pg_attribute
-             |  JOIN pg_class ON pg_attribute.attrelid = pg_class.oid
-             |  JOIN pg_namespace ON pg_class.relnamespace = pg_namespace.oid
-             |WHERE pg_class.relname = '$tableName' and pg_attribute.attname = '$columnName'
-             |""".stripMargin
-        } else {
-          s"SELECT array_ndims($columnName) FROM $tableName LIMIT 1"
-        }
+        val query = s"SELECT array_ndims($columnName) FROM $tableName LIMIT 1"
         try {
           Using.resource(conn.createStatement()) { stmt =>
             Using.resource(stmt.executeQuery(query)) { rs =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/jdbc/PostgresDialect.scala
@@ -382,42 +382,20 @@ private case class PostgresDialect()
       case Types.ARRAY =>
         val tableName = rsmd.getTableName(columnIdx)
         val columnName = rsmd.getColumnName(columnIdx)
-
-        /*
-         Spark does not support different dimensionality per row, therefore we retrieve the
-         dimensionality of any row from Postgres. This might fail later on as Postgres allows
-         different dimensions per row for arrays.
-         */
-        val query = s"SELECT array_ndims($columnName) FROM $tableName LIMIT 1"
-
+        val query =
+          s"""
+             |SELECT pg_attribute.attndims
+             |FROM pg_attribute
+             |  JOIN pg_class ON pg_attribute.attrelid = pg_class.oid
+             |  JOIN pg_namespace ON pg_class.relnamespace = pg_namespace.oid
+             |WHERE pg_class.relname = '$tableName' and pg_attribute.attname = '$columnName'
+             |""".stripMargin
         try {
           Using.resource(conn.createStatement()) { stmt =>
             Using.resource(stmt.executeQuery(query)) { rs =>
-              if (rs.next()) {
-                metadata.putLong("arrayDimension", rs.getLong(1))
-              } else {
-                /*
-                If previous query doesn't return any rows, we should fallback to querying the
-                Postgres metadata table.
-                 */
-                val fallbackQuery =
-                  s"""
-                     |SELECT pg_attribute.attndims
-                     |FROM pg_attribute
-                     |  JOIN pg_class ON pg_attribute.attrelid = pg_class.oid
-                     |  JOIN pg_namespace ON pg_class.relnamespace = pg_namespace.oid
-                     |WHERE pg_class.relname = '$tableName'
-                     |AND pg_attribute.attname = '$columnName'
-                     |""".stripMargin
-
-                Using.resource(conn.createStatement()) { stmt2 =>
-                  Using.resource(stmt2.executeQuery(fallbackQuery)) { rs2 =>
-                    if (rs2.next()) {
-                      metadata.putLong("arrayDimension", rs2.getLong(1))
-                    }
-                  }
-                }
-              }
+              // Metadata can return 0 for CTAS tables. For such tables, we are always reading
+              // them as 1D array
+              if (rs.next()) metadata.putLong("arrayDimension", Math.max(1L, rs.getLong(1)))
             }
           }
         } catch {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
There is a bug introduced in this PR https://github.com/apache/spark/pull/46006. This PR fixed the behaviour for PostgreSQL connector for multidimensional arrays since we have mapped all arrays to 1D arrays.

This PR has introduced a bug for one case. Following scenario is broken:

- User has a table t1 on Postgres and does CTAS command to create table t2 with same data.
PR 46006 is resolving the dimensionality of column by reading the metadata from pg_attribute table and attndims column.
- This query returns correct dimensionality for table t1, but for table t2 that is created via CTAS it returns 0 always. This leads to all of the arrays being mapped to 0-D array which is the type itself (for example int). This is a bug on Postgres side.
- As a solution, we can query array_ndims function on given column that will return the dimension of the column. It works for CTAS-like-created tables too. We can get the result of this function on first row of table. 


This change is doing additional query to PG table to find the dimension of array column instead of querying metadata table as before. It might be more expensive but we are sending LIMIT 1 in query.

Also, there is one caveat. In PG, there is no dimensionality of array as all the arrays are 1D arrays (https://www.postgresql.org/docs/current/arrays.html#ARRAYS-DECLARATION). Therefore, if there is table with 2D array column, it is totally fine from PG side to insert 1D or 3D array in this column. This makes the read path on Spark problematic since we will get the dimension of array, for example 1 if the first record is 1D array, and then we will try to read 3D array later on which will fail. Vice versa also, getting dimension 3 and reading 1D array later on. The change that I propose is fine with this scenario since it already doesn't work in Spark. What my change implies is that user can get different error message depending on the dimensionality of first record in table (namely, for one table they can get the error message that the expected type is ARRAY<ARRAY<INT>> and for the other that it is ARRAY\<INT\>.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Bug fix.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No. It just fixes one case that doesn't work currently.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
New tests.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
