### PR TITLE
[SPARK-49696][SQL][TESTS] Disable flaky test `Cancellation APIs in SparkSession are isolated`

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionJobTaggingAndCancellationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionJobTaggingAndCancellationSuite.scala
@@ -112,7 +112,8 @@ class SparkSessionJobTaggingAndCancellationSuite
         activeJob.properties.get(SQLExecution.EXECUTION_ROOT_ID_KEY).asInstanceOf[String].toLong)))
   }
 
-  test("Cancellation APIs in SparkSession are isolated") {
+  // TODO(SPARK-50205): Re-enable this test case.
+  ignore("Cancellation APIs in SparkSession are isolated") {
     sc = new SparkContext("local[2]", "test")
     val globalSession = SparkSession.builder().sparkContext(sc).getOrCreate()
     var (sessionA, sessionB, sessionC): (SparkSession, SparkSession, SparkSession) =


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR disables a flaky test `SparkSessionJobTaggingAndCancellationSuite.Cancellation APIs in SparkSession are isolated` (failure example: https://github.com/apache/spark/actions/runs/10915451051/job/30295259985). The flakiness is caused by CI sometimes creating only 2 threads instead of the requested 3. We should refactor the test to use only 2 threads.

I created https://issues.apache.org/jira/browse/SPARK-50205 to fix and re-enable this test case.

### Why are the changes needed?

To keep the CI green.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A.

### Was this patch authored or co-authored using generative AI tooling?

No.