### PR TITLE
[SPARK-50107][SQL][BUILD] Upgrade `protobuf-java` to 4.28.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.4.1</hadoop.version>
     <!-- SPARK-41247: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->
-    <protobuf.version>3.25.5</protobuf.version>
+    <protobuf.version>4.28.3</protobuf.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <zookeeper.version>3.9.2</zookeeper.version>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -89,7 +89,7 @@ object BuildCommons {
 
   // Google Protobuf version used for generating the protobuf.
   // SPARK-41247: needs to be consistent with `protobuf.version` in `pom.xml`.
-  val protoVersion = "3.25.5"
+  val protoVersion = "4.28.3"
   // GRPC version used for Spark Connect.
   val grpcVersion = "1.62.2"
 }

--- a/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/ResponseValidator.scala
+++ b/sql/connect/common/src/main/scala/org/apache/spark/sql/connect/client/ResponseValidator.scala
@@ -18,7 +18,7 @@ package org.apache.spark.sql.connect.client
 
 import java.util.concurrent.atomic.AtomicBoolean
 
-import com.google.protobuf.GeneratedMessageV3
+import com.google.protobuf.GeneratedMessage
 import io.grpc.{Status, StatusRuntimeException}
 import io.grpc.stub.StreamObserver
 
@@ -59,7 +59,7 @@ class ResponseValidator extends Logging {
     isSessionActive.getAcquire
   }
 
-  def verifyResponse[RespT <: GeneratedMessageV3](fn: => RespT): RespT = {
+  def verifyResponse[RespT <: GeneratedMessage](fn: => RespT): RespT = {
     val response =
       try {
         fn
@@ -100,7 +100,7 @@ class ResponseValidator extends Logging {
    * Wraps an existing iterator with another closeable iterator that verifies the response. This
    * is needed for server-side streaming calls that are converted to iterators.
    */
-  def wrapIterator[T <: GeneratedMessageV3, V <: CloseableIterator[T]](
+  def wrapIterator[T <: GeneratedMessage, V <: CloseableIterator[T]](
       inner: V): WrappedCloseableIterator[T] = {
     new WrappedCloseableIterator[T] {
 
@@ -118,7 +118,7 @@ class ResponseValidator extends Logging {
    * Wraps an existing stream observer with another stream observer that verifies the response.
    * This is necessary for client-side streaming calls.
    */
-  def wrapStreamObserver[T <: GeneratedMessageV3](inner: StreamObserver[T]): StreamObserver[T] = {
+  def wrapStreamObserver[T <: GeneratedMessage](inner: StreamObserver[T]): StreamObserver[T] = {
     new StreamObserver[T] {
       private val innerObserver = inner
       override def onNext(value: T): Unit = {

--- a/sql/core/src/main/java/org/apache/spark/sql/execution/streaming/state/StateMessage.java
+++ b/sql/core/src/main/java/org/apache/spark/sql/execution/streaming/state/StateMessage.java
@@ -217,12 +217,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.StateRequest}
    */
   public static final class StateRequest extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.StateRequest)
       StateRequestOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use StateRequest.newBuilder() to construct.
-    private StateRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private StateRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private StateRequest() {
@@ -246,7 +246,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_StateRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -553,39 +553,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateRequest parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateRequest parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateRequest parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateRequest parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateRequest parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateRequest parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -605,7 +605,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -613,7 +613,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.StateRequest}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.StateRequest)
         org.apache.spark.sql.execution.streaming.state.StateMessage.StateRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -622,7 +622,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_StateRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -635,7 +635,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -1407,12 +1407,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.StateResponse}
    */
   public static final class StateResponse extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.StateResponse)
       StateResponseOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use StateResponse.newBuilder() to construct.
-    private StateResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private StateResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private StateResponse() {
@@ -1438,7 +1438,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_StateResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -1522,8 +1522,8 @@ public final class StateMessage {
       if (statusCode_ != 0) {
         output.writeInt32(1, statusCode_);
       }
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(errorMessage_)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, errorMessage_);
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(errorMessage_)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 2, errorMessage_);
       }
       if (!value_.isEmpty()) {
         output.writeBytes(3, value_);
@@ -1541,8 +1541,8 @@ public final class StateMessage {
         size += com.google.protobuf.CodedOutputStream
           .computeInt32Size(1, statusCode_);
       }
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(errorMessage_)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, errorMessage_);
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(errorMessage_)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(2, errorMessage_);
       }
       if (!value_.isEmpty()) {
         size += com.google.protobuf.CodedOutputStream
@@ -1625,39 +1625,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateResponse parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateResponse parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateResponse parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateResponse parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateResponse parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateResponse parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -1677,7 +1677,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -1685,7 +1685,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.StateResponse}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.StateResponse)
         org.apache.spark.sql.execution.streaming.state.StateMessage.StateResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -1694,7 +1694,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_StateResponse_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -1707,7 +1707,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -2138,12 +2138,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.StatefulProcessorCall}
    */
   public static final class StatefulProcessorCall extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.StatefulProcessorCall)
       StatefulProcessorCallOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use StatefulProcessorCall.newBuilder() to construct.
-    private StatefulProcessorCall(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private StatefulProcessorCall(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private StatefulProcessorCall() {
@@ -2167,7 +2167,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_StatefulProcessorCall_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -2500,39 +2500,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StatefulProcessorCall parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StatefulProcessorCall parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StatefulProcessorCall parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StatefulProcessorCall parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StatefulProcessorCall parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StatefulProcessorCall parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -2552,7 +2552,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -2560,7 +2560,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.StatefulProcessorCall}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.StatefulProcessorCall)
         org.apache.spark.sql.execution.streaming.state.StateMessage.StatefulProcessorCallOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -2569,7 +2569,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_StatefulProcessorCall_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -2582,7 +2582,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -3498,12 +3498,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.StateVariableRequest}
    */
   public static final class StateVariableRequest extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.StateVariableRequest)
       StateVariableRequestOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use StateVariableRequest.newBuilder() to construct.
-    private StateVariableRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private StateVariableRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private StateVariableRequest() {
@@ -3527,7 +3527,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_StateVariableRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -3812,39 +3812,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateVariableRequest parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateVariableRequest parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateVariableRequest parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateVariableRequest parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateVariableRequest parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateVariableRequest parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -3864,7 +3864,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -3872,7 +3872,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.StateVariableRequest}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.StateVariableRequest)
         org.apache.spark.sql.execution.streaming.state.StateMessage.StateVariableRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -3881,7 +3881,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_StateVariableRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -3894,7 +3894,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -4632,12 +4632,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.ImplicitGroupingKeyRequest}
    */
   public static final class ImplicitGroupingKeyRequest extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.ImplicitGroupingKeyRequest)
       ImplicitGroupingKeyRequestOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use ImplicitGroupingKeyRequest.newBuilder() to construct.
-    private ImplicitGroupingKeyRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private ImplicitGroupingKeyRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private ImplicitGroupingKeyRequest() {
@@ -4661,7 +4661,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_ImplicitGroupingKeyRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -4898,39 +4898,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ImplicitGroupingKeyRequest parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ImplicitGroupingKeyRequest parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ImplicitGroupingKeyRequest parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ImplicitGroupingKeyRequest parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ImplicitGroupingKeyRequest parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ImplicitGroupingKeyRequest parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -4950,7 +4950,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -4958,7 +4958,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.ImplicitGroupingKeyRequest}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.ImplicitGroupingKeyRequest)
         org.apache.spark.sql.execution.streaming.state.StateMessage.ImplicitGroupingKeyRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -4967,7 +4967,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_ImplicitGroupingKeyRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -4980,7 +4980,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -5574,12 +5574,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.StateCallCommand}
    */
   public static final class StateCallCommand extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.StateCallCommand)
       StateCallCommandOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use StateCallCommand.newBuilder() to construct.
-    private StateCallCommand(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private StateCallCommand(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private StateCallCommand() {
@@ -5606,7 +5606,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_StateCallCommand_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -5767,14 +5767,14 @@ public final class StateMessage {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(stateName_)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, stateName_);
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(stateName_)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 1, stateName_);
       }
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(schema_)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, schema_);
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(schema_)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 2, schema_);
       }
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(mapStateValueSchema_)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, mapStateValueSchema_);
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(mapStateValueSchema_)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 3, mapStateValueSchema_);
       }
       if (ttl_ != null) {
         output.writeMessage(4, getTtl());
@@ -5788,14 +5788,14 @@ public final class StateMessage {
       if (size != -1) return size;
 
       size = 0;
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(stateName_)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, stateName_);
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(stateName_)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, stateName_);
       }
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(schema_)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, schema_);
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(schema_)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(2, schema_);
       }
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(mapStateValueSchema_)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, mapStateValueSchema_);
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(mapStateValueSchema_)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(3, mapStateValueSchema_);
       }
       if (ttl_ != null) {
         size += com.google.protobuf.CodedOutputStream
@@ -5887,39 +5887,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateCallCommand parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateCallCommand parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateCallCommand parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateCallCommand parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateCallCommand parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.StateCallCommand parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -5939,7 +5939,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -5947,7 +5947,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.StateCallCommand}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.StateCallCommand)
         org.apache.spark.sql.execution.streaming.state.StateMessage.StateCallCommandOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -5956,7 +5956,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_StateCallCommand_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -5969,7 +5969,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -6641,12 +6641,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.ValueStateCall}
    */
   public static final class ValueStateCall extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.ValueStateCall)
       ValueStateCallOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use ValueStateCall.newBuilder() to construct.
