### PR TITLE
[SPARK-50283][INFRA] Reuse `docs` image for linter

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -667,7 +667,7 @@ jobs:
       PYSPARK_PYTHON: python3.9
       GITHUB_PREV_SHA: ${{ github.event.before }}
     container:
-      image: ${{ needs.precondition.outputs.image_url }}
+      image: ${{ needs.precondition.outputs.image_docs_url_link }}
     steps:
     - name: Checkout Spark repository
       uses: actions/checkout@v4
@@ -741,18 +741,8 @@ jobs:
         # Should delete this section after SPARK 3.5 EOL.
         python3.9 -m pip install 'flake8==3.9.0' pydata_sphinx_theme 'mypy==0.982' 'pytest==7.1.3' 'pytest-mypy-plugins==1.9.3' numpydoc 'jinja2<3.0.0' 'black==22.6.0'
         python3.9 -m pip install 'pandas-stubs==1.2.0.53' ipython 'grpcio==1.56.0' 'grpc-stubs==1.24.11' 'googleapis-common-protos-stubs==2.2.0'
-    - name: Install Python dependencies for python linter and documentation generation
-      if: inputs.branch != 'branch-3.5'
-      run: |
-        # Should unpin 'sphinxcontrib-*' after upgrading sphinx>5
-        # See 'ipython_genutils' in SPARK-38517
-        # See 'docutils<0.18.0' in SPARK-39421
-        python3.9 -m pip install 'sphinx==4.5.0' mkdocs 'pydata_sphinx_theme>=0.13' sphinx-copybutton nbsphinx numpydoc jinja2 markupsafe 'pyzmq<24.0.0' \
-          ipython ipython_genutils sphinx_plotly_directive numpy pyarrow pandas 'plotly>=4.8' 'docutils<0.18.0' \
-          'flake8==3.9.0' 'mypy==1.8.0' 'pytest==7.1.3' 'pytest-mypy-plugins==1.9.3' 'black==23.9.1' \
-          'pandas-stubs==1.2.0.53' 'grpcio==1.67.0' 'grpc-stubs==1.24.11' 'googleapis-common-protos-stubs==2.2.0' \
-          'sphinxcontrib-applehelp==1.0.4' 'sphinxcontrib-devhelp==1.0.2' 'sphinxcontrib-htmlhelp==2.0.1' 'sphinxcontrib-qthelp==1.0.3' 'sphinxcontrib-serializinghtml==1.1.5'
-        python3.9 -m pip list
+    - name: List Python packages
+      run: python3.9 -m pip list
     - name: Python linter
       run: PYTHON_EXECUTABLE=python3.9 ./dev/lint-python
     # Should delete this section after SPARK 3.5 EOL.

--- a/dev/spark-test-image/docs/Dockerfile
+++ b/dev/spark-test-image/docs/Dockerfile
@@ -66,10 +66,11 @@ RUN apt-get update && apt-get install -y \
 
 
 # See more in SPARK-39959, roxygen2 < 7.2.1
-RUN Rscript -e "install.packages(c('devtools', 'knitr', 'markdown', 'rmarkdown', 'testthat'), repos='https://cloud.r-project.org/')" && \
-    Rscript -e "devtools::install_version('roxygen2', version='7.2.0', repos='https://cloud.r-project.org')" && \
-    Rscript -e "devtools::install_version('pkgdown', version='2.0.1', repos='https://cloud.r-project.org')" && \
-    Rscript -e "devtools::install_version('preferably', version='0.4', repos='https://cloud.r-project.org')"
+RUN Rscript -e "install.packages(c('devtools', 'knitr', 'markdown', 'rmarkdown', 'testthat'), repos='https://cloud.r-project.org/')" \
+    && Rscript -e "devtools::install_version('roxygen2', version='7.2.0', repos='https://cloud.r-project.org')" \
+    && Rscript -e "devtools::install_version('pkgdown', version='2.0.1', repos='https://cloud.r-project.org')" \
+    && Rscript -e "devtools::install_version('preferably', version='0.4', repos='https://cloud.r-project.org')" \
+    && Rscript -e "devtools::install_version('lintr', version='2.0.1', repos='https://cloud.r-project.org')"
 
 # See more in SPARK-39735
 ENV R_LIBS_SITE "/usr/local/lib/R/site-library:${R_LIBS_SITE}:/usr/lib/R/library"
@@ -83,9 +84,39 @@ RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.9
 # Should unpin 'sphinxcontrib-*' after upgrading sphinx>5
 # See 'ipython_genutils' in SPARK-38517
 # See 'docutils<0.18.0' in SPARK-39421
