### PR TITLE
[SPARK-48898][SQL] Fix Variant shredding bug

### DIFF
--- a/common/variant/src/main/java/org/apache/spark/types/variant/VariantShreddingWriter.java
+++ b/common/variant/src/main/java/org/apache/spark/types/variant/VariantShreddingWriter.java
@@ -101,7 +101,9 @@ public class VariantShreddingWriter {
           int id = v.getDictionaryIdAtIndex(i);
           fieldEntries.add(new VariantBuilder.FieldEntry(
               field.key, id, variantBuilder.getWritePos() - start));
-          variantBuilder.appendVariant(field.value);
+          // shallowAppendVariant is needed for correctness, since we're relying on the metadata IDs
+          // being unchanged.
+          variantBuilder.shallowAppendVariant(field.value);
         }
       }
       if (numFieldsMatched < objectSchema.length) {
@@ -133,8 +135,6 @@ public class VariantShreddingWriter {
         // Store the typed value.
         result.addScalar(typedValue);
       } else {
-        VariantBuilder variantBuilder = new VariantBuilder(false);
-        variantBuilder.appendVariant(v);
         result.addVariantValue(v.getValue());
       }
     } else {

--- a/sql/core/src/test/scala/org/apache/spark/sql/VariantWriteShreddingSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/VariantWriteShreddingSuite.scala
@@ -50,6 +50,7 @@ class VariantWriteShreddingSuite extends SparkFunSuite with ExpressionEvalHelper
     val variant = new Variant(variantVal.getValue, variantVal.getMetadata)
     val variantSchema = SparkShreddingUtils.buildVariantSchema(shreddingSchema)
     val actual = SparkShreddingUtils.castShredded(variant, variantSchema)
+
     val catalystExpected = CatalystTypeConverters.convertToCatalyst(expected)
     if (!checkResult(actual, catalystExpected, shreddingSchema, exprNullable = false)) {
       fail(s"Incorrect evaluation of castShredded: " +
@@ -179,9 +180,8 @@ class VariantWriteShreddingSuite extends SparkFunSuite with ExpressionEvalHelper
     testWithSchema(obj, ArrayType(StructType.fromDDL("a int, b string")),
       Row(obj.getMetadata, untypedValue(obj), null))
 
-
-    // Similar to the case above where we didn't shred one field, but with the unshredded value
-    // being an object. We need to check that the copied value is also not modified.
+    // Similar to the case above where "b" was not in the shredding schema, but with the unshredded
+    // value being an object. Check that the copied value has correct dictionary IDs.
     val obj2 = parseJson("""{"a": 1, "b": {"c": "hello"}}""")
     val residual2 = untypedValue("""{"b": {"c": "hello"}}""")
     // First byte is the type, second is number of fields, and the third is the ID for "b"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'common/utils/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?

In VariantShreddingWriter, there are two calls to `variantBuilder.appendVariant` that were left over from an earlier version of the shredding spec where we constructed new metadata for every shredded value. This method rebuilds the Variant value to refer to the new metadata dictionary in the builder, so we should not be using it in shredding, where all dictionary IDs now refer to the original Variant metadata.

1) When writing a Variant value that does not match the shredding type. The code was doing the right thing, but unnecessarily calling `variantBuilder.appendVariant` and then discarding the result. The PR removes that dead code.
2) When reconstructing a Variant object that contains only the fields of the original object that don't appear in the shredding schema. This is a correctness bug, since we would modify the value to use new dictionary IDs that do not correspond to the ones in the original metadata.

### Why are the changes needed?

Variant shredding correctness.

### Does this PR introduce _any_ user-facing change?

No, shredding has not yet been released.

### How was this patch tested?

Added a unit test that fails without the fix.

### Was this patch authored or co-authored using generative AI tooling?

No.