### PR TITLE
[WIP][SPARK-50323][CONNECT][PYTHON] Add missing schema check for createDataFrame from numpy ndarray on Spark Connect

### DIFF
--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -423,12 +423,12 @@ class SparkSession:
             infer_dict_as_struct,
             infer_array_from_first_element,
             infer_map_from_first_pair,
-            prefer_timestamp_ntz
+            prefer_timestamp_ntz,
         ) = self._client.get_configs(
             "spark.sql.pyspark.inferNestedDictAsStruct.enabled",
             "spark.sql.pyspark.legacy.inferArrayTypeFromFirstElement.enabled",
             "spark.sql.pyspark.legacy.inferMapTypeFromFirstPair.enabled",
-            "spark.sql.timestampType"
+            "spark.sql.timestampType",
         )
         return functools.reduce(
             _merge_type,
@@ -656,15 +656,14 @@ class SparkSession:
                     [pa.array(data[::, i]) for i in range(0, data.shape[1])], _cols
                 )
 
-            if verifySchema is _NoValue:
-                verifySchema = self._client.get_configs("spark.sql.execution.pandas.convertToArrowArraySafely")
-
-            if verifySchema:
-                schema = to_arrow_schema(schema, error_on_duplicated_field_names_in_struct=True)
-                _table = _table.cast(schema, safe=verifySchema)
-
             # The _table should already have the proper column names.
             _cols = None
+
+            if verifySchema is not _NoValue:
+                warnings.warn(
+                    "'verifySchema' is ignored. It is not supported"
+                    " with np.ndarray input on Spark Connect."
+                )
 
         else:
             _data = list(data)

--- a/python/pyspark/sql/connect/session.py
+++ b/python/pyspark/sql/connect/session.py
@@ -423,12 +423,12 @@ class SparkSession:
             infer_dict_as_struct,
             infer_array_from_first_element,
             infer_map_from_first_pair,
-            prefer_timestamp_ntz,
+            prefer_timestamp_ntz
         ) = self._client.get_configs(
             "spark.sql.pyspark.inferNestedDictAsStruct.enabled",
             "spark.sql.pyspark.legacy.inferArrayTypeFromFirstElement.enabled",
             "spark.sql.pyspark.legacy.inferMapTypeFromFirstPair.enabled",
-            "spark.sql.timestampType",
+            "spark.sql.timestampType"
         )
         return functools.reduce(
             _merge_type,
@@ -656,14 +656,15 @@ class SparkSession:
                     [pa.array(data[::, i]) for i in range(0, data.shape[1])], _cols
                 )
 
+            if verifySchema is _NoValue:
+                verifySchema = self._client.get_configs("spark.sql.execution.pandas.convertToArrowArraySafely")
+
+            if verifySchema:
+                schema = to_arrow_schema(schema, error_on_duplicated_field_names_in_struct=True)
+                _table = _table.cast(schema, safe=verifySchema)
+
             # The _table should already have the proper column names.
             _cols = None
-
-            if verifySchema is not _NoValue:
-                warnings.warn(
-                    "'verifySchema' is ignored. It is not supported"
-                    " with np.ndarray input on Spark Connect."
-                )
 
         else:
             _data = list(data)

--- a/python/pyspark/sql/tests/test_arrow.py
+++ b/python/pyspark/sql/tests/test_arrow.py
@@ -557,57 +557,31 @@ class ArrowTestsMixin:
         with self.assertRaises(Exception):
             self.spark.createDataFrame(table, schema=schema, verifySchema=True)
 