-    private ValueStateCall(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private ValueStateCall(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private ValueStateCall() {
@@ -6671,7 +6671,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_ValueStateCall_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -6899,8 +6899,8 @@ public final class StateMessage {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(stateName_)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, stateName_);
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(stateName_)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 1, stateName_);
       }
       if (methodCase_ == 2) {
         output.writeMessage(2, (org.apache.spark.sql.execution.streaming.state.StateMessage.Exists) method_);
@@ -6923,8 +6923,8 @@ public final class StateMessage {
       if (size != -1) return size;
 
       size = 0;
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(stateName_)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, stateName_);
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(stateName_)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, stateName_);
       }
       if (methodCase_ == 2) {
         size += com.google.protobuf.CodedOutputStream
@@ -7052,39 +7052,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ValueStateCall parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ValueStateCall parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ValueStateCall parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ValueStateCall parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ValueStateCall parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ValueStateCall parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -7104,7 +7104,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -7112,7 +7112,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.ValueStateCall}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.ValueStateCall)
         org.apache.spark.sql.execution.streaming.state.StateMessage.ValueStateCallOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -7121,7 +7121,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_ValueStateCall_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -7134,7 +7134,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -8195,12 +8195,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.ListStateCall}
    */
   public static final class ListStateCall extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.ListStateCall)
       ListStateCallOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use ListStateCall.newBuilder() to construct.
-    private ListStateCall(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private ListStateCall(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private ListStateCall() {
@@ -8225,7 +8225,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_ListStateCall_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -8519,8 +8519,8 @@ public final class StateMessage {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(stateName_)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, stateName_);
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(stateName_)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 1, stateName_);
       }
       if (methodCase_ == 2) {
         output.writeMessage(2, (org.apache.spark.sql.execution.streaming.state.StateMessage.Exists) method_);
@@ -8549,8 +8549,8 @@ public final class StateMessage {
       if (size != -1) return size;
 
       size = 0;
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(stateName_)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, stateName_);
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(stateName_)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, stateName_);
       }
       if (methodCase_ == 2) {
         size += com.google.protobuf.CodedOutputStream
@@ -8702,39 +8702,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ListStateCall parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ListStateCall parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ListStateCall parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ListStateCall parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ListStateCall parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ListStateCall parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -8754,7 +8754,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -8762,7 +8762,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.ListStateCall}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.ListStateCall)
         org.apache.spark.sql.execution.streaming.state.StateMessage.ListStateCallOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -8771,7 +8771,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_ListStateCall_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -8784,7 +8784,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -10216,12 +10216,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.MapStateCall}
    */
   public static final class MapStateCall extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.MapStateCall)
       MapStateCallOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use MapStateCall.newBuilder() to construct.
-    private MapStateCall(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private MapStateCall(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private MapStateCall() {
@@ -10246,7 +10246,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_MapStateCall_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -10639,8 +10639,8 @@ public final class StateMessage {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(stateName_)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, stateName_);
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(stateName_)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 1, stateName_);
       }
       if (methodCase_ == 2) {
         output.writeMessage(2, (org.apache.spark.sql.execution.streaming.state.StateMessage.Exists) method_);
@@ -10678,8 +10678,8 @@ public final class StateMessage {
       if (size != -1) return size;
 
       size = 0;
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(stateName_)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, stateName_);
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(stateName_)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, stateName_);
       }
       if (methodCase_ == 2) {
         size += com.google.protobuf.CodedOutputStream
@@ -10867,39 +10867,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.MapStateCall parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.MapStateCall parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.MapStateCall parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.MapStateCall parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.MapStateCall parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.MapStateCall parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -10919,7 +10919,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -10927,7 +10927,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.MapStateCall}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.MapStateCall)
         org.apache.spark.sql.execution.streaming.state.StateMessage.MapStateCallOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -10936,7 +10936,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_MapStateCall_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -10949,7 +10949,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -12727,12 +12727,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.SetImplicitKey}
    */
   public static final class SetImplicitKey extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.SetImplicitKey)
       SetImplicitKeyOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use SetImplicitKey.newBuilder() to construct.
-    private SetImplicitKey(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private SetImplicitKey(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private SetImplicitKey() {
@@ -12757,7 +12757,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_SetImplicitKey_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -12874,39 +12874,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.SetImplicitKey parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.SetImplicitKey parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.SetImplicitKey parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.SetImplicitKey parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.SetImplicitKey parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.SetImplicitKey parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -12926,7 +12926,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -12934,7 +12934,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.SetImplicitKey}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.SetImplicitKey)
         org.apache.spark.sql.execution.streaming.state.StateMessage.SetImplicitKeyOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -12943,7 +12943,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_SetImplicitKey_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -12956,7 +12956,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -13195,12 +13195,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.RemoveImplicitKey}
    */
   public static final class RemoveImplicitKey extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.RemoveImplicitKey)
       RemoveImplicitKeyOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use RemoveImplicitKey.newBuilder() to construct.
-    private RemoveImplicitKey(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private RemoveImplicitKey(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private RemoveImplicitKey() {
@@ -13224,7 +13224,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_RemoveImplicitKey_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -13319,39 +13319,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.RemoveImplicitKey parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.RemoveImplicitKey parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.RemoveImplicitKey parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.RemoveImplicitKey parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.RemoveImplicitKey parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.RemoveImplicitKey parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -13371,7 +13371,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -13379,7 +13379,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.RemoveImplicitKey}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.RemoveImplicitKey)
         org.apache.spark.sql.execution.streaming.state.StateMessage.RemoveImplicitKeyOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -13388,7 +13388,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_RemoveImplicitKey_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -13401,7 +13401,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -13595,12 +13595,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.Exists}
    */
   public static final class Exists extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.Exists)
       ExistsOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use Exists.newBuilder() to construct.
