### PR TITLE
[SPARK-50091][SQL] Handle case of aggregates in left-hand operand of IN-subquery

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -287,7 +287,7 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
       // create a mapping from aggregate expressions to attributes
       val aggregateExprAttrMap = aggregateExprs.zip(aggregateExprAttrs).toMap
 
-      // create Aggregate operator without the offending IN-subqueries, just
+      // create an Aggregate node without the offending IN-subqueries, just
       // the aggregates themselves and all the other aggregate expressions.
       val newAggregateExpressions = a.aggregateExpressions.flatMap { ae =>
         // if this expression contains IN-subqueries with aggregates in the left-hand

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -267,19 +267,14 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
         }
       }
     case a: Aggregate if aggregateExprsNestedInSubquery(a.aggregateExpressions) =>
-      print("Matched on aggregate!!\n")
-
       // find expressions with an in-subquery whose values contain aggregates
       val withInsubquery = a.aggregateExpressions.filter(aggregateExprContainsNestedInSubquery(_))
-      print(s"withInsubquery is ${withInsubquery}\n")
 
       // extract the aggregate expressions from withInsubquery
       val inSubqueryMapping = withInsubquery.map { e =>
-        val aggregateExpressions = e.collect {
-          case a: AggregateExpression => a
-        }
-        (e, aggregateExpressions)
+        (e, extractAggregateExpressions(e))
       }
+
       val inSubqueryMap = inSubqueryMapping.toMap
       val aggregateExprs = inSubqueryMapping.flatMap(_._2)
       val aggregateExprAliases = aggregateExprs.map(a => Alias(a, toPrettySQL(a))())

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -266,55 +266,191 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
             condition = Some(newCondition)))
         }
       }
+
+    // Handle the case where the left-hand side of an IN-subquery contains an aggregate.
+    //
+    // This handler pulls up any expression containing such an IN-subquery into a new Project
+    // node and then re-enters RewritePredicateSubquery#apply, where the new Project node
+    // will be handled by the Unary node handler. The Unary node handler will transform the
+    // plan into a join. Without this pre-transformation, the Unary node handler would
+    // create a join with an aggregate expression in the join condition, which is illegal
+    // (see SPARK-50091).
+    //
+    // For example:
+    //
+    //   SELECT col1, SUM(col2) IN (SELECT c2 FROM v1) as x
+    //   FROM v2 GROUP BY col1;
+    //
+    // The above query has this plan on entry to RewritePredicateSubquery#apply:
+    //
+    //   Aggregate [col1#28], [col1#28, sum(col2#29) IN (list#24 []) AS x#25]
+    //   :  +- LocalRelation [c2#35L]
+    //   +- LocalRelation [col1#28, col2#29]
+    //
+    // Note that the Aggregate node contains the IN-subquery and the left-hand
+    // side of the IN-subquery is an aggregate expression (sum(col2#28)).
+    //
+    // This handler transforms the above plan into the following:
+    //
+    //   Project [col1#28, sum(col2)#36L IN (list#24 []) AS x#25]
+    //   :  +- LocalRelation [c2#35L]
+    //   +- Aggregate [col1#28], [col1#28, sum(col2#29) AS sum(col2)#36L]
+    //      +- LocalRelation [col1#28, col2#29]
+    //
+    // The transformation pulled the IN-subquery up into a Project. The left-hand side of the
+    // In-subquery is now an attribute (sum(col2)#36L) that refers to the actual aggregation
+    // which is still performed in the Aggregate node (sum(col2#28) AS sum(col2)#36L).
+    //
+    // Note that if the IN-subquery is nested in a larger expression, that entire larger
+    // expression is pulled up into the Project. For example:
+    //
+    //   SELECT SUM(col2) IN (SELECT c3 FROM v1) AND SUM(col3) > -1 AS x
+    //   FROM v2;
+    //
+    // The input to RewritePredicateSubquery#apply is the following plan:
+    //
+    //   Aggregate [(sum(col2#34) IN (list#28 []) AND (sum(col3#35) > -1)) AS x#29]
+    //   :  +- LocalRelation [c3#44L]
+    //   +- LocalRelation [col2#34, col3#35]
+    //
+    // This handler transforms the plan into:
+    //
+    //   Project [(sum(col2)#45L IN (list#28 []) AND (sum(col3)#46L > -1)) AS x#29]
+    //   :  +- LocalRelation [c3#44L]
+    //   +- Aggregate [sum(col2#34) AS sum(col2)#45L, sum(col3#35) AS sum(col3)#46L]
+    //      +- LocalRelation [col2#34, col3#35]
+    //
+    // Note that the entire AND expression was pulled up into the Project, but the Aggregate
+    // node continues to perform the aggregations (but without the IN-subquery expression).
     case a: Aggregate if exprsContainsAggregateInSubquery(a.aggregateExpressions) =>
