### PR TITLE
[SPARK-50222][CORE] Support `spark.submit.appName`

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -889,6 +889,9 @@ object SparkSession extends api.BaseSparkSessionCompanion with Logging {
 
         // No active nor global default session. Create a new one.
         val sparkContext = userSuppliedContext.getOrElse {
+          // Override appName with the submitted appName
+          sparkConf.getOption("spark.submit.appName")
+            .map(sparkConf.setAppName)
           // set a random app name if not given.
           if (!sparkConf.contains("spark.app.name")) {
             sparkConf.setAppName(java.util.UUID.randomUUID().toString)

--- a/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/SparkSessionBuilderSuite.scala
@@ -589,4 +589,13 @@ class SparkSessionBuilderSuite extends SparkFunSuite with Eventually {
       assert(session.conf.get(e._1) == e._2.toString)
     }
   }
+
+  test("SPARK-50222: Support spark.submit.appName") {
+    val session = SparkSession.builder()
+      .master("local")
+      .appName("appName")
+      .config("spark.submit.appName", "newAppName")
+      .getOrCreate()
+    assert(session.sparkContext.appName === "newAppName")
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `spark.submit.appName`.

This is very useful for SRE and admins to re-submit a job multiple times.

### Why are the changes needed?

Usually, `appName` is fixed at compile time like the following and we cannot override with `-Dspark.app.name=xxx`. This PR aims to provide a way to override `appName` during submission time.

https://github.com/apache/spark/blob/0d2d031c2d907393ad6933677ea90ec95a652d50/examples/src/main/scala/org/apache/spark/examples/SparkPi.scala#L28-L31

**EXAMPLE 1**
```
$ bin/run-example -c spark.app.name=SPARK-50222       SparkPi 2>&1 | grep SPARK-50222 | jq

$ bin/run-example -c spark.submit.appName=SPARK-50222 SparkPi 2>&1 | grep SPARK-50222 | jq
{
  "ts": "2024-11-05T01:12:57.434Z",
  "level": "INFO",
  "msg": "Submitted application: SPARK-50222",
  "context": {
    "app_name": "SPARK-50222"
  },
  "logger": "SparkContext"
}
```

**EXAMPLE 2**
```
$ bin/spark-shell -c spark.app.name=SPARK-50222
scala> sc.appName
val res0: String = Spark shell

$ bin/spark-shell --driver-java-options "-Dspark.app.name=SPARK-50222"
scala> sc.appName
val res0: String = Spark shell

$ bin/spark-shell -c spark.submit.appName=SPARK-50222
scala> sc.appName
val res0: String = SPARK-50222
```

### Does this PR introduce _any_ user-facing change?

No, this is a new configuration.

### How was this patch tested?

Pass the CIs with a newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.