### PR TITLE
[SPARK-50249][PYTHON][SQL] Trigger Python source lookup only once

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
@@ -99,7 +99,7 @@ object DataSourceManager extends Logging {
 
   private def normalize(name: String): String = name.toLowerCase(Locale.ROOT)
 
-  private def initialStaticDataSourceBuilders: Map[String, UserDefinedPythonDataSource] = {
+  private lazy val initialStaticDataSourceBuilders: Map[String, UserDefinedPythonDataSource] = {
     if (shouldLoadPythonDataSources) this.synchronized {
       if (dataSourceBuilders.isEmpty) {
         val maybeResult = try {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to trigger Python source lookup only once.

### Why are the changes needed?

For now, we trigger Python source lookup for every session creation. Python source lookup is expensive so it should happen only once statically.

### Does this PR introduce _any_ user-facing change?

Yes, a bit of performance improvement.

### How was this patch tested?

Manually.

### Was this patch authored or co-authored using generative AI tooling?

No.