### PR TITLE
[DOCS] Add note on compatibility with Confluent Schema Registry in Avro Data Source Guide

### DIFF
--- a/docs/sql-data-sources-avro.md
+++ b/docs/sql-data-sources-avro.md
@@ -478,9 +478,9 @@ Submission Guide for more details.
 
 ## Compatibility with Confluent Schema Registry
 
-Note that Avro data produced by the [Confluent Schema Registry based Avro serializer](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/serdes-avro.html) prepends [a magic byte and the 4 byte schema ID](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format) to the serialized data. This means that the `from_avro` function will not deserialize the data correctly unless this is handled. 
+Note that Avro data produced by the [Confluent Schema Registry based Avro serializer](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/serdes-avro.html) prepends [a magic byte and the 4 byte schema ID](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format) to the serialized data. This means that the `from_avro` function will not deserialize the data correctly unless this is handled explicitly.
 
-A simple workaround is to remove the bytes from the `value` column
+A simple workaround is to remove the bytes from the `"value"` field.
 
 <div data-lang="python" markdown="1">
 {% highlight python %}

--- a/docs/sql-data-sources-avro.md
+++ b/docs/sql-data-sources-avro.md
@@ -476,6 +476,30 @@ Submission Guide for more details.
 
 [adm]: submitting-applications.html#advanced-dependency-management
 
+## Compatibility with Confluent Schema Registry
+
+Note that Avro data produced by the [Confluent Schema Registry based Avro serializer](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/serdes-avro.html) prepends [a magic byte and the 4 byte schema ID](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format) to the serialized data. This means that the `from_avro` function will not deserialize the data correctly unless this is handled. 
+
+A simple workaround is to remove the bytes from the `value` column
+
+<div data-lang="python" markdown="1">
+{% highlight python %}
+from pyspark.sql.avro.functions import from_avro, to_avro
+
+jsonFormatSchema = ... # your schema string
+
+df = spark\
+  .readStream\
+  .format("kafka")\
+  .option("kafka.bootstrap.servers", "host1:port1,host2:port2")\
+  .option("subscribe", "schema-registry-user-topic")\ 
+  .load()
+
+serialized_df = df.select(from_avro(f.expr("substring(value, 6, length(value) - 5)"), jsonFormatSchema))
+
+{% endhighlight %}
+</div>
+
 ## Supported types for Avro -> Spark SQL conversion
 Currently Spark supports reading all [primitive types](https://avro.apache.org/docs/1.11.3/specification/#primitive-types) and [complex types](https://avro.apache.org/docs/1.11.3/specification/#complex-types) under records of Avro.
 <table>

--- a/docs/sql-data-sources-avro.md
+++ b/docs/sql-data-sources-avro.md
@@ -478,13 +478,16 @@ Submission Guide for more details.
 
 ## Compatibility with Confluent Schema Registry
 
-Note that Avro data produced by the [Confluent Schema Registry based Avro serializer](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/serdes-avro.html) prepends [a magic byte and the 4 byte schema ID](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format) to the serialized data. This means that the `from_avro` function will not deserialize the data correctly unless this is handled explicitly.
+Note that Avro data produced by the [Confluent Schema Registry based Avro serializer](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/serdes-avro.html) prepends [a magic byte and the 4 byte schema ID](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#wire-format) to the serialized data. The `from_avro` function has no built-in support for the Schema Registry and so will not deserialize the data correctly unless handled explicitly, e.g. by [using the Confluent deserializer and a map](https://stackoverflow.com/a/49182004/15037018).
 
-A simple workaround is to remove the bytes from the `"value"` field.
+A simpler workaround is to just remove the bytes from the `"value"` field.
+
+<div class="codetabs">
 
 <div data-lang="python" markdown="1">
 {% highlight python %}
-from pyspark.sql.avro.functions import from_avro, to_avro
+from pyspark.sql.avro.functions import from_avro
+from pyspark.sql import functions as f
 
 jsonFormatSchema = ... # your schema string
 
@@ -498,6 +501,8 @@ df = spark\
 serialized_df = df.select(from_avro(f.expr("substring(value, 6, length(value) - 5)"), jsonFormatSchema))
 
 {% endhighlight %}
+</div>
+
 </div>
 
 ## Supported types for Avro -> Spark SQL conversion


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a note on compatibility issues between the `from_avro` function and the Confluent Schema Registry.

### Why are the changes needed?
Avro data produced by the Confluent Schema Registry serializer adds extra bytes to the serialised data, and the `from_avro` function lacks built-in support for this. This can lead to some very confusing errors if one is not aware of this technical detail. There is a [thread on StackOverflow](https://stackoverflow.com/questions/48882723/integrating-spark-structured-streaming-with-the-confluent-schema-registry) that discusses this, but a note in the official docs can be easier to discover for users that are looking for help with this issue.

### Does this PR introduce _any_ user-facing change?
Yes, it adds a section to the Apache Avro Data Source Guide

### How was this patch tested?
Manually by inspecting generated docs

### Was this patch authored or co-authored using generative AI tooling?
No
