### PR TITLE
[SPARK-50206][SQL] Added separate collation id for UTF8_BINARY and non-collated strings

### DIFF
--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationFactory.java
@@ -395,11 +395,7 @@ public final class CollationFactory {
         // instance.
         assert (collationId >= 0 && getDefinitionOrigin(collationId)
           == DefinitionOrigin.PREDEFINED);
-        if (collationId == NON_COLLATED_STRING_COLLATION_ID) {
-          // Skip cache.
-          return CollationSpecUTF8.NON_COLLATED_STRING_COLLATION;
-        }
-        else if (collationId == UTF8_BINARY_COLLATION_ID) {
+        if (collationId == UTF8_BINARY_COLLATION_ID || collationId == DEFAULT_COLLATION_ID) {
           // Skip cache.
           return CollationSpecUTF8.UTF8_BINARY_COLLATION;
         } else if (collationMap.containsKey(collationId)) {
@@ -479,7 +475,7 @@ public final class CollationFactory {
        * explicit/implicit/default UTF8_BINARY collation.
        */
       private enum Utf8BinaryCollationType {
-        STRING, UTF8_BINARY
+        DEFAULT, UTF8_BINARY
       }
 
       /**
@@ -505,10 +501,10 @@ public final class CollationFactory {
       private static final String UTF8_BINARY_COLLATION_NAME = "UTF8_BINARY";
       private static final String UTF8_LCASE_COLLATION_NAME = "UTF8_LCASE";
 
-      private static final int NON_COLLATED_STRING_COLLATION_ID =
+      private static final int DEFAULT_COLLATION_ID =
         new CollationSpecUTF8(
                 CaseSensitivity.UNSPECIFIED,
-                Utf8BinaryCollationType.STRING,
+                Utf8BinaryCollationType.DEFAULT,
                 SpaceTrimming.NONE).collationId;
       private static final int UTF8_BINARY_COLLATION_ID =
         new CollationSpecUTF8(
@@ -518,13 +514,8 @@ public final class CollationFactory {
       private static final int UTF8_LCASE_COLLATION_ID =
         new CollationSpecUTF8(
                 CaseSensitivity.LCASE,
-                Utf8BinaryCollationType.STRING,
+                Utf8BinaryCollationType.DEFAULT,
                 SpaceTrimming.NONE).collationId;
-      protected static Collation NON_COLLATED_STRING_COLLATION =
-        new CollationSpecUTF8(
-                CaseSensitivity.UNSPECIFIED,
-                Utf8BinaryCollationType.STRING,
-                SpaceTrimming.NONE).buildCollation();
       protected static Collation UTF8_BINARY_COLLATION =
         new CollationSpecUTF8(
                 CaseSensitivity.UNSPECIFIED,
@@ -532,7 +523,7 @@ public final class CollationFactory {
                 SpaceTrimming.NONE).buildCollation();
       protected static Collation UTF8_LCASE_COLLATION =
         new CollationSpecUTF8(CaseSensitivity.LCASE,
-                Utf8BinaryCollationType.STRING,
+                Utf8BinaryCollationType.DEFAULT,
                 SpaceTrimming.NONE).buildCollation();
 
       private final CaseSensitivity caseSensitivity;
@@ -1190,8 +1181,8 @@ public final class CollationFactory {
   public static final List<String> SUPPORTED_PROVIDERS = List.of(PROVIDER_SPARK, PROVIDER_ICU);
   public static final String COLLATION_PAD_ATTRIBUTE = "NO_PAD";
 
-  public static final int NON_COLLATED_STRING_COLLATION_ID =
-    Collation.CollationSpecUTF8.NON_COLLATED_STRING_COLLATION_ID;
+  public static final int DEFAULT_COLLATION_ID =
+    Collation.CollationSpecUTF8.DEFAULT_COLLATION_ID;
   public static final int UTF8_BINARY_COLLATION_ID =
     Collation.CollationSpecUTF8.UTF8_BINARY_COLLATION_ID;
   public static final int UTF8_LCASE_COLLATION_ID =
@@ -1268,7 +1259,7 @@ public final class CollationFactory {
    */
   public static boolean isUTF8BinaryCollation(int collationId) {
     return collationId == UTF8_BINARY_COLLATION_ID ||
-      collationId == NON_COLLATED_STRING_COLLATION_ID;
+      collationId == DEFAULT_COLLATION_ID;
   }
 
   public static void assertValidProvider(String provider) throws SparkException {

--- a/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationSupport.java
+++ b/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/util/CollationSupport.java
@@ -50,7 +50,7 @@ public final class CollationSupport {
     }
     public static String genCode(final String s, final String d, final int collationId) {
       String expr = "CollationSupport.StringSplitSQL.exec";
-      if (collationId == CollationFactory.UTF8_BINARY_COLLATION_ID) {
+      if (CollationFactory.isUTF8BinaryCollation(collationId)) {
         return String.format(expr + "Binary(%s, %s)", s, d);
       } else {
         return String.format(expr + "(%s, %s, %d)", s, d, collationId);
@@ -85,7 +85,7 @@ public final class CollationSupport {
     }
     public static String genCode(final String l, final String r, final int collationId) {
       String expr = "CollationSupport.Contains.exec";
-      if (collationId == CollationFactory.UTF8_BINARY_COLLATION_ID) {
+      if (CollationFactory.isUTF8BinaryCollation(collationId)) {
         return String.format(expr + "Binary(%s, %s)", l, r);
       } else {
         return String.format(expr + "(%s, %s, %d)", l, r, collationId);
@@ -125,7 +125,7 @@ public final class CollationSupport {
     }
     public static String genCode(final String l, final String r, final int collationId) {
       String expr = "CollationSupport.StartsWith.exec";
-      if (collationId == CollationFactory.UTF8_BINARY_COLLATION_ID) {
+      if (CollationFactory.isUTF8BinaryCollation(collationId)) {
         return String.format(expr + "Binary(%s, %s)", l, r);
       } else {
         return String.format(expr + "(%s, %s, %d)", l, r, collationId);
@@ -163,7 +163,7 @@ public final class CollationSupport {
     }
     public static String genCode(final String l, final String r, final int collationId) {
       String expr = "CollationSupport.EndsWith.exec";
-      if (collationId == CollationFactory.UTF8_BINARY_COLLATION_ID) {
+      if (CollationFactory.isUTF8BinaryCollation(collationId)) {
         return String.format(expr + "Binary(%s, %s)", l, r);
       } else {
         return String.format(expr + "(%s, %s, %d)", l, r, collationId);
@@ -303,7 +303,7 @@ public final class CollationSupport {
   public static class FindInSet {
     public static int exec(final UTF8String word, final UTF8String set, final int collationId) {
       // FindInSet does space trimming collation as comparison is space trimming collation aware
-      if (collationId == CollationFactory.UTF8_BINARY_COLLATION_ID) {
+      if (CollationFactory.isUTF8BinaryCollation(collationId)) {
         return execBinary(word, set);
       } else {
         return execCollationAware(word, set, collationId);
@@ -311,7 +311,7 @@ public final class CollationSupport {
     }
     public static String genCode(final String word, final String set, final int collationId) {
       String expr = "CollationSupport.FindInSet.exec";
-      if (collationId == CollationFactory.UTF8_BINARY_COLLATION_ID) {
+      if (CollationFactory.isUTF8BinaryCollation(collationId)) {
         return String.format(expr + "Binary(%s, %s)", word, set);
       } else {
         return String.format(expr + "CollationAware(%s, %s, %d)", word, set, collationId);
@@ -344,7 +344,7 @@ public final class CollationSupport {
     public static String genCode(final String string, final String substring,
         final int collationId) {
       String expr = "CollationSupport.StringInstr.exec";
-      if (collationId == CollationFactory.UTF8_BINARY_COLLATION_ID) {
+      if (CollationFactory.isUTF8BinaryCollation(collationId)) {
         return String.format(expr + "Binary(%s, %s)", string, substring);
       } else {
         return String.format(expr + "(%s, %s, %d)", string, substring, collationId);
@@ -419,7 +419,7 @@ public final class CollationSupport {
     public static String genCode(final String string, final String substring, final int start,
         final int collationId) {
       String expr = "CollationSupport.StringLocate.exec";
-      if (collationId == CollationFactory.UTF8_BINARY_COLLATION_ID) {
+      if (CollationFactory.isUTF8BinaryCollation(collationId)) {
         return String.format(expr + "Binary(%s, %s, %d)", string, substring, start);
       } else {
         return String.format(expr + "(%s, %s, %d, %d)", string, substring, start, collationId);
@@ -457,7 +457,7 @@ public final class CollationSupport {
     public static String genCode(final String string, final String delimiter,
         final String count, final int collationId) {
       String expr = "CollationSupport.SubstringIndex.exec";
-      if (collationId == CollationFactory.UTF8_BINARY_COLLATION_ID) {
+      if (CollationFactory.isUTF8BinaryCollation(collationId)) {
         return String.format(expr + "Binary(%s, %s, %s)", string, delimiter, count);
       } else {
         return String.format(expr + "(%s, %s, %s, %d)", string, delimiter, count, collationId);
@@ -532,7 +532,7 @@ public final class CollationSupport {
         final String trimString,
         final int collationId) {
       String expr = "CollationSupport.StringTrim.exec";
-      if (collationId == CollationFactory.UTF8_BINARY_COLLATION_ID) {
+      if (CollationFactory.isUTF8BinaryCollation(collationId)) {
         return String.format(expr + "Binary(%s, %s)", srcString, trimString);
       } else {
         return String.format(expr + "(%s, %s, %d)", srcString, trimString, collationId);
@@ -594,7 +594,7 @@ public final class CollationSupport {
         final String trimString,
         final int collationId) {
       String expr = "CollationSupport.StringTrimLeft.exec";
-      if (collationId == CollationFactory.UTF8_BINARY_COLLATION_ID) {
+      if (CollationFactory.isUTF8BinaryCollation(collationId)) {
         return String.format(expr + "Binary(%s, %s)", srcString, trimString);
       } else {
         return String.format(expr + "(%s, %s, %d)", srcString, trimString, collationId);
@@ -651,7 +651,7 @@ public final class CollationSupport {
         final String trimString,
         final int collationId) {
       String expr = "CollationSupport.StringTrimRight.exec";
-      if (collationId == CollationFactory.UTF8_BINARY_COLLATION_ID) {
+      if (CollationFactory.isUTF8BinaryCollation(collationId)) {
         return String.format(expr + "Binary(%s, %s)", srcString, trimString);
       } else {
         return String.format(expr + "(%s, %s, %d)", srcString, trimString, collationId);

--- a/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
+++ b/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
@@ -38,7 +38,13 @@ class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ig
   test("collationId stability") {
     assert(INDETERMINATE_COLLATION_ID == -1)
 
-    assert(UTF8_BINARY_COLLATION_ID == 0)
+    assert(NON_COLLATED_STRING_COLLATION_ID == 0)
+    val nonCollatedStringCollation = fetchCollation(NON_COLLATED_STRING_COLLATION_ID)
+    assert(nonCollatedStringCollation.collationName == "UTF8_BINARY")
+    assert(nonCollatedStringCollation.isUtf8BinaryType)
+    assert(nonCollatedStringCollation.version == currentIcuVersion)
+
+    assert(UTF8_BINARY_COLLATION_ID == (1 << 17))
     val utf8Binary = fetchCollation(UTF8_BINARY_COLLATION_ID)
     assert(utf8Binary.collationName == "UTF8_BINARY")
     assert(utf8Binary.isUtf8BinaryType)
@@ -435,32 +441,57 @@ class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ig
       1 << 30, // User-defined collation range.
       (1 << 30) | 1, // User-defined collation range.
       (1 << 30) | (1 << 29), // User-defined collation range.
-      1 << 1, // UTF8_BINARY mandatory zero bit 1 breach.
-      1 << 2, // UTF8_BINARY mandatory zero bit 2 breach.
-      1 << 3, // UTF8_BINARY mandatory zero bit 3 breach.
-      1 << 4, // UTF8_BINARY mandatory zero bit 4 breach.
-      1 << 5, // UTF8_BINARY mandatory zero bit 5 breach.
-      1 << 6, // UTF8_BINARY mandatory zero bit 6 breach.
-      1 << 7, // UTF8_BINARY mandatory zero bit 7 breach.
-      1 << 8, // UTF8_BINARY mandatory zero bit 8 breach.
-      1 << 9, // UTF8_BINARY mandatory zero bit 9 breach.
-      1 << 10, // UTF8_BINARY mandatory zero bit 10 breach.
-      1 << 11, // UTF8_BINARY mandatory zero bit 11 breach.
-      1 << 12, // UTF8_BINARY mandatory zero bit 12 breach.
-      1 << 13, // UTF8_BINARY mandatory zero bit 13 breach.
-      1 << 14, // UTF8_BINARY mandatory zero bit 14 breach.
-      1 << 15, // UTF8_BINARY mandatory zero bit 15 breach.
-      1 << 16, // UTF8_BINARY mandatory zero bit 16 breach.
-      1 << 17, // UTF8_BINARY mandatory zero bit 17 breach.
-      1 << 19, // UTF8_BINARY mandatory zero bit 19 breach.
-      1 << 20, // UTF8_BINARY mandatory zero bit 20 breach.
-      1 << 21, // UTF8_BINARY mandatory zero bit 21 breach.
-      1 << 23, // UTF8_BINARY mandatory zero bit 23 breach.
-      1 << 24, // UTF8_BINARY mandatory zero bit 24 breach.
-      1 << 25, // UTF8_BINARY mandatory zero bit 25 breach.
-      1 << 26, // UTF8_BINARY mandatory zero bit 26 breach.
-      1 << 27, // UTF8_BINARY mandatory zero bit 27 breach.
-      1 << 28, // UTF8_BINARY mandatory zero bit 28 breach.
+      1 << 1, // NON_COLLATED_STRING mandatory zero bit 1 breach.
+      1 << 2, // NON_COLLATED_STRING mandatory zero bit 2 breach.
+      1 << 3, // NON_COLLATED_STRING mandatory zero bit 3 breach.
+      1 << 4, // NON_COLLATED_STRING mandatory zero bit 4 breach.
+      1 << 5, // NON_COLLATED_STRING mandatory zero bit 5 breach.
+      1 << 6, // NON_COLLATED_STRING mandatory zero bit 6 breach.
+      1 << 7, // NON_COLLATED_STRING mandatory zero bit 7 breach.
+      1 << 8, // NON_COLLATED_STRING mandatory zero bit 8 breach.
+      1 << 9, // NON_COLLATED_STRING mandatory zero bit 9 breach.
+      1 << 10, // NON_COLLATED_STRING mandatory zero bit 10 breach.
+      1 << 11, // NON_COLLATED_STRING mandatory zero bit 11 breach.
+      1 << 12, // NON_COLLATED_STRING mandatory zero bit 12 breach.
+      1 << 13, // NON_COLLATED_STRING mandatory zero bit 13 breach.
+      1 << 14, // NON_COLLATED_STRING mandatory zero bit 14 breach.
+      1 << 15, // NON_COLLATED_STRING mandatory zero bit 15 breach.
+      1 << 16, // NON_COLLATED_STRING mandatory zero bit 16 breach.
+      1 << 18, // NON_COLLATED_STRING mandatory zero bit 18 breach.
+      1 << 19, // NON_COLLATED_STRING mandatory zero bit 19 breach.
+      1 << 20, // NON_COLLATED_STRING mandatory zero bit 20 breach.
+      1 << 21, // NON_COLLATED_STRING mandatory zero bit 21 breach.
+      1 << 23, // NON_COLLATED_STRING mandatory zero bit 23 breach.
+      1 << 24, // NON_COLLATED_STRING mandatory zero bit 24 breach.
+      1 << 25, // NON_COLLATED_STRING mandatory zero bit 25 breach.
+      1 << 26, // NON_COLLATED_STRING mandatory zero bit 26 breach.
+      1 << 27, // NON_COLLATED_STRING mandatory zero bit 27 breach.
+      1 << 28, // NON_COLLATED_STRING mandatory zero bit 28 breach.
+      (1 << 17) | (1 << 1), // UTF8_BINARY mandatory zero bit 1 breach.
+      (1 << 17) | (1 << 2), // UTF8_BINARY mandatory zero bit 2 breach.
+      (1 << 17) | (1 << 3), // UTF8_BINARY mandatory zero bit 3 breach.
+      (1 << 17) | (1 << 4), // UTF8_BINARY mandatory zero bit 4 breach.
+      (1 << 17) | (1 << 5), // UTF8_BINARY mandatory zero bit 5 breach.
+      (1 << 17) | (1 << 6), // UTF8_BINARY mandatory zero bit 6 breach.
+      (1 << 17) | (1 << 7), // UTF8_BINARY mandatory zero bit 7 breach.
+      (1 << 17) | (1 << 8), // UTF8_BINARY mandatory zero bit 8 breach.
+      (1 << 17) | (1 << 9), // UTF8_BINARY mandatory zero bit 9 breach.
+      (1 << 17) | (1 << 10), // UTF8_BINARY mandatory zero bit 10 breach.
+      (1 << 17) | (1 << 11), // UTF8_BINARY mandatory zero bit 11 breach.
+      (1 << 17) | (1 << 12), // UTF8_BINARY mandatory zero bit 12 breach.
+      (1 << 17) | (1 << 13), // UTF8_BINARY mandatory zero bit 13 breach.
+      (1 << 17) | (1 << 14), // UTF8_BINARY mandatory zero bit 14 breach.
+      (1 << 17) | (1 << 15), // UTF8_BINARY mandatory zero bit 15 breach.
+      (1 << 17) | (1 << 16), // UTF8_BINARY mandatory zero bit 16 breach.
+      (1 << 17) | (1 << 19), // UTF8_BINARY mandatory zero bit 19 breach.
+      (1 << 17) | (1 << 20), // UTF8_BINARY mandatory zero bit 20 breach.
+      (1 << 17) | (1 << 21), // UTF8_BINARY mandatory zero bit 21 breach.
+      (1 << 17) | (1 << 23), // UTF8_BINARY mandatory zero bit 23 breach.
+      (1 << 17) | (1 << 24), // UTF8_BINARY mandatory zero bit 24 breach.
+      (1 << 17) | (1 << 25), // UTF8_BINARY mandatory zero bit 25 breach.
+      (1 << 17) | (1 << 26), // UTF8_BINARY mandatory zero bit 26 breach.
+      (1 << 17) | (1 << 27), // UTF8_BINARY mandatory zero bit 27 breach.
+      (1 << 17) | (1 << 28), // UTF8_BINARY mandatory zero bit 28 breach.
       (1 << 29) | (1 << 12), // ICU mandatory zero bit 12 breach.
       (1 << 29) | (1 << 13), // ICU mandatory zero bit 13 breach.
       (1 << 29) | (1 << 14), // ICU mandatory zero bit 14 breach.

--- a/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
+++ b/common/unsafe/src/test/scala/org/apache/spark/unsafe/types/CollationFactorySuite.scala
@@ -38,8 +38,8 @@ class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ig
   test("collationId stability") {
     assert(INDETERMINATE_COLLATION_ID == -1)
 
-    assert(NON_COLLATED_STRING_COLLATION_ID == 0)
-    val nonCollatedStringCollation = fetchCollation(NON_COLLATED_STRING_COLLATION_ID)
+    assert(DEFAULT_COLLATION_ID == 0)
+    val nonCollatedStringCollation = fetchCollation(DEFAULT_COLLATION_ID)
     assert(nonCollatedStringCollation.collationName == "UTF8_BINARY")
     assert(nonCollatedStringCollation.isUtf8BinaryType)
     assert(nonCollatedStringCollation.version == currentIcuVersion)
@@ -441,32 +441,32 @@ class CollationFactorySuite extends AnyFunSuite with Matchers { // scalastyle:ig
       1 << 30, // User-defined collation range.
       (1 << 30) | 1, // User-defined collation range.
       (1 << 30) | (1 << 29), // User-defined collation range.
-      1 << 1, // NON_COLLATED_STRING mandatory zero bit 1 breach.
-      1 << 2, // NON_COLLATED_STRING mandatory zero bit 2 breach.
-      1 << 3, // NON_COLLATED_STRING mandatory zero bit 3 breach.
-      1 << 4, // NON_COLLATED_STRING mandatory zero bit 4 breach.
-      1 << 5, // NON_COLLATED_STRING mandatory zero bit 5 breach.
-      1 << 6, // NON_COLLATED_STRING mandatory zero bit 6 breach.
-      1 << 7, // NON_COLLATED_STRING mandatory zero bit 7 breach.
-      1 << 8, // NON_COLLATED_STRING mandatory zero bit 8 breach.
-      1 << 9, // NON_COLLATED_STRING mandatory zero bit 9 breach.
-      1 << 10, // NON_COLLATED_STRING mandatory zero bit 10 breach.
-      1 << 11, // NON_COLLATED_STRING mandatory zero bit 11 breach.
-      1 << 12, // NON_COLLATED_STRING mandatory zero bit 12 breach.
-      1 << 13, // NON_COLLATED_STRING mandatory zero bit 13 breach.
-      1 << 14, // NON_COLLATED_STRING mandatory zero bit 14 breach.
-      1 << 15, // NON_COLLATED_STRING mandatory zero bit 15 breach.
-      1 << 16, // NON_COLLATED_STRING mandatory zero bit 16 breach.
-      1 << 18, // NON_COLLATED_STRING mandatory zero bit 18 breach.
-      1 << 19, // NON_COLLATED_STRING mandatory zero bit 19 breach.
-      1 << 20, // NON_COLLATED_STRING mandatory zero bit 20 breach.
-      1 << 21, // NON_COLLATED_STRING mandatory zero bit 21 breach.
-      1 << 23, // NON_COLLATED_STRING mandatory zero bit 23 breach.
-      1 << 24, // NON_COLLATED_STRING mandatory zero bit 24 breach.
-      1 << 25, // NON_COLLATED_STRING mandatory zero bit 25 breach.
-      1 << 26, // NON_COLLATED_STRING mandatory zero bit 26 breach.
-      1 << 27, // NON_COLLATED_STRING mandatory zero bit 27 breach.
-      1 << 28, // NON_COLLATED_STRING mandatory zero bit 28 breach.
+      1 << 1, // DEFAULT_COLLATION mandatory zero bit 1 breach.
+      1 << 2, // DEFAULT_COLLATION mandatory zero bit 2 breach.
+      1 << 3, // DEFAULT_COLLATION mandatory zero bit 3 breach.
+      1 << 4, // DEFAULT_COLLATION mandatory zero bit 4 breach.
+      1 << 5, // DEFAULT_COLLATION mandatory zero bit 5 breach.
+      1 << 6, // DEFAULT_COLLATION mandatory zero bit 6 breach.
+      1 << 7, // DEFAULT_COLLATION mandatory zero bit 7 breach.
+      1 << 8, // DEFAULT_COLLATION mandatory zero bit 8 breach.
+      1 << 9, // DEFAULT_COLLATION mandatory zero bit 9 breach.
+      1 << 10, // DEFAULT_COLLATION mandatory zero bit 10 breach.
+      1 << 11, // DEFAULT_COLLATION mandatory zero bit 11 breach.
+      1 << 12, // DEFAULT_COLLATION mandatory zero bit 12 breach.
+      1 << 13, // DEFAULT_COLLATION mandatory zero bit 13 breach.
+      1 << 14, // DEFAULT_COLLATION mandatory zero bit 14 breach.
+      1 << 15, // DEFAULT_COLLATION mandatory zero bit 15 breach.
+      1 << 16, // DEFAULT_COLLATION mandatory zero bit 16 breach.
+      1 << 18, // DEFAULT_COLLATION mandatory zero bit 18 breach.
+      1 << 19, // DEFAULT_COLLATION mandatory zero bit 19 breach.
+      1 << 20, // DEFAULT_COLLATION mandatory zero bit 20 breach.
+      1 << 21, // DEFAULT_COLLATION mandatory zero bit 21 breach.
+      1 << 23, // DEFAULT_COLLATION mandatory zero bit 23 breach.
+      1 << 24, // DEFAULT_COLLATION mandatory zero bit 24 breach.
+      1 << 25, // DEFAULT_COLLATION mandatory zero bit 25 breach.
+      1 << 26, // DEFAULT_COLLATION mandatory zero bit 26 breach.
+      1 << 27, // DEFAULT_COLLATION mandatory zero bit 27 breach.
+      1 << 28, // DEFAULT_COLLATION mandatory zero bit 28 breach.
       (1 << 17) | (1 << 1), // UTF8_BINARY mandatory zero bit 1 breach.
       (1 << 17) | (1 << 2), // UTF8_BINARY mandatory zero bit 2 breach.
       (1 << 17) | (1 << 3), // UTF8_BINARY mandatory zero bit 3 breach.

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/StringType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/StringType.scala
@@ -56,9 +56,6 @@ class StringType private (val collationId: Int) extends AtomicType with Serializ
   private[sql] def isUTF8BinaryCollation: Boolean =
     CollationFactory.isUTF8BinaryCollation(collationId)
 
-  private[sql] def isNonCollatedString: Boolean =
-    collationId == CollationFactory.NON_COLLATED_STRING_COLLATION_ID
-
   private[sql] def isUTF8LcaseCollation: Boolean =
     collationId == CollationFactory.UTF8_LCASE_COLLATION_ID
 
@@ -77,7 +74,7 @@ class StringType private (val collationId: Int) extends AtomicType with Serializ
    * `string` due to backwards compatibility.
    */
   override def typeName: String =
-    if (isNonCollatedString) "string"
+    if (isUTF8BinaryCollation) "string"
     else s"string collate ${CollationFactory.fetchCollation(collationId).collationName}"
 
   // Due to backwards compatibility and compatibility with other readers
@@ -87,7 +84,7 @@ class StringType private (val collationId: Int) extends AtomicType with Serializ
 
   override def equals(obj: Any): Boolean =
     obj.isInstanceOf[StringType] && (obj.asInstanceOf[StringType].collationId == collationId ||
-        (isUTF8BinaryCollation && obj.asInstanceOf[StringType].isUTF8BinaryCollation))
+      (isUTF8BinaryCollation && obj.asInstanceOf[StringType].isUTF8BinaryCollation))
 
   override def hashCode(): Int = collationId.hashCode()
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/types/StringType.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/types/StringType.scala
@@ -86,7 +86,15 @@ class StringType private (val collationId: Int) extends AtomicType with Serializ
     obj.isInstanceOf[StringType] && (obj.asInstanceOf[StringType].collationId == collationId ||
       (isUTF8BinaryCollation && obj.asInstanceOf[StringType].isUTF8BinaryCollation))
 
-  override def hashCode(): Int = collationId.hashCode()
+  override def hashCode(): Int = {
+    if (isUTF8BinaryCollation) {
+      // Since we have two different collation ids for UTF8_BINARY collation,
+      // we need to separate this case and return the same hashCode for both of them.
+      CollationFactory.UTF8_BINARY_COLLATION_ID.hashCode()
+    } else {
+      collationId.hashCode()
+    }
+  }
 
   /**
    * The default size of a value of the StringType is 20 bytes.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiStringPromotionTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiStringPromotionTypeCoercion.scala
@@ -99,7 +99,7 @@ object AnsiStringPromotionTypeCoercion {
       case (_: StringType, _: AnsiIntervalType) => None
       // [SPARK-50060] If a binary operation contains two collated string types with different
       // collation IDs, we can't decide which collation ID the result should have.
-      case (st1: StringType, st2: StringType) if st1.collationId != st2.collationId => None
+      case (st1: StringType, st2: StringType) if st1 != st2 => None
       case (_: StringType, a: AtomicType) => Some(a)
       case (other, st: StringType) if !other.isInstanceOf[StringType] =>
         findWiderTypeForString(st, other)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
@@ -214,7 +214,7 @@ object CollationTypeCoercion {
 
   private def castStringType(inType: DataType, castType: StringType): Option[DataType] = {
     @Nullable val ret: DataType = inType match {
-      case st: StringType if st.collationId != castType.collationId => castType
+      case st: StringType if st != castType => castType
       case ArrayType(arrType, nullable) =>
         castStringType(arrType, castType).map(ArrayType(_, nullable)).orNull
       case _ => null

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CollationTypeCoercion.scala
@@ -242,17 +242,19 @@ object CollationTypeCoercion {
         case _: Collate => true
         case _ => false
       }
-      .map(_.dataType.asInstanceOf[StringType].collationId)
+      .map(_.dataType)
+      // Since distinct relies on hashCode which is rewritten in StringType,
+      // we can directly call it here.
       .distinct
 
     explicitTypes.size match {
       // We have 1 explicit collation
-      case 1 => StringType(explicitTypes.head)
+      case 1 => explicitTypes.head.asInstanceOf[StringType]
       // Multiple explicit collations occurred
       case size if size > 1 =>
         throw QueryCompilationErrors
           .explicitCollationMismatchError(
-            explicitTypes.map(t => StringType(t))
+            explicitTypes.map(t => t.asInstanceOf[StringType])
           )
       // Only implicit or default collations present
       case 0 =>
@@ -264,16 +266,18 @@ object CollationTypeCoercion {
           }
           .map(_.dataType)
           .filter(hasStringType)
-          .map(extractStringType(_).collationId)
+          .map(extractStringType)
+          // Since distinct relies on hashCode which is rewritten in StringType,
+          // we can directly call it here.
           .distinct
 
         if (implicitTypes.length > 1) {
           throw QueryCompilationErrors.implicitCollationMismatchError(
-            implicitTypes.map(t => StringType(t))
+            implicitTypes
           )
         }
         else {
-          implicitTypes.headOption.map(StringType(_)).getOrElse(SQLConf.get.defaultStringType)
+          implicitTypes.headOption.getOrElse(SQLConf.get.defaultStringType)
         }
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala
@@ -102,7 +102,7 @@ object TypeCoercion extends TypeCoercionBase {
   private def stringPromotion(dt1: DataType, dt2: DataType): Option[DataType] = (dt1, dt2) match {
     // [SPARK-50060] If a binary operation contains two collated string types with different
     // collation IDs, we can't decide which collation ID the result should have.
-    case (st1: StringType, st2: StringType) if st1.collationId != st2.collationId => None
+    case (st1: StringType, st2: StringType) if st1 != st2 => None
     case (st: StringType, t2: AtomicType) if t2 != BinaryType && t2 != BooleanType => Some(st)
     case (t1: AtomicType, st: StringType) if t1 != BinaryType && t1 != BooleanType => Some(st)
     case _ => None

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollationExpressionSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CollationExpressionSuite.scala
@@ -25,10 +25,11 @@ import org.apache.spark.unsafe.types.UTF8String
 class CollationExpressionSuite extends SparkFunSuite with ExpressionEvalHelper {
   test("validate default collation") {
     val collationId = CollationFactory.collationNameToId("UTF8_BINARY")
-    assert(collationId == 0)
+    assert(collationId == CollationFactory.UTF8_BINARY_COLLATION_ID)
     val collateExpr = Collate(Literal("abc"), "UTF8_BINARY")
     assert(collateExpr.dataType === StringType(collationId))
-    assert(collateExpr.dataType.asInstanceOf[StringType].collationId == 0)
+    assert(collateExpr.dataType.asInstanceOf[StringType].collationId ==
+      CollationFactory.UTF8_BINARY_COLLATION_ID)
     checkEvaluation(collateExpr, "abc")
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In this PR, I propose adding a separate collation id for `UTF8_BINARY` collation and for non-collated string type. Furthermore, refactoring of all classes that directly compare `collationId` is proposed, so that `UTF8_BINARY` and `NON_COLLATED_STRING_COLLATION` are considered the same.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
 These changes are needed to differentiate between test cases when we have just a string (e.g. `"abc"`) and a string collated with `UTF8_BINARY` collation (e.g. `"abc" COLLATE UTF8_BINARY`). This would also simplify the collation precedence in case of non-collated strings collation.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
This patch was tested by modifying existing tests in `CollationFactorySuite` and `CollationExpressionSuite`.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.