### PR TITLE
[SPARK-50232][PYTHON][CONNECT] Add 'protobuf==5.28.3' in dev/requirements.txt

### DIFF
--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -61,6 +61,7 @@ py
 grpcio>=1.67.0
 grpcio-status>=1.67.0
 googleapis-common-protos>=1.65.0
+protobuf==5.28.3
 
 # Spark Connect python proto generation plugin (optional)
 mypy-protobuf==3.3.0


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add 'protobuf==5.28.3' in `dev/requirements.txt`. If you have an old version in your env, you would face an error like:

```
google.protobuf.runtime_version.VersionError: Detected incompatible Protobuf Gencode/Runtime versions when loading spark/connect/base.proto: gencode 5.28.3 runtime 5.28.2. Runtime version cannot be older than the linked gencode version. See Protobuf version guarantees at https://protobuf.dev/support/cross-version-runtime-guarantee.
```

This PR is a sort of a followup of https://github.com/apache/spark/pull/48644

### Why are the changes needed?

So developers can easily set up their env.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually installed and tested.

### Was this patch authored or co-authored using generative AI tooling?

No.