### PR TITLE
[SPARK-50313][SQL][TESTS][FOLLOWUP] Regenerate golden files for Java 21

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -25,7 +25,7 @@ on:
       java:
         required: false
         type: string
-        default: 17
+        default: 21
       branch:
         description: Branch to run the build against
         required: false

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -25,7 +25,7 @@ on:
       java:
         required: false
         type: string
-        default: 21
+        default: 17
       branch:
         description: Branch to run the build against
         required: false

--- a/sql/core/src/test/resources/sql-tests/results/nonansi/try_aggregates.sql.out.java21
+++ b/sql/core/src/test/resources/sql-tests/results/nonansi/try_aggregates.sql.out.java21
@@ -82,91 +82,33 @@ NULL
 -- !query
 SELECT try_sum(col / 0) FROM VALUES (5), (10), (15) AS tab(col)
 -- !query schema
-struct<>
+struct<try_sum((col / 0)):double>
 -- !query output
-org.apache.spark.SparkArithmeticException
-{
-  "errorClass" : "DIVIDE_BY_ZERO",
-  "sqlState" : "22012",
-  "messageParameters" : {
-    "config" : "\"spark.sql.ansi.enabled\""
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 16,
-    "stopIndex" : 22,
-    "fragment" : "col / 0"
-  } ]
-}
+NULL
 
 
 -- !query
 SELECT try_sum(col / 0) FROM VALUES (5.0), (10.0), (15.0) AS tab(col)
 -- !query schema
-struct<>
+struct<try_sum((col / 0)):decimal(18,6)>
 -- !query output
-org.apache.spark.SparkArithmeticException
-{
-  "errorClass" : "DIVIDE_BY_ZERO",
-  "sqlState" : "22012",
-  "messageParameters" : {
-    "config" : "\"spark.sql.ansi.enabled\""
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 16,
-    "stopIndex" : 22,
-    "fragment" : "col / 0"
-  } ]
-}
+NULL
 
 
 -- !query
 SELECT try_sum(col / 0) FROM VALUES (NULL), (10), (15) AS tab(col)
 -- !query schema
-struct<>
+struct<try_sum((col / 0)):double>
 -- !query output
-org.apache.spark.SparkArithmeticException
-{
-  "errorClass" : "DIVIDE_BY_ZERO",
-  "sqlState" : "22012",
-  "messageParameters" : {
-    "config" : "\"spark.sql.ansi.enabled\""
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 16,
-    "stopIndex" : 22,
-    "fragment" : "col / 0"
-  } ]
-}
+NULL
 
 
 -- !query
 SELECT try_sum(col + 1L) FROM VALUES (9223372036854775807L), (1L) AS tab(col)
 -- !query schema
-struct<>
+struct<try_sum((col + 1)):bigint>
 -- !query output
-org.apache.spark.SparkArithmeticException
-{
-  "errorClass" : "ARITHMETIC_OVERFLOW",
-  "sqlState" : "22003",
-  "messageParameters" : {
-    "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
-    "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 16,
-    "stopIndex" : 23,
-    "fragment" : "col + 1L"
-  } ]
-}
+-9223372036854775806
 
 
 -- !query
@@ -290,91 +232,33 @@ NULL
 -- !query
 SELECT try_avg(col / 0) FROM VALUES (5), (10), (15) AS tab(col)
 -- !query schema
-struct<>
+struct<try_avg((col / 0)):double>
 -- !query output
-org.apache.spark.SparkArithmeticException
-{
-  "errorClass" : "DIVIDE_BY_ZERO",
-  "sqlState" : "22012",
-  "messageParameters" : {
-    "config" : "\"spark.sql.ansi.enabled\""
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 16,
-    "stopIndex" : 22,
-    "fragment" : "col / 0"
-  } ]
-}
+NULL
 
 
 -- !query
 SELECT try_avg(col / 0) FROM VALUES (5.0), (10.0), (15.0) AS tab(col)
 -- !query schema
-struct<>
+struct<try_avg((col / 0)):decimal(12,10)>
 -- !query output
-org.apache.spark.SparkArithmeticException
-{
-  "errorClass" : "DIVIDE_BY_ZERO",
-  "sqlState" : "22012",
-  "messageParameters" : {
-    "config" : "\"spark.sql.ansi.enabled\""
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 16,
-    "stopIndex" : 22,
-    "fragment" : "col / 0"
-  } ]
-}
+NULL
 
 
 -- !query
 SELECT try_avg(col / 0) FROM VALUES (NULL), (10), (15) AS tab(col)
 -- !query schema
-struct<>
+struct<try_avg((col / 0)):double>
 -- !query output
-org.apache.spark.SparkArithmeticException
-{
-  "errorClass" : "DIVIDE_BY_ZERO",
-  "sqlState" : "22012",
-  "messageParameters" : {
-    "config" : "\"spark.sql.ansi.enabled\""
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 16,
-    "stopIndex" : 22,
-    "fragment" : "col / 0"
-  } ]
-}
+NULL
 
 
 -- !query
 SELECT try_avg(col + 1L) FROM VALUES (9223372036854775807L), (1L) AS tab(col)
 -- !query schema
