### PR TITLE
[SPARK-50095][CONNECT][TESTS] Enable `ProtoToParsedPlanTestSuite` to run successfully in IDE

### DIFF
--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ProtoToParsedPlanTestSuite.scala
@@ -190,8 +190,9 @@ class ProtoToParsedPlanTestSuite
       val relation = readRelation(file)
       val planner = new SparkConnectPlanner(SparkConnectTestUtils.createDummySessionHolder(spark))
       val catalystPlan =
-        analyzer.executeAndCheck(planner.transformRelation(
-          normalizeRelation(relation)), new QueryPlanningTracker)
+        analyzer.executeAndCheck(
+          planner.transformRelation(normalizeRelation(relation)),
+          new QueryPlanningTracker)
       val finalAnalyzedPlan = {
         object Helper extends RuleExecutor[LogicalPlan] {
           val batches =
@@ -276,10 +277,12 @@ class ProtoToParsedPlanTestSuite
         if (read.getDataSource.getFormat != "jdbc" && read.getDataSource.getPredicatesCount == 0) {
           if (read.getDataSource.getPathsCount != 0) {
             val dataSourceBuilder = proto.Read.DataSource.newBuilder(read.getDataSource)
-            read.getDataSource.getPathsList.asScala.toSeq.map(path => normalizePath(path)).
-              zipWithIndex.foreach { case (newPath, index) =>
+            read.getDataSource.getPathsList.asScala.toSeq
+              .map(path => normalizePath(path))
+              .zipWithIndex
+              .foreach { case (newPath, index) =>
                 dataSourceBuilder.setPaths(index, newPath)
-            }
+              }
             return proto.Read.newBuilder(read).setDataSource(dataSourceBuilder.build()).build()
           }
         }
@@ -290,6 +293,8 @@ class ProtoToParsedPlanTestSuite
 
   private def normalizePath(path: String): String = {
     val paths: Seq[String] = path.split(java.io.File.separator).toSeq
-    getWorkspaceFilePath("sql", "connect" +: paths.slice(1, paths.size): _*).toFile.getAbsolutePath
+    getWorkspaceFilePath(
+      "sql",
+      "connect" +: paths.slice(1, paths.size): _*).toFile.getAbsolutePath
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to enable `ProtoToParsedPlanTestSuite` to run `successfully` in IDE.


### Why are the changes needed?
- Taking `read` as an example
  in the file `sql/connect/common/src/test/resources/query-tests/queries/read.json`, we found that the value of `paths` is `a relative directory` that cannot be correctly recognized in the IDE.
https://github.com/apache/spark/blob/b72bf79f5a26f1a57527fbb083bd3c74d42169e8/sql/connect/common/src/test/resources/query-tests/queries/read.json#L13

- Before:
  <img width="1277" alt="image" src="https://github.com/user-attachments/assets/9d9ac4d3-d66c-4b44-8793-87bb428aba45">
```shell
[PATH_NOT_FOUND] Path does not exist: file:/Users/panbingkun/Developer/spark/common/src/test/resources/query-tests/test-data/people.csv. SQLSTATE: 42K03
org.apache.spark.sql.AnalysisException: [PATH_NOT_FOUND] Path does not exist: file:/Users/panbingkun/Developer/spark/common/src/test/resources/query-tests/test-data/people.csv. SQLSTATE: 42K03
	at org.apache.spark.sql.errors.QueryCompilationErrors$.dataPathNotExistError(QueryCompilationErrors.scala:1643)
	at org.apache.spark.sql.execution.datasources.DataSource$.$anonfun$checkAndGlobPathIfNecessary$4(DataSource.scala:802)
	at org.apache.spark.sql.execution.datasources.DataSource$.$anonfun$checkAndGlobPathIfNecessary$4$adapted(DataSource.scala:799)
	at ... run in separate thread using org.apache.spark.util.ThreadUtils ... ()
	at org.apache.spark.sql.execution.datasources.DataSource$.checkAndGlobPathIfNecessary(DataSource.scala:806)
	at org.apache.spark.sql.execution.datasources.DataSource.checkAndGlobPathIfNecessary(DataSource.scala:566)
	at org.apache.spark.sql.execution.datasources.DataSource.resolveRelation(DataSource.scala:408)
	at org.apache.spark.sql.DataFrameReader.loadV1Source(DataFrameReader.scala:138)
```

- After:
  <img width="1011" alt="image" src="https://github.com/user-attachments/assets/362db82e-7d5a-4f45-961b-c5e10a68dfd5">


### Does this PR introduce _any_ user-facing change?
No, only for tests.


### How was this patch tested?
- Pass GA.
- Manually check
```shell
 build/sbt "connect/testOnly org.apache.spark.sql.connect.ProtoToParsedPlanTestSuite"
```

```shell
[info] - function_raise_error (1 millisecond)
[info] - column_when_otherwise (2 milliseconds)
[info] - function_date_trunc (1 millisecond)
[info] Run completed in 11 seconds, 394 milliseconds.
[info] Total number of tests run: 702
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 702, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 145 s (02:25), completed Oct 24, 2024, 9:54:09 AM
```

### Was this patch authored or co-authored using generative AI tooling?
No.