-      // find expressions with an IN-subquery whose left-hand operand contains aggregates
+      // Find any interesting expressions from Aggregate.aggregateExpressions.
+      //
+      // An interesting expression is one that contains an IN-subquery whose left-hand
+      // operand contains aggregates. For example:
+      //
+      //   SELECT col1, SUM(col2) IN (SELECT c2 FROM v1)
+      //   FROM v2 GROUP BY col1;
+      //
+      // withInSubquery will be a List containing a single Alias expression:
+      //
+      //   List(sum(col2#12) IN (list#8 []) AS (...)#19)
       val withInSubquery = a.aggregateExpressions.filter(exprContainsAggregateInSubquery(_))
 
-      // extract the aggregate expressions from withInSubquery
+      // Extract the aggregate expressions from each interesting expression. This will include
+      // any aggregate expressions that were not part of the IN-subquery but were part
+      // of the larger containing expression.
       val inSubqueryMapping = withInSubquery.map { e =>
         (e, extractAggregateExpressions(e))
       }
 
+      // Map each interesting expression to its contained aggregate expressions.
+      //
+      // Example #1:
+      //
+      //  SELECT col1, SUM(col2) IN (SELECT c2 FROM v1)
+      //  FROM v2 GROUP BY col1;
+      //
+      // inSubqueryMap will have a single entry mapping an Alias expression to a Vector
+      // with a single aggregate expression:
+      //
+      //   Map(
+      //     sum(col2#100) IN (list []) AS (...)#107 -> Vector(sum(col2#100))
+      //   )
+      //
+      // Example #2:
+      //
+      //   SELECT (SUM(col1), SUM(col2)) IN (SELECT c1, c2 FROM v1)
+      //   FROM v2;
+      //
+      // inSubqueryMap will have a single entry mapping an Alias expression to a Vector
+      // with two aggregate expressions:
+      //
+      //   Map(
+      //     named_struct(_0, sum(col1#169), _1, sum(col2#170)) IN (list#166 []) AS (...)#179
+      //       -> Vector(sum(col1#169), sum(col2#170))
+      //   )
+      //
+      // Example #3:
+      //
+      // select SUM(col1) IN (SELECT c1 FROM v1), SUM(col2) IN (SELECT c2 FROM v1)
+      // FROM v2;
+      //
+      // inSubqueryMap will have two entries, each mapping an Alias expression to a Vector
+      // with a single aggregate expression:
+      //
+      //   Map(
+      //     sum(col1#193) IN (list#189 []) AS (...)#207 -> Vector(sum(col1#193)),
+      //     sum(col2#194) IN (list#190 []) AS (...)#208 -> Vector(sum(col2#194))
+      //   )
+      //
+      // Example #5:
+      //
+      //   SELECT SUM(col2) IN (SELECT c3 FROM v1) AND SUM(col3) > -1 AS x
+      //   FROM v2;
+      //
+      // inSubqueryMap will contain a single AND expression that maps to two aggregate
+      // expressions, even though only one of those aggregate expressions is used as
+      // the left-hand operand of the IN-subquery expression.
+      //
+      //   Map(
+      //     (sum(col2#34) IN (list#28 []) AND (sum(col3#35) > -1)) AS x#29
+      //       -> Vector(sum(col2#34), sum(col3#35))
+      //   )
+      //
+      // The keys of inSubqueryMap will be used to determine which expressions in
+      // the old Aggregate node are interesting. The values of inSubqueryMap, after
+      // being wrapped in Alias expressions, will replace their associated interesting
+      // expressions in a new Aggregate node.
       val inSubqueryMap = inSubqueryMapping.toMap
