### PR TITLE
[SPARK-50354][SQL] No need to set initialInputBufferOffset when Aggregate mode is Complete

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/ReplaceHashWithSortAgg.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/ReplaceHashWithSortAgg.scala
@@ -75,6 +75,7 @@ object ReplaceHashWithSortAgg extends Rule[SparkPlan] {
                 partialAgg.child.outputOrdering, sortAgg.requiredChildOrdering.head)) {
               sortAgg.copy(
                 aggregateExpressions = sortAgg.aggregateExpressions.map(_.copy(mode = Complete)),
+                initialInputBufferOffset = 0,
                 child = partialAgg.child)
             } else {
               hashAgg


### PR DESCRIPTION

### What changes were proposed in this pull request?

Here:
https://github.com/apache/spark/blob/87a5b37ec3c4b383a5938144612c07187d597ff8/sql/core/src/main/scala/org/apache/spark/sql/execution/ReplaceHashWithSortAgg.scala#L73-L78


```
            if isHashBasedAggWithKeys(partialAgg) && isPartialAgg(partialAgg, hashAgg) =>
            if (SortOrder.orderingSatisfies(
                partialAgg.child.outputOrdering, sortAgg.requiredChildOrdering.head)) {
              sortAgg.copy(
                aggregateExpressions = sortAgg.aggregateExpressions.map(_.copy(mode = Complete)),
                child = partialAgg.child) 

```

Here. sortAgg comes from Final Aggregate, now becomes Complete mode. So need to disable the original initialInputBufferOffset

Just a small flaw.

 

### Why are the changes needed?

This makes the code more rigorous.

### Does this PR introduce _any_ user-facing change?

No


### How was this patch tested?

Existed UTs



