### PR TITLE
[SPARK-50136][BUILD] Upgrade `curator` to 5.7.1

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -51,9 +51,9 @@ commons-math3/3.6.1//commons-math3-3.6.1.jar
 commons-pool/1.5.4//commons-pool-1.5.4.jar
 commons-text/1.12.0//commons-text-1.12.0.jar
 compress-lzf/1.1.2//compress-lzf-1.1.2.jar
-curator-client/5.7.0//curator-client-5.7.0.jar
-curator-framework/5.7.0//curator-framework-5.7.0.jar
-curator-recipes/5.7.0//curator-recipes-5.7.0.jar
+curator-client/5.7.1//curator-client-5.7.1.jar
+curator-framework/5.7.1//curator-framework-5.7.1.jar
+curator-recipes/5.7.1//curator-recipes-5.7.1.jar
 datanucleus-api-jdo/4.2.4//datanucleus-api-jdo-4.2.4.jar
 datanucleus-core/4.1.17//datanucleus-core-4.1.17.jar
 datanucleus-rdbms/4.1.19//datanucleus-rdbms-4.1.19.jar

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <yarn.version>${hadoop.version}</yarn.version>
     <zookeeper.version>3.9.2</zookeeper.version>
-    <curator.version>5.7.0</curator.version>
+    <curator.version>5.7.1</curator.version>
     <hive.group>org.apache.hive</hive.group>
     <hive.classifier>core</hive.classifier>
     <!-- Version used in Maven Hive dependency -->


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `curator` from `5.7.0` to `5.7.1`.


### Why are the changes needed?
- Apache Curator 5.7.1 is released on `2024-10-13`.
https://curator.apache.org/download/#2024-10-13-release-571-available

- The full release notes:
https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12314425&version=12355135


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