-    private Exists(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private Exists(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private Exists() {
@@ -13624,7 +13624,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_Exists_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -13719,39 +13719,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Exists parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Exists parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Exists parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Exists parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Exists parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Exists parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -13771,7 +13771,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -13779,7 +13779,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.Exists}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.Exists)
         org.apache.spark.sql.execution.streaming.state.StateMessage.ExistsOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -13788,7 +13788,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_Exists_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -13801,7 +13801,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -13995,12 +13995,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.Get}
    */
   public static final class Get extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.Get)
       GetOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use Get.newBuilder() to construct.
-    private Get(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private Get(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private Get() {
@@ -14024,7 +14024,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_Get_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -14119,39 +14119,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Get parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Get parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Get parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Get parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Get parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Get parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -14171,7 +14171,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -14179,7 +14179,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.Get}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.Get)
         org.apache.spark.sql.execution.streaming.state.StateMessage.GetOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -14188,7 +14188,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_Get_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -14201,7 +14201,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -14401,12 +14401,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.ValueStateUpdate}
    */
   public static final class ValueStateUpdate extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.ValueStateUpdate)
       ValueStateUpdateOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use ValueStateUpdate.newBuilder() to construct.
-    private ValueStateUpdate(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private ValueStateUpdate(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private ValueStateUpdate() {
@@ -14431,7 +14431,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_ValueStateUpdate_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -14548,39 +14548,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ValueStateUpdate parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ValueStateUpdate parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ValueStateUpdate parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ValueStateUpdate parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ValueStateUpdate parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ValueStateUpdate parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -14600,7 +14600,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -14608,7 +14608,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.ValueStateUpdate}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.ValueStateUpdate)
         org.apache.spark.sql.execution.streaming.state.StateMessage.ValueStateUpdateOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -14617,7 +14617,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_ValueStateUpdate_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -14630,7 +14630,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -14869,12 +14869,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.Clear}
    */
   public static final class Clear extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.Clear)
       ClearOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use Clear.newBuilder() to construct.
-    private Clear(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private Clear(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private Clear() {
@@ -14898,7 +14898,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_Clear_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -14993,39 +14993,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Clear parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Clear parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Clear parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Clear parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Clear parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Clear parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -15045,7 +15045,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -15053,7 +15053,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.Clear}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.Clear)
         org.apache.spark.sql.execution.streaming.state.StateMessage.ClearOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -15062,7 +15062,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_Clear_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -15075,7 +15075,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -15281,12 +15281,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.ListStateGet}
    */
   public static final class ListStateGet extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.ListStateGet)
       ListStateGetOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use ListStateGet.newBuilder() to construct.
-    private ListStateGet(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private ListStateGet(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private ListStateGet() {
@@ -15311,7 +15311,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_ListStateGet_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -15370,8 +15370,8 @@ public final class StateMessage {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(iteratorId_)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, iteratorId_);
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(iteratorId_)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 1, iteratorId_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -15382,8 +15382,8 @@ public final class StateMessage {
       if (size != -1) return size;
 
       size = 0;
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(iteratorId_)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, iteratorId_);
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(iteratorId_)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, iteratorId_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
@@ -15454,39 +15454,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ListStateGet parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ListStateGet parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ListStateGet parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ListStateGet parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ListStateGet parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ListStateGet parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -15506,7 +15506,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -15514,7 +15514,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.ListStateGet}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.ListStateGet)
         org.apache.spark.sql.execution.streaming.state.StateMessage.ListStateGetOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -15523,7 +15523,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_ListStateGet_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -15536,7 +15536,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -15818,12 +15818,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.ListStatePut}
    */
   public static final class ListStatePut extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.ListStatePut)
       ListStatePutOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use ListStatePut.newBuilder() to construct.
-    private ListStatePut(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private ListStatePut(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private ListStatePut() {
@@ -15847,7 +15847,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_ListStatePut_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -15942,39 +15942,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ListStatePut parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ListStatePut parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ListStatePut parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ListStatePut parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ListStatePut parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ListStatePut parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -15994,7 +15994,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -16002,7 +16002,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.ListStatePut}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.ListStatePut)
         org.apache.spark.sql.execution.streaming.state.StateMessage.ListStatePutOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -16011,7 +16011,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_ListStatePut_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -16024,7 +16024,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -16224,12 +16224,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.AppendValue}
    */
   public static final class AppendValue extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.AppendValue)
       AppendValueOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use AppendValue.newBuilder() to construct.
-    private AppendValue(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private AppendValue(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private AppendValue() {
@@ -16254,7 +16254,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_AppendValue_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -16371,39 +16371,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.AppendValue parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.AppendValue parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.AppendValue parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.AppendValue parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.AppendValue parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.AppendValue parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -16423,7 +16423,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -16431,7 +16431,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.AppendValue}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.AppendValue)
         org.apache.spark.sql.execution.streaming.state.StateMessage.AppendValueOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -16440,7 +16440,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_AppendValue_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -16453,7 +16453,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -16692,12 +16692,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.AppendList}
    */
   public static final class AppendList extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.AppendList)
       AppendListOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use AppendList.newBuilder() to construct.
