### PR TITLE
[MINOR][INFRA] Add a space in the JIRA user assignment message

### DIFF
--- a/dev/merge_spark_pr.py
+++ b/dev/merge_spark_pr.py
@@ -419,7 +419,7 @@ def choose_jira_assignee(issue):
                     annotations.append("Commentator")
                 print("[%d] %s (%s)" % (idx, author.displayName, ",".join(annotations)))
             raw_assignee = bold_input(
-                "Enter number of user, or userid, to assign to (blank to leave unassigned):"
+                "Enter number of user, or userid, to assign to (blank to leave unassigned): "
             )
             if raw_assignee == "":
                 return None


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to add a space at the message at the merge script below:

```
Enter number of user, or userid, to assign to (blank to leave unassigned):0
```

### Why are the changes needed?

To be consistent with other messages in this script.

### Does this PR introduce _any_ user-facing change?

No, dev-only.

### How was this patch tested?

Manually

### Was this patch authored or co-authored using generative AI tooling?

No.