### PR TITLE
[SPARK-50160][SQL][KAFKA] KafkaWriteTask: allow customizing record timestamp

### DIFF
--- a/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaWriter.scala
+++ b/connector/kafka-0-10-sql/src/main/scala/org/apache/spark/sql/kafka010/KafkaWriter.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.catalyst.CatalystTypeConverters
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.execution.QueryExecution
-import org.apache.spark.sql.types.{BinaryType, DataType, IntegerType, StringType}
+import org.apache.spark.sql.types.{BinaryType, DataType, DoubleType, IntegerType, StringType, TimestampType}
 import org.apache.spark.util.Utils
 
 /**
@@ -43,6 +43,7 @@ private[kafka010] object KafkaWriter extends Logging {
   val VALUE_ATTRIBUTE_NAME: String = "value"
   val HEADERS_ATTRIBUTE_NAME: String = "headers"
   val PARTITION_ATTRIBUTE_NAME: String = "partition"
+  val TIMESTAMP_ATTRIBUTE_NAME: String = "timestamp"
 
   override def toString: String = "KafkaWriter"
 
@@ -108,6 +109,12 @@ private[kafka010] object KafkaWriter extends Logging {
   def partitionExpression(schema: Seq[Attribute]): Expression = {
     expression(schema, PARTITION_ATTRIBUTE_NAME, Seq(IntegerType)) {
       Literal(null, IntegerType)
+    }
+  }
+
+  def timestampExpression(schema: Seq[Attribute]): Expression = {
+    expression(schema, TIMESTAMP_ATTRIBUTE_NAME, Seq(DoubleType, TimestampType)) {
+      Literal(null, TimestampType)
     }
   }
 

--- a/docs/streaming/structured-streaming-kafka-integration.md
+++ b/docs/streaming/structured-streaming-kafka-integration.md
@@ -721,6 +721,10 @@ The Dataframe being written to Kafka should have the following columns in schema
   <td>partition (optional)</td>
   <td>int</td>
 </tr>
+<tr>
+  <td>timestamp (optional)</td>
+  <td>double or timestamp</td>
+</tr>
 </table>
 \* The topic column is required if the "topic" configuration option is not specified.<br>
 
@@ -733,8 +737,10 @@ If a "partition" column is not specified (or its value is ```null```)
 then the partition is calculated by the Kafka producer.
 A Kafka partitioner can be specified in Spark by setting the
 ```kafka.partitioner.class``` option. If not present, Kafka default partitioner
-will be used.
-
+will be used. If a "timestamp" column exists then its value is assigned to the resulting record.
+In case its value is ```null``` the timestamp is filled dynamically by the Kafka producer.
+Since eventually this value is cast as timestamp, a double value is the only way to preserve
+milliseconds.
 
 The following options must be set for the Kafka sink
 for both batch and streaming queries.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support customising kafka record timestamps via an optional column.

### Why are the changes needed?
As stated in the JIRA ticket, we do a lot of event-time processing to kafka records reflecting that would be nice.

### Does this PR introduce _any_ user-facing change?
Yes, kafka docs need an update to reflect the new, optional timestamp column (of type long/timestamp).

### How was this patch tested?
I added a unit test that makes sure the timestamps get passed through as expected.

### Was this patch authored or co-authored using generative AI tooling?
No.