-        # Pandas frame
-        if arrow_enabled:
-            with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": True}):
-                # pandas DataFrame with Arrow optimization
-                pdf = pd.DataFrame(data)
-                df = self.spark.createDataFrame(pdf, schema=schema)
-                # verifySchema defaults to `spark.sql.execution.pandas.convertToArrowArraySafely`,
-                # which is false by default
-                self.assertEqual(df.collect(), expected)
-                with self.assertRaises(Exception):
-                    with self.sql_conf(
-                        {"spark.sql.execution.pandas.convertToArrowArraySafely": True}
-                    ):
-                        df = self.spark.createDataFrame(pdf, schema=schema)
-                with self.assertRaises(Exception):
-                    df = self.spark.createDataFrame(pdf, schema=schema, verifySchema=True)
-        else:
-            # pandas DataFrame without Arrow optimization
-            with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": False}):
-                pdf = pd.DataFrame(data)
-                with self.assertRaises(Exception):
-                    self.spark.createDataFrame(pdf, schema=schema)  # verifySchema defaults to True
-                df = self.spark.createDataFrame(pdf, schema=schema, verifySchema=False)
-                self.assertEqual(df.collect(), expected)
-
-        # ndarray
-        if arrow_enabled:
-            with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": True}):
-                # ndarray with Arrow optimization
-                data_array = np.array(list(zip(data["id"], data["value"])))
-                df = self.spark.createDataFrame(data_array, schema=schema)
-                # verifySchema defaults to `spark.sql.execution.pandas.convertToArrowArraySafely`,
-                # which is false by default
-                self.assertEqual(df.collect(), expected)
-                with self.assertRaises(Exception):
-                    with self.sql_conf(
-                        {"spark.sql.execution.pandas.convertToArrowArraySafely": True}
-                    ):
-                        df = self.spark.createDataFrame(data_array, schema=schema)
-                with self.assertRaises(Exception):
-                    df = self.spark.createDataFrame(data_array, schema=schema, verifySchema=True)
-        else:
-            # ndarray without Arrow optimization
-            with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": False}):
-                data_array = np.array(list(zip(data["id"], data["value"])))
-                with self.assertRaises(Exception):
-                    self.spark.createDataFrame(
-                        data_array, schema=schema
-                    )  # verifySchema defaults to True
-                df = self.spark.createDataFrame(data_array, schema=schema, verifySchema=False)
-                self.assertEqual(df.collect(), expected)
+        # Pandas DataFrame / Numpy array
+        for from_obj in [pd.DataFrame(data), np.array(list(zip(data["id"], data["value"])))]:
+            if arrow_enabled:
+                with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": True}):
+                    # pandas DataFrame with Arrow optimization
+                    df = self.spark.createDataFrame(from_obj, schema=schema)
+                    # verifySchema defaults to `spark.sql.execution.pandas.convertToArrowArraySafely`,
+                    # which is false by default
+                    self.assertEqual(df.collect(), expected)
+                    with self.assertRaises(Exception):
+                        with self.sql_conf(
+                            {"spark.sql.execution.pandas.convertToArrowArraySafely": True}
+                        ):
+                            df = self.spark.createDataFrame(from_obj, schema=schema)
+                    with self.assertRaises(Exception):
+                        df = self.spark.createDataFrame(from_obj, schema=schema, verifySchema=True)
+            else:
+                # pandas DataFrame without Arrow optimization
+                with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": False}):
+                    with self.assertRaises(Exception):
+                        self.spark.createDataFrame(
+                            from_obj, schema=schema
+                        )  # verifySchema defaults to True
+                    df = self.spark.createDataFrame(from_obj, schema=schema, verifySchema=False)
+                    self.assertEqual(df.collect(), expected)
 
     def _createDataFrame_toggle(self, data, schema=None):
         with self.sql_conf({"spark.sql.execution.arrow.pyspark.enabled": False}):


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add missing schema check for createDataFrame from numpy ndarray on Spark Connect

### Why are the changes needed?
Currently, the conversion from ndarray to pa.table doesn’t consider the schema at all ([for e.g.](https://github.com/apache/spark/blob/master/python/pyspark/sql/connect/session.py#L649)).

If we handle the schema separately for ndarray -> Arrow, it will add additional complexity ([for e.g.](https://github.com/apache/spark/pull/48887/commits/244d8335f7c469f67e21c790d8e75dfc3477bfeb)) and may introduce inconsistencies with Pandas DataFrame behavior—where in Spark Classic, the process is ndarray -> pdf -> Arrow.

To maintain consistency and simplicity, we follow this approach in Spark Connect.

### Does this PR introduce _any_ user-facing change?
Schema check and verification aligns with Spark Classic now.

### How was this patch tested?
Unit tests.

### Was this patch authored or co-authored using generative AI tooling?
No.