### PR TITLE
[SPARK-50418][SQL] Allow an optional trailing comma at the end of SELECT lists

### DIFF
--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -40,6 +40,11 @@ options { tokenVocab = SqlBaseLexer; }
    * When true, double quoted literals are identifiers rather than STRINGs.
    */
   public boolean double_quoted_identifiers = false;
+
+  /**
+   * When true, SELECT lists (and other named expression lists) support an optional trailing comma.
+   */
+  public boolean optional_trailing_comma_in_named_expression_lists = true;
 }
 
 compoundOrSingleStatement
@@ -1025,7 +1030,10 @@ namedExpression
     ;
 
 namedExpressionSeq
-    : namedExpression (COMMA namedExpression)*
+    : namedExpression
+        {optional_trailing_comma_in_named_expression_lists}? (COMMA namedExpression)* COMMA?
+    | namedExpression
+        {!optional_trailing_comma_in_named_expression_lists}? (COMMA namedExpression)*
     ;
 
 partitionFieldList

--- a/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
+++ b/sql/api/src/main/antlr4/org/apache/spark/sql/catalyst/parser/SqlBaseParser.g4
@@ -1030,10 +1030,10 @@ namedExpression
     ;
 
 namedExpressionSeq
-    : namedExpression
-        {optional_trailing_comma_in_named_expression_lists}? (COMMA namedExpression)* COMMA?
-    | namedExpression
-        {!optional_trailing_comma_in_named_expression_lists}? (COMMA namedExpression)*
+    : {optional_trailing_comma_in_named_expression_lists}?
+        namedExpression (COMMA namedExpression)* COMMA?
+    | {!optional_trailing_comma_in_named_expression_lists}?
+        namedExpression (COMMA namedExpression)*
     ;
 
 partitionFieldList

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/parsers.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/parser/parsers.scala
@@ -70,6 +70,8 @@ abstract class AbstractParser extends DataTypeParserInterface with Logging {
     parser.legacy_exponent_literal_as_decimal_enabled = conf.exponentLiteralAsDecimalEnabled
     parser.SQL_standard_keyword_behavior = conf.enforceReservedKeywords
     parser.double_quoted_identifiers = conf.doubleQuotedIdentifiers
+    parser.optional_trailing_comma_in_named_expression_lists =
+      conf.optionalTrailingCommaInNamedExpressionLists
 
     // https://github.com/antlr/antlr4/issues/192#issuecomment-15238595
     // Save a great deal of time on correct inputs by using a two-stage parsing strategy.

--- a/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConf.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/internal/SqlApiConf.scala
@@ -47,6 +47,7 @@ private[sql] trait SqlApiConf {
   def stackTracesInDataFrameContext: Int
   def dataFrameQueryContextEnabled: Boolean
   def legacyAllowUntypedScalaUDFs: Boolean
+  def optionalTrailingCommaInNamedExpressionLists: Boolean
 }
 
 private[sql] object SqlApiConf {
@@ -87,4 +88,5 @@ private[sql] object DefaultSqlApiConf extends SqlApiConf {
   override def stackTracesInDataFrameContext: Int = 1
   override def dataFrameQueryContextEnabled: Boolean = true
   override def legacyAllowUntypedScalaUDFs: Boolean = false
+  override def optionalTrailingCommaInNamedExpressionLists: Boolean = true
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5268,6 +5268,15 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val OPTIONAL_TRAILING_COMMA_IN_NAMED_EXPRESSION_LISTS =
+    buildConf("spark.sql.optionalTrailingCommaInNamedExpressionLists")
+      .internal()
+      .doc("When set to true, SELECT lists (and other places named expression lists are " +
+        "supported) allow an optional trailing comma at the end of the list.")
+      .version("4.0.0")
+      .booleanConf
+      .createWithDefault(true)
+
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -6106,6 +6115,9 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
 
   override def setOpsPrecedenceEnforced: Boolean =
     getConf(SQLConf.LEGACY_SETOPS_PRECEDENCE_ENABLED)
+
+  override def optionalTrailingCommaInNamedExpressionLists: Boolean =
+    getConf(SQLConf.OPTIONAL_TRAILING_COMMA_IN_NAMED_EXPRESSION_LISTS)
 
   override def exponentLiteralAsDecimalEnabled: Boolean =
     getConf(SQLConf.LEGACY_EXPONENT_LITERAL_AS_DECIMAL_ENABLED)

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -1974,4 +1974,16 @@ class PlanParserSuite extends AnalysisTest {
     assert(unresolvedRelation2.options == CaseInsensitiveStringMap.empty)
     assert(unresolvedRelation2.isStreaming)
   }
+
+  test("SPARK-50418: Support an optional trailing comma at the end of SELECT lists") {
+    withSQLConf(SQLConf.OPTIONAL_TRAILING_COMMA_IN_NAMED_EXPRESSION_LISTS.key -> "true") {
+      assertEqual("select 1, ", OneRowRelation().select(1))
+    }
+    withSQLConf(SQLConf.OPTIONAL_TRAILING_COMMA_IN_NAMED_EXPRESSION_LISTS.key -> "false") {
+      checkError(
+        exception = parseException("select 1,"),
+        condition = "PARSE_SYNTAX_ERROR",
+        parameters = Map("error" -> "','", "hint" -> ""))
+    }
+  }
 }

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/parser/PlanParserSuite.scala
@@ -501,7 +501,7 @@ class PlanParserSuite extends AnalysisTest {
     checkError(
       exception = parseException(sql1),
       condition = "PARSE_SYNTAX_ERROR",
-      parameters = Map("error" -> "'b'", "hint" -> ": extra input 'b'"))
+      parameters = Map("error" -> "'b'", "hint" -> ""))
   }
 
   test("limit") {
@@ -1978,12 +1978,14 @@ class PlanParserSuite extends AnalysisTest {
   test("SPARK-50418: Support an optional trailing comma at the end of SELECT lists") {
     withSQLConf(SQLConf.OPTIONAL_TRAILING_COMMA_IN_NAMED_EXPRESSION_LISTS.key -> "true") {
       assertEqual("select 1, ", OneRowRelation().select(1))
+      assertEqual("select 1, 2", OneRowRelation().select(1, 2))
     }
     withSQLConf(SQLConf.OPTIONAL_TRAILING_COMMA_IN_NAMED_EXPRESSION_LISTS.key -> "false") {
+      assertEqual("select 1, 2", OneRowRelation().select(1, 2))
       checkError(
         exception = parseException("select 1,"),
         condition = "PARSE_SYNTAX_ERROR",
-        parameters = Map("error" -> "','", "hint" -> ""))
+        parameters = Map("error" -> "'1'", "hint" -> ""))
     }
   }
 }

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/window_part3.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/postgreSQL/window_part3.sql.out
@@ -400,7 +400,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "sqlState" : "42601",
   "messageParameters" : {
     "error" : "'BY'",
-    "hint" : ": extra input 'BY'"
+    "hint" : ""
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/analyzer-results/sql-session-variables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/analyzer-results/sql-session-variables.sql.out
@@ -2018,7 +2018,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "errorClass" : "PARSE_SYNTAX_ERROR",
   "sqlState" : "42601",
   "messageParameters" : {
-    "error" : "'('",
+    "error" : "'c1'",
     "hint" : ""
   }
 }

--- a/sql/core/src/test/resources/sql-tests/results/postgreSQL/window_part3.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/postgreSQL/window_part3.sql.out
@@ -425,7 +425,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "sqlState" : "42601",
   "messageParameters" : {
     "error" : "'BY'",
-    "hint" : ": extra input 'BY'"
+    "hint" : ""
   }
 }
 

