### PR TITLE
[SPARK-50274][CORE] Guard against use-after-close in DirectByteBufferOutputStream

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/DirectByteBufferOutputStream.scala
+++ b/core/src/main/scala/org/apache/spark/util/DirectByteBufferOutputStream.scala
@@ -20,6 +20,7 @@ package org.apache.spark.util
 import java.io.OutputStream
 import java.nio.ByteBuffer
 
+import org.apache.spark.SparkException
 import org.apache.spark.storage.StorageUtils
 import org.apache.spark.unsafe.Platform
 
@@ -67,7 +68,7 @@ private[spark] class DirectByteBufferOutputStream(capacity: Int) extends OutputS
 
   private def checkNotClosed(): Unit = {
     if (buffer == null) {
-      throw new IllegalStateException(
+      throw SparkException.internalError(
         "Cannot call methods on a closed DirectByteBufferOutputStream")
     }
   }

--- a/core/src/main/scala/org/apache/spark/util/DirectByteBufferOutputStream.scala
+++ b/core/src/main/scala/org/apache/spark/util/DirectByteBufferOutputStream.scala
@@ -29,7 +29,7 @@ import org.apache.spark.unsafe.Platform
  * @param capacity The initial capacity of the direct byte buffer
  */
 private[spark] class DirectByteBufferOutputStream(capacity: Int) extends OutputStream {
-  private var buffer = Platform.allocateDirectBuffer(capacity)
+  private[this] var buffer = Platform.allocateDirectBuffer(capacity)
 
   def this() = this(32)
 

--- a/core/src/test/scala/org/apache/spark/util/DirectByteBufferOutputStreamSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/DirectByteBufferOutputStreamSuite.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.util
+
+import org.apache.spark.SparkFunSuite
+
+class DirectByteBufferOutputStreamSuite extends SparkFunSuite {
+  test("use after close") {
+    val o = new DirectByteBufferOutputStream()
+    val size = 1000
+    o.write(new Array[Byte](size), 0, size)
+    val b = o.toByteBuffer
+    o.close()
+
+    // Using `o` after close should throw an exception rather than crashing.
+    assertThrows[IllegalStateException] { o.write(123) }
+    assertThrows[IllegalStateException] { o.write(new Array[Byte](size), 0, size) }
+    assertThrows[IllegalStateException] { o.reset() }
+    assertThrows[IllegalStateException] { o.size() }
+    assertThrows[IllegalStateException] { o.toByteBuffer }
+
+    // Using `b` after `o` is closed may crash.
+    // val arr = new Array[Byte](size)
+    // b.get(arr)
+  }
+}

--- a/core/src/test/scala/org/apache/spark/util/DirectByteBufferOutputStreamSuite.scala
+++ b/core/src/test/scala/org/apache/spark/util/DirectByteBufferOutputStreamSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.util
 
-import org.apache.spark.SparkFunSuite
+import org.apache.spark.{SparkException, SparkFunSuite}
 
 class DirectByteBufferOutputStreamSuite extends SparkFunSuite {
   test("use after close") {
@@ -28,11 +28,11 @@ class DirectByteBufferOutputStreamSuite extends SparkFunSuite {
     o.close()
 
     // Using `o` after close should throw an exception rather than crashing.
-    assertThrows[IllegalStateException] { o.write(123) }
-    assertThrows[IllegalStateException] { o.write(new Array[Byte](size), 0, size) }
-    assertThrows[IllegalStateException] { o.reset() }
-    assertThrows[IllegalStateException] { o.size() }
-    assertThrows[IllegalStateException] { o.toByteBuffer }
+    assertThrows[SparkException] { o.write(123) }
+    assertThrows[SparkException] { o.write(new Array[Byte](size), 0, size) }
+    assertThrows[SparkException] { o.reset() }
+    assertThrows[SparkException] { o.size() }
+    assertThrows[SparkException] { o.toByteBuffer }
 
     // Using `b` after `o` is closed may crash.
     // val arr = new Array[Byte](size)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

`DirectByteBufferOutputStream#close()` calls `StorageUtils.dispose()` to free its direct byte buffer. This puts the object into an unspecified and dangerous state after being closed, and can cause unpredictable JVM crashes if it the object is used after close.

This PR makes this safer by modifying `close()` to place the object into a known-closed state, and modifying all methods to assert not closed.

To minimize the performance impact from the extra checks, this PR also changes `DirectByteBufferOutputStream#buffer` from `private` to `private[this]`, which should produce more efficient direct field accesses.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Improves debuggability for users of DirectByteBufferOutputStream such as PythonRunner.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added a test in DirectByteBufferOutputStreamSuite to verify that use after close throws IllegalStateException.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.