### PR TITLE
[SPARK-50094][PYTHON][CONNECT] Better error message when using memory profiler on editors with no line numbers

### DIFF
--- a/python/pyspark/errors/error-conditions.json
+++ b/python/pyspark/errors/error-conditions.json
@@ -512,6 +512,11 @@
       "A master URL must be set in your configuration."
     ]
   },
+  "MEMORY_PROFILE_INVALID_SOURCE":{
+    "message": [
+      "Memory profiler can only be used on editors with line numbers."
+    ]
+  },
   "MISSING_LIBRARY_FOR_PROFILER": {
     "message": [
       "Install the 'memory_profiler' library in the cluster to enable memory profiling."

--- a/python/pyspark/profiler.py
+++ b/python/pyspark/profiler.py
@@ -45,7 +45,7 @@ except Exception:
     has_memory_profiler = False
 
 from pyspark.accumulators import AccumulatorParam
-from pyspark.errors import PySparkRuntimeError
+from pyspark.errors import PySparkRuntimeError, PySparkValueError
 
 if TYPE_CHECKING:
     from pyspark.core.context import SparkContext
@@ -473,6 +473,10 @@ class MemoryProfiler(Profiler):
             stream.write("=" * len(header) + "\n")
 
             all_lines = linecache.getlines(filename)
+            if len(all_lines) == 0:
+                raise PySparkValueError(
+                    errorClass="MEMORY_PROFILE_INVALID_SOURCE", messageParameters={}
+                )
 
             float_format = "{0}.{1}f".format(precision + 4, precision)
             template_mem = "{0:" + float_format + "} MiB"


### PR DESCRIPTION
### What changes were proposed in this pull request?
Better error message when using memory profiler on editors with no line numbers.

memory-profiler requires line numbers to function properly, the proposed error message directly communicates that requirement.

### Why are the changes needed?
Improve user experience and clarity in debugging.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests and mantual test:
```py
>>> from pyspark.sql.functions import pandas_udf
>>> df = spark.range(10)
>>> @pandas_udf("long")
... def add1(x):
...   return x + 1
... 
>>> spark.conf.set("spark.sql.pyspark.udf.profiler", "memory")
>>> added = df.select(add1("id"))
>>> spark.profile.show(type="memory")
...
pyspark.errors.exceptions.base.PySparkValueError: [MEMORY_PROFILE_INVALID_SOURCE] Memory profiler can only be used on editors with line numbers.
```

### Was this patch authored or co-authored using generative AI tooling?
No.
