### PR TITLE
Remove .*? from parser

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
@@ -95,7 +95,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
         " bonus BINARY_DOUBLE)").executeUpdate()
     connection.prepareStatement(
       s"""CREATE TABLE pattern_testing_table (
-         |pattern_testing_col VARCHAR(50)
+         |pattern_testing_col VARCHAR2(50)
          |)
                    """.stripMargin
     ).executeUpdate()

--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/v2/OracleIntegrationSuite.scala
@@ -95,7 +95,7 @@ class OracleIntegrationSuite extends DockerJDBCIntegrationV2Suite with V2JDBCTes
         " bonus BINARY_DOUBLE)").executeUpdate()
     connection.prepareStatement(
       s"""CREATE TABLE pattern_testing_table (
-         |pattern_testing_col VARCHAR2(50)
+         |pattern_testing_col VARCHAR(50)
          |)
                    """.stripMargin
     ).executeUpdate()

--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -275,7 +275,7 @@ statement
         (LIKE? (legacy=multipartIdentifier | pattern=stringLit))?      #showFunctions
     | SHOW CREATE TABLE identifierReference (AS SERDE)?                #showCreateTable
     | SHOW CURRENT namespace                                           #showCurrentNamespace
-    | SHOW CATALOGS (LIKE? pattern=stringLit)?                            #showCatalogs
+    | SHOW CATALOGS (LIKE? pattern=stringLit)?                         #showCatalogs
     | (DESC | DESCRIBE) FUNCTION EXTENDED? describeFuncName            #describeFunction
     | (DESC | DESCRIBE) namespace EXTENDED?
         identifierReference                                            #describeNamespace
@@ -287,7 +287,7 @@ statement
     | COMMENT ON TABLE identifierReference IS comment                  #commentTable
     | REFRESH TABLE identifierReference                                #refreshTable
     | REFRESH FUNCTION identifierReference                             #refreshFunction
-    | REFRESH (stringLit | .*?)                                        #refreshResource
+    | REFRESH (stringLit | UNRECOGNIZED*?)                             #refreshResource
     | CACHE LAZY? TABLE identifierReference
         (OPTIONS options=propertyList)? (AS? query)?                   #cacheTable
     | UNCACHE TABLE (IF EXISTS)? identifierReference                   #uncacheTable
@@ -297,7 +297,7 @@ statement
     | TRUNCATE TABLE identifierReference partitionSpec?                #truncateTable
     | (MSCK)? REPAIR TABLE identifierReference
         (option=(ADD|DROP|SYNC) PARTITIONS)?                           #repairTable
-    | op=(ADD | LIST) identifier .*?                                   #manageResource
+    | op=(ADD | LIST) identifier UNRECOGNIZED*?                        #manageResource
     | CREATE INDEX (IF errorCapturingNot EXISTS)? identifier ON TABLE?
         identifierReference (USING indexType=identifier)?
         LEFT_PAREN columns=multipartIdentifierPropertyList RIGHT_PAREN
@@ -307,24 +307,24 @@ statement
         LEFT_PAREN
         (functionArgument (COMMA functionArgument)*)?
         RIGHT_PAREN                                                    #call
-    | unsupportedHiveNativeCommands .*?                                #failNativeCommand
+    | unsupportedHiveNativeCommands UNRECOGNIZED*?                     #failNativeCommand
     ;
 
 setResetStatement
     : SET COLLATION collationName=identifier                           #setCollation
-    | SET ROLE .*?                                                     #failSetRole
+    | SET ROLE UNRECOGNIZED*?                                          #failSetRole
     | SET TIME ZONE interval                                           #setTimeZone
     | SET TIME ZONE timezone                                           #setTimeZone
-    | SET TIME ZONE .*?                                                #setTimeZone
+    | SET TIME ZONE UNRECOGNIZED*?                                     #setTimeZone
     | SET variable assignmentList                                      #setVariable
     | SET variable LEFT_PAREN multipartIdentifierList RIGHT_PAREN EQ
         LEFT_PAREN query RIGHT_PAREN                                   #setVariable
     | SET configKey EQ configValue                                     #setQuotedConfiguration
-    | SET configKey (EQ .*?)?                                          #setConfiguration
-    | SET .*? EQ configValue                                           #setQuotedConfiguration
-    | SET .*?                                                          #setConfiguration
+    | SET configKey (EQ UNRECOGNIZED*?)?                               #setConfiguration
+    | SET UNRECOGNIZED*? EQ configValue                                #setQuotedConfiguration
+    | SET UNRECOGNIZED*?                                               #setConfiguration
     | RESET configKey                                                  #resetQuotedConfiguration
-    | RESET .*?                                                        #resetConfiguration
+    | RESET UNRECOGNIZED*?                                             #resetConfiguration
     ;
 
 executeImmediate