-    private AppendList(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private AppendList(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private AppendList() {
@@ -16721,7 +16721,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_AppendList_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -16816,39 +16816,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.AppendList parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.AppendList parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.AppendList parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.AppendList parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.AppendList parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.AppendList parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -16868,7 +16868,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -16876,7 +16876,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.AppendList}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.AppendList)
         org.apache.spark.sql.execution.streaming.state.StateMessage.AppendListOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -16885,7 +16885,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_AppendList_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -16898,7 +16898,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -17098,12 +17098,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.GetValue}
    */
   public static final class GetValue extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.GetValue)
       GetValueOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use GetValue.newBuilder() to construct.
-    private GetValue(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private GetValue(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private GetValue() {
@@ -17128,7 +17128,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_GetValue_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -17245,39 +17245,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.GetValue parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.GetValue parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.GetValue parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.GetValue parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.GetValue parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.GetValue parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -17297,7 +17297,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -17305,7 +17305,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.GetValue}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.GetValue)
         org.apache.spark.sql.execution.streaming.state.StateMessage.GetValueOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -17314,7 +17314,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_GetValue_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -17327,7 +17327,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -17572,12 +17572,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.ContainsKey}
    */
   public static final class ContainsKey extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.ContainsKey)
       ContainsKeyOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use ContainsKey.newBuilder() to construct.
-    private ContainsKey(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private ContainsKey(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private ContainsKey() {
@@ -17602,7 +17602,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_ContainsKey_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -17719,39 +17719,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ContainsKey parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ContainsKey parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ContainsKey parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ContainsKey parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ContainsKey parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.ContainsKey parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -17771,7 +17771,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -17779,7 +17779,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.ContainsKey}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.ContainsKey)
         org.apache.spark.sql.execution.streaming.state.StateMessage.ContainsKeyOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -17788,7 +17788,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_ContainsKey_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -17801,7 +17801,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -18052,12 +18052,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.UpdateValue}
    */
   public static final class UpdateValue extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.UpdateValue)
       UpdateValueOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use UpdateValue.newBuilder() to construct.
-    private UpdateValue(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private UpdateValue(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private UpdateValue() {
@@ -18083,7 +18083,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_UpdateValue_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -18222,39 +18222,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.UpdateValue parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.UpdateValue parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.UpdateValue parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.UpdateValue parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.UpdateValue parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.UpdateValue parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -18274,7 +18274,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -18282,7 +18282,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.UpdateValue}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.UpdateValue)
         org.apache.spark.sql.execution.streaming.state.StateMessage.UpdateValueOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -18291,7 +18291,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_UpdateValue_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -18304,7 +18304,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -18600,12 +18600,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.Iterator}
    */
   public static final class Iterator extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.Iterator)
       IteratorOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use Iterator.newBuilder() to construct.
-    private Iterator(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private Iterator(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private Iterator() {
@@ -18630,7 +18630,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_Iterator_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -18689,8 +18689,8 @@ public final class StateMessage {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(iteratorId_)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, iteratorId_);
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(iteratorId_)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 1, iteratorId_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -18701,8 +18701,8 @@ public final class StateMessage {
       if (size != -1) return size;
 
       size = 0;
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(iteratorId_)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, iteratorId_);
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(iteratorId_)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, iteratorId_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
@@ -18773,39 +18773,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Iterator parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Iterator parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Iterator parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Iterator parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Iterator parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Iterator parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -18825,7 +18825,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -18833,7 +18833,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.Iterator}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.Iterator)
         org.apache.spark.sql.execution.streaming.state.StateMessage.IteratorOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -18842,7 +18842,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_Iterator_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -18855,7 +18855,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -19149,12 +19149,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.Keys}
    */
   public static final class Keys extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.Keys)
       KeysOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use Keys.newBuilder() to construct.
-    private Keys(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private Keys(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private Keys() {
@@ -19179,7 +19179,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_Keys_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -19238,8 +19238,8 @@ public final class StateMessage {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(iteratorId_)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, iteratorId_);
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(iteratorId_)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 1, iteratorId_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -19250,8 +19250,8 @@ public final class StateMessage {
       if (size != -1) return size;
 
       size = 0;
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(iteratorId_)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, iteratorId_);
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(iteratorId_)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, iteratorId_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
@@ -19322,39 +19322,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Keys parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Keys parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Keys parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Keys parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Keys parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Keys parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -19374,7 +19374,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -19382,7 +19382,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.Keys}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.Keys)
         org.apache.spark.sql.execution.streaming.state.StateMessage.KeysOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -19391,7 +19391,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_Keys_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -19404,7 +19404,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -19698,12 +19698,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.Values}
    */
   public static final class Values extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.Values)
       ValuesOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use Values.newBuilder() to construct.
-    private Values(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private Values(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private Values() {
@@ -19728,7 +19728,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_Values_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -19787,8 +19787,8 @@ public final class StateMessage {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(iteratorId_)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, iteratorId_);
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(iteratorId_)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 1, iteratorId_);
       }
       getUnknownFields().writeTo(output);
     }
@@ -19799,8 +19799,8 @@ public final class StateMessage {
       if (size != -1) return size;
 
       size = 0;
-      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(iteratorId_)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, iteratorId_);
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(iteratorId_)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, iteratorId_);
       }
       size += getUnknownFields().getSerializedSize();
       memoizedSize = size;
