### PR TITLE
[SPARK-49913][SQL] Add check for unique label names in nested labeled scopes

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1198,12 +1198,6 @@
     ],
     "sqlState" : "23505"
   },
-  "DUPLICATE_LABEL" : {
-    "message" : [
-      "Label <label> already exists."
-    ],
-    "sqlState" : "42K0L"
-  },
   "DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT" : {
     "message" : [
       "Call to routine <routineName> is invalid because it includes multiple argument assignments to the same parameter name <parameterName>."
@@ -3382,6 +3376,12 @@
   "LABELS_MISMATCH" : {
     "message" : [
       "Begin label <beginLabel> does not match the end label <endLabel>."
+    ],
+    "sqlState" : "42K0L"
+  },
+  "LABEL_ALREADY_EXISTS" : {
+    "message" : [
+      "The label <label> already exists. Choose another name or rename the existing label."
     ],
     "sqlState" : "42K0L"
   },

--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -1198,6 +1198,12 @@
     ],
     "sqlState" : "23505"
   },
+  "DUPLICATE_LABEL" : {
+    "message" : [
+      "Label <label> already exists."
+    ],
+    "sqlState" : "42K0L"
+  },
   "DUPLICATE_ROUTINE_PARAMETER_ASSIGNMENT" : {
     "message" : [
       "Call to routine <routineName> is invalid because it includes multiple argument assignments to the same parameter name <parameterName>."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/AstBuilder.scala
@@ -142,7 +142,7 @@ class AstBuilder extends DataTypeAstBuilder
   }
 
   override def visitSingleCompoundStatement(ctx: SingleCompoundStatementContext): CompoundBody = {
-    val labelCtx = new ScriptingLabelContext()
+    val labelCtx = new SqlScriptingLabelContext()
     visitBeginEndCompoundBlockImpl(ctx.beginEndCompoundBlock(), labelCtx)
   }
 
@@ -150,7 +150,7 @@ class AstBuilder extends DataTypeAstBuilder
       ctx: CompoundBodyContext,
       label: Option[String],
       allowVarDeclare: Boolean,
-      labelCtx: ScriptingLabelContext): CompoundBody = {
+      labelCtx: SqlScriptingLabelContext): CompoundBody = {
     val buff = ListBuffer[CompoundPlanStatement]()
     ctx.compoundStatements.forEach(
       compoundStatement => buff += visitCompoundStatementImpl(compoundStatement, labelCtx))
@@ -187,7 +187,7 @@ class AstBuilder extends DataTypeAstBuilder
 
   private def visitBeginEndCompoundBlockImpl(
       ctx: BeginEndCompoundBlockContext,
-      labelCtx: ScriptingLabelContext): CompoundBody = {
+      labelCtx: SqlScriptingLabelContext): CompoundBody = {
     val labelText =
       labelCtx.enterLabeledScope(Option(ctx.beginLabel()), Option(ctx.endLabel()))
     val body = visitCompoundBodyImpl(
@@ -202,7 +202,7 @@ class AstBuilder extends DataTypeAstBuilder
 
   private def visitCompoundStatementImpl(
       ctx: CompoundStatementContext,
-      labelCtx: ScriptingLabelContext): CompoundPlanStatement =
+      labelCtx: SqlScriptingLabelContext): CompoundPlanStatement =
     withOrigin(ctx) {
       Option(ctx.statement().asInstanceOf[ParserRuleContext])
         .orElse(Option(ctx.setStatementWithOptionalVarKeyword().asInstanceOf[ParserRuleContext]))
@@ -235,7 +235,7 @@ class AstBuilder extends DataTypeAstBuilder
 
   private def visitIfElseStatementImpl(
       ctx: IfElseStatementContext,
-      labelCtx: ScriptingLabelContext): IfElseStatement = {
+      labelCtx: SqlScriptingLabelContext): IfElseStatement = {
     IfElseStatement(
       conditions = ctx.booleanExpression().asScala.toList.map(boolExpr => withOrigin(boolExpr) {
         SingleStatement(
@@ -254,7 +254,7 @@ class AstBuilder extends DataTypeAstBuilder
 
   private def visitWhileStatementImpl(
       ctx: WhileStatementContext,
-      labelCtx: ScriptingLabelContext): WhileStatement = {
+      labelCtx: SqlScriptingLabelContext): WhileStatement = {
     val labelText =
       labelCtx.enterLabeledScope(Option(ctx.beginLabel()), Option(ctx.endLabel()))
     val boolExpr = ctx.booleanExpression()
@@ -272,7 +272,7 @@ class AstBuilder extends DataTypeAstBuilder
 
   private def visitSearchedCaseStatementImpl(
       ctx: SearchedCaseStatementContext,
-      labelCtx: ScriptingLabelContext): CaseStatement = {
+      labelCtx: SqlScriptingLabelContext): CaseStatement = {
     val conditions = ctx.conditions.asScala.toList.map(boolExpr => withOrigin(boolExpr) {
       SingleStatement(
         Project(
@@ -300,7 +300,7 @@ class AstBuilder extends DataTypeAstBuilder
 
   private def visitSimpleCaseStatementImpl(
       ctx: SimpleCaseStatementContext,
-      labelCtx: ScriptingLabelContext): CaseStatement = {
+      labelCtx: SqlScriptingLabelContext): CaseStatement = {
     // uses EqualTo to compare the case variable(the main case expression)
     // to the WHEN clause expressions
     val conditions = ctx.conditionExpressions.asScala.toList.map(expr => withOrigin(expr) {
@@ -330,7 +330,7 @@ class AstBuilder extends DataTypeAstBuilder
 
   private def visitRepeatStatementImpl(
       ctx: RepeatStatementContext,
-      labelCtx: ScriptingLabelContext): RepeatStatement = {
+      labelCtx: SqlScriptingLabelContext): RepeatStatement = {
     val labelText =
       labelCtx.enterLabeledScope(Option(ctx.beginLabel()), Option(ctx.endLabel()))
     val boolExpr = ctx.booleanExpression()
@@ -406,7 +406,7 @@ class AstBuilder extends DataTypeAstBuilder
 
   private def visitLoopStatementImpl(
       ctx: LoopStatementContext,
-      labelCtx: ScriptingLabelContext): LoopStatement = {
+      labelCtx: SqlScriptingLabelContext): LoopStatement = {
     val labelText =
       labelCtx.enterLabeledScope(Option(ctx.beginLabel()), Option(ctx.endLabel()))
     val body = visitCompoundBodyImpl(ctx.compoundBody(), None, allowVarDeclare = false, labelCtx)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -140,7 +140,7 @@ object ParserUtils extends SparkParserUtils {
   }
 }
 
-class ScriptingLabelContext {
+class SqlScriptingLabelContext {
   /** Set to keep track of labels seen so far */
   private val seenLabels = Set[String]()
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
@@ -28,6 +28,14 @@ import org.apache.spark.sql.exceptions.SqlScriptingException
  */
 private[sql] object SqlScriptingErrors {
 
+  def duplicateLabels(origin: Origin, label: String): Throwable = {
+    new SqlScriptingException(
+      origin = origin,
+      errorClass = "DUPLICATE_LABEL",
+      cause = null,
+      messageParameters = Map("label" -> toSQLId(label)))
+  }
+
   def labelsMismatch(origin: Origin, beginLabel: String, endLabel: String): Throwable = {
     new SqlScriptingException(
       origin = origin,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
@@ -31,7 +31,7 @@ private[sql] object SqlScriptingErrors {
   def duplicateLabels(origin: Origin, label: String): Throwable = {
     new SqlScriptingException(
       origin = origin,
-      errorClass = "DUPLICATE_LABEL",
+      errorClass = "LABEL_ALREADY_EXISTS",
       cause = null,
       messageParameters = Map("label" -> toSQLId(label)))
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -1605,6 +1605,227 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     assert(nestedLoopStmt.body.collection(1).asInstanceOf[IterateStatement].label == "lbl")
   }
 
+  test("unique label names: nested begin-end blocks") {
+    val sqlScriptText =
+      """BEGIN
+        |lbl: BEGIN
+        |  lbl: BEGIN
+        |    SELECT 1;
+        |  END;
+        |END;
+        |END
+      """.stripMargin
+    val exception = intercept[SqlScriptingException] {
+      parseScript(sqlScriptText)
+    }
+    checkError(
+      exception = exception,
+      condition = "DUPLICATE_LABEL",
+      parameters = Map("label" -> toSQLId("lbl")))
+  }
+
+  test("unique label names: multi-level nested begin-end blocks") {
+    val sqlScriptText =
+      """BEGIN
+        |lbl_1: BEGIN
+        |  lbl_2: BEGIN
+        |    lbl_1: BEGIN
+        |      SELECT 1;
+        |    END;
+        |  END;
+        |END;
+        |END
+      """.stripMargin
+    val exception = intercept[SqlScriptingException] {
+      parseScript(sqlScriptText)
+    }
+    checkError(
+      exception = exception,
+      condition = "DUPLICATE_LABEL",
+      parameters = Map("label" -> toSQLId("lbl_1")))
+  }
+
+  test("unique label names: while loop in begin-end block") {
+    val sqlScriptText =
+      """BEGIN
+        |lbl: BEGIN
+        |  lbl: WHILE 1=1 DO
+        |    SELECT 1;
+        |  END WHILE;
+        |END;
+        |END
+      """.stripMargin
+    val exception = intercept[SqlScriptingException] {
+      parseScript(sqlScriptText)
+    }
+    checkError(
+      exception = exception,
+      condition = "DUPLICATE_LABEL",
+      parameters = Map("label" -> toSQLId("lbl")))
+  }
+
+  test("unique label names: begin-end block in while loop") {
+    val sqlScriptText =
+      """BEGIN
+        |lbl: WHILE 1=1 DO
+        |  lbl: BEGIN
+        |    SELECT 1;
+        |  END;
+        |END WHILE;
+        |END
+      """.stripMargin
+    val exception = intercept[SqlScriptingException] {
+      parseScript(sqlScriptText)
+    }
+    checkError(
+      exception = exception,
+      condition = "DUPLICATE_LABEL",
+      parameters = Map("label" -> toSQLId("lbl")))
+  }
+
+  test("unique label names: nested while loops") {
+    val sqlScriptText =
+      """BEGIN
+        |w_loop: WHILE 1=1 DO
+        |  w_loop: WHILE 2=2 DO
+        |    SELECT 1;
+        |  END WHILE;
+        |END WHILE;
+        |END
+      """.stripMargin
+    val exception = intercept[SqlScriptingException] {
+      parseScript(sqlScriptText)
+    }
+    checkError(
+      exception = exception,
+      condition = "DUPLICATE_LABEL",
+      parameters = Map("label" -> toSQLId("w_loop")))
+  }
+
+  test("unique label names: nested repeat loops") {
+    val sqlScriptText =
+      """BEGIN
+        |r_loop: REPEAT
+        |  r_loop: REPEAT
+        |    SELECT 1;
+        |  UNTIL 1 = 1
+        |  END REPEAT;
+        |UNTIL 1 = 1
+        |END REPEAT;
+        |END
+      """.stripMargin
+    val exception = intercept[SqlScriptingException] {
+      parseScript(sqlScriptText)
+    }
+    checkError(
+      exception = exception,
+      condition = "DUPLICATE_LABEL",
+      parameters = Map("label" -> toSQLId("r_loop")))
+  }
+
+  test("unique label names: nested loop loops") {
+    val sqlScriptText =
+      """BEGIN
+        |l_loop: LOOP
+        |  l_loop: LOOP
+        |    SELECT 1;
+        |  END LOOP;
+        |END LOOP;
+        |END
+      """.stripMargin
+    val exception = intercept[SqlScriptingException] {
+      parseScript(sqlScriptText)
+    }
+    checkError(
+      exception = exception,
+      condition = "DUPLICATE_LABEL",
+      parameters = Map("label" -> toSQLId("l_loop")))
+  }
+
+  test("unique label names: begin-end block on the same level") {
+    val sqlScriptText =
+      """BEGIN
+        |lbl: BEGIN
+        |  SELECT 1;
+        |END;
+        |lbl: BEGIN
+        |  SELECT 2;
+        |END;
+        |END
+      """.stripMargin
+    val tree = parseScript(sqlScriptText)
+    assert(tree.collection.length == 2)
+    assert(tree.collection.head.isInstanceOf[CompoundBody])
+    assert(tree.collection.head.asInstanceOf[CompoundBody].label.get == "lbl")
+    assert(tree.collection(1).isInstanceOf[CompoundBody])
+    assert(tree.collection(1).asInstanceOf[CompoundBody].label.get == "lbl")
+  }
+
+  test("unique label names: begin-end block and loops on the same level") {
+    val sqlScriptText =
+      """BEGIN
+        |lbl: BEGIN
+        |  SELECT 1;
+        |END;
+        |lbl: WHILE 1=1 DO
+        |  SELECT 2;
+        |END WHILE;
+        |lbl: LOOP
+        |  SELECT 3;
+        |END LOOP;
+        |lbl: REPEAT
+        |  SELECT 4;
+        |UNTIL 1=1
+        |END REPEAT;
+        |END
+      """.stripMargin
+    val tree = parseScript(sqlScriptText)
+    assert(tree.collection.length == 4)
+    assert(tree.collection.head.isInstanceOf[CompoundBody])
+    assert(tree.collection.head.asInstanceOf[CompoundBody].label.get == "lbl")
+    assert(tree.collection(1).isInstanceOf[WhileStatement])
+    assert(tree.collection(1).asInstanceOf[WhileStatement].label.get == "lbl")
+    assert(tree.collection(2).isInstanceOf[LoopStatement])
+    assert(tree.collection(2).asInstanceOf[LoopStatement].label.get == "lbl")
+    assert(tree.collection(3).isInstanceOf[RepeatStatement])
+    assert(tree.collection(3).asInstanceOf[RepeatStatement].label.get == "lbl")
+  }
+
+  test("unique label names: nested labeled scope statements") {
+    val sqlScriptText =
+      """BEGIN
+        |lbl_0: BEGIN
+        |  lbl_1: WHILE 1=1 DO
+        |    lbl_2: LOOP
+        |      lbl_3: REPEAT
+        |        SELECT 4;
+        |      UNTIL 1=1
+        |      END REPEAT;
+        |    END LOOP;
+        |  END WHILE;
+        |END;
+        |END
+      """.stripMargin
+    val tree = parseScript(sqlScriptText)
+    assert(tree.collection.length == 1)
+    assert(tree.collection.head.isInstanceOf[CompoundBody])
+    // Compound body
+    val body = tree.collection.head.asInstanceOf[CompoundBody]
+    assert(body.label.get == "lbl_0")
+    assert(body.collection.head.isInstanceOf[WhileStatement])
+    // While statement
+    val whileStatement = body.collection.head.asInstanceOf[WhileStatement]
+    assert(whileStatement.label.get == "lbl_1")
+    assert(whileStatement.body.collection.head.isInstanceOf[LoopStatement])
+    // Loop statement
+    val loopStatement = whileStatement.body.collection.head.asInstanceOf[LoopStatement]
+    assert(loopStatement.label.get == "lbl_2")
+    assert(loopStatement.body.collection.head.isInstanceOf[RepeatStatement])
+    // Repeat statement
+    val repeatStatement = loopStatement.body.collection.head.asInstanceOf[RepeatStatement]
+    assert(repeatStatement.label.get == "lbl_3")
+  }
+
   // Helper methods
   def cleanupStatementString(statementStr: String): String = {
     statementStr

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/SqlScriptingParserSuite.scala
@@ -1620,8 +1620,29 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "DUPLICATE_LABEL",
+      condition = "LABEL_ALREADY_EXISTS",
       parameters = Map("label" -> toSQLId("lbl")))
+  }
+
+  test("unique label names: nested begin-end blocks with same prefix") {
+    val sqlScriptText =
+      """BEGIN
+        |lbl_1: BEGIN
+        |  lbl_11: BEGIN
+        |    SELECT 1;
+        |  END;
+        |END;
+        |END
+      """.stripMargin
+    val tree = parseScript(sqlScriptText)
+    assert(tree.collection.length == 1)
+    assert(tree.collection.head.isInstanceOf[CompoundBody])
+    val body_1 = tree.collection.head.asInstanceOf[CompoundBody]
+    assert(body_1.label.get == "lbl_1")
+    assert(body_1.collection.length == 1)
+    assert(body_1.collection.head.isInstanceOf[CompoundBody])
+    val body_11 = body_1.collection.head.asInstanceOf[CompoundBody]
+    assert(body_11.label.get == "lbl_11")
   }
 
   test("unique label names: multi-level nested begin-end blocks") {
@@ -1641,7 +1662,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "DUPLICATE_LABEL",
+      condition = "LABEL_ALREADY_EXISTS",
       parameters = Map("label" -> toSQLId("lbl_1")))
   }
 
@@ -1660,7 +1681,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "DUPLICATE_LABEL",
+      condition = "LABEL_ALREADY_EXISTS",
       parameters = Map("label" -> toSQLId("lbl")))
   }
 
@@ -1679,7 +1700,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "DUPLICATE_LABEL",
+      condition = "LABEL_ALREADY_EXISTS",
       parameters = Map("label" -> toSQLId("lbl")))
   }
 
@@ -1698,7 +1719,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "DUPLICATE_LABEL",
+      condition = "LABEL_ALREADY_EXISTS",
       parameters = Map("label" -> toSQLId("w_loop")))
   }
 
@@ -1719,7 +1740,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "DUPLICATE_LABEL",
+      condition = "LABEL_ALREADY_EXISTS",
       parameters = Map("label" -> toSQLId("r_loop")))
   }
 
@@ -1738,7 +1759,7 @@ class SqlScriptingParserSuite extends SparkFunSuite with SQLHelper {
     }
     checkError(
       exception = exception,
-      condition = "DUPLICATE_LABEL",
+      condition = "LABEL_ALREADY_EXISTS",
       parameters = Map("label" -> toSQLId("l_loop")))
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
We are introducing checks for unique label names.
New rules for label names:
- Labels can't have the same name as some of the labels in scope surrounding them 
- Labels can have the same name as other labels in the same scope

**Valid** code:
```
BEGIN
  lbl: BEGIN
    SELECT 1;
  END;

  lbl: BEGIN
    SELECT 2;
  END;

  BEGIN
    lbl: WHILE 1=1 DO
      LEAVE lbl;
    END WHILE;
  END;
END
```

**Invalid** code:
```
BEGIN
  lbl: BEGIN
    lbl: BEGIN
      SELECT 1;
    END;
  END;
END
```

#### Design explanation:

Even though there are _Listeners_ with `enterRule` and `exitRule` methods to check labels before and remove them from `seenLabels` after visiting node, we favor this approach because minimal changes were needed and code is more compact to avoid dependency issues.

Additionally, generating label text would need to be done in 2 places and we wanted to avoid duplicated logic:
- `enterRule`
- `visitRule`


### Why are the changes needed?
It will be needed in future when we release Local Scoped Variables for SQL Scripting so users can target variables from outer scopes if they are shadowed. 

### How was this patch tested?
New unit tests in 'SqlScriptingParserSuite.scala'.


### Was this patch authored or co-authored using generative AI tooling?
No.
