### PR TITLE
[SPARK-50425][BUILD] Bump Apache Parquet to 1.15.0

### DIFF
--- a/dev/deps/spark-deps-hadoop-3-hive-2.3
+++ b/dev/deps/spark-deps-hadoop-3-hive-2.3
@@ -111,7 +111,6 @@ jackson-core/2.18.2//jackson-core-2.18.2.jar
 jackson-databind/2.18.2//jackson-databind-2.18.2.jar
 jackson-dataformat-cbor/2.18.2//jackson-dataformat-cbor-2.18.2.jar
 jackson-dataformat-yaml/2.18.2//jackson-dataformat-yaml-2.18.2.jar
-jackson-datatype-jdk8/2.17.0//jackson-datatype-jdk8-2.17.0.jar
 jackson-datatype-jsr310/2.18.2//jackson-datatype-jsr310-2.18.2.jar
 jackson-mapper-asl/1.9.13//jackson-mapper-asl-1.9.13.jar
 jackson-module-scala_2.13/2.18.2//jackson-module-scala_2.13-2.18.2.jar
@@ -241,12 +240,12 @@ orc-shims/2.0.3//orc-shims-2.0.3.jar
 oro/2.0.8//oro-2.0.8.jar
 osgi-resource-locator/1.0.3//osgi-resource-locator-1.0.3.jar
 paranamer/2.8//paranamer-2.8.jar
-parquet-column/1.14.4//parquet-column-1.14.4.jar
-parquet-common/1.14.4//parquet-common-1.14.4.jar
-parquet-encoding/1.14.4//parquet-encoding-1.14.4.jar
-parquet-format-structures/1.14.4//parquet-format-structures-1.14.4.jar
-parquet-hadoop/1.14.4//parquet-hadoop-1.14.4.jar
-parquet-jackson/1.14.4//parquet-jackson-1.14.4.jar
+parquet-column/1.15.0//parquet-column-1.15.0.jar
+parquet-common/1.15.0//parquet-common-1.15.0.jar
+parquet-encoding/1.15.0//parquet-encoding-1.15.0.jar
+parquet-format-structures/1.15.0//parquet-format-structures-1.15.0.jar
+parquet-hadoop/1.15.0//parquet-hadoop-1.15.0.jar
+parquet-jackson/1.15.0//parquet-jackson-1.15.0.jar
 pickle/1.5//pickle-1.5.jar
 py4j/0.10.9.7//py4j-0.10.9.7.jar
 remotetea-oncrpc/1.1.2//remotetea-oncrpc-1.1.2.jar

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <kafka.version>3.9.0</kafka.version>
     <!-- After 10.17.1.0, the minimum required version is JDK19 -->
     <derby.version>10.16.1.1</derby.version>
-    <parquet.version>1.14.4</parquet.version>
+    <parquet.version>1.15.0</parquet.version>
     <orc.version>2.0.3</orc.version>
     <orc.classifier>shaded-protobuf</orc.classifier>
     <jetty.version>11.0.24</jetty.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Bumps to the latest version of Parquet. 

For the full list of changes, please check the pre-release:

https://github.com/apache/parquet-java/releases/tag/apache-parquet-1.15.0

Including some interesting patches for Spark, such as https://github.com/apache/parquet-java/pull/3030


### Why are the changes needed?

To bring the latest features and bug fixes for Apache Spark 4.0.0.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.