### PR TITLE
[SPARK-50437][SS] Reduce overhead of creating deserializers in TransformWithStateExec

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -86,14 +86,8 @@ case class TransformWithStateExec(
   // We need to just initialize key and value deserializer once per partition.
   // The deserializers need to be lazily created on the executor since they
   // are not serializable.
-  // TODO we can further optimize this to be done once per query.
-  // Currently, the deserializers are created once per partition per batch.
-  // We can improve this by creating the deserializers once per query run.
-  // To do this, we need adjust certain APIs in CodeGenerator to allow
-  // us to generate the code and compile it separately.  We can
-  // generate the java code on the driver side and compile it on the executor side.
-  // Note that we only need to compile it once on the executor side since there is a cache
-  // that allows us to reuse the compiled code.
+  // Ideas for for improvement can be found here:
+  // https://issues.apache.org/jira/browse/SPARK-50437
   private lazy val getKeyObj =
     ObjectOperator.deserializeRowToObject(keyDeserializer, groupingAttributes)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

An optimization that creates deserializers for keys and values at the beginning of a batch.

### Why are the changes needed?
Currently, deserializers for key and values are created every time `handleInputRows` gets called.   The function
`ObjectOperator.deserializeRowToObject` is called twice do generate the deserializer for the key and value.  The function will do the following things
1. Generate java code for the deserializer based on input expression and grouping attributes
2. Compile that java code to java class

The problem is that step 1 will occur every time the function is called.  The compiling the code, i.e. step 2, will only happen once since the generated class will be cached and can be reused.

Step 1 can incur a heavy penalty in situations where handleInputRows will be called many times.  For example, if there are many distinct keys.  Note that handleInputRows is called once per distinct key.

Here is a flamegraph:

![Uploading Screenshot 2024-11-26 at 11.55.12 PM.png…]()



### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

Existing tests should suffice

### Was this patch authored or co-authored using generative AI tooling?
No