@@ -19871,39 +19871,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Values parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Values parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Values parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Values parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Values parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.Values parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -19923,7 +19923,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -19931,7 +19931,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.Values}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.Values)
         org.apache.spark.sql.execution.streaming.state.StateMessage.ValuesOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -19940,7 +19940,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_Values_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -19953,7 +19953,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -20241,12 +20241,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.RemoveKey}
    */
   public static final class RemoveKey extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.RemoveKey)
       RemoveKeyOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use RemoveKey.newBuilder() to construct.
-    private RemoveKey(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private RemoveKey(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private RemoveKey() {
@@ -20271,7 +20271,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_RemoveKey_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -20388,39 +20388,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.RemoveKey parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.RemoveKey parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.RemoveKey parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.RemoveKey parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.RemoveKey parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.RemoveKey parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -20440,7 +20440,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -20448,7 +20448,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.RemoveKey}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.RemoveKey)
         org.apache.spark.sql.execution.streaming.state.StateMessage.RemoveKeyOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -20457,7 +20457,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_RemoveKey_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -20470,7 +20470,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -20720,12 +20720,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.SetHandleState}
    */
   public static final class SetHandleState extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.SetHandleState)
       SetHandleStateOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use SetHandleState.newBuilder() to construct.
-    private SetHandleState(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private SetHandleState(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private SetHandleState() {
@@ -20750,7 +20750,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_SetHandleState_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -20874,39 +20874,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.SetHandleState parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.SetHandleState parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.SetHandleState parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.SetHandleState parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.SetHandleState parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.SetHandleState parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -20926,7 +20926,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -20934,7 +20934,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.SetHandleState}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.SetHandleState)
         org.apache.spark.sql.execution.streaming.state.StateMessage.SetHandleStateOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -20943,7 +20943,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_SetHandleState_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -20956,7 +20956,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -21221,12 +21221,12 @@ public final class StateMessage {
    * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.TTLConfig}
    */
   public static final class TTLConfig extends
-      com.google.protobuf.GeneratedMessageV3 implements
+      com.google.protobuf.GeneratedMessage implements
       // @@protoc_insertion_point(message_implements:org.apache.spark.sql.execution.streaming.state.TTLConfig)
       TTLConfigOrBuilder {
   private static final long serialVersionUID = 0L;
     // Use TTLConfig.newBuilder() to construct.
-    private TTLConfig(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+    private TTLConfig(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
       super(builder);
     }
     private TTLConfig() {
@@ -21250,7 +21250,7 @@ public final class StateMessage {
     }
 
     @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
         internalGetFieldAccessorTable() {
       return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_TTLConfig_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -21367,39 +21367,39 @@ public final class StateMessage {
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.TTLConfig parseFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.TTLConfig parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.TTLConfig parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.TTLConfig parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.TTLConfig parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input);
     }
     public static org.apache.spark.sql.execution.streaming.state.StateMessage.TTLConfig parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
+      return com.google.protobuf.GeneratedMessage
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
@@ -21419,7 +21419,7 @@ public final class StateMessage {
 
     @java.lang.Override
     protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -21427,7 +21427,7 @@ public final class StateMessage {
      * Protobuf type {@code org.apache.spark.sql.execution.streaming.state.TTLConfig}
      */
     public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:org.apache.spark.sql.execution.streaming.state.TTLConfig)
         org.apache.spark.sql.execution.streaming.state.StateMessage.TTLConfigOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
@@ -21436,7 +21436,7 @@ public final class StateMessage {
       }
 
       @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
           internalGetFieldAccessorTable() {
         return org.apache.spark.sql.execution.streaming.state.StateMessage.internal_static_org_apache_spark_sql_execution_streaming_state_TTLConfig_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -21449,7 +21449,7 @@ public final class StateMessage {
       }
 
       private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
         super(parent);
 
       }
@@ -21680,142 +21680,142 @@ public final class StateMessage {
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_StateRequest_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_StateRequest_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_StateResponse_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_StateResponse_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_StatefulProcessorCall_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_StatefulProcessorCall_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_StateVariableRequest_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_StateVariableRequest_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_ImplicitGroupingKeyRequest_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_ImplicitGroupingKeyRequest_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_StateCallCommand_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_StateCallCommand_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_ValueStateCall_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_ValueStateCall_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_ListStateCall_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_ListStateCall_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_MapStateCall_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_MapStateCall_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_SetImplicitKey_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_SetImplicitKey_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_RemoveImplicitKey_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_RemoveImplicitKey_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_Exists_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_Exists_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_Get_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_Get_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_ValueStateUpdate_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_ValueStateUpdate_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_Clear_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_Clear_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_ListStateGet_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_ListStateGet_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_ListStatePut_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_ListStatePut_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_AppendValue_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_AppendValue_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_AppendList_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_AppendList_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_GetValue_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_GetValue_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_ContainsKey_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_ContainsKey_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_UpdateValue_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_UpdateValue_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_Iterator_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_Iterator_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_Keys_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_Keys_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_Values_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_Values_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_RemoveKey_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_RemoveKey_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_SetHandleState_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_SetHandleState_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_org_apache_spark_sql_execution_streaming_state_TTLConfig_descriptor;
   private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_org_apache_spark_sql_execution_streaming_state_TTLConfig_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
@@ -21931,169 +21931,169 @@ public final class StateMessage {
     internal_static_org_apache_spark_sql_execution_streaming_state_StateRequest_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_org_apache_spark_sql_execution_streaming_state_StateRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_StateRequest_descriptor,
         new java.lang.String[] { "Version", "StatefulProcessorCall", "StateVariableRequest", "ImplicitGroupingKeyRequest", "Method", });
     internal_static_org_apache_spark_sql_execution_streaming_state_StateResponse_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_org_apache_spark_sql_execution_streaming_state_StateResponse_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_StateResponse_descriptor,
         new java.lang.String[] { "StatusCode", "ErrorMessage", "Value", });
     internal_static_org_apache_spark_sql_execution_streaming_state_StatefulProcessorCall_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_org_apache_spark_sql_execution_streaming_state_StatefulProcessorCall_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_StatefulProcessorCall_descriptor,
         new java.lang.String[] { "SetHandleState", "GetValueState", "GetListState", "GetMapState", "Method", });
     internal_static_org_apache_spark_sql_execution_streaming_state_StateVariableRequest_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_org_apache_spark_sql_execution_streaming_state_StateVariableRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_StateVariableRequest_descriptor,
         new java.lang.String[] { "ValueStateCall", "ListStateCall", "MapStateCall", "Method", });
     internal_static_org_apache_spark_sql_execution_streaming_state_ImplicitGroupingKeyRequest_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_org_apache_spark_sql_execution_streaming_state_ImplicitGroupingKeyRequest_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_ImplicitGroupingKeyRequest_descriptor,
         new java.lang.String[] { "SetImplicitKey", "RemoveImplicitKey", "Method", });
     internal_static_org_apache_spark_sql_execution_streaming_state_StateCallCommand_descriptor =
       getDescriptor().getMessageTypes().get(5);
     internal_static_org_apache_spark_sql_execution_streaming_state_StateCallCommand_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_StateCallCommand_descriptor,
         new java.lang.String[] { "StateName", "Schema", "MapStateValueSchema", "Ttl", });
     internal_static_org_apache_spark_sql_execution_streaming_state_ValueStateCall_descriptor =
       getDescriptor().getMessageTypes().get(6);
     internal_static_org_apache_spark_sql_execution_streaming_state_ValueStateCall_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_ValueStateCall_descriptor,
         new java.lang.String[] { "StateName", "Exists", "Get", "ValueStateUpdate", "Clear", "Method", });
     internal_static_org_apache_spark_sql_execution_streaming_state_ListStateCall_descriptor =
       getDescriptor().getMessageTypes().get(7);
     internal_static_org_apache_spark_sql_execution_streaming_state_ListStateCall_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_ListStateCall_descriptor,
         new java.lang.String[] { "StateName", "Exists", "ListStateGet", "ListStatePut", "AppendValue", "AppendList", "Clear", "Method", });
     internal_static_org_apache_spark_sql_execution_streaming_state_MapStateCall_descriptor =
       getDescriptor().getMessageTypes().get(8);
     internal_static_org_apache_spark_sql_execution_streaming_state_MapStateCall_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_MapStateCall_descriptor,
         new java.lang.String[] { "StateName", "Exists", "GetValue", "ContainsKey", "UpdateValue", "Iterator", "Keys", "Values", "RemoveKey", "Clear", "Method", });
     internal_static_org_apache_spark_sql_execution_streaming_state_SetImplicitKey_descriptor =
       getDescriptor().getMessageTypes().get(9);
     internal_static_org_apache_spark_sql_execution_streaming_state_SetImplicitKey_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_SetImplicitKey_descriptor,
         new java.lang.String[] { "Key", });
     internal_static_org_apache_spark_sql_execution_streaming_state_RemoveImplicitKey_descriptor =
       getDescriptor().getMessageTypes().get(10);
     internal_static_org_apache_spark_sql_execution_streaming_state_RemoveImplicitKey_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_RemoveImplicitKey_descriptor,
         new java.lang.String[] { });
     internal_static_org_apache_spark_sql_execution_streaming_state_Exists_descriptor =
       getDescriptor().getMessageTypes().get(11);
     internal_static_org_apache_spark_sql_execution_streaming_state_Exists_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_Exists_descriptor,
         new java.lang.String[] { });
     internal_static_org_apache_spark_sql_execution_streaming_state_Get_descriptor =
       getDescriptor().getMessageTypes().get(12);
     internal_static_org_apache_spark_sql_execution_streaming_state_Get_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_Get_descriptor,
         new java.lang.String[] { });
     internal_static_org_apache_spark_sql_execution_streaming_state_ValueStateUpdate_descriptor =
       getDescriptor().getMessageTypes().get(13);
     internal_static_org_apache_spark_sql_execution_streaming_state_ValueStateUpdate_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_ValueStateUpdate_descriptor,
         new java.lang.String[] { "Value", });
     internal_static_org_apache_spark_sql_execution_streaming_state_Clear_descriptor =
       getDescriptor().getMessageTypes().get(14);
     internal_static_org_apache_spark_sql_execution_streaming_state_Clear_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_Clear_descriptor,
         new java.lang.String[] { });
     internal_static_org_apache_spark_sql_execution_streaming_state_ListStateGet_descriptor =
       getDescriptor().getMessageTypes().get(15);
     internal_static_org_apache_spark_sql_execution_streaming_state_ListStateGet_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_ListStateGet_descriptor,
         new java.lang.String[] { "IteratorId", });
     internal_static_org_apache_spark_sql_execution_streaming_state_ListStatePut_descriptor =
       getDescriptor().getMessageTypes().get(16);
     internal_static_org_apache_spark_sql_execution_streaming_state_ListStatePut_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_ListStatePut_descriptor,
         new java.lang.String[] { });
     internal_static_org_apache_spark_sql_execution_streaming_state_AppendValue_descriptor =
       getDescriptor().getMessageTypes().get(17);
     internal_static_org_apache_spark_sql_execution_streaming_state_AppendValue_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_AppendValue_descriptor,
         new java.lang.String[] { "Value", });
     internal_static_org_apache_spark_sql_execution_streaming_state_AppendList_descriptor =
       getDescriptor().getMessageTypes().get(18);
     internal_static_org_apache_spark_sql_execution_streaming_state_AppendList_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_AppendList_descriptor,
         new java.lang.String[] { });
     internal_static_org_apache_spark_sql_execution_streaming_state_GetValue_descriptor =
       getDescriptor().getMessageTypes().get(19);
     internal_static_org_apache_spark_sql_execution_streaming_state_GetValue_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_GetValue_descriptor,
         new java.lang.String[] { "UserKey", });
     internal_static_org_apache_spark_sql_execution_streaming_state_ContainsKey_descriptor =
       getDescriptor().getMessageTypes().get(20);
     internal_static_org_apache_spark_sql_execution_streaming_state_ContainsKey_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_ContainsKey_descriptor,
         new java.lang.String[] { "UserKey", });
     internal_static_org_apache_spark_sql_execution_streaming_state_UpdateValue_descriptor =
       getDescriptor().getMessageTypes().get(21);
     internal_static_org_apache_spark_sql_execution_streaming_state_UpdateValue_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_UpdateValue_descriptor,
         new java.lang.String[] { "UserKey", "Value", });
     internal_static_org_apache_spark_sql_execution_streaming_state_Iterator_descriptor =
       getDescriptor().getMessageTypes().get(22);
     internal_static_org_apache_spark_sql_execution_streaming_state_Iterator_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_Iterator_descriptor,
         new java.lang.String[] { "IteratorId", });
     internal_static_org_apache_spark_sql_execution_streaming_state_Keys_descriptor =
       getDescriptor().getMessageTypes().get(23);
     internal_static_org_apache_spark_sql_execution_streaming_state_Keys_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_Keys_descriptor,
         new java.lang.String[] { "IteratorId", });
     internal_static_org_apache_spark_sql_execution_streaming_state_Values_descriptor =
       getDescriptor().getMessageTypes().get(24);
     internal_static_org_apache_spark_sql_execution_streaming_state_Values_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_Values_descriptor,
         new java.lang.String[] { "IteratorId", });
     internal_static_org_apache_spark_sql_execution_streaming_state_RemoveKey_descriptor =
       getDescriptor().getMessageTypes().get(25);
     internal_static_org_apache_spark_sql_execution_streaming_state_RemoveKey_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_RemoveKey_descriptor,
         new java.lang.String[] { "UserKey", });
     internal_static_org_apache_spark_sql_execution_streaming_state_SetHandleState_descriptor =
       getDescriptor().getMessageTypes().get(26);
     internal_static_org_apache_spark_sql_execution_streaming_state_SetHandleState_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_SetHandleState_descriptor,
         new java.lang.String[] { "State", });
     internal_static_org_apache_spark_sql_execution_streaming_state_TTLConfig_descriptor =
       getDescriptor().getMessageTypes().get(27);
     internal_static_org_apache_spark_sql_execution_streaming_state_TTLConfig_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_org_apache_spark_sql_execution_streaming_state_TTLConfig_descriptor,
         new java.lang.String[] { "DurationMs", });
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `protobuf-java` to 4.28.3 for Apache Spark 4.0.0 on February 2025.

### Why are the changes needed?

`protobuf-java` `4.28.3` is the latest version which is released two days ago (Oct 23, 2024). 

https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java/4.28.3

This is a part of `v28.3`.
- https://github.com/protocolbuffers/protobuf/releases/tag/v28.3 (2024-10-22)

Note that `v26` introduced a breaking change to Java API last year.
- https://protobuf.dev/news/2023-12-05/#breaking-compatibility-with-old-generated-code

> v26.x will break compatibility with generated code from older major versions. Users should regenerate old generated code to be from the same version.
> For example, GeneratedMessageV3, which was originally introduced for backwards compatibility with generated code from v2.x.x against v3.x.x runtime, will be renamed to GeneratedMessage. Runtimes will be updated to support [Editions](https://protobuf.dev/editions/overview/), which will not be compatible with old generated code.

### Does this PR introduce _any_ user-facing change?



### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.