### PR TITLE
[SPARK-50173][PS][SQL] Make pandas expressions accept more datatypes

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PandasAggregate.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/PandasAggregate.scala
@@ -16,17 +16,20 @@
  */
 package org.apache.spark.sql.catalyst.expressions.aggregate
 
-import org.apache.spark.sql.catalyst.expressions.{BooleanLiteral, Expression, IntegerLiteral}
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.errors.QueryCompilationErrors
 
 private[expressions] object PandasAggregate {
-  def expressionToIgnoreNA(e: Expression, source: String): Boolean = e match {
-    case BooleanLiteral(ignoreNA) => ignoreNA
+  def expressionToIgnoreNA(e: Expression, source: String): Boolean = e.eval() match {
+    case b: Boolean => b
     case _ => throw QueryCompilationErrors.invalidIgnoreNAParameter(source, e)
   }
 
-  def expressionToDDOF(e: Expression, source: String): Int = e match {
-    case IntegerLiteral(ddof) => ddof
+  def expressionToDDOF(e: Expression, source: String): Int = e.eval() match {
+    case l: Long => l.toInt
+    case i: Int => i
+    case s: Short => s.toInt
+    case b: Byte => b.toInt
     case _ => throw QueryCompilationErrors.invalidDdofParameter(source, e)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/collect.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/collect.scala
@@ -252,13 +252,16 @@ case class CollectTopK(
 }
 
 private[aggregate] object CollectTopK {
-  def expressionToReverse(e: Expression): Boolean = e match {
-    case BooleanLiteral(reverse) => reverse
+  def expressionToReverse(e: Expression): Boolean = e.eval() match {
+    case b: Boolean => b
     case _ => throw QueryCompilationErrors.invalidReverseParameter(e)
   }
 
-  def expressionToNum(e: Expression): Int = e match {
-    case IntegerLiteral(num) => num
+  def expressionToNum(e: Expression): Int = e.eval() match {
+    case l: Long => l.toInt
+    case i: Int => i
+    case s: Short => s.toInt
+    case b: Byte => b.toInt
     case _ => throw QueryCompilationErrors.invalidNumParameter(e)
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/windowExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/windowExpressions.scala
@@ -1171,8 +1171,9 @@ case class EWM(input: Expression, alpha: Double, ignoreNA: Boolean)
 }
 
 private[expressions] object EWM {
-  def expressionToAlpha(e: Expression): Double = e match {
-    case DoubleLiteral(alpha) => alpha
+  def expressionToAlpha(e: Expression): Double = e.eval() match {
+    case d: Double => d
+    case f: Float => f.toDouble
     case _ => throw QueryCompilationErrors.invalidAlphaParameter(e)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make `ddof` in pandas expressions accept all IntegralType


### Why are the changes needed?
E.g. the `ddof`, existing implementation requires it to be exactly a int, this is too strict for directly using those expressions.



### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
