### PR TITLE
[SPARK-50304][INFRA] Remove `(any|empty).proto` from RAT exclusion

### DIFF
--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -126,9 +126,6 @@ exported_table/*
 node_modules
 spark-events-broken/*
 SqlBaseLexer.tokens
-# Spark Connect related files with custom licence
-any.proto
-empty.proto
 .*\.explain
 .*\.proto.bin
 LimitedInputStream.java


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `(any|empty).proto` from RAT exclusion.

### Why are the changes needed?

`(any|empty).proto` files were never a part of Apache Spark repository. Those files were only used in the initial `Connect` PR and removed before merging.
- #37710
  - Added: https://github.com/apache/spark/pull/37710/commits/45c7bc55498f38081818424d231ec12576a0dc54
  - Excluded from RAT check: https://github.com/apache/spark/pull/37710/commits/cf6b19a991c9bf8c0f208bb2de39dd7121b146a2
  - Removed: https://github.com/apache/spark/pull/37710/commits/497198051af069f9afa70c9435dd5d7a099f11f1

### Does this PR introduce _any_ user-facing change?

No. This is a dev-only change.

### How was this patch tested?

Pass the CIs or manual check.

```
$ ./dev/check-license
Ignored 0 lines in your exclusion files as comments or empty lines.
RAT checks passed.
```

### Was this patch authored or co-authored using generative AI tooling?

No.