### PR TITLE
[SPARK-50348][PYTHON] Make static import Python data source configurable

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5984,9 +5984,6 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   def pythonUDFWorkerFaulthandlerEnabled: Boolean = getConf(PYTHON_UDF_WORKER_FAULTHANLDER_ENABLED)
 
-  def pythonDataSourceStaticImportEnabled: Boolean =
-    getConf(StaticSQLConf.PYTHON_DATA_SOURCE_STATIC_IMPORT_ENABLED)
-
   def pysparkPlotMaxRows: Int = getConf(PYSPARK_PLOT_MAX_ROWS)
 
   def arrowSparkREnabled: Boolean = getConf(ARROW_SPARKR_EXECUTION_ENABLED)

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3197,6 +3197,14 @@ object SQLConf {
       .version("4.0.0")
       .fallbackConf(Python.PYTHON_WORKER_FAULTHANLDER_ENABLED)
 
+  val PYTHON_DATA_SOURCE_STATIC_IMPORT_ENABLED =
+    buildConf("spark.sql.pyspark.dataSource.staticImport.enabled")
+      .doc("When true, load all available Python data sources installed or " +
+        "discoverable in the Python environment.")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val PYSPARK_PLOT_MAX_ROWS =
     buildConf("spark.sql.pyspark.plotting.max_rows")
       .doc("The visual limit on plots. If set to 1000 for top-n-based plots (pie, bar, barh), " +
@@ -5983,6 +5991,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def pythonUDFProfiler: Option[String] = getConf(PYTHON_UDF_PROFILER)
 
   def pythonUDFWorkerFaulthandlerEnabled: Boolean = getConf(PYTHON_UDF_WORKER_FAULTHANLDER_ENABLED)
+
+  def pythonDataSourceStaticImportEnabled: Boolean =
+    getConf(PYTHON_DATA_SOURCE_STATIC_IMPORT_ENABLED)
 
   def pysparkPlotMaxRows: Int = getConf(PYSPARK_PLOT_MAX_ROWS)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -3197,14 +3197,6 @@ object SQLConf {
       .version("4.0.0")
       .fallbackConf(Python.PYTHON_WORKER_FAULTHANLDER_ENABLED)
 
-  val PYTHON_DATA_SOURCE_STATIC_IMPORT_ENABLED =
-    buildConf("spark.sql.pyspark.dataSource.staticImport.enabled")
-      .doc("When true, load all available Python data sources installed or " +
-        "discoverable in the Python environment.")
-      .version("4.0.0")
-      .booleanConf
-      .createWithDefault(false)
-
   val PYSPARK_PLOT_MAX_ROWS =
     buildConf("spark.sql.pyspark.plotting.max_rows")
       .doc("The visual limit on plots. If set to 1000 for top-n-based plots (pie, bar, barh), " +
@@ -5993,7 +5985,7 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def pythonUDFWorkerFaulthandlerEnabled: Boolean = getConf(PYTHON_UDF_WORKER_FAULTHANLDER_ENABLED)
 
   def pythonDataSourceStaticImportEnabled: Boolean =
-    getConf(PYTHON_DATA_SOURCE_STATIC_IMPORT_ENABLED)
+    getConf(StaticSQLConf.PYTHON_DATA_SOURCE_STATIC_IMPORT_ENABLED)
 
   def pysparkPlotMaxRows: Int = getConf(PYSPARK_PLOT_MAX_ROWS)
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -295,4 +295,12 @@ object StaticSQLConf {
       .version("3.1.0")
       .stringConf
       .createWithDefault("")
+
+  val PYTHON_DATA_SOURCE_STATIC_IMPORT_ENABLED =
+    buildStaticConf("spark.sql.pyspark.sources.staticImport.enabled")
+      .doc("When true, load all available Python data sources installed or " +
+        "discoverable in the Python environment.")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(false)
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/StaticSQLConf.scala
@@ -302,5 +302,5 @@ object StaticSQLConf {
         "discoverable in the Python environment.")
       .version("4.0.0")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
@@ -25,6 +25,7 @@ import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys.DATA_SOURCE
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.v2.python.UserDefinedPythonDataSource
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.Utils
 
 
@@ -94,6 +95,7 @@ object DataSourceManager extends Logging {
   // Visible for testing
   private[spark] var dataSourceBuilders: Option[Map[String, UserDefinedPythonDataSource]] = None
   private lazy val shouldLoadPythonDataSources: Boolean = {
+    SQLConf.get.pythonDataSourceStaticImportEnabled &&
     Utils.checkCommandAvailable(PythonUtils.defaultPythonExec)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSourceManager.scala
@@ -25,7 +25,7 @@ import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys.DATA_SOURCE
 import org.apache.spark.sql.errors.QueryCompilationErrors
 import org.apache.spark.sql.execution.datasources.v2.python.UserDefinedPythonDataSource
-import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.{SQLConf, StaticSQLConf}
 import org.apache.spark.util.Utils
 
 
@@ -90,12 +90,12 @@ class DataSourceManager extends Logging {
   }
 }
 
-
 object DataSourceManager extends Logging {
   // Visible for testing
   private[spark] var dataSourceBuilders: Option[Map[String, UserDefinedPythonDataSource]] = None
-  private lazy val shouldLoadPythonDataSources: Boolean = {
-    SQLConf.get.pythonDataSourceStaticImportEnabled &&
+
+  private[spark] lazy val shouldLoadPythonDataSources: Boolean = {
+    SQLConf.get.getConf(StaticSQLConf.PYTHON_DATA_SOURCE_STATIC_IMPORT_ENABLED) &&
     Utils.checkCommandAvailable(PythonUtils.defaultPythonExec)
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/python/PythonDataSourceSuite.scala
@@ -19,12 +19,12 @@ package org.apache.spark.sql.execution.python
 
 import java.io.{File, FileWriter}
 
-import org.apache.spark.{SparkClassNotFoundException, SparkException}
+import org.apache.spark.{SparkClassNotFoundException, SparkConf, SparkException}
 import org.apache.spark.api.python.PythonUtils
 import org.apache.spark.sql.{AnalysisException, IntegratedUDFTestUtils, QueryTest, Row}
 import org.apache.spark.sql.execution.datasources.DataSourceManager
 import org.apache.spark.sql.execution.datasources.v2.{BatchScanExec, DataSourceV2ScanRelation}
-import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.internal.StaticSQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.Utils
@@ -95,23 +95,13 @@ abstract class PythonDataSourceSuiteBase extends QueryTest with SharedSparkSessi
 class PythonDataSourceSuite extends PythonDataSourceSuiteBase {
   import IntegratedUDFTestUtils._
 
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(StaticSQLConf.PYTHON_DATA_SOURCE_STATIC_IMPORT_ENABLED, true)
+
   test("SPARK-45917: automatic registration of Python Data Source") {
     assume(shouldTestPandasUDFs)
-    withSQLConf(SQLConf.PYTHON_DATA_SOURCE_STATIC_IMPORT_ENABLED.key -> "true") {
-      val df = spark.read.format(staticSourceName).load()
-      checkAnswer(df, Seq(Row(0, 0), Row(0, 1), Row(1, 0), Row(1, 1), Row(2, 0), Row(2, 1)))
-    }
-  }
-
-  test("SPARK-50348: make static import Python data source configurable") {
-    assume(shouldTestPandasUDFs)
-    withSQLConf(SQLConf.PYTHON_DATA_SOURCE_STATIC_IMPORT_ENABLED.key -> "false") {
-      checkError(
-        exception = intercept[SparkClassNotFoundException](
-          spark.read.format(staticSourceName).load()),
-        condition = "DATA_SOURCE_NOT_FOUND",
-        parameters = Map("provider" -> "custom_source"))
-    }
+    val df = spark.read.format(staticSourceName).load()
+    checkAnswer(df, Seq(Row(0, 0), Row(0, 1), Row(1, 0), Row(1, 1), Row(2, 0), Row(2, 1)))
   }
 
   test("simple data source") {
@@ -877,5 +867,21 @@ class PythonDataSourceSuite extends PythonDataSourceSuiteBase {
       .format(dataSourceName).load()
     checkAnswer(df, Row("1", "2", "true"))
     df.write.option("foo", 1).option("bar", 2).format(dataSourceName).mode("append").save()
+  }
+}
+
+class PythonDataSourceSuiteWithStaticImportDisabled extends PythonDataSourceSuiteBase {
+  import IntegratedUDFTestUtils._
+
+  override protected def sparkConf: SparkConf = super.sparkConf
+    .set(StaticSQLConf.PYTHON_DATA_SOURCE_STATIC_IMPORT_ENABLED, false)
+
+  test("SPARK-50348: make static import Python data source configurable") {
+    assume(shouldTestPandasUDFs)
+    checkError(
+      exception = intercept[SparkClassNotFoundException](
+        spark.read.format(staticSourceName).load()),
+      condition = "DATA_SOURCE_NOT_FOUND",
+      parameters = Map("provider" -> "custom_source"))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR adds a new **static** config **`spark.sql.pyspark.sources.staticImport.enabled`** (default: true) to make the static import of Python data sources configurable.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This allows users to enable or disable the automatic loading of all Python data sources installed in the environment, providing greater flexibility over resource usage and startup behavior.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
UT and spark shell

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
