### PR TITLE
[SPARK-50200][PYTHON] Remove unused `have_numpy` testing utility from `sqlutils.py`

### DIFF
--- a/python/pyspark/testing/sqlutils.py
+++ b/python/pyspark/testing/sqlutils.py
@@ -55,12 +55,6 @@ except ImportError as e:
     plotly_requirement_message = str(e)
 have_plotly = plotly_requirement_message is None
 
-numpy_requirement_message = None
-try:
-    import numpy
-except ImportError as e:
-    numpy_requirement_message = str(e)
-have_numpy = numpy_requirement_message is None
 
 from pyspark.sql import SparkSession
 from pyspark.sql.types import ArrayType, DoubleType, UserDefinedType, Row
@@ -70,7 +64,6 @@ from pyspark.testing.utils import ReusedPySparkTestCase, PySparkErrorTestUtils
 have_pandas = pandas_requirement_message is None
 have_pyarrow = pyarrow_requirement_message is None
 test_compiled = test_not_compiled_message is None
-have_numpy = numpy_requirement_message is None
 
 
 class UTCOffsetTimezone(datetime.tzinfo):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove unused `have_numpy` testing utility.

### Why are the changes needed?
Code cleaning.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests.


### Was this patch authored or co-authored using generative AI tooling?
No.