-struct<>
+struct<try_avg((col + 1)):double>
 -- !query output
-org.apache.spark.SparkArithmeticException
-{
-  "errorClass" : "ARITHMETIC_OVERFLOW",
-  "sqlState" : "22003",
-  "messageParameters" : {
-    "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
-    "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 16,
-    "stopIndex" : 23,
-    "fragment" : "col + 1L"
-  } ]
-}
+-4.611686018427388E18
 
 
 -- !query

--- a/sql/core/src/test/resources/sql-tests/results/nonansi/try_arithmetic.sql.out.java21
+++ b/sql/core/src/test/resources/sql-tests/results/nonansi/try_arithmetic.sql.out.java21
@@ -26,9 +26,9 @@ struct<try_add(2147483647, 1):decimal(11,0)>
 -- !query
 SELECT try_add(2147483647, "1")
 -- !query schema
-struct<try_add(2147483647, 1):bigint>
+struct<try_add(2147483647, 1):double>
 -- !query output
-2147483648
+2.147483648E9
 
 
 -- !query
@@ -58,71 +58,25 @@ NULL
 -- !query
 SELECT try_add(1, (2147483647 + 1))
 -- !query schema
-struct<>
+struct<try_add(1, (2147483647 + 1)):int>
 -- !query output
-org.apache.spark.SparkArithmeticException
-{
-  "errorClass" : "ARITHMETIC_OVERFLOW",
-  "sqlState" : "22003",
-  "messageParameters" : {
-    "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
-    "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "integer overflow"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 20,
-    "stopIndex" : 33,
-    "fragment" : "2147483647 + 1"
-  } ]
-}
+-2147483647
 
 
 -- !query
 SELECT try_add(1L, (9223372036854775807L + 1L))
 -- !query schema
-struct<>
+struct<try_add(1, (9223372036854775807 + 1)):bigint>
 -- !query output
-org.apache.spark.SparkArithmeticException
-{
-  "errorClass" : "ARITHMETIC_OVERFLOW",
-  "sqlState" : "22003",
-  "messageParameters" : {
-    "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
-    "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 21,
-    "stopIndex" : 45,
-    "fragment" : "9223372036854775807L + 1L"
-  } ]
-}
+-9223372036854775807
 
 
 -- !query
 SELECT try_add(1, 1.0 / 0.0)
 -- !query schema
-struct<>
+struct<try_add(1, (1.0 / 0.0)):decimal(9,6)>
 -- !query output
-org.apache.spark.SparkArithmeticException
-{
-  "errorClass" : "DIVIDE_BY_ZERO",
-  "sqlState" : "22012",
-  "messageParameters" : {
-    "config" : "\"spark.sql.ansi.enabled\""
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 19,
-    "stopIndex" : 27,
-    "fragment" : "1.0 / 0.0"
-  } ]
-}
+NULL
 
 
 -- !query
@@ -290,71 +244,25 @@ NULL
 -- !query
 SELECT try_divide(1, (2147483647 + 1))
 -- !query schema
-struct<>
+struct<try_divide(1, (2147483647 + 1)):double>
 -- !query output
-org.apache.spark.SparkArithmeticException
-{
-  "errorClass" : "ARITHMETIC_OVERFLOW",
-  "sqlState" : "22003",
-  "messageParameters" : {
-    "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
-    "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "integer overflow"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 23,
-    "stopIndex" : 36,
-    "fragment" : "2147483647 + 1"
-  } ]
-}
+-4.656612873077393E-10
 
 
 -- !query
 SELECT try_divide(1L, (9223372036854775807L + 1L))
 -- !query schema
-struct<>
+struct<try_divide(1, (9223372036854775807 + 1)):double>
 -- !query output
-org.apache.spark.SparkArithmeticException
-{
-  "errorClass" : "ARITHMETIC_OVERFLOW",
-  "sqlState" : "22003",
-  "messageParameters" : {
-    "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
-    "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 24,
-    "stopIndex" : 48,
-    "fragment" : "9223372036854775807L + 1L"
-  } ]
-}
+-1.0842021724855044E-19
 
 
 -- !query
 SELECT try_divide(1, 1.0 / 0.0)
 -- !query schema
-struct<>
+struct<try_divide(1, (1.0 / 0.0)):decimal(16,9)>
 -- !query output
-org.apache.spark.SparkArithmeticException
-{
-  "errorClass" : "DIVIDE_BY_ZERO",
-  "sqlState" : "22012",
-  "messageParameters" : {
-    "config" : "\"spark.sql.ansi.enabled\""
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 22,
-    "stopIndex" : 30,
-    "fragment" : "1.0 / 0.0"
-  } ]
-}
+NULL
 
 
 -- !query
@@ -448,9 +356,9 @@ struct<try_subtract(2147483647, -1):decimal(11,0)>
 -- !query
 SELECT try_subtract(2147483647, "-1")
 -- !query schema
-struct<try_subtract(2147483647, -1):bigint>
+struct<try_subtract(2147483647, -1):double>
 -- !query output
