### PR TITLE
[SPARK-50124][SQL] LIMIT/OFFSET should preserve data ordering

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5207,6 +5207,16 @@ object SQLConf {
     .booleanConf
     .createWithDefault(false)
 
+  val ORDERING_AWARE_LIMIT_OFFSET = buildConf("spark.sql.orderingAwareLimitOffset")
+    .internal()
+    .doc("When set to true, a local sort will be inserted between GlobalLimitExec and " +
+      "single-partition ShuffleExchangeExec, if the underlying plan produces sorted data. " +
+      "This is because shuffle reader in Spark fetches shuffle blocks in a random order and " +
+      "can not preserve the data ordering, while LIMIT/OFFSET must preserve ordering.")
+    .version("4.0.0")
+    .booleanConf
+    .createWithDefault(true)
+
   /**
    * Holds information about keys that have been deprecated.
    *

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/InsertSortForLimitAndOffset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/InsertSortForLimitAndOffset.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.catalyst.expressions.SortOrder
+import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.adaptive.{AQEShuffleReadExec, ShuffleQueryStageExec}
+import org.apache.spark.sql.execution.exchange.ShuffleExchangeExec
+import org.apache.spark.sql.internal.SQLConf
+
+/**
+ * When LIMIT/OFFSET is the root node, Spark plans it as CollectLimitExec which preserves the data
+ * ordering. However, when OFFSET/LIMIT is not the root node, Spark uses GlobalLimitExec which
+ * shuffles all the data into one partition and then gets a slice of it. Unfortunately, the shuffle
+ * reader fetches shuffle blocks in a random order and can not preserve the data ordering, which
+ * violates the requirement of LIMIT/OFFSET.
+ *
+ * This rule inserts an extra local sort before LIMIT/OFFSET to preserve the data ordering.
+ * TODO: add a order preserving mode in the shuffle reader.
+ */
+object InsertSortForLimitAndOffset extends Rule[SparkPlan] {
+  override def apply(plan: SparkPlan): SparkPlan = {
+    if (!conf.getConf(SQLConf.ORDERING_AWARE_LIMIT_OFFSET)) return plan
+
+    plan transform {
+      case l @ GlobalLimitExec(
+          _,
+          SinglePartitionShuffleWithGlobalOrdering(ordering),
+          _) =>
+        val newChild = SortExec(ordering, global = false, child = l.child)
+        l.withNewChildren(Seq(newChild))
+    }
+  }
+
+  object SinglePartitionShuffleWithGlobalOrdering {
+    def unapply(plan: SparkPlan): Option[Seq[SortOrder]] = plan match {
+      case ShuffleExchangeExec(SinglePartition, GlobalOrdering(ordering), _, _) => Some(ordering)
+      case p: AQEShuffleReadExec => unapply(p.child)
+      case p: ShuffleQueryStageExec => unapply(p.plan)
+      case _ => None
+    }
+  }
+
+  object GlobalOrdering {
+    def unapply(plan: SparkPlan): Option[Seq[SortOrder]] = plan match {
+      case p: SortExec if p.global => Some(p.sortOrder)
+      case p: LocalLimitExec => unapply(p.child)
+      case p: WholeStageCodegenExec => unapply(p.child)
+      case _ => None
+    }
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala
@@ -518,6 +518,8 @@ object QueryExecution {
       PlanSubqueries(sparkSession),
       RemoveRedundantProjects,
       EnsureRequirements(),
+      // This rule must be run after `EnsureRequirements`.
+      InsertSortForLimitAndOffset,
       // `ReplaceHashWithSortAgg` needs to be added after `EnsureRequirements` to guarantee the
       // sort order of each node is checked to be valid.
       ReplaceHashWithSortAgg,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -145,6 +145,8 @@ case class AdaptiveSparkPlanExec(
       CoalesceBucketsInJoin,
       RemoveRedundantProjects,
       ensureRequirements,
+      // This rule must be run after `EnsureRequirements`.
+      InsertSortForLimitAndOffset,
       AdjustShuffleExchangePosition,
       ValidateSparkPlan,
       ReplaceHashWithSortAgg,

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/InsertSortForLimitAndOffsetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/InsertSortForLimitAndOffsetSuite.scala
@@ -50,7 +50,7 @@ class InsertSortForLimitAndOffsetSuite extends QueryTest
 
   private def hasLocalSort(plan: SparkPlan): Boolean = {
     find(plan) {
-      case s: SortExec => !s.global
+      case GlobalLimitExec(_, s: SortExec, _) => !s.global
       case _ => false
     }.isDefined
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/InsertSortForLimitAndOffsetSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/InsertSortForLimitAndOffsetSuite.scala
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+class InsertSortForLimitAndOffsetSuite extends QueryTest
+  with SharedSparkSession
+  with AdaptiveSparkPlanHelper {
+  import testImplicits._
+
+  private def assertHasTopKSort(plan: SparkPlan): Unit = {
+    assert(find(plan) {
+      case _: TakeOrderedAndProjectExec => true
+      case _ => false
+    }.isDefined)
+  }
+
+  private def assertHasCollectLimitExec(plan: SparkPlan): Unit = {
+    assert(find(plan) {
+      case _: CollectLimitExec => true
+      case _ => false
+    }.isDefined)
+  }
+
+  private def assertHasGlobalLimitExec(plan: SparkPlan): Unit = {
+    assert(find(plan) {
+      case _: GlobalLimitExec => true
+      case _ => false
+    }.isDefined)
+  }
+
+  private def hasLocalSort(plan: SparkPlan): Boolean = {
+    find(plan) {
+      case s: SortExec => !s.global
+      case _ => false
+    }.isDefined
+  }
+
+  test("root LIMIT preserves data ordering with top-K sort") {
+    val df = spark.range(10).orderBy($"id" % 8).limit(2)
+    df.collect()
+    val physicalPlan = df.queryExecution.executedPlan
+    assertHasTopKSort(physicalPlan)
+    // Extra local sort is not needed for LIMIT with top-K sort optimization.
+    assert(!hasLocalSort(physicalPlan))
+  }
+
+  test("middle LIMIT preserves data ordering with top-K sort") {
+    val df = spark.range(10).orderBy($"id" % 8).limit(2).distinct()
+    df.collect()
+    val physicalPlan = df.queryExecution.executedPlan
+    assertHasTopKSort(physicalPlan)
+    // Extra local sort is not needed for LIMIT with top-K sort optimization.
+    assert(!hasLocalSort(physicalPlan))
+  }
+
+  test("root LIMIT preserves data ordering with CollectLimitExec") {
+    withSQLConf(SQLConf.TOP_K_SORT_FALLBACK_THRESHOLD.key -> "1") {
+      val df = spark.range(10).orderBy($"id" % 8).limit(2)
+      df.collect()
+      val physicalPlan = df.queryExecution.executedPlan
+      assertHasCollectLimitExec(physicalPlan)
+      // Extra local sort is not needed for root LIMIT
+      assert(!hasLocalSort(physicalPlan))
+    }
+  }
+
+  test("middle LIMIT preserves data ordering with the extra sort") {
+    withSQLConf(
+      SQLConf.TOP_K_SORT_FALLBACK_THRESHOLD.key -> "1",
+      // To trigger the bug, we have to disable the coalescing optimization. Otherwise we use only
+      // one partition to read the range-partition shuffle and there is only one shuffle block for
+      // the final single-partition shuffle, random fetch order is no longer an issue.
+      SQLConf.COALESCE_PARTITIONS_ENABLED.key -> "false") {
+      val df = spark.range(10).orderBy($"id" % 8).limit(2).distinct()
+      df.collect()
+      val physicalPlan = df.queryExecution.executedPlan
+      assertHasGlobalLimitExec(physicalPlan)
+      // Extra local sort is needed for middle LIMIT
+      assert(hasLocalSort(physicalPlan))
+    }
+  }
+
+  test("root OFFSET preserves data ordering with CollectLimitExec") {
+    val df = spark.range(10).orderBy($"id" % 8).offset(2)
+    df.collect()
+    val physicalPlan = df.queryExecution.executedPlan
+    assertHasCollectLimitExec(physicalPlan)
+    // Extra local sort is not needed for root OFFSET
+    assert(!hasLocalSort(physicalPlan))
+  }
+
+  test("middle OFFSET preserves data ordering with the extra sort") {
+    val df = spark.range(10).orderBy($"id" % 8).offset(2).distinct()
+    df.collect()
+    val physicalPlan = df.queryExecution.executedPlan
+    assertHasGlobalLimitExec(physicalPlan)
+    // Extra local sort is needed for middle OFFSET
+    assert(hasLocalSort(physicalPlan))
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes a long-standing correctness bug for LIMIT/OFFSET. Spark has 3 execution paths for LIMIT:
1. If LIMIT is the root node, use `CollectLimitExec` to eliminate the shuffle and get the first N records on the driver side.
2. If there is a global sort under LIMIT, use `TakeOrderedAndProjectExec` to avoid a full sort using top-N algorithm
3. Otherwise, use `GlobalLimitExec` to get the first N records via a single-partition shuffle.

The third execution path has a problem: Spark shuffle reader fetches shuffle blocks in random order and can't preserve the data ordering. It's usually OK when the data order doesn't matter, but the second execution path is not always picked because it has a trigger condition: the LIMIT N must be smaller than TOP_K_SORT_FALLBACK_THRESHOLD .

This bug is more likely to happen for OFFSET because it doesn't have the top-K optimization.

An ideal solution is to have an order preserving mode for the shuffle reader, which is non-trivial work. This PR proposes a workaround: add a local sort after the single-partition shuffle to restore the data ordering.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  5. If you fix a bug, you can clarify why it is a bug.
-->
correctness fix

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes, now LIMIT/OFFSET with global sort can preserve the data ordering

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
new tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no