### PR TITLE
[SPARK-50098][PYTHON] Upgrade the minimum version of `googleapis-common-protos` to 1.65.0

### DIFF
--- a/dev/create-release/spark-rm/Dockerfile
+++ b/dev/create-release/spark-rm/Dockerfile
@@ -102,7 +102,7 @@ RUN pypy3 -m pip install numpy 'six==1.16.0' 'pandas==2.2.2' scipy coverage matp
 
 ARG BASIC_PIP_PKGS="numpy pyarrow>=15.0.0 six==1.16.0 pandas==2.2.2 scipy plotly>=4.8 mlflow>=2.8.1 coverage matplotlib openpyxl memory-profiler>=0.61.0 scikit-learn>=1.3.2 twine==3.4.1"
 # Python deps for Spark Connect
-ARG CONNECT_PIP_PKGS="grpcio==1.62.0 grpcio-status==1.62.0 protobuf==4.25.1 googleapis-common-protos==1.56.4"
+ARG CONNECT_PIP_PKGS="grpcio==1.62.0 grpcio-status==1.62.0 protobuf==4.25.1 googleapis-common-protos==1.65.0"
 
 # Install Python 3.10 packages
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10

--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -96,7 +96,7 @@ RUN pypy3 -m pip install numpy 'six==1.16.0' 'pandas==2.2.3' scipy coverage matp
 
 ARG BASIC_PIP_PKGS="numpy pyarrow>=15.0.0 six==1.16.0 pandas==2.2.3 scipy plotly>=4.8 mlflow>=2.8.1 coverage matplotlib openpyxl memory-profiler>=0.61.0 scikit-learn>=1.3.2"
 # Python deps for Spark Connect
-ARG CONNECT_PIP_PKGS="grpcio==1.62.0 grpcio-status==1.62.0 protobuf==4.25.1 googleapis-common-protos==1.56.4 graphviz==0.20.3"
+ARG CONNECT_PIP_PKGS="grpcio==1.62.0 grpcio-status==1.62.0 protobuf==4.25.1 googleapis-common-protos==1.65.0 graphviz==0.20.3"
 
 # Install Python 3.10 packages
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -60,7 +60,7 @@ py
 # Spark Connect (required)
 grpcio>=1.62.0
 grpcio-status>=1.62.0
-googleapis-common-protos>=1.56.4
+googleapis-common-protos>=1.65.0
 
 # Spark Connect python proto generation plugin (optional)
 mypy-protobuf==3.3.0

--- a/python/docs/source/getting_started/install.rst
+++ b/python/docs/source/getting_started/install.rst
@@ -210,7 +210,7 @@ Package                    Supported version Note
 `pyarrow`                  >=10.0.0          Required for Spark Connect
 `grpcio`                   >=1.62.0          Required for Spark Connect
 `grpcio-status`            >=1.62.0          Required for Spark Connect
-`googleapis-common-protos` >=1.56.4          Required for Spark Connect
+`googleapis-common-protos` >=1.65.0          Required for Spark Connect
 `graphviz`                 >=0.20            Optional for Spark Connect
 ========================== ================= ==========================
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade the minimum version of `googleapis-common-protos` from 1.56.4 to 1.65.0 for Apache Spark 4.0.0.

### Why are the changes needed?

`1.56.4` is too old (released on 2022-07-12) and incompatible with the last protobuf related libraries. We had better upgrade this to the latest versions in order to support the latest Python and protobuf versions in Apache Spark 4.0.0 on February 2025.

- https://pypi.org/project/googleapis-common-protos/1.65.0/ (2024-08-27)
- https://pypi.org/project/googleapis-common-protos/1.64.0/ (2024-08-26)
- https://pypi.org/project/googleapis-common-protos/1.63.0/ (2024-03-11)
- https://pypi.org/project/googleapis-common-protos/1.62.0/ (2023-12-07)
- https://pypi.org/project/googleapis-common-protos/1.61.0/ (2023-10-21)
- https://pypi.org/project/googleapis-common-protos/1.60.0/ (2023-07-31)
- https://pypi.org/project/googleapis-common-protos/1.60.0/ (2023-07-31)
- https://pypi.org/project/googleapis-common-protos/1.59.0/ (2023-03-21)
- https://pypi.org/project/googleapis-common-protos/1.58.0/ (2023-01-09)
- https://pypi.org/project/googleapis-common-protos/1.57.0/ (2022-11-15)

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.