### PR TITLE
[SPARK-50118][CONNET] Reset isolated state cache when tasks are running

### DIFF
--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -447,6 +447,9 @@ private[spark] class Executor(
         case NonFatal(e) =>
           logWarning("Unable to stop heartbeater", e)
       }
+      if (timer != null) {
+        timer.cancel()
+      }
       ShuffleBlockPusher.stop()
       if (threadPool != null) {
         threadPool.shutdown()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to reset the expire timeout of the isolated session. during the tasks running.

### Why are the changes needed?

To prevent removal of artifacts for long running tasks.

### Does this PR introduce _any_ user-facing change?

Yes. It fixes a bug. When users are running Python UDFs (or Scala UDF) for more than the specific timeout (30 minutes), and other tasks are submitted by other sessions - so the cache removal happens by Guava cache, it removes the artifact directory dedicated for the session.

### How was this patch tested?

Manually tested after taking the logic out. It's difficult to write a test.

### Was this patch authored or co-authored using generative AI tooling?

No.