### PR TITLE
[SPARK-50415][BUILD] Upgrade `zstd-jni` to 1.5.6-8

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -280,4 +280,4 @@ xz/1.10//xz-1.10.jar
 zjsonpatch/0.3.0//zjsonpatch-0.3.0.jar
 zookeeper-jute/3.9.3//zookeeper-jute-3.9.3.jar
 zookeeper/3.9.3//zookeeper-3.9.3.jar
-zstd-jni/1.5.6-7//zstd-jni-1.5.6-7.jar
+zstd-jni/1.5.6-8//zstd-jni-1.5.6-8.jar

--- a/pom.xml
+++ b/pom.xml
@@ -839,7 +839,7 @@
       <dependency>
         <groupId>com.github.luben</groupId>
         <artifactId>zstd-jni</artifactId>
-        <version>1.5.6-7</version>
+        <version>1.5.6-8</version>
       </dependency>
       <dependency>
         <groupId>com.clearspring.analytics</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `zstd-jni` to `1.5.6-8`.

### Why are the changes needed?

To bring the following bug fix,
- [Guard all native code execution behind the shared lock in the ZstdCompressionCtx and ZstdDecompressionCtx](https://github.com/luben/zstd-jni/commit/cec96538e692336eae11b033d9f09e7be30ff075)

Here is the release tag.
- https://github.com/luben/zstd-jni/releases/tag/v1.5.6-8

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.