### PR TITLE
[SPARK-50421][CORE] Fix executor related memory config incorrect when multiple resource profiles worked

### DIFF
--- a/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
@@ -243,7 +243,7 @@ private[spark] object LogKeys {
   case object EXECUTOR_LAUNCH_COMMANDS extends LogKey
   case object EXECUTOR_MEMORY_SIZE extends LogKey
   case object EXECUTOR_MEMORY_OFFHEAP extends LogKey
-  case object EXECUTOR_MEMORY_OVERHEAD extends LogKey
+  case object EXECUTOR_MEMORY_OVERHEAD_SIZE extends LogKey
   case object EXECUTOR_RESOURCES extends LogKey
   case object EXECUTOR_SHUFFLE_INFO extends LogKey
   case object EXECUTOR_STATE extends LogKey

--- a/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
@@ -241,9 +241,9 @@ private[spark] object LogKeys {
   case object EXECUTOR_ID extends LogKey
   case object EXECUTOR_IDS extends LogKey
   case object EXECUTOR_LAUNCH_COMMANDS extends LogKey
-  case object EXECUTOR_MEMORY_SIZE extends LogKey
   case object EXECUTOR_MEMORY_OFFHEAP extends LogKey
   case object EXECUTOR_MEMORY_OVERHEAD_SIZE extends LogKey
+  case object EXECUTOR_MEMORY_SIZE extends LogKey
   case object EXECUTOR_RESOURCES extends LogKey
   case object EXECUTOR_SHUFFLE_INFO extends LogKey
   case object EXECUTOR_STATE extends LogKey

--- a/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
+++ b/common/utils/src/main/scala/org/apache/spark/internal/LogKey.scala
@@ -242,6 +242,8 @@ private[spark] object LogKeys {
   case object EXECUTOR_IDS extends LogKey
   case object EXECUTOR_LAUNCH_COMMANDS extends LogKey
   case object EXECUTOR_MEMORY_SIZE extends LogKey
+  case object EXECUTOR_MEMORY_OFFHEAP extends LogKey
+  case object EXECUTOR_MEMORY_OVERHEAD extends LogKey
   case object EXECUTOR_RESOURCES extends LogKey
   case object EXECUTOR_SHUFFLE_INFO extends LogKey
   case object EXECUTOR_STATE extends LogKey

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -495,7 +495,7 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
               // Maybe don't need to set this since it's nearly used by tasks.
               driverConf.set(EXECUTOR_MEMORY_OVERHEAD.key, request.amount.toString + "m")
               logInfo(log"Set executor memory_overhead to " +
-                log"${MDC(LogKeys.EXECUTOR_MEMORY_OVERHEAD, request)}")
+                log"${MDC(LogKeys.EXECUTOR_MEMORY_OVERHEAD_SIZE, request)}")
             case (ResourceProfile.CORES, request) =>
               driverConf.set(EXECUTOR_CORES.key, request.amount.toString)
               logInfo(log"Set executor cores to ${MDC(LogKeys.NUM_EXECUTOR_CORES, request)}")

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -489,16 +489,19 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
               if (request.amount > 0) {
                 driverConf.set(MEMORY_OFFHEAP_ENABLED.key, "true")
               }
-              logInfo(s"set off heap memory to $request")
+              logInfo(log"Set executor off-heap memory to " +
+                log"${MDC(LogKeys.EXECUTOR_MEMORY_SIZE, request)}")
             case (ResourceProfile.MEMORY, request) =>
               driverConf.set(EXECUTOR_MEMORY.key, request.amount.toString + "m")
-              logInfo(s"set memory to $request")
+              logInfo(log"Set executor memory to ${MDC(LogKeys.EXECUTOR_MEMORY_SIZE, request)}")
             case (ResourceProfile.OVERHEAD_MEM, request) =>
               driverConf.set(EXECUTOR_MEMORY_OVERHEAD.key, request.amount.toString + "m")
-              logInfo(s"set memory_overhead to $request")
+              logInfo(log"Set executor memory_overhead to " +
+                log"${MDC(LogKeys.EXECUTOR_MEMORY_SIZE, request)}")
             case (ResourceProfile.CORES, request) =>
               driverConf.set(EXECUTOR_CORES.key, request.amount.toString)
-              logInfo(s"set executor cores to $request")
+              logInfo(log"Set executor executor cores to " +
+                log"${MDC(LogKeys.NUM_EXECUTOR_CORES, request)}")
             case _ =>
           }
       }

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -486,22 +486,19 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
           .foreach {
             case (ResourceProfile.OFFHEAP_MEM, request) =>
               driverConf.set(MEMORY_OFFHEAP_SIZE.key, request.amount.toString + "m")
-              if (request.amount > 0) {
-                driverConf.set(MEMORY_OFFHEAP_ENABLED.key, "true")
-              }
               logInfo(log"Set executor off-heap memory to " +
-                log"${MDC(LogKeys.EXECUTOR_MEMORY_SIZE, request)}")
+                log"${MDC(LogKeys.EXECUTOR_MEMORY_OFFHEAP, request)}")
             case (ResourceProfile.MEMORY, request) =>
               driverConf.set(EXECUTOR_MEMORY.key, request.amount.toString + "m")
               logInfo(log"Set executor memory to ${MDC(LogKeys.EXECUTOR_MEMORY_SIZE, request)}")
             case (ResourceProfile.OVERHEAD_MEM, request) =>
