### PR TITLE
[SPARK-49766][SPARK-49939][SPARK-49967][SPARK-49966][SQL][FOLLOWUP] Remove redundant whether is null check

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/json/JsonExpressionUtils.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/json/JsonExpressionUtils.java
@@ -32,10 +32,6 @@ import org.apache.spark.unsafe.types.UTF8String;
 public class JsonExpressionUtils {
 
   public static Integer lengthOfJsonArray(UTF8String json) {
-    // return null for null input
-    if (json == null) {
-      return null;
-    }
     try (JsonParser jsonParser =
         CreateJacksonParser.utf8String(SharedFactory.jsonFactory(), json)) {
       if (jsonParser.nextToken() == null) {
@@ -60,10 +56,6 @@ public class JsonExpressionUtils {
   }
 
   public static GenericArrayData jsonObjectKeys(UTF8String json) {
-    // return null for `NULL` input
-    if (json == null) {
-      return null;
-    }
     try (JsonParser jsonParser =
         CreateJacksonParser.utf8String(SharedFactory.jsonFactory(), json)) {
       // return null if an empty string or any other valid JSON string is encountered

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/json/JsonExpressionEvalUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/json/JsonExpressionEvalUtils.scala
@@ -103,7 +103,6 @@ case class JsonToStructsEvaluator(
   }
 
   final def evaluate(json: UTF8String): Any = {
-    if (json == null) return null
     nullableSchema match {
       case _: VariantType =>
         VariantExpressionEvalUtils.parseJson(json,
@@ -157,7 +156,6 @@ case class StructsToJsonEvaluator(
   }
 
   final def evaluate(value: Any): Any = {
-    if (value == null) return null
     converter(value)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
- The pr aims to remove redundant `whether is null check` when implementing codegen using `Invoke` and `StaticInvoke` (they have a `propagateNull` tag, with a default value of `true`)
- The pr is following up: 
  https://github.com/apache/spark/pull/48224
  https://github.com/apache/spark/pull/48428
  https://github.com/apache/spark/pull/48467
  https://github.com/apache/spark/pull/48509

### Why are the changes needed?
Delete unnecessary logic, improve performance, and reduce misunderstandings.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Pass GA.
- Manually check
```
./build/sbt "sql/testOnly org.apache.spark.sql.JsonFunctionsSuite"
./build/sbt "catalyst/testOnly org.apache.spark.sql.catalyst.expressions.JsonExpressionsSuite"
```
- json_array_length
  JsonFunctionsSuite#`json_array_length function`

- json_object_keys
  JsonFunctionsSuite#`json_object_keys function`

- to_json
 JsonFunctionsSuite#`roundtrip in to_json and from_json - struct`
 JsonFunctionsSuite#`roundtrip in to_json and from_json - array`

- from_json
  JsonFunctionsSuite#`roundtrip in to_json and from_json - struct`

### Was this patch authored or co-authored using generative AI tooling?
No.
