### PR TITLE
[SPARK-50324][PYTHON][CONNECT] Make `createDataFrame` trigger `Config` RPC at most once

### DIFF
--- a/python/pyspark/sql/connect/client/core.py
+++ b/python/pyspark/sql/connect/client/core.py
@@ -43,6 +43,7 @@ from typing import (
     Dict,
     Set,
     NoReturn,
+    Mapping,
     cast,
     TYPE_CHECKING,
     Type,
@@ -1575,6 +1576,10 @@ class SparkConnectClient(object):
         op = pb2.ConfigRequest.Operation(get=pb2.ConfigRequest.Get(keys=keys))
         configs = dict(self.config(op).pairs)
         return tuple(configs.get(key) for key in keys)
+
+    def get_config_dict(self, *keys: str) -> Mapping[str, Optional[str]]:
+        op = pb2.ConfigRequest.Operation(get=pb2.ConfigRequest.Get(keys=keys))
+        return dict(self.config(op).pairs)
 
     def get_config_with_defaults(
         self, *pairs: Tuple[str, Optional[str]]

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -609,9 +609,6 @@ class SparkSession:
                 ).cast(arrow_schema)
 
         elif isinstance(data, pa.Table):
-            prefer_timestamp_ntz = is_timestamp_ntz_preferred()
-
-
             # If no schema supplied by user then get the names of columns only
             if schema is None:
                 _cols = data.column_names

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -522,10 +522,10 @@ class SparkSession:
             "spark.sql.pyspark.legacy.inferArrayTypeFromFirstElement.enabled",
             "spark.sql.pyspark.legacy.inferMapTypeFromFirstPair.enabled",
         )
+        timezone = configs["spark.sql.session.timeZone"]
+        prefer_timestamp = configs["spark.sql.timestampType"]
 
         _table: Optional[pa.Table] = None
-        timezone: Optional[str] = configs["spark.sql.session.timeZone"]
-        prefer_timestamp = configs["spark.sql.timestampType"]
 
         if isinstance(data, pd.DataFrame):
             # Logic was borrowed from `_create_from_pandas_with_arrow` in

--- a/python/pyspark/sql/connect/utils.py
+++ b/python/pyspark/sql/connect/utils.py
@@ -15,10 +15,6 @@
 # limitations under the License.
 #
 import sys
-from typing import Optional, Sequence, Dict, TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from pyspark.sql.connect.session import SparkSession
 
 from pyspark.loose_version import LooseVersion
 from pyspark.sql.pandas.utils import require_minimum_pandas_version, require_minimum_pyarrow_version
@@ -102,27 +98,3 @@ def require_minimum_googleapis_common_protos_version() -> None:
 
 def get_python_ver() -> str:
     return "%d.%d" % sys.version_info[:2]
-
-
-class LazyConfigGetter:
-    def __init__(
-        self,
-        keys: Sequence[str],
-        session: "SparkSession",
-    ):
-        assert len(keys) > 0 and len(keys) == len(set(keys))
-        assert all(isinstance(key, str) for key in keys)
-        assert session is not None
-        self._keys = keys
-        self._session = session
-        self._values: Dict[str, Optional[str]] = {}
-
-    def __getitem__(self, key: str) -> Optional[str]:
-        assert key in self._keys
-
-        if len(self._values) == 0:
-            values = self._session._client.get_configs(*self._keys)
-            for i, value in enumerate(values):
-                self._values[self._keys[i]] = value
-
-        return self._values[key]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Get all configs in batch

### Why are the changes needed?
there are too many related configs in `createDataFrame`, they are fetched one by one (or group by group) in different branches:
1, it is possible no Config RPC is triggered, e.g. in this branch:
https://github.com/apache/spark/blob/26330355836f5b2dad9b7bd4c72d9830c7ce6788/python/pyspark/sql/connect/session.py#L502-L509

2, multiple Config RPCs for different configs, e.g. in this branch:
https://github.com/apache/spark/blob/26330355836f5b2dad9b7bd4c72d9830c7ce6788/python/pyspark/sql/connect/session.py#L599-L601

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci

### Was this patch authored or co-authored using generative AI tooling?
no