--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -287,7 +287,7 @@ statement
     | COMMENT ON TABLE identifierReference IS comment                  #commentTable
     | REFRESH TABLE identifierReference                                #refreshTable
     | REFRESH FUNCTION identifierReference                             #refreshFunction
-    | REFRESH (stringLit | UNRECOGNIZED*?)                             #refreshResource
+    | REFRESH (stringLit | unrecognizedText?)                          #refreshResource
     | CACHE LAZY? TABLE identifierReference
         (OPTIONS options=propertyList)? (AS? query)?                   #cacheTable
     | UNCACHE TABLE (IF EXISTS)? identifierReference                   #uncacheTable
@@ -297,7 +297,7 @@ statement
     | TRUNCATE TABLE identifierReference partitionSpec?                #truncateTable
     | (MSCK)? REPAIR TABLE identifierReference
         (option=(ADD|DROP|SYNC) PARTITIONS)?                           #repairTable
-    | op=(ADD | LIST) identifier UNRECOGNIZED*?                        #manageResource
+    | op=(ADD | LIST) identifier unrecognizedText?                     #manageResource
     | CREATE INDEX (IF errorCapturingNot EXISTS)? identifier ON TABLE?
         identifierReference (USING indexType=identifier)?
         LEFT_PAREN columns=multipartIdentifierPropertyList RIGHT_PAREN
@@ -307,24 +307,28 @@ statement
         LEFT_PAREN
         (functionArgument (COMMA functionArgument)*)?
         RIGHT_PAREN                                                    #call
-    | unsupportedHiveNativeCommands UNRECOGNIZED*?                     #failNativeCommand
+    | unsupportedHiveNativeCommands unrecognizedText?                  #failNativeCommand
     ;
 
 setResetStatement
     : SET COLLATION collationName=identifier                           #setCollation
-    | SET ROLE UNRECOGNIZED*?                                          #failSetRole
+    | SET ROLE unrecognizedText?                                       #failSetRole
     | SET TIME ZONE interval                                           #setTimeZone
     | SET TIME ZONE timezone                                           #setTimeZone
-    | SET TIME ZONE UNRECOGNIZED*?                                     #setTimeZone
+    | SET TIME ZONE unrecognizedText?                                  #setTimeZone
     | SET variable assignmentList                                      #setVariable
     | SET variable LEFT_PAREN multipartIdentifierList RIGHT_PAREN EQ
         LEFT_PAREN query RIGHT_PAREN                                   #setVariable
     | SET configKey EQ configValue                                     #setQuotedConfiguration
-    | SET configKey (EQ UNRECOGNIZED*?)?                               #setConfiguration
-    | SET UNRECOGNIZED*? EQ configValue                                #setQuotedConfiguration
-    | SET UNRECOGNIZED*?                                               #setConfiguration
+    | SET configKey (EQ unrecognizedText?)?                            #setConfiguration
+    | SET unrecognizedText? EQ configValue                             #setQuotedConfiguration
+    | SET unrecognizedText?                                            #setConfiguration
     | RESET configKey                                                  #resetQuotedConfiguration
-    | RESET UNRECOGNIZED*?                                             #resetConfiguration
+    | RESET unrecognizedText?                                          #resetConfiguration
+    ;
+
+unrecognizedText
+    : UNRECOGNIZED*                                                   #unrecognizedStatement
     ;
 
 executeImmediate

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/parser/ParserUtils.scala
@@ -64,12 +64,13 @@ object ParserUtils extends SparkParserUtils {
   }
 
   /** Get all the text which comes after the given rule. */
-  def remainder(ctx: ParserRuleContext): String = remainder(ctx.getStop)
+  def remainder(ctx: ParserRuleContext, parentCtx: ParserRuleContext): String =
+    remainder(ctx.getStop, parentCtx)
 
   /** Get all the text which comes after the given token. */
