### PR TITLE
[SPARK-50268][SQL][TESTS] Upgrade oracle jdbc driver to `ojdbc17:23.6.0.24.10`

### DIFF
--- a/connector/docker-integration-tests/pom.xml
+++ b/connector/docker-integration-tests/pom.xml
@@ -98,7 +98,7 @@
     </dependency>
     <dependency>
       <groupId>com.oracle.database.jdbc</groupId>
-      <artifactId>ojdbc11</artifactId>
+      <artifactId>ojdbc17</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1344,7 +1344,7 @@
       </dependency>
       <dependency>
         <groupId>com.oracle.database.jdbc</groupId>
-        <artifactId>ojdbc11</artifactId>
+        <artifactId>ojdbc17</artifactId>
         <version>${ojdbc11.version}</version>
         <scope>test</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -331,7 +331,7 @@
     <postgresql.version>42.7.4</postgresql.version>
     <db2.jcc.version>11.5.9.0</db2.jcc.version>
     <mssql.jdbc.version>12.8.1.jre11</mssql.jdbc.version>
-    <ojdbc11.version>23.5.0.24.07</ojdbc11.version>
+    <ojdbc11.version>23.6.0.24.10</ojdbc11.version>
     <!-- Used for SBT build to retrieve the Spark version -->
     <spark.version>${project.version}</spark.version>
   </properties>

--- a/sql/core/pom.xml
+++ b/sql/core/pom.xml
@@ -209,7 +209,7 @@
     </dependency>
     <dependency>
       <groupId>com.oracle.database.jdbc</groupId>
-      <artifactId>ojdbc11</artifactId>
+      <artifactId>ojdbc17</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade oracle jdbc driver from `com.oracle.database.jdbc:ojdbc11:23.3.0.23.09` to `com.oracle.database.jdbc:ojdbc17:23.6.0.24.10`.

### Why are the changes needed?
- The `oracle jdbc driver` currently used in Spark is `com.oracle.database.jdbc:ojdbc11`, it not for use with `JDK17`. However, currently our spark master is based on `JDK17`, `JDK21`.
https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html
<img width="1272" alt="image" src="https://github.com/user-attachments/assets/e700651e-23d0-41b2-b0f5-1a425ca824a6">

- The latest version has fixed some bugs, eg:
https://download.oracle.com/otn-pub/otn_software/jdbc/23c/Bugs-fixed-in-23ai.txt?AuthParam=1731026016_7eb0ae07b2f23760042771371f0acc58
Bug 36540636 - MUST USE CHAR TYPE WHEN QUERYING COLLATION,EBCDIC AS VARCHAR2 INCOMPATIBLE WITH DB2 VARCHAR
Bug 36113002 - TLS SSLCONTEXT CACHE FOR PERFORMANCE AND SESSION RESUMPTION
BUG-36695211 - MAKE JDBC (OJDBC17) AND UCP (UCP17) COMPATIBLE WITH JAKARTA
Bug 36967743 - JDBC DRIVER 23.5.0.24.07 - DOUBLE PRECISION ISSUE IN JDBC DRIVER
Bug 36956128 - [SHARDING DRIVER]: MEMORY LEAKS OF T4CCONNECTION
Bug 36939716 - JSON DV & PERF : MEMORY LEAK IN UPDATE OPERATION ON DUALITY VIEW WITH RETURNING CLAUSE
Bug 36784906 - BROKEN BATCHED INSERT AFTER UPGRADE FROM JDBC 21.13 TO 23.4
Bug 36744346 - TRACEEVENTLISTENER.TRACECONTEXT JAVADOC FOR GETDATABASEOPERATION METHOD IS WRONG
Bug 36476584 - CLIENT CONTEXT VALUES ARE RETURNED IN WRONG ORDER
Bug 36962333 - UCP ConnectionLabelingCallback contract broken for shared pool


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.