### PR TITLE
[SPARK-50240][CORE] Added Simple Sanitization of Extra JVM Options

### DIFF
--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -213,7 +213,7 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
 
     for (Map.Entry<String, String> e : conf.entrySet()) {
       args.add(parser.CONF);
-      args.add(String.format("%s=%s", e.getKey(), e.getValue()));
+      args.add(String.format("%s=%s", e.getKey(), sanitizeConfValue(e.getValue())));
     }
 
     if (propertiesFile != null) {
@@ -337,6 +337,16 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
         }
       }
     }
+  }
+
+  private String sanitizeConfValue(String value) {
+    if (value != null) {
+      String[] unsafeChars = {"`", "$(", ")", ";", "&", "|", "<", ">", "*", "?"};
+      for (String unsafeChar : unsafeChars) {
+        value = value.replace(unsafeChar, "");
+      }
+    }
+    return value;
   }
 
   private List<String> buildPySparkShellCommand(Map<String, String> env) throws IOException {

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -339,6 +339,14 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
     }
   }
 
+  /**
+   * Sanitizes the configuration value to prevent command injection vulnerabilities.
+   * Removes shell metacharacters that could be used to manipulate shell commands.
+   *
+   * References:
+   * - OWASP Command Injection Prevention Cheat Sheet
+   * (https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html)
+   */
   private String sanitizeConfValue(String value) {
     if (value != null) {
       String[] unsafeChars = {"`", "$(", ")", ";", "&", "|", "<", ">", "*", "?"};

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -212,8 +212,13 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
     }
 
     for (Map.Entry<String, String> e : conf.entrySet()) {
+      String key = e.getKey();
+      String value = e.getValue();
+      if ("spark.executor.extraJavaOptions".equals(key)) {
+        value = sanitizeExtraJavaOptions(value);
+      }
       args.add(parser.CONF);
-      args.add(String.format("%s=%s", e.getKey(), sanitizeConfValue(e.getValue())));
+      args.add(String.format("%s=%s", key, value));
     }
 
     if (propertiesFile != null) {
@@ -347,9 +352,9 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
    * - OWASP Command Injection Prevention Cheat Sheet
    * (https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html)
    */
-  private String sanitizeConfValue(String value) {
+  private String sanitizeExtraJavaOptions(String value) {
     if (value != null) {
-      String[] unsafeChars = {"`", "$(", ")", "&", "|", "<", ">", "*", "?"};
+      String[] unsafeChars = {"`", "$(", ")", "&", "|", "<", ";", ">", "*", "?"};
       for (String unsafeChar : unsafeChars) {
         value = value.replace(unsafeChar, "");
       }

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -214,7 +214,8 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
     for (Map.Entry<String, String> e : conf.entrySet()) {
       String key = e.getKey();
       String value = e.getValue();
-      if ("spark.executor.extraJavaOptions".equals(key)) {
+      if ("spark.executor.extraJavaOptions".equals(key)
+              || "spark.driver.extraJavaOptions".equals(key)) {
         value = sanitizeExtraJavaOptions(value);
       }
       args.add(parser.CONF);
@@ -354,10 +355,8 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
    */
   private String sanitizeExtraJavaOptions(String value) {
     if (value != null) {
-      String[] unsafeChars = {"`", "$(", ")", "&", "|", "<", ";", ">", "*", "?"};
-      for (String unsafeChar : unsafeChars) {
-        value = value.replace(unsafeChar, "");
-      }
+      String regex = "`|\\$\\(|\\)|&|\\||<|;|>|\\*|\\?";
+      value = value.replaceAll(regex, "");
     }
     return value;
   }

--- a/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
+++ b/launcher/src/main/java/org/apache/spark/launcher/SparkSubmitCommandBuilder.java
@@ -349,7 +349,7 @@ class SparkSubmitCommandBuilder extends AbstractCommandBuilder {
    */
   private String sanitizeConfValue(String value) {
     if (value != null) {
-      String[] unsafeChars = {"`", "$(", ")", ";", "&", "|", "<", ">", "*", "?"};
+      String[] unsafeChars = {"`", "$(", ")", "&", "|", "<", ">", "*", "?"};
       for (String unsafeChar : unsafeChars) {
         value = value.replace(unsafeChar, "");
       }

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -104,6 +104,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
 
   @Test
   public void testExtraJavaOptionsSanitization() throws Exception {
+    //SPARK-50240: Test to check extra Java options inputs are sanitized
     Map<String, String> env = new HashMap<>();
     List<String> sparkSubmitArgs = Arrays.asList(
             parser.MASTER,

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -128,15 +128,15 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
 
     assertNotNull(extraJavaOptions, "spark.executor.extraJavaOptions should be set");
 
-    assertFalse(extraJavaOptions.contains("`"), "Extra Java options should not contain backticks");
+    assertFalse(extraJavaOptions.contains("`"), "Extra Java options should not contain `");
     assertFalse(extraJavaOptions.contains("$"), "Extra Java options should not contain $");
-    assertFalse(extraJavaOptions.contains(";"), "Extra Java options should not contain semicolons");
-    assertFalse(extraJavaOptions.contains("&"), "Extra Java options should not contain ampersands");
-    assertFalse(extraJavaOptions.contains("|"), "Extra Java options should not contain pipe symbols");
-    assertFalse(extraJavaOptions.contains("<"), "Extra Java options should not contain less-than symbols");
-    assertFalse(extraJavaOptions.contains(">"), "Extra Java options should not contain greater-than symbols");
+    assertFalse(extraJavaOptions.contains(";"), "Extra Java options should not contain ;");
+    assertFalse(extraJavaOptions.contains("&"), "Extra Java options should not contain &");
+    assertFalse(extraJavaOptions.contains("|"), "Extra Java options should not contain |");
+    assertFalse(extraJavaOptions.contains("<"), "Extra Java options should not contain <");
+    assertFalse(extraJavaOptions.contains(">"), "Extra Java options should not contain >");
 
-    assertTrue(extraJavaOptions.contains("-Xmx2g"), "Valid Java options should remain intact");
+    assertTrue(extraJavaOptions.contains("-Xmx2g"), "Valid Java options should pass");
   }
 
 
@@ -482,7 +482,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     return builder;
   }
 
-  private List<String> buildCommand(List<String> args, Map<String, String> env) throws Exception {
+  private List<String>  buildCommand(List<String> args, Map<String, String> env) throws Exception {
     return newCommandBuilder(args).buildCommand(env);
   }
 

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -141,7 +141,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     assertFalse(executorExtraJavaOptions.contains("*"), "Should not contain *");
     assertFalse(executorExtraJavaOptions.contains("?"), "Should not contain ?");
 
-    assertTrue(executorExtraJavaOptions.contains("-Xmx2g"), "Valid executor Java options should pass");
+    assertTrue(executorExtraJavaOptions.contains("-Xmx2g"), "Valid options should pass");
 
     assertNotNull(driverExtraJavaOptions, "spark.driver.extraJavaOptions should be set");
     assertFalse(driverExtraJavaOptions.contains("`"), "Should not contain `");
@@ -153,7 +153,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     assertFalse(driverExtraJavaOptions.contains("*"), "Should not contain *");
     assertFalse(driverExtraJavaOptions.contains("?"), "Should not contain ?");
 
-    assertTrue(driverExtraJavaOptions.contains("-Xms1g"), "Valid driver Java options should pass");
+    assertTrue(driverExtraJavaOptions.contains("-Xms1g"), "Valid options should pass");
   }
 
 

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -482,7 +482,7 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     return builder;
   }
 
-  private List<String>  buildCommand(List<String> args, Map<String, String> env) throws Exception {
+  private List<String> buildCommand(List<String> args, Map<String, String> env) throws Exception {
     return newCommandBuilder(args).buildCommand(env);
   }
 

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -131,7 +131,6 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
 
     assertFalse(extraJavaOptions.contains("`"), "Extra Java options should not contain `");
     assertFalse(extraJavaOptions.contains("$"), "Extra Java options should not contain $");
-    assertFalse(extraJavaOptions.contains(";"), "Extra Java options should not contain ;");
     assertFalse(extraJavaOptions.contains("&"), "Extra Java options should not contain &");
     assertFalse(extraJavaOptions.contains("|"), "Extra Java options should not contain |");
     assertFalse(extraJavaOptions.contains("<"), "Extra Java options should not contain <");

--- a/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
+++ b/launcher/src/test/java/org/apache/spark/launcher/SparkSubmitCommandBuilderSuite.java
@@ -132,26 +132,26 @@ public class SparkSubmitCommandBuilderSuite extends BaseSuite {
     }
 
     assertNotNull(executorExtraJavaOptions, "spark.executor.extraJavaOptions should be set");
-    assertFalse(executorExtraJavaOptions.contains("`"), "Executor extra Java options should not contain `");
-    assertFalse(executorExtraJavaOptions.contains("$"), "Executor extra Java options should not contain $");
-    assertFalse(executorExtraJavaOptions.contains("&"), "Executor extra Java options should not contain &");
-    assertFalse(executorExtraJavaOptions.contains("|"), "Executor extra Java options should not contain |");
-    assertFalse(executorExtraJavaOptions.contains("<"), "Executor extra Java options should not contain <");
-    assertFalse(executorExtraJavaOptions.contains(">"), "Executor extra Java options should not contain >");
-    assertFalse(executorExtraJavaOptions.contains("*"), "Executor extra Java options should not contain *");
-    assertFalse(executorExtraJavaOptions.contains("?"), "Executor extra Java options should not contain ?");
+    assertFalse(executorExtraJavaOptions.contains("`"), "Should not contain `");
+    assertFalse(executorExtraJavaOptions.contains("$"), "Should not contain $");
+    assertFalse(executorExtraJavaOptions.contains("&"), "Should not contain &");
+    assertFalse(executorExtraJavaOptions.contains("|"), "Should not contain |");
+    assertFalse(executorExtraJavaOptions.contains("<"), "Should not contain <");
+    assertFalse(executorExtraJavaOptions.contains(">"), "Should not contain >");
+    assertFalse(executorExtraJavaOptions.contains("*"), "Should not contain *");
+    assertFalse(executorExtraJavaOptions.contains("?"), "Should not contain ?");
 
     assertTrue(executorExtraJavaOptions.contains("-Xmx2g"), "Valid executor Java options should pass");
 
     assertNotNull(driverExtraJavaOptions, "spark.driver.extraJavaOptions should be set");
-    assertFalse(driverExtraJavaOptions.contains("`"), "Driver extra Java options should not contain `");
-    assertFalse(driverExtraJavaOptions.contains("$"), "Driver extra Java options should not contain $");
-    assertFalse(driverExtraJavaOptions.contains("&"), "Driver extra Java options should not contain &");
-    assertFalse(driverExtraJavaOptions.contains("|"), "Driver extra Java options should not contain |");
-    assertFalse(driverExtraJavaOptions.contains("<"), "Driver extra Java options should not contain <");
-    assertFalse(driverExtraJavaOptions.contains(">"), "Driver extra Java options should not contain >");
-    assertFalse(driverExtraJavaOptions.contains("*"), "Driver extra Java options should not contain *");
-    assertFalse(driverExtraJavaOptions.contains("?"), "Driver extra Java options should not contain ?");
+    assertFalse(driverExtraJavaOptions.contains("`"), "Should not contain `");
+    assertFalse(driverExtraJavaOptions.contains("$"), "Should not contain $");
+    assertFalse(driverExtraJavaOptions.contains("&"), "Should not contain &");
+    assertFalse(driverExtraJavaOptions.contains("|"), "Should not contain |");
+    assertFalse(driverExtraJavaOptions.contains("<"), "Should not contain <");
+    assertFalse(driverExtraJavaOptions.contains(">"), "Should not contain >");
+    assertFalse(driverExtraJavaOptions.contains("*"), "Should not contain *");
+    assertFalse(driverExtraJavaOptions.contains("?"), "Should not contain ?");
 
     assertTrue(driverExtraJavaOptions.contains("-Xms1g"), "Valid driver Java options should pass");
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Added a method to sanitize extra JVM options. This prevents command injection vulnerability when using the `spark.executor.extraJavaOptions` configuration parameter

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This pull request addresses an issue where spark.executor.extraJavaOptions could potentially allow the execution of unintended shell commands due to improper sanitization of input parameters. By injecting shell commands into this configuration parameter, such as `touch$IFS/tmp/zzz123`, the command gets executed on the executor. This sanitization ensures that only valid Java options are processed.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Unit Test

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No