### PR TITLE
[SPARK-50179][CORE] Make `spark.app.name` property optional in REST API

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/rest/SubmitRestProtocolRequest.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/rest/SubmitRestProtocolRequest.scala
@@ -47,7 +47,6 @@ private[rest] class CreateSubmissionRequest extends SubmitRestProtocolRequest {
     super.doValidate()
     assert(sparkProperties != null, "No Spark properties set!")
     assertFieldIsSet(appResource, "appResource")
-    assertPropertyIsSet("spark.app.name")
     assertPropertyIsBoolean(config.DRIVER_SUPERVISE.key)
     assertPropertyIsNumeric(config.DRIVER_CORES.key)
     assertPropertyIsNumeric(config.CORES_MAX.key)

--- a/core/src/test/scala/org/apache/spark/deploy/rest/StandaloneRestSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/rest/StandaloneRestSubmitSuite.scala
@@ -94,7 +94,6 @@ class StandaloneRestSubmitSuite extends SparkFunSuite {
     val RANDOM_PORT = 9000
     val allMasters = s"$masterUrl,${Utils.localHostName()}:$RANDOM_PORT"
     conf.set("spark.master", allMasters)
-    conf.set("spark.app.name", "dreamer")
     val appArgs = Array("one", "two", "six")
     // main method calls this
     val response = new RestSubmissionClientApp().run("app-resource", "main-class", appArgs, conf)
@@ -112,7 +111,6 @@ class StandaloneRestSubmitSuite extends SparkFunSuite {
     val masterUrl = startDummyServer(submitId = submittedDriverId, submitMessage = submitMessage)
     val conf = new SparkConf(loadDefaults = false)
     conf.set("spark.master", masterUrl)
-    conf.set("spark.app.name", "dreamer")
     val appArgs = Array("one", "two", "six")
     // main method calls this
     val response = new RestSubmissionClientApp().run("app-resource", "main-class", appArgs, conf)

--- a/examples/src/main/scripts/submit_pi.sh
+++ b/examples/src/main/scripts/submit_pi.sh
@@ -34,7 +34,6 @@ curl -XPOST http://$SPARK_MASTER:6066/v1/submissions/create \
   "appResource": "",
   "sparkProperties": {
     "spark.submit.deployMode": "cluster",
-    "spark.app.name": "SparkPi",
     "spark.driver.cores": "1",
     "spark.driver.memory": "1g",
     "spark.executor.cores": "1",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `spark.app.name` property optional in REST API.

- When `spark.app.name` is given, Spark 4 will work in the same way without a behavior change like `app-20241030130510-0000` in the following.
- When `spark.app.name` is omitted, Spark 4 will work without any problem like `app-20241030130520-0001` in the following.

![Screenshot 2024-10-30 at 13 05 39](https://github.com/user-attachments/assets/1d75789c-020f-4a0f-9b45-70c1b9e8cde3)

### Why are the changes needed?

Like `SparkSession` and `SparkContext`, `spark.app.name` is optional.

- `SparkSession`
https://github.com/apache/spark/blob/bb8b691b0f66cf50937f24d0b63342ca0da07e9c/python/pyspark/sql/session.py#L396-L399

- `SparkContext`
https://github.com/apache/spark/blob/bb8b691b0f66cf50937f24d0b63342ca0da07e9c/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala#L890-L892

However, `CreateSubmissionRequest` enforces `spark.app.name` existence like the following.
```
{
  "action" : "ErrorResponse",
  "message" : "Malformed request: org.apache.spark.deploy.rest.SubmitRestProtocolException: Validation of message CreateSubmissionRequest failed!...",
  "serverSparkVersion" : "4.0.0-preview2"
}%
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.