### PR TITLE
[SPARK-50254][PS][TESTS] Enable test `DataFramePlotParityTests`

### DIFF
--- a/python/pyspark/pandas/tests/connect/plot/test_parity_frame_plot.py
+++ b/python/pyspark/pandas/tests/connect/plot/test_parity_frame_plot.py
@@ -24,13 +24,7 @@ from pyspark.testing.pandasutils import PandasOnSparkTestUtils
 class DataFramePlotParityTests(
     DataFramePlotTestsMixin, PandasOnSparkTestUtils, ReusedConnectTestCase
 ):
-    @unittest.skip("Test depends on Spark ML which is not supported from Spark Connect.")
-    def test_compute_hist_multi_columns(self):
-        super().test_compute_hist_multi_columns()
-
-    @unittest.skip("Test depends on Spark ML which is not supported from Spark Connect.")
-    def test_compute_hist_single_column(self):
-        super().test_compute_hist_single_column()
+    pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

### What changes were proposed in this pull request?
Enable test `DataFramePlotParityTests`, we have reimplemented these plotting functions with Spark SQL, and no longer depend on ML.


### Why are the changes needed?
test coverage


### Does this PR introduce _any_ user-facing change?
no, test only


### How was this patch tested?
CI

### Was this patch authored or co-authored using generative AI tooling?
No