### PR TITLE
[WIP][SPARK-50133][PYTHON] Support df.argument() for conversion to table argument in Spark Classic

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -588,6 +588,11 @@ class Dataset[T] private[sql] (
   // TODO(SPARK-50134): Support scalar Subquery API in Spark Connect
   // scalastyle:off not.implemented.error.usage
   /** @inheritdoc */
+  def argument(): Column = {
+    ???
+  }
+
+  /** @inheritdoc */
   def scalar(): Column = {
     ???
   }

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1786,6 +1786,9 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         else:
             return DataFrame(self._jdf.transpose(), self.sparkSession)
 
+    def argument(self) -> Column:
+        return Column(self._jdf.argument())
+
     def scalar(self) -> Column:
         return Column(self._jdf.scalar())
 

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1784,6 +1784,12 @@ class DataFrame(ParentDataFrame):
             self._session,
         )
 
+    def argument(self) -> Column:
+        raise PySparkNotImplementedError(
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "argument()"},
+        )
+
     def scalar(self) -> Column:
         # TODO(SPARK-50134): Implement this method
         raise PySparkNotImplementedError(

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1785,6 +1785,7 @@ class DataFrame(ParentDataFrame):
         )
 
     def argument(self) -> Column:
+        # TODO(SPARK-50393): Implement this method
         raise PySparkNotImplementedError(
             errorClass="NOT_IMPLEMENTED",
             messageParameters={"feature": "argument()"},

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -6499,7 +6499,7 @@ class DataFrame:
         ...         if row[0] > 5:
         ...             yield row[0],
         >>> df = spark.range(8)
-        >>> TestUDTF(df.argument()).show()
+        >>> TestUDTF(df.argument()).show()  # doctest: +SKIP
         +---+
         |  a|
         +---+

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -6476,6 +6476,39 @@ class DataFrame:
         """
         ...
 
+    def argument(self) -> Column:
+        """
+        Converts the DataFrame into a `Column` object for use with table-valued functions (TVFs)
+        or user-defined table functions (UDTFs).
+
+        .. versionadded:: 4.0.0
+
+        Returns
+        -------
+        :class:`Column`
+            A `Column` object representing the DataFrame.
+
+        Examples
+        --------
+        >>> from pyspark.sql import Row
+        >>> from pyspark.sql.functions import udtf
+        >>>
+        >>> @udtf(returnType="a: int")
+        ... class TestUDTF:
+        ...     def eval(self, row: Row):
+        ...         if row[0] > 5:
+        ...             yield row[0],
+        >>> df = spark.range(8)
+        >>> TestUDTF(df.argument()).show()
+        +---+
+        |  a|
+        +---+
+        |  6|
+        |  7|
+        +---+
+        """
+        ...
+
     def scalar(self) -> Column:
         """
         Return a `Column` object for a SCALAR Subquery containing exactly one row and one column.

--- a/python/pyspark/sql/tests/connect/test_parity_udtf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udtf.py
@@ -76,7 +76,7 @@ class UDTFParityTests(BaseUDTFTestsMixin, ReusedConnectTestCase):
     def test_udtf_access_spark_session(self):
         super().test_udtf_access_spark_session()
 
-    @unittest.skip("Spark Connect does not support df.argument()")
+    @unittest.skip("TODO(SPARK-50393): support df.argument() in Spark Connect")
     def test_df_argument(self):
         super().test_df_argument()
 

--- a/python/pyspark/sql/tests/connect/test_parity_udtf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udtf.py
@@ -76,6 +76,10 @@ class UDTFParityTests(BaseUDTFTestsMixin, ReusedConnectTestCase):
     def test_udtf_access_spark_session(self):
         super().test_udtf_access_spark_session()
 
+    @unittest.skip("Spark Connect does not support df.argument()")
+    def test_df_argument(self):
+        super().test_df_argument()
+
     def _add_pyfile(self, path):
         self.spark.addArtifacts(path, pyfile=True)
 

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -1024,6 +1024,19 @@ class BaseUDTFTestsMixin:
             [Row(a=6), Row(a=7)],
         )
 
