### PR TITLE
[SPARK-50329][SQL] fix InSet$toString

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -609,6 +609,9 @@ case class InSet(child: Expression, hset: Set[Any]) extends UnaryExpression with
   require(hset != null, "hset could not be null")
 
   override def toString: String = {
+    if (!child.resolved) {
+      return s"$child INSET (values with unresolved data types)"
+    }
     val listString = hset.toSeq
       .map(elem => Literal(elem, child.dataType).toString)
       // Sort elements for deterministic behaviours

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -459,7 +459,7 @@ case class In(value: Expression, list: Seq[Expression]) extends Predicate {
         errorSubClass = "DATA_DIFF_TYPES",
         messageParameters = Map(
           "functionName" -> toSQLId(prettyName),
-          "dataType" -> children.map(child => toSQLType(child.dataType)).mkString("[", ", ", "]")
+          "dataType" -> children.map(child => toSQLType(child.dataType)).("[", ", ", "]")
         )
       )
     } else {
@@ -487,7 +487,7 @@ case class In(value: Expression, list: Seq[Expression]) extends Predicate {
     }
   }
 
-  override def toString: String = s"$value IN ${list.mkString("(", ",", ")")}"
+  override def toString: String = s"$value IN ${list.("(", ",", ")")}"
 
   override def eval(input: InternalRow): Any = {
     if (list.isEmpty && !legacyNullInEmptyBehavior) {
@@ -610,7 +610,7 @@ case class InSet(child: Expression, hset: Set[Any]) extends UnaryExpression with
 
   override def toString: String = {
     if (!child.resolved) {
-      return s"$child INSET " + hset.toSeq.mkString(", ")
+      return s"$child INSET " + hset.toSeq.mkString("(", ", ", ")")
     }
     val listString = hset.toSeq
       .map(elem => Literal(elem, child.dataType).toString)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -459,7 +459,7 @@ case class In(value: Expression, list: Seq[Expression]) extends Predicate {
         errorSubClass = "DATA_DIFF_TYPES",
         messageParameters = Map(
           "functionName" -> toSQLId(prettyName),
-          "dataType" -> children.map(child => toSQLType(child.dataType)).("[", ", ", "]")
+          "dataType" -> children.map(child => toSQLType(child.dataType)).mkString("[", ", ", "]")
         )
       )
     } else {
@@ -487,7 +487,7 @@ case class In(value: Expression, list: Seq[Expression]) extends Predicate {
     }
   }
 
-  override def toString: String = s"$value IN ${list.("(", ",", ")")}"
+  override def toString: String = s"$value IN ${list.mkString("(", ",", ")")}"
 
   override def eval(input: InternalRow): Any = {
     if (list.isEmpty && !legacyNullInEmptyBehavior) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -610,7 +610,7 @@ case class InSet(child: Expression, hset: Set[Any]) extends UnaryExpression with
 
   override def toString: String = {
     if (!child.resolved) {
-      return s"$child INSET " + hset.toSeq.mkString("(", ", ", ")")
+      return s"$child INSET (values with unresolved data types)"
     }
     val listString = hset.toSeq
       .map(elem => Literal(elem, child.dataType).toString)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/predicates.scala
@@ -610,7 +610,7 @@ case class InSet(child: Expression, hset: Set[Any]) extends UnaryExpression with
 
   override def toString: String = {
     if (!child.resolved) {
-      return s"$child INSET (values with unresolved data types)"
+      return s"$child INSET " + hset.toSeq.mkString(", ")
     }
     val listString = hset.toSeq
       .map(elem => Literal(elem, child.dataType).toString)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerLoggingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerLoggingSuite.scala
@@ -163,8 +163,8 @@ class OptimizerLoggingSuite extends PlanTest {
       val query = input.select($"a", $"b").where(inSetPredicate)
       val analyzed = query.analyze
 
-      assert(query.toString.contains("INSET (values with unresolved data types)"))
-      assert(analyzed.toString.contains("INSET"))
+      assert(query.toString.contains("'a INSET (values with unresolved data types)"))
+      assert(analyzed.toString.contains("INSET 1, 2"))
       assert(!analyzed.toString.contains("unresolved"))
     }
   }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerLoggingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerLoggingSuite.scala
@@ -155,17 +155,12 @@ class OptimizerLoggingSuite extends PlanTest {
   }
 
   test("SPARK-50329: toString for InSet should be valid for unresolved plan") {
-    withSQLConf(
-      SQLConf.PLAN_CHANGE_LOG_LEVEL.key -> "INFO"
-    ) {
-      val input = LocalRelation($"a".int, $"b".string, $"c".double)
-      val inSetPredicate = InSet($"a", Set(1, 2))
-      val query = input.select($"a", $"b").where(inSetPredicate)
-      val analyzed = query.analyze
+    val input = LocalRelation($"a".int, $"b".string, $"c".double)
+    val inSetPredicate = InSet($"a", Set(1, 2))
+    val query = input.select($"a", $"b").where(inSetPredicate)
+    val analyzed = query.analyze
 
-      assert(query.toString.contains("'a INSET (values with unresolved data types)"))
-      assert(analyzed.toString.contains("INSET 1, 2"))
-      assert(!analyzed.toString.contains("unresolved"))
-    }
+    assert(query.toString.contains("'a INSET 1, 2"))
+    assert(analyzed.toString.contains("INSET 1, 2"))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerLoggingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerLoggingSuite.scala
@@ -160,7 +160,7 @@ class OptimizerLoggingSuite extends PlanTest {
     val query = input.select($"a", $"b").where(inSetPredicate)
     val analyzed = query.analyze
 
-    assert(query.toString.contains("'a INSET 1, 2"))
+    assert(query.toString.contains("'a INSET (1, 2)"))
     assert(analyzed.toString.contains("INSET 1, 2"))
   }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerLoggingSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/optimizer/OptimizerLoggingSuite.scala
@@ -160,7 +160,7 @@ class OptimizerLoggingSuite extends PlanTest {
     val query = input.select($"a", $"b").where(inSetPredicate)
     val analyzed = query.analyze
 
-    assert(query.toString.contains("'a INSET (1, 2)"))
+    assert(query.toString.contains("'a INSET (values with unresolved data types)"))
     assert(analyzed.toString.contains("INSET 1, 2"))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Fix InSet$toString for unresolved plan node


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
InSet$toString should always work even for unresolved node


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
end to end test by running TPCDS benchmark suite with planChangeLog enabled.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