-  def remainder(token: Token): String = {
+  def remainder(token: Token, parentCtx: ParserRuleContext): String = {
     val stream = token.getInputStream
-    val interval = Interval.of(token.getStopIndex + 1, stream.size() - 1)
+    val interval = Interval.of(token.getStopIndex + 1, parentCtx.getStop.getStopIndex)
     stream.getText(interval)
   }
 

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ParserUtilsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/ParserUtilsSuite.scala
@@ -184,15 +184,20 @@ class ParserUtilsSuite extends SparkFunSuite {
   }
 
   test("remainder") {
-    assert(remainder(setConfContext) == "")
-    assert(remainder(showFuncContext) == "")
-    assert(remainder(descFuncContext) == "")
-    assert(remainder(showDbsContext) == "")
+    assert(remainder(setConfContext, setConfContext) == "")
+    assert(remainder(showFuncContext, showFuncContext) == "")
+    assert(remainder(descFuncContext, descFuncContext) == "")
+    assert(remainder(showDbsContext, showDbsContext) == "")
 
-    assert(remainder(setConfContext.SET.getSymbol) == " example.setting.name=setting.value")
-    assert(remainder(showFuncContext.FUNCTIONS.getSymbol) == " foo.bar")
-    assert(remainder(descFuncContext.EXTENDED.getSymbol) == " bar")
-    assert(remainder(showDbsContext.LIKE.getSymbol) == " 'identifier_with_wildcards'")
+    assert(
+      remainder(setConfContext.SET.getSymbol, setConfContext)
+        == " example.setting.name=setting.value"
+    )
+    assert(remainder(showFuncContext.FUNCTIONS.getSymbol, showFuncContext) == " foo.bar")
+    assert(remainder(descFuncContext.EXTENDED.getSymbol, descFuncContext) == " bar")
+    assert(
+      remainder(showDbsContext.LIKE.getSymbol, showDbsContext) == " 'identifier_with_wildcards'"
+    )
   }
 
   test("string") {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -97,7 +97,7 @@ class SparkSqlAstBuilder extends AstBuilder {
     if (ctx.configKey() != null) {
       val keyStr = ctx.configKey().getText
       if (ctx.EQ() != null) {
-        remainder(ctx.EQ().getSymbol).trim match {
+        remainder(ctx.EQ().getSymbol, ctx).trim match {
           case configValueDef(valueStr) => SetCommand(Some(keyStr -> Option(valueStr)))
           case other => throw QueryParsingErrors.invalidPropertyValueForSetQuotedConfigurationError(
             other, keyStr, ctx)
@@ -106,7 +106,7 @@ class SparkSqlAstBuilder extends AstBuilder {
         SetCommand(Some(keyStr -> None))
       }
     } else {
-      remainder(ctx.SET.getSymbol).trim match {
+      remainder(ctx.SET.getSymbol, ctx).trim match {
         case configKeyValueDef(key, value) =>
           SetCommand(Some(key -> Option(value.trim)))
         case configKeyDef(key) =>
@@ -146,7 +146,7 @@ class SparkSqlAstBuilder extends AstBuilder {
    */
   override def visitResetConfiguration(
       ctx: ResetConfigurationContext): LogicalPlan = withOrigin(ctx) {
-    remainder(ctx.RESET.getSymbol).trim match {
+    remainder(ctx.RESET.getSymbol, ctx).trim match {
       case configKeyDef(key) =>
         ResetCommand(Some(key))
       case s if s.trim.isEmpty =>
@@ -244,7 +244,7 @@ class SparkSqlAstBuilder extends AstBuilder {
   }
 
   private def extractUnquotedResourcePath(ctx: RefreshResourceContext): String = withOrigin(ctx) {
-    val unquotedPath = remainder(ctx.REFRESH.getSymbol).trim
+    val unquotedPath = remainder(ctx.REFRESH.getSymbol, ctx).trim
     validate(
       unquotedPath != null && !unquotedPath.isEmpty,
       "Resource paths cannot be empty in REFRESH statements. Use / to match everything",
@@ -467,7 +467,7 @@ class SparkSqlAstBuilder extends AstBuilder {
    *  - '/path/to/fileOrJar'
    */
   override def visitManageResource(ctx: ManageResourceContext): LogicalPlan = withOrigin(ctx) {
-    val rawArg = remainder(ctx.identifier).trim
+    val rawArg = remainder(ctx.identifier, ctx).trim
     val maybePaths = strLiteralDef.findAllIn(rawArg).toSeq.map {
       case p if p.startsWith("\"") || p.startsWith("'") => unescapeSQLString(p)
       case p => p

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
@@ -2100,7 +2100,7 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
       Seq(Row("UTF8_BINARY"), Row("UTF8_LCASE")))
   }
 
-  test("set role") {
-    sql("set role ada;")
+  test("set") {
+    sql("set;")
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/CollationSuite.scala
@@ -2099,4 +2099,8 @@ class CollationSuite extends DatasourceV2SQLBase with AdaptiveSparkPlanHelper {
     checkAnswer(sql("SELECT NAME FROM collations() WHERE ICU_VERSION is null"),
       Seq(Row("UTF8_BINARY"), Row("UTF8_LCASE")))
   }
+
+  test("set role") {
+    sql("set role ada;")
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
I propose to remove .*? from parser rules.


### Why are the changes needed?
.*? will match anything and in that case will consume comments and all garbage, we need to fix this to make queries like `set /*comment*/ ;` work. This is a bug that we have from beginning of the parser and IMO should be fixed to work properly. 


### Does this PR introduce _any_ user-facing change?
Yes, fixing parser.


### How was this patch tested?
Existing tests and added tests to come.


### Was this patch authored or co-authored using generative AI tooling?
Yes.
