### PR TITLE
[SPARK-48898][SQL] Add Variant shredding functions

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3319,6 +3319,12 @@
     ],
     "sqlState" : "22023"
   },
+  "INVALID_VARIANT_SCHEMA" : {
+    "message" : [
+      "The schema `<schema>` is not a valid variant shredding schema."
+    ],
+    "sqlState" : "22023"
+  },
   "INVALID_WHERE_CONDITION" : {
     "message" : [
       "The WHERE condition <condition> contains invalid expressions: <expressionList>.",

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -3319,7 +3319,7 @@
     ],
     "sqlState" : "22023"
   },
-  "INVALID_VARIANT_SCHEMA" : {
+  "INVALID_VARIANT_SHREDDING_SCHEMA" : {
     "message" : [
       "The schema `<schema>` is not a valid variant shredding schema."
     ],

--- a/common/variant/src/main/java/org/apache/spark/types/variant/Variant.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/Variant.java
@@ -193,6 +193,18 @@ public final class Variant {
     });
   }
 
+  // Get the dictionary ID for the object field at the `index` slot. Throws malformedVariatn if
+  // `index` is out of the bound of `[0, objectSize())`.
+  // It is only legal to call it when `getType()` is `Type.OBJECT`.
+  public int getDictionaryIdAtIndex(int index) {
+    return handleObject(value, pos, (size, idSize, offsetSize, idStart, offsetStart, dataStart) -> {
+      if (index < 0 || index >= size) {
+        throw malformedVariant();
+      }
+      return readUnsigned(value, idStart + idSize * index, idSize);
+    });
+  }
+
   // Get the number of array elements in the variant.
   // It is only legal to call it when `getType()` is `Type.ARRAY`.
   public int arraySize() {

--- a/common/variant/src/main/java/org/apache/spark/types/variant/Variant.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/Variant.java
@@ -193,7 +193,7 @@ public final class Variant {
     });
   }
 
-  // Get the dictionary ID for the object field at the `index` slot. Throws malformedVariatn if
+  // Get the dictionary ID for the object field at the `index` slot. Throws malformedVariant if
   // `index` is out of the bound of `[0, objectSize())`.
   // It is only legal to call it when `getType()` is `Type.OBJECT`.
   public int getDictionaryIdAtIndex(int index) {

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantBuilder.java
@@ -109,7 +109,8 @@ public class VariantBuilder {
 
   // Return the variant value only, without metadata.
   // Used in shredding to produce a final value, where all shredded values refer to a common
-  // metadata.
+  // metadata. It is expected to be called instead of `result()`, although it is valid to call both
+  // methods, in any order.
   public byte[] valueWithoutMetadata() {
     return Arrays.copyOfRange(writeBuffer, 0, writePos);
   }
@@ -411,11 +412,7 @@ public class VariantBuilder {
         });
         break;
       default:
-        int size = valueSize(value, pos);
-        checkIndex(pos + size - 1, value.length);
-        checkCapacity(size);
-        System.arraycopy(value, pos, writeBuffer, writePos, size);
-        writePos += size;
+        shallowAppendVariantImpl(value, pos);
         break;
     }
   }
