### PR TITLE
[SPARK-48356][SQL] Support for FOR statement

### DIFF
--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -70,6 +70,7 @@ compoundStatement
     | leaveStatement
     | iterateStatement
     | loopStatement
+    | forStatement
     ;
 
 setStatementWithOptionalVarKeyword
@@ -109,6 +110,10 @@ caseStatement
 
 loopStatement
     : beginLabel? LOOP compoundBody END LOOP endLabel?
+    ;
+
+forStatement
+    : beginLabel? FOR (multipartIdentifier AS)? query DO compoundBody END FOR endLabel?
     ;
 
 singleStatement

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -350,8 +350,8 @@ class AstBuilder extends DataTypeAstBuilder
   }
 
   private def visitForStatementImpl(
-    ctx: ForStatementContext,
-    labelCtx: SqlScriptingLabelContext): ForStatement = {
+      ctx: ForStatementContext,
+      labelCtx: SqlScriptingLabelContext): ForStatement = {
     val labelText = labelCtx.enterLabeledScope(Option(ctx.beginLabel()), Option(ctx.endLabel()))
 
     val queryCtx = ctx.query()

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -351,10 +351,10 @@ class AstBuilder extends DataTypeAstBuilder
     val labelText = generateLabelText(Option(ctx.beginLabel()), Option(ctx.endLabel()))
 
     val query = SingleStatement(visitQuery(ctx.query()))
-    val identifier = Option(ctx.multipartIdentifier()).map(_.getText)
+    val varName = Option(ctx.multipartIdentifier()).map(_.getText)
     val body = visitCompoundBody(ctx.compoundBody())
 
-    ForStatement(query, identifier, body, Some(labelText))
+    ForStatement(query, varName, body, Some(labelText))
   }
 
   private def leaveOrIterateContextHasLabel(

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -347,6 +347,16 @@ class AstBuilder extends DataTypeAstBuilder
     RepeatStatement(condition, body, Some(labelText))
   }
 
