### PR TITLE
Revert [SPARK-50230][SQL] Added logic to support reading unknown collation name as utf8_binary

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConf.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConf.scala
@@ -47,7 +47,6 @@ private[sql] trait SqlApiConf {
   def stackTracesInDataFrameContext: Int
   def dataFrameQueryContextEnabled: Boolean
   def legacyAllowUntypedScalaUDFs: Boolean
-  def allowReadingUnknownCollations: Boolean
 }
 
 private[sql] object SqlApiConf {
@@ -60,7 +59,6 @@ private[sql] object SqlApiConf {
     SqlApiConfHelper.LOCAL_RELATION_CACHE_THRESHOLD_KEY
   }
   val DEFAULT_COLLATION: String = SqlApiConfHelper.DEFAULT_COLLATION
-  val ALLOW_READING_UNKNOWN_COLLATIONS: String = SqlApiConfHelper.ALLOW_READING_UNKNOWN_COLLATIONS
 
   def get: SqlApiConf = SqlApiConfHelper.getConfGetter.get()()
 
@@ -89,5 +87,4 @@ private[sql] object DefaultSqlApiConf extends SqlApiConf {
   override def stackTracesInDataFrameContext: Int = 1
   override def dataFrameQueryContextEnabled: Boolean = true
   override def legacyAllowUntypedScalaUDFs: Boolean = false
-  override def allowReadingUnknownCollations: Boolean = false
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConfHelper.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConfHelper.scala
@@ -33,8 +33,6 @@ private[sql] object SqlApiConfHelper {
   val SESSION_LOCAL_TIMEZONE_KEY: String = "spark.sql.session.timeZone"
   val LOCAL_RELATION_CACHE_THRESHOLD_KEY: String = "spark.sql.session.localRelationCacheThreshold"
   val DEFAULT_COLLATION: String = "spark.sql.session.collation.default"
-  val ALLOW_READING_UNKNOWN_COLLATIONS: String =
-    "spark.sql.collation.allowReadingUnknownCollations"
 
   val confGetter: AtomicReference[() => SqlApiConf] = {
     new AtomicReference[() => SqlApiConf](() => DefaultSqlApiConf)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -778,15 +778,6 @@ object SQLConf {
       .booleanConf
       .createWithDefault(Utils.isTesting)
 
-  val ALLOW_READING_UNKNOWN_COLLATIONS =
-    buildConf(SqlApiConfHelper.ALLOW_READING_UNKNOWN_COLLATIONS)
-      .internal()
-      .doc("Enables spark to read unknown collation name as UTF8_BINARY. If the config is " +
-        "not enabled, when spark encounters an unknown collation name, it will throw an error.")
-      .version("4.0.0")
-      .booleanConf
-      .createWithDefault(false)
-
   val DEFAULT_COLLATION =
     buildConf(SqlApiConfHelper.DEFAULT_COLLATION)
       .doc("Sets default collation to use for string literals, parameter markers or the string" +
@@ -5581,8 +5572,6 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
       StringType(CollationFactory.collationNameToId(getConf(DEFAULT_COLLATION)))
     }
   }
-
-  override def allowReadingUnknownCollations: Boolean = getConf(ALLOW_READING_UNKNOWN_COLLATIONS)
 
   def adaptiveExecutionEnabled: Boolean = getConf(ADAPTIVE_EXECUTION_ENABLED)
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/types/DataTypeSuite.scala
@@ -23,13 +23,11 @@ import org.json4s.jackson.JsonMethods
 import org.apache.spark.{SparkException, SparkFunSuite, SparkIllegalArgumentException}
 import org.apache.spark.sql.catalyst.analysis.{caseInsensitiveResolution, caseSensitiveResolution}
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
-import org.apache.spark.sql.catalyst.plans.SQLHelper
 import org.apache.spark.sql.catalyst.types.DataTypeUtils
 import org.apache.spark.sql.catalyst.util.{CollationFactory, StringConcat}
-import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.DataTypeTestUtils.{dayTimeIntervalTypes, yearMonthIntervalTypes}
 
-class DataTypeSuite extends SparkFunSuite with SQLHelper {
+class DataTypeSuite extends SparkFunSuite {
 
   private val UNICODE_COLLATION_ID = CollationFactory.collationNameToId("UNICODE")
 
@@ -878,90 +876,6 @@ class DataTypeSuite extends SparkFunSuite with SQLHelper {
       }
   }
 
-  test("string field with invalid collation name") {
-    val collationProviders = Seq("spark", "icu")
-    collationProviders.foreach { provider =>
-      val json =
-        s"""
-           |{
-           |  "type": "struct",
-           |  "fields": [
-           |    {
-           |      "name": "c1",
-           |      "type": "string",
-           |      "nullable": false,
-           |      "metadata": {
-           |        "${DataType.COLLATIONS_METADATA_KEY}": {
-           |          "c1": "$provider.INVALID"
-           |        }
-           |      }
-           |    }
-           |  ]
-           |}
-           |""".stripMargin
-
-      // Check that the exception will be thrown in case of invalid collation name and
-      // UNKNOWN_COLLATION_NAME config not enabled.
-      checkError(
-        exception = intercept[SparkException] {
-          DataType.fromJson(json)
-        },
-        condition = "COLLATION_INVALID_NAME",
-        parameters = Map(
-          "proposals" -> "id",
-          "collationName" -> "INVALID"))
-
-      // Check that the exception will not be thrown in case of invalid collation name and
-      // UNKNOWN_COLLATION_NAME enabled, but UTF8_BINARY collation will be returned.
-      withSQLConf(SQLConf.ALLOW_READING_UNKNOWN_COLLATIONS.key -> "true") {
-        val dataType = DataType.fromJson(json)
-        assert(dataType === StructType(
-          StructField("c1", StringType(CollationFactory.UTF8_BINARY_COLLATION_ID), false) :: Nil))
-      }
-    }
-  }
-
-  test("string field with invalid collation provider") {
-    val json =
-      s"""
-         |{
-         |  "type": "struct",
-         |  "fields": [
-         |    {
-         |      "name": "c1",
-         |      "type": "string",
-         |      "nullable": false,
-         |      "metadata": {
-         |        "${DataType.COLLATIONS_METADATA_KEY}": {
-         |          "c1": "INVALID.INVALID"
-         |        }
-         |      }
-         |    }
-         |  ]
-         |}
-         |""".stripMargin
-
-
-    // Check that the exception will be thrown in case of invalid collation name and
-    // UNKNOWN_COLLATION_NAME config not enabled.
-    checkError(
-      exception = intercept[SparkException] {
-        DataType.fromJson(json)
-      },
-      condition = "COLLATION_INVALID_PROVIDER",
-      parameters = Map(
-        "supportedProviders" -> "spark, icu",
-        "provider" -> "INVALID"))
-
-    // Check that the exception will not be thrown in case of invalid collation name and
-    // UNKNOWN_COLLATION_NAME enabled, but UTF8_BINARY collation will be returned.
-    withSQLConf(SQLConf.ALLOW_READING_UNKNOWN_COLLATIONS.key -> "true") {
-      val dataType = DataType.fromJson(json)
-      assert(dataType === StructType(
-        StructField("c1", StringType(CollationFactory.UTF8_BINARY_COLLATION_ID), false) :: Nil))
-    }
-  }
-
   test("non string field has collation metadata") {
     val json =
       s"""
@@ -1109,42 +1023,6 @@ class DataTypeSuite extends SparkFunSuite with SQLHelper {
     assert(parsedWithCollations === ArrayType(StringType(unicodeCollationId)))
   }
 
-  test("parse array type with invalid collation metadata") {
-    val utf8BinaryCollationId = CollationFactory.UTF8_BINARY_COLLATION_ID
-    val arrayJson =
-      s"""
-         |{
-         |  "type": "array",
-         |  "elementType": "string",
-         |  "containsNull": true
-         |}
-         |""".stripMargin
-
-    val collationsMap = Map("element" -> "INVALID")
-
-    // Parse without collations map
-    assert(DataType.parseDataType(JsonMethods.parse(arrayJson)) === ArrayType(StringType))
-
-    // Check that the exception will be thrown in case of invalid collation name and
-    // UNKNOWN_COLLATION_NAME config not enabled.
-    checkError(
-      exception = intercept[SparkException] {
-        DataType.parseDataType(JsonMethods.parse(arrayJson), collationsMap = collationsMap)
-      },
-      condition = "COLLATION_INVALID_NAME",
-      parameters = Map(
-        "proposals" -> "id",
-        "collationName" -> "INVALID"))
-
-    // Check that the exception will not be thrown in case of invalid collation name and
-    // UNKNOWN_COLLATION_NAME enabled, but UTF8_BINARY collation will be returned.
-    withSQLConf(SQLConf.ALLOW_READING_UNKNOWN_COLLATIONS.key -> "true") {
-      val dataType = DataType.parseDataType(
-        JsonMethods.parse(arrayJson), collationsMap = collationsMap)
-      assert(dataType === ArrayType(StringType(utf8BinaryCollationId)))
-    }
-  }
-
   test("parse map type with collation metadata") {
     val unicodeCollationId = CollationFactory.collationNameToId("UNICODE")
     val mapJson =
@@ -1166,44 +1044,6 @@ class DataTypeSuite extends SparkFunSuite with SQLHelper {
       JsonMethods.parse(mapJson), collationsMap = collationsMap)
     assert(parsedWithCollations ===
       MapType(StringType(unicodeCollationId), StringType(unicodeCollationId)))
-  }
-
-  test("parse map type with invalid collation metadata") {
-    val utf8BinaryCollationId = CollationFactory.UTF8_BINARY_COLLATION_ID
-    val mapJson =
-      s"""
-         |{
-         |  "type": "map",
-         |  "keyType": "string",
-         |  "valueType": "string",
-         |  "valueContainsNull": true
-         |}
-         |""".stripMargin
-
-    val collationsMap = Map("key" -> "INVALID", "value" -> "INVALID")
-
-    // Parse without collations map
-    assert(DataType.parseDataType(JsonMethods.parse(mapJson)) === MapType(StringType, StringType))
-
-    // Check that the exception will be thrown in case of invalid collation name and
-    // UNKNOWN_COLLATION_NAME config not enabled.
-    checkError(
-      exception = intercept[SparkException] {
-        DataType.parseDataType(JsonMethods.parse(mapJson), collationsMap = collationsMap)
-      },
-      condition = "COLLATION_INVALID_NAME",
-      parameters = Map(
-        "proposals" -> "id",
-        "collationName" -> "INVALID"))
-
-    // Check that the exception will not be thrown in case of invalid collation name and
-    // UNKNOWN_COLLATION_NAME enabled, but UTF8_BINARY collation will be returned.
-    withSQLConf(SQLConf.ALLOW_READING_UNKNOWN_COLLATIONS.key -> "true") {
-      val dataType = DataType.parseDataType(
-        JsonMethods.parse(mapJson), collationsMap = collationsMap)
-      assert(dataType === MapType(
-        StringType(utf8BinaryCollationId), StringType(utf8BinaryCollationId)))
-    }
   }
 
   test("SPARK-48680: Add CharType and VarcharType to DataTypes JAVA API") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
I propose reverting changes for  new `SQLConf` entry which enables spark to read an invalid collation name as `UTF8_BINARY`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Since the original changes may bring unwanted data corruption when a user writes in a table that has unknown collation and modifies its properties, the original PR must be reverted.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Not applicable.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.