+              // Maybe don't need to set this since it's nearly used by tasks.
               driverConf.set(EXECUTOR_MEMORY_OVERHEAD.key, request.amount.toString + "m")
               logInfo(log"Set executor memory_overhead to " +
-                log"${MDC(LogKeys.EXECUTOR_MEMORY_SIZE, request)}")
+                log"${MDC(LogKeys.EXECUTOR_MEMORY_OVERHEAD, request)}")
             case (ResourceProfile.CORES, request) =>
               driverConf.set(EXECUTOR_CORES.key, request.amount.toString)
-              logInfo(log"Set executor executor cores to " +
-                log"${MDC(LogKeys.NUM_EXECUTOR_CORES, request)}")
+              logInfo(log"Set executor cores to ${MDC(LogKeys.NUM_EXECUTOR_CORES, request)}")
             case _ =>
           }
       }

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -485,14 +485,14 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
           .executorResources
           .foreach {
             case (ResourceProfile.OFFHEAP_MEM, request) =>
-              driverConf.set(MEMORY_OFFHEAP_SIZE.key, request.amount.toString)
+              driverConf.set(MEMORY_OFFHEAP_SIZE.key, request.amount.toString + "m")
               driverConf.set(MEMORY_OFFHEAP_ENABLED.key, "true")
               logInfo(s"set off heap memory to $request")
             case (ResourceProfile.MEMORY, request) =>
-              driverConf.set(EXECUTOR_MEMORY.key, request.amount.toString)
+              driverConf.set(EXECUTOR_MEMORY.key, request.amount.toString + "m")
               logInfo(s"set memory to $request")
             case (ResourceProfile.OVERHEAD_MEM, request) =>
-              driverConf.set(EXECUTOR_MEMORY_OVERHEAD.key, request.amount.toString)
+              driverConf.set(EXECUTOR_MEMORY_OVERHEAD.key, request.amount.toString + "m")
               logInfo(s"set memory_overhead to $request")
             case _ =>
           }

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -486,7 +486,9 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
           .foreach {
             case (ResourceProfile.OFFHEAP_MEM, request) =>
               driverConf.set(MEMORY_OFFHEAP_SIZE.key, request.amount.toString + "m")
-              driverConf.set(MEMORY_OFFHEAP_ENABLED.key, "true")
+              if (request.amount > 0) {
+                driverConf.set(MEMORY_OFFHEAP_ENABLED.key, "true")
+              }
               logInfo(s"set off heap memory to $request")
             case (ResourceProfile.MEMORY, request) =>
               driverConf.set(EXECUTOR_MEMORY.key, request.amount.toString + "m")

--- a/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/CoarseGrainedExecutorBackend.scala
@@ -494,6 +494,9 @@ private[spark] object CoarseGrainedExecutorBackend extends Logging {
             case (ResourceProfile.OVERHEAD_MEM, request) =>
               driverConf.set(EXECUTOR_MEMORY_OVERHEAD.key, request.amount.toString + "m")
               logInfo(s"set memory_overhead to $request")
+            case (ResourceProfile.CORES, request) =>
+              driverConf.set(EXECUTOR_CORES.key, request.amount.toString)
+              logInfo(s"set executor cores to $request")
             case _ =>
           }
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Reset the executor's env memory related config when resource profile is not as the default resource profile!




### Why are the changes needed?
When multiple resource profile exists in the same spark application, now the executor's memory related config is not override by resource profile's memory size, which will cause maxOffHeap in `UnifiedMemoryManager` is not correct.
See https://issues.apache.org/jira/browse/SPARK-50421 for more details


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Tests in our inner spark version and jobs.

### Was this patch authored or co-authored using generative AI tooling?
No