+  override def visitForStatement(ctx: ForStatementContext): ForStatement = {
+    val labelText = generateLabelText(Option(ctx.beginLabel()), Option(ctx.endLabel()))
+
+    val query = SingleStatement(visitQuery(ctx.query()))
+    val identifier = Option(ctx.multipartIdentifier()).map(_.getText)
+    val body = visitCompoundBody(ctx.compoundBody())
+
+    ForStatement(query, identifier, body, Some(labelText))
+  }
+
   private def leaveOrIterateContextHasLabel(
       ctx: RuleContext, label: String, isIterate: Boolean): Boolean = {
     ctx match {
@@ -366,6 +376,10 @@ class AstBuilder extends DataTypeAstBuilder
           c.beginLabel().multipartIdentifier().getText.toLowerCase(Locale.ROOT).equals(label)
         => true
       case c: LoopStatementContext
+        if Option(c.beginLabel()).isDefined &&
+          c.beginLabel().multipartIdentifier().getText.toLowerCase(Locale.ROOT).equals(label)
+        => true
+      case c: ForStatementContext
         if Option(c.beginLabel()).isDefined &&
           c.beginLabel().multipartIdentifier().getText.toLowerCase(Locale.ROOT).equals(label)
         => true

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -350,7 +350,10 @@ class AstBuilder extends DataTypeAstBuilder
   override def visitForStatement(ctx: ForStatementContext): ForStatement = {
     val labelText = generateLabelText(Option(ctx.beginLabel()), Option(ctx.endLabel()))
 
-    val query = SingleStatement(visitQuery(ctx.query()))
+    val queryCtx = ctx.query()
+    val query = withOrigin(queryCtx) {
+      SingleStatement(visitQuery(queryCtx))
+    }
     val varName = Option(ctx.multipartIdentifier()).map(_.getText)
     val body = visitCompoundBody(ctx.compoundBody())
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -369,28 +369,28 @@ class AstBuilder extends DataTypeAstBuilder
       ctx: RuleContext, label: String, isIterate: Boolean): Boolean = {
     ctx match {
       case c: BeginEndCompoundBlockContext
-        if Option(c.beginLabel()).isDefined &&
-          c.beginLabel().multipartIdentifier().getText.toLowerCase(Locale.ROOT).equals(label) =>
-        if (isIterate) {
+        if Option(c.beginLabel()).exists { b =>
+          b.multipartIdentifier().getText.toLowerCase(Locale.ROOT).equals(label)
+        } => if (isIterate) {
           throw SqlScriptingErrors.invalidIterateLabelUsageForCompound(CurrentOrigin.get, label)
         }
         true
       case c: WhileStatementContext
-        if Option(c.beginLabel()).isDefined &&
-          c.beginLabel().multipartIdentifier().getText.toLowerCase(Locale.ROOT).equals(label)
-        => true
+        if Option(c.beginLabel()).exists { b =>
+          b.multipartIdentifier().getText.toLowerCase(Locale.ROOT).equals(label)
+        } => true
       case c: RepeatStatementContext
-        if Option(c.beginLabel()).isDefined &&
-          c.beginLabel().multipartIdentifier().getText.toLowerCase(Locale.ROOT).equals(label)
-        => true
+        if Option(c.beginLabel()).exists { b =>
+          b.multipartIdentifier().getText.toLowerCase(Locale.ROOT).equals(label)
+        } => true
       case c: LoopStatementContext
-        if Option(c.beginLabel()).isDefined &&
-          c.beginLabel().multipartIdentifier().getText.toLowerCase(Locale.ROOT).equals(label)
-        => true
+        if Option(c.beginLabel()).exists { b =>
+          b.multipartIdentifier().getText.toLowerCase(Locale.ROOT).equals(label)
+        } => true
       case c: ForStatementContext
-        if Option(c.beginLabel()).isDefined &&
-          c.beginLabel().multipartIdentifier().getText.toLowerCase(Locale.ROOT).equals(label)
-        => true
+        if Option(c.beginLabel()).exists { b =>
+          b.multipartIdentifier().getText.toLowerCase(Locale.ROOT).equals(label)
+        } => true
       case _ => false
     }
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SqlScriptingLogicalPlans.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SqlScriptingLogicalPlans.scala
@@ -267,3 +267,18 @@ case class LoopStatement(
     LoopStatement(newChildren(0).asInstanceOf[CompoundBody], label)
   }
 }
+
+/**
+ * Logical operator for REPEAT statement.
+ * @param body Compound body is a collection of statements that are executed once no matter what,
+ *             and then as long as condition is false.
+ * @param label An optional label for the loop which is unique amongst all labels for statements
+ *              within which the REPEAT statement is contained.
+ *              If an end label is specified it must match the beginning label.
+ *              The label can be used to LEAVE or ITERATE the loop.
+ */
+case class ForStatement(
+  query: SingleStatement,
+  identifier: Option[String],
+  body: CompoundBody,
+  label: Option[String]) extends CompoundPlanStatement

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SqlScriptingLogicalPlans.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SqlScriptingLogicalPlans.scala
@@ -269,16 +269,18 @@ case class LoopStatement(
 }
 
 /**
- * Logical operator for REPEAT statement.
- * @param body Compound body is a collection of statements that are executed once no matter what,
- *             and then as long as condition is false.
+ * Logical operator for FOR statement.
+ * @param query Query which is executed once, then it's result is iterated on, row by row
+ * @param variableName Name of variable which is used to access the current row during iteration
+ * @param body Compound body is a collection of statements that are executed once for each row in
+ *             the result set of the query
  * @param label An optional label for the loop which is unique amongst all labels for statements
- *              within which the REPEAT statement is contained.
+ *              within which the FOR statement is contained.
  *              If an end label is specified it must match the beginning label.
  *              The label can be used to LEAVE or ITERATE the loop.
  */
 case class ForStatement(
   query: SingleStatement,
-  identifier: Option[String],
+  variableName: Option[String],
   body: CompoundBody,
   label: Option[String]) extends CompoundPlanStatement

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SqlScriptingLogicalPlans.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SqlScriptingLogicalPlans.scala
@@ -280,7 +280,7 @@ case class LoopStatement(
  *              The label can be used to LEAVE or ITERATE the loop.
  */
 case class ForStatement(
-  query: SingleStatement,
-  variableName: Option[String],
-  body: CompoundBody,
-  label: Option[String]) extends CompoundPlanStatement
+    query: SingleStatement,
+    variableName: Option[String],
+    body: CompoundBody,
+    label: Option[String]) extends CompoundPlanStatement

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SqlScriptingLogicalPlans.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SqlScriptingLogicalPlans.scala
@@ -270,10 +270,10 @@ case class LoopStatement(
 
 /**
  * Logical operator for FOR statement.
- * @param query Query which is executed once, then it's result is iterated on, row by row
- * @param variableName Name of variable which is used to access the current row during iteration
- * @param body Compound body is a collection of statements that are executed once for each row in
- *             the result set of the query
+ * @param query Query which is executed once, then it's result set is iterated on, row by row.
+ * @param variableName Name of variable which is used to access the current row during iteration.
+ * @param body Compound body is a collection of statements that are executed for each row in
+ *             the result set of the query.
  * @param label An optional label for the loop which is unique amongst all labels for statements
  *              within which the FOR statement is contained.
  *              If an end label is specified it must match the beginning label.

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SqlScriptingLogicalPlans.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SqlScriptingLogicalPlans.scala
@@ -290,7 +290,7 @@ case class ForStatement(
   override def children: Seq[LogicalPlan] = Seq(query, body)
 
   override protected def withNewChildrenInternal(
-    newChildren: IndexedSeq[LogicalPlan]): LogicalPlan = newChildren match {
+      newChildren: IndexedSeq[LogicalPlan]): LogicalPlan = newChildren match {
     case IndexedSeq(query: SingleStatement, body: CompoundBody) =>
       ForStatement(query, variableName, body, label)
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SqlScriptingLogicalPlans.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SqlScriptingLogicalPlans.scala
@@ -283,4 +283,19 @@ case class ForStatement(
     query: SingleStatement,
     variableName: Option[String],
     body: CompoundBody,
-    label: Option[String]) extends CompoundPlanStatement
+    label: Option[String]) extends CompoundPlanStatement {
+
+  override def output: Seq[Attribute] = Seq.empty
+
+  override def children: Seq[LogicalPlan] = Seq(query, body)
+
+  override protected def withNewChildrenInternal(
+    newChildren: IndexedSeq[LogicalPlan]): LogicalPlan = {
+    assert(newChildren.length == 2)
+    ForStatement(
+      newChildren(0).asInstanceOf[SingleStatement],
+      variableName,
+      newChildren(1).asInstanceOf[CompoundBody],
+      label)
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SqlScriptingLogicalPlans.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SqlScriptingLogicalPlans.scala
@@ -290,12 +290,8 @@ case class ForStatement(
   override def children: Seq[LogicalPlan] = Seq(query, body)
 
   override protected def withNewChildrenInternal(
-    newChildren: IndexedSeq[LogicalPlan]): LogicalPlan = {
-    assert(newChildren.length == 2)
-    ForStatement(
-      newChildren(0).asInstanceOf[SingleStatement],
-      variableName,
-      newChildren(1).asInstanceOf[CompoundBody],
-      label)
+    newChildren: IndexedSeq[LogicalPlan]): LogicalPlan = newChildren match {
+    case IndexedSeq(query: SingleStatement, body: CompoundBody) =>
+      ForStatement(query, variableName, body, label)
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -41,8 +41,8 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
 
   // Tests
   test("testtest") {
-    val sqlScriptText =
-      """SELECT named_struct('a', 1, 'b', 2, 'c', 3); """.stripMargin
+    val sqlScriptText = "DECLARE my_map DEFAULT MAP('x', 0, 'y', 0);"
+
     val tree = parseScript(sqlScriptText)
     assert(tree.collection.length == 1)
     assert(tree.collection.head.isInstanceOf[ForStatement])

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.catalyst.parser
 import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.catalyst.expressions.{Alias, EqualTo, Expression, In, Literal, ScalarSubquery}
 import org.apache.spark.sql.catalyst.plans.SQLHelper
-import org.apache.spark.sql.catalyst.plans.logical.{CaseStatement, CompoundBody, CreateVariable, IfElseStatement, IterateStatement, LeaveStatement, LoopStatement, Project, RepeatStatement, SingleStatement, WhileStatement}
+import org.apache.spark.sql.catalyst.plans.logical.{CaseStatement, CompoundBody, CreateVariable, ForStatement, IfElseStatement, IterateStatement, LeaveStatement, LoopStatement, Project, RepeatStatement, SingleStatement, WhileStatement}
 import org.apache.spark.sql.errors.DataTypeErrors.toSQLId
 import org.apache.spark.sql.exceptions.SqlScriptingException
 import org.apache.spark.sql.internal.SQLConf
@@ -37,37 +37,6 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
   protected override def afterAll(): Unit = {
     conf.unsetConf(SQLConf.SQL_SCRIPTING_ENABLED.key)
     super.afterAll()
-  }
-
-  // Tests
-  test("testtest") {
-    val sqlScriptText = "DECLARE my_map DEFAULT MAP('x', 0, 'y', 0);"
-
-    val tree = parseScript(sqlScriptText)
-    assert(tree.collection.length == 1)
-    assert(tree.collection.head.isInstanceOf[ForStatement])
-  }
-
-  test("testtesttest") {
-    val sqlScriptText = "DECLARE my_struct DEFAULT STRUCT<'x', 0, 1.2>;"
-
-    val tree = parseScript(sqlScriptText)
-    assert(tree.collection.length == 1)
-    assert(tree.collection.head.isInstanceOf[ForStatement])
-  }
-
-  test("initial for") {
-    val sqlScriptText =
-      """
-        |BEGIN
-        |  FOR x AS SELECT 1 DO
-        |    SELECT 1;
-        |    SELECT 2;
-        |  END FOR;
-        |END""".stripMargin
-    val tree = parseScript(sqlScriptText)
-    assert(tree.collection.length == 1)
-    assert(tree.collection.head.isInstanceOf[ForStatement])
   }
 
   test("single select") {
@@ -1944,7 +1913,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
         |    SELECT 1;
         |  END FOR;
         |END""".stripMargin
-    val tree = parseScript(sqlScriptText)
+    val tree = parsePlan(sqlScriptText).asInstanceOf[CompoundBody]
     assert(tree.collection.length == 1)
     assert(tree.collection.head.isInstanceOf[ForStatement])
 
@@ -1969,7 +1938,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
         |    SELECT 1;
         |  END FOR;
         |END""".stripMargin
-    val tree = parseScript(sqlScriptText)
+    val tree = parsePlan(sqlScriptText).asInstanceOf[CompoundBody]
     assert(tree.collection.length == 1)
     assert(tree.collection.head.isInstanceOf[ForStatement])
 
@@ -1996,7 +1965,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
         |    SELECT x.c2;
         |  END FOR;
         |END""".stripMargin
-    val tree = parseScript(sqlScriptText)
+    val tree = parsePlan(sqlScriptText).asInstanceOf[CompoundBody]
     assert(tree.collection.length == 1)
     assert(tree.collection.head.isInstanceOf[ForStatement])
 
@@ -2025,7 +1994,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
         |    END FOR lbl2;
         |  END FOR lbl1;
         |END""".stripMargin
-    val tree = parseScript(sqlScriptText)
+    val tree = parsePlan(sqlScriptText).asInstanceOf[CompoundBody]
     assert(tree.collection.length == 1)
     assert(tree.collection.head.isInstanceOf[ForStatement])
 
@@ -2060,7 +2029,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
         |    SELECT 1;
         |  END FOR;
         |END""".stripMargin
-    val tree = parseScript(sqlScriptText)
+    val tree = parsePlan(sqlScriptText).asInstanceOf[CompoundBody]
     assert(tree.collection.length == 1)
     assert(tree.collection.head.isInstanceOf[ForStatement])
 
@@ -2085,7 +2054,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
         |    SELECT 1;
         |  END FOR;
         |END""".stripMargin
-    val tree = parseScript(sqlScriptText)
+    val tree = parsePlan(sqlScriptText).asInstanceOf[CompoundBody]
     assert(tree.collection.length == 1)
     assert(tree.collection.head.isInstanceOf[ForStatement])
 
@@ -2112,7 +2081,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
         |    SELECT 2;
         |  END FOR;
         |END""".stripMargin
-    val tree = parseScript(sqlScriptText)
+    val tree = parsePlan(sqlScriptText).asInstanceOf[CompoundBody]
     assert(tree.collection.length == 1)
     assert(tree.collection.head.isInstanceOf[ForStatement])
 
@@ -2141,7 +2110,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
         |    END FOR lbl2;
         |  END FOR lbl1;
         |END""".stripMargin
-    val tree = parseScript(sqlScriptText)
+    val tree = parsePlan(sqlScriptText).asInstanceOf[CompoundBody]
     assert(tree.collection.length == 1)
     assert(tree.collection.head.isInstanceOf[ForStatement])
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -1961,7 +1961,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     assert(forStmt.label.contains("lbl"))
   }
 
-  test("for statement no label") {
+  test("for statement - no label") {
     val sqlScriptText =
       """
         |BEGIN
@@ -1987,7 +1987,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     assert(forStmt.label.isDefined)
   }
 
-  test("for statement with complex subquery") {
+  test("for statement - with complex subquery") {
     val sqlScriptText =
       """
         |BEGIN
@@ -2015,7 +2015,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     assert(forStmt.label.contains("lbl"))
   }
 
-  test("nested for statement") {
+  test("for statement - nested") {
     val sqlScriptText =
       """
         |BEGIN
@@ -2052,7 +2052,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
       head.asInstanceOf[SingleStatement].getText == "SELECT i + j")
   }
 
-  test("for statement no variable") {
+  test("for statement - no variable") {
     val sqlScriptText =
       """
         |BEGIN
@@ -2077,7 +2077,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     assert(forStmt.label.contains("lbl"))
   }
 
-  test("for statement no label no variable") {
+  test("for statement - no variable - no label") {
     val sqlScriptText =
       """
         |BEGIN
@@ -2103,7 +2103,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     assert(forStmt.label.isDefined)
   }
 
-  test("for statement with complex subquery no variable") {
+  test("for statement - no variable - with complex subquery") {
     val sqlScriptText =
       """
         |BEGIN
@@ -2131,7 +2131,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     assert(forStmt.label.contains("lbl"))
   }
 
-  test("nested for statement no variable") {
+  test("for statement - no variable - nested") {
     val sqlScriptText =
       """
         |BEGIN

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -52,7 +52,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     val sqlScriptText =
       """
         |BEGIN
-        |  FOR x AS (SELECT 1) DO
+        |  FOR x AS SELECT 1 DO
         |    SELECT 1;
         |    SELECT 2;
         |  END FOR;

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -48,6 +48,14 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     assert(tree.collection.head.isInstanceOf[ForStatement])
   }
 
+  test("testtesttest") {
+    val sqlScriptText = "DECLARE my_struct DEFAULT STRUCT<'x', 0, 1.2>;"
+
+    val tree = parseScript(sqlScriptText)
+    assert(tree.collection.length == 1)
+    assert(tree.collection.head.isInstanceOf[ForStatement])
+  }
+
   test("initial for") {
     val sqlScriptText =
       """

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -40,6 +40,28 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
   }
 
   // Tests
+  test("testtest") {
+    val sqlScriptText =
+      """SELECT named_struct('a', 1, 'b', 2, 'c', 3); """.stripMargin
+    val tree = parseScript(sqlScriptText)
+    assert(tree.collection.length == 1)
+    assert(tree.collection.head.isInstanceOf[ForStatement])
+  }
+
+  test("initial for") {
+    val sqlScriptText =
+      """
+        |BEGIN
+        |  FOR x AS (SELECT 1) DO
+        |    SELECT 1;
+        |    SELECT 2;
+        |  END FOR;
+        |END""".stripMargin
+    val tree = parseScript(sqlScriptText)
+    assert(tree.collection.length == 1)
+    assert(tree.collection.head.isInstanceOf[ForStatement])
+  }
+
   test("single select") {
     val sqlScriptText = "SELECT 1;"
     val statement = parsePlan(sqlScriptText)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -39,6 +39,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     super.afterAll()
   }
 
+  // Tests
   test("single select") {
     val sqlScriptText = "SELECT 1;"
     val statement = parsePlan(sqlScriptText)

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -698,9 +698,8 @@ class ForStatementExec(
     new Iterator[CompoundStatementExec] {
       override def hasNext: Boolean = {
         val resultSize = cachedQueryResult().length
-        val ret = state == ForState.VariableCleanup ||
+        state == ForState.VariableCleanup ||
           (!interrupted && resultSize > 0 && currRow < resultSize)
-        ret
       }
 
       override def next(): CompoundStatementExec = state match {
@@ -732,7 +731,7 @@ class ForStatementExec(
                 leaveStatementExec.hasBeenMatched = true
               }
               interrupted = true
-              // If this for statement encounters LEAVE, it will either not be executed ever
+              // If this for statement encounters LEAVE, it will either not be executed
               // again, or it will be reset before being executed.
               // In either case, variables will not
               // be dropped normally, from ForState.VariableCleanup, so we drop them here.
@@ -743,7 +742,7 @@ class ForStatementExec(
                 iterStatementExec.hasBeenMatched = true
               } else {
                 // if an outer loop is being iterated, this for statement will either not be
-                // executed ever again, or it will be reset before being executed.
+                // executed again, or it will be reset before being executed.
                 // In either case, variables will not
                 // be dropped normally, from ForState.VariableCleanup, so we drop them here.
                 dropVars()
@@ -761,6 +760,7 @@ class ForStatementExec(
         case ForState.VariableCleanup =>
           val ret = dropVariablesExec.getTreeIterator.next()
           if (!dropVariablesExec.getTreeIterator.hasNext) {
+            // stops execution, as at this point currRow == resultSize
             state = ForState.VariableAssignment
           }
           ret
@@ -862,6 +862,8 @@ class ForStatementExec(
     currRow = 0
     variablesMap = Map()
     areVariablesDeclared = false
+    dropVariablesExec = null
+    interrupted = false
     body.reset()
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -693,7 +693,6 @@ class ForStatementExec(
             return next()
           }
           currVariable = createExpressionFromValue(cachedQueryResult()(currRow))
-
           state = ForState.VariableAssignment
           createDeclareVarExec(variableName.get, currVariable)
 
@@ -731,6 +730,9 @@ class ForStatementExec(
       }
     }
 
+  /**
+   * Creates a Catalyst expression from Scala value.
+   */
   private def createExpressionFromValue(value: Any): Expression = value match {
     case m: Map[_, _] =>
       // arguments of CreateMap are in the format: (key1, val1, key2, val2, ...)

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -734,9 +734,9 @@ class ForStatementExec(
   private def createExpressionFromValue(value: Any): Expression = value match {
     case m: Map[_, _] =>
       // arguments of CreateMap are in the format: (key1, val1, key2, val2, ...)
-      val mapArgs = m.keys.zip(m.values).flatMap {case (k, v) =>
+      val mapArgs = m.keys.toSeq.zip(m.values.toSeq).flatMap { case (k, v) =>
         Seq(createExpressionFromValue(k), createExpressionFromValue(v))
-      }.toSeq
+      }
       CreateMap(mapArgs, false)
     case s: GenericRowWithSchema =>
     // struct types match this case

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -27,7 +27,6 @@ import org.apache.spark.sql.catalyst.trees.{Origin, WithOrigin}
 import org.apache.spark.sql.errors.SqlScriptingErrors
 import org.apache.spark.sql.types.BooleanType
 
-
 /**
  * Trait for all SQL scripting execution nodes used during interpretation phase.
  */

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -650,11 +650,11 @@ class LoopStatementExec(
  * @param session Spark session that SQL script is executed within.
  */
 class ForStatementExec(
-  query: SingleStatementExec,
-  variableName: Option[String],
-  body: CompoundBodyExec,
-  label: Option[String],
-  session: SparkSession) extends NonLeafStatementExec {
+    query: SingleStatementExec,
+    variableName: Option[String],
+    body: CompoundBodyExec,
+    label: Option[String],
+    session: SparkSession) extends NonLeafStatementExec {
 
   private object ForState extends Enumeration {
     val VariableDeclaration, VariableAssignment, Body = Value

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -131,7 +131,6 @@ class SingleStatementExec(
    *   The DataFrame.
    */
   def buildDataFrame(session: SparkSession): DataFrame = {
-      isExecuted = true
       Dataset.ofRows(session, parsedPlan)
   }
 
@@ -684,6 +683,7 @@ class ForStatementExec(
   private def cachedQueryResult(): Array[Row] = {
     if (!isResultCacheValid) {
       queryResult = query.buildDataFrame(session).collect()
+      query.isExecuted = true
       isResultCacheValid = true
     }
     queryResult

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -734,8 +734,8 @@ class ForStatementExec(
   private def createExpressionFromValue(value: Any): Expression = value match {
     case m: Map[_, _] =>
       // arguments of CreateMap are in the format: (key1, val1, key2, val2, ...)
-      val mapArgs = m.keys.toSeq.zip(m.values.toSeq).flatMap { case (k, v) =>
-        Seq(createExpressionFromValue(k), createExpressionFromValue(v))
+      val mapArgs = m.keys.toSeq.flatMap { key =>
+        Seq(createExpressionFromValue(key), createExpressionFromValue(m(key)))
       }
       CreateMap(mapArgs, false)
     case s: GenericRowWithSchema =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -749,7 +749,7 @@ class ForStatementExec(
       defaultExpression,
       replace = true
     )
-    new SingleStatementExec(declareVariable, Origin(), false)
+    new SingleStatementExec(declareVariable, Origin(), isInternal = true)
   }
 
   private def createSetVarExec(variable: Expression): SingleStatementExec = {
@@ -759,7 +759,7 @@ class ForStatementExec(
     )
     val setIdentifierToCurrentRow =
       SetVariable(Seq(UnresolvedAttribute(identifier.get)), projectNamedStruct)
-    new SingleStatementExec(setIdentifierToCurrentRow, Origin(), false)
+    new SingleStatementExec(setIdentifierToCurrentRow, Origin(), isInternal = true)
   }
 
   override def getTreeIterator: Iterator[CompoundStatementExec] = treeIterator

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -791,6 +791,7 @@ class ForStatementExec(
     case a: collection.Seq[_] =>
       val arrayArgs = a.toSeq.map(createExpressionFromValue(_))
       CreateArray(arrayArgs, useStringTypeWhenEmpty = false)
+
     case _ => Literal(value)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.scripting
 
+import java.util
+
 import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
@@ -26,8 +28,6 @@ import org.apache.spark.sql.catalyst.plans.logical.{CreateVariable, DefaultValue
 import org.apache.spark.sql.catalyst.trees.{Origin, WithOrigin}
 import org.apache.spark.sql.errors.SqlScriptingErrors
 import org.apache.spark.sql.types.BooleanType
-
-import java.util
 
 /**
  * Trait for all SQL scripting execution nodes used during interpretation phase.

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreter.scala
@@ -127,17 +127,7 @@ case class SqlScriptingInterpreter() {
         val queryExec = new SingleStatementExec(query.parsedPlan, query.origin, isInternal = false)
         val bodyExec =
           transformTreeIntoExecutable(body, session).asInstanceOf[CompoundBodyExec]
-        val finalExec = variableNameOpt match {
-          case None => bodyExec
-          case Some(variableName) =>
-            val dropVariableExec = new SingleStatementExec(
-              DropVariable(UnresolvedIdentifier(Seq(variableName)), ifExists = true),
-              Origin(),
-              isInternal = true
-            )
-            new CompoundBodyExec(Seq(bodyExec, dropVariableExec))
-        }
-        new ForStatementExec(queryExec, variableNameOpt, finalExec, label, session)
+        new ForStatementExec(queryExec, variableNameOpt, bodyExec, label, session)
 
       case leaveStatement: LeaveStatement =>
         new LeaveStatementExec(leaveStatement.label)

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreter.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.scripting
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.analysis.UnresolvedIdentifier
-import org.apache.spark.sql.catalyst.plans.logical.{CaseStatement, CompoundBody, CompoundPlanStatement, CreateVariable, DropVariable, IfElseStatement, IterateStatement, LeaveStatement, LogicalPlan, LoopStatement, RepeatStatement, SingleStatement, WhileStatement}
+import org.apache.spark.sql.catalyst.plans.logical.{CaseStatement, CompoundBody, CompoundPlanStatement, CreateVariable, DropVariable, ForStatement, IfElseStatement, IterateStatement, LeaveStatement, LogicalPlan, LoopStatement, RepeatStatement, SingleStatement, WhileStatement}
 import org.apache.spark.sql.catalyst.trees.Origin
 
 /**
@@ -122,6 +122,12 @@ case class SqlScriptingInterpreter() {
       case LoopStatement(body, label) =>
         val bodyExec = transformTreeIntoExecutable(body, session).asInstanceOf[CompoundBodyExec]
         new LoopStatementExec(bodyExec, label)
+
+      case ForStatement(query, identifier, body, label) =>
+        val queryExec = new SingleStatementExec(query.parsedPlan, query.origin, isInternal = false)
+        val bodyExec =
+          transformTreeIntoExecutable(body, session).asInstanceOf[CompoundBodyExec]
+        new ForStatementExec(queryExec, identifier, bodyExec, label, session)
 
       case leaveStatement: LeaveStatement =>
         new LeaveStatementExec(leaveStatement.label)

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreter.scala
@@ -123,21 +123,21 @@ case class SqlScriptingInterpreter() {
         val bodyExec = transformTreeIntoExecutable(body, session).asInstanceOf[CompoundBodyExec]
         new LoopStatementExec(bodyExec, label)
 
-      case ForStatement(query, identifierOpt, body, label) =>
+      case ForStatement(query, variableNameOpt, body, label) =>
         val queryExec = new SingleStatementExec(query.parsedPlan, query.origin, isInternal = false)
         val bodyExec =
           transformTreeIntoExecutable(body, session).asInstanceOf[CompoundBodyExec]
-        val finalExec = identifierOpt match {
+        val finalExec = variableNameOpt match {
           case None => bodyExec
-          case Some(identifier) =>
+          case Some(variableName) =>
             val dropVariableExec = new SingleStatementExec(
-              DropVariable(UnresolvedIdentifier(Seq(identifier)), ifExists = true),
+              DropVariable(UnresolvedIdentifier(Seq(variableName)), ifExists = true),
               Origin(),
-              isInternal = true)
+              isInternal = true
+            )
             new CompoundBodyExec(Seq(bodyExec, dropVariableExec))
         }
-
-        new ForStatementExec(queryExec, identifierOpt, finalExec, label, session)
+        new ForStatementExec(queryExec, variableNameOpt, finalExec, label, session)
 
       case leaveStatement: LeaveStatement =>
         new LeaveStatementExec(leaveStatement.label)

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
@@ -93,14 +93,14 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
       statement: LeafStatementExec): Boolean = evaluator.evaluateLoopBooleanCondition()
   }
 
-  case class TestForStatementQuery(numberOfRows: Int, description: String)
+  case class TestForStatementQuery(numberOfRows: Int, columnName: String, description: String)
       extends SingleStatementExec(
         DummyLogicalPlan(),
         Origin(startIndex = Some(0), stopIndex = Some(description.length)),
         isInternal = false) {
     override def buildDataFrame(session: SparkSession): DataFrame = {
       val data = Seq.range(0, numberOfRows).map(Row(_))
-      val schema = List(StructField("intCol", IntegerType))
+      val schema = List(StructField(columnName, IntegerType))
 
       spark.createDataFrame(
         spark.sparkContext.parallelize(data),
@@ -708,7 +708,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement - enters body once") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(1, "query1"),
+        query = TestForStatementQuery(1, "intCol", "query1"),
         variableName = Some("x"),
         body = new CompoundBodyExec(Seq(TestLeafStatement("body"))),
         label = Some("for1"),
@@ -724,7 +724,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement - enters body with multiple statements multiple times") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "query1"),
+        query = TestForStatementQuery(2, "intCol", "query1"),
         variableName = Some("x"),
         body = new CompoundBodyExec(Seq(
           TestLeafStatement("statement1"),
@@ -745,7 +745,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement - empty result") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(0, "query1"),
+        query = TestForStatementQuery(0, "intCol", "query1"),
         variableName = Some("x"),
         body = new CompoundBodyExec(Seq(TestLeafStatement("body1"))),
         label = Some("for1"),
@@ -759,11 +759,11 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement - nested") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "query1"),
+        query = TestForStatementQuery(2, "intCol", "query1"),
         variableName = Some("x"),
         body = new CompoundBodyExec(Seq(
           new ForStatementExec(
-            query = TestForStatementQuery(2, "query2"),
+            query = TestForStatementQuery(2, "intCol1", "query2"),
             variableName = Some("y"),
             body = new CompoundBodyExec(Seq(TestLeafStatement("body"))),
             label = Some("for2"),
@@ -786,7 +786,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement no variable - enters body once") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(1, "query1"),
+        query = TestForStatementQuery(1, "intCol", "query1"),
         variableName = None,
         body = new CompoundBodyExec(Seq(TestLeafStatement("body"))),
         label = Some("for1"),
@@ -800,7 +800,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement no variable - enters body with multiple statements multiple times") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "query1"),
+        query = TestForStatementQuery(2, "intCol", "query1"),
         variableName = None,
         body = new CompoundBodyExec(Seq(
           TestLeafStatement("statement1"),
@@ -816,7 +816,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement no variable - empty result") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(0, "query1"),
+        query = TestForStatementQuery(0, "intCol", "query1"),
         variableName = None,
         body = new CompoundBodyExec(Seq(TestLeafStatement("body1"))),
         label = Some("for1"),
@@ -830,11 +830,11 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement no variable - nested") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "query1"),
+        query = TestForStatementQuery(2, "intCol", "query1"),
         variableName = None,
         body = new CompoundBodyExec(Seq(
           new ForStatementExec(
-            query = TestForStatementQuery(2, "query2"),
+            query = TestForStatementQuery(2, "intCol1", "query2"),
             variableName = None,
             body = new CompoundBodyExec(Seq(TestLeafStatement("body"))),
             label = Some("for2"),
@@ -852,7 +852,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement - iterate") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "query1"),
+        query = TestForStatementQuery(2, "intCol", "query1"),
         variableName = Some("x"),
         body = new CompoundBodyExec(Seq(
           TestLeafStatement("statement1"),
@@ -874,7 +874,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement - leave") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "query1"),
+        query = TestForStatementQuery(2, "intCol", "query1"),
         variableName = Some("x"),
         body = new CompoundBodyExec(Seq(
           TestLeafStatement("statement1"),
@@ -894,11 +894,11 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement - nested - iterate outer loop") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "query1"),
+        query = TestForStatementQuery(2, "intCol", "query1"),
         variableName = Some("x"),
         body = new CompoundBodyExec(Seq(
           new ForStatementExec(
-            query = TestForStatementQuery(2, "query2"),
+            query = TestForStatementQuery(2, "intCol1", "query2"),
             variableName = Some("y"),
             body = new CompoundBodyExec(Seq(
               TestLeafStatement("body1"),
@@ -924,11 +924,11 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement - nested - leave outer loop") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "query1"),
+        query = TestForStatementQuery(2, "intCol", "query1"),
         variableName = Some("x"),
         body = new CompoundBodyExec(Seq(
           new ForStatementExec(
-            query = TestForStatementQuery(2, "query2"),
+            query = TestForStatementQuery(2, "intCol", "query2"),
             variableName = Some("y"),
             body = new CompoundBodyExec(Seq(
               TestLeafStatement("body1"),
@@ -952,7 +952,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement no variable - iterate") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "query1"),
+        query = TestForStatementQuery(2, "intCol", "query1"),
         variableName = None,
         body = new CompoundBodyExec(Seq(
           TestLeafStatement("statement1"),
@@ -969,7 +969,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement no variable - leave") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "query1"),
+        query = TestForStatementQuery(2, "intCol", "query1"),
         variableName = None,
         body = new CompoundBodyExec(Seq(
           TestLeafStatement("statement1"),
@@ -986,11 +986,11 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement no variable - nested - iterate outer loop") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "query1"),
+        query = TestForStatementQuery(2, "intCol", "query1"),
         variableName = None,
         body = new CompoundBodyExec(Seq(
           new ForStatementExec(
-            query = TestForStatementQuery(2, "query2"),
+            query = TestForStatementQuery(2, "intCol1", "query2"),
             variableName = None,
             body = new CompoundBodyExec(Seq(
               TestLeafStatement("body1"),
@@ -1011,11 +1011,11 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement no variable - nested - leave outer loop") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "query1"),
+        query = TestForStatementQuery(2, "intCol", "query1"),
         variableName = None,
         body = new CompoundBodyExec(Seq(
           new ForStatementExec(
-            query = TestForStatementQuery(2, "query2"),
+            query = TestForStatementQuery(2, "intCol1", "query2"),
             variableName = None,
             body = new CompoundBodyExec(Seq(
               TestLeafStatement("body1"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
@@ -744,7 +744,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
       "statement1",
       "statement2",
       "DropVariable", // drop for query var intCol
-      "DropVariable", // drop for loop var x
+      "DropVariable" // drop for loop var x
     ))
   }
 
@@ -791,7 +791,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
       "DropVariable", // drop for query var intCol1
       "DropVariable", // drop for loop var y
       "DropVariable", // drop for query var intCol
-      "DropVariable", // drop for loop var x
+      "DropVariable" // drop for loop var x
     ))
   }
 
@@ -808,7 +808,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
     val statements = iter.map(extractStatementValue).toSeq
     assert(statements === Seq(
       "body",
-      "DropVariable", // drop for query var intCol
+      "DropVariable" // drop for query var intCol
     ))
   }
 
@@ -827,7 +827,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
     val statements = iter.map(extractStatementValue).toSeq
     assert(statements === Seq(
       "statement1", "statement2", "statement1", "statement2",
-      "DropVariable", // drop for query var intCol
+      "DropVariable" // drop for query var intCol
     ))
   }
 
@@ -869,7 +869,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
       "DropVariable", // drop for query var intCol1
       "body", "body",
       "DropVariable", // drop for query var intCol1
-      "DropVariable", // drop for query var intCol
+      "DropVariable" // drop for query var intCol
     ))
   }
 
@@ -893,7 +893,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
       "statement1",
       "lbl1",
       "DropVariable", // drop for query var intCol
-      "DropVariable", // drop for loop var x
+      "DropVariable" // drop for loop var x
     ))
   }
 
@@ -945,7 +945,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
       "body1",
       "lbl1",
       "DropVariable", // drop for query var intCol
-      "DropVariable", // drop for loop var x
+      "DropVariable" // drop for loop var x
     ))
   }
 
@@ -990,7 +990,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
     val statements = iter.map(extractStatementValue).toSeq
     assert(statements === Seq(
       "statement1", "lbl1", "statement1", "lbl1",
-      "DropVariable", // drop for query var intCol
+      "DropVariable" // drop for query var intCol
     ))
   }
 
@@ -1036,7 +1036,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
     val statements = iter.map(extractStatementValue).toSeq
     assert(statements === Seq(
       "outer_body", "body1", "lbl1", "outer_body", "body1", "lbl1",
-      "DropVariable", // drop for query var intCol
+      "DropVariable" // drop for query var intCol
     ))
   }
 
@@ -1056,9 +1056,9 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
             body = new CompoundBodyExec(Seq(
               TestLeafStatement("body1"),
               new LeaveStatementExec("lbl1"),
-              TestLeafStatement("body2"))),
+              TestLeafStatement("body2")))
           )
-        )),
+        ))
       )
     )).getTreeIterator
     val statements = iter.map(extractStatementValue).toSeq

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
@@ -118,7 +118,6 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
       case leaveStmt: LeaveStatementExec => leaveStmt.label
       case iterateStmt: IterateStatementExec => iterateStmt.label
       case forStmt: ForStatementExec => forStmt.label.get
-      case _: SingleStatementExec => "SingleStatementExec"
       case _ => fail("Unexpected statement type")
     }
 
@@ -718,8 +717,6 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
     )).getTreeIterator
     val statements = iter.map(extractStatementValue).toSeq
     assert(statements === Seq(
-      "SingleStatementExec", // declare var
-      "SingleStatementExec", // set var
       "body"
     ))
   }
@@ -738,12 +735,8 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
     )).getTreeIterator
     val statements = iter.map(extractStatementValue).toSeq
     assert(statements === Seq(
-      "SingleStatementExec", // declare var
-      "SingleStatementExec", // set var
       "statement1",
       "statement2",
-      "SingleStatementExec", // declare var
-      "SingleStatementExec", // set var
       "statement1",
       "statement2"
     ))
@@ -783,21 +776,9 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
     )).getTreeIterator
     val statements = iter.map(extractStatementValue).toSeq
     assert(statements === Seq(
-      "SingleStatementExec", // declare x
-      "SingleStatementExec", // set x
-      "SingleStatementExec", // declare y
-      "SingleStatementExec", // set y
       "body",
-      "SingleStatementExec", // declare y
-      "SingleStatementExec", // set y
       "body",
-      "SingleStatementExec", // declare x
-      "SingleStatementExec", // set x
-      "SingleStatementExec", // declare y
-      "SingleStatementExec", // set y
       "body",
-      "SingleStatementExec", // declare y
-      "SingleStatementExec", // set y
       "body"
     ))
   }
@@ -883,12 +864,8 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
     )).getTreeIterator
     val statements = iter.map(extractStatementValue).toSeq
     assert(statements === Seq(
-      "SingleStatementExec", // declare var
-      "SingleStatementExec", // set var
       "statement1",
       "lbl1",
-      "SingleStatementExec", // declare var
-      "SingleStatementExec", // set var
       "statement1",
       "lbl1"
     ))
@@ -909,8 +886,6 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
     )).getTreeIterator
     val statements = iter.map(extractStatementValue).toSeq
     assert(statements === Seq(
-      "SingleStatementExec", // declare var
-      "SingleStatementExec", // set var
       "statement1",
       "lbl1"
     ))
@@ -939,16 +914,8 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
     )).getTreeIterator
     val statements = iter.map(extractStatementValue).toSeq
     assert(statements === Seq(
-      "SingleStatementExec", // declare x
-      "SingleStatementExec", // set x
-      "SingleStatementExec", // declare y
-      "SingleStatementExec", // set y
       "body1",
       "lbl1",
-      "SingleStatementExec", // declare x
-      "SingleStatementExec", // set x
-      "SingleStatementExec", // declare y
-      "SingleStatementExec", // set y
       "body1",
       "lbl1"
     ))
@@ -977,10 +944,6 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
     )).getTreeIterator
     val statements = iter.map(extractStatementValue).toSeq
     assert(statements === Seq(
-      "SingleStatementExec", // declare x
-      "SingleStatementExec", // set x
-      "SingleStatementExec", // declare y
-      "SingleStatementExec", // set y
       "body1",
       "lbl1"
     ))

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
@@ -93,7 +93,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
       statement: LeafStatementExec): Boolean = evaluator.evaluateLoopBooleanCondition()
   }
 
-  case class TestForStatementQuery(numberOfRows: Int, columnName: String, description: String)
+  case class MockQuery(numberOfRows: Int, columnName: String, description: String)
       extends SingleStatementExec(
         DummyLogicalPlan(),
         Origin(startIndex = Some(0), stopIndex = Some(description.length)),
@@ -709,7 +709,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement - enters body once") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(1, "intCol", "query1"),
+        query = MockQuery(1, "intCol", "query1"),
         variableName = Some("x"),
         body = new CompoundBodyExec(Seq(TestLeafStatement("body"))),
         label = Some("for1"),
@@ -727,7 +727,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement - enters body with multiple statements multiple times") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "intCol", "query1"),
+        query = MockQuery(2, "intCol", "query1"),
         variableName = Some("x"),
         body = new CompoundBodyExec(Seq(
           TestLeafStatement("statement1"),
@@ -750,7 +750,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement - empty result") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(0, "intCol", "query1"),
+        query = MockQuery(0, "intCol", "query1"),
         variableName = Some("x"),
         body = new CompoundBodyExec(Seq(TestLeafStatement("body1"))),
         label = Some("for1"),
@@ -764,11 +764,11 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement - nested") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "intCol", "query1"),
+        query = MockQuery(2, "intCol", "query1"),
         variableName = Some("x"),
         body = new CompoundBodyExec(Seq(
           new ForStatementExec(
-            query = TestForStatementQuery(2, "intCol1", "query2"),
+            query = MockQuery(2, "intCol1", "query2"),
             variableName = Some("y"),
             body = new CompoundBodyExec(Seq(TestLeafStatement("body"))),
             label = Some("for2"),
@@ -797,7 +797,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement no variable - enters body once") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(1, "intCol", "query1"),
+        query = MockQuery(1, "intCol", "query1"),
         variableName = None,
         body = new CompoundBodyExec(Seq(TestLeafStatement("body"))),
         label = Some("for1"),
@@ -814,7 +814,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement no variable - enters body with multiple statements multiple times") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "intCol", "query1"),
+        query = MockQuery(2, "intCol", "query1"),
         variableName = None,
         body = new CompoundBodyExec(Seq(
           TestLeafStatement("statement1"),
@@ -833,7 +833,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement no variable - empty result") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(0, "intCol", "query1"),
+        query = MockQuery(0, "intCol", "query1"),
         variableName = None,
         body = new CompoundBodyExec(Seq(TestLeafStatement("body1"))),
         label = Some("for1"),
@@ -847,11 +847,11 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement no variable - nested") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "intCol", "query1"),
+        query = MockQuery(2, "intCol", "query1"),
         variableName = None,
         body = new CompoundBodyExec(Seq(
           new ForStatementExec(
-            query = TestForStatementQuery(2, "intCol1", "query2"),
+            query = MockQuery(2, "intCol1", "query2"),
             variableName = None,
             body = new CompoundBodyExec(Seq(TestLeafStatement("body"))),
             label = Some("for2"),
@@ -875,7 +875,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement - iterate") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "intCol", "query1"),
+        query = MockQuery(2, "intCol", "query1"),
         variableName = Some("x"),
         body = new CompoundBodyExec(Seq(
           TestLeafStatement("statement1"),
@@ -899,7 +899,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement - leave") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "intCol", "query1"),
+        query = MockQuery(2, "intCol", "query1"),
         variableName = Some("x"),
         body = new CompoundBodyExec(Seq(
           TestLeafStatement("statement1"),
@@ -919,12 +919,12 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement - nested - iterate outer loop") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "intCol", "query1"),
+        query = MockQuery(2, "intCol", "query1"),
         variableName = Some("x"),
         body = new CompoundBodyExec(Seq(
           TestLeafStatement("outer_body"),
           new ForStatementExec(
-            query = TestForStatementQuery(2, "intCol1", "query2"),
+            query = MockQuery(2, "intCol1", "query2"),
             variableName = Some("y"),
             body = new CompoundBodyExec(Seq(
               TestLeafStatement("body1"),
@@ -954,11 +954,11 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement - nested - leave outer loop") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "intCol", "query1"),
+        query = MockQuery(2, "intCol", "query1"),
         variableName = Some("x"),
         body = new CompoundBodyExec(Seq(
           new ForStatementExec(
-            query = TestForStatementQuery(2, "intCol", "query2"),
+            query = MockQuery(2, "intCol", "query2"),
             variableName = Some("y"),
             body = new CompoundBodyExec(Seq(
               TestLeafStatement("body1"),
@@ -982,7 +982,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement no variable - iterate") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "intCol", "query1"),
+        query = MockQuery(2, "intCol", "query1"),
         variableName = None,
         body = new CompoundBodyExec(Seq(
           TestLeafStatement("statement1"),
@@ -1002,7 +1002,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement no variable - leave") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "intCol", "query1"),
+        query = MockQuery(2, "intCol", "query1"),
         variableName = None,
         body = new CompoundBodyExec(Seq(
           TestLeafStatement("statement1"),
@@ -1019,12 +1019,12 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement no variable - nested - iterate outer loop") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "intCol", "query1"),
+        query = MockQuery(2, "intCol", "query1"),
         variableName = None,
         body = new CompoundBodyExec(Seq(
           TestLeafStatement("outer_body"),
           new ForStatementExec(
-            query = TestForStatementQuery(2, "intCol1", "query2"),
+            query = MockQuery(2, "intCol1", "query2"),
             variableName = None,
             body = new CompoundBodyExec(Seq(
               TestLeafStatement("body1"),
@@ -1048,11 +1048,11 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
   test("for statement no variable - nested - leave outer loop") {
     val iter = new CompoundBodyExec(Seq(
       new ForStatementExec(
-        query = TestForStatementQuery(2, "intCol", "query1"),
+        query = MockQuery(2, "intCol", "query1"),
         variableName = None,
         body = new CompoundBodyExec(Seq(
           new ForStatementExec(
-            query = TestForStatementQuery(2, "intCol1", "query2"),
+            query = MockQuery(2, "intCol1", "query2"),
             variableName = None,
             body = new CompoundBodyExec(Seq(
               TestLeafStatement("body1"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
@@ -99,6 +99,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
       extends SingleStatementExec(
         DummyLogicalPlan(),
         Origin(startIndex = Some(0), stopIndex = Some(description.length)),
+        Map.empty,
         isInternal = false) {
     override def buildDataFrame(session: SparkSession): DataFrame = {
       val data = Seq.range(0, numberOfRows).map(Row(_))

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -1548,8 +1548,6 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
     verifySqlScriptResult(sqlScriptText, expected)
   }
 
-  // todo: duplicate for non var tests, negative tests,
-  //  for statement nested, nested leave, nested iterate
   test("for statement - enters body once") {
     withTable("t") {
       val sqlScript =
@@ -2070,6 +2068,468 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq(Row(3)), // select y.intCol2
         Seq(Row(3)), // select intCol2
         Seq.empty[Row], // drop outer var
+        Seq.empty[Row], // drop outer var
+      )
+      verifySqlScriptResult(sqlScript, expected)
+    }
+  }
+
+  test("for statement - no variable - enters body once") {
+    withTable("t") {
+      val sqlScript =
+        """
+          |BEGIN
+          | CREATE TABLE t (intCol INT, stringCol STRING, doubleCol DOUBLE) using parquet;
+          | INSERT INTO t VALUES (1, 'first', 1.0);
+          | FOR SELECT * FROM t DO
+          |   SELECT intCol;
+          |   SELECT stringCol;
+          |   SELECT doubleCol;
+          | END FOR;
+          |END
+          |""".stripMargin
+
+      val expected = Seq(
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // insert
+        Seq(Row(1)), // select intCol
+        Seq(Row("first")), // select stringCol
+        Seq(Row(1.0)), // select doubleCol
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+      )
+      verifySqlScriptResult(sqlScript, expected)
+    }
+  }
+
+  test("for statement - no variable - enters body with multiple statements multiple times") {
+    withTable("t") {
+      val sqlScript =
+        """
+          |BEGIN
+          | CREATE TABLE t (intCol INT, stringCol STRING, doubleCol DOUBLE) using parquet;
+          | INSERT INTO t VALUES (1, 'first', 1.0);
+          | INSERT INTO t VALUES (2, 'second', 2.0);
+          | FOR SELECT * FROM t ORDER BY intCol DO
+          |   SELECT intCol;
+          |   SELECT stringCol;
+          |   SELECT doubleCol;
+          | END FOR;
+          |END
+          |""".stripMargin
+
+      val expected = Seq(
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // insert
+        Seq.empty[Row], // insert
+        Seq(Row(1)), // select intCol
+        Seq(Row("first")), // select stringCol
+        Seq(Row(1.0)), // select doubleCol
+        Seq(Row(2)), // select intCol
+        Seq(Row("second")), // select stringCol
+        Seq(Row(2.0)), // select doubleCol
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+      )
+      verifySqlScriptResult(sqlScript, expected)
+    }
+  }
+
+  test("for statement - no variable - map, struct, array") {
+    withTable("t") {
+      val sqlScript =
+        """
+          |BEGIN
+          | CREATE TABLE t (int_column INT, map_column MAP<STRING, INT>, struct_column STRUCT<name: STRING, age: INT>, array_column ARRAY<STRING>);
+          | INSERT INTO t VALUES
+          |  (1, MAP('a', 1), STRUCT('John', 25), ARRAY('apricot', 'quince')),
+          |  (2, MAP('b', 2), STRUCT('Jane', 30), ARRAY('plum', 'pear'));
+          | FOR SELECT * FROM t ORDER BY int_column DO
+          |   SELECT map_column;
+          |   SELECT struct_column;
+          |   SELECT array_column;
+          | END FOR;
+          |END
+          |""".stripMargin
+
+      val expected = Seq(
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // insert
+        Seq(Row(Map("a" -> 1))), // select map_column
+        Seq(Row(Row("John", 25))), // select struct_column
+        Seq(Row(Array("apricot", "quince"))), // select array_column
+        Seq(Row(Map("b" -> 2))), // select map_column
+        Seq(Row(Row("Jane", 30))), // select struct_column
+        Seq(Row(Array("plum", "pear"))), // select array_column
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+      )
+      verifySqlScriptResult(sqlScript, expected)
+    }
+  }
+
+  test("for statement - no variable - nested struct") {
+    withTable("t") {
+      val sqlScript =
+        """
+          |BEGIN
+          | CREATE TABLE t
+          | (int_column INT, struct_column STRUCT<num: INT, struct2: STRUCT<struct3: STRUCT<name: STRING>>>);
+          | INSERT INTO t VALUES
+          |  (1, STRUCT(1, STRUCT(STRUCT("one")))),
+          |  (2, STRUCT(2, STRUCT(STRUCT("two"))));
+          | FOR SELECT * FROM t ORDER BY int_column DO
+          |   SELECT struct_column;
+          | END FOR;
+          |END
+          |""".stripMargin
+
+      val expected = Seq(
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // insert
+        Seq(Row(Row(1, Row(Row("one"))))), // select struct_column
+        Seq(Row(Row(2, Row(Row("two"))))), // select struct_column
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+      )
+      verifySqlScriptResult(sqlScript, expected)
+    }
+  }
+
+  test("for statement - no variable - nested map") {
+    withTable("t") {
+      val sqlScript =
+        """
+          |BEGIN
+          | CREATE TABLE t (int_column INT, map_column MAP<STRING, MAP<INT, MAP<BOOLEAN, INT>>>);
+          | INSERT INTO t VALUES
+          |  (1, MAP('a', MAP(1, MAP(false, 10)))),
+          |  (2, MAP('b', MAP(2, MAP(true, 20))));
+          | FOR SELECT * FROM t ORDER BY int_column DO
+          |   SELECT map_column;
+          | END FOR;
+          |END
+          |""".stripMargin
+
+      val expected = Seq(
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // insert
+        Seq(Row(Map("a" -> Map(1 -> Map(false -> 10))))), // select map_column
+        Seq(Row(Map("b" -> Map(2 -> Map(true -> 20))))), // select map_column
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+      )
+      verifySqlScriptResult(sqlScript, expected)
+    }
+  }
+
+  test("for statement - no variable - nested array") {
+    withTable("t") {
+      val sqlScript =
+        """
+          |BEGIN
+          | CREATE TABLE t
+          | (int_column INT, array_column ARRAY<ARRAY<ARRAY<INT>>>);
+          | INSERT INTO t VALUES
+          |  (1, ARRAY(ARRAY(ARRAY(1, 2), ARRAY(3, 4)), ARRAY(ARRAY(5, 6)))),
+          |  (2, ARRAY(ARRAY(ARRAY(7, 8), ARRAY(9, 10)), ARRAY(ARRAY(11, 12))));
+          | FOR SELECT * FROM t ORDER BY int_column DO
+          |   SELECT array_column;
+          | END FOR;
+          |END
+          |""".stripMargin
+
+      val expected = Seq(
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // insert
+        Seq(Row(Seq(Seq(Seq(1, 2), Seq(3, 4)), Seq(Seq(5, 6))))), // array_column
+        Seq(Row(Array(Seq(Seq(7, 8), Seq(9, 10)), Seq(Seq(11, 12))))), // array_column
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+      )
+      verifySqlScriptResult(sqlScript, expected)
+    }
+  }
+
+  test("for statement - no variable - empty result") {
+    withTable("t") {
+      val sqlScript =
+        """
+          |BEGIN
+          | CREATE TABLE t (intCol INT) using parquet;
+          | FOR SELECT * FROM t ORDER BY intCol DO
+          |   SELECT intCol;
+          | END FOR;
+          |END
+          |""".stripMargin
+
+      val expected = Seq(
+        Seq.empty[Row], // create table
+      )
+      verifySqlScriptResult(sqlScript, expected)
+    }
+  }
+
+  test("for statement - no variable - iterate") {
+    withTable("t") {
+      val sqlScript =
+        """
+          |BEGIN
+          | CREATE TABLE t (intCol INT, stringCol STRING) using parquet;
+          | INSERT INTO t VALUES (1, 'first'), (2, 'second'), (3, 'third'), (4, 'fourth');
+          |
+          | lbl: FOR SELECT * FROM t ORDER BY intCol DO
+          |   IF intCol = 2 THEN
+          |     ITERATE lbl;
+          |   END IF;
+          |   SELECT stringCol;
+          | END FOR;
+          |END
+          |""".stripMargin
+
+      val expected = Seq(
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // insert
+        Seq(Row("first")), // select stringCol
+        Seq(Row("third")), // select stringCol
+        Seq(Row("fourth")), // select stringCol
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+      )
+      verifySqlScriptResult(sqlScript, expected)
+    }
+  }
+
+  test("for statement - no variable - leave") {
+    withTable("t") {
+      val sqlScript =
+        """
+          |BEGIN
+          | CREATE TABLE t (intCol INT, stringCol STRING) using parquet;
+          | INSERT INTO t VALUES (1, 'first'), (2, 'second'), (3, 'third'), (4, 'fourth');
+          |
+          | lbl: FOR SELECT * FROM t ORDER BY intCol DO
+          |   IF intCol = 3 THEN
+          |     LEAVE lbl;
+          |   END IF;
+          |   SELECT stringCol;
+          | END FOR;
+          |END
+          |""".stripMargin
+
+      val expected = Seq(
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // insert
+        Seq(Row("first")), // select stringCol
+        Seq(Row("second")), // select stringCol
+      )
+      verifySqlScriptResult(sqlScript, expected)
+    }
+  }
+
+  test("for statement - no variable - nested - in while") {
+    withTable("t") {
+      val sqlScript =
+        """
+          |BEGIN
+          | DECLARE cnt = 0;
+          | CREATE TABLE t (intCol INT) using parquet;
+          | INSERT INTO t VALUES (0);
+          | WHILE cnt < 2 DO
+          |   SET cnt = cnt + 1;
+          |   FOR SELECT * FROM t ORDER BY intCol DO
+          |     SELECT intCol;
+          |   END FOR;
+          |   INSERT INTO t VALUES (cnt);
+          | END WHILE;
+          |END
+          |""".stripMargin
+
+      val expected = Seq(
+        Seq.empty[Row], // declare cnt
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // insert
+        Seq.empty[Row], // set cnt
+        Seq(Row(0)), // select intCol
+        Seq.empty[Row], // insert
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // set cnt
+        Seq(Row(0)), // select intCol
+        Seq(Row(1)), // select intCol
+        Seq.empty[Row], // insert
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row] // drop cnt
+      )
+      verifySqlScriptResult(sqlScript, expected)
+    }
+  }
+
+  test("for statement - no variable - nested - in other for") {
+    withTable("t", "t2") {
+      val sqlScript =
+        """
+          |BEGIN
+          | CREATE TABLE t (intCol INT) using parquet;
+          | CREATE TABLE t2 (intCol2 INT) using parquet;
+          | INSERT INTO t VALUES (0), (1);
+          | INSERT INTO t2 VALUES (2), (3);
+          | FOR SELECT * FROM t ORDER BY intCol DO
+          |   FOR SELECT * FROM t2 ORDER BY intCol2 DESC DO
+          |     SELECT intCol;
+          |     SELECT intCol2;
+          |   END FOR;
+          | END FOR;
+          |END
+          |""".stripMargin
+
+      val expected = Seq(
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // insert
+        Seq.empty[Row], // insert
+        Seq(Row(0)), // select intCol
+        Seq(Row(3)), // select intCol2
+        Seq(Row(0)), // select intCol
+        Seq(Row(2)), // select intCol2
+        Seq.empty[Row], // drop local var
+        Seq(Row(1)), // select intCol
+        Seq(Row(3)), // select intCol2
+        Seq(Row(1)), // select intCol
+        Seq(Row(2)), // select intCol2
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row] // drop outer var
+      )
+      verifySqlScriptResult(sqlScript, expected)
+    }
+  }
+
+  // ignored until loops are fixed to support empty bodies
+  ignore("for statement - no variable - nested - empty result set") {
+    withTable("t") {
+      val sqlScript =
+        """
+          |BEGIN
+          | CREATE TABLE t (intCol INT) using parquet;
+          | REPEAT
+          |   FOR SELECT * FROM t ORDER BY intCol DO
+          |     SELECT intCol;
+          |   END FOR;
+          | UNTIL 1 = 1
+          | END REPEAT;
+          |END
+          |""".stripMargin
+
+      val expected = Seq(
+        Seq.empty[Row], // declare cnt
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // insert
+        Seq.empty[Row], // set cnt
+        Seq(Row(0)), // select intCol
+        Seq.empty[Row], // insert
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // set cnt
+        Seq(Row(0)), // select intCol
+        Seq(Row(1)), // select intCol
+        Seq.empty[Row], // insert
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row] // drop cnt
+      )
+      verifySqlScriptResult(sqlScript, expected)
+    }
+  }
+
+  test("for statement - no variable - nested - iterate outer loop") {
+    withTable("t", "t2") {
+      val sqlScript =
+        """
+          |BEGIN
+          | CREATE TABLE t (intCol INT) using parquet;
+          | CREATE TABLE t2 (intCol2 INT) using parquet;
+          | INSERT INTO t VALUES (0), (1);
+          | INSERT INTO t2 VALUES (2), (3);
+          | lbl1: FOR SELECT * FROM t ORDER BY intCol DO
+          |   lbl2: FOR SELECT * FROM t2 ORDER BY intCol2 DESC DO
+          |     SELECT intCol2;
+          |     ITERATE lbl1;
+          |     SELECT 1;
+          |   END FOR;
+          | END FOR;
+          |END
+          |""".stripMargin
+
+      val expected = Seq(
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // insert
+        Seq.empty[Row], // insert
+        Seq(Row(3)), // select intCol2
+        Seq(Row(3)), // select intCol2
+        Seq.empty[Row] // drop outer var
+      )
+      verifySqlScriptResult(sqlScript, expected)
+    }
+  }
+
+  test("for statement - no variable - nested - leave outer loop") {
+    withTable("t", "t2") {
+      val sqlScript =
+        """
+          |BEGIN
+          | CREATE TABLE t (intCol INT) using parquet;
+          | CREATE TABLE t2 (intCol2 INT) using parquet;
+          | INSERT INTO t VALUES (0), (1);
+          | INSERT INTO t2 VALUES (2), (3);
+          | lbl1: FOR SELECT * FROM t ORDER BY intCol DO
+          |   lbl2: FOR SELECT * FROM t2 ORDER BY intCol2 DESC DO
+          |     SELECT intCol2;
+          |     LEAVE lbl1;
+          |     SELECT 1;
+          |   END FOR;
+          | END FOR;
+          |END
+          |""".stripMargin
+
+      val expected = Seq(
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // insert
+        Seq.empty[Row], // insert
+        Seq(Row(3)), // select intCol2
+      )
+      verifySqlScriptResult(sqlScript, expected)
+    }
+  }
+
+  test("for statement - no variable - nested - leave inner loop") {
+    withTable("t", "t2") {
+      val sqlScript =
+        """
+          |BEGIN
+          | CREATE TABLE t (intCol INT) using parquet;
+          | CREATE TABLE t2 (intCol2 INT) using parquet;
+          | INSERT INTO t VALUES (0), (1);
+          | INSERT INTO t2 VALUES (2), (3);
+          | lbl1: FOR SELECT * FROM t ORDER BY intCol DO
+          |   lbl2: FOR SELECT * FROM t2 ORDER BY intCol2 DESC DO
+          |     SELECT intCol2;
+          |     LEAVE lbl2;
+          |     SELECT 1;
+          |   END FOR;
+          | END FOR;
+          |END
+          |""".stripMargin
+
+      val expected = Seq(
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // insert
+        Seq.empty[Row], // insert
+        Seq(Row(3)), // select intCol2
+        Seq(Row(3)), // select intCol2
         Seq.empty[Row], // drop outer var
       )
       verifySqlScriptResult(sqlScript, expected)

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -1564,8 +1564,11 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
           | INSERT INTO t VALUES (2, 'second', 2.0);
           | FOR x AS SELECT * FROM t ORDER BY intCol DO
           |   SELECT x.intCol;
+          |   SELECT intCol;
           |   SELECT x.stringCol;
+          |   SELECT stringCol;
           |   SELECT x.doubleCol;
+          |   SELECT doubleCol;
           | END FOR;
           |END
           |""".stripMargin
@@ -1574,18 +1577,18 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq.empty[Row], // create table
         Seq.empty[Row], // insert
         Seq.empty[Row], // insert
-        Seq.empty[Row], // declare x
-        Seq.empty[Row], // set x to row 0
+        Seq(Row(1)), // select x.intCol
         Seq(Row(1)), // select intCol
+        Seq(Row("first")), // select x.stringCol
         Seq(Row("first")), // select stringCol
+        Seq(Row(1.0)), // select x.doubleCol
         Seq(Row(1.0)), // select doubleCol
-        Seq.empty[Row], // drop x
-        Seq.empty[Row], // declare x
-        Seq.empty[Row], // set x to row 1
+        Seq(Row(2)), // select x.intCol
         Seq(Row(2)), // select intCol
+        Seq(Row("second")), // select x.stringCol
         Seq(Row("second")), // select stringCol
-        Seq(Row(2.0)), // select doubleCol
-        Seq.empty[Row] // drop x
+        Seq(Row(2.0)), // select x.doubleCol
+        Seq(Row(2.0)) // select doubleCol
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -1602,8 +1605,11 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
           |  (2, MAP('b', MAP(2, 20)), STRUCT('Jane', 30), ARRAY('apple', 'banana'));
           | FOR row AS SELECT * FROM t ORDER BY int_column DO
           |   SELECT row.map_column;
+          |   SELECT map_column;
           |   SELECT row.struct_column;
+          |   SELECT struct_column;
           |   SELECT row.array_column;
+          |   SELECT array_column;
           | END FOR;
           |END
           |""".stripMargin
@@ -1611,18 +1617,18 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
       val expected = Seq(
         Seq.empty[Row], // create table
         Seq.empty[Row], // insert
-        Seq.empty[Row], // declare x
-        Seq.empty[Row], // set x to row 0
+        Seq(Row(Map("a" -> Map(1 -> 10)))), // select row.map_column
         Seq(Row(Map("a" -> Map(1 -> 10)))), // select map_column
+        Seq(Row(Row("John", 25))), // select row.struct_column
         Seq(Row(Row("John", 25))), // select struct_column
+        Seq(Row(Array("apple", "banana"))), // select row.array_column
         Seq(Row(Array("apple", "banana"))), // select array_column
-        Seq.empty[Row], // drop x
-        Seq.empty[Row], // declare x
-        Seq.empty[Row], // set x to row 1
+        Seq(Row(Map("b" -> Map(2 -> 20)))), // select row.map_column
         Seq(Row(Map("b" -> Map(2 -> 20)))), // select map_column
+        Seq(Row(Row("Jane", 30))), // select row.struct_column
         Seq(Row(Row("Jane", 30))), // select struct_column
-        Seq(Row(Array("apple", "banana"))), // select array_column
-        Seq.empty[Row] // drop x
+        Seq(Row(Array("apple", "banana"))), // select row.array_column
+        Seq(Row(Array("apple", "banana"))) // select array_column
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -1712,21 +1718,9 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq.empty[Row], // insert
         Seq.empty[Row], // insert
         Seq.empty[Row], // insert
-        Seq.empty[Row], // declare x
-        Seq.empty[Row], // set x to row 0
         Seq(Row("first")), // select stringCol
-        Seq.empty[Row], // drop x
-        Seq.empty[Row], // declare x
-        Seq.empty[Row], // set x to row 1
-        //        Seq.empty[Row], // drop x - TODO: uncomment when iterate can handle dropping vars
-        Seq.empty[Row], // declare x
-        Seq.empty[Row], // set x to row 2
         Seq(Row("third")), // select stringCol
-        Seq.empty[Row], // drop x
-        Seq.empty[Row], // declare x
-        Seq.empty[Row], // set x to row 3
-        Seq(Row("fourth")), // select stringCol
-        Seq.empty[Row], // drop x
+        Seq(Row("fourth")) // select stringCol
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -1758,17 +1752,8 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq.empty[Row], // insert
         Seq.empty[Row], // insert
         Seq.empty[Row], // insert
-        Seq.empty[Row], // declare x
-        Seq.empty[Row], // set x to row 0
         Seq(Row("first")), // select stringCol
-        Seq.empty[Row], // drop x
-        Seq.empty[Row], // declare x
-        Seq.empty[Row], // set x to row 1
-        Seq(Row("second")), // select stringCol
-        Seq.empty[Row], // drop x
-        Seq.empty[Row], // declare x
-        Seq.empty[Row], // set x to row 2
-        //        Seq.empty[Row], // drop x
+        Seq(Row("second")) // select stringCol
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -1797,22 +1782,13 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq.empty[Row], // create table
         Seq.empty[Row], // insert
         Seq.empty[Row], // set i
-        Seq.empty[Row], // declare x
-        Seq.empty[Row], // set x to row 0
         Seq(Row(0)), // select intCol
-        Seq.empty[Row], // drop x
         Seq.empty[Row], // insert
         Seq.empty[Row], // set i
-        Seq.empty[Row], // declare x
-        Seq.empty[Row], // set x to row 0
         Seq(Row(0)), // select intCol
-        Seq.empty[Row], // drop x
-        Seq.empty[Row], // declare x
-        Seq.empty[Row], // set x to row 1
         Seq(Row(1)), // select intCol
-        Seq.empty[Row], // drop x
         Seq.empty[Row], // insert
-        Seq.empty[Row], // drop i
+        Seq.empty[Row] // drop i
       )
       verifySqlScriptResult(sqlScript, expected)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -98,6 +98,31 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
     }
   }
 
+  test("for test no variable") {
+    withTable("t") {
+      val sqlScript =
+        """
+          |BEGIN
+          | CREATE TABLE t (intCol INT, stringCol STRING, doubleCol DOUBLE) using parquet;
+          | INSERT INTO t VALUES (1, 'first', 1.0);
+          | INSERT INTO t VALUES (2, 'second', 2.0);
+          | FOR SELECT * FROM t ORDER BY intCol DO
+          |   SELECT 1;
+          | END FOR;
+          |END
+          |""".stripMargin
+
+      val expected = Seq(
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // insert
+        Seq.empty[Row], // insert
+        Seq(Row(1)), // select 1
+        Seq(Row(1)), // select 1
+      )
+      verifySqlScriptResult(sqlScript, expected)
+    }
+  }
+
   // Tests
   test("multi statement - simple") {
     withTable("t") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -1568,7 +1568,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq.empty[Row], // drop local var
         Seq.empty[Row], // drop local var
         Seq.empty[Row], // drop local var
-        Seq.empty[Row], // drop local var
+        Seq.empty[Row] // drop local var
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -1612,7 +1612,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq.empty[Row], // drop local var
         Seq.empty[Row], // drop local var
         Seq.empty[Row], // drop local var
-        Seq.empty[Row], // drop local var
+        Seq.empty[Row] // drop local var
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -1623,7 +1623,8 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
       val sqlScript =
         """
           |BEGIN
-          | CREATE TABLE t (int_column INT, map_column MAP<STRING, INT>, struct_column STRUCT<name: STRING, age: INT>, array_column ARRAY<STRING>);
+          | CREATE TABLE t (int_column INT, map_column MAP<STRING, INT>,
+          | struct_column STRUCT<name: STRING, age: INT>, array_column ARRAY<STRING>);
           | INSERT INTO t VALUES
           |  (1, MAP('a', 1), STRUCT('John', 25), ARRAY('apricot', 'quince')),
           |  (2, MAP('b', 2), STRUCT('Jane', 30), ARRAY('plum', 'pear'));
@@ -1657,7 +1658,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq.empty[Row], // drop local var
         Seq.empty[Row], // drop local var
         Seq.empty[Row], // drop local var
-        Seq.empty[Row], // drop local var
+        Seq.empty[Row] // drop local var
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -1669,7 +1670,8 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         """
           |BEGIN
           | CREATE TABLE t
-          | (int_column INT, struct_column STRUCT<num: INT, struct2: STRUCT<struct3: STRUCT<name: STRING>>>);
+          | (int_column INT,
+          | struct_column STRUCT<num: INT, struct2: STRUCT<struct3: STRUCT<name: STRING>>>);
           | INSERT INTO t VALUES
           |  (1, STRUCT(1, STRUCT(STRUCT("one")))),
           |  (2, STRUCT(2, STRUCT(STRUCT("two"))));
@@ -1689,7 +1691,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq(Row(Row(2, Row(Row("two"))))), // select struct_column
         Seq.empty[Row], // drop local var
         Seq.empty[Row], // drop local var
-        Seq.empty[Row], // drop local var
+        Seq.empty[Row] // drop local var
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -1720,7 +1722,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq(Row(Map("b" -> Map(2 -> Map(true -> 20))))), // select map_column
         Seq.empty[Row], // drop local var
         Seq.empty[Row], // drop local var
-        Seq.empty[Row], // drop local var
+        Seq.empty[Row] // drop local var
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -1752,7 +1754,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq(Row(Array(Seq(Seq(7, 8), Seq(9, 10)), Seq(Seq(11, 12))))), // array_column
         Seq.empty[Row], // drop local var
         Seq.empty[Row], // drop local var
-        Seq.empty[Row], // drop local var
+        Seq.empty[Row] // drop local var
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -1771,7 +1773,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
           |""".stripMargin
 
       val expected = Seq(
-        Seq.empty[Row], // create table
+        Seq.empty[Row] // create table
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -1806,7 +1808,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq(Row("fourth")), // select x.stringCol
         Seq.empty[Row], // drop local var
         Seq.empty[Row], // drop local var
-        Seq.empty[Row], // drop local var
+        Seq.empty[Row] // drop local var
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -2032,7 +2034,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq.empty[Row], // insert
         Seq.empty[Row], // insert
         Seq(Row(3)), // select y.intCol2
-        Seq(Row(3)), // select intCol2
+        Seq(Row(3)) // select intCol2
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -2068,7 +2070,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq(Row(3)), // select y.intCol2
         Seq(Row(3)), // select intCol2
         Seq.empty[Row], // drop outer var
-        Seq.empty[Row], // drop outer var
+        Seq.empty[Row] // drop outer var
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -2097,7 +2099,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq(Row(1.0)), // select doubleCol
         Seq.empty[Row], // drop local var
         Seq.empty[Row], // drop local var
-        Seq.empty[Row], // drop local var
+        Seq.empty[Row] // drop local var
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -2131,7 +2133,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq(Row(2.0)), // select doubleCol
         Seq.empty[Row], // drop local var
         Seq.empty[Row], // drop local var
-        Seq.empty[Row], // drop local var
+        Seq.empty[Row] // drop local var
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -2142,7 +2144,8 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
       val sqlScript =
         """
           |BEGIN
-          | CREATE TABLE t (int_column INT, map_column MAP<STRING, INT>, struct_column STRUCT<name: STRING, age: INT>, array_column ARRAY<STRING>);
+          | CREATE TABLE t (int_column INT, map_column MAP<STRING, INT>,
+          | struct_column STRUCT<name: STRING, age: INT>, array_column ARRAY<STRING>);
           | INSERT INTO t VALUES
           |  (1, MAP('a', 1), STRUCT('John', 25), ARRAY('apricot', 'quince')),
           |  (2, MAP('b', 2), STRUCT('Jane', 30), ARRAY('plum', 'pear'));
@@ -2166,7 +2169,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq.empty[Row], // drop local var
         Seq.empty[Row], // drop local var
         Seq.empty[Row], // drop local var
-        Seq.empty[Row], // drop local var
+        Seq.empty[Row] // drop local var
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -2177,8 +2180,8 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
       val sqlScript =
         """
           |BEGIN
-          | CREATE TABLE t
-          | (int_column INT, struct_column STRUCT<num: INT, struct2: STRUCT<struct3: STRUCT<name: STRING>>>);
+          | CREATE TABLE t (int_column INT,
+          | struct_column STRUCT<num: INT, struct2: STRUCT<struct3: STRUCT<name: STRING>>>);
           | INSERT INTO t VALUES
           |  (1, STRUCT(1, STRUCT(STRUCT("one")))),
           |  (2, STRUCT(2, STRUCT(STRUCT("two"))));
@@ -2194,7 +2197,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq(Row(Row(1, Row(Row("one"))))), // select struct_column
         Seq(Row(Row(2, Row(Row("two"))))), // select struct_column
         Seq.empty[Row], // drop local var
-        Seq.empty[Row], // drop local var
+        Seq.empty[Row] // drop local var
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -2221,7 +2224,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq(Row(Map("a" -> Map(1 -> Map(false -> 10))))), // select map_column
         Seq(Row(Map("b" -> Map(2 -> Map(true -> 20))))), // select map_column
         Seq.empty[Row], // drop local var
-        Seq.empty[Row], // drop local var
+        Seq.empty[Row] // drop local var
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -2249,7 +2252,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq(Row(Seq(Seq(Seq(1, 2), Seq(3, 4)), Seq(Seq(5, 6))))), // array_column
         Seq(Row(Array(Seq(Seq(7, 8), Seq(9, 10)), Seq(Seq(11, 12))))), // array_column
         Seq.empty[Row], // drop local var
-        Seq.empty[Row], // drop local var
+        Seq.empty[Row] // drop local var
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -2268,7 +2271,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
           |""".stripMargin
 
       val expected = Seq(
-        Seq.empty[Row], // create table
+        Seq.empty[Row] // create table
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -2298,7 +2301,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq(Row("third")), // select stringCol
         Seq(Row("fourth")), // select stringCol
         Seq.empty[Row], // drop local var
-        Seq.empty[Row], // drop local var
+        Seq.empty[Row] // drop local var
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -2325,7 +2328,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq.empty[Row], // create table
         Seq.empty[Row], // insert
         Seq(Row("first")), // select stringCol
-        Seq(Row("second")), // select stringCol
+        Seq(Row("second")) // select stringCol
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -2498,7 +2501,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq.empty[Row], // create table
         Seq.empty[Row], // insert
         Seq.empty[Row], // insert
-        Seq(Row(3)), // select intCol2
+        Seq(Row(3)) // select intCol2
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -2530,7 +2533,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq.empty[Row], // insert
         Seq(Row(3)), // select intCol2
         Seq(Row(3)), // select intCol2
-        Seq.empty[Row], // drop outer var
+        Seq.empty[Row] // drop outer var
       )
       verifySqlScriptResult(sqlScript, expected)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -66,19 +66,30 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
       val sqlScript =
         """
           |BEGIN
-          | CREATE TABLE t (a INT, b STRING, c DOUBLE) USING parquet;
-          | INSERT INTO t VALUES (1, 'a', 1.0);
-          | INSERT INTO t VALUES (2, 'b', 2.0);
-          | FOR x AS SELECT * FROM t DO
-          |   SELECT x;
+          | CREATE TABLE t (intCol INT, stringCol STRING, doubleCol DOUBLE) using parquet;
+          | INSERT INTO t VALUES (1, 'first', 1.0);
+          | INSERT INTO t VALUES (2, 'second', 2.0);
+          | FOR x AS SELECT * FROM t ORDER BY intCol DO
+          |   SELECT x.intCol;
+          |   SELECT x.stringCol;
+          |   SELECT x.doubleCol;
           | END FOR;
           |END
           |""".stripMargin
+
       val expected = Seq(
         Seq.empty[Row], // create table
         Seq.empty[Row], // insert
-        Seq.empty[Row], // select with filter
-        Seq(Row(1)) // select
+        Seq.empty[Row], // insert
+        Seq.empty[Row], // declare x
+        Seq.empty[Row], // set x to row 0
+        Seq(Row(1)), // select intCol
+        Seq(Row("first")), // select stringCol
+        Seq(Row(1.0)), // select doubleCol
+        Seq.empty[Row], // set x to row 1
+        Seq(Row(2)), // select intCol
+        Seq(Row("second")), // select stringCol
+        Seq(Row(2.0)) // select doubleCol
       )
       verifySqlScriptResult(sqlScript, expected)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -1803,7 +1803,9 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
           | INSERT INTO t VALUES (1, 'first', 1.0);
           | INSERT INTO t VALUES (2, 'second', 2.0);
           | FOR SELECT * FROM t ORDER BY intCol DO
-          |   SELECT 1;
+          |   SELECT intCol;
+          |   SELECT stringCol;
+          |   SELECT doubleCol;
           | END FOR;
           |END
           |""".stripMargin

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -61,7 +61,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
   }
 
   test("testetst") {
-    val sqlScript = "DECLARE my_map DEFAULT MAP('x', 0, 'y', 0);"
+    val sqlScript = "DECLARE my_map DEFAULT MAP(1,1);"
     verifySqlScriptResult(sqlScript, Seq.empty[Seq[Row]])
   }
 
@@ -109,10 +109,10 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
       val sqlScript =
         """
           |BEGIN
-          | CREATE TABLE t (int_column INT, map_column MAP<STRING, MAP<STRING, INT>>, struct_column STRUCT<name: STRING, age: INT>, array_column ARRAY<STRING>);
+          | CREATE TABLE t (int_column INT, map_column MAP<STRING, MAP<INT, INT>>, struct_column STRUCT<name: STRING, age: INT>, array_column ARRAY<STRING>);
           | INSERT INTO t VALUES
-          |  (1, MAP('a', MAP('1', 1)), STRUCT('John', 25), ARRAY('apple', 'banana')),
-          |  (1, MAP('b', MAP('2', 2)), STRUCT('Jane', 30), ARRAY('apple', 'banana'));
+          |  (1, MAP('a', MAP(1, 1)), STRUCT('John', 25), ARRAY('apple', 'banana')),
+          |  (1, MAP('b', MAP(2, 2)), STRUCT('Jane', 30), ARRAY('apple', 'banana'));
           | FOR row AS SELECT * FROM t ORDER BY int_column DO
           |   SELECT row.map_column;
           |   SELECT row.struct_column;

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -89,7 +89,8 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq.empty[Row], // set x to row 1
         Seq(Row(2)), // select intCol
         Seq(Row("second")), // select stringCol
-        Seq(Row(2.0)) // select doubleCol
+        Seq(Row(2.0)), // select doubleCol
+        Seq.empty[Row] // drop x
       )
       verifySqlScriptResult(sqlScript, expected)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -60,6 +60,30 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
     result.zip(expected).foreach { case (df, expectedAnswer) => checkAnswer(df, expectedAnswer) }
   }
 
+
+  test("for test") {
+    withTable("t") {
+      val sqlScript =
+        """
+          |BEGIN
+          | CREATE TABLE t (a INT, b STRING, c DOUBLE) USING parquet;
+          | INSERT INTO t VALUES (1, 'a', 1.0);
+          | INSERT INTO t VALUES (2, 'b', 2.0);
+          | FOR x AS SELECT * FROM t DO
+          |   SELECT x;
+          | END FOR;
+          |END
+          |""".stripMargin
+      val expected = Seq(
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // insert
+        Seq.empty[Row], // select with filter
+        Seq(Row(1)) // select
+      )
+      verifySqlScriptResult(sqlScript, expected)
+    }
+  }
+
   // Tests
   test("multi statement - simple") {
     withTable("t") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -1548,13 +1548,34 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
     verifySqlScriptResult(sqlScriptText, expected)
   }
 
-  test("testetst") {
-    val sqlScript = "DECLARE my_map DEFAULT MAP(1,1);"
-    verifySqlScriptResult(sqlScript, Seq.empty[Seq[Row]])
+  // todo: duplicate for non var tests, negative tests
+  test("for statement - enters body once") {
+    withTable("t") {
+      val sqlScript =
+        """
+          |BEGIN
+          | CREATE TABLE t (intCol INT, stringCol STRING, doubleCol DOUBLE) using parquet;
+          | INSERT INTO t VALUES (1, 'first', 1.0);
+          | FOR row AS SELECT * FROM t DO
+          |   SELECT row.intCol;
+          | END FOR;
+          |END
+          |""".stripMargin
+
+      val expected = Seq(
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // insert
+        Seq(Row(1)), // select row.intCol
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+      )
+      verifySqlScriptResult(sqlScript, expected)
+    }
   }
 
-  // todo: complex types in for, better var names in tests
-  test("for test") {
+  test("for statement - enters body with multiple statements multiple times") {
     withTable("t") {
       val sqlScript =
         """
@@ -1562,12 +1583,12 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
           | CREATE TABLE t (intCol INT, stringCol STRING, doubleCol DOUBLE) using parquet;
           | INSERT INTO t VALUES (1, 'first', 1.0);
           | INSERT INTO t VALUES (2, 'second', 2.0);
-          | FOR x AS SELECT * FROM t ORDER BY intCol DO
-          |   SELECT x.intCol;
+          | FOR row AS SELECT * FROM t ORDER BY intCol DO
+          |   SELECT row.intCol;
           |   SELECT intCol;
-          |   SELECT x.stringCol;
+          |   SELECT row.stringCol;
           |   SELECT stringCol;
-          |   SELECT x.doubleCol;
+          |   SELECT row.doubleCol;
           |   SELECT doubleCol;
           | END FOR;
           |END
@@ -1577,32 +1598,36 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq.empty[Row], // create table
         Seq.empty[Row], // insert
         Seq.empty[Row], // insert
-        Seq(Row(1)), // select x.intCol
+        Seq(Row(1)), // select row.intCol
         Seq(Row(1)), // select intCol
-        Seq(Row("first")), // select x.stringCol
+        Seq(Row("first")), // select row.stringCol
         Seq(Row("first")), // select stringCol
-        Seq(Row(1.0)), // select x.doubleCol
+        Seq(Row(1.0)), // select row.doubleCol
         Seq(Row(1.0)), // select doubleCol
-        Seq(Row(2)), // select x.intCol
+        Seq(Row(2)), // select row.intCol
         Seq(Row(2)), // select intCol
-        Seq(Row("second")), // select x.stringCol
+        Seq(Row("second")), // select row.stringCol
         Seq(Row("second")), // select stringCol
-        Seq(Row(2.0)), // select x.doubleCol
-        Seq(Row(2.0)) // select doubleCol
+        Seq(Row(2.0)), // select row.doubleCol
+        Seq(Row(2.0)), // select doubleCol
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
       )
       verifySqlScriptResult(sqlScript, expected)
     }
   }
 
-  test("for test complex types") {
+  test("for test - map, struct, array") {
     withTable("t") {
       val sqlScript =
         """
           |BEGIN
-          | CREATE TABLE t (int_column INT, map_column MAP<STRING, MAP<INT, INT>>, struct_column STRUCT<name: STRING, age: INT>, array_column ARRAY<STRING>);
+          | CREATE TABLE t (int_column INT, map_column MAP<STRING, INT>, struct_column STRUCT<name: STRING, age: INT>, array_column ARRAY<STRING>);
           | INSERT INTO t VALUES
-          |  (1, MAP('a', MAP(1, 10)), STRUCT('John', 25), ARRAY('apple', 'banana')),
-          |  (2, MAP('b', MAP(2, 20)), STRUCT('Jane', 30), ARRAY('apple', 'banana'));
+          |  (1, MAP('a', 1), STRUCT('John', 25), ARRAY('apricot', 'quince')),
+          |  (2, MAP('b', 2), STRUCT('Jane', 30), ARRAY('plum', 'pear'));
           | FOR row AS SELECT * FROM t ORDER BY int_column DO
           |   SELECT row.map_column;
           |   SELECT map_column;
@@ -1617,61 +1642,122 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
       val expected = Seq(
         Seq.empty[Row], // create table
         Seq.empty[Row], // insert
-        Seq(Row(Map("a" -> Map(1 -> 10)))), // select row.map_column
-        Seq(Row(Map("a" -> Map(1 -> 10)))), // select map_column
+        Seq(Row(Map("a" -> 1))), // select row.map_column
+        Seq(Row(Map("a" -> 1))), // select map_column
         Seq(Row(Row("John", 25))), // select row.struct_column
         Seq(Row(Row("John", 25))), // select struct_column
-        Seq(Row(Array("apple", "banana"))), // select row.array_column
-        Seq(Row(Array("apple", "banana"))), // select array_column
-        Seq(Row(Map("b" -> Map(2 -> 20)))), // select row.map_column
-        Seq(Row(Map("b" -> Map(2 -> 20)))), // select map_column
+        Seq(Row(Array("apricot", "quince"))), // select row.array_column
+        Seq(Row(Array("apricot", "quince"))), // select array_column
+        Seq(Row(Map("b" -> 2))), // select row.map_column
+        Seq(Row(Map("b" -> 2))), // select map_column
         Seq(Row(Row("Jane", 30))), // select row.struct_column
         Seq(Row(Row("Jane", 30))), // select struct_column
-        Seq(Row(Array("apple", "banana"))), // select row.array_column
-        Seq(Row(Array("apple", "banana"))) // select array_column
+        Seq(Row(Array("plum", "pear"))), // select row.array_column
+        Seq(Row(Array("plum", "pear"))), // select array_column
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
       )
       verifySqlScriptResult(sqlScript, expected)
     }
   }
 
-  //  test("for test complex types") {
-  //    withTable("t") {
-  //      val sqlScript =
-  //        """
-  //          |BEGIN
-  //          | CREATE TABLE t (int_column INT, map_column MAP<STRING, INT>, struct_column STRUCT<name: STRING, age: INT>, array_column ARRAY<STRING>);
-  //          | INSERT INTO t VALUES
-  //          |  (1, MAP('a', 1, 'b', 2), STRUCT('John', 25), ARRAY('apple', 'banana')),
-  //          |  (2, MAP('c', 3, 'd', 4), STRUCT('Jane', 30), ARRAY('orange', 'grape')),
-  //          |  (3, MAP('e', 5, 'f', 6), STRUCT('Bob', 35), ARRAY('pear', 'peach'));
-  //          | FOR row AS SELECT * FROM t ORDER BY int_column DO
-  //          |   SELECT row.map_column;
-  //          |   SELECT row.struct_column;
-  //          |   SELECT row.array_column;
-  //          | END FOR;
-  //          |END
-  //          |""".stripMargin
-  //
-  //      val expected = Seq(
-  //        Seq.empty[Row], // create table
-  //        Seq.empty[Row], // insert
-  //        Seq.empty[Row], // insert
-  //        Seq.empty[Row], // declare x
-  //        Seq.empty[Row], // set x to row 0
-  //        Seq(Row(1)), // select intCol
-  //        Seq(Row("first")), // select stringCol
-  //        Seq(Row(1.0)), // select doubleCol
-  //        Seq.empty[Row], // drop x
-  //        Seq.empty[Row], // declare x
-  //        Seq.empty[Row], // set x to row 1
-  //        Seq(Row(2)), // select intCol
-  //        Seq(Row("second")), // select stringCol
-  //        Seq(Row(2.0)), // select doubleCol
-  //        Seq.empty[Row] // drop x
-  //      )
-  //      verifySqlScriptResult(sqlScript, expected)
-  //    }
-  //  }
+  test("for test - nested struct") {
+    withTable("t") {
+      val sqlScript =
+        """
+          |BEGIN
+          | CREATE TABLE t
+          | (int_column INT, struct_column STRUCT<num: INT, struct2: STRUCT<struct3: STRUCT<name: STRING>>>);
+          | INSERT INTO t VALUES
+          |  (1, STRUCT(1, STRUCT(STRUCT("one")))),
+          |  (2, STRUCT(2, STRUCT(STRUCT("two"))));
+          | FOR row AS SELECT * FROM t ORDER BY int_column DO
+          |   SELECT row.struct_column;
+          |   SELECT struct_column;
+          | END FOR;
+          |END
+          |""".stripMargin
+
+      val expected = Seq(
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // insert
+        Seq(Row(Row(1, Row(Row("one"))))), // select row.struct_column
+        Seq(Row(Row(1, Row(Row("one"))))), // select struct_column
+        Seq(Row(Row(2, Row(Row("two"))))), // select row.struct_column
+        Seq(Row(Row(2, Row(Row("two"))))), // select struct_column
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+      )
+      verifySqlScriptResult(sqlScript, expected)
+    }
+  }
+
+  test("for test - nested map") {
+    withTable("t") {
+      val sqlScript =
+        """
+          |BEGIN
+          | CREATE TABLE t (int_column INT, map_column MAP<STRING, MAP<INT, MAP<BOOLEAN, INT>>>);
+          | INSERT INTO t VALUES
+          |  (1, MAP('a', MAP(1, MAP(false, 10)))),
+          |  (2, MAP('b', MAP(2, MAP(true, 20))));
+          | FOR row AS SELECT * FROM t ORDER BY int_column DO
+          |   SELECT row.map_column;
+          |   SELECT map_column;
+          | END FOR;
+          |END
+          |""".stripMargin
+
+      val expected = Seq(
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // insert
+        Seq(Row(Map("a" -> Map(1 -> Map(false -> 10))))), // select row.map_column
+        Seq(Row(Map("a" -> Map(1 -> Map(false -> 10))))), // select map_column
+        Seq(Row(Map("b" -> Map(2 -> Map(true -> 20))))), // select row.map_column
+        Seq(Row(Map("b" -> Map(2 -> Map(true -> 20))))), // select map_column
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+      )
+      verifySqlScriptResult(sqlScript, expected)
+    }
+  }
+
+  test("for test - nested array") {
+    withTable("t") {
+      val sqlScript =
+        """
+          |BEGIN
+          | CREATE TABLE t
+          | (int_column INT, array_column ARRAY<ARRAY<ARRAY<INT>>>);
+          | INSERT INTO t VALUES
+          |  (1, ARRAY(ARRAY(ARRAY(1, 2), ARRAY(3, 4)), ARRAY(ARRAY(5, 6)))),
+          |  (2, ARRAY(ARRAY(ARRAY(7, 8), ARRAY(9, 10)), ARRAY(ARRAY(11, 12))));
+          | FOR row AS SELECT * FROM t ORDER BY int_column DO
+          |   SELECT row.array_column;
+          |   SELECT array_column;
+          | END FOR;
+          |END
+          |""".stripMargin
+
+      val expected = Seq(
+        Seq.empty[Row], // create table
+        Seq.empty[Row], // insert
+        Seq(Row(Seq(Seq(Seq(1, 2), Seq(3, 4)), Seq(Seq(5, 6))))), // row.array_column
+        Seq(Row(Seq(Seq(Seq(1, 2), Seq(3, 4)), Seq(Seq(5, 6))))), // array_column
+        Seq(Row(Array(Seq(Seq(7, 8), Seq(9, 10)), Seq(Seq(11, 12))))), // row.array_column
+        Seq(Row(Array(Seq(Seq(7, 8), Seq(9, 10)), Seq(Seq(11, 12))))), // array_column
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+      )
+      verifySqlScriptResult(sqlScript, expected)
+    }
+  }
 
   test("for test empty result") {
     withTable("t") {
@@ -1679,8 +1765,8 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         """
           |BEGIN
           | CREATE TABLE t (intCol INT) using parquet;
-          | FOR x AS SELECT * FROM t ORDER BY intCol DO
-          |   SELECT x.intCol;
+          | FOR row AS SELECT * FROM t ORDER BY intCol DO
+          |   SELECT row.intCol;
           | END FOR;
           |END
           |""".stripMargin
@@ -1698,15 +1784,13 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         """
           |BEGIN
           | CREATE TABLE t (intCol INT, stringCol STRING) using parquet;
-          | INSERT INTO t VALUES (1, 'first');
-          | INSERT INTO t VALUES (2, 'second');
-          | INSERT INTO t VALUES (3, 'third');
-          | INSERT INTO t VALUES (4, 'fourth');
+          | INSERT INTO t VALUES (1, 'first'), (2, 'second'), (3, 'third'), (4, 'fourth');
           |
           | lbl: FOR x AS SELECT * FROM t ORDER BY intCol DO
           |   IF x.intCol = 2 THEN
           |     ITERATE lbl;
           |   END IF;
+          |   SELECT stringCol;
           |   SELECT x.stringCol;
           | END FOR;
           |END
@@ -1715,12 +1799,15 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
       val expected = Seq(
         Seq.empty[Row], // create table
         Seq.empty[Row], // insert
-        Seq.empty[Row], // insert
-        Seq.empty[Row], // insert
-        Seq.empty[Row], // insert
         Seq(Row("first")), // select stringCol
+        Seq(Row("first")), // select x.stringCol
         Seq(Row("third")), // select stringCol
-        Seq(Row("fourth")) // select stringCol
+        Seq(Row("third")), // select x.stringCol
+        Seq(Row("fourth")), // select stringCol
+        Seq(Row("fourth")), // select x.stringCol
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -1732,15 +1819,13 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         """
           |BEGIN
           | CREATE TABLE t (intCol INT, stringCol STRING) using parquet;
-          | INSERT INTO t VALUES (1, 'first');
-          | INSERT INTO t VALUES (2, 'second');
-          | INSERT INTO t VALUES (3, 'third');
-          | INSERT INTO t VALUES (4, 'fourth');
+          | INSERT INTO t VALUES (1, 'first'), (2, 'second'), (3, 'third'), (4, 'fourth');
           |
           | lbl: FOR x AS SELECT * FROM t ORDER BY intCol DO
           |   IF x.intCol = 3 THEN
           |     LEAVE lbl;
           |   END IF;
+          |   SELECT stringCol;
           |   SELECT x.stringCol;
           | END FOR;
           |END
@@ -1749,11 +1834,10 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
       val expected = Seq(
         Seq.empty[Row], // create table
         Seq.empty[Row], // insert
-        Seq.empty[Row], // insert
-        Seq.empty[Row], // insert
-        Seq.empty[Row], // insert
         Seq(Row("first")), // select stringCol
-        Seq(Row("second")) // select stringCol
+        Seq(Row("first")), // select x.stringCol
+        Seq(Row("second")), // select stringCol
+        Seq(Row("second")) // select x.stringCol
       )
       verifySqlScriptResult(sqlScript, expected)
     }
@@ -1764,58 +1848,35 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
       val sqlScript =
         """
           |BEGIN
-          | DECLARE i = 0;
+          | DECLARE cnt = 0;
           | CREATE TABLE t (intCol INT) using parquet;
           | INSERT INTO t VALUES (0);
-          | WHILE i < 2 DO
-          |   SET i = i + 1;
+          | WHILE cnt < 2 DO
+          |   SET cnt = cnt + 1;
           |   FOR x AS SELECT * FROM t ORDER BY intCol DO
           |     SELECT x.intCol;
           |   END FOR;
-          |   INSERT INTO t VALUES (i);
+          |   INSERT INTO t VALUES (cnt);
           | END WHILE;
           |END
           |""".stripMargin
 
       val expected = Seq(
-        Seq.empty[Row], // declare i
+        Seq.empty[Row], // declare cnt
         Seq.empty[Row], // create table
         Seq.empty[Row], // insert
-        Seq.empty[Row], // set i
+        Seq.empty[Row], // set cnt
         Seq(Row(0)), // select intCol
         Seq.empty[Row], // insert
-        Seq.empty[Row], // set i
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // set cnt
         Seq(Row(0)), // select intCol
         Seq(Row(1)), // select intCol
         Seq.empty[Row], // insert
-        Seq.empty[Row] // drop i
-      )
-      verifySqlScriptResult(sqlScript, expected)
-    }
-  }
-
-  test("for test no variable") {
-    withTable("t") {
-      val sqlScript =
-        """
-          |BEGIN
-          | CREATE TABLE t (intCol INT, stringCol STRING, doubleCol DOUBLE) using parquet;
-          | INSERT INTO t VALUES (1, 'first', 1.0);
-          | INSERT INTO t VALUES (2, 'second', 2.0);
-          | FOR SELECT * FROM t ORDER BY intCol DO
-          |   SELECT intCol;
-          |   SELECT stringCol;
-          |   SELECT doubleCol;
-          | END FOR;
-          |END
-          |""".stripMargin
-
-      val expected = Seq(
-        Seq.empty[Row], // create table
-        Seq.empty[Row], // insert
-        Seq.empty[Row], // insert
-        Seq(Row(1)), // select 1
-        Seq(Row(1)), // select 1
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row], // drop local var
+        Seq.empty[Row] // drop cnt
       )
       verifySqlScriptResult(sqlScript, expected)
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -86,6 +86,8 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         Seq(Row(1)), // select intCol
         Seq(Row("first")), // select stringCol
         Seq(Row(1.0)), // select doubleCol
+        Seq.empty[Row], // drop x
+        Seq.empty[Row], // declare x
         Seq.empty[Row], // set x to row 1
         Seq(Row(2)), // select intCol
         Seq(Row("second")), // select stringCol


### PR DESCRIPTION
### What changes were proposed in this pull request?
In this PR, support for FOR statement in SQL scripting is introduced. Examples:

```
FOR row AS SELECT * FROM t DO
   SELECT row.intCol;
 END FOR;
```

```
FOR SELECT * FROM t DO
   SELECT intCol;
 END FOR;
```

Implementation notes:
As local variables for SQL scripting are currently a work in progress, session variables are used to simulate them.
When FOR begins executing, session variables are declared for each column in the result set, and optionally for the for variable if it is present ("row" in the example above). 
On each iteration, these variables are overwritten with the values from the row currently being iterated.
The variables are dropped upon loop completion.

This means that if a session variable which matches the name of a column in the result set already exists, the for statement will drop that variable after completion. If that variable would be referenced after the for statement, the script would fail as the variable would not exist. This limitation is already present in the current iteration of SQL scripting, and will be fixed once local variables are introduced. Also, with local variables the implementation of for statement will be much simpler.

Grammar/parser changes:
`forStatement` grammar rule
`visitForStatement` rule visitor
`ForStatement` logical operator

### Why are the changes needed?
FOR statement is an part of SQL scripting control flow logic.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
New tests are introduced to all of the three scripting test suites: `SqlScriptingParserSuite`, `SqlScriptingExecutionNodeSuite` and `SqlScriptingInterpreterSuite`.


### Was this patch authored or co-authored using generative AI tooling?
No