@@ -424,10 +421,14 @@ public class VariantBuilder {
   // building an object during shredding, where there is a fixed pre-existing metadata that
   // all shredded values will refer to.
   public void shallowAppendVariant(Variant v) {
-    int size = valueSize(v.value, v.pos);
-    checkIndex(v.pos + size - 1, v.value.length);
+    shallowAppendVariantImpl(v.value, v.pos);
+  }
+
+  private void shallowAppendVariantImpl(byte[] value, int pos) {
+    int size = valueSize(value, pos);
+    checkIndex(pos + size - 1, value.length);
     checkCapacity(size);
-    System.arraycopy(v.value, v.pos, writeBuffer, writePos, size);
+    System.arraycopy(value, pos, writeBuffer, writePos, size);
     writePos += size;
   }
 

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantSchema.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantSchema.java
@@ -99,14 +99,21 @@ public class VariantSchema {
   public static final class TimestampNTZType extends ScalarType {
   }
 
+  // The index of the typed_value, value, and metadata fields in the schema, respectively. I given
+  // field is not in the schema, its value must be set to -1 to indicate that it is invalid. The
+  // indices of valid fields should be contiguous and start from 0.
   public final int typedIdx;
   public final int variantIdx;
+  // topLevelMetadataIdx must be non-negative in the top-level schema, and -1 at all other nesting
+  // levels.
   public final int topLevelMetadataIdx;
+  // The number of fields in the schema. I.e. a value between 1 and 3, depending on which of value,
+  // typed_value and metadata are present.
   public final int numFields;
 
   public final ScalarType scalarSchema;
   public final ObjectField[] objectSchema;
-  // Map for fast lookup of object fields by name.
+  // Map for fast lookup of object fields by name. The values are an index into `objectSchema`.
   public final Map<String, Integer> objectSchemaMap;
   public final VariantSchema arraySchema;
 

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantSchema.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantSchema.java
@@ -99,9 +99,9 @@ public class VariantSchema {
   public static final class TimestampNTZType extends ScalarType {
   }
 
-  // The index of the typed_value, value, and metadata fields in the schema, respectively. I given
-  // field is not in the schema, its value must be set to -1 to indicate that it is invalid. The
-  // indices of valid fields should be contiguous and start from 0.
+  // The index of the typed_value, value, and metadata fields in the schema, respectively. If a
+  // given field is not in the schema, its value must be set to -1 to indicate that it is invalid.
+  // The indices of valid fields should be contiguous and start from 0.
   public final int typedIdx;
   public final int variantIdx;
   // topLevelMetadataIdx must be non-negative in the top-level schema, and -1 at all other nesting

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantSchema.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantSchema.java
@@ -50,7 +50,7 @@ public class VariantSchema {
     }
   }
 
-  public static abstract class ScalarType {
+  public abstract static class ScalarType {
   }
 
   public static final class StringType extends ScalarType {

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantSchema.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantSchema.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.types.variant;
+
+import java.util.Map;
+
+/**
+ * Defines a valid shredding schema, as described in
+ * https://github.com/apache/parquet-format/blob/master/VariantShredding.md.
+ * A shredding schema contains a value and optional typed_value field.
+ * If a typed_value is an array or struct, it recursively contain its own shredding schema for
+ * elements and fields, respectively.
+ * The schema also contains a metadata field at the top level, but not in recursively shredded
+ * fields.
+ */
+public class VariantSchema {
+
+  // Represents one field of an object in the shredding schema.
+  public static final class ObjectField {
+    // The index of the field in the write schema. E.g. in Spark, it is the position within the
+    // corresponding InternalRow. Indices for an object schema must be zero-indexed and dense; i.e.
+    // they must cover the range [0, numFields - 1] with no gaps.
+    public final int idx;
+    public final VariantSchema schema;
+
+    public ObjectField(int idx, VariantSchema schema) {
+      this.idx = idx;
+      this.schema = schema;
+    }
+
+    @Override
+    public String toString() {
+      return "ObjectField{" +
+          "idx=" + idx +
+          ", schema=" + schema +
+          '}';
+    }
+  }
+
+  public static abstract class ScalarType {
+  }
+
+  public static final class StringType extends ScalarType {
+  }
+
+  public enum IntegralSize {
+    BYTE, SHORT, INT, LONG
+  }
+
+  public static final class IntegralType extends ScalarType {
+    public final IntegralSize size;
+
+    public IntegralType(IntegralSize size) {
+      this.size = size;
+    }
+  }
+
+  public static final class FloatType extends ScalarType {
+  }
+
+  public static final class DoubleType extends ScalarType {
+  }
+
+  public static final class BooleanType extends ScalarType {
+  }
+
+  public static final class BinaryType extends ScalarType {
+  }
+
+  public static final class DecimalType extends ScalarType {
+    public final int precision;
+    public final int scale;
+
+    public DecimalType(int precision, int scale) {
+      this.precision = precision;
+      this.scale = scale;
+    }
+  }
+
+  public static final class DateType extends ScalarType {
+  }
+
+  public static final class TimestampType extends ScalarType {
+  }
+
+  public static final class TimestampNTZType extends ScalarType {
+  }
+
+  public final int typedIdx;
+  public final int variantIdx;
+  public final int topLevelMetadataIdx;
+  public final int numFields;
+
+  public final ScalarType scalarSchema;
+  public final Map<String, ObjectField> objectSchema;
+  public final VariantSchema arraySchema;
+
+  public VariantSchema(int typedIdx, int variantIdx, int topLevelMetadataIdx, int numFields,
+                       ScalarType scalarSchema, Map<String, ObjectField> objectSchema,
+                       VariantSchema arraySchema) {
+    this.typedIdx = typedIdx;
+    this.numFields = numFields;
+    this.variantIdx = variantIdx;
+    this.topLevelMetadataIdx = topLevelMetadataIdx;
+    this.scalarSchema = scalarSchema;
+    this.objectSchema = objectSchema;
+    this.arraySchema = arraySchema;
+  }
+
+  @Override
+  public String toString() {
+    return "VariantSchema{" +
+        "typedIdx=" + typedIdx +
+        ", variantIdx=" + variantIdx +
+        ", topLevelMetadataIdx=" + topLevelMetadataIdx +
+        ", numFields=" + numFields +
+        ", scalarSchema=" + scalarSchema +
+        ", objectSchema=" + objectSchema +
+        ", arraySchema=" + arraySchema +
+        '}';
+  }
+}

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantShreddingWriter.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantShreddingWriter.java
@@ -1,0 +1,298 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.types.variant;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Class to implement shredding a Variant value.
+ */
+public class VariantShreddingWriter {
+
+  // Interface to build up a shredded result. Callers should implement a ShreddedResultBuilder
+  // to create an empty result. The castShredded method will call one or more of the add* methods
+  // to populate it.
+  public interface ShreddedResult {
+    // Create an array. The elements are the result of shredding each element.
+    void addArray(VariantSchema schema, List<ShreddedResult> array);
+    // Create an object. The values are the result of shredding each field, order by the index in
+    // objectSchema. Missing fields are populated with an empty result.
+    void addObject(VariantSchema schema, ShreddedResult[] values);
+    void addVariantValue(VariantSchema schema, byte[] result);
+    // Add a scalar to typed_value. The type of Object depends on the scalarSchema in the shredding
+    // schema.
+    void addScalar(VariantSchema schema, Object result);
+    void addMetadata(VariantSchema schema, byte[] result);
+  }
+
+  public interface ShreddedResultBuilder {
+    ShreddedResult createEmpty(VariantSchema schema);
+
+    // If true, we will shred decimals to a different scale or to integers, as long as they are
+    // numerically equivalent. Similarly, integers will be allowed to shred to decimals.
+    boolean allowNumericScaleChanges();
+  }
+
+  /**
+   * Converts an input variant into shredded components. Returns the shredded result, as well
+   * as the original Variant with shredded fields removed.
+   * `dataType` must be a valid shredding schema, as described in common/variant/shredding.md.
+   */
+  public static ShreddedResult castShredded(
+          Variant v,
+          VariantSchema schema,
+          ShreddedResultBuilder builder) {
+    VariantUtil.Type variantType = v.getType();
+    ShreddedResult result = builder.createEmpty(schema);
+
+    if (schema.topLevelMetadataIdx >= 0) {
+      result.addMetadata(schema, v.getMetadata());
+    }
+
+    if (schema.arraySchema != null && variantType == VariantUtil.Type.ARRAY) {
+      // The array element is always a struct containing untyped and typed fields.
+      VariantSchema elementSchema = schema.arraySchema;
+      int size = v.arraySize();
+      ArrayList<ShreddedResult> array = new ArrayList<>(size);
+      for (int i = 0; i < size; ++i) {
+        ShreddedResult shreddedArray = castShredded(v.getElementAtIndex(i), elementSchema, builder);
+        array.add(shreddedArray);
+      }
+      result.addArray(schema, array);
+    } else if (schema.objectSchema != null && variantType == VariantUtil.Type.OBJECT) {
+      Map<String, VariantSchema.ObjectField> objectSchema = schema.objectSchema;
+      int maxSize = Math.min(v.objectSize(), objectSchema.size());
+      ShreddedResult[] shreddedValues = new ShreddedResult[objectSchema.size()];
+
+      // Create a variantBuilder for any mismatched fields.
+      VariantBuilder variantBuilder = new VariantBuilder(false);
+      ArrayList<VariantBuilder.FieldEntry> fieldEntries = new ArrayList<>();
+      // Keep track of which schema fields we actually found in the Variant value.
+      Set<String> presentKeys = new HashSet<String>();
+      int start = variantBuilder.getWritePos();
+      for (int i = 0; i < v.objectSize(); ++i) {
+        Variant.ObjectField field = v.getFieldAtIndex(i);
+        VariantSchema.ObjectField keySchema = objectSchema.get(field.key);
+        if (keySchema != null) {
+          // The field exists in the shredding schema. Recursively shred, and write the result.
+          ShreddedResult shreddedField = castShredded(field.value, keySchema.schema, builder);
+          shreddedValues[keySchema.idx] = shreddedField;
+          presentKeys.add(field.key);
+        } else {
+          // The field is not shredded. Put it in the untyped_value column.
+          int id = v.getDictionaryIdAtIndex(i);
+          fieldEntries.add(new VariantBuilder.FieldEntry(field.key, id, variantBuilder.getWritePos() - start));
+          variantBuilder.appendVariant(field.value);
+        }
+      }
+      if (presentKeys.size() != objectSchema.size()) {
+        // Set missing fields to non-null with all fields set to null.
+        // Iterate over objectSchema key-value pairs and add them to the result.
+        for (Map.Entry<String, VariantSchema.ObjectField> entry : objectSchema.entrySet()) {
+          String key = entry.getKey();
+          if (!presentKeys.contains(key)) {
+            ShreddedResult emptyChild = builder.createEmpty(entry.getValue().schema);
+            shreddedValues[entry.getValue().idx] = emptyChild;
+          }
+        }
+      }
+      result.addObject(schema, shreddedValues);
+      if (variantBuilder.getWritePos() != start) {
+        // We added something to the untyped value.
+        variantBuilder.finishWritingObject(start, fieldEntries);
+        result.addVariantValue(schema, variantBuilder.valueWithoutMetadata());
+      }
+    } else if (schema.scalarSchema != null) {
+      VariantSchema.ScalarType scalarType = schema.scalarSchema;
+      Object typedValue = tryTypedShred(v, variantType, scalarType, builder);
+      if (typedValue != null) {
+        // Store the typed value.
+        result.addScalar(schema, typedValue);
+      } else {
+        VariantBuilder variantBuilder = new VariantBuilder(false);
+        variantBuilder.appendVariant(v);
+        result.addVariantValue(schema, v.getValue());
+      }
+    } else {
+      // Store in untyped.
+      result.addVariantValue(schema, v.getValue());
+    }
+    return result;
+  }
+
+  /**
+   * Tries to cast a Variant into a typed value. If the cast fails, returns null.
+   *
+   * @param v
+   * @param variantType The Variant Type of v
+   * @param targetType The target type
+   * @return The scalar value, or null if the cast is not valid.
+   */
+  private static Object tryTypedShred(
+          Variant v,
+          VariantUtil.Type variantType,
+          VariantSchema.ScalarType targetType,
+          ShreddedResultBuilder builder) {
+    switch (variantType) {
+      case LONG:
+        if (targetType instanceof VariantSchema.IntegralType) {
+          // Check that the target type can hold the actual value.
+          VariantSchema.IntegralSize size = ((VariantSchema.IntegralType) targetType).size;
+          long value = v.getLong();
+          switch (size) {
+            case BYTE:
+              if (value == (byte) value) {
+                  return (byte) value;
+              }
+              break;
+            case SHORT:
+              if (value == (short) value) {
+                  return (short) value;
+              }
+              break;
+            case INT:
+              if (value == (int) value) {
+                  return (int) value;
+              }
+              break;
+            case LONG:
+              return value;
+          }
+        } else if (targetType instanceof VariantSchema.DecimalType &&
+                   builder.allowNumericScaleChanges()) {
+          // If the integer can fit in the given decimal precision, allow it.
+          long value = v.getLong();
+          VariantSchema.DecimalType decimalType = (VariantSchema.DecimalType) targetType;
+          // Set to the requested scale, and check if the precision is large enough.
+          BigDecimal decimalValue = BigDecimal.valueOf(value);
+          BigDecimal scaledValue = decimalValue.setScale(decimalType.scale);
+          // The initial value should have scale 0, so rescaling shouldn't lose information.
+          assert(decimalValue.compareTo(scaledValue) == 0);
+          if (scaledValue.precision() <= decimalType.precision) {
+            return scaledValue;
+          }
+        }
+        break;
+      case DECIMAL:
+        if (targetType instanceof VariantSchema.DecimalType) {
+          VariantSchema.DecimalType decimalType = (VariantSchema.DecimalType) targetType;
+          // Use getDecimalWithOriginalScale so that we retain scale information if
+          // allowNumericScaleChanges() is false.
+          BigDecimal value = VariantUtil.getDecimalWithOriginalScale(v.value, v.pos);
+          if (value.precision() <= decimalType.precision &&
+              value.scale() == decimalType.scale) {
+            return value;
+          }
+          if (builder.allowNumericScaleChanges()) {
+            // Convert to the target scale, and see if it fits. Rounding mode doesn't matter,
+            // since we'll reject it if it turned out to require rounding.
+            BigDecimal scaledValue = value.setScale(decimalType.scale, RoundingMode.FLOOR);
+            if (scaledValue.compareTo(value) == 0 &&
+                    scaledValue.precision() <= decimalType.precision) {
+              return scaledValue;
+            }
+          }
+        } else if (targetType instanceof VariantSchema.IntegralType &&
+          builder.allowNumericScaleChanges()) {
+          // Check if the decimal happens to be an integer.
+          BigDecimal value = v.getDecimal();
+          VariantSchema.IntegralSize size = ((VariantSchema.IntegralType) targetType).size;
+          // Try to cast to the appropriate type, and check if any information is lost.
+          switch (size) {
+            case BYTE:
+              if (value.compareTo(BigDecimal.valueOf(value.byteValue())) == 0) {
+                return value.byteValue();
+              }
+              break;
+            case SHORT:
+              if (value.compareTo(BigDecimal.valueOf(value.shortValue())) == 0) {
+                return value.shortValue();
+              }
+              break;
+            case INT:
+              if (value.compareTo(BigDecimal.valueOf(value.intValue())) == 0) {
+                return value.intValue();
+              }
+              break;
+            case LONG:
+              if (value.compareTo(BigDecimal.valueOf(value.longValue())) == 0) {
+                return value.longValue();
+              }
+          }
+        }
+        break;
+      case BOOLEAN:
+        if (targetType instanceof VariantSchema.BooleanType) {
+          return v.getBoolean();
+        }
+        break;
+      case STRING:
+        if (targetType instanceof VariantSchema.StringType) {
+          return v.getString();
+        }
+        break;
+      case DOUBLE:
+        if (targetType instanceof VariantSchema.DoubleType) {
+          return v.getDouble();
+        }
+        break;
+      case DATE:
+        if (targetType instanceof VariantSchema.DateType) {
+          return (int) v.getLong();
+        }
+        break;
+      case TIMESTAMP:
+        if (targetType instanceof VariantSchema.TimestampType) {
+          return v.getLong();
+        }
+        break;
+      case TIMESTAMP_NTZ:
+        if (targetType instanceof VariantSchema.TimestampNTZType) {
+          return v.getLong();
+        }
+        break;
+      case FLOAT:
+        if (targetType instanceof VariantSchema.FloatType) {
+          return v.getFloat();
+        }
+        break;
+      case BINARY:
+        if (targetType instanceof VariantSchema.BinaryType) {
+          return v.getBinary();
+        }
+        break;
+    }
+    // The stored type does not match the requested shredding type. Return null, and the caller
+    // will store the result in untyped_value.
+    return null;
+  }
+
+  // Add the result to the shredding result.
+  private static void addVariantValueVariant(Variant variantResult,
+      VariantSchema schema, ShreddedResult result) {
+    result.addVariantValue(schema, variantResult.getValue());
+  }
+
+}

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantShreddingWriter.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantShreddingWriter.java
@@ -18,13 +18,8 @@
 package org.apache.spark.types.variant;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.util.ArrayList;
-import java.util.List;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * Class to implement shredding a Variant value.
@@ -96,13 +91,15 @@ public class VariantShreddingWriter {
         Integer fieldIdx = schema.objectSchemaMap.get(field.key);
         if (fieldIdx != null) {
           // The field exists in the shredding schema. Recursively shred, and write the result.
-          ShreddedResult shreddedField = castShredded(field.value, objectSchema[fieldIdx].schema, builder);
+          ShreddedResult shreddedField = castShredded(
+              field.value, objectSchema[fieldIdx].schema, builder);
           shreddedValues[fieldIdx] = shreddedField;
           numFieldsMatched++;
         } else {
           // The field is not shredded. Put it in the untyped_value column.
           int id = v.getDictionaryIdAtIndex(i);
-          fieldEntries.add(new VariantBuilder.FieldEntry(field.key, id, variantBuilder.getWritePos() - start));
+          fieldEntries.add(new VariantBuilder.FieldEntry(
+              field.key, id, variantBuilder.getWritePos() - start));
           variantBuilder.appendVariant(field.value);
         }
       }

--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantUtil.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantUtil.java
@@ -413,7 +413,7 @@ public class VariantUtil {
 
   // Get a decimal value from variant value `value[pos...]`.
   // Throw `MALFORMED_VARIANT` if the variant is malformed.
-  public static BigDecimal getDecimal(byte[] value, int pos) {
+  public static BigDecimal getDecimalWithOriginalScale(byte[] value, int pos) {
     checkIndex(pos, value.length);
     int basicType = value[pos] & BASIC_TYPE_MASK;
     int typeInfo = (value[pos] >> BASIC_TYPE_BITS) & TYPE_INFO_MASK;
@@ -445,7 +445,11 @@ public class VariantUtil {
       default:
         throw unexpectedType(Type.DECIMAL);
     }
-    return result.stripTrailingZeros();
+    return result;
+  }
+
+  public static BigDecimal getDecimal(byte[] value, int pos) {
+    return getDecimalWithOriginalScale(value, pos).stripTrailingZeros();
   }
 
   // Get a float value from variant value `value[pos...]`.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1989,6 +1989,11 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("field" -> field))
   }
 
+  def invalidVariantSchema(schema: DataType): Throwable = {
+    new AnalysisException(errorClass = "INVALID_VARIANT_SCHEMA",
+      messageParameters = Map("schema" -> toSQLType(schema)))
+  }
+
   def invalidVariantWrongNumFieldsError(): Throwable = {
     new AnalysisException(errorClass = "INVALID_VARIANT_FROM_PARQUET.WRONG_NUM_FIELDS",
       messageParameters = Map.empty)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -1989,8 +1989,8 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
       messageParameters = Map("field" -> field))
   }
 
-  def invalidVariantSchema(schema: DataType): Throwable = {
-    new AnalysisException(errorClass = "INVALID_VARIANT_SCHEMA",
+  def invalidVariantShreddingSchema(schema: DataType): Throwable = {
+    new AnalysisException(errorClass = "INVALID_VARIANT_SHREDDING_SCHEMA",
       messageParameters = Map("schema" -> toSQLType(schema)))
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/SparkShreddingUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/SparkShreddingUtils.scala
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.parquet
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.util.GenericArrayData
+import org.apache.spark.sql.errors.QueryCompilationErrors
+import org.apache.spark.sql.types._
+import org.apache.spark.types.variant._
+import org.apache.spark.unsafe.types._
+
+case object SparkShreddingUtils {
+  def buildVariantSchema(schema: DataType): VariantSchema = {
+    schema match {
+      case s: StructType => buildVariantSchema(s, topLevel = true)
+      case _ => throw QueryCompilationErrors.invalidVariantSchema(schema)
+    }
+  }
+
+  /**
+   * Given an expected schema of a Variant value, returns a suitable schema for shredding, by
+   * inserting appropriate intermediate value/typed_value fields at each level.
+   * For example, to represent the JSON {"a": 1, "b": "hello"},
+   * the schema struct<a: int, b: string> could be passed into this function, and it would return
+   * the shredding scheme:
+   * struct<
+   *  metadata: binary,
+   *  value: binary,
+   *  object: struct<
+   *   a: struct<typed_value: int, value: binary>,
+   *   b: struct<typed_value: string, value: binary>>>
+   *
+   */
+  def variantShreddingSchema(dataType: DataType, isTopLevel: Boolean = true): StructType = {
+    val fields = dataType match {
+      case ArrayType(elementType, containsNull) =>
+        val arrayShreddingSchema =
+          ArrayType(variantShreddingSchema(elementType, false), containsNull)
+        Seq(
+          StructField("value", BinaryType, nullable = true),
+          StructField("typed_value", arrayShreddingSchema, nullable = true)
+        )
+      case StructType(fields) =>
+        val objectShreddingSchema = StructType(fields.map(f =>
+            f.copy(dataType = variantShreddingSchema(f.dataType, false))))
+        Seq(
+          StructField("value", BinaryType, nullable = true),
+          StructField("typed_value", objectShreddingSchema, nullable = true)
+        )
+      case VariantType =>
+        // For Variant, we don't need a typed column
+        Seq(
+          StructField("value", BinaryType, nullable = true)
+        )
+      case _: NumericType | BooleanType | _: StringType | BinaryType | _: DatetimeType =>
+        Seq(
+          StructField("value", BinaryType, nullable = true),
+          StructField("typed_value", dataType, nullable = true)
+        )
+      case _ =>
+        // No other types have a corresponding shreddings schema.
+        throw QueryCompilationErrors.invalidVariantSchema(dataType)
+    }
+
+    if (isTopLevel) {
+      StructType(StructField("metadata", BinaryType, nullable = true) +: fields)
+    } else {
+      StructType(fields)
+    }
+  }
+
+  /*
+   * Given a Spark schema that represents a valid shredding schema (e.g. constructed by
+   * SparkShreddingUtils.variantShreddingSchema), return the corresponding VariantSchema.
+   */
+  private def buildVariantSchema(schema: StructType, topLevel: Boolean): VariantSchema = {
+    var typedIdx = -1
+    var variantIdx = -1
+    var topLevelMetadataIdx = -1
+    var scalarSchema: VariantSchema.ScalarType = null
+    var objectSchema: java.util.HashMap[String, VariantSchema.ObjectField] = null
+    var arraySchema: VariantSchema = null
+
+    schema.fields.zipWithIndex.foreach { case (f, i) =>
+      f.name match {
+        case "typed_value" =>
+          if (typedIdx != -1) {
+            throw QueryCompilationErrors.invalidVariantSchema(schema)
+          }
+          typedIdx = i
+          f.dataType match {
+            case StructType(fields) =>
+              objectSchema = new java.util.HashMap[String, VariantSchema.ObjectField]
+              fields.zipWithIndex.foreach { case (field, fieldIdx) =>
+                field.dataType match {
+                  case s: StructType =>
+                    val fieldSchema = buildVariantSchema(s, topLevel = false)
+                    objectSchema.put(field.name,
+                      new VariantSchema.ObjectField(fieldIdx, fieldSchema))
+                  case _ => throw QueryCompilationErrors.invalidVariantSchema(schema)
+                }
+              }
+            case ArrayType(elementType, _) =>
+              elementType match {
+                case s: StructType => arraySchema = buildVariantSchema(s, topLevel = false)
+                case _ => throw QueryCompilationErrors.invalidVariantSchema(schema)
+              }
+            case t => scalarSchema = (t match {
+              case BooleanType => new VariantSchema.BooleanType
+              case ByteType => new VariantSchema.IntegralType(VariantSchema.IntegralSize.BYTE)
+              case ShortType => new VariantSchema.IntegralType(VariantSchema.IntegralSize.SHORT)
+              case IntegerType => new VariantSchema.IntegralType(VariantSchema.IntegralSize.INT)
+              case LongType => new VariantSchema.IntegralType(VariantSchema.IntegralSize.LONG)
+              case FloatType => new VariantSchema.FloatType
+              case DoubleType => new VariantSchema.DoubleType
+              case StringType => new VariantSchema.StringType
+              case BinaryType => new VariantSchema.BinaryType
+              case DateType => new VariantSchema.DateType
+              case TimestampType => new VariantSchema.TimestampType
+              case TimestampNTZType => new VariantSchema.TimestampNTZType
+              case d: DecimalType => new VariantSchema.DecimalType(d.precision, d.scale)
+              case _ => throw QueryCompilationErrors.invalidVariantSchema(schema)
+            })
+          }
+        case "value" =>
+          if (variantIdx != -1 || f.dataType != BinaryType) {
+            throw QueryCompilationErrors.invalidVariantSchema(schema)
+          }
+          variantIdx = i
+        case "metadata" =>
+          if (topLevelMetadataIdx != -1 || f.dataType != BinaryType) {
+            throw QueryCompilationErrors.invalidVariantSchema(schema)
+          }
+          topLevelMetadataIdx = i
+        case _ => throw QueryCompilationErrors.invalidVariantSchema(schema)
+      }
+    }
+
+    if (topLevel != (topLevelMetadataIdx >= 0)) {
+      throw QueryCompilationErrors.invalidVariantSchema(schema)
+    }
+    new VariantSchema(typedIdx, variantIdx, topLevelMetadataIdx, schema.fields.length,
+      scalarSchema, objectSchema, arraySchema)
+  }
+
+  class SparkShreddedResult(schema: VariantSchema) extends VariantShreddingWriter.ShreddedResult {
+    // Result is stored as an InternalRow.
+    val row = new GenericInternalRow(schema.numFields)
+
+    override def addArray(schema: VariantSchema,
+        array: java.util.List[VariantShreddingWriter.ShreddedResult]): Unit = {
+      val arrayResult = new GenericArrayData(
+          array.asScala.map(_.asInstanceOf[SparkShreddedResult].row))
+      row.update(schema.typedIdx, arrayResult)
+    }
+
+    override def addObject(schema: VariantSchema,
+                           values: Array[VariantShreddingWriter.ShreddedResult]): Unit = {
+      val objectSchema = schema.objectSchema;
+      val innerRow = new GenericInternalRow(objectSchema.size())
+      for (i <- 0 until values.length) {
+        innerRow.update(i, values(i).asInstanceOf[SparkShreddedResult].row)
+      }
+      row.update(schema.typedIdx, innerRow)
+    }
+
+    override def addVariantValue(schema: VariantSchema, result: Array[Byte]): Unit = {
+      row.update(schema.variantIdx, result)
+    }
+
+    override def addScalar(schema: VariantSchema, result: Any): Unit = {
+      // Convert to native spark value, if necessary.
+      val sparkValue = schema.scalarSchema match {
+        case _: VariantSchema.StringType => UTF8String.fromString(result.asInstanceOf[String])
+        case _: VariantSchema.DecimalType => Decimal(result.asInstanceOf[java.math.BigDecimal])
+        case _ => result
+      }
+      row.update(schema.typedIdx, sparkValue)
+    }
+
+    override def addMetadata(schema: VariantSchema, result: Array[Byte]): Unit = {
+      row.update(schema.topLevelMetadataIdx, result)
+    }
+  }
+
+  class SparkShreddedResultBuilder() extends VariantShreddingWriter.ShreddedResultBuilder {
+    override def createEmpty(schema: VariantSchema): VariantShreddingWriter.ShreddedResult = {
+      new SparkShreddedResult(schema)
+    }
+
+    // Consider allowing this to be set via config?
+    override def allowNumericScaleChanges(): Boolean = true
+  }
+
+  /**
+   * Converts an input variant into shredded components. Returns the shredded result.
+   */
+  def castShredded(v: Variant, schema: VariantSchema): InternalRow = {
+    VariantShreddingWriter.castShredded(v, schema, new SparkShreddedResultBuilder())
+        .asInstanceOf[SparkShreddedResult]
+        .row
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/SparkShreddingUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/SparkShreddingUtils.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.sql.execution.datasources.parquet
 
-import scala.jdk.CollectionConverters._
-
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.util.GenericArrayData
@@ -166,9 +164,9 @@ case object SparkShreddingUtils {
     val row = new GenericInternalRow(schema.numFields)
 
     override def addArray(schema: VariantSchema,
-        array: java.util.List[VariantShreddingWriter.ShreddedResult]): Unit = {
+        array: Array[VariantShreddingWriter.ShreddedResult]): Unit = {
       val arrayResult = new GenericArrayData(
-          array.asScala.map(_.asInstanceOf[SparkShreddedResult].row))
+          array.map(_.asInstanceOf[SparkShreddedResult].row))
       row.update(schema.typedIdx, arrayResult)
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/SparkShreddingUtils.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/parquet/SparkShreddingUtils.scala
@@ -42,7 +42,7 @@ case object SparkShreddingUtils {
    * struct<
    *  metadata: binary,
    *  value: binary,
-   *  object: struct<
+   *  typed_value: struct<
    *   a: struct<typed_value: int, value: binary>,
    *   b: struct<typed_value: string, value: binary>>>
    *

--- a/sql/core/src/test/scala/org/apache/spark/sql/VariantWriteShreddingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/VariantWriteShreddingSuite.scala
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.SparkFunSuite
+import org.apache.spark.sql.catalyst.CatalystTypeConverters
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.variant.VariantExpressionEvalUtils
+import org.apache.spark.sql.execution.datasources.parquet.SparkShreddingUtils
+import org.apache.spark.sql.types._
+import org.apache.spark.types.variant.Variant
+import org.apache.spark.unsafe.types.{UTF8String, VariantVal}
+
+class VariantWriteShreddingSuite extends SparkFunSuite with ExpressionEvalHelper {
+
+  private def parseJson(input: String): VariantVal =
+    VariantExpressionEvalUtils.parseJson(UTF8String.fromString(input))
+
+  private def toVariant(input: Expression): VariantVal = {
+    Cast(input, VariantType, true).eval().asInstanceOf[VariantVal]
+  }
+
+  private def untypedValue(input: String): Array[Byte] = {
+    val variantVal = parseJson(input)
+    variantVal.getValue
+  }
+
+  private def untypedValue(input: VariantVal): Array[Byte] = input.getValue
+
+  // Shreds variantVal with the requested schema, and verifies that the result is
+  // equal to `expected`.
+  private def testWithSchema(variantVal: VariantVal,
+                             schema: DataType, expected: Row): Unit = {
+    val shreddingSchema = SparkShreddingUtils.variantShreddingSchema(schema)
+    val variant = new Variant(variantVal.getValue, variantVal.getMetadata)
+    val variantSchema = SparkShreddingUtils.buildVariantSchema(shreddingSchema)
+    val actual = SparkShreddingUtils.castShredded(variant, variantSchema)
+
+    val catalystExpected = CatalystTypeConverters.convertToCatalyst(expected)
+    if (!checkResult(actual, catalystExpected, shreddingSchema, exprNullable = false)) {
+      fail(s"Incorrect evaluation of castShredded: " +
+        s"actual: $actual, " +
+        s"expected: $expected")
+    }
+  }
+
+  // Parse the provided JSON into a Variant, shred it to the provided schema, and verify the result.
+  private def testWithSchema(input: String, dataType: DataType, expected: Row): Unit = {
+    val variantVal = parseJson(input)
+    testWithSchema(variantVal, dataType, expected)
+  }
+
+  private val emptyMetadata: Array[Byte] = parseJson("null").getMetadata
+
+  test("shredding as fixed numeric types") {
+    /* Cast integer to any wider numeric type. */
+    testWithSchema("1", IntegerType, Row(emptyMetadata, null, 1))
+    testWithSchema("1", LongType, Row(emptyMetadata, null, 1))
+    testWithSchema("1", ShortType, Row(emptyMetadata, null, 1))
+    testWithSchema("1", ByteType, Row(emptyMetadata, null, 1))
+
+    // Invalid casts
+    Seq(StringType, DecimalType(5, 5), TimestampType, DateType, BooleanType, DoubleType, FloatType,
+      BinaryType, ArrayType(IntegerType),
+      StructType.fromDDL("a int, b int")).foreach { t =>
+      testWithSchema("1", t, Row(emptyMetadata, untypedValue("1"), null))
+    }
+
+    /* Test conversions between numeric types and scales. */
+    testWithSchema("1", DecimalType(5, 2), Row(emptyMetadata, null, Decimal("1")))
+    testWithSchema("1", DecimalType(38, 37), Row(emptyMetadata, null, Decimal("1")))
+    // Decimals that are effectively storing integers can also be cast to integer.
+    testWithSchema("1.0", IntegerType, Row(emptyMetadata, null, 1))
+    testWithSchema("1.0000000000000000000000000000000000000", IntegerType,
+      Row(emptyMetadata, null, 1))
+    // Don't overflow the integer type when converting from decimal.
+    testWithSchema("32767.0", ShortType, Row(emptyMetadata, null, 32767))
+    testWithSchema("32768.0", ShortType, Row(emptyMetadata, untypedValue("32768.0"), null))
+    // Don't overflow decimal type when converting from integer.
+    testWithSchema("99999", DecimalType(7, 2), Row(emptyMetadata, null, Decimal("99999.00")))
+    testWithSchema("100000", DecimalType(7, 2), Row(emptyMetadata, untypedValue("100000"), null))
+    // Allow scale to increase
+    testWithSchema("12.34", DecimalType(7, 4), Row(emptyMetadata, null, Decimal("12.3400")))
+    // Allow scale to decrease if there are trailing zeros
+    testWithSchema("12.3400", DecimalType(4, 2), Row(emptyMetadata, null, Decimal("12.34")))
+    testWithSchema("12.3410", DecimalType(4, 2), Row(emptyMetadata, untypedValue("12.3410"), null))
+
+    // The string 1 is not numeric
+    testWithSchema("\"1\"", IntegerType, Row(emptyMetadata, untypedValue("\"1\""), null))
+    // Decimal would lose information.
+    testWithSchema("1.1", IntegerType, Row(emptyMetadata, untypedValue("1.1"), null))
+    // Exponential notation is parsed as double, cannot be shredded to other numeric types.
+    testWithSchema("1e2", IntegerType, Row(emptyMetadata, untypedValue("1e2"), null))
+    // Null is not an integer
+    testWithSchema("null", IntegerType, Row(emptyMetadata, untypedValue("null"), null))
+
+    // Overflow leads to storing as unshredded.
+    testWithSchema("32767", ShortType, Row(emptyMetadata, null, 32767))
+    testWithSchema("32768", ShortType, Row(emptyMetadata, untypedValue("32768"), null))
+
+    testWithSchema("1e2", DoubleType, Row(emptyMetadata, null, 1e2))
+    // We currently don't allow shredding double as float.
+    testWithSchema("1e2", FloatType, Row(emptyMetadata, untypedValue("1e2"), null))
+  }
+
+  test("shredding as other scalar types") {
+    // Test types that aren't produced by parseJson
+    val floatV = toVariant(Literal(1.2f, FloatType))
+    testWithSchema(floatV, FloatType, Row(emptyMetadata, null, 1.2f))
+    testWithSchema(floatV, DoubleType, Row(emptyMetadata, untypedValue(floatV), null))
+
+    val booleanV = toVariant(Literal(true, BooleanType))
+    testWithSchema(booleanV, BooleanType, Row(emptyMetadata, null, true))
+    testWithSchema(booleanV, StringType, Row(emptyMetadata, untypedValue(booleanV), null))
+
+    val binaryV = toVariant(Literal(Array[Byte](-1, -2), BinaryType))
+    testWithSchema(binaryV, BinaryType, Row(emptyMetadata, null, Array[Byte](-1, -2)))
+    testWithSchema(binaryV, StringType, Row(emptyMetadata, untypedValue(binaryV), null))
+
+    val dateV = toVariant(Literal(0, DateType))
+    testWithSchema(dateV, DateType, Row(emptyMetadata, null, 0))
+    testWithSchema(dateV, TimestampType, Row(emptyMetadata, untypedValue(dateV), null))
+
+    val timestampV = toVariant(Literal(0L, TimestampType))
+    testWithSchema(timestampV, TimestampType, Row(emptyMetadata, null, 0))
+    testWithSchema(timestampV, TimestampNTZType, Row(emptyMetadata, untypedValue(timestampV), null))
+
+    val timestampNtzV = toVariant(Literal(0L, TimestampNTZType))
+    testWithSchema(timestampNtzV, TimestampNTZType, Row(emptyMetadata, null, 0))
+    testWithSchema(timestampNtzV, TimestampType,
+        Row(emptyMetadata, untypedValue(timestampNtzV), null))
+  }
+
+  test("shredding as object") {
+    val obj = parseJson("""{"a": 1, "b": "hello"}""")
+    // Can't be cast to scalar or array.
+    Seq(IntegerType, LongType, ShortType, ByteType, StringType, DecimalType(5, 5),
+        TimestampType, DateType, BooleanType, DoubleType, FloatType, BinaryType,
+        ArrayType(IntegerType)).foreach { t =>
+      testWithSchema(obj, t, Row(obj.getMetadata, untypedValue(obj), null))
+    }
+
+    // Happy path
+    testWithSchema(obj, StructType.fromDDL("a int, b string"),
+      Row(obj.getMetadata, null, Row(Row(null, 1), Row(null, "hello"))))
+    // Missing field.
+    testWithSchema(obj, StructType.fromDDL("a int, c string, b string"),
+      Row(obj.getMetadata, null, Row(Row(null, 1), Row(null, null), Row(null, "hello"))))
+    // "a" is not present in shredding schema.
+    testWithSchema(obj, StructType.fromDDL("b string, c string"),
+      Row(obj.getMetadata, untypedValue("""{"a": 1}"""), Row(Row(null, "hello"), Row(null, null))))
+    // "b" is not present in shredding schema. This case is a bit trickier, because the ID
+    // will be 1, not 0, since we'll use the original metadata dictionary that contains a and b.
+    // So we need to edit the variant value produced by parseJson.
+    val residual = untypedValue("""{"b": "hello"}""")
+    // First byte is the type, second is number of fields, and the third is the
+    // dictionary ID of the first field.
+    residual(2) = 1
+    testWithSchema(obj, StructType.fromDDL("a int, c string"),
+      Row(obj.getMetadata, residual, Row(Row(null, 1), Row(null, null))))
+    // "a" is the wrong type.
+    testWithSchema(obj, StructType.fromDDL("a string, b string"),
+      Row(obj.getMetadata, null, Row(Row(untypedValue("1"), null), Row(null, "hello"))))
+    // Not an object
+    testWithSchema(obj, ArrayType(StructType.fromDDL("a int, b string")),
+      Row(obj.getMetadata, untypedValue(obj), null))
+  }
+
+  test("shredding as array") {
+    val arr = parseJson("""[{"a": 1, "b": "hello"}, 2, null, 4]""")
+    // Can't be cast to scalar or object.
+    Seq(IntegerType, LongType, ShortType, ByteType, StringType, DecimalType(5, 5),
+      TimestampType, DateType, BooleanType, DoubleType, FloatType, BinaryType,
+      StructType.fromDDL("a int, b string")).foreach { t =>
+      testWithSchema(arr, t, Row(arr.getMetadata, untypedValue(arr), null))
+    }
+    // First element is shredded
+    testWithSchema(arr, ArrayType(StructType.fromDDL("a int, b string")),
+      Row(arr.getMetadata, null, Array(
+        Row(null, Row(Row(null, 1), Row(null, "hello"))),
+        Row(untypedValue("2"), null),
+        Row(untypedValue("null"), null),
+        Row(untypedValue("4"), null)
+      )))
+    // Second and fourth are shredded
+    testWithSchema(arr, ArrayType(LongType),
+      Row(arr.getMetadata, null, Array(
+        Row(untypedValue("""{"a": 1, "b": "hello"}"""), null),
+        Row(null, 2),
+        Row(untypedValue("null"), null),
+        Row(null, 4)
+      )))
+
+    // Fully shredded
+    testWithSchema("[1,2,3]", ArrayType(LongType),
+      Row(emptyMetadata, null, Array(
+        Row(null, 1),
+        Row(null, 2),
+        Row(null, 3)
+      )))
+  }
+
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

This is a first step towards adding Variant shredding support for the Parquet writer. It adds functionality to convert a Variant value to an InternalRow that matches the current shredding spec in https://github.com/apache/parquet-format/pull/461.

Once this merges, the next step will be to set up the Parquet writer to accept a shredding schema, and write these InternalRow values to Parquet instead of the raw Variant binary.

### Why are the changes needed?

First step towards adding support for shredding, which can improve Variant performance (and will be important for functionality on the read side once other tools begin writing shredded Variant columns to Parquet).

### Does this PR introduce _any_ user-facing change?

No, none of this code is currently called outside of the added tests.

### How was this patch tested?

Unit tests.

### Was this patch authored or co-authored using generative AI tooling?

No.