### PR TITLE
[SPARK-50093][SQL] Collations that use ICU should have the version of the used ICU library

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
@@ -113,7 +113,8 @@ public final class CollationFactory {
 
     /**
      * Version of the collation. This is the version of the ICU library Collator.
-     * For non-ICU collations (e.g. UTF8 Binary) the version is set to "1.0".
+     * For UTF8 Binary the version is set to "1.0". For ICU collations and UTF8_LCASE
+     * (because it uses ICU mappings) the version is set to the version of the ICU library.
      * When using ICU Collator this version is exposed through collator.getVersion().
      * Whenever the collation is updated, the version should be updated as well or kept
      * for backwards compatibility.
@@ -323,6 +324,11 @@ public final class CollationFactory {
       protected static final int SPACE_TRIMMING_MASK = 0b1;
 
       private static final int INDETERMINATE_COLLATION_ID = -1;
+
+      /**
+       * UTF8 Binary collation version.
+       */
+      private static final String UTF8_BINARY_VERSION = "1.0";
 
       /**
        * Thread-safe cache mapping collation IDs to corresponding `Collation` instances.
@@ -574,7 +580,7 @@ public final class CollationFactory {
             PROVIDER_SPARK,
             null,
             comparator,
-            "1.0",
+            CollationSpec.UTF8_BINARY_VERSION,
             hashFunction,
             equalsFunction,
             /* isUtf8BinaryType = */ true,
@@ -601,7 +607,7 @@ public final class CollationFactory {
             PROVIDER_SPARK,
             null,
             comparator,
-            "1.0",
+            CollationSpecICU.ICU_VERSION,
             hashFunction,
             (s1, s2) -> comparator.compare(s1, s2) == 0,
             /* isUtf8BinaryType = */ false,
@@ -661,10 +667,16 @@ public final class CollationFactory {
       }
 
       static List<CollationIdentifier> listCollations() {
-        CollationIdentifier UTF8_BINARY_COLLATION_IDENT =
-          new CollationIdentifier(PROVIDER_SPARK, UTF8_BINARY_COLLATION_NAME, "1.0");
-        CollationIdentifier UTF8_LCASE_COLLATION_IDENT =
-          new CollationIdentifier(PROVIDER_SPARK, UTF8_LCASE_COLLATION_NAME, "1.0");
+        CollationIdentifier UTF8_BINARY_COLLATION_IDENT = new CollationIdentifier(
+            PROVIDER_SPARK,
+            UTF8_BINARY_COLLATION_NAME,
+            CollationSpec.UTF8_BINARY_VERSION
+        );
+        CollationIdentifier UTF8_LCASE_COLLATION_IDENT = new CollationIdentifier(
+            PROVIDER_SPARK,
+            UTF8_LCASE_COLLATION_NAME,
+            CollationSpecICU.ICU_VERSION
+        );
         return Arrays.asList(UTF8_BINARY_COLLATION_IDENT, UTF8_LCASE_COLLATION_IDENT);
       }
 
@@ -739,9 +751,9 @@ public final class CollationFactory {
       private static final Map<String, Integer> ICULocaleToId = new HashMap<>();
 
       /**
-       * ICU library Collator version passed to `Collation` instance.
+       * ICU library version.
        */
-      private static final String ICU_COLLATOR_VERSION = "153.120.0.0";
+      private static final String ICU_VERSION = VersionInfo.ICU_VERSION.toString();
 
       static {
         ICULocaleMap.put("UNICODE", ULocale.ROOT);
@@ -987,7 +999,7 @@ public final class CollationFactory {
           PROVIDER_ICU,
           collator,
           comparator,
-          ICU_COLLATOR_VERSION,
+          ICU_VERSION,
           hashFunction,
           (s1, s2) -> comparator.compare(s1, s2) == 0,
           /* isUtf8BinaryType = */ false,

--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
@@ -326,11 +326,6 @@ public final class CollationFactory {
       private static final int INDETERMINATE_COLLATION_ID = -1;
 
       /**
-       * UTF8 Binary collation version.
-       */
-      private static final String UTF8_BINARY_VERSION = "1.0";
-
-      /**
        * Thread-safe cache mapping collation IDs to corresponding `Collation` instances.
        * We add entries to this cache lazily as new `Collation` instances are requested.
        */
@@ -580,7 +575,7 @@ public final class CollationFactory {
             PROVIDER_SPARK,
             null,
             comparator,
-            CollationSpec.UTF8_BINARY_VERSION,
+            CollationSpecICU.ICU_VERSION,
             hashFunction,
             equalsFunction,
             /* isUtf8BinaryType = */ true,
@@ -670,7 +665,7 @@ public final class CollationFactory {
         CollationIdentifier UTF8_BINARY_COLLATION_IDENT = new CollationIdentifier(
             PROVIDER_SPARK,
             UTF8_BINARY_COLLATION_NAME,
-            CollationSpec.UTF8_BINARY_VERSION
+            CollationSpecICU.ICU_VERSION
         );
         CollationIdentifier UTF8_LCASE_COLLATION_IDENT = new CollationIdentifier(
             PROVIDER_SPARK,
@@ -753,7 +748,9 @@ public final class CollationFactory {
       /**
        * ICU library version.
        */
-      private static final String ICU_VERSION = VersionInfo.ICU_VERSION.toString();
+      private static final String ICU_VERSION = String.format("%d.%d",
+        VersionInfo.ICU_VERSION.getMajor(),
+        VersionInfo.ICU_VERSION.getMinor());
 
       static {
         ICULocaleMap.put("UNICODE", ULocale.ROOT);

--- a/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
+++ b/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
@@ -33,7 +33,7 @@ import org.apache.spark.unsafe.types.UTF8String.{fromString => toUTF8}
 
 class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ignore funsuite
 
-  val currentIcuVersion: String = "75.1.0.0"
+  val currentIcuVersion: String = "75.1"
 
   test("collationId stability") {
     assert(INDETERMINATE_COLLATION_ID == -1)
@@ -42,7 +42,7 @@ class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ig
     val utf8Binary = fetchCollation(UTF8_BINARY_COLLATION_ID)
     assert(utf8Binary.collationName == "UTF8_BINARY")
     assert(utf8Binary.isUtf8BinaryType)
-    assert(utf8Binary.version == "1.0")
+    assert(utf8Binary.version == currentIcuVersion)
 
     assert(UTF8_LCASE_COLLATION_ID == 1)
     val utf8Lcase = fetchCollation(UTF8_LCASE_COLLATION_ID)

--- a/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
+++ b/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
@@ -32,6 +32,9 @@ import org.apache.spark.sql.catalyst.util.CollationFactory._
 import org.apache.spark.unsafe.types.UTF8String.{fromString => toUTF8}
 
 class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ignore funsuite
+
+  val currentIcuVersion: String = "75.1.0.0"
+
   test("collationId stability") {
     assert(INDETERMINATE_COLLATION_ID == -1)
 
@@ -39,21 +42,25 @@ class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ig
     val utf8Binary = fetchCollation(UTF8_BINARY_COLLATION_ID)
     assert(utf8Binary.collationName == "UTF8_BINARY")
     assert(utf8Binary.isUtf8BinaryType)
+    assert(utf8Binary.version == "1.0")
 
     assert(UTF8_LCASE_COLLATION_ID == 1)
     val utf8Lcase = fetchCollation(UTF8_LCASE_COLLATION_ID)
     assert(utf8Lcase.collationName == "UTF8_LCASE")
     assert(!utf8Lcase.isUtf8BinaryType)
+    assert(utf8Lcase.version == currentIcuVersion)
 
     assert(UNICODE_COLLATION_ID == (1 << 29))
     val unicode = fetchCollation(UNICODE_COLLATION_ID)
     assert(unicode.collationName == "UNICODE")
     assert(!unicode.isUtf8BinaryType)
+    assert(unicode.version == currentIcuVersion)
 
     assert(UNICODE_CI_COLLATION_ID == ((1 << 29) | (1 << 17)))
     val unicodeCi = fetchCollation(UNICODE_CI_COLLATION_ID)
     assert(unicodeCi.collationName == "UNICODE_CI")
     assert(!unicodeCi.isUtf8BinaryType)
+    assert(unicodeCi.version == currentIcuVersion)
   }
 
   test("UTF8_BINARY and ICU root locale collation names") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
Changing the versions of the collations that use ICU to be that of the currently used ICU library in spark.


### Why are the changes needed?
Changing the version of the ICU library should automatically change the versions of collations that depend on it. Also, even though the UTF8_LCASE doesn't use ICU for comparisons it still relies on ICU's case mappings between upper and lower  case letters and is for that reason included as well.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Added  new unit tests.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.