### PR TITLE
[SPARK-50290][SQL] Add a flag to disable DataFrameQueryContext creation

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/trees/origin.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/trees/origin.scala
@@ -101,13 +101,16 @@ object CurrentOrigin {
    * invoke other APIs) only the first `withOrigin` is captured because that is closer to the user
    * code.
    *
+   * `withOrigin` has non-trivial performance overhead, since it collects a stack trace. This
+   * feature can be disabled by setting "spark.sql.dataFrameQueryContext.enabled" to "false".
+   *
    * @param f
    *   The function that can use the origin.
    * @return
    *   The result of `f`.
    */
   private[sql] def withOrigin[T](f: => T): T = {
-    if (CurrentOrigin.get.stackTrace.isDefined) {
+    if (CurrentOrigin.get.stackTrace.isDefined || !SqlApiConf.get.dataFrameQueryContextEnabled) {
       f
     } else {
       val st = Thread.currentThread().getStackTrace

--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConf.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConf.scala
@@ -45,6 +45,7 @@ private[sql] trait SqlApiConf {
   def legacyTimeParserPolicy: LegacyBehaviorPolicy.Value
   def defaultStringType: StringType
   def stackTracesInDataFrameContext: Int
+  def dataFrameQueryContextEnabled: Boolean
   def legacyAllowUntypedScalaUDFs: Boolean
 }
 
@@ -84,5 +85,6 @@ private[sql] object DefaultSqlApiConf extends SqlApiConf {
   override def legacyTimeParserPolicy: LegacyBehaviorPolicy.Value = LegacyBehaviorPolicy.CORRECTED
   override def defaultStringType: StringType = StringType
   override def stackTracesInDataFrameContext: Int = 1
+  override def dataFrameQueryContextEnabled: Boolean = true
   override def legacyAllowUntypedScalaUDFs: Boolean = false
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5167,6 +5167,15 @@ object SQLConf {
     .checkValue(_ > 0, "The number of stack traces in the DataFrame context must be positive.")
     .createWithDefault(1)
 
+  val DATA_FRAME_QUERY_CONTEXT_ENABLED = buildConf("spark.sql.dataFrameQueryContext.enabled")
+    .internal()
+    .doc(
+      "Enable the DataFrame query context. This feature is enabled by default, but has a " +
+      "non-trivial performance overhead because of the stack trace collection.")
+    .version("4.0.0")
+    .booleanConf
+    .createWithDefault(true)
+
   val LEGACY_JAVA_CHARSETS = buildConf("spark.sql.legacy.javaCharsets")
     .internal()
     .doc("When set to true, the functions like `encode()` can use charsets from JDK while " +
@@ -6177,6 +6186,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   override def stackTracesInDataFrameContext: Int =
     getConf(SQLConf.STACK_TRACES_IN_DATAFRAME_CONTEXT)
+
+  def dataFrameQueryContextEnabled: Boolean = getConf(SQLConf.DATA_FRAME_QUERY_CONTEXT_ENABLED)
 
   override def legacyAllowUntypedScalaUDFs: Boolean =
     getConf(SQLConf.LEGACY_ALLOW_UNTYPED_SCALA_UDF)

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryContextSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryContextSuite.scala
@@ -16,27 +16,40 @@
  */
 package org.apache.spark.sql.errors
 
-import org.apache.spark.SparkArithmeticException
+import org.apache.spark.{SparkArithmeticException, SparkConf}
 import org.apache.spark.sql.QueryTest
-import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.functions.{col, lit}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 
 class QueryContextSuite extends QueryTest with SharedSparkSession {
+  override def sparkConf: SparkConf = super.sparkConf.set(SQLConf.ANSI_ENABLED.key, "true")
+
+  private val ansiConf = "\"" + SQLConf.ANSI_ENABLED.key + "\""
 
   test("summary of DataFrame context") {
-    withSQLConf(
-      SQLConf.ANSI_ENABLED.key -> "true",
-      SQLConf.STACK_TRACES_IN_DATAFRAME_CONTEXT.key -> "2") {
+    withSQLConf(SQLConf.STACK_TRACES_IN_DATAFRAME_CONTEXT.key -> "2") {
       val e = intercept[SparkArithmeticException] {
         spark.range(1).select(lit(1) / lit(0)).collect()
       }
       assert(e.getQueryContext.head.summary() ==
         """== DataFrame ==
           |"div" was called from
-          |org.apache.spark.sql.errors.QueryContextSuite.$anonfun$new$3(QueryContextSuite.scala:32)
+          |org.apache.spark.sql.errors.QueryContextSuite.$anonfun$new$3(QueryContextSuite.scala:33)
           |org.scalatest.Assertions.intercept(Assertions.scala:749)
           |""".stripMargin)
+    }
+  }
+
+  test("SPARK-50290: Add a flag to disable DataFrame context") {
+    withSQLConf(SQLConf.DATA_FRAME_QUERY_CONTEXT_ENABLED.key -> "false") {
+      val df = spark.range(1).select(lit(1) / col("id"))
+      checkError(
+        exception = intercept[SparkArithmeticException](df.collect()),
+        condition = "DIVIDE_BY_ZERO",
+        parameters = Map("config" -> ansiConf),
+        context = ExpectedContext("", -1, -1)
+      )
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a new `spark.sql.dataFrameQueryContext.enabled` flag to disable the `DataFrameQueryContext` creation.

### Why are the changes needed?

`DataFrameQueryContext` creation requires a stack trace. Stack trace collection has a non-trivial perf overhead, some users might want to disable this feature.

`spark.sql.dataFrameQueryContext.enabled` == `true`:

![image](https://github.com/user-attachments/assets/0fe16b9e-56b8-4ff5-82b5-1e5875c6d26b)

`spark.sql.dataFrameQueryContext.enabled` == `false`:

![image](https://github.com/user-attachments/assets/5721cd26-5016-422b-bf06-fa63072bae2d)


### Does this PR introduce _any_ user-facing change?

No, the default is still to collect the query context.

### How was this patch tested?

Added a new test case.

### Was this patch authored or co-authored using generative AI tooling?

No.