### PR TITLE
[SPARK-50151][SS][RocksDB Hardening] - Fix ineffective file reuse bug in the new file management change

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -291,6 +291,7 @@ class RocksDB(
     acquire(LoadStore)
     recordedMetrics = None
     logInfo(log"Loading ${MDC(LogKeys.VERSION_NUM, version)}")
+    // Updating the current version, so the mapping can correctly identify reusable files.
     rocksDBFileMapping.currentVersion = version
     try {
       if (loadedVersion != version ||

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
@@ -637,7 +637,7 @@ class RocksDBFileManager(
     localImmutableFiles.foreach { existingFile =>
       val existingFileSize = existingFile.length()
       val requiredFile = requiredFileNameToFileDetails.get(existingFile.getName)
-      val prevDfsFile = rocksDBFileMapping.getDfsFile(this, existingFile.getName)
+      val prevDfsFile = rocksDBFileMapping.getDfsFileForLoad(this, existingFile.getName)
       val isSameFile = if (requiredFile.isDefined && prevDfsFile.isDefined) {
         requiredFile.get.dfsFileName == prevDfsFile.get.dfsFileName &&
           existingFile.length() == requiredFile.get.sizeBytes

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBFileManager.scala
@@ -288,7 +288,7 @@ class RocksDBFileManager(
       val metadata = RocksDBCheckpointMetadata.readFromFile(metadataFile)
       logInfo(log"Read metadata for version ${MDC(LogKeys.VERSION_NUM, version)}:\n" +
         log"${MDC(LogKeys.METADATA_JSON, metadata.prettyJson)}")
-      loadImmutableFilesFromDfs(metadata.immutableFiles, localDir, rocksDBFileMapping)
+      loadImmutableFilesFromDfs(metadata.immutableFiles, localDir, rocksDBFileMapping, version)
       versionToRocksDBFiles.put(version, metadata.immutableFiles)
       metadataFile.delete()
       metadata
@@ -628,7 +628,8 @@ class RocksDBFileManager(
   private def loadImmutableFilesFromDfs(
       immutableFiles: Seq[RocksDBImmutableFile],
       localDir: File,
-      rocksDBFileMapping: RocksDBFileMapping): Unit = {
+      rocksDBFileMapping: RocksDBFileMapping,
+      version: Long): Unit = {
     val requiredFileNameToFileDetails = immutableFiles.map(f => f.localFileName -> f).toMap
 
     val localImmutableFiles = listRocksDBFiles(localDir)._1
@@ -637,7 +638,7 @@ class RocksDBFileManager(
     localImmutableFiles.foreach { existingFile =>
       val existingFileSize = existingFile.length()
       val requiredFile = requiredFileNameToFileDetails.get(existingFile.getName)
-      val prevDfsFile = rocksDBFileMapping.getDfsFileForLoad(this, existingFile.getName)
+      val prevDfsFile = rocksDBFileMapping.getDfsFileForLoad(this, existingFile.getName, version)
       val isSameFile = if (requiredFile.isDefined && prevDfsFile.isDefined) {
         requiredFile.get.dfsFileName == prevDfsFile.get.dfsFileName &&
           existingFile.length() == requiredFile.get.sizeBytes
@@ -679,7 +680,7 @@ class RocksDBFileManager(
         }
         filesCopied += 1
         bytesCopied += localFileSize
-        rocksDBFileMapping.mapToDfsFileForCurrentVersion(localFileName, file)
+        rocksDBFileMapping.mapToDfsFile(localFileName, file, version)
         logInfo(log"Copied ${MDC(LogKeys.DFS_FILE, dfsFile)} to " +
           log"${MDC(LogKeys.FILE_NAME, localFile)} - " +
           log"${MDC(LogKeys.NUM_BYTES, localFileSize)} bytes")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
There are 2 bugs in the recently added new approach for RocksDB SST file mapping in this PR: https://github.com/apache/spark/pull/47875 (cc @sahnib )

1. The file mapping version is not properly advancing and only advances when we are reopening the RocksDB. This causes ineffective file reuse and we end up not reusing files that should have been reused. Leading to a lot of unnecessary file upload/download, and in the worst case it will make us act like file reuse is disabled.

2. Ineffective file reuse when creating a checkpoint. We currently will not reuse the files for creating checkpoint, if it was added in the current version i.e. if you do load(v1) -> save(v2), the SST files loaded in v1 will not be reused in v2, and we will upload them again.

3. These two bugs were not caught even though we have tests to catch them, because there was also a bug in the test.

NOTE: these bugs will not cause corruption and more of a performance bug. They just make file reuse ineffective. And end up working like there's no file reuse enabled. i.e. A lot of file upload/download 

**To Repro**:
You can add the test changes in this PR to current master and run RocksDB test, you will see test failures for file mapping version not advancing and for incorrect file reuse.

### Why are the changes needed?
Bug fix. Without this change, it will work like file reuse is disabled. This is a performance bug.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests fixed and added assertion


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No