--- a/sql/core/src/test/resources/sql-tests/results/sql-session-variables.sql.out
+++ b/sql/core/src/test/resources/sql-tests/results/sql-session-variables.sql.out
@@ -2189,7 +2189,7 @@ org.apache.spark.sql.catalyst.parser.ParseException
   "errorClass" : "PARSE_SYNTAX_ERROR",
   "sqlState" : "42601",
   "messageParameters" : {
-    "error" : "'('",
+    "error" : "'c1'",
     "hint" : ""
   }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryCompilationErrorsSuite.scala
@@ -1029,8 +1029,10 @@ class QueryCompilationErrorsSuite
         sql(s"SELECT from from FROM from from")
         sql(s"SELECT c1, from FROM VALUES(1, 2) AS T(c1, from)")
 
-        intercept[ParseException] {
-          sql("SELECT 1,")
+        withSQLConf(SQLConf.OPTIONAL_TRAILING_COMMA_IN_NAMED_EXPRESSION_LISTS.key -> "false") {
+          intercept[ParseException] {
+            sql("SELECT 1,")
+          }
         }
       }
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -680,7 +680,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession with SQL
       exception = parseException("SELECT CAST(struct(1,2,3) AS STRUCT<INT>)"),
       condition = "PARSE_SYNTAX_ERROR",
       sqlState = "42601",
-      parameters = Map("error" -> "'<'", "hint" -> ": missing ')'"))
+      parameters = Map("error" -> "'>'", "hint" -> ""))
     // Create column of struct type without specifying field type in lowercase
     checkError(
       exception = parseException("CREATE TABLE tbl_120691 (col1 struct)"),
@@ -707,7 +707,7 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession with SQL
       exception = parseException("SELECT CAST(map('1',2) AS MAP<STRING>)"),
       condition = "PARSE_SYNTAX_ERROR",
       sqlState = "42601",
-      parameters = Map("error" -> "'<'", "hint" -> ": missing ')'"))
+      parameters = Map("error" -> "'>'", "hint" -> ""))
     // Create column of map type without specifying key/value types in lowercase
     checkError(
       exception = parseException("SELECT CAST(map('1',2) AS map)"),


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR extends the Spark SQL grammar to allow an optional trailing comma at the end of SELECT lists, and other named expression lists.

This behavior is controlled by the configuration `spark.sql.optionalTrailingCommaInNamedExpressionLists` (`SQLConf.get.OPTIONAL_TRAILING_COMMA_IN_NAMED_EXPRESSION_LISTS`). The new configuration is true by default as of its introduction in this PR.

For example, this query was not valid syntax before, but is now:

```
SELECT 1, 2, FROM t
```

### Why are the changes needed?

After deliberation, we decided it was useful to have this support to help with migration from other legacy databases.

### Does this PR introduce _any_ user-facing change?

Yes, see above.

### How was this patch tested?

This PR adds unit test cases with the configuration enabled and disabled.

### Was this patch authored or co-authored using generative AI tooling?

No.