### PR TITLE
[SPARK-50152][SS] Support handleInitialState with state data source reader

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -4233,12 +4233,6 @@
     ],
     "sqlState" : "42802"
   },
-  "STATEFUL_PROCESSOR_CANNOT_REINITIALIZE_STATE_ON_KEY" : {
-    "message" : [
-      "Cannot re-initialize state on the same grouping key during initial state handling for stateful processor. Invalid grouping key=<groupingKey>."
-    ],
-    "sqlState" : "42802"
-  },
   "STATEFUL_PROCESSOR_DUPLICATE_STATE_VARIABLE_DEFINED" : {
     "message" : [
       "State variable with name <stateVarName> has already been defined in the StatefulProcessor."

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessor.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessor.scala
@@ -121,6 +121,8 @@ private[sql] abstract class StatefulProcessorWithInitialState[K, I, O, S]
 
   /**
    * Function that will be invoked only in the first batch for users to process initial states.
+   * Allow multiple initial state rows mapping to the same grouping key to support integration
+   * with passing state data source reader dataframe as initial state.
    *
    * @param key
    *   \- grouping key

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessor.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessor.scala
@@ -121,8 +121,9 @@ private[sql] abstract class StatefulProcessorWithInitialState[K, I, O, S]
 
   /**
    * Function that will be invoked only in the first batch for users to process initial states.
-   * Allow multiple initial state rows mapping to the same grouping key to support integration
-   * with passing state data source reader dataframe as initial state.
+   * The provided initial state can be arbitrary dataframe with the same grouping
+   * key schema with the input rows, e.g. dataframe from data source reader of existing
+   * streaming query checkpoint.
    *
    * @param key
    *   \- grouping key

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessor.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessor.scala
@@ -121,9 +121,9 @@ private[sql] abstract class StatefulProcessorWithInitialState[K, I, O, S]
 
   /**
    * Function that will be invoked only in the first batch for users to process initial states.
-   * The provided initial state can be arbitrary dataframe with the same grouping
-   * key schema with the input rows, e.g. dataframe from data source reader of existing
-   * streaming query checkpoint.
+   * The provided initial state can be arbitrary dataframe with the same grouping key schema with
+   * the input rows, e.g. dataframe from data source reader of existing streaming query
+   * checkpoint.
    *
    * @param key
    *   \- grouping key

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -271,13 +271,9 @@ case class TransformWithStateExec(
     ImplicitGroupingKeyTracker.setImplicitKey(keyObj)
     val initStateObjIter = initStateIter.map(getInitStateValueObj.apply)
 
-    var seenInitStateOnKey = false
     initStateObjIter.foreach { initState =>
-      // cannot re-initialize state on the same grouping key during initial state handling
-      if (seenInitStateOnKey) {
-        throw StateStoreErrors.cannotReInitializeStateOnKey(keyObj.toString)
-      }
-      seenInitStateOnKey = true
+      // allow multiple initial state rows on the same grouping key for integration
+      // with state data source reader with initial state
       statefulProcessor
         .asInstanceOf[StatefulProcessorWithInitialState[Any, Any, Any, Any]]
         .handleInitialState(keyObj, initState,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreErrors.scala
@@ -123,11 +123,6 @@ object StateStoreErrors {
     new StatefulProcessorCannotPerformOperationWithInvalidHandleState(operationType, handleState)
   }
 
-  def cannotReInitializeStateOnKey(groupingKey: String):
-    StatefulProcessorCannotReInitializeState = {
-    new StatefulProcessorCannotReInitializeState(groupingKey)
-  }
-
   def cannotProvideTTLConfigForTimeMode(stateName: String, timeMode: String):
     StatefulProcessorCannotAssignTTLInTimeMode = {
     new StatefulProcessorCannotAssignTTLInTimeMode(stateName, timeMode)
@@ -271,11 +266,6 @@ class StatefulProcessorCannotPerformOperationWithInvalidHandleState(
     errorClass = "STATEFUL_PROCESSOR_CANNOT_PERFORM_OPERATION_WITH_INVALID_HANDLE_STATE",
     messageParameters = Map("operationType" -> operationType, "handleState" -> handleState)
   )
-
-class StatefulProcessorCannotReInitializeState(groupingKey: String)
-  extends SparkUnsupportedOperationException(
-  errorClass = "STATEFUL_PROCESSOR_CANNOT_REINITIALIZE_STATE_ON_KEY",
-  messageParameters = Map("groupingKey" -> groupingKey))
 
 class StateStoreUnsupportedOperationOnMissingColumnFamily(
     operationType: String,

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateInitialStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateInitialStateSuite.scala
@@ -146,7 +146,9 @@ class InitialStatefulProcessorWithUnflattenStateDataSource
         "list"
       } else if (initialState.mapValue.isDefined) {
         "map"
-      } else "invalid"
+      } else {
+        "invalid"
+      }
     }
     stateVar match {
       case "value" => _valState.update(initialState.value.get.toDouble)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateInitialStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateInitialStateSuite.scala
@@ -666,7 +666,8 @@ class TransformWithStateInitialStateSuite extends StateStoreMetricsTest
       inputData: MemoryStream[InitInputRow]): DataFrame = {
     if (flattenOption) {
       // when we read the state rows with flattened option set to true, values of a composite
-      // state variable will be flattened into multiple rows where each row is a key-value pair
+      // state variable will be flattened into multiple rows where each row is a
+      // key -> single value pair
       val valueDf = valDf.selectExpr("key.value AS groupingKey", "value.value AS value")
       val flattenListDf = listDf
         .selectExpr("key.value AS groupingKey", "list_element.value AS listValue")

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateInitialStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateInitialStateSuite.scala
@@ -112,14 +112,11 @@ class InitialStatefulProcessorWithStateDataSource
     val stateVar = {
       if (initialState.value.isDefined) {
         "value"
-      }
-      else if (initialState.listValue.isDefined) {
+      } else if (initialState.listValue.isDefined) {
         "list"
-      }
-      else if (initialState.userMapKey.isDefined) {
+      } else if (initialState.userMapKey.isDefined) {
         "map"
-      }
-      else {
+      } else {
         "invalid"
       }
     }
@@ -143,10 +140,13 @@ class InitialStatefulProcessorWithUnflattenStateDataSource
   override def handleInitialState(
       key: String, initialState: UnionUnflattenInitialStateRow, timerValues: TimerValues): Unit = {
     val stateVar = {
-      if (initialState.value.isDefined) "value"
-      else if (initialState.listValue.isDefined) "list"
-      else if (initialState.mapValue.isDefined) "map"
-      else "invalid"
+      if (initialState.value.isDefined) {
+        "value"
+      } else if (initialState.listValue.isDefined) {
+        "list"
+      } else if (initialState.mapValue.isDefined) {
+        "map"
+      } else "invalid"
     }
     stateVar match {
       case "value" => _valState.update(initialState.value.get.toDouble)

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateInitialStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateInitialStateSuite.scala
@@ -113,10 +113,10 @@ abstract class InitialStateWithStateDataSourceBase[V]
   override def init(
       outputMode: OutputMode,
       timeMode: TimeMode): Unit = {
-    _valState = getHandle.getValueState[String]("testValueInit", Encoders.STRING)
-    _listState = getHandle.getListState[Long]("testListInit", Encoders.scalaLong)
+    _valState = getHandle.getValueState[String]("testValueInit", Encoders.STRING, TTLConfig.NONE)
+    _listState = getHandle.getListState[Long]("testListInit", Encoders.scalaLong, TTLConfig.NONE)
     _mapState = getHandle.getMapState[String, Long](
-      "testMapInit", Encoders.STRING, Encoders.scalaLong)
+      "testMapInit", Encoders.STRING, Encoders.scalaLong, TTLConfig.NONE)
   }
 
   override def handleInputRows(
@@ -310,11 +310,11 @@ class StatefulProcessorWithAllStateVars extends RunningCountStatefulProcessor {
   override def init(
       outputMode: OutputMode,
       timeMode: TimeMode): Unit = {
-    _countState = getHandle.getValueState[Long]("countState", Encoders.scalaLong)
+    _countState = getHandle.getValueState[Long]("countState", Encoders.scalaLong, TTLConfig.NONE)
     _listState = getHandle.getListState[Long](
-      "listState", Encoders.scalaLong)
+      "listState", Encoders.scalaLong, TTLConfig.NONE)
     _mapState = getHandle.getMapState[String, Long](
-      "mapState", Encoders.STRING, Encoders.scalaLong)
+      "mapState", Encoders.STRING, Encoders.scalaLong, TTLConfig.NONE)
   }
 
   override def handleInputRows(

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateInitialStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateInitialStateSuite.scala
@@ -300,14 +300,18 @@ class StatefulProcessorWithAllStateVars extends RunningCountStatefulProcessor {
       timerValues: TimerValues): Iterator[(String, String)] = {
     val curCountValue = if (_countState.exists()) {
       _countState.get()
-    } else 0L
+    } else {
+      0L
+    }
     var cnt = curCountValue
     inputRows.foreach { row =>
       cnt += 1
       _listState.appendValue(cnt)
       val mapCurVal = if (_mapState.containsKey(row)) {
         _mapState.getValue(row)
-      } else 0
+      } else {
+        0
+      }
       _mapState.updateValue(row, mapCurVal + 1L)
     }
     _countState.update(cnt)
@@ -638,7 +642,11 @@ class TransformWithStateInitialStateSuite extends StateStoreMetricsTest
       (TransformWithStateSuiteUtils.NUM_SHUFFLE_PARTITIONS.toString,
         TransformWithStateSuiteUtils.NUM_SHUFFLE_PARTITIONS.toString)
     ).foreach { partitions =>
-      val samePartition = if (partitions._1 == partitions._2) "" else "not "
+      val samePartition = if (partitions._1 == partitions._2) {
+        ""
+      } else {
+        "not "
+      }
       test("transformWithStateWithInitialState - state data source reader dataframe " +
         s"as initial state with flatten option set to $flattenOption, initial state rows are " +
         s"${samePartition}coming from the same shuffle partition number with current query") {
@@ -681,7 +689,6 @@ class TransformWithStateInitialStateSuite extends StateStoreMetricsTest
               .option(StateSourceOptions.STATE_VAR_NAME, "mapState")
               .option(StateSourceOptions.FLATTEN_COLLECTION_TYPES, flattenOption)
               .load()
-
 
             // create a df where each row contains all value, list, map state rows
             // fill the missing column with null

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateInitialStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateInitialStateSuite.scala
@@ -637,19 +637,11 @@ class TransformWithStateInitialStateSuite extends StateStoreMetricsTest
       flattenOption: Boolean)
       (startQuery: (DataFrame, DataFrame, DataFrame,
         MemoryStream[InitInputRow]) => DataFrame): Unit = {
-    Seq(
-      (TransformWithStateSuiteUtils.NUM_SHUFFLE_PARTITIONS.toString, "1"),
-      (TransformWithStateSuiteUtils.NUM_SHUFFLE_PARTITIONS.toString,
-        TransformWithStateSuiteUtils.NUM_SHUFFLE_PARTITIONS.toString)
-    ).foreach { partitions =>
-      val samePartition = if (partitions._1 == partitions._2) {
-        ""
-      } else {
-        "not "
-      }
+    Seq(("5", "2"), ("5", "8"), ("5", "5")).foreach { partitions =>
       test("transformWithStateWithInitialState - state data source reader dataframe " +
-        s"as initial state with flatten option set to $flattenOption, initial state rows are " +
-        s"${samePartition}coming from the same shuffle partition number with current query") {
+        s"as initial state with flatten option set to $flattenOption, the first stream and " +
+        s"the second stream is running on shuffle partition number of ${partitions._1} and " +
+        s"${partitions._2} respectively.") {
         withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
           classOf[RocksDBStateStoreProvider].getName) {
           withTempDir { checkpointDir =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds support for users to provide a Dataframe that can be used to instantiate state for the query in the first batch for arbitrary state API v2. More specifically, this dataframe is coming from state data source reader.

Remove the restraints that initialState dataframe can only contains one value row for a grouping key. This is to enable the integration with state data source reader. In flattened state data source reader for composite type, we will have multiple value rows mapping to the same grouping key.

For example, we can union dataframe created by state data source reader on a single state variable and union them together and get an output dataframe as initial state for a transformWithState operator like this:
```
+-----------+-----+---------+----------+------------+
|groupingKey|value|listValue|userMapKey|userMapValue|
+-----------+-----+---------+----------+------------+
|a          |3    |NULL     |NULL      |NULL        |
|b          |2    |NULL     |NULL      |NULL        |
|a          |NULL |1        |NULL      |NULL        |
|a          |NULL |2        |NULL      |NULL        |
|a          |NULL |3        |NULL      |NULL        |
|b          |NULL |1        |NULL      |NULL        |
|b          |NULL |2        |NULL      |NULL        |
|a          |NULL |NULL     |a         |3           |
|b          |NULL |NULL     |b         |2           |
+-----------+-----+---------+----------+------------+
```
### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This change is for supporting initial state handling for integration with state data source reader.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No. The user API is the same as prior PR: https://github.com/apache/spark/pull/45467 for initial state support without state data source reader.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit test cases added in `TransformWithStateWithInitialStateSuite`.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.