### PR TITLE
[SPARK-50178][INFRA] Use `PyArrow>=18.0.0` for Python 3.13

### DIFF
--- a/dev/infra/Dockerfile
+++ b/dev/infra/Dockerfile
@@ -148,7 +148,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.13
 # TODO(SPARK-49862) Add BASIC_PIP_PKGS and CONNECT_PIP_PKGS to Python 3.13 image when it supports Python 3.13
 RUN python3.13 -m pip install --ignore-installed blinker>=1.6.2 # mlflow needs this
-RUN python3.13 -m pip install numpy six==1.16.0 pandas==2.2.3 scipy coverage matplotlib openpyxl grpcio==1.67.0 grpcio-status==1.67.0 lxml numpy>=2.1 && \
+RUN python3.13 -m pip install numpy>=2.1 pyarrow>=18.0.0 six==1.16.0 pandas==2.2.3 scipy coverage matplotlib openpyxl grpcio==1.67.0 grpcio-status==1.67.0 lxml && \
     python3.13 -m pip cache purge
 
 # Remove unused installation packages to free up disk space


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `PyArrow>=18.0.0` for Python 3.13 to ensure the test coverage of `PyArrow 18 on Python 3.13`.

### Why are the changes needed?

PyArrow 18.0.0 is the first version which supports Python 3.13 officially.
- https://pypi.org/project/pyarrow/18.0.0/

### Does this PR introduce _any_ user-facing change?

No, this is an infra only change.

### How was this patch tested?

Pass the CI image building. The installed version will be used in Python 3.13 Daily CI.

### Was this patch authored or co-authored using generative AI tooling?

No.