### PR TITLE
[SPARK-50193][SS] Fix exception handling for validating time modes

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -678,14 +678,10 @@ case class TransformWithStateExec(
   private def validateTimeMode(): Unit = {
     timeMode match {
       case ProcessingTime =>
-        if (batchTimestampMs.isEmpty) {
-          StateStoreErrors.missingTimeValues(timeMode.toString)
-        }
+        TransformWithStateVariableUtils.validateTimeMode(timeMode, batchTimestampMs)
 
       case EventTime =>
-        if (eventTimeWatermarkForEviction.isEmpty) {
-          StateStoreErrors.missingTimeValues(timeMode.toString)
-        }
+        TransformWithStateVariableUtils.validateTimeMode(timeMode, eventTimeWatermarkForEviction)
 
       case _ =>
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateVariableUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateVariableUtils.scala
@@ -25,6 +25,7 @@ import org.json4s.jackson.JsonMethods.{compact, render}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.streaming.StateVariableType.StateVariableType
 import org.apache.spark.sql.execution.streaming.state.StateStoreErrors
+import org.apache.spark.sql.streaming.TimeMode
 
 /**
  * This file contains utility classes and functions for managing state variables in
@@ -46,6 +47,12 @@ object TransformWithStateVariableUtils {
 
   def getTimerState(stateName: String): TransformWithStateVariableInfo = {
     TransformWithStateVariableInfo(stateName, StateVariableType.TimerState, ttlEnabled = false)
+  }
+
+  def validateTimeMode(timeMode: TimeMode, timestampOpt: Option[Long]): Unit = {
+    if (timeMode != TimeMode.None() && timestampOpt.isEmpty) {
+      throw StateStoreErrors.missingTimeValues(timeMode.toString)
+    }
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix exception handling for validating time modes


### Why are the changes needed?
We were not throwing the exception correctly when time mode validation fails


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added unit tests. Test fails without the change

```
[info] Run completed in 6 seconds, 548 milliseconds.
[info] Total number of tests run: 3
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 3, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```


### Was this patch authored or co-authored using generative AI tooling?
No
