### PR TITLE
[SPARK-50135][BUILD] Upgrade ZooKeeper to 3.9.3

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -278,6 +278,6 @@ xbean-asm9-shaded/4.26//xbean-asm9-shaded-4.26.jar
 xmlschema-core/2.3.1//xmlschema-core-2.3.1.jar
 xz/1.10//xz-1.10.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
-zookeeper-jute/3.9.2//zookeeper-jute-3.9.2.jar
-zookeeper/3.9.2//zookeeper-3.9.2.jar
+zookeeper-jute/3.9.3//zookeeper-jute-3.9.3.jar
+zookeeper/3.9.3//zookeeper-3.9.3.jar
 zstd-jni/1.5.6-7//zstd-jni-1.5.6-7.jar

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <protobuf.version>4.28.3</protobuf.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <yarn.version>${hadoop.version}</yarn.version>
-    <zookeeper.version>3.9.2</zookeeper.version>
+    <zookeeper.version>3.9.3</zookeeper.version>
     <curator.version>5.7.1</curator.version>
     <hive.group>org.apache.hive</hive.group>
     <hive.classifier>core</hive.classifier>

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1059,9 +1059,25 @@ object KubernetesIntegrationTests {
 object DependencyOverrides {
   lazy val guavaVersion = sys.props.get("guava.version").getOrElse("33.1.0-jre")
   lazy val settings = Seq(
-    dependencyOverrides += "com.google.guava" % "guava" % guavaVersion,
-    dependencyOverrides += "jline" % "jline" % "2.14.6",
-    dependencyOverrides += "org.apache.avro" % "avro" % "1.11.3")
+    dependencyOverrides ++= {
+      val nettyVersion = SbtPomKeys.effectivePom.value.getProperties.get(
+        "netty.version").asInstanceOf[String]
+      Seq(
+        "com.google.guava" % "guava" % guavaVersion,
+        "jline" % "jline" % "2.14.6",
+        "org.apache.avro" % "avro" % "1.11.3",
+        "io.netty" % "netty-buffer" % nettyVersion,
+        "io.netty" % "netty-codec" % nettyVersion,
+        "io.netty" % "netty-common" % nettyVersion,
+        "io.netty" % "netty-handler" % nettyVersion,
+        "io.netty" % "netty-resolver" % nettyVersion,
+        "io.netty" % "netty-transport" % nettyVersion,
+        "io.netty" % "netty-transport-classes-epoll" % nettyVersion,
+        "io.netty" % "netty-transport-native-epoll" % nettyVersion,
+        "io.netty" % "netty-transport-native-unix-common" % nettyVersion
+      )
+    }
+  )
 }
 
 /**

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1059,25 +1059,9 @@ object KubernetesIntegrationTests {
 object DependencyOverrides {
   lazy val guavaVersion = sys.props.get("guava.version").getOrElse("33.1.0-jre")
   lazy val settings = Seq(
-    dependencyOverrides ++= {
-      val nettyVersion = SbtPomKeys.effectivePom.value.getProperties.get(
-        "netty.version").asInstanceOf[String]
-      Seq(
-        "com.google.guava" % "guava" % guavaVersion,
-        "jline" % "jline" % "2.14.6",
-        "org.apache.avro" % "avro" % "1.11.3",
-        "io.netty" % "netty-buffer" % nettyVersion,
-        "io.netty" % "netty-codec" % nettyVersion,
-        "io.netty" % "netty-common" % nettyVersion,
-        "io.netty" % "netty-handler" % nettyVersion,
-        "io.netty" % "netty-resolver" % nettyVersion,
-        "io.netty" % "netty-transport" % nettyVersion,
-        "io.netty" % "netty-transport-classes-epoll" % nettyVersion,
-        "io.netty" % "netty-transport-native-epoll" % nettyVersion,
-        "io.netty" % "netty-transport-native-unix-common" % nettyVersion
-      )
-    }
-  )
+    dependencyOverrides += "com.google.guava" % "guava" % guavaVersion,
+    dependencyOverrides += "jline" % "jline" % "2.14.6",
+    dependencyOverrides += "org.apache.avro" % "avro" % "1.11.3")
 }
 
 /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade `ZooKeeper` from `3.9.2` to `3.9.3`.
This PR is to fix potential issues with PR https://github.com/apache/spark/pull/48666


### Why are the changes needed?
The full release notes: https://zookeeper.apache.org/doc/r3.9.3/releasenotes.html

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
- Pass GA.
- Manually check
```shell
./build/sbt -Phadoop-3 -Pkubernetes -Pkinesis-asl -Phive-thriftserver -Pdocker-integration-tests -Pyarn -Phadoop-cloud -Pspark-ganglia-lgpl -Phive -Pjvm-profiler clean package

[info] Note: Some input files use or override a deprecated API.
[info] Note: Recompile with -Xlint:deprecation for details.
[warn] multiple main classes detected: run 'show discoveredMainClasses' to see the list
[success] Total time: 272 s (04:32), completed Nov 6, 2024, 4:29:52 PM
```

```shell
(pyspark) ➜  spark-community git:(SPARK-50135_FOLLOWUP) ✗ ./python/run-tests --python-executables=python3 --testnames "pyspark.sql.tests.connect.test_connect_collection"
Running PySpark tests. Output is in /Users/panbingkun/Developer/spark/spark-community/python/unit-tests.log
Will test against the following Python executables: ['python3']
Will test the following Python tests: ['pyspark.sql.tests.connect.test_connect_collection']
python3 python_implementation is CPython
python3 version is: Python 3.9.19
Starting test(python3): pyspark.sql.tests.connect.test_connect_collection (temp output: /Users/panbingkun/Developer/spark/spark-community/python/target/097bd7e0-9311-4484-ae2d-c0f4c63fc6f9/python3__pyspark.sql.tests.connect.test_connect_collection__8dzaeio9.log)
Finished test(python3): pyspark.sql.tests.connect.test_connect_collection (14s)
Tests passed in 14 seconds

```

### Was this patch authored or co-authored using generative AI tooling?
No.