-      // get all aggregate expressions found in left-hand operands of IN-subqueries
+
+      // Get all aggregate expressions associated with interesting expressions.
       val aggregateExprs = inSubqueryMapping.flatMap(_._2)
-      // create aliases for each above aggregate expression
+      // Create aliases for each above aggregate expression. We can't use the aggregate
+      // expressions directly in the new Aggregate node because Aggregate.aggregateExpressions
+      // has the type Seq[NamedExpression].
       val aggregateExprAliases = aggregateExprs.map(a => Alias(a, toPrettySQL(a))())
-      // create a mapping from each aggregate expression to its alias
+      // Create a mapping from each aggregate expression to its alias.
       val aggregateExprAliasMap = aggregateExprs.zip(aggregateExprAliases).toMap
-      // create attributes from those aliases of aggregate expressions
+      // Create attributes from those aliases of aggregate expressions. These attributes
+      // will be used in the new Project node to refer to the aliased aggregate expressions
+      // in the new Aggregate node.
       val aggregateExprAttrs = aggregateExprAliases.map(_.toAttribute)
-      // create a mapping from aggregate expressions to attributes
+      // Create a mapping from aggregate expressions to attributes. This will be
+      // used when patching the interesting expressions after they are pulled up
+      // into the new Project node: aggregate expressions will be replaced by attributes.
       val aggregateExprAttrMap = aggregateExprs.zip(aggregateExprAttrs).toMap
 
-      // create an Aggregate node without the offending IN-subqueries, just
-      // the aggregates themselves and all the other aggregate expressions.
+      // Create an Aggregate node without the interesting expressions, just
+      // the associated aggregate expressions plus any other group-by or aggregate expressions
+      // that were not involved in the interesting expressions.
       val newAggregateExpressions = a.aggregateExpressions.flatMap {
-        // if this expression contains IN-subqueries with aggregates in the left-hand
-        // operand, replace with just the aggregates
+        // If this expression contains IN-subqueries with aggregates in the left-hand
+        // operand, replace with just the aggregates.
         case ae: Expression if inSubqueryMap.contains(ae) =>
-          // replace the expression with an aliased aggregate expression
+          // Replace the expression with an aliased aggregate expression.
           inSubqueryMap(ae).map(aggregateExprAliasMap(_))
-        case ae @ _ => Seq(ae)
+        case ae => Seq(ae)
       }
       val newAggregate = a.copy(aggregateExpressions = newAggregateExpressions)
 
       // Create a projection with the IN-subquery expressions that contain aggregates, replacing
-      // the aggregate expressions with attribute references to the output of the Aggregate
+      // the aggregate expressions with attribute references to the output of the new Aggregate
       // operator. Also include the other output of the Aggregate operator.
       val projList = a.aggregateExpressions.map {
-        // if this expression contains an IN-subquery that uses an aggregate, we
+        // If this expression contains an IN-subquery that uses an aggregate, we
         // need to do something special
         case ae: Expression if inSubqueryMap.contains(ae) =>
           ae.transform {
-            // patch any aggregate expression with its corresponding attribute
+            // Patch any aggregate expression with its corresponding attribute.
             case a: AggregateExpression => aggregateExprAttrMap(a)
           }.asInstanceOf[NamedExpression]
-        case ae @ _ => ae.toAttribute
+        case ae => ae.toAttribute
       }
+      val newProj = Project(projList, newAggregate)
 
-      // reapply this rule, now with a Project as parent to the Aggregate
-      apply(Project(projList, newAggregate))
+      // Reapply this rule, but now with all interesting expressions
+      // from Aggregate.aggregateExpressions pulled up into a Project node.
+      apply(newProj)
 
     case u: UnaryNode if u.expressions.exists(
         SubqueryExpression.hasInOrCorrelatedExistsSubquery) =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -292,7 +292,7 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
     //   +- LocalRelation [col1#28, col2#29]
     //
     // Note that the Aggregate node contains the IN-subquery and the left-hand
-    // side of the IN-subquery is an aggregate expression (sum(col2#28)).
+    // side of the IN-subquery is an aggregate expression (sum(col2#29)).
     //
     // This handler transforms the above plan into the following:
     //
