### PR TITLE
[SPARK-50404][PYTHON] PySpark DataFrame Pipe Method

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,0 +1,34 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Scala CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 11
+      uses: actions/setup-java@v4
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: 'sbt'
+    - name: Run tests
+      run: sbt test
+      # Optional: This step uploads information to the GitHub dependency graph and unblocking Dependabot alerts for the repository
+    - name: Upload dependency graph
+      uses: scalacenter/sbt-dependency-submission@ab086b50c947c9774b70f39fc7f6e20ca2706c91

--- a/R/pkg/DESCRIPTION
+++ b/R/pkg/DESCRIPTION
@@ -58,7 +58,7 @@ Collate:
     'utils.R'
     'window.R'
     'zzz.R'
-RoxygenNote: 7.1.2
+RoxygenNote: 7.3.1
 VignetteBuilder: knitr
 NeedsCompilation: no
 Encoding: UTF-8

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -19,6 +19,7 @@ import os
 import json
 import sys
 import random
+import functools
 import warnings
 from collections.abc import Iterable
 from functools import reduce
@@ -1694,6 +1695,19 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         self, func: Callable[..., ParentDataFrame], *args: Any, **kwargs: Any
     ) -> ParentDataFrame:
         result = func(self, *args, **kwargs)
+        assert isinstance(
+            result, DataFrame
+        ), "Func returned an instance of type [%s], " "should have been DataFrame." % type(result)
+        return result
+
+    def pipe(
+        self, *funcs: tuple[Callable[..., ParentDataFrame]]
+    ) -> ParentDataFrame:
+        result = functools.reduce(
+            lambda init, func: init.transform(func),
+            funcs,
+            self
+        )
         assert isinstance(
             result, DataFrame
         ), "Func returned an instance of type [%s], " "should have been DataFrame." % type(result)

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -5895,6 +5895,59 @@ class DataFrame:
         ...
 
     @dispatch_df_method
+    def pipe(self, *funcs: tuple[Callable[..., "DataFrame"]]) -> "DataFrame":
+        """Returns a new :class:`DataFrame`. Concise syntax for piping multiple custom transformations.
+
+        .. versionadded:: 3.0.0
+
+        .. versionchanged:: 3.4.0
+            Supports Spark Connect.
+
+        Parameters
+        ----------
+        funcs : collection of function(s)
+            each element is a function that takes and returns a :class:`DataFrame`.
+
+        Returns
+        -------
+        :class:`DataFrame`
+            Transformed DataFrame.
+
+        Examples
+        --------
+        >>> from pyspark.sql.functions import col
+        >>> df = spark.createDataFrame([(1, 1.0), (2, 2.0)], ["int", "float"])
+        >>> def cast_all_to_int(input_df):
+        ...     return input_df.select([col(col_name).cast("int") for col_name in input_df.columns])
+        ...
+        >>> def sort_columns_asc(input_df):
+        ...     return input_df.select(*sorted(input_df.columns))
+        ...
+        >>> df.pipe(cast_all_to_int, sort_columns_asc).show()
+        +-----+---+
+        |float|int|
+        +-----+---+
+        |    1|  1|
+        |    2|  2|
+        +-----+---+
+
+        >>> def add_n(n):
+        ...     def closure(input_df):
+        ...         return input_df.select([(col(col_name) + n).alias(col_name)
+        ...                                 for col_name in input_df.columns])
+        ...     return closure
+        ... 
+        >>> df.pipe(add_n(n=1), add_n(n=10)).show()
+        +---+-----+
+        |int|float|
+        +---+-----+
+        | 12| 12.0|
+        | 13| 13.0|
+        +---+-----+
+        """
+        ...
+
+    @dispatch_df_method
     def sameSemantics(self, other: "DataFrame") -> bool:
         """
         Returns `True` when the logical query plans inside both :class:`DataFrame`\\s are equal and


### PR DESCRIPTION
Suggested implementation for a pipe method in the PySpark DataFrame. Similar to the transform method, this method can be called directly on a DataFrame to perform custom transformations functions. However, unlike the current transform method which requires one call per custom transformation, pipe can accept an ambiguous number of transformations and chain them together on the user's behalf.

Using the existing documentation for `DataFrame.transform`, the suggested pipe method would look like such:

```python
from pyspark.sql.functions import col


df = spark.createDataFrame([(1, 1.0), (2, 2.0)], ["int", "float"])

def cast_all_to_int(input_df):
    return input_df.select([col(col_name).cast("int") for col_name in input_df.columns])

def sort_columns_asc(input_df):
    return input_df.select(*sorted(input_df.columns))

# with transform method
df.transform(cast_all_to_int).transform(sort_columns_asc).show()

# with pipe method
df.pipe(cast_all_to_int, sort_columns_asc)
```

For functions that take parameters, users can pass closures or partially defined functions.

```python
from typing import Callable
import functools

def add_n(input_df, n):
    return input_df.select([(col(col_name) + n).alias(col_name)
                            for col_name in input_df.columns])

# define a partial function
add_one = functools.partial(add_n, n=1)

# or, define a function that returns a closure
def add_n(n: int) -> Callable:
    def closure(input_df: DataFrame) -> DataFrame:
        return input_df.select([(col(col_name) + n).alias(col_name)
                            for col_name in input_df.columns])
    return closure

# with transform method
df.transform(add_n, 1).transform(add_n, n=10).show()

# with pipe method
df.pipe(add_one, add_n(n=10)).show()
```