### PR TITLE
[SPARK-50400][BUILD] Upgrade log4j2 to 2.24.2

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -189,11 +189,11 @@ leveldbjni-all/1.8//leveldbjni-all-1.8.jar
 libfb303/0.9.3//libfb303-0.9.3.jar
 libthrift/0.16.0//libthrift-0.16.0.jar
 listenablefuture/9999.0-empty-to-avoid-conflict-with-guava//listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
-log4j-1.2-api/2.24.1//log4j-1.2-api-2.24.1.jar
-log4j-api/2.24.1//log4j-api-2.24.1.jar
-log4j-core/2.24.1//log4j-core-2.24.1.jar
-log4j-layout-template-json/2.24.1//log4j-layout-template-json-2.24.1.jar
-log4j-slf4j2-impl/2.24.1//log4j-slf4j2-impl-2.24.1.jar
+log4j-1.2-api/2.24.2//log4j-1.2-api-2.24.2.jar
+log4j-api/2.24.2//log4j-api-2.24.2.jar
+log4j-core/2.24.2//log4j-core-2.24.2.jar
+log4j-layout-template-json/2.24.2//log4j-layout-template-json-2.24.2.jar
+log4j-slf4j2-impl/2.24.2//log4j-slf4j2-impl-2.24.2.jar
 logging-interceptor/3.12.12//logging-interceptor-3.12.12.jar
 lz4-java/1.8.0//lz4-java-1.8.0.jar
 metrics-core/4.2.28//metrics-core-4.2.28.jar

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
     <sbt.project.name>spark</sbt.project.name>
     <asm.version>9.7.1</asm.version>
     <slf4j.version>2.0.16</slf4j.version>
-    <log4j.version>2.24.1</log4j.version>
+    <log4j.version>2.24.2</log4j.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
     <hadoop.version>3.4.1</hadoop.version>
     <!-- SPARK-41247: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->


### PR DESCRIPTION
### What changes were proposed in this pull request?
The pr aims to upgrade log4j2 from `2.24.1` to `2.24.2`.


### Why are the changes needed?
- The full release notes:
https://github.com/apache/logging-log4j2/releases/tag/rel%2F2.24.2


- This release fixes a critical bug in Log4j API initialization code, which can cause LogManager.getLogger() to return null under certain conditions. See https://github.com/apache/logging-log4j2/issues/3143 for details.
  Fix key removal issues in Thread Context (https://github.com/apache/logging-log4j2/issues/3048)
  Use hard references to Loggers in LoggerRegistry. (https://github.com/apache/logging-log4j2/issues/3143)
  Fix ArrayIndexOutOfBoundsException in JSON Template Layout truncated exception resolver (https://github.com/apache/logging-log4j2/pull/3216)


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Pass GA.


### Was this patch authored or co-authored using generative AI tooling?
No.