-RUN python3.9 -m pip install 'sphinx==4.5.0' mkdocs 'pydata_sphinx_theme>=0.13' sphinx-copybutton nbsphinx numpydoc jinja2 markupsafe 'pyzmq<24.0.0' \
-  ipython ipython_genutils sphinx_plotly_directive 'numpy>=1.20.0' pyarrow pandas 'plotly>=4.8' 'docutils<0.18.0' \
-  'flake8==3.9.0' 'mypy==1.8.0' 'pytest==7.1.3' 'pytest-mypy-plugins==1.9.3' 'black==23.9.1' \
-  'pandas-stubs==1.2.0.53' 'grpcio==1.62.0' 'grpcio-status==1.62.0' 'grpc-stubs==1.24.11' 'googleapis-common-protos-stubs==2.2.0' \
-  'sphinxcontrib-applehelp==1.0.4' 'sphinxcontrib-devhelp==1.0.2' 'sphinxcontrib-htmlhelp==2.0.1' 'sphinxcontrib-qthelp==1.0.3' 'sphinxcontrib-serializinghtml==1.1.5' \
-  && python3.9 -m pip cache purge
+RUN python3.9 -m pip install \
+    'black==23.9.1' \
+    'docutils<0.18.0' \
+    'flake8==3.9.0' \
+    'googleapis-common-protos-stubs==2.2.0' \
+    'grpc-stubs==1.24.11' \
+    'grpcio-status==1.62.0' \
+    'grpcio==1.62.0' \
+    'ipython' \
+    'ipython_genutils' \
+    'jinja2' \
+    'markupsafe' \
+    'mkdocs' \
+    'mypy==1.8.0' \
+    'nbsphinx' \
+    'numpy==1.26.4' \
+    'numpydoc' \
+    'pandas' \
+    'pandas-stubs==1.2.0.53' \
+    'plotly>=4.8' \
+    'pyarrow' \
+    'pydata_sphinx_theme>=0.13' \
+    'pytest-mypy-plugins==1.9.3' \
+    'pytest==7.1.3' \
+    'pyzmq<24.0.0' \
+    'sphinx-copybutton' \
+    'sphinx==4.5.0' \
+    'sphinx_plotly_directive' \
+    'sphinxcontrib-applehelp==1.0.4' \
+    'sphinxcontrib-devhelp==1.0.2' \
+    'sphinxcontrib-htmlhelp==2.0.1' \
+    'sphinxcontrib-qthelp==1.0.3' \
+    'sphinxcontrib-serializinghtml==1.1.5' \
+    && python3.9 -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu \
+    && python3.9 -m pip install torcheval \
+    && python3.9 -m pip cache purge

--- a/dev/spark-test-image/docs/Dockerfile
+++ b/dev/spark-test-image/docs/Dockerfile
@@ -90,8 +90,8 @@ RUN python3.9 -m pip install \
     'flake8==3.9.0' \
     'googleapis-common-protos-stubs==2.2.0' \
     'grpc-stubs==1.24.11' \
-    'grpcio-status==1.62.0' \
-    'grpcio==1.62.0' \
+    'grpcio-status==1.67.0' \
+    'grpcio==1.67.0' \
     'ipython' \
     'ipython_genutils' \
     'jinja2' \
@@ -105,7 +105,7 @@ RUN python3.9 -m pip install \
     'pandas' \
     'pandas-stubs==1.2.0.53' \
     'plotly>=4.8' \
-    'pyarrow' \
+    'pyarrow>=18.0.0' \
     'pydata_sphinx_theme>=0.13' \
     'pytest-mypy-plugins==1.9.3' \
     'pytest==7.1.3' \

--- a/dev/spark-test-image/docs/Dockerfile
+++ b/dev/spark-test-image/docs/Dockerfile
@@ -95,6 +95,7 @@ RUN python3.9 -m pip install \
     'ipython' \
     'ipython_genutils' \
     'jinja2' \
+    'matplotlib' \
     'markupsafe' \
     'mkdocs' \
     'mypy==1.8.0' \

--- a/dev/spark-test-image/docs/Dockerfile
+++ b/dev/spark-test-image/docs/Dockerfile
@@ -100,7 +100,7 @@ RUN python3.9 -m pip install \
     'mkdocs' \
     'mypy==1.8.0' \
     'nbsphinx' \
-    'numpy==1.26.4' \
+    'numpy==2.0.2' \
     'numpydoc' \
     'pandas' \
     'pandas-stubs==1.2.0.53' \

--- a/python/pyspark/sql/connect/expressions.py
+++ b/python/pyspark/sql/connect/expressions.py
@@ -490,7 +490,7 @@ class LiteralExpression(Expression):
                 # is sightly different:
                 # java.time.Duration only applies HOURS, MINUTES, SECONDS units,
                 # while Pandas applies all supported units.
-                return pd.Timedelta(delta).isoformat()  # type: ignore[attr-defined]
+                return pd.Timedelta(delta).isoformat()
         return f"{self._value}"
 
 

--- a/python/pyspark/sql/pandas/conversion.py
+++ b/python/pyspark/sql/pandas/conversion.py
@@ -520,7 +520,7 @@ class SparkConversionMixin:
                                 else:
                                     return (
                                         pd.Timestamp(value)
-                                        .tz_localize(timezone, ambiguous=False)  # type: ignore
+                                        .tz_localize(timezone, ambiguous=False)
                                         .tz_convert(_get_local_timezone())
                                         .tz_localize(None)
                                         .to_pydatetime()


### PR DESCRIPTION
### What changes were proposed in this pull request?
resolve the conflicts between `docs` and `lint`, so that we can reuse `docs` image for `lint`

after this PR:
branch-3.5: still use old `dev/infra/Dockerfile`;
master: reuse `dev/spark-test-image/docs/Dockerfile`


### Why are the changes needed?
to spin off linter from old image

### Does this PR introduce _any_ user-facing change?
no, infra-only


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no