### PR TITLE
[SPARK-50398][CORE] Use ExitCode `0` for `--help` usage in Spark scripts

### DIFF
--- a/sbin/start-connect-server.sh
+++ b/sbin/start-connect-server.sh
@@ -33,7 +33,7 @@ if [[ "$@" = *--help ]] || [[ "$@" = *-h ]]; then
   echo "Usage: ./sbin/start-connect-server.sh [--wait] [options]"
 
   "${SPARK_HOME}"/bin/spark-submit --help 2>&1 | grep -v Usage 1>&2
-  exit 1
+  exit 0
 fi
 
 . "${SPARK_HOME}/bin/load-spark-env.sh"

--- a/sbin/start-history-server.sh
+++ b/sbin/start-history-server.sh
@@ -40,7 +40,7 @@ if [[ "$@" = *--help ]] || [[ "$@" = *-h ]]; then
   pattern+="\|Registered signal handler for"
 
   "${SPARK_HOME}"/bin/spark-class $CLASS --help 2>&1 | grep -v "$pattern" 1>&2
-  exit 1
+  exit 0
 fi
 
 . "${SPARK_HOME}/sbin/spark-config.sh"

--- a/sbin/start-master.sh
+++ b/sbin/start-master.sh
@@ -35,7 +35,7 @@ if [[ "$@" = *--help ]] || [[ "$@" = *-h ]]; then
   pattern+="\|Registered signal handler for"
 
   "${SPARK_HOME}"/bin/spark-class $CLASS --help 2>&1 | grep -v "$pattern" 1>&2
-  exit 1
+  exit 0
 fi
 
 ORIGINAL_ARGS="$@"

--- a/sbin/start-thriftserver.sh
+++ b/sbin/start-thriftserver.sh
@@ -52,7 +52,7 @@ function usage {
 
 if [[ "$@" = *--help ]] || [[ "$@" = *-h ]]; then
   usage
-  exit 1
+  exit 0
 fi
 
 export SUBMIT_USAGE_FUNCTION=usage

--- a/sbin/start-worker.sh
+++ b/sbin/start-worker.sh
@@ -47,7 +47,7 @@ if [[ $# -lt 1 ]] || [[ "$@" = *--help ]] || [[ "$@" = *-h ]]; then
   pattern+="\|Registered signal handler for"
 
   "${SPARK_HOME}"/bin/spark-class $CLASS --help 2>&1 | grep -v "$pattern" 1>&2
-  exit 1
+  [[ $# -lt 1 ]] && exit 1 || exit 0
 fi
 
 . "${SPARK_HOME}/sbin/spark-config.sh"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `0` as the exit code for `--help` usage in Spark scripts consistently to provide better and consistent UX from Apache Spark 4.0.0.

### Why are the changes needed?

Initially, Apache Spark was designed to exit with `0` when `--help` is given because `--help` argument is not a error case.

**SparkSubmit**
https://github.com/apache/spark/blob/d5da49d56d7dec5f8a96c5252384d865f7efd4d9/core/src/main/scala/org/apache/spark/deploy/SparkSubmitArguments.scala#L458-L459

**Spark Master**
https://github.com/apache/spark/blob/d5da49d56d7dec5f8a96c5252384d865f7efd4d9/core/src/main/scala/org/apache/spark/deploy/master/MasterArguments.scala#L88-L89

**Spark Worker**

https://github.com/apache/spark/blob/d5da49d56d7dec5f8a96c5252384d865f7efd4d9/core/src/main/scala/org/apache/spark/deploy/worker/WorkerArguments.scala#L107-L108

**Spark History Server**

https://github.com/apache/spark/blob/d5da49d56d7dec5f8a96c5252384d865f7efd4d9/core/src/main/scala/org/apache/spark/deploy/history/HistoryServerArguments.scala#L39-L40

In addition, all scripts under `bin/*` return `0` consistently like the following. This PR changes `sbin/*` scripts additionally for consistency.

| Command | Before | After |
| ---------- | ------- | ------- |
| bin/spark-class --help | 0 | 0 |
| bin/spark-shell --help | 0 | 0 |
| bin/pyspark --help | 0 | 0 |
| bin/spark-sql --help | 0 | 0 |
| bin/beeline --help | 0 | 0 |
| bin/sparkR --help | 0 | 0 |
| bin/docker-image-tool.sh --help | 0 | 0 |
| sbin/start-master.sh --help | 1 | 0 |
| sbin/start-worker.sh --help | 1 | 0 |
| sbin/start-history-server.sh --help | 1 | 0 |
| sbin/start-thriftserver.sh --help | 1 | 0 |
| sbin/start-connect-server.sh --help | 1 | 0 |

### Does this PR introduce _any_ user-facing change?

Yes, but this is a exit status code for `--help` or `-h`.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.