### PR TITLE
[SPARK-50417] Make number of FallbackStorage sub-directories configurable

### DIFF
--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -590,11 +590,23 @@ package object config {
     ConfigBuilder("spark.storage.decommission.fallbackStorage.path")
       .doc("The location for fallback storage during block manager decommissioning. " +
         "For example, `s3a://spark-storage/`. In case of empty, fallback storage is disabled. " +
-        "The storage should be managed by TTL because Spark will not clean it up.")
+        "The storage should be managed by TTL because Spark will not clean it up, " +
+        "unless spark.storage.decommission.fallbackStorage.cleanUp is true.")
       .version("3.1.0")
       .stringConf
       .checkValue(_.endsWith(java.io.File.separator), "Path should end with separator.")
       .createOptional
+
+  private[spark] val STORAGE_DECOMMISSION_FALLBACK_STORAGE_SUBPATHS =
+    ConfigBuilder("spark.storage.decommission.fallbackStorage.subPaths")
+      .doc("The fallback storage puts all files of one shuffle in one directory when this is 0. " +
+        "When this option is larger than 0, it will instead distribute the files across " +
+        "this number of subdirectories.")
+      .version("4.0.0")
+      .intConf
+      .checkValue(_ >= 0, "The number of subdirectories must be 0 or larger.")
+      .createWithDefault(Int.MaxValue)
+
 
   private[spark] val STORAGE_DECOMMISSION_FALLBACK_STORAGE_CLEANUP =
     ConfigBuilder("spark.storage.decommission.fallbackStorage.cleanUp")

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -599,12 +599,10 @@ package object config {
 
   private[spark] val STORAGE_DECOMMISSION_FALLBACK_STORAGE_SUBPATHS =
     ConfigBuilder("spark.storage.decommission.fallbackStorage.subPaths")
-      .doc("The fallback storage puts all files of one shuffle in one directory when this is 0. " +
-        "When this option is larger than 0, it will instead distribute the files across " +
-        "this number of subdirectories.")
+      .doc("The fallback storage stores files across this number of subdirectories.")
       .version("4.0.0")
       .intConf
-      .checkValue(_ >= 0, "The number of subdirectories must be 0 or larger.")
+      .checkValue(_ > 0, "The number of subdirectories must be positive.")
       .createWithDefault(Int.MaxValue)
 
 

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -597,8 +597,8 @@ package object config {
       .checkValue(_.endsWith(java.io.File.separator), "Path should end with separator.")
       .createOptional
 
-  private[spark] val STORAGE_DECOMMISSION_FALLBACK_STORAGE_SUBPATHS =
-    ConfigBuilder("spark.storage.decommission.fallbackStorage.subPaths")
+  private[spark] val STORAGE_DECOMMISSION_FALLBACK_STORAGE_SUB_DIRECTORIES =
+    ConfigBuilder("spark.storage.decommission.fallbackStorage.subDirectories")
       .doc("The fallback storage stores files across this number of subdirectories.")
       .version("4.0.0")
       .intConf

--- a/core/src/main/scala/org/apache/spark/storage/FallbackStorage.scala
+++ b/core/src/main/scala/org/apache/spark/storage/FallbackStorage.scala
@@ -162,12 +162,8 @@ private[spark] object FallbackStorage extends Logging {
                                filename: String): Path = {
     val fallbackPath = new Path(conf.get(STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH).get)
     val subPaths = conf.get(STORAGE_DECOMMISSION_FALLBACK_STORAGE_SUBPATHS)
-    if (subPaths > 0) {
-      val hash = JavaUtils.nonNegativeHash(filename) % subPaths
-      new Path(fallbackPath, s"$appId/$shuffleId/$hash/$filename")
-    } else {
-      new Path(fallbackPath, s"$appId/$shuffleId/$filename")
-    }
+    val hash = JavaUtils.nonNegativeHash(filename) % subPaths
+    new Path(fallbackPath, s"$appId/$shuffleId/$hash/$filename")
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/storage/FallbackStorage.scala
+++ b/core/src/main/scala/org/apache/spark/storage/FallbackStorage.scala
@@ -30,7 +30,7 @@ import org.apache.spark.{SparkConf, SparkException}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.internal.{Logging, MDC}
 import org.apache.spark.internal.LogKeys._
-import org.apache.spark.internal.config.{STORAGE_DECOMMISSION_FALLBACK_STORAGE_CLEANUP, STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH, STORAGE_DECOMMISSION_FALLBACK_STORAGE_SUBPATHS}
+import org.apache.spark.internal.config.{STORAGE_DECOMMISSION_FALLBACK_STORAGE_CLEANUP, STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH, STORAGE_DECOMMISSION_FALLBACK_STORAGE_SUB_DIRECTORIES}
 import org.apache.spark.network.buffer.{ManagedBuffer, NioManagedBuffer}
 import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.rpc.{RpcAddress, RpcEndpointRef, RpcTimeout}
@@ -161,7 +161,7 @@ private[spark] object FallbackStorage extends Logging {
                                shuffleId: Int,
                                filename: String): Path = {
     val fallbackPath = new Path(conf.get(STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH).get)
-    val subPaths = conf.get(STORAGE_DECOMMISSION_FALLBACK_STORAGE_SUBPATHS)
+    val subPaths = conf.get(STORAGE_DECOMMISSION_FALLBACK_STORAGE_SUB_DIRECTORIES)
     val hash = JavaUtils.nonNegativeHash(filename) % subPaths
     new Path(fallbackPath, s"$appId/$shuffleId/$hash/$filename")
   }

--- a/core/src/test/scala/org/apache/spark/storage/FallbackStorageSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/FallbackStorageSuite.scala
@@ -293,26 +293,22 @@ class FallbackStorageSuite extends SparkFunSuite with LocalSparkContext {
     }
   }
 
-  Seq(0, 1, 2, 4, 1024, Int.MaxValue).foreach { subPaths =>
-    test(s"Get path for filename with $subPaths subdirectories") {
-      val conf = getSparkConf(2, 2).set(STORAGE_DECOMMISSION_FALLBACK_STORAGE_SUBPATHS, subPaths)
+  Seq(1, 2, 4, 1024, Int.MaxValue).foreach { subDirs =>
+    test(s"Get path for filename with $subDirs subdirectories") {
+      val conf = getSparkConf(2, 2).set(STORAGE_DECOMMISSION_FALLBACK_STORAGE_SUB_DIRECTORIES, subDirs)
       val path = conf.get(STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH).get
       val appId = "app-id"
       val shuffleId = 123
       val filename = "the-file"
       val actual = FallbackStorage.getPath(conf, appId, shuffleId, filename)
-      val expected = if (subPaths == 0) {
-        new Path(s"${path}/$appId/$shuffleId/$filename")
-      } else {
-        new Path(s"${path}/$appId/$shuffleId/${1049883992 % subPaths}/$filename")
-      }
+      new Path(s"${path}/$appId/$shuffleId/${1049883992 % subDirs}/$filename")
       assert(actual == expected)
     }
   }
 
-  Seq(0, 1, 2, 4, 1024, Int.MaxValue).foreach { subPaths =>
-    test(s"Control number of sub-directories ($subPaths)") {
-      val conf = getSparkConf(2, 2).set(STORAGE_DECOMMISSION_FALLBACK_STORAGE_SUBPATHS, subPaths)
+  Seq(1, 2, 4, 1024, Int.MaxValue).foreach { subDirs =>
+    test(s"Control number of sub-directories ($subDirs)") {
+      val conf = getSparkConf(2, 2).set(STORAGE_DECOMMISSION_FALLBACK_STORAGE_SUB_DIRECTORIES, subDirs)
       sc = new SparkContext(conf)
       withSpark(sc) { sc =>
         TestUtils.waitUntilExecutorsUp(sc, 2, 60000)
@@ -350,7 +346,7 @@ class FallbackStorageSuite extends SparkFunSuite with LocalSparkContext {
         assert(shuffleDirs.length == 1)
         // third level is controlled number of hash / bucket dirs
         val subDirs = shuffleDirs(0).listFiles(dirsOnly)
-        assert(subDirs.length == Math.min(subPaths, 20), subDirs.mkString(", "))
+        assert(subDirs.length == Math.min(subDirs, 20), subDirs.mkString(", "))
       }
     }
    }

--- a/core/src/test/scala/org/apache/spark/storage/FallbackStorageSuite.scala
+++ b/core/src/test/scala/org/apache/spark/storage/FallbackStorageSuite.scala
@@ -295,20 +295,22 @@ class FallbackStorageSuite extends SparkFunSuite with LocalSparkContext {
 
   Seq(1, 2, 4, 1024, Int.MaxValue).foreach { subDirs =>
     test(s"Get path for filename with $subDirs subdirectories") {
-      val conf = getSparkConf(2, 2).set(STORAGE_DECOMMISSION_FALLBACK_STORAGE_SUB_DIRECTORIES, subDirs)
+      val conf = getSparkConf(2, 2)
+        .set(STORAGE_DECOMMISSION_FALLBACK_STORAGE_SUB_DIRECTORIES, subDirs)
       val path = conf.get(STORAGE_DECOMMISSION_FALLBACK_STORAGE_PATH).get
       val appId = "app-id"
       val shuffleId = 123
       val filename = "the-file"
       val actual = FallbackStorage.getPath(conf, appId, shuffleId, filename)
-      new Path(s"${path}/$appId/$shuffleId/${1049883992 % subDirs}/$filename")
+      val expected = new Path(s"${path}/$appId/$shuffleId/${1049883992 % subDirs}/$filename")
       assert(actual == expected)
     }
   }
 
   Seq(1, 2, 4, 1024, Int.MaxValue).foreach { subDirs =>
     test(s"Control number of sub-directories ($subDirs)") {
-      val conf = getSparkConf(2, 2).set(STORAGE_DECOMMISSION_FALLBACK_STORAGE_SUB_DIRECTORIES, subDirs)
+      val conf = getSparkConf(2, 2)
+        .set(STORAGE_DECOMMISSION_FALLBACK_STORAGE_SUB_DIRECTORIES, subDirs)
       sc = new SparkContext(conf)
       withSpark(sc) { sc =>
         TestUtils.waitUntilExecutorsUp(sc, 2, 60000)
@@ -345,8 +347,8 @@ class FallbackStorageSuite extends SparkFunSuite with LocalSparkContext {
         val shuffleDirs = appDirs(0).listFiles(dirsOnly)
         assert(shuffleDirs.length == 1)
         // third level is controlled number of hash / bucket dirs
-        val subDirs = shuffleDirs(0).listFiles(dirsOnly)
-        assert(subDirs.length == Math.min(subDirs, 20), subDirs.mkString(", "))
+        val dirs = shuffleDirs(0).listFiles(dirsOnly)
+        assert(dirs.length == Math.min(subDirs, 20), dirs.mkString(", "))
       }
     }
    }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This adds option `spark.storage.decommission.fallbackStorage.subDirectories` that allows to control the maximum number of directories created by the `FallbackStorage` per shuffle.

### Why are the changes needed?
The current implementation creates a directory foreach shuffle file that is being copied. For instance, a 100,000 partition shuffle creates 100,000 directories, each containing a single file. While S3 is very happy about this strategy, other filesystem might unnecessarily struggle. Some control about the upper limit of directories is useful.

### Does this PR introduce _any_ user-facing change?
Adds option `spark.storage.decommission.fallbackStorage.subDirectories`.

### How was this patch tested?
Added unit tests.

### Was this patch authored or co-authored using generative AI tooling?
No