-2147483648
+2.147483648E9
 
 
 -- !query
@@ -480,71 +388,25 @@ NULL
 -- !query
 SELECT try_subtract(1, (2147483647 + 1))
 -- !query schema
-struct<>
+struct<try_subtract(1, (2147483647 + 1)):int>
 -- !query output
-org.apache.spark.SparkArithmeticException
-{
-  "errorClass" : "ARITHMETIC_OVERFLOW",
-  "sqlState" : "22003",
-  "messageParameters" : {
-    "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
-    "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "integer overflow"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 25,
-    "stopIndex" : 38,
-    "fragment" : "2147483647 + 1"
-  } ]
-}
+NULL
 
 
 -- !query
 SELECT try_subtract(1L, (9223372036854775807L + 1L))
 -- !query schema
-struct<>
+struct<try_subtract(1, (9223372036854775807 + 1)):bigint>
 -- !query output
-org.apache.spark.SparkArithmeticException
-{
-  "errorClass" : "ARITHMETIC_OVERFLOW",
-  "sqlState" : "22003",
-  "messageParameters" : {
-    "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
-    "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 26,
-    "stopIndex" : 50,
-    "fragment" : "9223372036854775807L + 1L"
-  } ]
-}
+NULL
 
 
 -- !query
 SELECT try_subtract(1, 1.0 / 0.0)
 -- !query schema
-struct<>
+struct<try_subtract(1, (1.0 / 0.0)):decimal(9,6)>
 -- !query output
-org.apache.spark.SparkArithmeticException
-{
-  "errorClass" : "DIVIDE_BY_ZERO",
-  "sqlState" : "22012",
-  "messageParameters" : {
-    "config" : "\"spark.sql.ansi.enabled\""
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 24,
-    "stopIndex" : 32,
-    "fragment" : "1.0 / 0.0"
-  } ]
-}
+NULL
 
 
 -- !query
@@ -606,9 +468,9 @@ struct<try_multiply(2147483647, -2):decimal(21,0)>
 -- !query
 SELECT try_multiply(2147483647, "-2")
 -- !query schema
-struct<try_multiply(2147483647, -2):bigint>
+struct<try_multiply(2147483647, -2):double>
 -- !query output
--4294967294
+-4.294967294E9
 
 
 -- !query
@@ -638,71 +500,25 @@ NULL
 -- !query
 SELECT try_multiply(1, (2147483647 + 1))
 -- !query schema
-struct<>
+struct<try_multiply(1, (2147483647 + 1)):int>
 -- !query output
-org.apache.spark.SparkArithmeticException
-{
-  "errorClass" : "ARITHMETIC_OVERFLOW",
-  "sqlState" : "22003",
-  "messageParameters" : {
-    "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
-    "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "integer overflow"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 25,
-    "stopIndex" : 38,
-    "fragment" : "2147483647 + 1"
-  } ]
-}
+-2147483648
 
 
 -- !query
 SELECT try_multiply(1L, (9223372036854775807L + 1L))
 -- !query schema
-struct<>
+struct<try_multiply(1, (9223372036854775807 + 1)):bigint>
 -- !query output
-org.apache.spark.SparkArithmeticException
-{
-  "errorClass" : "ARITHMETIC_OVERFLOW",
-  "sqlState" : "22003",
-  "messageParameters" : {
-    "alternative" : " Use 'try_add' to tolerate overflow and return NULL instead.",
-    "config" : "\"spark.sql.ansi.enabled\"",
-    "message" : "long overflow"
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 26,
-    "stopIndex" : 50,
-    "fragment" : "9223372036854775807L + 1L"
-  } ]
-}
+-9223372036854775808
 
 
 -- !query
 SELECT try_multiply(1, 1.0 / 0.0)
 -- !query schema
-struct<>
+struct<try_multiply(1, (1.0 / 0.0)):decimal(10,6)>
 -- !query output
-org.apache.spark.SparkArithmeticException
-{
-  "errorClass" : "DIVIDE_BY_ZERO",
-  "sqlState" : "22012",
-  "messageParameters" : {
-    "config" : "\"spark.sql.ansi.enabled\""
-  },
-  "queryContext" : [ {
-    "objectType" : "",
-    "objectName" : "",
-    "startIndex" : 24,
-    "stopIndex" : 32,
-    "fragment" : "1.0 / 0.0"
-  } ]
-}
+NULL
 
 
 -- !query


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr uses the command 

```
java -version
openjdk version "21.0.5" 2024-10-15 LTS
OpenJDK Runtime Environment Zulu21.38+21-CA (build 21.0.5+11-LTS)
OpenJDK 64-Bit Server VM Zulu21.38+21-CA (build 21.0.5+11-LTS, mixed mode, sharing)

SPARK_GENERATE_GOLDEN_FILES=1 build/sbt "sql/testOnly org.apache.spark.sql.SQLQueryTestSuite"
```

to regenerate golden files for Java 21.

### Why are the changes needed?
Regenerate golden files for Java 21.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Pass GitHub Actions


### Was this patch authored or co-authored using generative AI tooling?
No
