### PR TITLE
[SPARK-50195][CORE] Fix `StandaloneRestServer` to propagate `spark.app.name` to `SparkSubmit` properly

### DIFF
--- a/core/src/test/scala/org/apache/spark/deploy/rest/StandaloneRestSubmitSuite.scala
+++ b/core/src/test/scala/org/apache/spark/deploy/rest/StandaloneRestSubmitSuite.scala
@@ -530,6 +530,21 @@ class StandaloneRestSubmitSuite extends SparkFunSuite {
     assert(conn.getResponseCode === HttpServletResponse.SC_FORBIDDEN)
   }
 
+  test("SPARK-50195: Fix StandaloneRestServer to propagate app name to SparkSubmit properly") {
+    Seq((classOf[SparkSubmit].getName, Seq("-c", "spark.app.name=app1")),
+        ("", Seq.empty)).foreach { case (mainClass, expectedArguments) =>
+      val request = new CreateSubmissionRequest
+      request.appResource = ""
+      request.mainClass = mainClass
+      request.appArgs = Array.empty[String]
+      request.sparkProperties = Map("spark.app.name" -> "app1")
+      request.environmentVariables = Map.empty[String, String]
+      val servlet = new StandaloneSubmitRequestServlet(null, null, null)
+      val desc = servlet.buildDriverDescription(request, "spark://master:7077", 6066)
+      assert(desc.command.arguments.slice(3, 5) === expectedArguments)
+    }
+  }
+
   /* --------------------- *
    |     Helper methods    |
    * --------------------- */


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `StandaloneRestServer` to propagate `spark.app.name` to `SparkSubmit` properly.

### Why are the changes needed?

This is a long-standing bug which PySpark job didn't get a proper `spark.app.name` propagation unlike Scala/Java Spark jobs. Since PySpark jobs are invoked indirectly via `SparkSubmit`, we need to hand over `spark.app.name` via `-c` configuration.

### Does this PR introduce _any_ user-facing change?

This is a bug fix. The new behavior is the expected bahavior.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.