### PR TITLE
[SPARK-50306][PYTHON][CONNECT] Support Python 3.13 in Spark Connect

### DIFF
--- a/python/packaging/connect/setup.py
+++ b/python/packaging/connect/setup.py
@@ -212,6 +212,7 @@ try:
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
             "Programming Language :: Python :: 3.12",
+            "Programming Language :: Python :: 3.13",
             "Programming Language :: Python :: Implementation :: CPython",
             "Programming Language :: Python :: Implementation :: PyPy",
             "Typing :: Typed",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to note Python 3.13 in `pyspark-connect` package as its supported version.

### Why are the changes needed?

To officially support Python 3.13

### Does this PR introduce _any_ user-facing change?

Yes, in `pyspark-connect` package, Python 3.13 will be explicitly noted as a supported Python version.

### How was this patch tested?

CI passed at https://github.com/apache/spark/actions/runs/11824865909

### Was this patch authored or co-authored using generative AI tooling?

No.
