### PR TITLE
[SPARK-48344][SQL] Add SQL Scripting Execution Framework

### DIFF
--- a/common/utils/src/main/resources/error/error-conditions.json
+++ b/common/utils/src/main/resources/error/error-conditions.json
@@ -5375,6 +5375,11 @@
           "SQL Scripting is under development and not all features are supported. SQL Scripting enables users to write procedural SQL including control flow and error handling. To enable existing features set <sqlScriptingEnabled> to `true`."
         ]
       },
+      "SQL_SCRIPTING_WITH_POSITIONAL_PARAMETERS" : {
+        "message" : [
+          "Positional parameters are not supported with SQL Scripting."
+        ]
+      },
       "STATE_STORE_MULTIPLE_COLUMN_FAMILIES" : {
         "message" : [
           "Creating multiple column families with <stateStoreProvider> is not supported."

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/SqlScriptingErrors.scala
@@ -103,6 +103,14 @@ private[sql] object SqlScriptingErrors {
       messageParameters = Map("invalidStatement" -> toSQLStmt(stmt)))
   }
 
+  def positionalParametersAreNotSupportedWithSqlScripting(): Throwable = {
+    new SqlScriptingException(
+      origin = null,
+      errorClass = "UNSUPPORTED_FEATURE.SQL_SCRIPTING_WITH_POSITIONAL_PARAMETERS",
+      cause = null,
+      messageParameters = Map.empty)
+  }
+
   def labelDoesNotExist(
       origin: Origin,
       labelName: String,

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -22,10 +22,12 @@ import java.nio.file.Paths
 import java.util.{ServiceLoader, UUID}
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
+
 import scala.concurrent.duration.DurationInt
 import scala.jdk.CollectionConverters._
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.control.NonFatal
+
 import org.apache.spark.{SPARK_VERSION, SparkConf, SparkContext, SparkException, TaskContext}
 import org.apache.spark.annotation.{DeveloperApi, Experimental, Stable, Unstable}
 import org.apache.spark.api.java.JavaRDD
@@ -389,6 +391,7 @@ class SparkSession private(
       isStreaming = isStreaming)(self)
     Dataset.ofRows(self, logicalPlan)
   }
+
 
   /* ------------------------- *
    |  Catalog-related methods  |

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -420,7 +420,7 @@ class SparkSession private(
     var result: Option[Seq[Row]] = None
 
     while (sse.hasNext) {
-      sse.withErrorHandling() {
+      sse.withErrorHandling {
         val df = sse.next()
         if (sse.hasNext) {
           df.write.format("noop").mode("overwrite").save()

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -413,6 +413,14 @@ class SparkSession private(
    |  Everything else  |
    * ----------------- */
 
+  /**
+   * Executes given script and return the result of the last statement.
+   *
+   * @param script A SQL script to execute.
+   * @param args A map of parameter names to SQL literal expressions.
+   *
+   * @return The result as a `DataFrame`.
+   */
   private def executeSqlScript(
       script: CompoundBody,
       args: Map[String, Expression] = Map.empty): DataFrame = {
@@ -425,7 +433,7 @@ class SparkSession private(
         if (sse.hasNext) {
           df.write.format("noop").mode("overwrite").save()
         } else {
-          // Collect results from the last DataFrame
+          // Collect results from the last DataFrame.
           result = Some(df.collect().toSeq)
         }
       }
@@ -462,7 +470,7 @@ class SparkSession private(
         parsedPlan match {
           case compoundBody: CompoundBody =>
             if (args.nonEmpty) {
-              // Positional parameters are not supported for SQL scripting
+              // Positional parameters are not supported for SQL scripting.
               throw SqlScriptingErrors.positionalParametersAreNotSupportedWithSqlScripting()
             }
             compoundBody
@@ -477,10 +485,10 @@ class SparkSession private(
 
       plan match {
         case compoundBody: CompoundBody =>
-          // execute the SQL script
+          // Execute the SQL script.
           executeSqlScript(compoundBody)
         case logicalPlan: LogicalPlan =>
-          // execute the standalone SQL statement
+          // Execute the standalone SQL statement.
           Dataset.ofRows(self, plan, tracker)
       }
     }
@@ -528,10 +536,10 @@ class SparkSession private(
 
       plan match {
         case compoundBody: CompoundBody =>
-          // execute the SQL script
+          // Execute the SQL script.
           executeSqlScript(compoundBody, args.transform((_, v) => lit(v).expr))
         case logicalPlan: LogicalPlan =>
-          // execute the standalone SQL statement
+          // Execute the standalone SQL statement.
           Dataset.ofRows(self, plan, tracker)
       }
     }

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -390,6 +390,10 @@ class SparkSession private(
     Dataset.ofRows(self, logicalPlan)
   }
 
+  private def executeSqlScript(): Unit = {
+
+  }
+
 
   /* ------------------------- *
    |  Catalog-related methods  |

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -415,6 +415,7 @@ class SparkSession private(
 
   /**
    * Executes given script and return the result of the last statement.
+   * If script contains no queries, an empty `DataFrame` is returned.
    *
    * @param script A SQL script to execute.
    * @param args A map of parameter names to SQL literal expressions.

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSession.scala
@@ -413,8 +413,10 @@ class SparkSession private(
    |  Everything else  |
    * ----------------- */
 
-  private def executeSqlScript(script: CompoundBody): DataFrame = {
-    val sse = new SqlScriptingExecution(script, this)
+  private def executeSqlScript(
+      script: CompoundBody,
+      args: Map[String, Expression] = Map.empty): DataFrame = {
+    val sse = new SqlScriptingExecution(script, this, args)
     var df: DataFrame = null
     var result: Option[Seq[Row]] = null
 
@@ -528,7 +530,7 @@ class SparkSession private(
       plan match {
         case compoundBody: CompoundBody =>
           // execute the SQL script
-          executeSqlScript(compoundBody)
+          executeSqlScript(compoundBody, args.transform((_, v) => lit(v).expr))
         case logicalPlan: LogicalPlan =>
           // execute the standalone SQL statement
           Dataset.ofRows(self, plan, tracker)

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecution.scala
@@ -20,7 +20,7 @@ package org.apache.spark.sql.scripting
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.Expression
-import org.apache.spark.sql.catalyst.plans.logical.{CommandResult, CompoundBody, MultiResult}
+import org.apache.spark.sql.catalyst.plans.logical.{CommandResult, CompoundBody}
 
 /**
  * SQL scripting executor - executes script and returns result statements.

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecution.scala
@@ -31,7 +31,7 @@ class SqlScriptingExecution(
 
   // Build the execution plan for the script
   private val executionPlan: Iterator[CompoundStatementExec] =
-    SqlScriptingInterpreter().buildExecutionPlan(sqlScript, session, args)
+    SqlScriptingInterpreter(session).buildExecutionPlan(sqlScript, args)
 
   private var current = getNextResult
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecution.scala
@@ -64,7 +64,7 @@ class SqlScriptingExecution(
           withErrorHandling {
             val df = stmt.buildDataFrame(session)
             df.logicalPlan match {
-              case _: CommandResult | _: MultiResult => // pass
+              case _: CommandResult => // pass
               case _ => return Some(df) // If the statement is a result, return it to the caller.
             }
           }

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecution.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.sql.scripting
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.CompoundBody
 
 /**
@@ -25,11 +26,12 @@ import org.apache.spark.sql.catalyst.plans.logical.CompoundBody
  */
 class SqlScriptingExecution(
     sqlScript: CompoundBody,
-    session: SparkSession) extends Iterator[DataFrame] {
+    session: SparkSession,
+    args: Map[String, Expression]) extends Iterator[DataFrame] {
 
   // Build the execution plan for the script
   private val executionPlan: Iterator[CompoundStatementExec] =
-    SqlScriptingInterpreter().buildExecutionPlan(sqlScript, session)
+    SqlScriptingInterpreter().buildExecutionPlan(sqlScript, session, args)
 
   private var current = getNextResult
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecution.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.scripting
+
+import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
+import org.apache.spark.sql.catalyst.plans.logical.CompoundBody
+
+/**
+ * SQL scripting interpreter - builds SQL script execution plan.
+ */
+class SqlScriptingExecution(
+    sqlScript: CompoundBody,
+    session: SparkSession) extends Iterator[DataFrame] {
+
+  private val executionPlan: Iterator[CompoundStatementExec] =
+    SqlScriptingInterpreter().buildExecutionPlan(sqlScript, session)
+
+  private var current = if (executionPlan.hasNext) Some(executionPlan.next()) else None
+
+  override def hasNext: Boolean = {
+    current.isDefined
+  }
+
+  override def next(): DataFrame = {
+    if (!hasNext) {
+      throw new NoSuchElementException("No more statements to execute")
+    }
+    moveCurrentToNextResult()
+    current.get.asInstanceOf[SingleStatementExec].buildDataFrame(session)
+  }
+
+  private def moveCurrentToNextResult(): Unit = {
+    while (current.isDefined && !current.get.isResult) {
+      current.get match {
+        case exec: SingleStatementExec =>
+          exec.buildDataFrame(session).collect()
+        case _ => // Do nothing
+      }
+      current = if (executionPlan.hasNext) Some(executionPlan.next()) else None
+    }
+  }
+
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecution.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecution.scala
@@ -44,9 +44,7 @@ class SqlScriptingExecution(
   override def hasNext: Boolean = current.isDefined
 
   override def next(): DataFrame = {
-    if (!hasNext) {throw SparkException.internalError(
-      "No more elements to iterate through.")
-    }
+    if (!hasNext) throw SparkException.internalError("No more elements to iterate through.")
     val nextDataFrame = current.get
     current = getNextResult
     nextDataFrame

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -39,7 +39,7 @@ sealed trait CompoundStatementExec extends Logging {
   /**
    * Whether the statement originates from the SQL statement that returns the result.
    */
-  val isResult: Boolean = false
+  def isResult: Boolean = false
 
   /**
    * Reset execution of the current node.
@@ -127,7 +127,7 @@ class SingleStatementExec(
    */
   var isExecuted = false
 
-  override val isResult: Boolean = parsedPlan.isInstanceOf[Project]
+  override def isResult: Boolean = parsedPlan.isInstanceOf[Project] && !isExecuted
 
   /**
    * Get the SQL query text corresponding to this statement.

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -107,6 +107,8 @@ trait NonLeafStatementExec extends CompoundStatementExec {
  *   Logical plan of the parsed statement.
  * @param origin
  *   Origin descriptor for the statement.
+ * @param args
+ *   A map of parameter names to SQL literal expressions.
  * @param isInternal
  *   Whether the statement originates from the SQL script or it is created during the
  *   interpretation. Example: DropVariable statements are automatically created at the end of each
@@ -148,7 +150,7 @@ class SingleStatementExec(
 
   /**
    * Builds a DataFrame from the parsedPlan of this SingleStatementExec
-   * @param session The SparkSession on which the parsedPlan is built
+   * @param session The SparkSession on which the parsedPlan is built.
    * @return
    *   The DataFrame.
    */

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -82,7 +82,7 @@ trait NonLeafStatementExec extends CompoundStatementExec {
 
       // DataFrame evaluates to True if it is single row, single column
       //  of boolean type with value True.
-      val df = Dataset.ofRows(session, statement.parsedPlan)
+      val df = statement.buildDataFrame(session)
       df.schema.fields match {
         case Array(field) if field.dataType == BooleanType =>
           df.limit(2).collect() match {

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNode.scala
@@ -127,6 +127,7 @@ class SingleStatementExec(
    */
   var isExecuted = false
 
+  /** Statement is result if it is a SELECT query, and it is not in control flow condition */
   override def isResult: Boolean = parsedPlan.isInstanceOf[Project] && !isExecuted
 
   /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreter.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreter.scala
@@ -37,6 +37,8 @@ case class SqlScriptingInterpreter(session: SparkSession) {
    *
    * @param compound
    *   CompoundBody for which to build the plan.
+   * @param args
+   *   A map of parameter names to SQL literal expressions.
    * @return
    *   Iterator through collection of statements to be executed.
    */
@@ -65,6 +67,8 @@ case class SqlScriptingInterpreter(session: SparkSession) {
    *
    * @param node
    *   Root node of the parsed tree.
+   * @param args
+   *   A map of parameter names to SQL literal expressions.
    * @return
    *   Executable statement.
    */
@@ -102,7 +106,6 @@ case class SqlScriptingInterpreter(session: SparkSession) {
 
       case CaseStatement(conditions, conditionalBodies, elseBody) =>
         val conditionsExec = conditions.map(condition =>
-          // todo: what to put here for isInternal, in case of simple case statement
           new SingleStatementExec(
             condition.parsedPlan,
             condition.origin,

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingE2eSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingE2eSuite.scala
@@ -99,13 +99,22 @@ class SqlScriptingE2eSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("last statement without result") {
+  test("script without result statement") {
     val sqlScript =
       """
         |BEGIN
         |  DECLARE x INT;
         |  SET x = 1;
         |  DROP TEMPORARY VARIABLE x;
+        |END
+        |""".stripMargin
+    verifySqlScriptResult(sqlScript, Seq.empty)
+  }
+
+  test("empty script") {
+    val sqlScript =
+      """
+        |BEGIN
         |END
         |""".stripMargin
     verifySqlScriptResult(sqlScript, Seq.empty)

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingE2eSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingE2eSuite.scala
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.scripting
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.catalyst.plans.logical.CompoundBody
+import org.apache.spark.sql.catalyst.util.QuotingUtils.toSQLConf
+import org.apache.spark.sql.exceptions.SqlScriptingException
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+
+/**
+ * End-to-end tests for SQL Scripting.
+ * This suite is not intended to heavily test the SQL scripting (parser & interpreter) logic.
+ * It is rather focused on testing the sql() API - whether it can handle SQL scripts correctly,
+ *  results are returned in expected manner, config flags are applied properly, etc.
+ * For full functionality tests, see SqlScriptingParserSuite and SqlScriptingInterpreterSuite.
+ */
+class SqlScriptingE2eSuite extends QueryTest with SharedSparkSession {
+  // Helpers
+  private def verifySqlScriptResult(sqlText: String, expected: Seq[Row]): Unit = {
+    val df = spark.sql(sqlText)
+    checkAnswer(df, expected)
+  }
+
+  // Tests setup
+  override protected def sparkConf: SparkConf = {
+    super.sparkConf.set(SQLConf.SQL_SCRIPTING_ENABLED.key, "true")
+  }
+
+  // Tests
+  test("SQL Scripting not enabled") {
+    withSQLConf(SQLConf.SQL_SCRIPTING_ENABLED.key -> "false") {
+      val sqlScriptText =
+        """
+          |BEGIN
+          |  SELECT 1;
+          |END""".stripMargin
+      checkError(
+        exception = intercept[SqlScriptingException] {
+          spark.sql(sqlScriptText).asInstanceOf[CompoundBody]
+        },
+        condition = "UNSUPPORTED_FEATURE.SQL_SCRIPTING",
+        parameters = Map("sqlScriptingEnabled" -> toSQLConf(SQLConf.SQL_SCRIPTING_ENABLED.key)))
+    }
+  }
+
+  test("single select") {
+    val sqlText = "SELECT 1;"
+    verifySqlScriptResult(sqlText, Seq(Row(1)))
+  }
+
+  test("multiple selects") {
+    val sqlText =
+      """
+        |BEGIN
+        |  SELECT 1;
+        |  SELECT 2;
+        |END""".stripMargin
+    verifySqlScriptResult(sqlText, Seq(Row(2)))
+  }
+
+  test("multi statement - simple") {
+    withTable("t") {
+      val sqlScript =
+        """
+          |BEGIN
+          |  CREATE TABLE t (a INT, b STRING, c DOUBLE) USING parquet;
+          |  INSERT INTO t VALUES (1, 'a', 1.0);
+          |  SELECT a FROM t;
+          |END
+          |""".stripMargin
+      verifySqlScriptResult(sqlScript, Seq(Row(1)))
+    }
+  }
+
+  test("last statement without result") {
+    val sqlScript =
+      """
+        |BEGIN
+        |  DECLARE x INT;
+        |  SET x = 1;
+        |  DROP TEMPORARY VARIABLE x;
+        |END
+        |""".stripMargin
+    verifySqlScriptResult(sqlScript, Seq.empty)
+  }
+
+  test("positional params") {
+    val sqlScriptText =
+      """
+        |BEGIN
+        |  SELECT 1;
+        |  IF ? > 10 THEN
+        |    SELECT ?;
+        |  ELSE
+        |    SELECT ?;
+        |  END IF;
+        |END""".stripMargin
+    // Define an array with SQL parameters in the correct order
+    val args: Array[Any] = Array(5, "greater", "smaller")
+    checkError(
+      exception = intercept[SqlScriptingException] {
+        spark.sql(sqlScriptText, args).asInstanceOf[CompoundBody]
+      },
+      condition = "UNSUPPORTED_FEATURE.SQL_SCRIPTING_WITH_POSITIONAL_PARAMETERS",
+      parameters = Map.empty)
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionNodeSuite.scala
@@ -39,6 +39,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
     extends SingleStatementExec(
       parsedPlan = Project(Seq(Alias(Literal(condVal), description)()), OneRowRelation()),
       Origin(startIndex = Some(0), stopIndex = Some(description.length)),
+      Map.empty,
       isInternal = false)
 
   case class DummyLogicalPlan() extends LeafNode {
@@ -50,6 +51,7 @@ class SqlScriptingExecutionNodeSuite extends SparkFunSuite with SharedSparkSessi
     extends SingleStatementExec(
       parsedPlan = DummyLogicalPlan(),
       Origin(startIndex = Some(0), stopIndex = Some(description.length)),
+      Map.empty,
       isInternal = false)
 
   class LoopBooleanConditionEvaluator(condition: TestLoopCondition) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
@@ -90,9 +90,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
           |FROM t;
           |END
           |""".stripMargin
-      val expected = Seq(
-        Seq(Row(false)) // select
-      )
+      val expected = Seq(Seq(Row(false)))
       verifySqlScriptResult(sqlScript, expected)
     }
   }
@@ -106,9 +104,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         |SELECT var;
         |END
         |""".stripMargin
-    val expected = Seq(
-      Seq(Row(2)), // select
-    )
+    val expected = Seq(Seq(Row(2)))
     verifySqlScriptResult(sqlScript, expected)
   }
 
@@ -121,9 +117,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         |SELECT var;
         |END
         |""".stripMargin
-    val expected = Seq(
-      Seq(Row(2)), // select
-    )
+    val expected = Seq(Seq(Row(2)))
     verifySqlScriptResult(sqlScript, expected)
   }
 
@@ -149,7 +143,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
     val expected = Seq(
       Seq(Row(1)), // select
       Seq(Row(2)), // select
-      Seq(Row(4)), // select
+      Seq(Row(4)) // select
     )
     verifySqlScriptResult(sqlScript, expected)
   }
@@ -164,9 +158,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         |DROP TEMPORARY VARIABLE var;
         |END
         |""".stripMargin
-    val expected = Seq(
-      Seq(Row(2)), // select
-    )
+    val expected = Seq(Seq(Row(2)))
     verifySqlScriptResult(sqlScript, expected)
   }
 
@@ -179,9 +171,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         | END IF;
         |END
         |""".stripMargin
-    val expected = Seq(
-      Seq(Row(42))
-    )
+    val expected = Seq(Seq(Row(42)))
     verifySqlScriptResult(commands, expected)
   }
 
@@ -214,7 +204,6 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         | END IF;
         |END
         |""".stripMargin
-
     val expected = Seq(Seq(Row(42)))
     verifySqlScriptResult(commands, expected)
   }
@@ -234,7 +223,6 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         |  END IF;
         |END
         |""".stripMargin
-
     val expected = Seq(Seq(Row(43)))
     verifySqlScriptResult(commands, expected)
   }
@@ -251,7 +239,6 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         | END IF;
         |END
         |""".stripMargin
-
     val expected = Seq(Seq(Row(43)))
     verifySqlScriptResult(commands, expected)
   }
@@ -271,7 +258,6 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         |  END IF;
         |END
         |""".stripMargin
-
     val expected = Seq(Seq(Row(44)))
     verifySqlScriptResult(commands, expected)
   }
@@ -291,7 +277,6 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
           | END IF;
           |END
           |""".stripMargin
-
       val expected = Seq(Seq(Row(43)))
       verifySqlScriptResult(commands, expected)
     }
@@ -314,7 +299,6 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
           |  END IF;
           |END
           |""".stripMargin
-
       val expected = Seq(Seq(Row(43)))
       verifySqlScriptResult(commands, expected)
     }
@@ -405,7 +389,6 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
           | END CASE;
           |END
           |""".stripMargin
-
       val expected = Seq(Seq(Row(43)))
       verifySqlScriptResult(commands, expected)
     }
@@ -429,7 +412,6 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
           |  END CASE;
           |END
           |""".stripMargin
-
       val expected = Seq(Seq(Row(43)))
       verifySqlScriptResult(commands, expected)
     }
@@ -447,7 +429,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         | END CASE;
         |END
         |""".stripMargin
-    val expected = Seq()
+    val expected = Seq.empty
     verifySqlScriptResult(commands, expected)
   }
 
@@ -538,7 +520,6 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
           | END CASE;
           |END
           |""".stripMargin
-
       val expected = Seq(Seq(Row(42)))
       verifySqlScriptResult(commands, expected)
     }
@@ -562,7 +543,6 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
           |  END CASE;
           |END
           |""".stripMargin
-
       val expected = Seq(Seq(Row(44)))
       verifySqlScriptResult(commands, expected)
     }
@@ -580,7 +560,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         | END CASE;
         |END
         |""".stripMargin
-    val expected = Seq()
+    val expected = Seq.empty
     verifySqlScriptResult(commands, expected)
   }
 
@@ -598,7 +578,6 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
           |  END CASE;
           |END
           |""".stripMargin
-
       val expected = Seq(Seq(Row(43)))
       verifySqlScriptResult(commands, expected)
     }
@@ -615,11 +594,10 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         | END WHILE;
         |END
         |""".stripMargin
-
     val expected = Seq(
       Seq(Row(0)), // select i
       Seq(Row(1)), // select i
-      Seq(Row(2)), // select i
+      Seq(Row(2)) // select i
     )
     verifySqlScriptResult(commands, expected)
   }
@@ -635,7 +613,6 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         | END WHILE;
         |END
         |""".stripMargin
-
     val expected = Seq.empty
     verifySqlScriptResult(commands, expected)
   }
@@ -656,12 +633,11 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         | END WHILE;
         |END
         |""".stripMargin
-
     val expected = Seq(
       Seq(Row(0, 0)), // select i, j
       Seq(Row(0, 1)), // select i, j
       Seq(Row(1, 0)), // select i, j
-      Seq(Row(1, 1)), // select i, j
+      Seq(Row(1, 1)) // select i, j
     )
     verifySqlScriptResult(commands, expected)
   }
@@ -678,10 +654,9 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
           |END WHILE;
           |END
           |""".stripMargin
-
       val expected = Seq(
         Seq(Row(42)), // select
-        Seq(Row(42)), // select
+        Seq(Row(42)) // select
       )
       verifySqlScriptResult(commands, expected)
     }
@@ -700,11 +675,10 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         | END REPEAT;
         |END
         |""".stripMargin
-
     val expected = Seq(
       Seq(Row(0)), // select i
       Seq(Row(1)), // select i
-      Seq(Row(2)), // select i
+      Seq(Row(2)) // select i
     )
     verifySqlScriptResult(commands, expected)
   }
@@ -723,9 +697,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         |END
         |""".stripMargin
 
-    val expected = Seq(
-      Seq(Row(3)), // select i
-    )
+    val expected = Seq(Seq(Row(3)))
     verifySqlScriptResult(commands, expected)
   }
 
@@ -752,7 +724,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
       Seq(Row(0, 0)), // select i, j
       Seq(Row(0, 1)), // select i, j
       Seq(Row(1, 0)), // select i, j
-      Seq(Row(1, 1)), // select i, j
+      Seq(Row(1, 1)) // select i, j
     )
     verifySqlScriptResult(commands, expected)
   }
@@ -773,7 +745,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
 
       val expected = Seq(
         Seq(Row(42)), // select
-        Seq(Row(42)), // select
+        Seq(Row(42)) // select
       )
       verifySqlScriptResult(commands, expected)
     }
@@ -789,9 +761,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         |    SELECT 2;
         |  END;
         |END""".stripMargin
-    val expected = Seq(
-      Seq(Row(1)) // select
-    )
+    val expected = Seq(Seq(Row(1)))
     verifySqlScriptResult(sqlScriptText, expected)
   }
 
@@ -804,9 +774,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         |    LEAVE lbl;
         |  END WHILE;
         |END""".stripMargin
-    val expected = Seq(
-      Seq(Row(1)) // select
-    )
+    val expected = Seq(Seq(Row(1)))
     verifySqlScriptResult(sqlScriptText, expected)
   }
 
@@ -820,9 +788,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         |  UNTIL 1 = 2
         |  END REPEAT;
         |END""".stripMargin
-    val expected = Seq(
-      Seq(Row(1)) // select 1
-    )
+    val expected = Seq(Seq(Row(1)))
     verifySqlScriptResult(sqlScriptText, expected)
   }
 
@@ -839,9 +805,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         |  END WHILE;
         |  SELECT x;
         |END""".stripMargin
-    val expected = Seq(
-      Seq(Row(2)), // select
-    )
+    val expected = Seq(Seq(Row(2)))
     verifySqlScriptResult(sqlScriptText, expected)
   }
 
@@ -859,9 +823,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         |  END REPEAT;
         |  SELECT x;
         |END""".stripMargin
-    val expected = Seq(
-      Seq(Row(2)), // select x
-    )
+    val expected = Seq(Seq(Row(2)))
     verifySqlScriptResult(sqlScriptText, expected)
   }
 
@@ -878,9 +840,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         |  UNTIL 1 = 2
         |  END REPEAT;
         |END""".stripMargin
-    val expected = Seq(
-      Seq(Row(1)) // select 1
-    )
+    val expected = Seq(Seq(Row(1)))
     verifySqlScriptResult(sqlScriptText, expected)
   }
 
@@ -895,9 +855,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         |    END WHILE;
         |  END WHILE;
         |END""".stripMargin
-    val expected = Seq(
-      Seq(Row(1)) // select
-    )
+    val expected = Seq(Seq(Row(1)))
     verifySqlScriptResult(sqlScriptText, expected)
   }
 
@@ -919,7 +877,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
     val expected = Seq(
       Seq(Row(1)), // select 1
       Seq(Row(1)), // select 1
-      Seq(Row(2)), // select x
+      Seq(Row(2)) // select x
     )
     verifySqlScriptResult(sqlScriptText, expected)
   }
@@ -948,7 +906,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
       Seq(Row(2)), // select 2
       Seq(Row(1)), // select 1
       Seq(Row(2)), // select 2
-      Seq(Row(2)), // select x
+      Seq(Row(2)) // select x
     )
     verifySqlScriptResult(sqlScriptText, expected)
   }
@@ -973,7 +931,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
     val expected = Seq(
       Seq(Row(1)), // select 1
       Seq(Row(1)), // select 1
-      Seq(Row(2)), // select x
+      Seq(Row(2)) // select x
     )
     verifySqlScriptResult(sqlScriptText, expected)
   }
@@ -998,7 +956,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
       Seq(Row(1)), // select x
       Seq(Row(2)), // select x
       Seq(Row(3)), // select x
-      Seq(Row(3)), // select x
+      Seq(Row(3)) // select x
     )
     verifySqlScriptResult(sqlScriptText, expected)
   }
@@ -1030,7 +988,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
       Seq(Row(0, 0)), // select x, y
       Seq(Row(0, 1)), // select x, y
       Seq(Row(1, 0)), // select x, y
-      Seq(Row(1, 1)), // select x, y
+      Seq(Row(1, 1)) // select x, y
     )
     verifySqlScriptResult(commands, expected)
   }
@@ -1051,9 +1009,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         |  END LOOP;
         |  SELECT x;
         |END""".stripMargin
-    val expected = Seq(
-      Seq(Row(2)), // select x
-    )
+    val expected = Seq(Seq(Row(2)))
     verifySqlScriptResult(sqlScriptText, expected)
   }
 
@@ -1068,9 +1024,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         |    END LOOP;
         |  END LOOP;
         |END""".stripMargin
-    val expected = Seq(
-      Seq(Row(1)) // select 1
-    )
+    val expected = Seq(Seq(Row(1)))
     verifySqlScriptResult(sqlScriptText, expected)
   }
 
@@ -1096,7 +1050,7 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
     val expected = Seq(
       Seq(Row(1)), // select 1
       Seq(Row(1)), // select 1
-      Seq(Row(3)), // select x
+      Seq(Row(3)) // select x
     )
     verifySqlScriptResult(sqlScriptText, expected)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
@@ -1024,6 +1024,8 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
         |    END LOOP;
         |  END LOOP;
         |END""".stripMargin
+    // Execution immediately leaves the outer loop after SELECT,
+    //   so we expect only a single row in the result set.
     val expected = Seq(Seq(Row(1)))
     verifySqlScriptResult(sqlScriptText, expected)
   }

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
@@ -17,10 +17,9 @@
 
 package org.apache.spark.sql.scripting
 
-import org.apache.spark.{SparkConf, SparkException, SparkNumberFormatException}
-import org.apache.spark.sql.{AnalysisException, QueryTest, Row}
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{QueryTest, Row}
 import org.apache.spark.sql.catalyst.plans.logical.CompoundBody
-import org.apache.spark.sql.exceptions.SqlScriptingException
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingExecutionSuite.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.scripting
 
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.{QueryTest, Row}
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.CompoundBody
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.test.SharedSparkSession
@@ -37,9 +38,11 @@ class SqlScriptingExecutionSuite extends QueryTest with SharedSparkSession {
   }
 
   // Helpers
-  private def runSqlScript(sqlText: String): Seq[Array[Row]] = {
+  private def runSqlScript(
+      sqlText: String,
+      args: Map[String, Expression] = Map.empty): Seq[Array[Row]] = {
     val compoundBody = spark.sessionState.sqlParser.parsePlan(sqlText).asInstanceOf[CompoundBody]
-    val sse = new SqlScriptingExecution(compoundBody, spark)
+    val sse = new SqlScriptingExecution(compoundBody, spark, args)
     sse.map { df => df.collect() }.toList
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.scripting
 import org.apache.spark.{SparkConf, SparkException, SparkNumberFormatException}
 import org.apache.spark.sql.{AnalysisException, DataFrame, Dataset, QueryTest, Row}
 import org.apache.spark.sql.catalyst.QueryPlanningTracker
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.CompoundBody
 import org.apache.spark.sql.exceptions.SqlScriptingException
 import org.apache.spark.sql.internal.SQLConf
@@ -39,10 +40,12 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
   }
 
   // Helpers
-  private def runSqlScript(sqlText: String): Array[DataFrame] = {
+  private def runSqlScript(
+      sqlText: String,
+      args: Map[String, Expression] = Map.empty): Array[DataFrame] = {
     val interpreter = SqlScriptingInterpreter()
     val compoundBody = spark.sessionState.sqlParser.parsePlan(sqlText).asInstanceOf[CompoundBody]
-    val executionPlan = interpreter.buildExecutionPlan(compoundBody, spark)
+    val executionPlan = interpreter.buildExecutionPlan(compoundBody, spark, args)
     executionPlan.flatMap {
       case statement: SingleStatementExec =>
         if (statement.isExecuted) {

--- a/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/scripting/SqlScriptingInterpreterSuite.scala
@@ -43,9 +43,9 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
   private def runSqlScript(
       sqlText: String,
       args: Map[String, Expression] = Map.empty): Array[DataFrame] = {
-    val interpreter = SqlScriptingInterpreter()
+    val interpreter = SqlScriptingInterpreter(spark)
     val compoundBody = spark.sessionState.sqlParser.parsePlan(sqlText).asInstanceOf[CompoundBody]
-    val executionPlan = interpreter.buildExecutionPlan(compoundBody, spark, args)
+    val executionPlan = interpreter.buildExecutionPlan(compoundBody, args)
     executionPlan.flatMap {
       case statement: SingleStatementExec =>
         if (statement.isExecuted) {
@@ -236,9 +236,7 @@ class SqlScriptingInterpreterSuite extends QueryTest with SharedSparkSession {
         | END IF;
         |END
         |""".stripMargin
-    val expected = Seq(
-      Seq(Row(42))
-    )
+    val expected = Seq(Seq(Row(42)))
     verifySqlScriptResult(commands, expected)
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR is second in series of refactoring Initial refactoring of SQL Scripting to prepare it for addition of **Execution Framework**:
- Introducing `SqlScriptExecution`, new iterator that collects and returns only results.
- Enabling execution of SQL Scripting using `sql()` API.
- Enabling named parameters to be used with SQL Scripting.

### Why are the changes needed?
This changes are needed to enable execution of SQL Scripts.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
New `SqlScriptingExecutionSuite` to test behavior of newly added component.
New `SqlScriptingE2eSuite` to test end to end behavior using `sql()` API.


### Was this patch authored or co-authored using generative AI tooling?
No.
