### PR TITLE
[SPARK-50357][Core]If a stage contains ExpandExec, the CoalesceShuffl…

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -712,6 +712,14 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val PARTIAL_STAGE_NOT_COALESCE_PARTITIONS_ENABLED =
+    buildConf("spark.sql.adaptive.partial.stage.not.coalescePartitions.enabled")
+      .doc(s"Partial stages do not merge partitions. For example, if the stage includes Expand, it will not merge, and merging may cause the stage to run too slowly.")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(false)
+
+
   val COALESCE_PARTITIONS_PARALLELISM_FIRST =
     buildConf("spark.sql.adaptive.coalescePartitions.parallelismFirst")
       .doc("When true, Spark does not respect the target size specified by " +
@@ -5532,6 +5540,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
     getConf(NON_EMPTY_PARTITION_RATIO_FOR_BROADCAST_JOIN)
 
   def coalesceShufflePartitionsEnabled: Boolean = getConf(COALESCE_PARTITIONS_ENABLED)
+
+  def partialStageNotcoalesceShufflePartitionsEnabled: Boolean =
+    getConf(PARTIAL_STAGE_NOT_COALESCE_PARTITIONS_ENABLED)
 
   def minBatchesToRetain: Int = getConf(MIN_BATCHES_TO_RETAIN)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/CoalesceShufflePartitions.scala
@@ -45,6 +45,12 @@ case class CoalesceShufflePartitions(session: SparkSession) extends AQEShuffleRe
     if (!conf.coalesceShufflePartitionsEnabled) {
       return plan
     }
+    if (conf.partialStageNotcoalesceShufflePartitionsEnabled) {
+      val shuffleStageInfos = collectShuffleStageInfos(plan)
+      if (!shuffleStageInfos.forall(s => s.shuffleStage.getUseCoalesceShufflePartitions)) {
+        return plan
+      }
+    }
 
     // Ideally, this rule should simply coalesce partitions w.r.t. the target size specified by
     // ADVISORY_PARTITION_SIZE_IN_BYTES (default 64MB). To avoid perf regression in AQE, this

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
@@ -203,6 +203,14 @@ case class ShuffleQueryStageExec(
 
   override protected def doMaterialize(): Future[Any] = shuffle.submitShuffleJob()
 
+  private var useCoalesceShufflePartitions: Boolean = true
+
+  def getUseCoalesceShufflePartitions: Boolean = useCoalesceShufflePartitions
+
+  def setUseCoalesceShufflePartitions(useCoalesceShufflePartitions: Boolean): Unit = {
+    this.useCoalesceShufflePartitions = useCoalesceShufflePartitions
+  }
+
   override def newReuseInstance(
       newStageId: Int, newOutput: Seq[Attribute]): ExchangeQueryStageExec = {
     val reuse = ShuffleQueryStageExec(

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/CoalesceShufflePartitionsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/CoalesceShufflePartitionsSuite.scala
@@ -373,6 +373,19 @@ class CoalesceShufflePartitionsSuite extends SparkFunSuite with SQLConfHelper {
     withSparkSession(test, 100, None)
   }
 
+//  test("SPARK-50257 If a stage contains ExpandExec, the CoalesceShufflePartitions rule " +
+//    "will not be adjusted during the AQE phase") {
+//    val test: SparkSession => Unit = { spark: SparkSession =>
+//      withSQLConf(
+//        ("spark.sql.adaptive.partial.stage.not.coalescePartitions.enabled" -> "true"),
+//        ("spark.sql.shuffle.partitions" -> 1000)
+//      ) {
+//
+//
+//      }
+//    }
+//  }
+
   test("SPARK-24705 adaptive query execution works correctly when exchange reuse enabled") {
     val test: SparkSession => Unit = { spark: SparkSession =>
       withSQLConf("spark.sql.exchange.reuse" -> "true") {


### PR DESCRIPTION
…ePartitions rule will not be adjusted during the AQE phase

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
In the Aqe scenario, the optimization phase includes the ExpandEXEC scenario and does not perform partition merging.
For example

`SELECT

       /*+ SHUFFLE_MERGE(b) */

       s_date,

       sum(s_quantity * i_price) AS total_sales

   FROM

       sales a

       JOIN items b ON s_item_id = i_item_id
   WHERE
       i_price < 10
   GROUP BY
       s_date with rollup;`









### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
