### PR TITLE
[SPARK-50322][SQL] Fix parameterized identifier in a sub-query

### DIFF
--- a/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
@@ -744,14 +744,14 @@ class ParametersSuite extends QueryTest with SharedSparkSession with PlanTest {
 
   test("SPARK-50322: parameterized identifier in a sub-query") {
     withTable("tt1") {
-      sql("create table tt1(c1 int)")
-      sql("insert into tt1 values (1)")
+      sql("CREATE TABLE tt1 (c1 INT)")
+      sql("INSERT INTO tt1 VALUES (1)")
       def query(p: String): String = {
         s"""
-          |with v1 as (
-          |  select * from tt1
-          |  where 1 = (Select * from identifier($p))
-          |) select * from v1""".stripMargin
+          |WITH v1 AS (
+          |  SELECT * FROM tt1
+          |  WHERE 1 = (SELECT * FROM IDENTIFIER($p))
+          |) SELECT * FROM v1""".stripMargin
       }
 
       checkAnswer(spark.sql(query(":tab"), args = Map("tab" -> "tt1")), Row(1))

--- a/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/ParametersSuite.scala
@@ -741,4 +741,18 @@ class ParametersSuite extends QueryTest with SharedSparkSession with PlanTest {
         Row("c1"))
     }
   }
+
+  test("parameterized identifier in a sub-query") {
+    withTable("tt1") {
+      sql("create table tt1(c1 int)")
+      sql("insert into tt1 values (1)")
+      val df = spark.sql("""
+        |with v1 as (
+        |  select * from tt1
+        |  where 1 = (Select * from identifier(:tab))
+        |) select * from v1""".stripMargin,
+        args = Map("tab" -> "tt1"))
+      checkAnswer(df, Row(1))
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In the PR, I propose to postpone parameters resolution till `UnresolvedWithCTERelations` is resolved. 

### Why are the changes needed?
To fix the query failure:
```sql
execute immediate 'with v1 as (select * from tt1 where 1 = (Select * from identifier(:tab))) select * from v1' using 'tt1' as tab;
[UNBOUND_SQL_PARAMETER] Found the unbound parameter: tab. Please, fix `args` and provide a mapping of the parameter to either a SQL literal or collection constructor functions such as `map()`, `array()`, `struct()`. SQLSTATE: 42P02
```

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By running new test:
```
$ build/sbt "sql/test:testOnly org.apache.spark.sql.ParametersSuite
```

### Was this patch authored or co-authored using generative AI tooling?
No.