### PR TITLE
[WIP][SPARK-50392][PYTHON] Implement partitionBy, orderBy and withSinglePartition of df.argument() in Spark Classic

### DIFF
--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -588,6 +588,11 @@ class Dataset[T] private[sql] (
   // TODO(SPARK-50134): Support scalar Subquery API in Spark Connect
   // scalastyle:off not.implemented.error.usage
   /** @inheritdoc */
+  def argument(): Column = {
+    ???
+  }
+
+  /** @inheritdoc */
   def scalar(): Column = {
     ???
   }

--- a/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/connector/connect/client/jvm/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -588,7 +588,11 @@ class Dataset[T] private[sql] (
   // TODO(SPARK-50134): Support scalar Subquery API in Spark Connect
   // scalastyle:off not.implemented.error.usage
   /** @inheritdoc */
-  def argument(): Column = {
+  def argument(
+    partitionBy: Seq[Column] = Seq.empty,
+    orderBy: Seq[Column] = Seq.empty,
+    withSinglePartition: Boolean = false
+  ): Column = {
     ???
   }
 

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1786,6 +1786,9 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         else:
             return DataFrame(self._jdf.transpose(), self.sparkSession)
 
+    def argument(self) -> Column:
+        return Column(self._jdf.argument())
+
     def scalar(self) -> Column:
         return Column(self._jdf.scalar())
 

--- a/python/pyspark/sql/classic/dataframe.py
+++ b/python/pyspark/sql/classic/dataframe.py
@@ -1786,8 +1786,15 @@ class DataFrame(ParentDataFrame, PandasMapOpsMixin, PandasConversionMixin):
         else:
             return DataFrame(self._jdf.transpose(), self.sparkSession)
 
-    def argument(self) -> Column:
-        return Column(self._jdf.argument())
+    def argument(
+        self,
+        partitionBy: Optional[List["ColumnOrName"]] = None,
+        orderBy: Optional[List["ColumnOrName"]] = None,
+        withSinglePartition: bool = False,
+    ) -> Column:
+        partitionByExprs = self._jcols(*(partitionBy or []))
+        orderByExprs = self._jcols(*(orderBy or []))
+        return Column(self._jdf.argument(partitionByExprs, orderByExprs, withSinglePartition))
 
     def scalar(self) -> Column:
         return Column(self._jdf.scalar())

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1784,6 +1784,12 @@ class DataFrame(ParentDataFrame):
             self._session,
         )
 
+    def argument(self) -> Column:
+        raise PySparkNotImplementedError(
+            errorClass="NOT_IMPLEMENTED",
+            messageParameters={"feature": "argument()"},
+        )
+
     def scalar(self) -> Column:
         # TODO(SPARK-50134): Implement this method
         raise PySparkNotImplementedError(

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1785,6 +1785,7 @@ class DataFrame(ParentDataFrame):
         )
 
     def argument(self) -> Column:
+        # TODO(SPARK-50393): Implement this method
         raise PySparkNotImplementedError(
             errorClass="NOT_IMPLEMENTED",
             messageParameters={"feature": "argument()"},

--- a/python/pyspark/sql/connect/dataframe.py
+++ b/python/pyspark/sql/connect/dataframe.py
@@ -1784,7 +1784,12 @@ class DataFrame(ParentDataFrame):
             self._session,
         )
 
-    def argument(self) -> Column:
+    def argument(
+        self,
+        partitionBy: Optional[List["ColumnOrName"]] = None,
+        orderBy: Optional[List["ColumnOrName"]] = None,
+        withSinglePartition: bool = False,
+    ) -> Column:
         # TODO(SPARK-50393): Implement this method
         raise PySparkNotImplementedError(
             errorClass="NOT_IMPLEMENTED",

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -6499,7 +6499,7 @@ class DataFrame:
         ...         if row[0] > 5:
         ...             yield row[0],
         >>> df = spark.range(8)
-        >>> TestUDTF(df.argument()).show()
+        >>> TestUDTF(df.argument()).show()  # doctest: +SKIP
         +---+
         |  a|
         +---+

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -6476,6 +6476,39 @@ class DataFrame:
         """
         ...
 
+    def argument(self) -> Column:
+        """
+        Converts the DataFrame into a `Column` object for use with table-valued functions (TVFs)
+        or user-defined table functions (UDTFs).
+
+        .. versionadded:: 4.0.0
+
+        Returns
+        -------
+        :class:`Column`
+            A `Column` object representing the DataFrame.
+
+        Examples
+        --------
+        >>> from pyspark.sql import Row
+        >>> from pyspark.sql.functions import udtf
+        >>>
+        >>> @udtf(returnType="a: int")
+        ... class TestUDTF:
+        ...     def eval(self, row: Row):
+        ...         if row[0] > 5:
+        ...             yield row[0],
+        >>> df = spark.range(8)
+        >>> TestUDTF(df.argument()).show()
+        +---+
+        |  a|
+        +---+
+        |  6|
+        |  7|
+        +---+
+        """
+        ...
+
     def scalar(self) -> Column:
         """
         Return a `Column` object for a SCALAR Subquery containing exactly one row and one column.

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -6476,12 +6476,28 @@ class DataFrame:
         """
         ...
 
-    def argument(self) -> Column:
+    def argument(
+        self,
+        partitionBy: Optional[List["ColumnOrName"]] = None,
+        orderBy: Optional[List["ColumnOrName"]] = None,
+        withSinglePartition: bool = False,
+    ) -> Column:
         """
         Converts the DataFrame into a `Column` object for use with table-valued functions (TVFs)
         or user-defined table functions (UDTFs).
 
         .. versionadded:: 4.0.0
+
+        Parameters
+        ----------
+        partitionBy : list of str or :class:`Column`, optional
+            A list of `Column` objects specifying how to partition the data. Rows with the same values
+            in the specified columns are grouped into the same partition. If None, no partitioning is applied.
+        orderBy : list of str or :class:`Column`, optional
+            A list of `Column` objects specifying how to order rows within each partition.
+            If None, no specific ordering is applied.
+        withSinglePartition : bool, optional
+            If True, forces the entire data into a single partition. Defaults to False.
 
         Returns
         -------

--- a/python/pyspark/sql/tests/connect/test_parity_udtf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udtf.py
@@ -76,7 +76,7 @@ class UDTFParityTests(BaseUDTFTestsMixin, ReusedConnectTestCase):
     def test_udtf_access_spark_session(self):
         super().test_udtf_access_spark_session()
 
-    @unittest.skip("Spark Connect does not support df.argument()")
+    @unittest.skip("TODO(SPARK-50393): support df.argument() in Spark Connect")
     def test_df_argument(self):
         super().test_df_argument()
 

--- a/python/pyspark/sql/tests/connect/test_parity_udtf.py
+++ b/python/pyspark/sql/tests/connect/test_parity_udtf.py
@@ -76,6 +76,10 @@ class UDTFParityTests(BaseUDTFTestsMixin, ReusedConnectTestCase):
     def test_udtf_access_spark_session(self):
         super().test_udtf_access_spark_session()
 
+    @unittest.skip("Spark Connect does not support df.argument()")
+    def test_df_argument(self):
+        super().test_df_argument()
+
     def _add_pyfile(self, path):
         self.spark.addArtifacts(path, pyfile=True)
 

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -1024,6 +1024,19 @@ class BaseUDTFTestsMixin:
             [Row(a=6), Row(a=7)],
         )
 
+    def test_df_argument(self):
+        class TestUDTF:
+            def eval(self, row: Row):
+                if row["id"] > 5:
+                    yield row["id"],
+
+        func = udtf(TestUDTF, returnType="a: int")
+        df = self.spark.range(8)
+        self.assertEqual(
+            func(df.argument()).collect(),
+            [Row(a=6), Row(a=7)],
+        )
+
     def udtf_for_table_argument(self):
         class TestUDTF:
             def eval(self, row: Row):

--- a/python/pyspark/sql/tests/test_udtf.py
+++ b/python/pyspark/sql/tests/test_udtf.py
@@ -1025,16 +1025,12 @@ class BaseUDTFTestsMixin:
         )
 
     def test_df_argument(self):
-        class TestUDTF:
-            def eval(self, row: Row):
-                if row["id"] > 5:
-                    yield row["id"],
-
-        func = udtf(TestUDTF, returnType="a: int")
+        func = self.udtf_for_table_argument()
         df = self.spark.range(8)
-        self.assertEqual(
-            func(df.argument()).collect(),
-            [Row(a=6), Row(a=7)],
+        self.spark.udtf.register("test_udtf", func)
+        assertDataFrameEqual(
+            func(df.argument()),
+            self.spark.sql("SELECT * FROM test_udtf(TABLE (SELECT id FROM range(0, 8)))"),
         )
 
     def udtf_for_table_argument(self):

--- a/sql/api/src/main/scala/org/apache/spark/sql/api/Dataset.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/api/Dataset.scala
@@ -1700,6 +1700,15 @@ abstract class Dataset[T] extends Serializable {
   def transpose(): Dataset[Row]
 
   /**
+   * Converts the DataFrame into a `Column` object for use with table-valued functions (TVFs)
+   * or user-defined table functions (UDTFs).
+   *
+   * @group typedrel
+   * @since 4.0.0
+   */
+  def argument(): Column
+
+  /**
    * Return a `Column` object for a SCALAR Subquery containing exactly one row and one column.
    *
    * The `scalar()` method is useful for extracting a `Column` object that represents a scalar

--- a/sql/api/src/main/scala/org/apache/spark/sql/api/Dataset.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/api/Dataset.scala
@@ -1700,8 +1700,8 @@ abstract class Dataset[T] extends Serializable {
   def transpose(): Dataset[Row]
 
   /**
-   * Converts the DataFrame into a `Column` object for use with table-valued functions (TVFs)
-   * or user-defined table functions (UDTFs).
+   * Converts the DataFrame into a `Column` object for use with table-valued functions (TVFs) or
+   * user-defined table functions (UDTFs).
    *
    * @group typedrel
    * @since 4.0.0

--- a/sql/api/src/main/scala/org/apache/spark/sql/api/Dataset.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/api/Dataset.scala
@@ -1703,10 +1703,18 @@ abstract class Dataset[T] extends Serializable {
    * Converts the DataFrame into a `Column` object for use with table-valued functions (TVFs) or
    * user-defined table functions (UDTFs).
    *
+   * @param partitionBy Columns to partition by (default: empty).
+   * @param orderBy Columns to order by within partitions (default: empty).
+   * @param withSinglePartition Whether to force a single partition (default: false).
+   *
    * @group typedrel
    * @since 4.0.0
    */
-  def argument(): Column
+  def argument(
+    partitionBy: Seq[Column] = Seq.empty,
+    orderBy: Seq[Column] = Seq.empty,
+    withSinglePartition: Boolean = false
+  ): Column
 
   /**
    * Return a `Column` object for a SCALAR Subquery containing exactly one row and one column.

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -995,8 +995,20 @@ class Dataset[T] private[sql](
   }
 
   /** @inheritdoc */
-  def argument(): Column = {
-    val tableExpr = FunctionTableSubqueryArgumentExpression(logicalPlan)
+  def argument(
+    partitionBy: Seq[Column] = Seq.empty,
+    orderBy: Seq[Column] = Seq.empty,
+    withSinglePartition: Boolean = false
+  ): Column = {
+    val partitionByExpressions: Seq[Expression] = partitionBy.map(_.expr)
+    val orderByExpressions: Seq[SortOrder] = orderBy.map(_.expr.asInstanceOf[SortOrder])
+
+    val tableExpr = FunctionTableSubqueryArgumentExpression(
+      plan = logicalPlan,
+      partitionByExpressions = partitionByExpressions,
+      withSinglePartition = withSinglePartition,
+      orderByExpressions = orderByExpressions
+    )
     Column(tableExpr)
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -994,6 +994,7 @@ class Dataset[T] private[sql](
     )
   }
 
+  /** @inheritdoc */
   def argument(): Column = {
     val tableExpr = FunctionTableSubqueryArgumentExpression(logicalPlan)
     Column(tableExpr)

--- a/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/Dataset.scala
@@ -994,6 +994,11 @@ class Dataset[T] private[sql](
     )
   }
 
+  def argument(): Column = {
+    val tableExpr = FunctionTableSubqueryArgumentExpression(logicalPlan)
+    Column(tableExpr)
+  }
+
   /** @inheritdoc */
   def scalar(): Column = {
     Column(ExpressionColumnNode(

--- a/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/DataFrameSuite.scala
@@ -282,6 +282,10 @@ class DataFrameSuite extends QueryTest
       Row("1", 1) :: Nil)
   }
 
+  test("df.argument") {
+    assert(spark.range(1).argument().isInstanceOf[Column])
+  }
+
   test("filterExpr") {
     val res = testData.collect().filter(_.getInt(0) > 90).toSeq
     checkAnswer(testData.filter("key > 90"), res)


### PR DESCRIPTION


### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
