### PR TITLE
[SPARK-50149][INFRA] Update INFRA docker image to use `jammy-20240911.1`

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -17,14 +17,14 @@
 
 # Image for building and testing Spark branches. Based on Ubuntu 22.04.
 # See also in https://hub.docker.com/_/ubuntu
-FROM ubuntu:jammy-20240227
+FROM ubuntu:jammy-20240911.1
 LABEL org.opencontainers.image.authors="Apache Spark project <dev@spark.apache.org>"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.ref.name="Apache Spark Infra Image"
 # Overwrite this label to avoid exposing the underlying Ubuntu OS version label
 LABEL org.opencontainers.image.version=""
 
-ENV FULL_REFRESH_DATE 20241007
+ENV FULL_REFRESH_DATE 20241028
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN true


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `infra` docker image to use `jammy-20240911.1` instead of `jammy-20240227`.

### Why are the changes needed?

To use the latest image as the base image.

### Does this PR introduce _any_ user-facing change?

No, this is an infra only change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.