### PR TITLE
[SPARK-49999][PYTHON][CONNECT] Support optional "column" parameter in box, kde and hist plots

### DIFF
--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -812,6 +812,11 @@
       "Pipe function `<func_name>` exited with error code <error_code>."
     ]
   },
+    "PLOT_INVALID_TYPE_COLUMN": {
+    "message": [
+      "Column <col_name> must be one of <valid_types> for plotting, got <col_type>."
+    ]
+  },
   "PLOT_NOT_NUMERIC_COLUMN": {
     "message": [
       "Argument <arg_name> must be a numerical column for plotting, got <arg_type>."

--- a/python/pyspark/sql/plot/core.py
+++ b/python/pyspark/sql/plot/core.py
@@ -400,6 +400,7 @@ class PySparkPlotAccessor:
         ... ]
         >>> columns = ["student", "math_score", "english_score"]
         >>> df = spark.createDataFrame(data, columns)
+        >>> df.plot.box()  # doctest: +SKIP
         >>> df.plot.box(column="math_score")  # doctest: +SKIP
         >>> df.plot.box(column=["math_score", "english_score"])  # doctest: +SKIP
         """
@@ -444,6 +445,7 @@ class PySparkPlotAccessor:
         >>> data = [(5.1, 3.5, 0), (4.9, 3.0, 0), (7.0, 3.2, 1), (6.4, 3.2, 1), (5.9, 3.0, 2)]
         >>> columns = ["length", "width", "species"]
         >>> df = spark.createDataFrame(data, columns)
+        >>> df.plot.kde(bw_method=0.3)  # doctest: +SKIP
         >>> df.plot.kde(column=["length", "width"], bw_method=0.3)  # doctest: +SKIP
         >>> df.plot.kde(column="length", bw_method=0.3)  # doctest: +SKIP
         """
@@ -478,6 +480,7 @@ class PySparkPlotAccessor:
         >>> data = [(5.1, 3.5, 0), (4.9, 3.0, 0), (7.0, 3.2, 1), (6.4, 3.2, 1), (5.9, 3.0, 2)]
         >>> columns = ["length", "width", "species"]
         >>> df = spark.createDataFrame(data, columns)
+        >>> df.plot.hist(bins=4)  # doctest: +SKIP
         >>> df.plot.hist(column=["length", "width"])  # doctest: +SKIP
         >>> df.plot.hist(column="length", bins=4)  # doctest: +SKIP
         """

--- a/python/pyspark/sql/plot/core.py
+++ b/python/pyspark/sql/plot/core.py
@@ -360,7 +360,7 @@ class PySparkPlotAccessor:
             )
         return self(kind="pie", x=x, y=y, **kwargs)
 
-    def box(self, column: Union[str, List[str]], **kwargs: Any) -> "Figure":
+    def box(self, column: Optional[Union[str, List[str]]] = None, **kwargs: Any) -> "Figure":
         """
         Make a box plot of the DataFrame columns.
 
@@ -374,8 +374,9 @@ class PySparkPlotAccessor:
 
         Parameters
         ----------
-        column: str or list of str
-            Column name or list of names to be used for creating the boxplot.
+        column: str or list of str, optional
+            Column name or list of names to be used for creating the box plot.
+            If None (default), all numeric columns will be used.
         **kwargs
             Extra arguments to `precision`: refer to a float that is used by
             pyspark to compute approximate statistics for building a boxplot.
@@ -406,9 +407,9 @@ class PySparkPlotAccessor:
 
     def kde(
         self,
-        column: Union[str, List[str]],
         bw_method: Union[int, float],
-        ind: Union["np.ndarray", int, None] = None,
+        column: Optional[Union[str, List[str]]] = None,
+        ind: Optional[Union["np.ndarray", int]] = None,
         **kwargs: Any,
     ) -> "Figure":
         """
@@ -420,11 +421,12 @@ class PySparkPlotAccessor:
 
         Parameters
         ----------
-        column: str or list of str
-            Column name or list of names to be used for creating the kde plot.
         bw_method : int or float
             The method used to calculate the estimator bandwidth.
             See KernelDensity in PySpark for more information.
+        column: str or list of str, optional
+            Column name or list of names to be used for creating the kde plot.
+            If None (default), all numeric columns will be used.
         ind : NumPy array or integer, optional
             Evaluation points for the estimated PDF. If None (default),
             1000 equally spaced points are used. If `ind` is a NumPy array, the
@@ -447,7 +449,9 @@ class PySparkPlotAccessor:
         """
         return self(kind="kde", column=column, bw_method=bw_method, ind=ind, **kwargs)
 
-    def hist(self, column: Union[str, List[str]], bins: int = 10, **kwargs: Any) -> "Figure":
+    def hist(
+        self, column: Optional[Union[str, List[str]]] = None, bins: int = 10, **kwargs: Any
+    ) -> "Figure":
         """
         Draw one histogram of the DataFrame’s columns.
 
@@ -457,8 +461,9 @@ class PySparkPlotAccessor:
 
         Parameters
         ----------
-        column: str or list of str
-            Column name or list of names to be used for creating the histogram.
+        column: str or list of str, optional
+            Column name or list of names to be used for creating the hostogram plot.
+            If None (default), all numeric columns will be used.
         bins : integer, default 10
             Number of histogram bins to be used.
         **kwargs
@@ -481,7 +486,7 @@ class PySparkPlotAccessor:
 
 class PySparkKdePlotBase:
     @staticmethod
-    def get_ind(sdf: "DataFrame", ind: Union["np.ndarray", int, None]) -> "np.ndarray":
+    def get_ind(sdf: "DataFrame", ind: Optional[Union["np.ndarray", int]]) -> "np.ndarray":
         require_minimum_numpy_version()
         import numpy as np
 

--- a/python/pyspark/sql/plot/plotly.py
+++ b/python/pyspark/sql/plot/plotly.py
@@ -216,9 +216,10 @@ def process_column_param(column: Optional[Union[str, List[str]]], data: "DataFra
     Processes the provided column parameter for a DataFrame.
     - If `column` is None, returns a list of numeric or datetime columns from the DataFrame.
     - If `column` is a string, converts it to a list first.
-    - If `column` is a list, it checks if all specified columns exist in the DataFrame and are of valid types
-      (NumericType, DateType, or TimestampType).
-    - Raises a PySparkTypeError if any column in the list is not present in the DataFrame or has an invalid type.
+    - If `column` is a list, it checks if all specified columns exist in the DataFrame
+      and are of valid types (NumericType, DateType, or TimestampType).
+    - Raises a PySparkTypeError if any column in the list is not present in the DataFrame
+      or has an invalid type.
     """
     valid_types = (NumericType, DateType, TimestampType)
     if column is None:

--- a/python/pyspark/sql/plot/plotly.py
+++ b/python/pyspark/sql/plot/plotly.py
@@ -174,7 +174,7 @@ def plot_histogram(data: "DataFrame", **kwargs: Any) -> "Figure":
     import plotly.graph_objs as go
 
     bins = kwargs.get("bins", 10)
-    colnames = (kwargs.pop("column", None), data)
+    colnames = process_column_param(kwargs.pop("column", None), data)
     numeric_data = data.select(*colnames)  # type: ignore
     bins = PySparkHistogramPlotBase.get_bins(numeric_data, bins)
     assert len(bins) > 2, "the number of buckets must be higher than 2."

--- a/python/pyspark/sql/plot/plotly.py
+++ b/python/pyspark/sql/plot/plotly.py
@@ -175,10 +175,10 @@ def plot_histogram(data: "DataFrame", **kwargs: Any) -> "Figure":
 
     bins = kwargs.get("bins", 10)
     colnames = (kwargs.pop("column", None), data)
-    data = data.select(*colnames)
-    bins = PySparkHistogramPlotBase.get_bins(data, bins)
+    numeric_data = data.select(*colnames)  # type: ignore
+    bins = PySparkHistogramPlotBase.get_bins(numeric_data, bins)
     assert len(bins) > 2, "the number of buckets must be higher than 2."
-    output_series = PySparkHistogramPlotBase.compute_hist(data, bins)
+    output_series = PySparkHistogramPlotBase.compute_hist(numeric_data, bins)
     prev = float("%.9f" % bins[0])  # to make it prettier, truncate.
     text_bins = []
     for b in bins[1:]:

--- a/python/pyspark/sql/plot/plotly.py
+++ b/python/pyspark/sql/plot/plotly.py
@@ -175,7 +175,7 @@ def plot_histogram(data: "DataFrame", **kwargs: Any) -> "Figure":
 
     bins = kwargs.get("bins", 10)
     colnames = process_column_param(kwargs.pop("column", None), data)
-    numeric_data = data.select(*colnames)  # type: ignore
+    numeric_data = data.select(*colnames)
     bins = PySparkHistogramPlotBase.get_bins(numeric_data, bins)
     assert len(bins) > 2, "the number of buckets must be higher than 2."
     output_series = PySparkHistogramPlotBase.compute_hist(numeric_data, bins)

--- a/python/pyspark/sql/plot/plotly.py
+++ b/python/pyspark/sql/plot/plotly.py
@@ -25,7 +25,7 @@ from pyspark.sql.plot import (
     PySparkKdePlotBase,
     PySparkHistogramPlotBase,
 )
-from pyspark.sql.types import NumericType, DateType, TimestampType
+from pyspark.sql.types import NumericType
 
 if TYPE_CHECKING:
     from pyspark.sql import DataFrame
@@ -214,29 +214,28 @@ def plot_histogram(data: "DataFrame", **kwargs: Any) -> "Figure":
 def process_column_param(column: Optional[Union[str, List[str]]], data: "DataFrame") -> List[str]:
     """
     Processes the provided column parameter for a DataFrame.
-    - If `column` is None, returns a list of numeric or datetime columns from the DataFrame.
+    - If `column` is None, returns a list of numeric columns from the DataFrame.
     - If `column` is a string, converts it to a list first.
     - If `column` is a list, it checks if all specified columns exist in the DataFrame
-      and are of valid types (NumericType, DateType, or TimestampType).
+      and are of NumericType.
     - Raises a PySparkTypeError if any column in the list is not present in the DataFrame
-      or has an invalid type.
+      or is not of NumericType.
     """
-    valid_types = (NumericType, DateType, TimestampType)
     if column is None:
         return [
-            field.name for field in data.schema.fields if isinstance(field.dataType, valid_types)
+            field.name for field in data.schema.fields if isinstance(field.dataType, NumericType)
         ]
     if isinstance(column, str):
         column = [column]
 
     for col in column:
         field = next((f for f in data.schema.fields if f.name == col), None)
-        if not field or not isinstance(field.dataType, valid_types):
+        if not field or not isinstance(field.dataType, NumericType):
             raise PySparkTypeError(
                 errorClass="PLOT_INVALID_TYPE_COLUMN",
                 messageParameters={
                     "col_name": col,
-                    "valid_types": ", ".join([t.__name__ for t in valid_types]),
+                    "valid_types": NumericType.__name__,
                     "col_type": field.dataType.__class__.__name__ if field else "None",
                 },
             )

--- a/python/pyspark/sql/tests/plot/test_frame_plot_plotly.py
+++ b/python/pyspark/sql/tests/plot/test_frame_plot_plotly.py
@@ -45,7 +45,7 @@ class DataFramePlotPlotlyTestsMixin:
 
     @property
     def sdf2(self):
-        data = [(5.1, 3.5, 0), (4.9, 3.0, 0), (7.0, 3.2, 1), (6.4, 3.2, 1), (5.9, 3.0, 2)]
+        data = [(5.1, 3.5, "0"), (4.9, 3.0, "0"), (7.0, 3.2, "1"), (6.4, 3.2, "1"), (5.9, 3.0, "2")]
         columns = ["length", "width", "species"]
         return self.spark.createDataFrame(data, columns)
 
@@ -330,7 +330,7 @@ class DataFramePlotPlotlyTestsMixin:
 
     def test_box_plot(self):
         fig = self.sdf4.plot.box(column="math_score")
-        expected_fig_data = {
+        expected_fig_data1 = {
             "boxpoints": "suspectedoutliers",
             "lowerfence": (5,),
             "mean": (50.0,),
@@ -343,11 +343,11 @@ class DataFramePlotPlotlyTestsMixin:
             "x": [0],
             "type": "box",
         }
-        self._check_fig_data(fig["data"][0], **expected_fig_data)
+        self._check_fig_data(fig["data"][0], **expected_fig_data1)
 
         fig = self.sdf4.plot(kind="box", column=["math_score", "english_score"])
-        self._check_fig_data(fig["data"][0], **expected_fig_data)
-        expected_fig_data = {
+        self._check_fig_data(fig["data"][0], **expected_fig_data1)
+        expected_fig_data2 = {
             "boxpoints": "suspectedoutliers",
             "lowerfence": (55,),
             "mean": (72.5,),
@@ -361,7 +361,12 @@ class DataFramePlotPlotlyTestsMixin:
             "y": [[150, 15]],
             "type": "box",
         }
-        self._check_fig_data(fig["data"][1], **expected_fig_data)
+        self._check_fig_data(fig["data"][1], **expected_fig_data2)
+
+        fig = self.sdf4.plot(kind="box")
+        self._check_fig_data(fig["data"][0], **expected_fig_data1)
+        self._check_fig_data(fig["data"][1], **expected_fig_data2)
+
         with self.assertRaises(PySparkValueError) as pe:
             self.sdf4.plot.box(column="math_score", boxpoints=True)
         self.check_error(
@@ -390,7 +395,7 @@ class DataFramePlotPlotlyTestsMixin:
     @unittest.skipIf(not have_numpy, numpy_requirement_message)
     def test_kde_plot(self):
         fig = self.sdf4.plot.kde(column="math_score", bw_method=0.3, ind=5)
-        expected_fig_data = {
+        expected_fig_data1 = {
             "mode": "lines",
             "name": "math_score",
             "orientation": "v",
@@ -398,11 +403,11 @@ class DataFramePlotPlotlyTestsMixin:
             "yaxis": "y",
             "type": "scatter",
         }
-        self._check_fig_data(fig["data"][0], **expected_fig_data)
+        self._check_fig_data(fig["data"][0], **expected_fig_data1)
 
         fig = self.sdf4.plot.kde(column=["math_score", "english_score"], bw_method=0.3, ind=5)
-        self._check_fig_data(fig["data"][0], **expected_fig_data)
-        expected_fig_data = {
+        self._check_fig_data(fig["data"][0], **expected_fig_data1)
+        expected_fig_data2 = {
             "mode": "lines",
             "name": "english_score",
             "orientation": "v",
@@ -410,7 +415,12 @@ class DataFramePlotPlotlyTestsMixin:
             "yaxis": "y",
             "type": "scatter",
         }
-        self._check_fig_data(fig["data"][1], **expected_fig_data)
+        self._check_fig_data(fig["data"][1], **expected_fig_data2)
+        self.assertEqual(list(fig["data"][0]["x"]), list(fig["data"][1]["x"]))
+
+        fig = self.sdf4.plot.kde(bw_method=0.3, ind=5)
+        self._check_fig_data(fig["data"][0], **expected_fig_data1)
+        self._check_fig_data(fig["data"][1], **expected_fig_data2)
         self.assertEqual(list(fig["data"][0]["x"]), list(fig["data"][1]["x"]))
 
     def test_hist_plot(self):
@@ -423,23 +433,28 @@ class DataFramePlotPlotlyTestsMixin:
             "type": "bar",
         }
         self._check_fig_data(fig["data"][0], **expected_fig_data)
+
         fig = self.sdf2.plot.hist(column=["length", "width"], bins=4)
-        expected_fig_data = {
+        expected_fig_data1 = {
             "name": "length",
             "x": [3.5, 4.5, 5.5, 6.5],
             "y": [0, 1, 2, 2],
             "text": ("[3.0, 4.0)", "[4.0, 5.0)", "[5.0, 6.0)", "[6.0, 7.0]"),
             "type": "bar",
         }
-        self._check_fig_data(fig["data"][0], **expected_fig_data)
-        expected_fig_data = {
+        self._check_fig_data(fig["data"][0], **expected_fig_data1)
+        expected_fig_data2 = {
             "name": "width",
             "x": [3.5, 4.5, 5.5, 6.5],
             "y": [5, 0, 0, 0],
             "text": ("[3.0, 4.0)", "[4.0, 5.0)", "[5.0, 6.0)", "[6.0, 7.0]"),
             "type": "bar",
         }
-        self._check_fig_data(fig["data"][1], **expected_fig_data)
+        self._check_fig_data(fig["data"][1], **expected_fig_data2)
+
+        fig = self.sdf2.plot.hist(bins=4)
+        self._check_fig_data(fig["data"][0], **expected_fig_data1)
+        self._check_fig_data(fig["data"][1], **expected_fig_data2)
 
 
 class DataFramePlotPlotlyTests(DataFramePlotPlotlyTestsMixin, ReusedSQLTestCase):

--- a/python/pyspark/sql/tests/plot/test_frame_plot_plotly.py
+++ b/python/pyspark/sql/tests/plot/test_frame_plot_plotly.py
@@ -456,6 +456,33 @@ class DataFramePlotPlotlyTestsMixin:
         self._check_fig_data(fig["data"][0], **expected_fig_data1)
         self._check_fig_data(fig["data"][1], **expected_fig_data2)
 
+    def test_process_column_param_errors(self):
+        with self.assertRaises(PySparkTypeError) as pe:
+            self.sdf4.plot.box(column="math_scor")
+
+        self.check_error(
+            exception=pe.exception,
+            errorClass="PLOT_INVALID_TYPE_COLUMN",
+            messageParameters={
+                "col_name": "math_scor",
+                "valid_types": "NumericType, DateType, TimestampType",
+                "col_type": "None",
+            },
+        )
+
+        with self.assertRaises(PySparkTypeError) as pe:
+            self.sdf4.plot.box(column="student")
+
+        self.check_error(
+            exception=pe.exception,
+            errorClass="PLOT_INVALID_TYPE_COLUMN",
+            messageParameters={
+                "col_name": "student",
+                "valid_types": "NumericType, DateType, TimestampType",
+                "col_type": "StringType",
+            },
+        )
+
 
 class DataFramePlotPlotlyTests(DataFramePlotPlotlyTestsMixin, ReusedSQLTestCase):
     pass

--- a/python/pyspark/sql/tests/plot/test_frame_plot_plotly.py
+++ b/python/pyspark/sql/tests/plot/test_frame_plot_plotly.py
@@ -465,7 +465,7 @@ class DataFramePlotPlotlyTestsMixin:
             errorClass="PLOT_INVALID_TYPE_COLUMN",
             messageParameters={
                 "col_name": "math_scor",
-                "valid_types": "NumericType, DateType, TimestampType",
+                "valid_types": "NumericType",
                 "col_type": "None",
             },
         )
@@ -478,7 +478,7 @@ class DataFramePlotPlotlyTestsMixin:
             errorClass="PLOT_INVALID_TYPE_COLUMN",
             messageParameters={
                 "col_name": "student",
-                "valid_types": "NumericType, DateType, TimestampType",
+                "valid_types": "NumericType",
                 "col_type": "StringType",
             },
         )


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support for the optional “column” parameter has been added in box, kde, and hist plots. Now, when the column is not provided, all columns of valid types (NumericType, DateType, TimestampType) will be used to build the plots.

### Why are the changes needed?
- Reach parity with Pandas (on Spark) default behavior.
- Simplify usage by reducing the need for explicitly specifying columns.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Unit tests.

### Was this patch authored or co-authored using generative AI tooling?
No.