### PR TITLE
[SPARK-50430][CORE][FOLLOW-UP] Keep the logic of manual putting key and values in Properties

### DIFF
--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
+++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
@@ -2982,7 +2982,9 @@ private[spark] object Utils
     if (props == null) {
       return props
     }
-    props.clone().asInstanceOf[Properties]
+    val resultProps = new Properties()
+    resultProps.putAll(props.clone().asInstanceOf[Properties])
+    resultProps
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR proposes to actually more conservatively preserve the original code of creating new properties instead of cloning.

### Why are the changes needed?

Previous codes only copied the key and values but `clone` actually copies more fields in `Properties`. `cloneProperties` is being used in Spark Core, and all other components so I propose to keep the logic as is.

### Does this PR introduce _any_ user-facing change?

This is more a fix of a potential bug.

### How was this patch tested?

No, it is difficult to add a test.

### Was this patch authored or co-authored using generative AI tooling?

No.