### PR TITLE
[SPARK-49349][SQL] Improve error message for LCA with Generate

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5253,6 +5253,11 @@
           "Referencing lateral column alias <lca> in the aggregate query both with window expressions and with having clause. Please rewrite the aggregate query by removing the having clause or removing lateral alias reference in the SELECT list."
         ]
       },
+      "LATERAL_COLUMN_ALIAS_IN_GENERATOR" : {
+        "message" : [
+          "Referencing a lateral column alias <lca> in generator expression <generatorExpr>."
+        ]
+      },
       "LATERAL_COLUMN_ALIAS_IN_GROUP_BY" : {
         "message" : [
           "Referencing a lateral column alias via GROUP BY alias/ALL is not supported yet."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/CheckAnalysis.scala
@@ -352,6 +352,21 @@ trait CheckAnalysis extends PredicateHelper with LookupCatalog with QueryErrorsB
           // surrounded with single quotes, or there is a typo in the attribute name.
           case GetMapValue(map, key: Attribute) if isMapWithStringKey(map) && !key.resolved =>
             failUnresolvedAttribute(operator, key, "UNRESOLVED_MAP_KEY")
+
+          case e: Expression if e.containsPattern(LATERAL_COLUMN_ALIAS_REFERENCE) &&
+            operator.expressions.exists {
+              case a: Alias
+                  if e.collect { case l: LateralColumnAliasReference => l.nameParts.head }
+                    .contains(a.name) =>
+                a.exists(_.isInstanceOf[Generator])
+              case _ => false
+            } =>
+            val lcaRefNames =
+              e.collect { case lcaRef: LateralColumnAliasReference => lcaRef.name }.distinct
+            failAnalysis(
+              errorClass = "UNSUPPORTED_FEATURE.LATERAL_COLUMN_ALIAS_IN_GENERATOR",
+              messageParameters =
+                Map("lca" -> toSQLId(lcaRefNames), "generatorExpr" -> toSQLExpr(e)))
         }
 
         // Fail if we still have an unresolved all in group by. This needs to run before the


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR add a new check in `CheckAnalysis` to improve error message for LCA with `Generate`.

### Why are the changes needed?

Improve error message.

Before this PR:
```
[INTERNAL_ERROR] Invalid call to dataType on unresolved object SQLSTATE: XX000
org.apache.spark.sql.catalyst.analysis.UnresolvedException: [INTERNAL_ERROR] Invalid call to dataType on unresolved object SQLSTATE: XX000
	at org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute.dataType(unresolved.scala:292)
	at org.apache.spark.sql.catalyst.expressions.LateralColumnAliasReference.dataType(namedExpressions.scala:472)
```
After this PR:
```
[UNSUPPORTED_FEATURE.LATERAL_COLUMN_ALIAS_IN_GENERATOR] The feature is not supported: Referencing a lateral column alias `new_name` in generator expression "unresolvedalias(lateralAliasReference(new_name) LIKE a%)". SQLSTATE: 0A000;
'Project [explode(split(name#21, ,, -1)) AS new_name#19, unresolvedalias(lateralAliasReference(new_name) LIKE a%)]
+- SubqueryAlias spark_catalog.default.employee
   +- Relation spark_catalog.default.employee[dept#20,name#21,salary#22,bonus#23,properties#24] orc
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit test.

### Was this patch authored or co-authored using generative AI tooling?

No.