### PR TITLE
[SPARK-50229] Reduce memory usage on driver for wide schemas by reducing the lifetime of AttributeReference objects created during logical planning

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala
@@ -2098,7 +2098,7 @@ case class LateralJoin(
     joinType: JoinType,
     condition: Option[Expression]) extends UnaryNode {
 
-  override lazy val allAttributes: AttributeSeq = left.output ++ right.plan.output
+  override def allAttributes: AttributeSeq = left.output ++ right.plan.output
 
   require(Seq(Inner, LeftOuter, Cross).contains(joinType),
     s"Unsupported lateral join type $joinType")

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/HashAggregateExec.scala
@@ -63,7 +63,7 @@ case class HashAggregateExec(
 
   require(Aggregate.supportsHashAggregate(aggregateBufferAttributes, groupingExpressions))
 
-  override lazy val allAttributes: AttributeSeq =
+  override def allAttributes: AttributeSeq =
     child.output ++ aggregateBufferAttributes ++ aggregateAttributes ++
       aggregateExpressions.flatMap(_.aggregateFunction.inputAggBufferAttributes)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/aggregate/ObjectHashAggregateExec.scala
@@ -69,7 +69,7 @@ case class ObjectHashAggregateExec(
     child: SparkPlan)
   extends BaseAggregateExec {
 
-  override lazy val allAttributes: AttributeSeq =
+  override def allAttributes: AttributeSeq =
     child.output ++ aggregateBufferAttributes ++ aggregateAttributes ++
       aggregateExpressions.flatMap(_.aggregateFunction.inputAggBufferAttributes)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

This PR changes the `allAttributes` in `QueryPlan` to be a `def` instead of a `lazy val` to avoid holding on to a copy of `AttributeReferences` in the `QueryPlan` object. This change should not result in a performance penalty as `allAttributes` is used only once during canonicalization in `doCanonicalize` (which only happens once since it itself is a `lazy val`).


## Context 
The allAttributes method in QueryPlan ([code](https://github.com/apache/spark/blob/57f6824e78e2e615778827ddebce9d7fcaae1698/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/basicLogicalOperators.scala#L2101)) unions the output of all of its children. Although this is okay in an optimized plan, in a pre-optimized analyzed plan, these attributes add up multiplicatively with the size of the plan. Because output is usually defined as a def, each node’s allAttributes also ends up with a distinct copy of each attribute, potentially causing significant memory pressure on the driver (especially under concurrency and with wide tables).

Here is a simple example with TPC-DS Q42. SQL:
```
  select dt.d_year, item.i_category_id, item.i_category, sum(ss_ext_sales_price)
 from 	date_dim dt, store_sales, item
 where dt.d_date_sk = store_sales.ss_sold_date_sk
 	and store_sales.ss_item_sk = item.i_item_sk
 	and item.i_manager_id = 1
 	and dt.d_moy=11
 	and dt.d_year=2000
 group by 	dt.d_year
 		,item.i_category_id
 		,item.i_category
 order by       sum(ss_ext_sales_price) desc,dt.d_year
 		,item.i_category_id
 		,item.i_category
 limit 100
```
If we print out the size of each operator’s output and the size of its allAttributes:
```
GlobalLimit: allAttrs: 4, output: 4
  LocalLimit: allAttrs: 4, output: 4
    Sort: allAttrs: 4, output: 4
      Aggregate: allAttrs: 73, output: 4
        Filter: allAttrs: 73, output: 73
          Join: allAttrs: 73, output: 73
            Join: allAttrs: 51, output: 51
              SubqueryAlias: allAttrs: 28, output: 28
                SubqueryAlias: allAttrs: 28, output: 28
                  LogicalRelation: allAttrs: 0, output: 28
              SubqueryAlias: allAttrs: 23, output: 23
                LogicalRelation: allAttrs: 0, output: 23
            SubqueryAlias: allAttrs: 22, output: 22
              LogicalRelation: allAttrs: 0, output: 22
```
Note how the joins and aggregate have 73 attributes each, by adding the width of each relation. For prod queries with wide schemas, this issue is much worse. Optimized plans after column pruning look far better:
```
Aggregate: allAttrs: 0, output: 1
  Project: allAttrs: 2, output: 0
    Join: allAttrs: 2, output: 2
      Project: allAttrs: 3, output: 1
        Join: allAttrs: 3, output: 3
          Project: allAttrs: 4, output: 2
            Join: allAttrs: 4, output: 4
              Project: allAttrs: 5, output: 3
                Join: allAttrs: 5, output: 5
                  Project: allAttrs: 23, output: 4
                    Filter: allAttrs: 23, output: 23
                      LogicalRelation: allAttrs: 0, output: 23
                  Project: allAttrs: 29, output: 1
                    Filter: allAttrs: 29, output: 29
                      LogicalRelation: allAttrs: 0, output: 29
              Project: allAttrs: 13, output: 1
                Filter: allAttrs: 13, output: 13
                  LogicalRelation: allAttrs: 0, output: 13
          Project: allAttrs: 22, output: 1
            Filter: allAttrs: 22, output: 22
              LogicalRelation: allAttrs: 0, output: 22
      Project: allAttrs: 18, output: 1
        Filter: allAttrs: 18, output: 18
          LogicalRelation: allAttrs: 0, output: 18
```



### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Reduce driver's heap usage.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Existing tests

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No