### PR TITLE
[SPARK-50224][SQL] The replacements of IsValidUTF8|ValidateUTF8|TryValidateUTF8|MakeValidUTF8 shall be NullIntolerant

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -413,25 +413,25 @@ case class StaticInvoke(
 }
 
 object StaticInvoke {
-    def withNullIntolerant(
-        staticObject: Class[_],
-        dataType: DataType,
-        functionName: String,
-        arguments: Seq[Expression] = Nil,
-        inputTypes: Seq[AbstractDataType] = Nil,
-        propagateNull: Boolean = true,
-        returnNullable: Boolean = true,
-        isDeterministic: Boolean = true,
-        scalarFunction: Option[ScalarFunction[_]] = None): StaticInvoke =
-      new StaticInvoke(
-        staticObject,
-        dataType,
-        functionName,
-        arguments,
-        inputTypes,
-        propagateNull,
-        returnNullable,
-        isDeterministic, scalarFunction) with NullIntolerant
+  def withNullIntolerant(
+      staticObject: Class[_],
+      dataType: DataType,
+      functionName: String,
+      arguments: Seq[Expression] = Nil,
+      inputTypes: Seq[AbstractDataType] = Nil,
+      propagateNull: Boolean = true,
+      returnNullable: Boolean = true,
+      isDeterministic: Boolean = true,
+      scalarFunction: Option[ScalarFunction[_]] = None): StaticInvoke =
+    new StaticInvoke(
+      staticObject,
+      dataType,
+      functionName,
+      arguments,
+      inputTypes,
+      propagateNull,
+      returnNullable,
+      isDeterministic, scalarFunction) with NullIntolerant
 }
 
 /**

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/objects/objects.scala
@@ -412,6 +412,28 @@ case class StaticInvoke(
     }.$functionName(${arguments.mkString(", ")}))"
 }
 
+object StaticInvoke {
+    def withNullIntolerant(
+        staticObject: Class[_],
+        dataType: DataType,
+        functionName: String,
+        arguments: Seq[Expression] = Nil,
+        inputTypes: Seq[AbstractDataType] = Nil,
+        propagateNull: Boolean = true,
+        returnNullable: Boolean = true,
+        isDeterministic: Boolean = true,
+        scalarFunction: Option[ScalarFunction[_]] = None): StaticInvoke =
+      new StaticInvoke(
+        staticObject,
+        dataType,
+        functionName,
+        arguments,
+        inputTypes,
+        propagateNull,
+        returnNullable,
+        isDeterministic, scalarFunction) with NullIntolerant
+}
+
 /**
  * Calls the specified function on an object, optionally passing arguments.  If the `targetObject`
  * expression evaluates to null then null will be returned.
@@ -553,6 +575,27 @@ case class Invoke(
 
   override protected def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Invoke =
     copy(targetObject = newChildren.head, arguments = newChildren.tail)
+}
+
+object Invoke {
+  def withNullIntolerant(
+      targetObject: Expression,
+      functionName: String,
+      dataType: DataType,
+      arguments: Seq[Expression] = Nil,
+      methodInputTypes: Seq[AbstractDataType] = Nil,
+      propagateNull: Boolean = true,
+      returnNullable: Boolean = true,
+      isDeterministic: Boolean = true): Invoke =
+    new Invoke(
+      targetObject,
+      functionName,
+      dataType,
+      arguments,
+      methodInputTypes,
+      propagateNull,
+      returnNullable,
+      isDeterministic) with NullIntolerant
 }
 
 object NewInstance {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala
@@ -747,7 +747,8 @@ case class EndsWith(left: Expression, right: Expression) extends StringPredicate
 case class IsValidUTF8(input: Expression) extends RuntimeReplaceable with ImplicitCastInputTypes
   with UnaryLike[Expression] with NullIntolerant {
 
-  override lazy val replacement: Expression = Invoke(input, "isValid", BooleanType)
+  override lazy val replacement: Expression =
+    Invoke.withNullIntolerant(input, "isValid", BooleanType)
 
   override def inputTypes: Seq[AbstractDataType] =
     Seq(StringTypeWithCollation(supportsTrimCollation = true))
@@ -795,7 +796,8 @@ case class IsValidUTF8(input: Expression) extends RuntimeReplaceable with Implic
 case class MakeValidUTF8(input: Expression) extends RuntimeReplaceable with ImplicitCastInputTypes
   with UnaryLike[Expression] with NullIntolerant {
 
-  override lazy val replacement: Expression = Invoke(input, "makeValid", input.dataType)
+  override lazy val replacement: Expression =
+    Invoke.withNullIntolerant(input, "makeValid", input.dataType)
 
   override def inputTypes: Seq[AbstractDataType] =
     Seq(StringTypeWithCollation(supportsTrimCollation = true))
@@ -836,12 +838,13 @@ case class MakeValidUTF8(input: Expression) extends RuntimeReplaceable with Impl
 case class ValidateUTF8(input: Expression) extends RuntimeReplaceable with ImplicitCastInputTypes
   with UnaryLike[Expression] with NullIntolerant {
 
-  override lazy val replacement: Expression = StaticInvoke(
-    classOf[ExpressionImplUtils],
-    input.dataType,
-    "validateUTF8String",
-    Seq(input),
-    inputTypes)
+  override lazy val replacement: Expression =
+    StaticInvoke.withNullIntolerant(
+      classOf[ExpressionImplUtils],
+      input.dataType,
+      "validateUTF8String",
+      Seq(input),
+      inputTypes)
 
   override def inputTypes: Seq[AbstractDataType] =
     Seq(StringTypeWithCollation(supportsTrimCollation = true))
@@ -886,12 +889,13 @@ case class ValidateUTF8(input: Expression) extends RuntimeReplaceable with Impli
 case class TryValidateUTF8(input: Expression) extends RuntimeReplaceable with ImplicitCastInputTypes
   with UnaryLike[Expression] with NullIntolerant {
 
-  override lazy val replacement: Expression = StaticInvoke(
-    classOf[ExpressionImplUtils],
-    input.dataType,
-    "tryValidateUTF8String",
-    Seq(input),
-    inputTypes)
+  override lazy val replacement: Expression =
+    StaticInvoke.withNullIntolerant(
+      classOf[ExpressionImplUtils],
+      input.dataType,
+      "tryValidateUTF8String",
+      Seq(input),
+      inputTypes)
 
   override def inputTypes: Seq[AbstractDataType] =
     Seq(StringTypeWithCollation(supportsTrimCollation = true))


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes replacements of IsValidUTF8|ValidateUTF8|TryValidateUTF8|MakeValidUTF8 functions to be NullIntolerant deriving from their origins so that we can actually construct IsNotNull constraints for them.

This is also a common issue for other RuntimeReplaceable expressions, I will revisit them in groups. SPARK-50223.

### Why are the changes needed?

Common strategy for performance improvement.


### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->

new tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
no