### PR TITLE
[SPARK-50163][SS] Fix the RocksDB extra acquireLock release due to the completion listener

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -1480,10 +1480,9 @@ object RocksDBNativeHistogram {
   }
 }
 
-case class AcquiredThreadInfo() {
-  val threadRef: WeakReference[Thread] = new WeakReference[Thread](Thread.currentThread())
-  val tc: TaskContext = TaskContext.get()
-
+case class AcquiredThreadInfo(
+    threadRef: WeakReference[Thread] = new WeakReference[Thread](Thread.currentThread()),
+    tc: TaskContext = TaskContext.get()) {
   override def toString(): String = {
     val taskStr = if (tc != null) {
       val taskDetails =

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -992,7 +992,9 @@ class RocksDB(
 
         if (acquiredThreadInfo.threadRef.get.isDefined
           && acquiredThreadInfo != releaseForThreadOpt.get) {
-          logInfo(log"Thread info does not match the acquired thread when attempting to" +
+          logInfo(log"Thread info for release" +
+            log" ${MDC(LogKeys.THREAD, releaseForThreadOpt.get)}" +
+            log" does not match the acquired thread when attempting to" +
             log" release for opType=${MDC(LogKeys.OP_TYPE, opType.toString)}, ignoring release." +
             log" Lock is held by ${MDC(LogKeys.THREAD, acquiredThreadInfo)}")
           return

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -975,8 +975,9 @@ class RocksDB(
    * @param opType - operation type releasing the lock
    * @param releaseForThreadOpt - optional thread to check against acquired thread
    */
-  private def release(opType: RocksDBOpType,
-    releaseForThreadOpt: Option[AcquiredThreadInfo] = None): Unit = acquireLock.synchronized {
+  private def release(
+      opType: RocksDBOpType,
+      releaseForThreadOpt: Option[AcquiredThreadInfo] = None): Unit = acquireLock.synchronized {
     if (acquiredThreadInfo != null) {
       if (releaseForThreadOpt.nonEmpty) {
         if (releaseForThreadOpt.get.threadRef.get.isEmpty) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -973,13 +973,13 @@ class RocksDB(
    * thread is the one that acquired the lock.
    *
    * @param opType - operation type releasing the lock
-   * @param forThreadOpt - optional thread to check against acquired thread
+   * @param releaseForThreadOpt - optional thread to check against acquired thread
    */
   private def release(opType: RocksDBOpType,
-    forThreadOpt: Option[AcquiredThreadInfo] = None): Unit = acquireLock.synchronized {
+    releaseForThreadOpt: Option[AcquiredThreadInfo] = None): Unit = acquireLock.synchronized {
     if (acquiredThreadInfo != null) {
-      if (forThreadOpt.nonEmpty) {
-        if (forThreadOpt.get.threadRef.get.isEmpty) {
+      if (releaseForThreadOpt.nonEmpty) {
+        if (releaseForThreadOpt.get.threadRef.get.isEmpty) {
           logInfo(log"Thread reference is empty when attempting to release for" +
             log" opType=${MDC(LogKeys.OP_TYPE, opType.toString)}, ignoring release." +
             log" Lock is held by ${MDC(LogKeys.THREAD, acquiredThreadInfo)}")
@@ -987,7 +987,7 @@ class RocksDB(
         }
 
         if (acquiredThreadInfo.threadRef.get.isDefined
-          && acquiredThreadInfo != forThreadOpt.get) {
+          && acquiredThreadInfo != releaseForThreadOpt.get) {
           logInfo(log"Thread info does not match the acquired thread when attempting to" +
             log" release for opType=${MDC(LogKeys.OP_TYPE, opType.toString)}, ignoring release." +
             log" Lock is held by ${MDC(LogKeys.THREAD, acquiredThreadInfo)}")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -1028,6 +1028,10 @@ class RocksDB(
     }
   }
 
+  private[state] def getAcquiredThreadInfo(): AcquiredThreadInfo = acquireLock.synchronized {
+    acquiredThreadInfo.copy()
+  }
+
   /** Create a native RocksDB logger that forwards native logs to log4j with correct log levels. */
   private def createLogger(): Logger = {
     val dbLogger = new Logger(rocksDbOptions.infoLogLevel()) {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -1031,8 +1031,8 @@ class RocksDB(
     }
   }
 
-  private[state] def getAcquiredThreadInfo(): AcquiredThreadInfo = acquireLock.synchronized {
-    acquiredThreadInfo.copy()
+  private[state] def getAcquiredThreadInfo(): Option[AcquiredThreadInfo] = acquireLock.synchronized {
+    Option(acquiredThreadInfo).map(_.copy())
   }
 
   /** Create a native RocksDB logger that forwards native logs to log4j with correct log levels. */

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -999,7 +999,8 @@ class RocksDB(
       }
 
       if (release) {
-        logInfo(log"RocksDB instance was released by ${MDC(LogKeys.THREAD, AcquiredThreadInfo())}. " +
+        logInfo(log"RocksDB instance was released by " +
+          log"${MDC(LogKeys.THREAD, AcquiredThreadInfo())}. " +
           log"acquiredThreadInfo: ${MDC(LogKeys.THREAD, acquiredThreadInfo)} " +
           log"for opType=${MDC(LogKeys.OP_TYPE, opType.toString)}")
         acquiredThreadInfo = null
@@ -1031,7 +1032,8 @@ class RocksDB(
     }
   }
 
-  private[state] def getAcquiredThreadInfo(): Option[AcquiredThreadInfo] = acquireLock.synchronized {
+  private[state] def getAcquiredThreadInfo(): Option[AcquiredThreadInfo] =
+      acquireLock.synchronized {
     Option(acquiredThreadInfo).map(_.copy())
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -987,7 +987,8 @@ class RocksDB(
         }
 
         if (acquiredThreadInfo.threadRef.get.isDefined
-          && acquiredThreadInfo != releaseForThreadOpt.get) {
+          && releaseForThreadOpt.get.threadRef.get.get.getId
+          != acquiredThreadInfo.threadRef.get.get.getId) {
           logInfo(log"Thread info for release" +
             log" ${MDC(LogKeys.THREAD, releaseForThreadOpt.get)}" +
             log" does not match the acquired thread when attempting to" +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -753,7 +753,6 @@ class RocksDB(
       changelogWriter.foreach(_.abort())
       // Make sure changelogWriter gets recreated next time.
       changelogWriter = None
-
       logInfo(log"Rolled back to ${MDC(LogKeys.VERSION_NUM, loadedVersion)}")
     } finally {
       release(RollbackStore)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -987,8 +987,11 @@ class RocksDB(
         }
 
         if (acquiredThreadInfo.threadRef.get.isDefined
-          && releaseForThreadOpt.get.threadRef.get.get.getId
-          != acquiredThreadInfo.threadRef.get.get.getId) {
+          // NOTE: we compare the entire acquiredThreadInfo object to ensure that we are
+          // releasing not only for the right thread but the right task as well. This is
+          // inconsistent with the logic for acquire which uses only the thread ID, consider
+          // updating this in future.
+          && acquiredThreadInfo != releaseForThreadOpt.get) {
           logInfo(log"Thread info for release" +
             log" ${MDC(LogKeys.THREAD, releaseForThreadOpt.get)}" +
             log" does not match the acquired thread when attempting to" +

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -2264,7 +2264,7 @@ class RocksDBSuite extends AlsoTestWithChangelogCheckpointingEnabled with Shared
 
     // Create a custom ExecutionContext with 3 threads
     implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(
-      ThreadUtils.newDaemonFixedThreadPool(5, "pool-thread-executor"))
+      ThreadUtils.newDaemonFixedThreadPool(3, "pool-thread-executor"))
     val timeout = 5.seconds
 
     val stateLock = new Object()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -21,14 +21,20 @@ import java.io._
 import java.nio.charset.Charset
 import java.util.concurrent.Executors
 
+import scala.collection.mutable
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
+import scala.language.implicitConversions
+import scala.util.Random
+
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.rocksdb.CompressionType
 import org.scalactic.source.Position
 import org.scalatest.Tag
-import org.apache.spark.{SparkConf, SparkException, TaskContext}
 
+import org.apache.spark.{SparkConf, SparkException, TaskContext}
 import org.apache.spark.sql.catalyst.util.quietly
 import org.apache.spark.sql.execution.streaming.{CreateAtomicTestManager, FileSystemBasedCheckpointFileManager}
 import org.apache.spark.sql.execution.streaming.CheckpointFileManager.{CancellableFSDataOutputStream, RenameBasedFSDataOutputStream}

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -2346,7 +2346,8 @@ class RocksDBSuite extends AlsoTestWithChangelogCheckpointingEnabled with Shared
         val e = intercept[SparkException] {
           ThreadUtils.awaitResult(thread3, 10.seconds)
         }
-        assert(e.getMessage.contains("CANNOT_LOAD_STATE_STORE.UNRELEASED_THREAD_ERROR"))
+        assert(e.getCause.getMessage.contains(
+          "CANNOT_LOAD_STATE_STORE.UNRELEASED_THREAD_ERROR"))
 
         stateLock.synchronized {
           // Signal that we have entered state 3 (thread 2 can now release lock)

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -2426,12 +2426,13 @@ class RocksDBSuite extends AlsoTestWithChangelogCheckpointingEnabled with Shared
 
   private def assertAcquiredThreadIsCurrentThread(db: RocksDB): Unit = {
     val threadInfo = db.getAcquiredThreadInfo()
-    assert(threadInfo != null,
+    assert(threadInfo != None,
       "acquired thread info should not be null after load")
+    val threadId = threadInfo.get.threadRef.get.get.getId
     assert(
-      threadInfo.threadRef.get.get.getId == Thread.currentThread().getId,
+      threadId == Thread.currentThread().getId,
       s"acquired thread should be curent thread ${Thread.currentThread().getId} " +
-        s"after load but was ${threadInfo.threadRef.get.get.getId}")
+        s"after load but was $threadId")
   }
 
   private def dbConf = RocksDBConf(StateStoreConf(SQLConf.get.clone()))

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -2293,9 +2293,6 @@ class RocksDBSuite extends AlsoTestWithChangelogCheckpointingEnabled with Shared
           db.load(0)
           db.put("a", "1")
           db.commit()
-          assert(db.getAcquiredThreadInfo() == null,
-            s"acquired thread info after commit should be null but was "
-              + s"${db.getAcquiredThreadInfo()}")
 
           Future { // THREAD 2
             // Set thread 2's task context so that it is not a clone of thread 1's

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -2244,7 +2244,6 @@ class RocksDBSuite extends AlsoTestWithChangelogCheckpointingEnabled with Shared
     // This test verifies that a thread that locks then unlocks the db and then
     // fires a completion listener (Thread 1) does not unlock the lock validly
     // acquired by another thread (Thread 2).
-    // Thread 3 verifies that Thread 2 still holds the lock by timing out.
     //
     // Timeline of this test (* means thread is active):
     // STATE | MAIN             | THREAD 1         | THREAD 2         |

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -2243,7 +2243,7 @@ class RocksDBSuite extends AlsoTestWithChangelogCheckpointingEnabled with Shared
   test("Rocks DB task completion listener does not double unlock acquireThread") {
     // Create a custom ExecutionContext with 3 threads
     implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(
-      ThreadUtils.newDaemonFixedThreadPool(5, "pool-thread-executor"))
+      ThreadUtils.newDaemonFixedThreadPool(3, "pool-thread-executor"))
     val timeout = 5.seconds
 
     val stateLock = new Object()

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/RocksDBSuite.scala
@@ -2269,17 +2269,14 @@ class RocksDBSuite extends AlsoTestWithChangelogCheckpointingEnabled with Shared
     // Create a custom ExecutionContext with 3 threads
     implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(
       ThreadUtils.newDaemonFixedThreadPool(3, "pool-thread-executor"))
-    val timeout = 5.seconds
-
     val stateLock = new Object()
     var state = 0
 
     withTempDir { dir =>
       val remoteDir = dir.getCanonicalPath
-      val conf = dbConf.copy(lockAcquireTimeoutMs = timeout.toMillis.toInt)
       val db = new RocksDB(
         remoteDir,
-        conf = conf,
+        conf = dbConf,
         localRootDir = Utils.createTempDir(),
         hadoopConf = new Configuration(),
         loggingId = s"[Thread-${Thread.currentThread.getId}]",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Adds a new `releaseForThread(opType, threadRef)` method that only releases the RocksDB acquireLock if the provided threadRef is the same as the threadRef in `acquiredThreadInfo`. Also, modify the task completion listener created in `acquire` to use the new method so that it doesn't accidentally release the lock if it's owned by another thread. 

Also some small changes to usages of acquire() and release() in `rollback` and `close` to follow this pattern to avoid extraneous or missed releases due to exceptions/interrupts: 
```
acquire()
try {
  ...
} finally {
  release()
}
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
There currently exists a race condition in RocksDB where the completion listener may release a lock validly held by another thread, resulting in a thread-unsafe condition. We have seen this bug in production.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added unit tests in RocksDB.scala, all other unit tests continue to pass as expected.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Github Co-pilot 1.5.25.10