### PR TITLE
[SPARK-50464] Support unsigned integer for Arrow

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala
@@ -72,6 +72,10 @@ private[sql] object ArrowUtils {
     case int: ArrowType.Int if int.getIsSigned && int.getBitWidth == 8 * 2 => ShortType
     case int: ArrowType.Int if int.getIsSigned && int.getBitWidth == 8 * 4 => IntegerType
     case int: ArrowType.Int if int.getIsSigned && int.getBitWidth == 8 * 8 => LongType
+    case int: ArrowType.Int if !int.getIsSigned && int.getBitWidth == 8 => ShortType
+    case int: ArrowType.Int if !int.getIsSigned && int.getBitWidth == 8 * 2 => IntegerType
+    case int: ArrowType.Int if !int.getIsSigned && int.getBitWidth == 8 * 4 => LongType
+    case int: ArrowType.Int if !int.getIsSigned && int.getBitWidth == 8 * 8 => DecimalType(20, 0)
     case float: ArrowType.FloatingPoint
         if float.getPrecision() == FloatingPointPrecision.SINGLE =>
       FloatType

--- a/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
+++ b/sql/catalyst/src/main/java/org/apache/spark/sql/vectorized/ArrowColumnVector.java
@@ -162,6 +162,14 @@ public class ArrowColumnVector extends ColumnVector {
       accessor = new IntAccessor(intVector);
     } else if (vector instanceof BigIntVector bigIntVector) {
       accessor = new LongAccessor(bigIntVector);
+    } else if (vector instanceof UInt1Vector uInt1Vector) {
+      accessor = new UInt1Accessor(uInt1Vector);
+    } else if (vector instanceof UInt2Vector uInt2Vector) {
+      accessor = new UInt2Accessor(uInt2Vector);
+    } else if (vector instanceof UInt4Vector uInt4Vector) {
+      accessor = new UInt4Accessor(uInt4Vector);
+    } else if (vector instanceof UInt8Vector uInt8Vector) {
+      accessor = new UInt8Accessor(uInt8Vector);
     } else if (vector instanceof Float4Vector float4Vector) {
       accessor = new FloatAccessor(float4Vector);
     } else if (vector instanceof Float8Vector float8Vector) {
@@ -351,6 +359,66 @@ public class ArrowColumnVector extends ColumnVector {
     @Override
     final long getLong(int rowId) {
       return accessor.get(rowId);
+    }
+  }
+
+  static class UInt1Accessor extends ArrowVectorAccessor {
+
+    private final UInt1Vector accessor;
+
+    UInt1Accessor(UInt1Vector vector) {
+      super(vector);
+      this.accessor = vector;
+    }
+
+    @Override
+    final short getShort(int rowId) {
+      return (short)Byte.toUnsignedInt(accessor.get(rowId));
+    }
+  }
+
+  static class UInt2Accessor extends ArrowVectorAccessor {
+
+    private final UInt2Vector accessor;
+
+    UInt2Accessor(UInt2Vector vector) {
+      super(vector);
+      this.accessor = vector;
+    }
+
+    @Override
+    final int getInt(int rowId) {
+      return accessor.get(rowId);
+    }
+  }
+
+  static class UInt4Accessor extends ArrowVectorAccessor {
+
+    private final UInt4Vector accessor;
+
+    UInt4Accessor(UInt4Vector vector) {
+      super(vector);
+      this.accessor = vector;
+    }
+
+    @Override
+    final long getLong(int rowId) {
+      return Integer.toUnsignedLong(accessor.get(rowId));
+    }
+  }
+
+  static class UInt8Accessor extends ArrowVectorAccessor {
+
+    private final UInt8Vector accessor;
+
+    UInt8Accessor(UInt8Vector vector) {
+      super(vector);
+      this.accessor = vector;
+    }
+
+    @Override
+    final Decimal getDecimal(int rowId, int precision, int scale) {
+      return Decimal.apply(accessor.get(rowId), precision, scale);
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/vectorized/ArrowColumnVectorSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/vectorized/ArrowColumnVectorSuite.scala
@@ -29,8 +29,10 @@ class ArrowColumnVectorSuite extends SparkFunSuite {
 
   test("boolean") {
     val allocator = ArrowUtils.rootAllocator.newChildAllocator("boolean", 0, Long.MaxValue)
-    val vector = ArrowUtils.toArrowField("boolean", BooleanType, nullable = true, null)
-      .createVector(allocator).asInstanceOf[BitVector]
+    val vector = ArrowUtils
+      .toArrowField("boolean", BooleanType, nullable = true, null)
+      .createVector(allocator)
+      .asInstanceOf[BitVector]
     vector.allocateNew()
 
     (0 until 10).foreach { i =>
@@ -57,8 +59,10 @@ class ArrowColumnVectorSuite extends SparkFunSuite {
 
   test("byte") {
     val allocator = ArrowUtils.rootAllocator.newChildAllocator("byte", 0, Long.MaxValue)
-    val vector = ArrowUtils.toArrowField("byte", ByteType, nullable = true, null)
-      .createVector(allocator).asInstanceOf[TinyIntVector]
+    val vector = ArrowUtils
+      .toArrowField("byte", ByteType, nullable = true, null)
+      .createVector(allocator)
+      .asInstanceOf[TinyIntVector]
     vector.allocateNew()
 
     (0 until 10).foreach { i =>
@@ -85,8 +89,10 @@ class ArrowColumnVectorSuite extends SparkFunSuite {
 
   test("short") {
     val allocator = ArrowUtils.rootAllocator.newChildAllocator("short", 0, Long.MaxValue)
-    val vector = ArrowUtils.toArrowField("short", ShortType, nullable = true, null)
-      .createVector(allocator).asInstanceOf[SmallIntVector]
+    val vector = ArrowUtils
+      .toArrowField("short", ShortType, nullable = true, null)
+      .createVector(allocator)
+      .asInstanceOf[SmallIntVector]
     vector.allocateNew()
 
     (0 until 10).foreach { i =>
@@ -113,8 +119,10 @@ class ArrowColumnVectorSuite extends SparkFunSuite {
 
   test("int") {
     val allocator = ArrowUtils.rootAllocator.newChildAllocator("int", 0, Long.MaxValue)
-    val vector = ArrowUtils.toArrowField("int", IntegerType, nullable = true, null)
-      .createVector(allocator).asInstanceOf[IntVector]
+    val vector = ArrowUtils
+      .toArrowField("int", IntegerType, nullable = true, null)
+      .createVector(allocator)
+      .asInstanceOf[IntVector]
     vector.allocateNew()
 
     (0 until 10).foreach { i =>
@@ -141,8 +149,10 @@ class ArrowColumnVectorSuite extends SparkFunSuite {
 
   test("long") {
     val allocator = ArrowUtils.rootAllocator.newChildAllocator("long", 0, Long.MaxValue)
-    val vector = ArrowUtils.toArrowField("long", LongType, nullable = true, null)
-      .createVector(allocator).asInstanceOf[BigIntVector]
+    val vector = ArrowUtils
+      .toArrowField("long", LongType, nullable = true, null)
+      .createVector(allocator)
+      .asInstanceOf[BigIntVector]
     vector.allocateNew()
 
     (0 until 10).foreach { i =>
@@ -169,8 +179,10 @@ class ArrowColumnVectorSuite extends SparkFunSuite {
 
   test("float") {
     val allocator = ArrowUtils.rootAllocator.newChildAllocator("float", 0, Long.MaxValue)
-    val vector = ArrowUtils.toArrowField("float", FloatType, nullable = true, null)
-      .createVector(allocator).asInstanceOf[Float4Vector]
+    val vector = ArrowUtils
+      .toArrowField("float", FloatType, nullable = true, null)
+      .createVector(allocator)
+      .asInstanceOf[Float4Vector]
     vector.allocateNew()
 
     (0 until 10).foreach { i =>
@@ -197,8 +209,10 @@ class ArrowColumnVectorSuite extends SparkFunSuite {
 
   test("double") {
     val allocator = ArrowUtils.rootAllocator.newChildAllocator("double", 0, Long.MaxValue)
-    val vector = ArrowUtils.toArrowField("double", DoubleType, nullable = true, null)
-      .createVector(allocator).asInstanceOf[Float8Vector]
+    val vector = ArrowUtils
+      .toArrowField("double", DoubleType, nullable = true, null)
+      .createVector(allocator)
+      .asInstanceOf[Float8Vector]
     vector.allocateNew()
 
     (0 until 10).foreach { i =>
@@ -225,8 +239,10 @@ class ArrowColumnVectorSuite extends SparkFunSuite {
 
   test("string") {
     val allocator = ArrowUtils.rootAllocator.newChildAllocator("string", 0, Long.MaxValue)
-    val vector = ArrowUtils.toArrowField("string", StringType, nullable = true, null)
-      .createVector(allocator).asInstanceOf[VarCharVector]
+    val vector = ArrowUtils
+      .toArrowField("string", StringType, nullable = true, null)
+      .createVector(allocator)
+      .asInstanceOf[VarCharVector]
     vector.allocateNew()
 
     (0 until 10).foreach { i =>
@@ -252,8 +268,10 @@ class ArrowColumnVectorSuite extends SparkFunSuite {
 
   test("large_string") {
     val allocator = ArrowUtils.rootAllocator.newChildAllocator("string", 0, Long.MaxValue)
-    val vector = ArrowUtils.toArrowField("string", StringType, nullable = true, null, true)
-      .createVector(allocator).asInstanceOf[LargeVarCharVector]
+    val vector = ArrowUtils
+      .toArrowField("string", StringType, nullable = true, null, true)
+      .createVector(allocator)
+      .asInstanceOf[LargeVarCharVector]
     vector.allocateNew()
 
     (0 until 10).foreach { i =>
@@ -279,8 +297,10 @@ class ArrowColumnVectorSuite extends SparkFunSuite {
 
   test("binary") {
     val allocator = ArrowUtils.rootAllocator.newChildAllocator("binary", 0, Long.MaxValue)
-    val vector = ArrowUtils.toArrowField("binary", BinaryType, nullable = true, null, false)
-      .createVector(allocator).asInstanceOf[VarBinaryVector]
+    val vector = ArrowUtils
+      .toArrowField("binary", BinaryType, nullable = true, null, false)
+      .createVector(allocator)
+      .asInstanceOf[VarBinaryVector]
     vector.allocateNew()
 
     (0 until 10).foreach { i =>
@@ -306,8 +326,10 @@ class ArrowColumnVectorSuite extends SparkFunSuite {
 
   test("large_binary") {
     val allocator = ArrowUtils.rootAllocator.newChildAllocator("binary", 0, Long.MaxValue)
-    val vector = ArrowUtils.toArrowField("binary", BinaryType, nullable = true, null, true)
-      .createVector(allocator).asInstanceOf[LargeVarBinaryVector]
+    val vector = ArrowUtils
+      .toArrowField("binary", BinaryType, nullable = true, null, true)
+      .createVector(allocator)
+      .asInstanceOf[LargeVarBinaryVector]
     vector.allocateNew()
 
     (0 until 10).foreach { i =>
@@ -333,8 +355,10 @@ class ArrowColumnVectorSuite extends SparkFunSuite {
 
   test("array") {
     val allocator = ArrowUtils.rootAllocator.newChildAllocator("array", 0, Long.MaxValue)
-    val vector = ArrowUtils.toArrowField("array", ArrayType(IntegerType), nullable = true, null)
-      .createVector(allocator).asInstanceOf[ListVector]
+    val vector = ArrowUtils
+      .toArrowField("array", ArrayType(IntegerType), nullable = true, null)
+      .createVector(allocator)
+      .asInstanceOf[ListVector]
     vector.allocateNew()
     val elementVector = vector.getDataVector().asInstanceOf[IntVector]
 
@@ -388,8 +412,10 @@ class ArrowColumnVectorSuite extends SparkFunSuite {
   test("non nullable struct") {
     val allocator = ArrowUtils.rootAllocator.newChildAllocator("struct", 0, Long.MaxValue)
     val schema = new StructType().add("int", IntegerType).add("long", LongType)
-    val vector = ArrowUtils.toArrowField("struct", schema, nullable = false, null)
-      .createVector(allocator).asInstanceOf[StructVector]
+    val vector = ArrowUtils
+      .toArrowField("struct", schema, nullable = false, null)
+      .createVector(allocator)
+      .asInstanceOf[StructVector]
 
     vector.allocateNew()
     val intVector = vector.getChildByOrdinal(0).asInstanceOf[IntVector]
@@ -425,8 +451,10 @@ class ArrowColumnVectorSuite extends SparkFunSuite {
   test("struct") {
     val allocator = ArrowUtils.rootAllocator.newChildAllocator("struct", 0, Long.MaxValue)
     val schema = new StructType().add("int", IntegerType).add("long", LongType)
-    val vector = ArrowUtils.toArrowField("struct", schema, nullable = true, null)
-      .createVector(allocator).asInstanceOf[StructVector]
+    val vector = ArrowUtils
+      .toArrowField("struct", schema, nullable = true, null)
+      .createVector(allocator)
+      .asInstanceOf[StructVector]
     vector.allocateNew()
     val intVector = vector.getChildByOrdinal(0).asInstanceOf[IntVector]
     val longVector = vector.getChildByOrdinal(1).asInstanceOf[BigIntVector]
@@ -485,17 +513,19 @@ class ArrowColumnVectorSuite extends SparkFunSuite {
     allocator.close()
   }
 
-  test ("SPARK-38086: subclassing") {
+  test("SPARK-38086: subclassing") {
     class ChildArrowColumnVector(vector: ValueVector, n: Int)
-      extends ArrowColumnVector(vector: ValueVector) {
+        extends ArrowColumnVector(vector: ValueVector) {
 
       override def getValueVector: ValueVector = accessor.vector
       override def getInt(rowId: Int): Int = accessor.getInt(rowId) + n
     }
 
     val allocator = ArrowUtils.rootAllocator.newChildAllocator("int", 0, Long.MaxValue)
-    val vector = ArrowUtils.toArrowField("int", IntegerType, nullable = true, null)
-      .createVector(allocator).asInstanceOf[IntVector]
+    val vector = ArrowUtils
+      .toArrowField("int", IntegerType, nullable = true, null)
+      .createVector(allocator)
+      .asInstanceOf[IntVector]
     vector.allocateNew()
 
     (0 until 10).foreach { i =>
@@ -514,5 +544,52 @@ class ArrowColumnVectorSuite extends SparkFunSuite {
 
     columnVector.close()
     allocator.close()
+  }
+  test("SPARK-50464: support unsigned byte for arrow") {
+    val allocator = ArrowUtils.rootAllocator.newChildAllocator("uint1", 0, Long.MaxValue)
+    val vector = new UInt1Vector("uint1", allocator)
+    vector.allocateNew()
+    (0 until 10).foreach { i =>
+      vector.setSafe(i, i)
+    }
+    val columnVector = new ArrowColumnVector(vector)
+    assert(columnVector.dataType === ShortType)
+    assert(!columnVector.hasNull)
+  }
+
+  test("SPARK-50464: support unsigned short for arrow") {
+    val allocator = ArrowUtils.rootAllocator.newChildAllocator("uint2", 0, Long.MaxValue)
+    val vector = new UInt2Vector("uint2", allocator)
+    vector.allocateNew()
+    (0 until 10).foreach { i =>
+      vector.setSafe(i, i)
+    }
+    val columnVector = new ArrowColumnVector(vector)
+    assert(columnVector.dataType === IntegerType)
+    assert(!columnVector.hasNull)
+  }
+
+  test("SPARK-50464: support unsigned integer for arrow") {
+    val allocator = ArrowUtils.rootAllocator.newChildAllocator("uint4", 0, Long.MaxValue)
+    val vector = new UInt4Vector("uint4", allocator)
+    vector.allocateNew()
+    (0 until 10).foreach { i =>
+      vector.setSafe(i, i)
+    }
+    val columnVector = new ArrowColumnVector(vector)
+    assert(columnVector.dataType === LongType)
+    assert(!columnVector.hasNull)
+  }
+
+  test("SPARK-50464: support unsigned long for arrow") {
+    val allocator = ArrowUtils.rootAllocator.newChildAllocator("uint8", 0, Long.MaxValue)
+    val vector = new UInt8Vector("uint8", allocator)
+    vector.allocateNew()
+    (0 until 10).foreach { i =>
+      vector.setSafe(i, i)
+    }
+    val columnVector = new ArrowColumnVector(vector)
+    assert(columnVector.dataType === DecimalType(20, 0))
+    assert(!columnVector.hasNull)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support unsigned integers for arrow format.

1. Unsigned byte is converted into short.
2. Unsigned short is converted into integer.
3. Unsigned integer is converted into long.
4. Unsinged long is converted into Decimal(20, 0)

### Why are the changes needed?
currently spark will throw UNSUPPORTED_ARROWTYPE exception when reading arrow format file which contains unsigned integer.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?


### Was this patch authored or co-authored using generative AI tooling?
No
