### PR TITLE
[SPARK-50210][CORE] Fix `SparkSubmit` to show REST API `kill` response properly

### DIFF
--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -109,8 +109,13 @@ private[spark] class SparkSubmit extends Logging {
    */
   private def kill(args: SparkSubmitArguments, sparkConf: SparkConf): Unit = {
     if (RestSubmissionClient.supportsRestClient(args.master)) {
-      new RestSubmissionClient(args.master)
+      val response = new RestSubmissionClient(args.master)
         .killSubmission(args.submissionToKill)
+      if (response.success) {
+        logInfo(s"${args.submissionToKill} is killed successfully.")
+      } else {
+        logError(response.message)
+      }
     } else {
       sparkConf.set("spark.master", args.master)
       SparkSubmitUtils


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `SparkSubmit` to show `REST API` `kill` response properly.

### Why are the changes needed?

**PREPARE SPARK CLUSTER**
```
$ SPARK_MASTER_OPTS='-Dspark.master.rest.enabled=true' sbin/start-master.sh
$ sbin/start-worker.sh spark://$(hostname):7077
```

**BEFORE (4.0.0-preview2)**
`spark-submit` didn't show error messages properly.
```
$ bin/spark-submit --master spark://$(hostname):6066 --kill invalid-submission-id
```

**AFTER**
```
$ bin/spark-submit --master spark://$(hostname):6066 --kill invalid-submission-id
Error: Driver invalid-submission-id has already finished or does not exist
```

```
$ sh examples/src/main/scripts/submit-pi.sh
{
  "action" : "CreateSubmissionResponse",
  "message" : "Driver successfully submitted as driver-20241102232042-0000",
  "serverSparkVersion" : "4.0.0-SNAPSHOT",
  "submissionId" : "driver-20241102232042-0000",
  "success" : true
}%

$ bin/spark-submit --master spark://$(hostname):6066 --kill driver-20241102232042-0000
driver-20241102232042-0000 is killed successfully.
```

### Does this PR introduce _any_ user-facing change?

Yes, but this logs show additional log messages.

### How was this patch tested?

Manual tests because this requires a Spark Standalone Cluster and the difference is only a log of `spark-submit`.

### Was this patch authored or co-authored using generative AI tooling?

No.