@@ -303,7 +303,7 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
     //
     // The transformation pulled the IN-subquery up into a Project. The left-hand side of the
     // IN-subquery is now an attribute (sum(col2)#36L) that refers to the actual aggregation
-    // which is still performed in the Aggregate node (sum(col2#28) AS sum(col2)#36L). The Unary
+    // which is still performed in the Aggregate node (sum(col2#29) AS sum(col2)#36L). The Unary
     // node handler will use that attribute in the join condition (rather than the aggregate
     // expression).
     //

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/subquery.scala
@@ -27,11 +27,11 @@ import org.apache.spark.sql.catalyst.expressions.ScalarSubquery._
 import org.apache.spark.sql.catalyst.expressions.SubExprUtils._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.optimizer.RewriteCorrelatedScalarSubquery.splitSubquery
+import org.apache.spark.sql.catalyst.planning.PhysicalAggregation
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules._
 import org.apache.spark.sql.catalyst.trees.TreePattern.{EXISTS_SUBQUERY, IN_SUBQUERY, LATERAL_JOIN, LIST_SUBQUERY, PLAN_EXPRESSION, SCALAR_SUBQUERY}
-import org.apache.spark.sql.catalyst.util.toPrettySQL
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.SQLConf.{DECORRELATE_PREDICATE_SUBQUERIES_IN_JOIN_CONDITION, OPTIMIZE_UNCORRELATED_IN_SUBQUERIES_IN_JOIN_CONDITION,
@@ -269,9 +269,9 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
 
     // Handle the case where the left-hand side of an IN-subquery contains an aggregate.
     //
-    // This handler pulls up any expression containing such an IN-subquery into a new Project
-    // node, replacing aggregate expressions with attributes. The new Project node will be
-    // handled by the Unary node handler.
+    // If an Aggregate node contains such an IN-subquery, this handler will pull up all
+    // expressions from the Aggregate node into a new Project node. The new Project node
+    // will then be handled by the Unary node handler.
     //
     // The Unary node handler uses the left-hand side of the IN-subquery in a
     // join condition. Thus, without this pre-transformation, the join condition
@@ -281,180 +281,44 @@ object RewritePredicateSubquery extends Rule[LogicalPlan] with PredicateHelper {
     //
     // For example:
     //
-    //   SELECT col1, SUM(col2) IN (SELECT c2 FROM v1) as x
-    //   FROM v2 GROUP BY col1;
-    //
-    // The above query has this plan on entry to RewritePredicateSubquery#apply:
-    //
-    //   Aggregate [col1#28], [col1#28, sum(col2#29) IN (list#24 []) AS x#25]
-    //   :  +- LocalRelation [c2#35L]
-    //   +- LocalRelation [col1#28, col2#29]
-    //
-    // Note that the Aggregate node contains the IN-subquery and the left-hand
-    // side of the IN-subquery is an aggregate expression (sum(col2#29)).
-    //
-    // This handler transforms the above plan into the following:
-    //
-    //   Project [col1#28, sum(col2)#36L IN (list#24 []) AS x#25]
-    //   :  +- LocalRelation [c2#35L]
-    //   +- Aggregate [col1#28], [col1#28, sum(col2#29) AS sum(col2)#36L]
-    //      +- LocalRelation [col1#28, col2#29]
-    //
-    // The transformation pulled the IN-subquery up into a Project. The left-hand side of the
-    // IN-subquery is now an attribute (sum(col2)#36L) that refers to the actual aggregation
-    // which is still performed in the Aggregate node (sum(col2#29) AS sum(col2)#36L). The Unary
-    // node handler will use that attribute in the join condition (rather than the aggregate
-    // expression).
-    //
-    // If the IN-subquery is nested in a larger expression, that entire larger
-    // expression is pulled up into the Project. For example:
-    //
     //   SELECT SUM(col2) IN (SELECT c3 FROM v1) AND SUM(col3) > -1 AS x
     //   FROM v2;
     //
-    // The input to RewritePredicateSubquery#apply is the following plan:
+    // The above query has this plan on entry to RewritePredicateSubquery#apply:
     //
-    //   Aggregate [(sum(col2#34) IN (list#28 []) AND (sum(col3#35) > -1)) AS x#29]
-    //   :  +- LocalRelation [c3#44L]
-    //   +- LocalRelation [col2#34, col3#35]
+    //   Aggregate [(sum(col2#18) IN (list#12 []) AND (sum(col3#19) > -1)) AS x#13]
+    //   :  +- LocalRelation [c3#28L]
+    //   +- LocalRelation [col2#18, col3#19]
     //
-    // This handler transforms the plan into:
+    // Note that the Aggregate node contains the IN-subquery and the left-hand
+    // side of the IN-subquery is an aggregate expression sum(col2#18)).
     //
-    //   Project [(sum(col2)#45L IN (list#28 []) AND (sum(col3)#46L > -1)) AS x#29]
-    //   :  +- LocalRelation [c3#44L]
-    //   +- Aggregate [sum(col2#34) AS sum(col2)#45L, sum(col3#35) AS sum(col3)#46L]
-    //      +- LocalRelation [col2#34, col3#35]
+    // This handler transforms the above plan into the following:
+    // scalastyle:off line.size.limit
     //
-    // Note that the entire AND expression was pulled up into the Project, but the Aggregate
-    // node continues to perform the aggregations (but without the IN-subquery expression).
-    case a: Aggregate if exprsContainsAggregateInSubquery(a.aggregateExpressions) =>
-      // Find any interesting expressions from Aggregate.aggregateExpressions.
-      //
-      // An interesting expression is one that contains an IN-subquery whose left-hand
-      // operand contains aggregates. For example:
-      //
-      //   SELECT col1, SUM(col2) IN (SELECT c2 FROM v1)
-      //   FROM v2 GROUP BY col1;
-      //
-      // withInSubquery will be a List containing a single Alias expression:
-      //
-      //   List(sum(col2#12) IN (list#8 []) AS (...)#19)
-      val withInSubquery = a.aggregateExpressions.filter(exprContainsAggregateInSubquery(_))
-
-      // Extract the aggregate expressions from each interesting expression. This will include
-      // any aggregate expressions that were not part of the IN-subquery but were part
-      // of the larger containing expression.
-      val inSubqueryMapping = withInSubquery.map { e =>
-        (e, extractAggregateExpressions(e))
-      }
-
-      // Map each interesting expression to its contained aggregate expressions.
-      //
-      // Example #1:
-      //
-      //  SELECT col1, SUM(col2) IN (SELECT c2 FROM v1)
-      //  FROM v2 GROUP BY col1;
-      //
-      // inSubqueryMap will have a single entry mapping an Alias expression to a Vector
-      // with a single aggregate expression:
-      //
-      //   Map(
-      //     sum(col2#100) IN (list []) AS (...)#107 -> Vector(sum(col2#100))
-      //   )
-      //
-      // Example #2:
-      //
-      //   SELECT (SUM(col1), SUM(col2)) IN (SELECT c1, c2 FROM v1)
-      //   FROM v2;
-      //
-      // inSubqueryMap will have a single entry mapping an Alias expression to a Vector
-      // with two aggregate expressions:
-      //
-      //   Map(
-      //     named_struct(_0, sum(col1#169), _1, sum(col2#170)) IN (list#166 []) AS (...)#179
-      //       -> Vector(sum(col1#169), sum(col2#170))
-      //   )
-      //
-      // Example #3:
-      //
-      // select SUM(col1) IN (SELECT c1 FROM v1), SUM(col2) IN (SELECT c2 FROM v1)
-      // FROM v2;
-      //
-      // inSubqueryMap will have two entries, each mapping an Alias expression to a Vector
-      // with a single aggregate expression:
-      //
-      //   Map(
-      //     sum(col1#193) IN (list#189 []) AS (...)#207 -> Vector(sum(col1#193)),
-      //     sum(col2#194) IN (list#190 []) AS (...)#208 -> Vector(sum(col2#194))
-      //   )
-      //
-      // Example #5:
-      //
-      //   SELECT SUM(col2) IN (SELECT c3 FROM v1) AND SUM(col3) > -1 AS x
-      //   FROM v2;
-      //
-      // inSubqueryMap will contain a single AND expression that maps to two aggregate
-      // expressions, even though only one of those aggregate expressions is used as
-      // the left-hand operand of the IN-subquery expression.
-      //
-      //   Map(
-      //     (sum(col2#34) IN (list#28 []) AND (sum(col3#35) > -1)) AS x#29
-      //       -> Vector(sum(col2#34), sum(col3#35))
-      //   )
-      //
-      // The keys of inSubqueryMap will be used to determine which expressions in
-      // the old Aggregate node are interesting. The values of inSubqueryMap, after
-      // being wrapped in Alias expressions, will replace their associated interesting
-      // expressions in a new Aggregate node.
-      val inSubqueryMap = inSubqueryMapping.toMap
-
-      // Get all aggregate expressions associated with interesting expressions.
-      val aggregateExprs = inSubqueryMapping.flatMap(_._2)
-      // Create aliases for each above aggregate expression. We can't use the aggregate
-      // expressions directly in the new Aggregate node because Aggregate.aggregateExpressions
-      // has the type Seq[NamedExpression].
-      val aggregateExprAliases = aggregateExprs.map(a => Alias(a, toPrettySQL(a))())
-      // Create a mapping from each aggregate expression to its alias.
-      val aggregateExprAliasMap = aggregateExprs.zip(aggregateExprAliases).toMap
-      // Create attributes from those aliases of aggregate expressions. These attributes
-      // will be used in the new Project node to refer to the aliased aggregate expressions
-      // in the new Aggregate node.
-      val aggregateExprAttrs = aggregateExprAliases.map(_.toAttribute)
-      // Create a mapping from aggregate expressions to attributes. This will be
-      // used when patching the interesting expressions after they are pulled up
-      // into the new Project node: aggregate expressions will be replaced by attributes.
-      val aggregateExprAttrMap = aggregateExprs.zip(aggregateExprAttrs).toMap
-
-      // Create an Aggregate node without the interesting expressions, just
-      // the associated aggregate expressions plus any other group-by or aggregate expressions
-      // that were not involved in the interesting expressions.
-      val newAggregateExpressions = a.aggregateExpressions.flatMap {
-        // If this expression contains IN-subqueries with aggregates in the left-hand
-        // operand, replace with just the aggregates.
-        case ae: Expression if inSubqueryMap.contains(ae) =>
-          // Replace the expression with an aliased aggregate expression.
-          inSubqueryMap(ae).map(aggregateExprAliasMap(_))
-        case ae => Seq(ae)
-      }
-      val newAggregate = a.copy(aggregateExpressions = newAggregateExpressions)
-
-      // Create a projection with the IN-subquery expressions that contain aggregates, replacing
-      // the aggregate expressions with attribute references to the output of the new Aggregate
-      // operator. Also include the other output of the Aggregate operator.
-      val projList = a.aggregateExpressions.map {
-        // If this expression contains an IN-subquery that uses an aggregate, we
-        // need to do something special
-        case ae: Expression if inSubqueryMap.contains(ae) =>
-          ae.transform {
-            // Patch any aggregate expression with its corresponding attribute.
-            case a: AggregateExpression => aggregateExprAttrMap(a)
-          }.asInstanceOf[NamedExpression]
-        case ae => ae.toAttribute
-      }
-      val newProj = Project(projList, newAggregate)
-
-      // Call the unary node handler, but now with all interesting expressions
-      // from Aggregate.aggregateExpressions pulled up into a Project node.
+    //   Project [(_aggregateexpression#20L IN (list#12 []) AND (_aggregateexpression#21L > -1)) AS x#13]
+    //   :  +- LocalRelation [c3#28L]
+    //   +- Aggregate [sum(col2#18) AS _aggregateexpression#20L, sum(col3#19) AS _aggregateexpression#21L]
+    //      +- LocalRelation [col2#18, col3#19]
+    //
+    // scalastyle:on
+    // Note that both the IN-subquery and the greater-than expressions have been
+    // pulled up into the Project node. These expressions use attributes
+    // (_aggregateexpression#20L and _aggregateexpression#21L) to refer to the aggregations
+    // which are still performed in the Aggregate node (sum(col2#18) and sum(col3#19)).
+    case p @ PhysicalAggregation(
+        groupingExpressions, aggregateExpressions, resultExpressions, child)
+        if exprsContainsAggregateInSubquery(p.expressions) =>
+      val aggExprs = aggregateExpressions.map(
+        ae => Alias(ae, "_aggregateexpression")(ae.resultId))
+      val aggExprIds = aggExprs.map(_.exprId).toSet
+      val resExprs = resultExpressions.map(_.transform {
+        case a: AttributeReference if aggExprIds.contains(a.exprId) =>
+          a.withName("_aggregateexpression")
+      }.asInstanceOf[NamedExpression])
+      // Rewrite the projection and the aggregate separately and then piece them together.
+      val newAgg = Aggregate(groupingExpressions, groupingExpressions ++ aggExprs, child)
+      val newProj = Project(resExprs, newAgg)
       handleUnaryNode(newProj)
 
     case u: UnaryNode if u.expressions.exists(

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
@@ -81,7 +81,7 @@ class RewriteSubquerySuite extends PlanTest {
     assert(tracker.rules(RewritePredicateSubquery.ruleName).numEffectiveInvocations == 0)
   }
 
-  test("stuffing") {
+  test("SPARK-50091: Don't put aggregate expression in join condition") {
     val relation1 = LocalRelation($"c1".int, $"c2".int, $"c3".int)
     val relation2 = LocalRelation($"col1".int, $"col2".int, $"col3".int)
     val query = relation2.select(sum($"col2").in(ListQuery(relation1.select($"c3"))))

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/RewriteSubquerySuite.scala
@@ -21,8 +21,9 @@ import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.dsl.expressions._
 import org.apache.spark.sql.catalyst.dsl.plans._
 import org.apache.spark.sql.catalyst.expressions.{IsNull, ListQuery, Not}
+import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.plans.{ExistenceJoin, LeftSemi, PlanTest}
-import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{Join, LocalRelation, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.RuleExecutor
 
 
@@ -78,5 +79,15 @@ class RewriteSubquerySuite extends PlanTest {
     val tracker = new QueryPlanningTracker
     Optimize.executeAndTrack(query.analyze, tracker)
     assert(tracker.rules(RewritePredicateSubquery.ruleName).numEffectiveInvocations == 0)
+  }
+
+  test("stuffing") {
+    val relation1 = LocalRelation($"c1".int, $"c2".int, $"c3".int)
+    val relation2 = LocalRelation($"col1".int, $"col2".int, $"col3".int)
+    val query = relation2.select(sum($"col2").in(ListQuery(relation1.select($"c3"))))
+
+    val optimized = Optimize.execute(query.analyze)
+    val join = optimized.find(_.isInstanceOf[Join]).get.asInstanceOf[Join]
+    assert(!join.condition.get.exists(_.isInstanceOf[AggregateExpression]))
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -2801,7 +2801,7 @@ class SubquerySuite extends QueryTest
     }
   }
 
-  test("stuffing") {
+  test("SPARK-50091: Handle aggregates in left-hand operand of IN-subquery") {
     withTable("v1", "v2") {
       sql("""CREATE OR REPLACE TEMP VIEW v1 (c1, c2, c3) AS VALUES
             |(1, 2, 2), (1, 5, 3), (2, 0, 4), (3, 7, 7), (3, 8, 8)""".stripMargin)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -2755,6 +2755,16 @@ class SubquerySuite extends QueryTest
     }
   }
 
+  test("stuffing") {
+    withTable("v1", "v2") {
+      sql("create or replace temp view v1(c1, c2) as values (1, 2), (1, 3), (2, 2)")
+      sql("create or replace temp view v2(col1, col2) as values (1, 2), (1, 3), (2, 2)")
+      val df = sql("select col1, sum(col2) in (select c2 from v1) from v2 group by col1")
+      checkAnswer(df,
+        Row(1, false) :: Row(2, true) :: Nil)
+    }
+  }
+
   test("SPARK-45580: Handle case where a nested subquery becomes an existence join") {
     withTempView("t1", "t2", "t3") {
       Seq((1), (2), (3), (7)).toDF("a").persist().createOrReplaceTempView("t1")

--- a/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SubquerySuite.scala
@@ -2802,11 +2802,13 @@ class SubquerySuite extends QueryTest
   }
 
   test("SPARK-50091: Handle aggregates in left-hand operand of IN-subquery") {
-    withTable("v1", "v2") {
-      sql("""CREATE OR REPLACE TEMP VIEW v1 (c1, c2, c3) AS VALUES
-            |(1, 2, 2), (1, 5, 3), (2, 0, 4), (3, 7, 7), (3, 8, 8)""".stripMargin)
-      sql("""CREATE OR REPLACE TEMP VIEW v2 (col1, col2, col3) AS VALUES
-            |(1, 2, 2), (1, 3, 3), (2, 2, 4), (3, 7, 7), (3, 1, 1)""".stripMargin)
+    withView("v1", "v2") {
+      Seq((1, 2, 2), (1, 5, 3), (2, 0, 4), (3, 7, 7), (3, 8, 8))
+        .toDF("c1", "c2", "c3")
+        .createOrReplaceTempView("v1")
+      Seq((1, 2, 2), (1, 3, 3), (2, 2, 4), (3, 7, 7), (3, 1, 1))
+        .toDF("col1", "col2", "col3")
+        .createOrReplaceTempView("v2")
 
       val df1 = sql("SELECT col1, SUM(col2) IN (SELECT c3 FROM v1) FROM v2 GROUP BY col1")
       checkAnswer(df1,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds code to `RewritePredicateSubquery#apply` to explicitly handle the case where an `Aggregate` node contains an aggregate expression in the left-hand operand of an IN-subquery expression. The explicit handler moves the IN-subquery expressions out of the `Aggregate` and into a parent `Project` node. The `Aggregate` will continue to perform the aggregations that were used as an operand to the IN-subquery expression, but will not include the IN-subquery expression itself. After pulling up IN-subquery expressions into a Project node, `RewritePredicateSubquery#apply` is called again to handle the `Project` as a `UnaryNode`. The `Join` will now be inserted between the `Project` and the `Aggregate` node, and the join condition will use an attribute rather than an aggregate expression, e.g.:
```
Project [col1#32, exists#42 AS (sum(col2) IN (listquery()))#40]
+- Join ExistenceJoin(exists#42), (sum(col2)#41L = c2#39L)
   :- Aggregate [col1#32], [col1#32, sum(col2#33) AS sum(col2)#41L]
   :  +- LocalRelation [col1#32, col2#33]
   +- LocalRelation [c2#39L]
```
`sum(col2)#41L` in the above join condition, despite how it looks, is the name of the attribute, not an aggregate expression.

### Why are the changes needed?

The following query fails:
```
create or replace temp view v1(c1, c2) as values (1, 2), (1, 3), (2, 2), (3, 7), (3, 1);
create or replace temp view v2(col1, col2) as values (1, 2), (1, 3), (2, 2), (3, 7), (3, 1);

select col1, sum(col2) in (select c2 from v1)
from v2 group by col1;
```
It fails with this error:
```
[INTERNAL_ERROR] Cannot generate code for expression: sum(input[1, int, false]) SQLSTATE: XX000
```
With SPARK_TESTING=1, it fails with this error:
```
[PLAN_VALIDATION_FAILED_RULE_IN_BATCH] Rule org.apache.spark.sql.catalyst.optimizer.RewritePredicateSubquery in batch RewriteSubquery generated an invalid plan: Special expressions are placed in the wrong plan:
Aggregate [col1#11], [col1#11, first(exists#20, false) AS (sum(col2) IN (listquery()))#19]
+- Join ExistenceJoin(exists#20), (sum(col2#12) = c2#18L)
   :- LocalRelation [col1#11, col2#12]
   +- LocalRelation [c2#18L]
```
The issue is that `RewritePredicateSubquery` builds a `Join` operator where the join condition contains an aggregate expression.

The bug is in the handler for `UnaryNode` in `RewritePredicateSubquery#apply`, which adds a `Join` below the `Aggregate` and assumes that the left-hand operand of IN-subquery can be used in the join condition. This works fine for most cases, but not when the left-hand operand is an aggregate expression.

This PR moves the offending IN-subqueries to a `Project` node, with the aggregates replaced by attributes referring to the aggregate expressions. The resulting join condition now uses those attributes rather than the actual aggregate expressions.

### Does this PR introduce _any_ user-facing change?

No, other than allowing this type of query to succeed.

### How was this patch tested?

New unit tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
