### PR TITLE
[SPARK-50258][SQL] Fix output column order changed issue after AQE optimization

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/RemoveRedundantProjects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/RemoveRedundantProjects.scala
@@ -91,6 +91,10 @@ object RemoveRedundantProjects extends Rule[SparkPlan] {
   private def checkNullability(output: Seq[Attribute], childOutput: Seq[Attribute]): Boolean =
     output.zip(childOutput).forall { case (attr1, attr2) => attr1.nullable || !attr2.nullable }
 
+  private[sql] def isOutputMatched(output: Seq[Attribute], childOutput: Seq[Attribute]): Boolean = {
+    output.map(_.exprId.id) == childOutput.map(_.exprId.id) && checkNullability(output, childOutput)
+  }
+
   private def isRedundant(
       project: ProjectExec,
       child: SparkPlan,
@@ -102,13 +106,9 @@ object RemoveRedundantProjects extends Rule[SparkPlan] {
       case FilterExec(_, d: DataSourceV2ScanExecBase) if !d.supportsColumnar => false
       case _ =>
         if (requireOrdering) {
-          project.output.map(_.exprId.id) == child.output.map(_.exprId.id) &&
-            checkNullability(project.output, child.output)
+          isOutputMatched(project.output, child.output)
         } else {
-          val orderedProjectOutput = project.output.sortBy(_.exprId.id)
-          val orderedChildOutput = child.output.sortBy(_.exprId.id)
-          orderedProjectOutput.map(_.exprId.id) == orderedChildOutput.map(_.exprId.id) &&
-            checkNullability(orderedProjectOutput, orderedChildOutput)
+          isOutputMatched(project.output.sortBy(_.exprId.id), child.output.sortBy(_.exprId.id))
         }
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/RemoveRedundantProjects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/RemoveRedundantProjects.scala
@@ -58,8 +58,8 @@ object RemoveRedundantProjects extends Rule[SparkPlan] {
           p.mapChildren(removeProject(_, false))
         }
       case op: TakeOrderedAndProjectExec =>
-        // TakeOrderedAndProjectExec requires keep column ordering if AQE is enabled.
-        op.mapChildren(removeProject(_, conf.adaptiveExecutionEnabled))
+        val requireColOrdering = conf.adaptiveExecutionEnabled && op.projectList == op.child.output
+        op.mapChildren(removeProject(_, requireColOrdering))
       case a: BaseAggregateExec =>
         // BaseAggregateExec require specific column ordering when mode is Final or PartialMerge.
         // See comments in BaseAggregateExec inputAttributes method.

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/RemoveRedundantProjects.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/RemoveRedundantProjects.scala
@@ -58,6 +58,11 @@ object RemoveRedundantProjects extends Rule[SparkPlan] {
           p.mapChildren(removeProject(_, false))
         }
       case op: TakeOrderedAndProjectExec =>
+        // The planner turns Limit + Sort into TakeOrderedAndProjectExec which adds an additional
+        // Project that does not exist in the logical plan. We shouldn't use this additional Project
+        // to optimize out other Projects, otherwise when AQE turns physical plan back to
+        // logical plan, we lose the Project and may mess up the output column order. So column
+        // ordering is required if AQE is enabled and projectList is the same as child output.
         val requireColOrdering = conf.adaptiveExecutionEnabled && op.projectList == op.child.output
         op.mapChildren(removeProject(_, requireColOrdering))
       case a: BaseAggregateExec =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -773,7 +773,11 @@ case class AdaptiveSparkPlanExec(
         case _ => newPlan
       }
 
-      Some((finalPlan, optimized))
+      if (!RemoveRedundantProjects.isOutputMatched(inputPlan.output, finalPlan.output)) {
+        Some((ProjectExec(inputPlan.output, finalPlan), optimized))
+      } else {
+        Some((finalPlan, optimized))
+      }
     } catch {
       case e: InvalidAQEPlanException[_] =>
         logOnLevel(log"Re-optimize - ${MDC(ERROR, e.getMessage())}:\n" +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -773,15 +773,7 @@ case class AdaptiveSparkPlanExec(
         case _ => newPlan
       }
 
-      if (!RemoveRedundantProjects.isOutputMatched(inputPlan.output, finalPlan.output)) {
-        val wrapProjectPlan = finalPlan match {
-          case e: Exchange => e.withNewChildren(ProjectExec(inputPlan.output, e.child) :: Nil)
-          case _ => ProjectExec(inputPlan.output, finalPlan)
-        }
-        Some((wrapProjectPlan, optimized))
-      } else {
-        Some((finalPlan, optimized))
-      }
+      Some((finalPlan, optimized))
     } catch {
       case e: InvalidAQEPlanException[_] =>
         logOnLevel(log"Re-optimize - ${MDC(ERROR, e.getMessage())}:\n" +

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/AdaptiveSparkPlanExec.scala
@@ -774,7 +774,11 @@ case class AdaptiveSparkPlanExec(
       }
 
       if (!RemoveRedundantProjects.isOutputMatched(inputPlan.output, finalPlan.output)) {
-        Some((ProjectExec(inputPlan.output, finalPlan), optimized))
+        val wrapProjectPlan = finalPlan match {
+          case e: Exchange => e.withNewChildren(ProjectExec(inputPlan.output, e.child) :: Nil)
+          case _ => ProjectExec(inputPlan.output, finalPlan)
+        }
+        Some((wrapProjectPlan, optimized))
       } else {
         Some((finalPlan, optimized))
       }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -3088,7 +3088,7 @@ class AdaptiveQueryExecSuite
     }
   }
 
-  test("SPARK-50258: Keep the output column order after AQE optimization") {
+  test("SPARK-50258: Fix output column order changed issue after AQE optimization") {
     withTable("t") {
       sql("SELECT course, year, earnings FROM courseSales").write.saveAsTable("t")
       val df = sql(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/adaptive/AdaptiveQueryExecSuite.scala
@@ -3087,7 +3087,7 @@ class AdaptiveQueryExecSuite
     }
   }
 
-  test("SPARK-50258: Keep the output order after AQE optimization") {
+  test("SPARK-50258: Keep the output column order after AQE optimization") {
     withTable("t") {
       sql("SELECT course, year, earnings FROM courseSales").write.saveAsTable("t")
       val df = sql(


### PR DESCRIPTION
### What changes were proposed in this pull request?

The root cause of this issue is the planner turns `Limit` + `Sort` into `TakeOrderedAndProjectExec` which adds an additional `Project` that does not exist in the logical plan. We shouldn't use this additional `Project` to optimize out other `Project`s, otherwise when AQE turns physical plan back to logical plan, we lose the `Project` and may mess up the output column order.

This PR makes it does not remove redundant projects if AEQ is enabled and projectList is the same as child output in `TakeOrderedAndProjectExec`.

### Why are the changes needed?

Fix potential data issue and avoid Spark Driver crash:
```
# more hs_err_pid193136.log
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007f9d14841bc0, pid=193136, tid=223205
#
# JRE version: OpenJDK Runtime Environment Zulu17.36+18-SA (17.0.4.1+1) (build 17.0.4.1+1-LTS)
# Java VM: OpenJDK 64-Bit Server VM Zulu17.36+18-SA (17.0.4.1+1-LTS, mixed mode, sharing, tiered, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# v  ~StubRoutines::jint_disjoint_arraycopy_avx3
#
# Core dump will be written. Default location: /apache/spark-release/3.5.0-20241105/spark/core.193136
...
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.

### Was this patch authored or co-authored using generative AI tooling?

No.
