### PR TITLE
[SPARK-50198][ML][CONNECT] Skip CrossValidatorTestsOnConnect if torch is not installed

### DIFF
--- a/python/pyspark/ml/tests/connect/test_connect_tuning.py
+++ b/python/pyspark/ml/tests/connect/test_connect_tuning.py
@@ -19,6 +19,10 @@
 import unittest
 import os
 
+from pyspark.ml.tests.connect.test_connect_classification import (
+    have_torch,
+    torch_requirement_message,
+)
 from pyspark.util import is_remote_only
 from pyspark.sql import SparkSession
 from pyspark.testing.connectutils import should_test_connect, connect_requirement_message
@@ -27,8 +31,10 @@ if should_test_connect:
     from pyspark.ml.tests.connect.test_legacy_mode_tuning import CrossValidatorTestsMixin
 
     @unittest.skipIf(
-        not should_test_connect or is_remote_only(),
-        connect_requirement_message or "Requires PySpark core library in Spark Connect server",
+        not should_test_connect or not have_torch or is_remote_only(),
+        connect_requirement_message
+        or torch_requirement_message
+        or "Requires PySpark core library in Spark Connect server",
     )
     class CrossValidatorTestsOnConnect(CrossValidatorTestsMixin, unittest.TestCase):
         def setUp(self) -> None:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to skip CrossValidatorTestsOnConnect if torch is not installed

### Why are the changes needed?

If tourch isn't available, we should run the tests `CrossValidatorTestsOnConnect`. That's an optional dependency.


To fix Python 3.13 build
https://github.com/apache/spark/actions/runs/11619004508/job/32357758340

### Does this PR introduce _any_ user-facing change?

No, test-only.

### How was this patch tested?

Manually tested.

### Was this patch authored or co-authored using generative AI tooling?

No.