+    def test_df_argument(self):
+        class TestUDTF:
+            def eval(self, row: Row):
+                if row["id"] > 5:
+                    yield row["id"],
+
+        func = udtf(TestUDTF, returnType="a: int")
+        df = self.spark.range(8)
+        self.assertEqual(
+            func(df.argument()).collect(),
+            [Row(a=6), Row(a=7)],
+        )
+
     def udtf_for_table_argument(self):
         class TestUDTF:
             def eval(self, row: Row):

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -1025,16 +1025,12 @@ class BaseUDTFTestsMixin:
         )
 
     def test_df_argument(self):
-        class TestUDTF:
-            def eval(self, row: Row):
-                if row["id"] > 5:
-                    yield row["id"],
-
-        func = udtf(TestUDTF, returnType="a: int")
+        func = self.udtf_for_table_argument()
         df = self.spark.range(8)
-        self.assertEqual(
-            func(df.argument()).collect(),
-            [Row(a=6), Row(a=7)],
+        self.spark.udtf.register("test_udtf", func)
+        assertDataFrameEqual(
+            func(df.argument()),
+            self.spark.sql("SELECT * FROM test_udtf(TABLE (SELECT id FROM range(0, 8)))"),
         )
 
     def udtf_for_table_argument(self):

--- a/sql/api/src/main/scala/org/apache/spark/sql/api/Dataset.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/api/Dataset.scala
@@ -1700,6 +1700,15 @@ abstract class Dataset[T] extends Serializable {
   def transpose(): Dataset[Row]
 
   /**
+   * Converts the DataFrame into a `Column` object for use with table-valued functions (TVFs)
+   * or user-defined table functions (UDTFs).
+   *
+   * @group typedrel
+   * @since 4.0.0
+   */
+  def argument(): Column
+
+  /**
    * Return a `Column` object for a SCALAR Subquery containing exactly one row and one column.
    *
    * The `scalar()` method is useful for extracting a `Column` object that represents a scalar

--- a/sql/api/src/main/scala/org/apache/spark/sql/api/Dataset.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/api/Dataset.scala
@@ -1700,8 +1700,8 @@ abstract class Dataset[T] extends Serializable {
   def transpose(): Dataset[Row]
 
   /**
-   * Converts the DataFrame into a `Column` object for use with table-valued functions (TVFs)
-   * or user-defined table functions (UDTFs).
+   * Converts the DataFrame into a `Column` object for use with table-valued functions (TVFs) or
+   * user-defined table functions (UDTFs).
    *
    * @group typedrel
    * @since 4.0.0

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -994,6 +994,7 @@ class Dataset[T] private[sql](
     )
   }
 
+  /** @inheritdoc */
   def argument(): Column = {
     val tableExpr = FunctionTableSubqueryArgumentExpression(logicalPlan)
     Column(tableExpr)

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -994,6 +994,11 @@ class Dataset[T] private[sql](
     )
   }
 
+  def argument(): Column = {
+    val tableExpr = FunctionTableSubqueryArgumentExpression(logicalPlan)
+    Column(tableExpr)
+  }
+
   /** @inheritdoc */
   def scalar(): Column = {
     Column(ExpressionColumnNode(

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -282,6 +282,10 @@ class DataFrameSuite extends QueryTest
       Row("1", 1) :: Nil)
   }
 
+  test("df.argument") {
+    assert(spark.range(1).argument().isInstanceOf[Column])
+  }
+
   test("filterExpr") {
     val res = testData.collect().filter(_.getInt(0) > 90).toSeq
     checkAnswer(testData.filter("key > 90"), res)


### PR DESCRIPTION
### What changes were proposed in this pull request?
We want to implement a function df.argument(), which returns a Column object as a table arument. This Column can then be passed as input to call a User-Defined Table Function (UDTF) for example.

The PR targets at Spark Classic only.

### Why are the changes needed?
To reach parity with SQL functionality, specifically, https://github.com/apache/spark/pull/41750.

### Does this PR introduce _any_ user-facing change?
Yes.

For example:

```py
>>> @udtf(returnType="a: int")
... class TestUDTF:
...     def eval(self, row: Row):
...         if row[0] > 5:
...             yield row[0],
... 
>>> df.argument()
Column<'functiontablesubqueryargumentexpression()'>
>>> TestUDTF(df.argument()).show()
+---+                                                                           
|  a|
+---+
|  6|
|  7|
+---+
```

### How was this patch tested?
Unit tests.


### Was this patch authored or co-authored using generative AI tooling?
No.
