### PR TITLE
[SPARK-50145][BUILD] Upgrade Jetty to 11.0.24

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -140,8 +140,8 @@ jersey-container-servlet/3.0.16//jersey-container-servlet-3.0.16.jar
 jersey-hk2/3.0.16//jersey-hk2-3.0.16.jar
 jersey-server/3.0.16//jersey-server-3.0.16.jar
 jettison/1.5.4//jettison-1.5.4.jar
-jetty-util-ajax/11.0.23//jetty-util-ajax-11.0.23.jar
-jetty-util/11.0.23//jetty-util-11.0.23.jar
+jetty-util-ajax/11.0.24//jetty-util-ajax-11.0.24.jar
+jetty-util/11.0.24//jetty-util-11.0.24.jar
 jjwt-api/0.12.6//jjwt-api-0.12.6.jar
 jline/2.14.6//jline-2.14.6.jar
 jline/3.26.3//jline-3.26.3.jar

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <parquet.version>1.14.3</parquet.version>
     <orc.version>2.0.2</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>
-    <jetty.version>11.0.23</jetty.version>
+    <jetty.version>11.0.24</jetty.version>
     <jakartaservlet.version>5.0.0</jakartaservlet.version>
     <!-- SPARK-46938: Required by Hive / LibThrift libs -->
     <javaxservlet.version>4.0.1</javaxservlet.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `Jetty` to 11.0.24 for Apache Spark 4.0.0.

### Why are the changes needed?

To bring the latest bug fixes like the following.
- https://github.com/jetty/jetty.project/pull/12201

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.