### PR TITLE
[SPARK-50296][PYTHON][CONNECT] Avoid using a classproperty in threadpool for Python Connect client

### DIFF
--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -60,9 +60,8 @@ class ExecutePlanResponseReattachableIterator(Generator):
     _lock: ClassVar[RLock] = RLock()
     _release_thread_pool_instance: Optional[ThreadPoolExecutor] = None
 
-    @classmethod  # type: ignore[misc]
-    @property
-    def _release_thread_pool(cls) -> ThreadPoolExecutor:
+    @classmethod
+    def _get_or_create_release_thread_pool(cls) -> ThreadPoolExecutor:
         # Perform a first check outside the critical path.
         if cls._release_thread_pool_instance is not None:
             return cls._release_thread_pool_instance
@@ -129,6 +128,10 @@ class ExecutePlanResponseReattachableIterator(Generator):
 
         # Current item from this iterator.
         self._current: Optional[pb2.ExecutePlanResponse] = None
+
+    @property
+    def _release_thread_pool(self) -> ThreadPoolExecutor:
+        return self._get_or_create_release_thread_pool()
 
     def send(self, value: Any) -> pb2.ExecutePlanResponse:
         # will trigger reattach in case the stream completed without result_complete

--- a/python/pyspark/sql/connect/client/reattach.py
+++ b/python/pyspark/sql/connect/client/reattach.py
@@ -79,7 +79,7 @@ class ExecutePlanResponseReattachableIterator(Generator):
         """
         with cls._lock:
             if cls._release_thread_pool_instance is not None:
-                cls._release_thread_pool.shutdown()  # type: ignore[attr-defined]
+                cls._get_or_create_release_thread_pool().shutdown()
                 cls._release_thread_pool_instance = None
 
     def __init__(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to avoid using `@classmethod` and `@property` combination in Python Connect client

### Why are the changes needed?

In order to fix up the test failure at https://github.com/apache/spark/actions/runs/11804766326/job/32885813371.

https://docs.python.org/3.13/library/functions.html#classmethod

Seems like this combination was deprecated in Python 3.11, and removed in 3.13. 

### Does this PR introduce _any_ user-facing change?

Yes, it properly supports Python 3.13 with Python Connect client.

### How was this patch tested?

Manually tested locally.

### Was this patch authored or co-authored using generative AI tooling?

No.