### PR TITLE
[SPARK-50447][SQL] Skip the parameter mode check in `Call` command

### DIFF
--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/procedures/ProcedureParameter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/procedures/ProcedureParameter.java
@@ -24,6 +24,7 @@ import org.apache.spark.sql.internal.connector.ProcedureParameterImpl;
 import org.apache.spark.sql.types.DataType;
 
 import static org.apache.spark.sql.connector.catalog.procedures.ProcedureParameter.Mode.IN;
+import static org.apache.spark.sql.connector.catalog.procedures.ProcedureParameter.Mode.INOUT;
 import static org.apache.spark.sql.connector.catalog.procedures.ProcedureParameter.Mode.OUT;
 
 /**

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/procedures/ProcedureParameter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/procedures/ProcedureParameter.java
@@ -24,6 +24,7 @@ import org.apache.spark.sql.internal.connector.ProcedureParameterImpl;
 import org.apache.spark.sql.types.DataType;
 
 import static org.apache.spark.sql.connector.catalog.procedures.ProcedureParameter.Mode.IN;
+import static org.apache.spark.sql.connector.catalog.procedures.ProcedureParameter.Mode.OUT;
 
 /**
  * A {@link Procedure procedure} parameter.
@@ -46,6 +47,28 @@ public interface ProcedureParameter {
    */
   static Builder in(String name, DataType dataType) {
     return new Builder(IN, name, dataType);
+  }
+
+  /**
+   * Creates a builder for an OUT procedure parameter.
+   *
+   * @param name the name of the parameter
+   * @param dataType the type of the parameter
+   * @return the constructed stored procedure parameter
+   */
+  static Builder out(String name, DataType dataType) {
+    return new Builder(OUT, name, dataType);
+  }
+
+  /**
+   * Creates a builder for an INOUT procedure parameter.
+   *
+   * @param name the name of the parameter
+   * @param dataType the type of the parameter
+   * @return the constructed stored procedure parameter
+   */
+  static Builder inout(String name, DataType dataType) {
+    return new Builder(INOUT, name, dataType);
   }
 
   /**

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/procedures/ProcedureParameter.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/connector/catalog/procedures/ProcedureParameter.java
@@ -92,7 +92,7 @@ public interface ProcedureParameter {
     private String defaultValueExpression;
     private String comment;
 
-    private Builder(Mode mode, String name, DataType dataType) {
+    public Builder(Mode mode, String name, DataType dataType) {
       this.mode = mode;
       this.name = name;
       this.dataType = dataType;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -48,7 +48,7 @@ import org.apache.spark.sql.connector.catalog.{View => _, _}
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
 import org.apache.spark.sql.connector.catalog.TableChange.{After, ColumnPosition}
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction
-import org.apache.spark.sql.connector.catalog.procedures.{BoundProcedure, ProcedureParameter, UnboundProcedure}
+import org.apache.spark.sql.connector.catalog.procedures.{ProcedureParameter, UnboundProcedure}
 import org.apache.spark.sql.connector.expressions.{FieldReference, IdentityTransform}
 import org.apache.spark.sql.errors.{QueryCompilationErrors, QueryExecutionErrors}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -2150,7 +2150,6 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
           if args.forall(_.resolved) =>
         val inputType = extractInputType(args)
         val bound = unbound.bind(inputType)
-        validateParameterModes(bound)
         val rearrangedArgs = NamedParametersSupport.defaultRearrange(bound, args)
         Call(ResolvedProcedure(catalog, ident, bound), rearrangedArgs, execute)
     }
@@ -2170,12 +2169,6 @@ class Analyzer(override val catalogManager: CatalogManager) extends RuleExecutor
         .putBoolean(ProcedureParameter.BY_NAME_METADATA_KEY, value = true)
         .build()
     }
-
-   private def validateParameterModes(procedure: BoundProcedure): Unit = {
-     procedure.parameters.find(_.mode != ProcedureParameter.Mode.IN).foreach { param =>
-       throw SparkException.internalError(s"Unsupported parameter mode: ${param.mode}")
-     }
-   }
   }
 
   /**

--- a/sql/core/src/test/scala/org/apache/spark/sql/connector/ProcedureSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/connector/ProcedureSuite.scala
@@ -282,22 +282,6 @@ class ProcedureSuite extends QueryTest with SharedSparkSession with BeforeAndAft
     assert(e.getMessage.contains("required arguments should come before optional arguments"))
   }
 
-  test("INOUT parameters are not supported") {
-    catalog.createProcedure(Identifier.of(Array("ns"), "procedure"), UnboundInoutProcedure)
-    val e = intercept[SparkException] {
-      sql("CALL cat.ns.procedure(1)")
-    }
-    assert(e.getMessage.contains(" Unsupported parameter mode: INOUT"))
-  }
-
-  test("OUT parameters are not supported") {
-    catalog.createProcedure(Identifier.of(Array("ns"), "procedure"), UnboundOutProcedure)
-    val e = intercept[SparkException] {
-      sql("CALL cat.ns.procedure(1)")
-    }
-    assert(e.getMessage.contains("Unsupported parameter mode: OUT"))
-  }
-
   test("EXPLAIN") {
     catalog.createProcedure(Identifier.of(Array("ns"), "sum"), UnboundNonExecutableSum)
     val explain1 = sql("EXPLAIN CALL cat.ns.sum(5, 5)").head().get(0)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Skip the parameter mode check in `Call` command


### Why are the changes needed?
The procedure interface requires all parameters's mode must be `IN` in a `Call` command, this is too strict, e.g. in [postgresql](https://www.postgresql.org/docs/current/sql-call.html)

> Arguments must be supplied for all procedure parameters that lack defaults, including OUT parameters. However, arguments matching OUT parameters are not evaluated, so it's customary to just write NULL for them. (Writing something else for an OUT parameter might cause compatibility problems with future PostgreSQL versions.)


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
ci


### Was this patch authored or co-authored using generative AI tooling?
no
